### PR TITLE
Changes in manual regarding compressibility and Juliane's fixes to certain terms

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -12,9 +12,9 @@
 % have an index. we use the imakeidx' replacement of the 'multind' package so
 % that we can have an index of all run-time parameters separate from other
 % items (if we ever wanted one)
-\usepackage{imakeidx}
-\makeindex[name=prmindex, title=Index of run-time parameter entries]
-\makeindex[name=prmindexfull, title=Index of run-time parameters with section names]
+%\usepackage{imakeidx}
+%\makeindex[name=prmindex, title=Index of run-time parameter entries]
+%\makeindex[name=prmindexfull, title=Index of run-time parameters with %section names]
 
 % be able to use \note environments with a box around the text
 \usepackage{fancybox}
@@ -356,7 +356,7 @@ $c_i$ that we call \textit{compositional fields}:
   \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right)
   \\
   &\quad
-  +\frac{\partial \rho}{\partial T} T \mathbf u \cdot \mathbf g
+  +\alpha T \left( \mathbf u \cdot \nabla \mathbf p \right)
   \notag
   \\
   &\quad
@@ -442,7 +442,7 @@ which it is in fact implemented:
   \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right)
   \\
   &\quad
-  +\frac{\partial \rho}{\partial T} T \mathbf u \cdot \mathbf g
+  +\alpha T \left( \mathbf u \cdot \nabla \mathbf p \right)
   \notag
   \\
   &\quad
@@ -451,6 +451,19 @@ which it is in fact implemented:
   \notag
 \end{align}
 
+\subsubsection{Comment on adiabatic heating}
+In other codes and texts there is sometimes a simplification in the previous equation. If the pressure gradient is in the vertical direction, then $ -\rho \mathbf g \approx \nabla \mathbf{p} $, and we have the following relation
+\begin{align}
+\alpha T \left( \mathbf u \cdot \nabla \mathbf p \right)
+  & \approx \alpha \rho T \mathbf u \cdot \mathbf g 
+  \notag
+  \\
+  &=
+  - \alpha T \rho \mathbf g \cdot \mathbf u 
+  \notag
+\end{align}
+
+\subsubsection{Boundary conditions}
 Having discussed \eqref{eq:temperature}, let us come to the last one of the
 original set of equations, \eqref{eq:compositional}. It describes the
 motion of a set of advected quantities $c_i(\mathbf x,t),i=1\ldots C$. We call these
@@ -500,6 +513,7 @@ $\Gamma_{D,T}\cup\Gamma_{N,T}=\Gamma$. No boundary conditions have to be posed
 for the compositional fields at those parts of the boundary where flow is either
 tangential to the boundary or points outward.
 
+\subsubsection{Comment on final set of equations}
 \aspect{} solves these equations in essentially the form stated. In
 particular, the form given in \eqref{eq:stokes-1} implies that the pressure
 $p$ we compute is in fact the \textit{total pressure}, i.e., the sum of
@@ -1176,7 +1190,6 @@ Section~\ref{parameters:Material_20model} also gives an answer which of the
 models already implemented uses the approximation or considers the material
 sufficiently compressible to go with the fully compressible continuity equation.}
 
-
 \subsubsection{Almost linear models}
 
 A further simplification can be obtained if one assumes that all coefficients
@@ -1269,11 +1282,21 @@ to as \textit{IMPES} methods (they originate in the porous media flow
 community, where the acronym stands for \textit{Im}plicit \textit{P}ressure,
 \textit{E}xplicit \textit{S}aturation). For details see \cite{KHB12}.
 
-\note{In \aspect{} 0.1, using the IMPES scheme is the only available
+\note{In \aspect{} 1.0, using the IMPES scheme is the only available
   option. However, in later versions we will implement a fully nonlinear
   scheme that treats the equations as coupled, and one will be able to choose
   between the two variants using a run-time parameter.}
 
+\subsubsection{Compressible formula}
+In the compressible case, we have in the convergence of mass formula that $\nabla \cdot \left( \rho \textbf{u} \right)= 0$ instead of $\nabla \cdot \textbf{u} = 0$, which implies nonlinear and nonsymmetric (which makes preconditioning really difficult).  The following explanation describes what is done in \aspect{} for the linear solver to work.  Dividing by $\rho$, then:
+\begin{equation*}
+\frac{1}{\rho} \nabla \cdot \left( \rho \textbf{u} \right) = \nabla \cdot \textbf{u} + \frac{1}{\rho} \nabla \rho \cdot  \textbf{u} 
+\end{equation*}
+Simplifying the second term on the right hand side of the above equality yields:
+\begin{equation*}
+\frac{1}{\rho} \nabla \rho \cdot \textbf{u} \approx \frac{1}{\rho} \frac{\partial \rho}{\partial p} \nabla p \cdot \textbf{u} \approx \frac{1}{\rho} \frac{\partial \rho}{\partial p} \nabla p_s \cdot \textbf{u} \approx \frac{1}{\rho} \frac{\partial \rho}{\partial p} \rho \textbf{g} \cdot \textbf{u} 
+\end{equation*}
+where compressibility is $\frac{1}{\rho} \frac{\partial \rho}{\partial p}$ and static pressure is used to get $\nabla p \approx \nabla p_s \approx \rho \textbf{g}$.
 
 \section{Installation}
 \label{sec:installation}


### PR DESCRIPTION
Ignore 
-\usepackage{imakeidx}
-\makeindex[name=prmindex, title=Index of run-time parameter entries]
-\makeindex[name=prmindexfull, title=Index of run-time parameters with section names]

+%\usepackage{imakeidx}
+%\makeindex[name=prmindex, title=Index of run-time parameter entries]
+%\makeindex[name=prmindexfull, title=Index of run-time parameters with %section names]
