### PR TITLE
Use a random number generator that we know is predictable.

### DIFF
--- a/source/particle/generator.cc
+++ b/source/particle/generator.cc
@@ -20,6 +20,9 @@
 
 #include <aspect/particle/generator.h>
 
+#include <boost/random.hpp>
+
+
 namespace aspect
 {
   namespace Particle
@@ -150,7 +153,8 @@ namespace aspect
                   {
                     for (d=0; d<dim; ++d)
                       {
-                        pt[d] = drand48()*(max_bounds[d]-min_bounds[d]) + min_bounds[d];
+                        pt[d] = uniform_distribution_01(random_number_generator) *
+				(max_bounds[d]-min_bounds[d]) + min_bounds[d];
                       }
                     try
                       {
@@ -174,7 +178,16 @@ namespace aspect
 
                 cur_id++;
               }
-          };
+          }
+
+      private:
+	/**
+	 * Random number generator and an object that describes a
+	 * uniform distribution on the interval [0,1]. These
+	 * will be used to generate particle locations at random.
+	 */
+	boost::mt19937            random_number_generator;
+	boost::uniform_01<double> uniform_distribution_01;
       };
 
 


### PR DESCRIPTION
The previous version used drand48 which is not thread-safe and whose
implementation can, at least in principle, be different on different
systems. The new version is more predictable, using a member variable
and a known random number generator from the BOOST library.
