### PR TITLE
The heating rate should be a scalar function.

### DIFF
--- a/source/heating_model/function.cc
+++ b/source/heating_model/function.cc
@@ -68,7 +68,7 @@ namespace aspect
       {
         prm.enter_subsection("Function");
         {
-          Functions::ParsedFunction<dim>::declare_parameters (prm, dim);
+          Functions::ParsedFunction<dim>::declare_parameters (prm, 1);
         }
         prm.leave_subsection();
       }


### PR DESCRIPTION
The heating rate is currently defined as a vector-valued function. This makes no sense.
