### PR TITLE
Add the option to increase output resolution.

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,16 @@
  *
  *
  * <ol>
+ *<li> New: There is now the possibility to interpolate the visualization
+ * output to a refined output mesh. This accounts for the fact that most
+ * visualization software only offers linear interpolation between grid points
+ * and therefore the output file is a very coarse representation of the actual
+ * solution field. The new output is still a linear interpolation, but at least
+ * on a finer grid. The visualization output quality and used disk space will
+ * increase when activating this option.
+ * <br>
+ * (Rene Gassmoeller, 2014/09/14)
+ *
  * <li> Fixed: There was a race condition in writing output files: we
  * write to them in a temporary location and then move them to their
  * final location. We used to do the second step before actually closing

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -359,6 +359,19 @@ namespace aspect
         unsigned int group_files;
 
         /**
+         * deal.II offers the possibility to linearly interpolate
+         * output fields of higher order elements to a finer resolution.
+         * This somewhat compensates the fact that most visualization
+         * software only offers linear interpolation between grid points
+         * and therefore the output file is a very coarse representation
+         * of the actual solution field. Activating this option increases
+         * the spatial resolution in each dimension by a factor equal
+         * to the polynomial degree used for the velocity finite element
+         * (usually 2).
+         */
+        bool interpolate_output;
+
+        /**
          * Compute the next output time from the current one. In the simplest
          * case, this is simply the previous next output time plus the
          * interval, but in general we'd like to ensure that it is larger than

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -191,6 +191,13 @@ namespace aspect
       include_latent_heat () const;
 
       /**
+       * Return the stokes velocity degree.
+       */
+      int
+      get_stokes_velocity_degree () const;
+
+
+      /**
        * Return the adiabatic surface temperature.
        */
       double

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -290,7 +290,10 @@ namespace aspect
         }
 
       // now build the patches and see how we can output these
-      data_out.build_patches ();
+      data_out.build_patches ((interpolate_output) ?
+                               this->get_stokes_velocity_degree()
+                               :
+                               0);
 
       std::string solution_file_prefix = "solution-" + Utilities::int_to_string (output_file_number, 5);
       std::string mesh_file_prefix = "mesh-" + Utilities::int_to_string (output_file_number, 5);
@@ -638,6 +641,18 @@ namespace aspect
                              "A value of 1 will generate one big file containing the whole "
                              "solution.");
 
+          prm.declare_entry ("Interpolate output", "false",
+                             Patterns::Bool(),
+                             "deal.II offers the possibility to linearly interpolate "
+                             "output fields of higher order elements to a finer resolution. "
+                             "This somewhat compensates the fact that most visualization "
+                             "software only offers linear interpolation between grid points "
+                             "and therefore the output file is a very coarse representation "
+                             "of the actual solution field. Activating this option increases "
+                             "the spatial resolution in each dimension by a factor equal "
+                             "to the polynomial degree used for the velocity finite element "
+                             "(usually 2).");
+
           // finally also construct a string for Patterns::MultipleSelection that
           // contains the names of all registered visualization postprocessors
           const std::string pattern_of_names
@@ -685,6 +700,7 @@ namespace aspect
           output_interval = prm.get_double ("Time between graphical output");
           output_format   = prm.get ("Output format");
           group_files     = prm.get_integer("Number of grouped files");
+          interpolate_output = prm.get_bool("Interpolate output");
 
           // now also see which derived quantities we are to compute
           viz_names = Utilities::split_string_list(prm.get("List of output variables"));

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -157,6 +157,12 @@ namespace aspect
     return simulator->parameters.include_latent_heat;
   }
 
+  template <int dim>
+  int
+  SimulatorAccess<dim>::get_stokes_velocity_degree () const
+  {
+    return simulator->parameters.stokes_velocity_degree;
+  }
 
   template <int dim>
   double


### PR DESCRIPTION
deal.II offers to interpolate higher-order cell output to a finer output mesh. This actually represents the internal accuracy much better than the usual output only at the cell corners (see attached figure, same model, different output resolution). Should we offer the user an option for this in the visualization postprocessor? At least I am pretty sure I would always prefer the higher resolution output, even when I know it is only a bilinear interpolation of the quadratic element functions. I was always annoyed that aspect output with the same number of degrees of freedom looks much coarser than Citcom output in Paraview, although the internal resolution is similar ;-) 

![image](https://cloud.githubusercontent.com/assets/7582930/4263642/bb0b8254-3bf5-11e4-9d2c-f8950f85346c.png)
