### PR TITLE
Be more verbose in a warning message.

### DIFF
--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -510,13 +510,14 @@ namespace aspect
         // assemble the error message completely, and then output it atomically
         if (tmp_file_desc == -1)
           {
-            std::string x = std::string(
-                              "***** WARNING: could not create temporary file, will "
-                              "output directly to final location. This may negatively "
-                              "affect performance. (On processor ")
-                            + Utilities::int_to_string(
-                              Utilities::MPI::this_mpi_process (MPI_COMM_WORLD))
-                            + ".)\n";
+            const std::string x = ("***** WARNING: could not create temporary file <"
+				   +
+				   tmp_filename
+				   +
+				   ">, will output directly to final location. This may negatively "
+				   "affect performance. (On processor "
+				   + Utilities::int_to_string(Utilities::MPI::this_mpi_process (MPI_COMM_WORLD))
+				   + ".)\n");
 
             std::cerr << x << std::flush;
 


### PR DESCRIPTION
In order to track down what's happening, knowing which file we were trying to write to turned out to be about as useful as knowing the processor number.
