### PR TITLE
add try/catch around functionparser to give more info

### DIFF
--- a/source/compositional_initial_conditions/function.cc
+++ b/source/compositional_initial_conditions/function.cc
@@ -70,10 +70,20 @@ namespace aspect
       prm.enter_subsection("Compositional initial conditions");
       {
         prm.enter_subsection("Function");
+        try
         {
           function.reset (new Functions::ParsedFunction<dim>(n_compositional_fields));
           function->parse_parameters (prm);
         }
+        catch (...)
+        {
+            std::cerr << "ERROR: FunctionParser failed to parse\n"
+                << "\t'Compositional initial conditions.Function'\n"
+                << "with expression\n"
+                << "\t'" << prm.get("Function expression") << "'";
+            throw;
+        }
+
         prm.leave_subsection();
       }
       prm.leave_subsection();

--- a/source/heating_model/function.cc
+++ b/source/heating_model/function.cc
@@ -83,9 +83,20 @@ namespace aspect
       prm.enter_subsection("Heating model");
       {
         prm.enter_subsection("Function");
+        try
         {
-          heating_model_function.parse_parameters (prm);
+            heating_model_function.parse_parameters (prm);
         }
+        catch (...)
+        {
+            std::cerr << "ERROR: FunctionParser failed to parse\n"
+                << "\t'Heating model.Function'\n"
+                << "with expression\n"
+                << "\t'" << prm.get("Function expression") << "'";
+            throw;
+        }
+        {
+       }
         prm.leave_subsection();
       }
       prm.leave_subsection();

--- a/source/initial_conditions/adiabatic.cc
+++ b/source/initial_conditions/adiabatic.cc
@@ -247,10 +247,20 @@ namespace aspect
           if (n_compositional_fields > 0)
             {
               prm.enter_subsection("Function");
+              try
               {
                 function.reset (new Functions::ParsedFunction<1>(n_compositional_fields));
                 function->parse_parameters (prm);
               }
+              catch (...)
+              {
+                  std::cerr << "ERROR: FunctionParser failed to parse\n"
+                      << "\t'Initial conditions.Adiabatic.Function'\n"
+                      << "with expression\n"
+                      << "\t'" << prm.get("Function expression") << "'";
+                  throw;
+              }
+
               prm.leave_subsection();
             }
         }

--- a/source/initial_conditions/function.cc
+++ b/source/initial_conditions/function.cc
@@ -62,8 +62,17 @@ namespace aspect
       prm.enter_subsection("Initial conditions");
       {
         prm.enter_subsection("Function");
+        try
         {
           function.parse_parameters (prm);
+        }
+        catch (...)
+        {
+            std::cerr << "ERROR: FunctionParser failed to parse\n"
+                << "\t'Initial conditions.Function'\n"
+                << "with expression\n"
+                << "\t'" << prm.get("Function expression") << "'";
+            throw;
         }
         prm.leave_subsection();
       }

--- a/source/mesh_refinement/minimum_refinement_function.cc
+++ b/source/mesh_refinement/minimum_refinement_function.cc
@@ -92,9 +92,19 @@ namespace aspect
       prm.enter_subsection("Mesh refinement");
       {
         prm.enter_subsection("Minimum refinement function");
+        try
         {
         	min_refinement_level.parse_parameters (prm);
         }
+        catch (...)
+        {
+            std::cerr << "ERROR: FunctionParser failed to parse\n"
+                << "\t'Mesh refinement.Minimum refinement function'\n"
+                << "with expression\n"
+                << "\t'" << prm.get("Function expression") << "'";
+            throw;
+        }
+
         prm.leave_subsection();
       }
       prm.leave_subsection();

--- a/source/velocity_boundary_conditions/function.cc
+++ b/source/velocity_boundary_conditions/function.cc
@@ -94,8 +94,17 @@ namespace aspect
       prm.enter_subsection("Boundary velocity model");
       {
         prm.enter_subsection("Function");
+        try
         {
           boundary_velocity_function.parse_parameters (prm);
+        }
+        catch (...)
+        {
+            std::cerr << "ERROR: FunctionParser failed to parse\n"
+                << "\t'Boundary velocity model.Function'\n"
+                << "with expression\n"
+                << "\t'" << prm.get("Function expression") << "'";
+            throw;
         }
         prm.leave_subsection();
       }


### PR DESCRIPTION
It is frustrating if you have a parser error inside FunctionParser
because it won't tell you which expression is wrong or which parameter
in the prm is wrong. This is now fixed.
