### PR TITLE
Use a manifold to generate better meshes for the shell.

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,7 +6,17 @@
  *
  *
  * <ol>
- *<li> New: There is now the possibility to interpolate the visualization
+ * <li> New: With a sufficiently new version of deal.II, ASPECT now uses
+ * meshes for the spherical shell where each node is placed on concentric
+ * shells. Previously, upon mesh refinement, new vertices were placed at
+ * an averaged location of the vertices of the mother cell, leading to
+ * a certain degree of distortion of cells. It also led to a situation
+ * where not all cells are equally shaped due to this distortion. The new
+ * mesh, in contrast, is completely symmetric.
+ * <br>
+ * (Wolfgang Bangerth, 2014/10/31)
+ *
+ * <li> New: There is now the possibility to interpolate the visualization
  * output to a refined output mesh. This accounts for the fact that most
  * visualization software only offers linear interpolation between grid points
  * and therefore the output file is a very coarse representation of the actual


### PR DESCRIPTION
This PR is, for now, intended mainly for discussion. I thought I'd give it a try to use a manifold description for the spherical shell. This works and produces nicer meshes indeed. But there are questions we need to answer first:

1/ It is not backward compatible. Meshes change from before, and that's going to break a lot of testcases.
2/ It requires a new enough deal.II version.
3/ It requires a bit of a hack at the boundaries because we need normal vectors there that the manifold does not provide. 

My original motivation was to see whether this helps with the issue we have with shell_simple_3d.prm. The answer is: in parts; the time step where it breaks moves from time step6 to time step 12.