### PR TITLE
Work around a problem with deallog when loading shared libs.

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,12 @@
  *
  *
  * <ol>
+ * <li> Fixed: When running in release mode and with user-defined libraries
+ * loaded, the deal.II solvers we use in ASPECT produced a lot more output
+ * than desired. This is now fixed.
+ * <br>
+ * (Wolfgang Bangerth, 2014/09/01)
+ *
  * <li> New: There is now a new section in the manual that documents running
  * the benchmarks proposed by Davies et al.
  * <br>

--- a/source/main.cc
+++ b/source/main.cc
@@ -134,6 +134,13 @@ void possibly_load_shared_libs (const std::string &parameter_filename)
                                    + shared_libs_list[i] + ">. The operating system reports "
                                    + "that the error is this: <"
                                    + dlerror() + ">."));
+
+	  // for reasons not entirely clear, dlopening a shared
+	  // library resets the log level of the deallog variable to
+	  // its default. however, this only happens in release mode,
+	  // not in debug mode. to work around this problem, set the
+	  // log depth again to where we want it to be
+	  deallog.depth_console(0);
         }
 
       if (Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)


### PR DESCRIPTION
I have no idea how this happens, but the patch at least explains the symptoms...
