### PR TITLE
adjust a default value to account for the use of a different temperature...

### DIFF
--- a/source/material_model/latent_heat_melt.cc
+++ b/source/material_model/latent_heat_melt.cc
@@ -607,11 +607,15 @@ namespace aspect
                              "function that approximates the solidus "
                              "of pyroxenite. "
                              "Units: $°C$.");
-          prm.declare_entry ("D2", "1.23e-7",
+          prm.declare_entry ("D2", "1.329e-7",
                              Patterns::Double (),
                              "Prefactor of the linear pressure term "
                              "in the quadratic function that approximates "
                              "the solidus of pyroxenite. "
+                             "Note that this factor is different from the "
+                             "value given in Sobolev, 2011, because they use "
+                             "the potential temperature whereas we use the "
+                             "absolute temperature. "
                              "Units: $°C/Pa$.");
           prm.declare_entry ("D3", "-5.1e-18",
                              Patterns::Double (),

--- a/source/postprocess/visualization/melt_fraction.cc
+++ b/source/postprocess/visualization/melt_fraction.cc
@@ -221,11 +221,15 @@ namespace aspect
                                  "function that approximates the solidus "
                                  "of pyroxenite. "
                                  "Units: $°C$.");
-              prm.declare_entry ("D2", "1.23e-7",
+              prm.declare_entry ("D2", "1.329e-7",
                                  Patterns::Double (),
                                  "Prefactor of the linear pressure term "
                                  "in the quadratic function that approximates "
                                  "the solidus of pyroxenite. "
+                                 "Note that this factor is different from the "
+                                 "value given in Sobolev, 2011, because they use "
+                                 "the potential temperature whereas we use the "
+                                 "absolute temperature. "
                                  "Units: $°C/Pa$.");
               prm.declare_entry ("D3", "-5.1e-18",
                                  Patterns::Double (),


### PR DESCRIPTION
... in the original source of the melting model. 

I just noticed that in the Sobolev et al (2011) paper they use the potential temperature instead of the absolute temperature. This means they do not consider the adiabatic temperature change and their melting temperature is lower compared to the one that should be used in a model with the "real" temperature.  
