### PR TITLE
only open log.txt on processor 0

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -173,15 +173,17 @@ namespace aspect
     rebuild_stokes_matrix (true),
     rebuild_stokes_preconditioner (true)
   {
-    if (parameters.resume_computation)
-      log_file_stream.open((parameters.output_directory + "log.txt").c_str(), std::ios_base::app);
-    else
-      log_file_stream.open((parameters.output_directory + "log.txt").c_str());
-
-    // we already printed the header to the screen, so here we just dump it
-    // into the logfile.
     if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
-      print_aspect_header(log_file_stream);
+      {
+	// only open the logfile on processor 0, the other processors won't be
+	// writing into the stream anyway
+	log_file_stream.open((parameters.output_directory + "log.txt").c_str(),
+			     parameters.resume_computation ? std::ios_base::app : std::ios_base::out);
+
+	// we already printed the header to the screen, so here we just dump it
+	// into the logfile.
+	print_aspect_header(log_file_stream);
+      }
 
     computing_timer.enter_section("Initialization");
 


### PR DESCRIPTION
Only processor 0 will be writing into the file output/log.txt anyway, so
we only need to open it there. This might also fix some filesystem race
conditions.
