### PR TITLE
fix c8a76830 with deal 8.1

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -761,9 +761,14 @@ namespace aspect
     LinearAlgebra::CompressedBlockSparsityPattern sp(introspection.index_sets.system_relevant_partitioning);
 
 #else
+
+#if (DEAL_II_MAJOR*100 + DEAL_II_MINOR) > 801
     TrilinosWrappers::BlockSparsityPattern sp (system_partitioning,
                                                system_partitioning,
                                                introspection.index_sets.system_relevant_partitioning,
+                                               mpi_communicator);
+#else
+    TrilinosWrappers::BlockSparsityPattern sp (system_partitioning,
                                                mpi_communicator);
 #endif
 
@@ -815,10 +820,17 @@ namespace aspect
     LinearAlgebra::CompressedBlockSparsityPattern sp(introspection.index_sets.system_relevant_partitioning);
 
 #else
+
+#if (DEAL_II_MAJOR*100 + DEAL_II_MINOR) > 801
     TrilinosWrappers::BlockSparsityPattern sp (system_partitioning,
                                                system_partitioning,
                                                introspection.index_sets.system_relevant_partitioning,
                                                mpi_communicator);
+#else
+    TrilinosWrappers::BlockSparsityPattern sp (system_partitioning,
+                                               mpi_communicator);
+#endif
+    
 #endif
     DoFTools::make_sparsity_pattern (dof_handler,
                                      coupling, sp,


### PR DESCRIPTION
The constructor taking an IndexSet was added after the 8.1 release.
