### PR TITLE
Close a file before we attempt to move it.

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,14 @@
  *
  *
  * <ol>
+ * <li> Fixed: There was a race condition in writing output files: we
+ * write to them in a temporary location and then move them to their
+ * final location. We used to do the second step before actually closing
+ * the file we just wrote to. Under some circumstances, this could lead
+ * to incomplete or empty output files. This is now fixed.
+ * <br>
+ * (Wolfgang Bangerth, 2014/09/03)
+ *
  * <li> Fixed: Running in release mode and with user-defined libraries
  * loaded that were compiled against the debug version of deal.II, or the
  * other way around, likely produces effects that are undesirable. ASPECT

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -547,6 +547,7 @@ namespace aspect
       // now write and then move the tmp file to its final destination
       // if necessary
       out << *file_contents;
+      out.close ();
 
       if (tmp_filename != *filename)
         {


### PR DESCRIPTION
I am completely dumbfounded that we've never had trouble with this: we write into a file and then move it, but we don't close it before moving so sometimes nothing is in it yet (presumably if the file is large enough it is actually flushed, but if it's small it isn't). Fix this by closing the file before moving.
