### PR TITLE
Added code which enables to use breakline (//) in the input file.

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -157,6 +157,43 @@ void possibly_load_shared_libs (const std::string &parameter_filename)
 }
 
 
+/** Look up break line sign (//) at the end of a line and merge this line with the next one  */
+std::string
+expand_backslashes (const std::string &filename)
+{
+  std::string result;
+
+  unsigned int need_empty_lines = 0;
+
+  std::ifstream input (filename.c_str());
+  while (input)
+    {
+      // get one line and strip spaces at the front and back
+      std::string line;
+      std::getline(input, line);
+      while ((line.size() > 0)
+             && (line[line.size() - 1] == ' ' || line[line.size() - 1] == '\t'))
+        line.erase(line.size() - 1, std::string::npos);
+
+      if ((line.size() > 0) && (line[line.size()-1] == '\\'))
+        {
+          result += line.substr(0, line.size()-2);;
+          ++need_empty_lines;
+        }
+      else
+        {
+          result += line;
+          result += '\n';
+
+          for (; need_empty_lines>0; --need_empty_lines)
+            result += '\n';
+        }
+    }
+
+  return result;
+}
+
+
 int main (int argc, char *argv[])
 {
   using namespace dealii;
@@ -236,14 +273,14 @@ int main (int argc, char *argv[])
       // is only read at run-time
       ParameterHandler prm;
 
-      std::ifstream parameter_file(parameter_filename.c_str());
+      const std::string input_file = expand_backslashes (parameter_filename);
       switch (dim)
         {
           case 2:
           {
             aspect::Simulator<2>::declare_parameters(prm);
 
-            const bool success = prm.read_input(parameter_file);
+            const bool success = prm.read_input_from_string(input_file.c_str());
             AssertThrow(success, ExcMessage ("Invalid input parameter file."));
 
             aspect::Simulator<2> flow_problem(MPI_COMM_WORLD, prm);
@@ -256,7 +293,7 @@ int main (int argc, char *argv[])
           {
             aspect::Simulator<3>::declare_parameters(prm);
 
-            const bool success = prm.read_input(parameter_file);
+            const bool success = prm.read_input_from_string(input_file.c_str());
             AssertThrow(success, ExcMessage ("Invalid input parameter file."));
 
             aspect::Simulator<3> flow_problem(MPI_COMM_WORLD, prm);


### PR DESCRIPTION
This code (mostly writen by wolfgang) enables the use of breakllines within the inputfiles. It lookes at the end of each line in the input file for the breakline marker (//) and attaches the next line to that line.
