### PR TITLE
Allow mesh refinement plugins to act on global refinement

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -5,6 +5,11 @@
  * 1.0. All entries are signed with the names of the author. </p>
  *
  * <ol>
+ * <li> Mesh refinement plugins can now interact with initial global mesh
+ * refinement and unflag certain cells if desired.
+ * <br>
+ * (Timo Heister, 2014/05/22)
+ *
  * <li> Fixed: We accidentally evaluated the viscosity of the material model
  * from the place where we compute the adiabatic conditions, but this
  * required information that we didn't have. This is also unnecessary

--- a/tests/global_refine_amr.cc
+++ b/tests/global_refine_amr.cc
@@ -1,0 +1,105 @@
+/*
+  Copyright (C) 2014 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+
+#include <aspect/mesh_refinement/interface.h>
+#include <aspect/simulator_access.h>
+#include <math.h>
+
+
+using namespace dealii;
+
+
+namespace aspect
+{
+  template <int dim>
+  class AMRLeft : public MeshRefinement::Interface<dim>,
+      public SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * After cells have been marked for coarsening/refinement, apply
+         * additional criteria independent of the error estimate.
+         *
+         */
+        virtual
+        void
+        tag_additional_cells () const;
+
+        /**
+         * Declare the parameters this class takes through input files.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter
+         * file.
+         */
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
+
+      private:
+    };
+
+    
+    template <int dim>
+    void
+    AMRLeft<dim>::tag_additional_cells () const
+    {
+      std::cout << "plugin is called!" << std::endl;
+      
+      for (typename Triangulation<dim>::active_cell_iterator
+           cell = this->get_triangulation().begin_active();
+           cell != this->get_triangulation().end(); ++cell)
+        {
+          if (cell->is_locally_owned() && cell->center()[0]<0.5)
+	    cell->clear_refine_flag ();
+        }
+    }
+
+    template <int dim>
+    void
+    AMRLeft<dim>::
+    declare_parameters (ParameterHandler &prm)
+    {
+    }
+
+    template <int dim>
+    void
+    AMRLeft<dim>::parse_parameters (ParameterHandler &prm)
+    {
+    }
+
+  }
+
+
+
+
+// explicit instantiations
+namespace aspect
+{
+    ASPECT_REGISTER_MESH_REFINEMENT_CRITERION(AMRLeft,
+                                              "AMRLeft",
+                                              "TODO")
+}

--- a/tests/global_refine_amr.prm
+++ b/tests/global_refine_amr.prm
@@ -1,0 +1,71 @@
+set Dimension = 2
+set CFL number                             = 1.0
+set End time                               = 0
+set Start time                             = 0
+set Adiabatic surface temperature          = 0
+set Surface pressure                       = 0
+set Use years in output instead of seconds = false  # default: true
+set Nonlinear solver scheme                = IMPES
+
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+
+
+subsection Gravity model
+  set Model name = vertical
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1.2 # default: 1
+    set Y extent = 1
+    set Z extent = 1
+  end
+end
+
+
+subsection Initial conditions
+  set Model name = perturbed box
+end
+
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1    # default: 3300
+    set Reference specific heat       = 1250
+    set Reference temperature         = 1    # default: 293
+    set Thermal conductivity          = 1e-6 # default: 4.7
+    set Thermal expansion coefficient = 2e-5
+    set Viscosity                     = 1    # default: 5e24
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 6
+  set Strategy = AMRLeft
+
+
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = 0, 1
+  set Prescribed velocity boundary indicators =
+  set Tangential velocity boundary indicators = 1
+  set Zero velocity boundary indicators       = 0, 2, 3
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, velocity statistics, temperature statistics, heat flux statistics
+end
+

--- a/tests/global_refine_amr/screen-output
+++ b/tests/global_refine_amr/screen-output
@@ -1,0 +1,61 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . running in OPTIMIZED mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Loading shared library <./libglobal_refine_amr.so>
+
+plugin is called!
+plugin is called!
+plugin is called!
+plugin is called!
+plugin is called!
+plugin is called!
+Number of active cells: 2,140 (on 7 levels)
+Number of degrees of freedom: 28,711 (17,646+2,242+8,823)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 18 iterations.
+
+   Postprocessing:
+
+     Reference density (kg/m^3):                    1
+     Reference gravity (m/s^2):                     1
+     Reference thermal expansion (1/K):             2e-05
+     Temperature contrast across model domain (K): 1
+     Model domain depth (m):                        1
+     Reference thermal diffusivity (m^2/s):         8e-10
+     Reference viscosity (Pas):                     1
+     Ra number:                                     25000
+     k_value:                                       1e-06
+     reference_cp:                                  1250
+     reference_thermal_diffusivity:                 8e-10
+
+     Writing graphical output:           output-global_refine_amr/solution-00000
+     RMS, max velocity:                  7.71e-09 m/s, 2.57e-08 m/s
+     Temperature min/avg/max:            0 K, 1.038 K, 1.1 K
+     Heat fluxes through boundary parts: 1.748e-07 W, 0.0001602 W, 2.426e-07 W, 2.426e-07 W
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.625s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |    0.0996s |        16% |
+| Assemble temperature system     |         1 |    0.0515s |       8.2% |
+| Build Stokes preconditioner     |         1 |     0.101s |        16% |
+| Build temperature preconditioner|         1 |    0.0164s |       2.6% |
+| Solve Stokes system             |         1 |    0.0878s |        14% |
+| Solve temperature system        |         1 |   0.00203s |      0.33% |
+| Initialization                  |         2 |    0.0428s |       6.9% |
+| Postprocessing                  |         1 |     0.131s |        21% |
+| Setup dof systems               |         1 |    0.0759s |        12% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/global_refine_amr/statistics
+++ b/tests/global_refine_amr/statistics
@@ -1,0 +1,20 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Iterations for temperature solver
+# 7: Iterations for Stokes solver
+# 8: Time step size (seconds)
+# 9: Visualization file name
+# 10: RMS velocity (m/s)
+# 11: Max. velocity (m/s)
+# 12: Minimal temperature (K)
+# 13: Average temperature (K)
+# 14: Maximal temperature (K)
+# 15: Average nondimensional temperature (K)
+# 16: Outward heat flux through boundary with indicator 0 (W)
+# 17: Outward heat flux through boundary with indicator 1 (W)
+# 18: Outward heat flux through boundary with indicator 2 (W)
+# 19: Outward heat flux through boundary with indicator 3 (W)
+0 0.0000e+00 2140 19888 8823 0 18 3.0258e+05 output-global_refine_amr/solution-00000 7.71052448e-09 2.57225788e-08 0.00000000e+00 1.03792614e+00 1.10000000e+00 1.03792614e+00 1.74802589e-07 1.60166700e-04 2.42564104e-07 2.42564104e-07 


### PR DESCRIPTION
Instead of calling global_refine(n) we now flag all cells for refinement
and then allow the mesh refinement plugins to unflag the cells if
desired. This procedure needs to be repeated n times. If there is no
plugin that modifies the flags, it is equivalent to refine_global().
