### PR TITLE
Make basic statistics

### DIFF
--- a/include/aspect/postprocess/basic_statistics.h
+++ b/include/aspect/postprocess/basic_statistics.h
@@ -40,7 +40,7 @@ namespace aspect
     {
       public:
         /**
-         * Evaluate the solution for some velocity statistics.
+         * Evaluate the solution for some general statistics.
          */
         virtual
         std::pair<std::string,std::string>

--- a/source/postprocess/basic_statistics.cc
+++ b/source/postprocess/basic_statistics.cc
@@ -27,9 +27,6 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>
 
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/archive/text_iarchive.hpp>
-
 
 namespace aspect
 {

--- a/source/postprocess/velocity_statistics.cc
+++ b/source/postprocess/velocity_statistics.cc
@@ -27,9 +27,6 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>
 
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/archive/text_iarchive.hpp>
-
 
 namespace aspect
 {
@@ -132,68 +129,6 @@ namespace aspect
                << global_max_velocity
                << " m/s";
 
-// TODO: This really doesn't belong here
-      if (this->get_time() == 0e0)
-        {
-          if (dynamic_cast<const MaterialModel::Simple<dim> *>(&this->get_material_model()) != 0)
-            {
-
-              const MaterialModel::Simple<dim> &material_model
-                = dynamic_cast<const MaterialModel::Simple<dim> &>(this->get_material_model());
-
-              const double h = this->get_geometry_model().maximal_depth();
-
-              const double dT = this->get_boundary_temperature().maximal_temperature(this->get_fixed_temperature_boundary_indicators())
-                                - this->get_boundary_temperature().minimal_temperature(this->get_fixed_temperature_boundary_indicators());
-              // we do not compute the compositions but give the functions below the value 0.0 instead
-              std::vector<double> composition_values(this->n_compositional_fields(),0.0);
-
-              Point<dim> representative_point = this->get_geometry_model().representative_point(0);
-              const double gravity = this->get_gravity_model().gravity_vector(representative_point).norm();
-              const double Ra = material_model.reference_density()*
-                                gravity*
-                                material_model.reference_thermal_expansion_coefficient()*
-                                dT*std::pow(h,3)/
-                                (material_model.reference_thermal_diffusivity()*
-                                 material_model.reference_viscosity());
-
-              this->get_pcout()<<  std::endl;
-              this->get_pcout()<< "     Reference density (kg/m^3):                    "
-                               << material_model.reference_density()
-                               << std::endl;
-              this->get_pcout()<< "     Reference gravity (m/s^2):                     "
-                               << gravity
-                               << std::endl;
-              this->get_pcout()<< "     Reference thermal expansion (1/K):             "
-                               << material_model.reference_thermal_expansion_coefficient()
-                               << std::endl;
-              this->get_pcout()<< "     Temperature contrast across model domain (K): "
-                               << dT
-                               << std::endl;
-              this->get_pcout()<< "     Model domain depth (m):                        "
-                               << h
-                               << std::endl;
-              this->get_pcout()<< "     Reference thermal diffusivity (m^2/s):         "
-                               << material_model.reference_thermal_diffusivity()
-                               << std::endl;
-              this->get_pcout()<< "     Reference viscosity (Pas):                     "
-                               << material_model.reference_viscosity()
-                               << std::endl;
-              this->get_pcout()<< "     Ra number:                                     "
-                               << Ra
-                               << std::endl;
-              this->get_pcout()<< "     k_value:                                       "
-                               << material_model.thermal_conductivity(dT, dT, composition_values, representative_point) //TODO: dT for the pressure is wrong
-                               << std::endl;
-              this->get_pcout()<< "     reference_cp:                                  "
-                               << material_model.reference_cp()
-                               << std::endl;
-              this->get_pcout()<< "     reference_thermal_diffusivity:                 "
-                               << material_model.thermal_conductivity(dT, dT, composition_values, representative_point)/(material_model.reference_density()*material_model.reference_cp()) //TODO: dT for the pressure is wrong
-                               << std::endl;
-              this->get_pcout()<<  std::endl;
-            }
-        }
       return std::pair<std::string, std::string> ("RMS, max velocity:",
                                                   output.str());
     }

--- a/tests/adiabatic_conditions.prm
+++ b/tests/adiabatic_conditions.prm
@@ -75,6 +75,6 @@ subsection Model settings
 end
 
 subsection Postprocess
-  set List of postprocessors = visualization, velocity statistics, temperature statistics, heat flux statistics, depth average
+  set List of postprocessors = visualization, velocity statistics, basic statistics,  temperature statistics, heat flux statistics, depth average
 end
 

--- a/tests/box-first-time-step-alternate-bc.prm
+++ b/tests/box-first-time-step-alternate-bc.prm
@@ -69,6 +69,6 @@ subsection Model settings
 end
 
 subsection Postprocess
-  set List of postprocessors = visualization, velocity statistics, temperature statistics, heat flux statistics
+  set List of postprocessors = visualization, velocity statistics, basic statistics,  temperature statistics, heat flux statistics
 end
 

--- a/tests/box-first-time-step.prm
+++ b/tests/box-first-time-step.prm
@@ -63,6 +63,6 @@ subsection Model settings
 end
 
 subsection Postprocess
-  set List of postprocessors = visualization, velocity statistics, temperature statistics, heat flux statistics
+  set List of postprocessors = visualization, velocity statistics, basic statistics,  temperature statistics, heat flux statistics
 end
 

--- a/tests/box-repetitions.prm
+++ b/tests/box-repetitions.prm
@@ -66,6 +66,6 @@ subsection Model settings
 end
 
 subsection Postprocess
-  set List of postprocessors = visualization#, velocity statistics, temperature statistics, heat flux statistics
+  set List of postprocessors = visualization#, velocity statistics, basic statistics,  temperature statistics, heat flux statistics
 end
 

--- a/tests/diffusion-velocity.prm
+++ b/tests/diffusion-velocity.prm
@@ -370,7 +370,7 @@ subsection Postprocess
   # into files that can be read by a graphical visualization program.
   # Additional run time parameters are read from the parameter subsection
   # 'Visualization'.
-  set List of postprocessors = temperature statistics, heat flux statistics, velocity statistics
+  set List of postprocessors = temperature statistics, heat flux statistics, velocity statistics, basic statistics
 
   subsection Depth average
     # The time interval between each generation of graphical output files. A

--- a/tests/free_surface_blob.prm
+++ b/tests/free_surface_blob.prm
@@ -107,5 +107,5 @@ subsection Termination criteria
 end
 
 subsection Postprocess
-  set List of postprocessors = topography,velocity statistics,
+  set List of postprocessors = topography,velocity statistics, basic statistics, 
 end

--- a/tests/free_surface_relaxation.prm
+++ b/tests/free_surface_relaxation.prm
@@ -112,5 +112,5 @@ subsection Termination criteria
 end
 
 subsection Postprocess
-  set List of postprocessors = topography,velocity statistics
+  set List of postprocessors = topography,velocity statistics, basic statistics
 end

--- a/tests/minimum_refinement_function.prm
+++ b/tests/minimum_refinement_function.prm
@@ -174,7 +174,7 @@ end
 
 subsection Postprocess
 
-  set List of postprocessors = visualization,velocity statistics,temperature statistics,heat flux statistics, depth average # default: all
+  set List of postprocessors = visualization,velocity statistics, basic statistics, temperature statistics,heat flux statistics, depth average # default: all
 
   subsection Depth average
     # The time interval between each generation of graphical output files. A

--- a/tests/no_adiabatic_heating_02.prm
+++ b/tests/no_adiabatic_heating_02.prm
@@ -93,7 +93,7 @@ subsection Boundary velocity model
 end
 
 subsection Postprocess
-  set List of postprocessors = temperature statistics, velocity statistics
+  set List of postprocessors = temperature statistics, velocity statistics, basic statistics
 
   subsection Visualization
     set Time between graphical output = 0.1

--- a/tests/no_adiabatic_heating_03.prm
+++ b/tests/no_adiabatic_heating_03.prm
@@ -125,7 +125,7 @@ subsection Boundary velocity model
 end
 
 subsection Postprocess
-  set List of postprocessors = temperature statistics, velocity statistics, visualization
+  set List of postprocessors = temperature statistics, velocity statistics, basic statistics,  visualization
 
   subsection Visualization
     set Time between graphical output = 0.1

--- a/tests/passive_comp.prm
+++ b/tests/passive_comp.prm
@@ -376,7 +376,7 @@ subsection Postprocess
   #
   # `heat flux statistics': A postprocessor
   # that computes some statistics about the heat flux across boundaries.
-  set List of postprocessors = visualization,velocity statistics,temperature statistics,heat flux statistics, depth average
+  set List of postprocessors = visualization,velocity statistics, basic statistics, temperature statistics,heat flux statistics, depth average
 
 
   subsection Visualization

--- a/tests/periodic_box.prm
+++ b/tests/periodic_box.prm
@@ -100,5 +100,5 @@ subsection Termination criteria
 end
 
 subsection Postprocess
-  set List of postprocessors = velocity statistics
+  set List of postprocessors = velocity statistics, basic statistics
 end

--- a/tests/periodic_box_freesurface.prm
+++ b/tests/periodic_box_freesurface.prm
@@ -106,5 +106,5 @@ subsection Termination criteria
 end
 
 subsection Postprocess
-  set List of postprocessors = velocity statistics, topography, 
+  set List of postprocessors = velocity statistics, basic statistics,  topography, 
 end

--- a/tests/refine_vel.prm
+++ b/tests/refine_vel.prm
@@ -98,7 +98,7 @@ subsection Model settings
 end
 
 subsection Postprocess
-  set List of postprocessors = visualization, velocity statistics, temperature statistics, heat flux statistics, depth average
+  set List of postprocessors = visualization, velocity statistics, basic statistics,  temperature statistics, heat flux statistics, depth average
 
   subsection Visualization
      set Time between graphical output = 0

--- a/tests/remove_angular_momentum.prm
+++ b/tests/remove_angular_momentum.prm
@@ -65,5 +65,5 @@ end
 
 
 subsection Postprocess
-  set List of postprocessors = velocity statistics
+  set List of postprocessors = velocity statistics, basic statistics
 end

--- a/tests/remove_net_rotation.prm
+++ b/tests/remove_net_rotation.prm
@@ -65,5 +65,5 @@ end
 
 
 subsection Postprocess
-  set List of postprocessors = velocity statistics
+  set List of postprocessors = velocity statistics, basic statistics
 end

--- a/tests/simple-compressible.prm
+++ b/tests/simple-compressible.prm
@@ -86,7 +86,7 @@ end
 
 
 subsection Postprocess
-  set List of postprocessors = visualization,velocity statistics,temperature statistics,heat flux statistics, depth average
+  set List of postprocessors = visualization,velocity statistics, basic statistics, temperature statistics,heat flux statistics, depth average
 
 
   subsection Visualization

--- a/tests/simple-incompressible.prm
+++ b/tests/simple-incompressible.prm
@@ -83,7 +83,7 @@ end
 
 
 subsection Postprocess
-  set List of postprocessors = visualization,velocity statistics,temperature statistics,heat flux statistics, depth average
+  set List of postprocessors = visualization,velocity statistics, basic statistics, temperature statistics,heat flux statistics, depth average
 
 
   subsection Visualization

--- a/tests/spherical_velocity_statistics.prm
+++ b/tests/spherical_velocity_statistics.prm
@@ -101,7 +101,7 @@ subsection Model settings
 end
 
 subsection Postprocess
-  set List of postprocessors = visualization, velocity statistics, temperature statistics, heat flux statistics, depth average, spherical velocity statistics
+  set List of postprocessors = visualization, velocity statistics, basic statistics,  temperature statistics, heat flux statistics, depth average, spherical velocity statistics
 
   subsection Visualization
      set Time between graphical output = 0

--- a/tests/steinberger-compressible.prm
+++ b/tests/steinberger-compressible.prm
@@ -87,7 +87,7 @@ end
 
 
 subsection Postprocess
-  set List of postprocessors = visualization,velocity statistics,temperature statistics,heat flux statistics, depth average
+  set List of postprocessors = visualization,velocity statistics, basic statistics, temperature statistics,heat flux statistics, depth average
 
 
   subsection Visualization

--- a/tests/steinberger-incompressible.prm
+++ b/tests/steinberger-incompressible.prm
@@ -89,7 +89,7 @@ end
 
 
 subsection Postprocess
-  set List of postprocessors = visualization,velocity statistics,temperature statistics,heat flux statistics, depth average
+  set List of postprocessors = visualization,velocity statistics, basic statistics, temperature statistics,heat flux statistics, depth average
 
 
   subsection Visualization

--- a/tests/stokes.prm
+++ b/tests/stokes.prm
@@ -134,7 +134,7 @@ end
 # velocity field.
 
 subsection Postprocess
-  set List of postprocessors = visualization, velocity statistics
+  set List of postprocessors = visualization, velocity statistics, basic statistics
 
   subsection Visualization
     set List of output variables = density, viscosity

--- a/tests/temperature-dependent-stokes-matrix.prm
+++ b/tests/temperature-dependent-stokes-matrix.prm
@@ -76,7 +76,7 @@ subsection Model settings
 end
 
 subsection Postprocess
-  set List of postprocessors = visualization, velocity statistics
+  set List of postprocessors = visualization, velocity statistics, basic statistics
 
   subsection Visualization
     set List of output variables = viscosity

--- a/tests/velocity_boundary_statistics.prm
+++ b/tests/velocity_boundary_statistics.prm
@@ -98,7 +98,7 @@ subsection Model settings
 end
 
 subsection Postprocess
-  set List of postprocessors = visualization, velocity statistics, temperature statistics, heat flux statistics, depth average, velocity boundary statistics
+  set List of postprocessors = visualization, velocity statistics, basic statistics,  temperature statistics, heat flux statistics, depth average, velocity boundary statistics
 
   subsection Visualization
      set Time between graphical output = 0

--- a/tests/velocity_in_years.prm
+++ b/tests/velocity_in_years.prm
@@ -92,7 +92,7 @@ end
 
 
 subsection Postprocess
-  set List of postprocessors = velocity statistics
+  set List of postprocessors = velocity statistics, basic statistics
 
   subsection Visualization
     set List of output variables = density


### PR DESCRIPTION
Removed a part from the velocity statistics postprocessor that did not belong there and moved it to a new postprocessor called basic statistics. Updated the tests to create the same output as before.
