### PR TITLE
fully qualify interface names in plugin macros

### DIFF
--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -156,10 +156,10 @@ namespace aspect
   template class classname<3>; \
   namespace ASPECT_REGISTER_BOUNDARY_COMPOSITION_MODEL_ ## classname \
   { \
-    aspect::internal::Plugins::RegisterHelper<Interface<2>,classname<2> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::BoundaryComposition::Interface<2>,classname<2> > \
     dummy_ ## classname ## _2d (&aspect::BoundaryComposition::register_boundary_composition<2>, \
                                 name, description); \
-    aspect::internal::Plugins::RegisterHelper<Interface<3>,classname<3> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::BoundaryComposition::Interface<3>,classname<3> > \
     dummy_ ## classname ## _3d (&aspect::BoundaryComposition::register_boundary_composition<3>, \
                                 name, description); \
   }

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -175,10 +175,10 @@ namespace aspect
   template class classname<3>; \
   namespace ASPECT_REGISTER_BOUNDARY_TEMPERATURE_MODEL_ ## classname \
   { \
-    aspect::internal::Plugins::RegisterHelper<Interface<2>,classname<2> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::BoundaryTemperature::Interface<2>,classname<2> > \
     dummy_ ## classname ## _2d (&aspect::BoundaryTemperature::register_boundary_temperature<2>, \
                                 name, description); \
-    aspect::internal::Plugins::RegisterHelper<Interface<3>,classname<3> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::BoundaryTemperature::Interface<3>,classname<3> > \
     dummy_ ## classname ## _3d (&aspect::BoundaryTemperature::register_boundary_temperature<3>, \
                                 name, description); \
   }

--- a/include/aspect/compositional_initial_conditions/interface.h
+++ b/include/aspect/compositional_initial_conditions/interface.h
@@ -166,10 +166,10 @@ namespace aspect
   template class classname<3>; \
   namespace ASPECT_REGISTER_COMPOSITIONAL_INITIAL_CONDITIONS_ ## classname \
   { \
-    aspect::internal::Plugins::RegisterHelper<Interface<2>,classname<2> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::CompositionalInitialConditions::Interface<2>,classname<2> > \
     dummy_ ## classname ## _2d (&aspect::CompositionalInitialConditions::register_initial_conditions_model<2>, \
                                 name, description); \
-    aspect::internal::Plugins::RegisterHelper<Interface<3>,classname<3> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::CompositionalInitialConditions::Interface<3>,classname<3> > \
     dummy_ ## classname ## _3d (&aspect::CompositionalInitialConditions::register_initial_conditions_model<3>, \
                                 name, description); \
   }

--- a/include/aspect/geometry_model/interface.h
+++ b/include/aspect/geometry_model/interface.h
@@ -216,10 +216,10 @@ namespace aspect
   template class classname<3>; \
   namespace ASPECT_REGISTER_GEOMETRY_MODEL_ ## classname \
   { \
-    aspect::internal::Plugins::RegisterHelper<Interface<2>,classname<2> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::GeometryModel::Interface<2>,classname<2> > \
     dummy_ ## classname ## _2d (&aspect::GeometryModel::register_geometry_model<2>, \
                                 name, description); \
-    aspect::internal::Plugins::RegisterHelper<Interface<3>,classname<3> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::GeometryModel::Interface<3>,classname<3> > \
     dummy_ ## classname ## _3d (&aspect::GeometryModel::register_geometry_model<3>, \
                                 name, description); \
   }

--- a/include/aspect/gravity_model/interface.h
+++ b/include/aspect/gravity_model/interface.h
@@ -149,10 +149,10 @@ namespace aspect
   template class classname<3>; \
   namespace ASPECT_REGISTER_GRAVITY_MODEL_ ## classname \
   { \
-    aspect::internal::Plugins::RegisterHelper<Interface<2>,classname<2> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::GravityModel::Interface<2>,classname<2> > \
     dummy_ ## classname ## _2d (&aspect::GravityModel::register_gravity_model<2>, \
                                 name, description); \
-    aspect::internal::Plugins::RegisterHelper<Interface<3>,classname<3> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::GravityModel::Interface<3>,classname<3> > \
     dummy_ ## classname ## _3d (&aspect::GravityModel::register_gravity_model<3>, \
                                 name, description); \
   }

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -180,10 +180,10 @@ namespace aspect
   template class classname<3>; \
   namespace ASPECT_REGISTER_HEATING_MODEL_ ## classname \
   { \
-    aspect::internal::Plugins::RegisterHelper<Interface<2>,classname<2> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::HeatingModel::Interface<2>,classname<2> > \
     dummy_ ## classname ## _2d (&aspect::HeatingModel::register_heating_model<2>, \
                                 name, description); \
-    aspect::internal::Plugins::RegisterHelper<Interface<3>,classname<3> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::HeatingModel::Interface<3>,classname<3> > \
     dummy_ ## classname ## _3d (&aspect::HeatingModel::register_heating_model<3>, \
                                 name, description); \
   }

--- a/include/aspect/initial_conditions/interface.h
+++ b/include/aspect/initial_conditions/interface.h
@@ -182,10 +182,10 @@ namespace aspect
   template class classname<3>; \
   namespace ASPECT_REGISTER_INITIAL_CONDITIONS_ ## classname \
   { \
-    aspect::internal::Plugins::RegisterHelper<Interface<2>,classname<2> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::InitialConditions::Interface<2>,classname<2> > \
     dummy_ ## classname ## _2d (&aspect::InitialConditions::register_initial_conditions_model<2>, \
                                 name, description); \
-    aspect::internal::Plugins::RegisterHelper<Interface<3>,classname<3> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::InitialConditions::Interface<3>,classname<3> > \
     dummy_ ## classname ## _3d (&aspect::InitialConditions::register_initial_conditions_model<3>, \
                                 name, description); \
   }

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -844,10 +844,10 @@ namespace aspect
   template class classname<3>; \
   namespace ASPECT_REGISTER_MATERIAL_MODEL_ ## classname \
   { \
-    aspect::internal::Plugins::RegisterHelper<Interface<2>,classname<2> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::MaterialModel::Interface<2>,classname<2> > \
     dummy_ ## classname ## _2d (&aspect::MaterialModel::register_material_model<2>, \
                                 name, description); \
-    aspect::internal::Plugins::RegisterHelper<Interface<3>,classname<3> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::MaterialModel::Interface<3>,classname<3> > \
     dummy_ ## classname ## _3d (&aspect::MaterialModel::register_material_model<3>, \
                                 name, description); \
   }

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -271,10 +271,10 @@ namespace aspect
   template class classname<3>; \
   namespace ASPECT_REGISTER_MESH_REFINEMENT_CRITERION_ ## classname \
   { \
-    aspect::internal::Plugins::RegisterHelper<Interface<2>,classname<2> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::MeshRefinement::Interface<2>,classname<2> > \
     dummy_ ## classname ## _2d (&aspect::MeshRefinement::Manager<2>::register_mesh_refinement_criterion, \
                                 name, description); \
-    aspect::internal::Plugins::RegisterHelper<Interface<3>,classname<3> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::MeshRefinement::Interface<3>,classname<3> > \
     dummy_ ## classname ## _3d (&aspect::MeshRefinement::Manager<3>::register_mesh_refinement_criterion, \
                                 name, description); \
   }

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -326,10 +326,10 @@ namespace aspect
   template class classname<3>; \
   namespace ASPECT_REGISTER_POSTPROCESSOR_ ## classname \
   { \
-    aspect::internal::Plugins::RegisterHelper<Interface<2>,classname<2> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::Postprocess::Interface<2>,classname<2> > \
     dummy_ ## classname ## _2d (&aspect::Postprocess::Manager<2>::register_postprocessor, \
                                 name, description); \
-    aspect::internal::Plugins::RegisterHelper<Interface<3>,classname<3> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::Postprocess::Interface<3>,classname<3> > \
     dummy_ ## classname ## _3d (&aspect::Postprocess::Manager<3>::register_postprocessor, \
                                 name, description); \
   }

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -458,10 +458,10 @@ namespace aspect
   template class classname<3>; \
   namespace ASPECT_REGISTER_VISUALIZATION_POSTPROCESSOR_ ## classname \
   { \
-    aspect::internal::Plugins::RegisterHelper<VisualizationPostprocessors::Interface<2>,classname<2> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::Postprocess::VisualizationPostprocessors::Interface<2>,classname<2> > \
     dummy_ ## classname ## _2d (&aspect::Postprocess::Visualization<2>::register_visualization_postprocessor, \
                                 name, description); \
-    aspect::internal::Plugins::RegisterHelper<VisualizationPostprocessors::Interface<3>,classname<3> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::Postprocess::VisualizationPostprocessors::Interface<3>,classname<3> > \
     dummy_ ## classname ## _3d (&aspect::Postprocess::Visualization<3>::register_visualization_postprocessor, \
                                 name, description); \
   }

--- a/include/aspect/termination_criteria/interface.h
+++ b/include/aspect/termination_criteria/interface.h
@@ -275,10 +275,10 @@ namespace aspect
   template class classname<3>; \
   namespace ASPECT_REGISTER_TERMINATION_CRITERION_ ## classname \
   { \
-    aspect::internal::Plugins::RegisterHelper<Interface<2>,classname<2> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::TerminationCriteria::Interface<2>,classname<2> > \
     dummy_ ## classname ## _2d (&aspect::TerminationCriteria::Manager<2>::register_termination_criterion, \
                                 name, description); \
-    aspect::internal::Plugins::RegisterHelper<Interface<3>,classname<3> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::TerminationCriteria::Interface<3>,classname<3> > \
     dummy_ ## classname ## _3d (&aspect::TerminationCriteria::Manager<3>::register_termination_criterion, \
                                 name, description); \
   }

--- a/include/aspect/velocity_boundary_conditions/interface.h
+++ b/include/aspect/velocity_boundary_conditions/interface.h
@@ -188,10 +188,10 @@ namespace aspect
   template class classname<3>; \
   namespace ASPECT_REGISTER_VELOCITY_BOUNDARY_CONDITIONS_ ## classname \
   { \
-    aspect::internal::Plugins::RegisterHelper<Interface<2>,classname<2> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::VelocityBoundaryConditions::Interface<2>,classname<2> > \
     dummy_ ## classname ## _2d (&aspect::VelocityBoundaryConditions::register_velocity_boundary_conditions_model<2>, \
                                 name, description); \
-    aspect::internal::Plugins::RegisterHelper<Interface<3>,classname<3> > \
+    aspect::internal::Plugins::RegisterHelper<aspect::VelocityBoundaryConditions::Interface<3>,classname<3> > \
     dummy_ ## classname ## _3d (&aspect::VelocityBoundaryConditions::register_velocity_boundary_conditions_model<3>, \
                                 name, description); \
   }


### PR DESCRIPTION
This allows the user to register plugins without having to put them into
the correct aspect::XXXPlugin namespace.
