### PR TITLE
Petsc configure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,27 +45,48 @@ ENDIF()
 
 MESSAGE(STATUS "found deal.II version ${DEAL_II_PACKAGE_VERSION} at '${deal.II_DIR}'")
 
-IF(NOT DEAL_II_WITH_TRILINOS OR NOT DEAL_II_WITH_P4EST)
-  IF(NOT DEAL_II_WITH_TRILINOS)
-    MESSAGE(SEND_ERROR
-      "\n-- deal.II was built without support for Trilinos!\n"
-      )
-  ENDIF()
+SET(ASPECT_USE_PETSC OFF CACHE BOOL "Use PETSc instead of Trilinos if set to 'on'.")
 
-  IF(NOT DEAL_II_WITH_P4EST)
+MESSAGE(STATUS "using PETSc = '${ASPECT_USE_PETSC}'")
+
+SET(_DEALII_GOOD ON)
+
+IF(ASPECT_USE_PETSC AND NOT DEAL_II_WITH_PETSC)
+    MESSAGE(SEND_ERROR
+      "\n-- deal.II was built without support for PETSc!\n"
+      )
+    SET(_DEALII_GOOD OFF)
+ENDIF()
+
+IF(NOT DEAL_II_WITH_P4EST)
     MESSAGE(SEND_ERROR
       "\n-- deal.II was built without support for p4est!\n"
       )
-  ENDIF()
+    SET(_DEALII_GOOD OFF)
+ENDIF()
 
+IF(NOT ASPECT_USE_PETSC AND NOT DEAL_II_WITH_TRILINOS)
+    MESSAGE(SEND_ERROR
+      "\n-- deal.II was built without support for Trilinos!\n"
+      )
+    SET(_DEALII_GOOD OFF)
+ENDIF()
+
+IF (NOT _DEALII_GOOD)
   MESSAGE(FATAL_ERROR
-    "\nAspect requires a deal.II installation built with support for Trilinos and p4est but one or both of these appears to be missing!\n"
+    "\nAspect requires a deal.II installation built with support for Trilinos/PETSc and p4est but one or both of these appears to be missing!\n"
     )
-
 ENDIF()
 
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
 PROJECT(${TARGET})
+
+IF (ASPECT_USE_PETSC)
+FOREACH(_source_file ${TARGET_SRC})
+  SET_PROPERTY(SOURCE ${_source_file}
+    APPEND PROPERTY COMPILE_DEFINITIONS ASPECT_USE_PETSC="1")
+ENDFOREACH()
+ENDIF()
 
 
 # Pass down the source directory to the sources. This can be used

--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -5,6 +5,10 @@
  * 1.0. All entries are signed with the names of the author. </p>
  *
  * <ol>
+ * <li> PETSc support can now be enabled using 'cmake -D ASPECT_USE_PETSC=ON'.
+ * <br>
+ * (Timo Heister, 2014/05/27)
+ *
  * <li> Fixed: The GPlates plugin now correctly handles meshes created by 
  * GPlates 1.4 and later. Previous Aspect versions may only read in files
  * created by GPlates 1.3.

--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -22,10 +22,7 @@
 #ifndef __aspect__global_h
 #define __aspect__global_h
 
-// uncomment this to use PETSc for linear algebra
-//#define USE_PETSC
-
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
 #include <deal.II/lac/petsc_block_vector.h>
 #include <deal.II/lac/petsc_block_sparse_matrix.h>
 #include <deal.II/lac/petsc_precondition.h>
@@ -79,7 +76,7 @@ namespace aspect
   {
     using namespace dealii;
 
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
     /**
      * Typedef for the vector type used.
      */

--- a/source/main.cc
+++ b/source/main.cc
@@ -241,7 +241,7 @@ int main (int argc, char *argv[])
           if (n_threads>1)
             std::cout << "--     . using " << n_threads << " threads " << (n_tasks == 1 ? "\n" : "each\n");
 #endif
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
           std::cout << "--     . using PETSc\n";
 #else
           std::cout << "--     . using Trilinos\n";

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1021,7 +1021,7 @@ namespace aspect
     Amg_preconditioner.reset (new LinearAlgebra::PreconditionAMG());
 
     LinearAlgebra::PreconditionAMG::AdditionalData Amg_data;
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
     Amg_data.symmetric_operator = false;
 #else
     Amg_data.constant_modes = constant_modes;

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -673,7 +673,7 @@ namespace aspect
           = DoFTools::always;
     }
 
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
     LinearAlgebra::CompressedBlockSparsityPattern sp(introspection.index_sets.system_relevant_partitioning);
 
 #else
@@ -687,7 +687,7 @@ namespace aspect
                                      Utilities::MPI::
                                      this_mpi_process(mpi_communicator));
 
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
     SparsityTools::distribute_sparsity_pattern(sp,
                                                dof_handler.locally_owned_dofs_per_processor(),
                                                mpi_communicator, introspection.index_sets.system_relevant_set);
@@ -725,7 +725,7 @@ namespace aspect
           coupling[c][d] = DoFTools::none;
 
 
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
     LinearAlgebra::CompressedBlockSparsityPattern sp(introspection.index_sets.system_relevant_partitioning);
 
 #else
@@ -737,7 +737,7 @@ namespace aspect
                                      constraints, false,
                                      Utilities::MPI::
                                      this_mpi_process(mpi_communicator));
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
     SparsityTools::distribute_sparsity_pattern(sp,
                                                dof_handler.locally_owned_dofs_per_processor(),
                                                mpi_communicator, introspection.index_sets.system_relevant_set);

--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -221,7 +221,7 @@ namespace aspect
 
     //set up the matrix
     LinearAlgebra::SparseMatrix mass_matrix;
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
     CompressedSimpleSparsityPattern sp(mesh_locally_relevant);
 
 #else
@@ -230,7 +230,7 @@ namespace aspect
 #endif
     DoFTools::make_sparsity_pattern (free_surface_dof_handler, sp, mass_matrix_constraints, false,
                                       Utilities::MPI::this_mpi_process(sim.mpi_communicator));
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
     SparsityTools::distribute_sparsity_pattern(sp,
                                                free_surface_dof_handler.n_locally_owned_dofs_per_processor(),
                                                sim.mpi_communicator, mesh_locally_relevant);
@@ -365,7 +365,7 @@ namespace aspect
     // TODO: think about keeping object between time steps
     LinearAlgebra::PreconditionAMG preconditioner_stiffness;
     LinearAlgebra::PreconditionAMG::AdditionalData Amg_data;
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
     Amg_data.symmetric_operator = false;
 #else
     Amg_data.constant_modes = constant_modes;
@@ -522,7 +522,7 @@ namespace aspect
       for (unsigned int c=0; c<dim; ++c)
         coupling[c][c] = DoFTools::always;
 
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
       CompressedSimpleSparsityPattern sp(mesh_locally_relevant);
 
 #else
@@ -536,7 +536,7 @@ namespace aspect
                                        Utilities::MPI::
                                        this_mpi_process(sim.mpi_communicator));
 
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
       SparsityTools::distribute_sparsity_pattern(sp,
                                                  free_surface_dof_handler.n_locally_owned_dofs_per_processor(),
                                                  sim.mpi_communicator, mesh_locally_relevant);

--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -25,7 +25,7 @@
 #include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/constraint_matrix.h>
 
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
 #include <deal.II/lac/solver_cg.h>
 #else
 #include <deal.II/lac/trilinos_solver.h>

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -25,7 +25,7 @@
 #include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/constraint_matrix.h>
 
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
 #include <deal.II/lac/solver_cg.h>
 #else
 #include <deal.II/lac/trilinos_solver.h>
@@ -245,7 +245,7 @@ namespace aspect
       {
         SolverControl solver_control(5000, 1e-6 * src.block(1).l2_norm());
 
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
         SolverCG<LinearAlgebra::Vector> solver(solver_control);
 #else
         TrilinosWrappers::SolverCG solver(solver_control);
@@ -273,7 +273,7 @@ namespace aspect
       if (do_solve_A == true)
         {
           SolverControl solver_control(5000, utmp.l2_norm()*1e-2);
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
           SolverCG<LinearAlgebra::Vector> solver(solver_control);
 #else
           TrilinosWrappers::SolverCG solver(solver_control);
@@ -389,7 +389,7 @@ namespace aspect
 
         SolverControl cn;
         // TODO: can we re-use the direct solver?
-#ifdef USE_PETSC
+#ifdef ASPECT_USE_PETSC
         PETScWrappers::SparseDirectMUMPS solver(cn, mpi_communicator);
 #else
         TrilinosWrappers::SolverDirect solver(cn);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,33 @@ FUNCTION(get_mpi_count _filename)
   endif()
 ENDFUNCTION()
 
+# extract from the prm if the test should be run with trilinos or
+# petsc. This is encoded in the .prm in form of line
+# '# LINEAR ALGEBRA: PETSC'
+# '# LINEAR ALGEBRA: PETSC TRILINOS'
+# If no line is there, Trilinos is assumed. 
+FUNCTION(check_linear_algebra _filename)
+  FILE(STRINGS ${_filename} _input_lines
+       REGEX "LINEAR ALGEBRA:")
+  IF("${_input_lines}" STREQUAL "")
+    IF(ASPECT_USE_PETSC)
+      SET(_use_test 0 PARENT_SCOPE)
+    ELSE()
+      SET(_use_test 1 PARENT_SCOPE)
+    ENDIF()
+  ELSE()
+    SET(_use_test 0 PARENT_SCOPE)
+    FOREACH(_input_line ${_input_lines})
+      IF (${_input_line} MATCHES "PETSC" AND ASPECT_USE_PETSC)
+        SET(_use_test 1 PARENT_SCOPE)
+      ENDIF()
+      IF (${_input_line} MATCHES "TRILINOS" AND NOT ASPECT_USE_PETSC)
+        SET(_use_test 1 PARENT_SCOPE)
+      ENDIF()
+    ENDFOREACH()
+  ENDIF()
+ENDFUNCTION()
+
 
 # set a time limit of 10 minutes per test. this should be long
 # enough even for long-running tests, and short enough to not
@@ -77,12 +104,15 @@ IF("${TEST_DIFF}" STREQUAL "")
   ENDIF()
 ENDIF()
 
-
 FILE(GLOB _tests *.prm)
+
 LIST(SORT _tests)
 FOREACH(_test ${_tests})
   GET_FILENAME_COMPONENT(_test ${_test} NAME_WE)
-  MESSAGE(STATUS "Adding test ${_test}")
+
+  CHECK_LINEAR_ALGEBRA(${CMAKE_CURRENT_SOURCE_DIR}/${_test}.prm)
+
+  IF("${_use_test}" STREQUAL "1")
 
   IF(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${_test}.cc)
     ADD_LIBRARY(${_test} SHARED EXCLUDE_FROM_ALL ${_test}.cc)
@@ -148,7 +178,6 @@ FOREACH(_test ${_tests})
       DEPENDS aspect ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm ${_testdepends}
       )
   ELSE()
-    MESSAGE(STATUS "    MPI status: ${_mpi_count} processes")
     ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output
       COMMAND
 	for i in ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/* \; do
@@ -259,5 +288,7 @@ FOREACH(_test ${_tests})
   SET_TESTS_PROPERTIES(${_test} PROPERTIES
 	TIMEOUT ${TEST_TIME_LIMIT}
     )
+
+  ENDIF()
 ENDFOREACH()
 

--- a/tests/composition_names.prm
+++ b/tests/composition_names.prm
@@ -1,3 +1,5 @@
+# LINEAR ALGEBRA: TRILINOS PETSC
+
 # Listing of Parameters
 # ---------------------
 # In order to make the problem in the first time step easier to solve, we need

--- a/write_config.cmake
+++ b/write_config.cmake
@@ -31,6 +31,7 @@ _detailed(
 #  ASPECT configuration:
 #        DEAL_II_DIR:            ${deal.II_DIR}
 #        DEAL_II VERSION:        ${DEAL_II_PACKAGE_VERSION}
+#        ASPECT_USE_PETSC:       ${ASPECT_USE_PETSC}
 #        CMAKE_BUILD_TYPE:       ${CMAKE_BUILD_TYPE}
 #        CMAKE_INSTALL_PREFIX:   ${CMAKE_INSTALL_PREFIX}
 #        CMAKE_SOURCE_DIR:       ${CMAKE_SOURCE_DIR} 


### PR DESCRIPTION
- add ASPECT_USE_PETSC configuration flag
- check if we have deal.II with PETSc if ON, Trilinos otherwise
- log info into detailed.log
- be more silent (do not list every test we find)
- do not run the testsuite with PETSc (because most tests would fail and I want to at least compile ASPECT on the tester).

We can think about adding separate tests/test-output for PETSc.
