### PR TITLE
Use strain rate for viscosity mesh refinement.

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -7,6 +7,14 @@
  *
  * <ol>
  *
+ * <li> Fixed: The viscosity mesh refinement criterion did not ask
+ * the material model for the viscosity, therefore it did not work
+ * with many material models. Some material models calculate the
+ * viscosity anyway, so it worked in that cases. Now the criterion 
+ * asks correctly for the viscosity.
+ * <br>
+ * (Rene Gassmoeller, Juliane Dannberg 2014/08/04)
+ *
  * <li> Changed: The minimum refinement function now always declares
  * three variables. In the 'depth' option only the first one is
  * set to the depth, the other variables are set to zero.

--- a/source/mesh_refinement/viscosity.cc
+++ b/source/mesh_refinement/viscosity.cc
@@ -57,7 +57,7 @@ namespace aspect
       FEValues<dim> fe_values (this->get_mapping(),
                                this->get_fe(),
                                quadrature,
-                               update_quadrature_points | update_values);
+                               update_quadrature_points | update_values | update_gradients);
 
       // the values of the compositional fields are stored as blockvectors for each field
       // we have to extract them in this structure
@@ -81,12 +81,14 @@ namespace aspect
                                                                                       in.pressure);
             fe_values[this->introspection().extractors.temperature].get_function_values (this->get_solution(),
                                                                                          in.temperature);
+            fe_values[this->introspection().extractors.velocities].get_function_symmetric_gradients (this->get_solution(),
+                                                                                                     in.strain_rate);
+
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
               fe_values[this->introspection().extractors.compositional_fields[c]].get_function_values (this->get_solution(),
                   prelim_composition_values[c]);
 
             in.position = fe_values.get_quadrature_points();
-            in.strain_rate.resize(0);// we are not reading the viscosity
             for (unsigned int i=0; i<quadrature.size(); ++i)
               {
                 for (unsigned int c=0; c<this->n_compositional_fields(); ++c)

--- a/tests/viscosity-refinement.prm
+++ b/tests/viscosity-refinement.prm
@@ -1,0 +1,84 @@
+# Test the viscosity refinement criterion
+set Adiabatic surface temperature          = 1623               # default: 0
+set Dimension                              = 2
+
+set End time                               = 0
+
+subsection Boundary temperature model
+  set Model name = initial temperature
+
+  subsection Initial temperature
+    set Maximal temperature = 3773
+    set Minimal temperature = 273
+  end
+
+end
+
+
+subsection Geometry model
+  set Model name = box # default: 
+
+  subsection Box
+    set X extent  = 500000
+    set Y extent  = 500000
+  end
+
+end
+
+
+subsection Gravity model
+  set Model name = vertical # default: 
+
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+
+end
+
+
+subsection Initial conditions
+  set Model name = function # default: 
+  subsection Function
+    set Function constants  = l=250000
+    set Function expression = if(x < l, 1873, 1623)
+    set Variable names      = x,y
+  end
+end
+
+
+subsection Material model
+
+  set Model name = simple # default: 
+  subsection Simple model
+    set Thermal viscosity exponent = 5.0
+    set Reference temperature = 1750
+  end
+end
+
+
+subsection Mesh refinement
+  set Coarsening fraction                      = 0.05
+  set Refinement fraction                      = 0.3
+
+  set Initial adaptive refinement              = 3                    # default: 2
+  set Initial global refinement                = 2                    # default: 2
+
+  set Strategy                                 = viscosity
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = 0,3        # default: 
+  set Prescribed velocity boundary indicators =  
+
+  set Tangential velocity boundary indicators = 0,1,2,3
+  set Zero velocity boundary indicators       =           # default: 
+end
+
+
+subsection Postprocess
+  set List of postprocessors = 
+end
+
+
+

--- a/tests/viscosity-refinement/screen-output
+++ b/tests/viscosity-refinement/screen-output
@@ -1,0 +1,63 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.2.pre
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Number of active cells: 16 (on 3 levels)
+Number of degrees of freedom: 268 (162+25+81)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 22 iterations.
+
+Number of active cells: 40 (on 4 levels)
+Number of degrees of freedom: 646 (394+55+197)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 24 iterations.
+
+Number of active cells: 88 (on 5 levels)
+Number of degrees of freedom: 1,388 (850+113+425)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 24 iterations.
+
+Number of active cells: 184 (on 6 levels)
+Number of degrees of freedom: 2,858 (1,754+227+877)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 24 iterations.
+
+   Postprocessing:
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      2.06s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         4 |     0.445s |        22% |
+| Assemble temperature system     |         4 |     0.259s |        13% |
+| Build Stokes preconditioner     |         4 |     0.336s |        16% |
+| Build temperature preconditioner|         4 |   0.00505s |      0.24% |
+| Solve Stokes system             |         4 |    0.0783s |       3.8% |
+| Solve temperature system        |         4 |   0.00399s |      0.19% |
+| Initialization                  |         5 |     0.172s |       8.3% |
+| Postprocessing                  |         1 |  0.000344s |     0.017% |
+| Refine mesh structure, part 1   |         3 |     0.326s |        16% |
+| Refine mesh structure, part 2   |         3 |    0.0127s |      0.61% |
+| Setup dof systems               |         4 |     0.309s |        15% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/viscosity-refinement/statistics
+++ b/tests/viscosity-refinement/statistics
@@ -1,0 +1,14 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Iterations for temperature solver
+# 7: Iterations for Stokes solver
+# 8: Velocity iterations in Stokes preconditioner
+# 9: Schur complement iterations in Stokes preconditioner
+# 10: Time step size (years)
+0 0.0000e+00  16  187  81 0 22 23  22 1.1362e+10 
+0 0.0000e+00  40  449 197 0 24 25  96 5.5024e+09 
+0 0.0000e+00  88  963 425 0 24 25 100 2.7364e+09 
+0 0.0000e+00 184 1981 877 0 24 25 110 1.3690e+09 


### PR DESCRIPTION
The viscosity refinement criterion was so far only working with material models, which did not check for strain_rate.size() == 0. This was introduced at the creation of the viscosity criterion by copying from other plugins and is fixed now. The test checks for the number of dofs during refinement.
