### PR TITLE
Change tracer default output format to vtu as in visualization.

### DIFF
--- a/source/postprocess/tracer.cc
+++ b/source/postprocess/tracer.cc
@@ -149,7 +149,7 @@ namespace aspect
                              "Units: years if the "
                              "'Use years in output instead of seconds' parameter is set; "
                              "seconds otherwise.");
-          prm.declare_entry("Data output format", "none",
+          prm.declare_entry("Data output format", "vtu",
                             Patterns::Selection(Particle::Output::output_object_names()),
                             "File format to output raw particle data in.");
           prm.declare_entry("Integration scheme", "rk2",


### PR DESCRIPTION
I think the tracer output postprocessor should use the same default values for data format and output times as visualization. Currently nothing happens if you choose 'tracers' as postprocessor, because you first need to choose a data format.
