### PR TITLE
update make commands to build manual.pdf

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -56,13 +56,14 @@ manual.pdf: manual/manual.tex manual/manual.bib manual/parameters.tex \
                  -a -x "`which makeindex`" ; then \
 	   (cd manual ; \
 		rm -f manual.{aux,bbl,blg,log,out,pdf,toc} prm*.{idx,ilg,ind} ; \
-		pdflatex manual.tex ; \
-		bibtex manual       ; \
-		makeindex prmindex  ; \
-		pdflatex manual.tex ; \
-		pdflatex manual.tex ; \
-		pdflatex manual.tex) ; \
-	   mv manual/manual.pdf . ; \
+		pdflatex --interaction=batchmode manual.tex && \
+		bibtex manual       && \
+		makeindex prmindex  && \
+		pdflatex --interaction=batchmode manual.tex && \
+		pdflatex --interaction=batchmode manual.tex && \
+		pdflatex --interaction=batchmode manual.tex) && \
+	   mv manual/manual.pdf . || \
+	   (echo "Error compiling manual.pdf, check manual/manual.log" && false); \
          else \
 	  echo "------------------------------------------------------" ; \
 	  echo "Can't find either 'pdflatex', 'bibtex' or 'makeindex'." ; \


### PR DESCRIPTION
Enable batchmode and fail if an error happens. This way we can test
automatically if the manual still builds.
