### PR TITLE
fix denormalize pressure in parallel

### DIFF
--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -725,9 +725,10 @@ namespace aspect
           {
             // velocity and pressure are in the same block, so we have to modify the values manually
 
+            const unsigned int block_idx = introspection.block_indices.pressure;
             LinearAlgebra::BlockVector distributed_vector (introspection.index_sets.stokes_partitioning,
                                                            mpi_communicator);
-            distributed_vector = vector;
+            distributed_vector.block(block_idx) = vector.block(block_idx);
 
             std::vector<types::global_dof_index> local_dof_indices (finite_element.dofs_per_cell);
             typename DoFHandler<dim>::active_cell_iterator
@@ -751,7 +752,7 @@ namespace aspect
                     }
                 }
             distributed_vector.compress(VectorOperation::insert);
-            vector = distributed_vector;
+            vector.block(block_idx) = distributed_vector.block(block_idx);
           }
       }
     else

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -471,8 +471,9 @@ namespace aspect
         // nonlinear residual (see initial_residual below).
         // TODO: if there was an easy way to know if the caller needs the
         // initial residual we could skip all of this stuff.
-        distributed_stokes_solution.block(0) = current_linearization_point.block(0);
-        denormalize_pressure (distributed_stokes_solution);
+        solution.block(0) = current_linearization_point.block(0);
+        denormalize_pressure (solution);
+        distributed_stokes_solution.block(0) = solution.block(0);
         current_constraints.set_zero (distributed_stokes_solution);
 
         // Undo the pressure scaling:


### PR DESCRIPTION
We were not handing a ghosted vector to denormalize pressure when using a direct solver, which broke it with more than one MPI process. All tests are passing now.
