### PR TITLE
Fix a bug in gplate plugin

### DIFF
--- a/source/velocity_boundary_conditions/gplates.cc
+++ b/source/velocity_boundary_conditions/gplates.cc
@@ -240,7 +240,10 @@ namespace aspect
             // Currently it would not be necessary to update the grid positions at every timestep
             // since they are not allowed to change. In case we allow this later, do it anyway.
             Tensor<1,3> spherical_position = get_grid_point_position(idx_theta,idx_phi,false);
-            if(idx_theta==0 || idx_theta==n_theta-1)spherical_position[1]=0.;
+            if(idx_theta==0 || idx_theta==n_theta-1)
+              // Gplate gpml files set the longitude of all points at poles to zero instead of vary from -180 to 180 degrees,
+              // we set this here as well to make sure that we get the correct cartesian velocity.
+              spherical_position[1]=0.;
             velocity_positions[idx_theta][idx_phi] = cartesian_surface_coordinates(spherical_position);
             (*velocity_values)[idx_theta][idx_phi] = sphere_to_cart_velocity(spherical_velocities,spherical_position)
                                                      / cmyr_si;


### PR DESCRIPTION
While gplate uses zero longitude at all grid points at poles, we assume the longitude at those points vary from 0 to 360.
This results wrong velocity to be interpolated near the poles (the velocity between poles to the first latitude grid points would be wrong, however the velocity right at the pole will be OK). 
This patch will fix this problem.
