### PR TITLE
Silence linear solver fails from all but processor zero.

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -7,6 +7,13 @@
  *
  * <ol>
  *
+ * <li> Fixed: When a linear solver fails to converge in a parallel program,
+ * every processor would output the same error message -- leading to incredible
+ * amounts of entangled error messages. This has now been resolved: every processor
+ * still fails, but only processor 0 reports the error.
+ * <br>
+ * (Wolfgang Bangerth, 2014/06/06)
+ *
  * <li> Fixed: When setting "Use years in output instead of seconds" the
  * velocity solution is now exported in m/year instead of m/s in visualization
  * files.

--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011, 2012 by the authors of the ASPECT code.
+  Copyright (C) 2011, 2012, 2014 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -70,6 +70,21 @@ namespace aspect
    */
   typedef boost::archive::binary_oarchive oarchive;
 
+  /**
+   * A class we throw in exceptions in parallel jobs and that we can
+   * silently treat in main(). We do this, for example, in
+   * read_parameters() where each processor would otherwise throw the
+   * same exception and every processor would produce a tangle of
+   * output that is impenetrable in large parallel jobs. The same
+   * situation happens if a linear solver fails. Rather, we make
+   * processor 0 throw the real exception and every other processor
+   * converts the exception it wants to throw to an object of the
+   * current type -- which is caught in main() but doesn't produce any
+   * output (because processor 0 will already produce the output).
+   */
+  class QuietException {};
+
+  
   /**
    * A namespace that contains typedefs for classes used in the linear algebra
    * description.

--- a/source/main.cc
+++ b/source/main.cc
@@ -211,11 +211,6 @@ expand_backslashes (const std::string &filename)
 
 
 /**
- * An exception that we can silently treat in main(). Used in read_parameters().
- */
-class QuietException {};
-
-/**
  * Let ParameterHandler parse the input file, here given as a string.
  * Since ParameterHandler unconditionally writes to the screen when it
  * finds something it doesn't like, we get massive amounts of output
@@ -226,7 +221,7 @@ class QuietException {};
  *
  * In case of an error, we need to abort all processors without them
  * having read their data. This is done by throwing an exception of the
- * special class QuietException that we can catch in main() and terminate
+ * special class aspect::QuietException that we can catch in main() and terminate
  * the program quietly without generating other output.
  */
 void
@@ -256,7 +251,7 @@ parse_parameters (const std::string &input_as_string,
           AssertThrow(false, dealii::ExcMessage ("Invalid input parameter file."));
         }
       else
-        throw QuietException();
+        throw aspect::QuietException();
     }
 
   // otherwise, processor 0 was ok reading the data, so we can expect the
@@ -371,7 +366,7 @@ int main (int argc, char *argv[])
 
       return 1;
     }
-  catch (QuietException &)
+  catch (aspect::QuietException &)
     {
       // quitly treat an exception used on processors other than
       // root when we already know that processor 0 will generate


### PR DESCRIPTION
When a linear solver fails to converge in a parallel program, every processor would output the same error message -- leading to incredible amounts of entangled error messages. This has now been resolved: every processor still fails, but only processor 0 reports the error.
