### PR TITLE
Fix bug in multicomponent

### DIFF
--- a/source/material_model/multicomponent.cc
+++ b/source/material_model/multicomponent.cc
@@ -396,6 +396,8 @@ namespace aspect
             viscosity_averaging = geometric;
           else if (prm.get ("Viscosity averaging scheme") == "maximum composition")
             viscosity_averaging = maximum_composition;
+          else
+            AssertThrow(false, ExcMessage("Not a valid viscosity averaging scheme"));
 
           std::vector<double> x_values;
 


### PR DESCRIPTION
Anne Glerum pointed out a bug in the multicomponent material model which prevented the user from selecting other viscosity averaging schemes than harmonic.  Fix this, and update tests to reflect it.
