### PR TITLE
[WIP] ASPECT on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,90 @@
+FROM ubuntu:14.04
+
+MAINTAINER Rene Gassmoeller <r.gassmoeller@mailbox.org>
+
+ENV HOME /root
+
+RUN apt-get update
+RUN apt-get -yq install gcc \
+                        build-essential \
+                        wget \
+                        bzip2 \
+                        tar \
+                        g++ \
+                        gfortran \
+                        libblas-dev \
+                        liblapack-dev \
+                        libboost-dev \
+                        libopenmpi-dev \
+                        openmpi-bin \
+                        cmake \
+                        git
+
+#Build HDF5
+RUN wget http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.13.tar.bz2; \
+    tar xjvf hdf5-1.8.13.tar.bz2; \
+    cd hdf5-1.8.13; \
+    ./configure --enable-parallel \
+                --enable-shared \
+                --prefix=/usr/local/; \
+    make -j2 && make install; \
+    cd ..; \
+    rm -rf /hdf5-1.8.13 /hdf5-1.8.13.tar.bz2 
+
+#Build Trilinos
+RUN wget http://trilinos.sandia.gov/download/files/trilinos-11.8.1-Source.tar.bz2; \
+    tar xjvf trilinos-11.8.1-Source.tar.bz2; \
+    mkdir trilinos-11.8.1-Source/build; \
+    cd trilinos-11.8.1-Source/build; \
+    cmake -D Trilinos_ENABLE_Sacado=ON \
+          -D Trilinos_ENABLE_Stratimikos=ON \
+          -D CMAKE_BUILD_TYPE=RELEASE \
+          -D CMAKE_CXX_FLAGS="-O3" \
+          -D CMAKE_C_FLAGS="-O3" \
+          -D CMAKE_FORTRAN_FLAGS="-O5" \
+          -D Trilinos_EXTRA_LINK_FLAGS="-lgfortran" \
+          -D CMAKE_VERBOSE_MAKEFILE=FALSE \
+          -D Trilinos_VERBOSE_CONFIGURE=FALSE \
+          -D TPL_ENABLE_MPI=ON \
+          -D BUILD_SHARED_LIBS=ON \
+          .. ; \
+    make -j4 && make install; \
+    cd ../..; \
+    rm -rf trilinos-11.8.1-Source trilinos-11.8.1-Source.tar.bz2 
+
+#Build p4est
+RUN wget http://p4est.github.io/release/p4est-0.3.4.2.tar.gz; \
+    wget http://www.dealii.org/developer/external-libs/p4est-setup.sh; \
+    chmod +x p4est-setup.sh; \
+    ./p4est-setup.sh p4est-0.3.4.2.tar.gz /usr/local/p4est-0.3.4.2; \
+    rm -rf p4est-build p4est-0.3.4.2 p4est-setup.sh p4est-0.3.4.2.tar.gz
+
+#Build deal.II
+RUN wget http://www.ces.clemson.edu/dealii/deal.II-8.1.0.tar.gz; \
+    tar xzvf deal.II-8.1.0.tar.gz; \
+    mkdir deal.II/build; \
+    cd deal.II/build; \
+    cmake -DDEAL_II_WITH_MPI=ON \
+          -DDEAL_II_COMPONENT_COMPAT_FILES=OFF \
+          -DDEAL_II_COMPONENT_EXAMPLES=OFF \
+          -DCMAKE_INSTALL_PREFIX=/usr/local \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DP4EST_DIR=/usr/local/p4est-0.3.4.2/ \
+          .. ; \
+    make -j4 && make install; \
+    cd ../..; \
+    rm -rf deal.II deal.II-8.1.0.tar.gz
+
+#Build aspect
+RUN git clone https://github.com/geodynamics/aspect.git; \ 
+    mkdir aspect/build; \
+    cd aspect/build; \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+          -DDEAL_II_DIR=/usr/local/deal.II \
+          .. ; \
+    make -j4; \
+    mv aspect /usr/local/bin/; \
+    cd /\
+    rm -rf aspect
+
+CMD ["aspect"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@ FROM ubuntu:14.04
 
 MAINTAINER Rene Gassmoeller <r.gassmoeller@mailbox.org>
 
-ENV HOME /root
-
-RUN apt-get update
-RUN apt-get -yq install gcc \
+RUN apt-get update && \
+    apt-get -yq install gcc \
                         build-essential \
                         wget \
                         bzip2 \
@@ -14,7 +12,6 @@ RUN apt-get -yq install gcc \
                         gfortran \
                         libblas-dev \
                         liblapack-dev \
-                        libboost-dev \
                         libopenmpi-dev \
                         openmpi-bin \
                         cmake \
@@ -27,7 +24,7 @@ RUN wget http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.13.tar.bz2; \
     ./configure --enable-parallel \
                 --enable-shared \
                 --prefix=/usr/local/; \
-    make -j2 && make install; \
+    make -j4 && make install; \
     cd ..; \
     rm -rf /hdf5-1.8.13 /hdf5-1.8.13.tar.bz2 
 
@@ -75,16 +72,25 @@ RUN wget http://www.ces.clemson.edu/dealii/deal.II-8.1.0.tar.gz; \
     cd ../..; \
     rm -rf deal.II deal.II-8.1.0.tar.gz
 
+# Add and log in as a user
+RUN adduser aspect
+USER aspect
+
 #Build aspect
-RUN git clone https://github.com/geodynamics/aspect.git; \ 
-    mkdir aspect/build; \
+RUN cd /home/aspect; \
+    git clone https://github.com/geodynamics/aspect.git; \
+    mkdir aspect/build; \ 
     cd aspect/build; \
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DDEAL_II_DIR=/usr/local/deal.II \
           .. ; \
     make -j4; \
-    mv aspect /usr/local/bin/; \
-    cd /\
-    rm -rf aspect
+    mv aspect ../; \
+    cd ..; \
+    rm -rf build
 
+#Set environment up to run aspect easily
+ENV PATH /home/aspect/aspect:$PATH
+ENV HOME /home/aspect
+WORKDIR /home/aspect/aspect
 CMD ["aspect"]


### PR DESCRIPTION
I thought it might be a nice idea to provide another way of using and installing ASPECT, apart from the native compilation procedure and the virtual machine. Maybe you have heard about Docker (https://www.docker.com/), a software to provide applications in so called containers. A container is more light-weight than a virtual machine, and runs faster while still providing an easy installation by delivering all dependencies inside the container. I created a preliminary container for Aspect with the commit below.

The potential users of this way of installation would be:
1. People, which just want to play with Aspect without intention of spending much time on the installation and do not like/understand the concept of a virtual machine or find it to large to download and keep.
2. People, which are very familiar with a different operating system and would like to use as little linux as possible (e.g. windows,mac). This of course only works for smaller models.
(3.) An idea that was not my original intention: Docker in principle is able to run on clusters / the cloud as well and as fast. Amazon EC, Google Cloud and Microsoft Azure are supported. So if you feel tempted, I would be interested to get feedback about using docker on a cluster or cloud environment.

The benefits for the user in all cases would be:
1. Installation is as easy as typing: "docker run geodynamics/aspect" (for productive cases you have to provide some command line arguments for creating a shared folder, but still, installation and start is a one-liner). It will download the container (~1GB for aspect-release) from the docker-hub and you are ready to go.
2. Support of nearly every major operating system. In fact, because I use Ubuntu 12.04 and its kernel is too old for Docker, I created the preliminary Aspect Docker image on Windows 7. So now one could run aspect in a very lightweight (50~Mb) virtual machine on Windows and analyze the models with Windows Paraview without the need for much Linux use (same for Mac). The first performance tests I did, showed less than 10% slowdown on Windows compared to a native Aspect installation on Ubuntu (compared to 30-50% for the usual virtual machine).

The benefits for developers would be:
1. The docker image can be simply linked to the github development version, and automatically updates with every commit to master. It can also provide different "tags" (like branches in git), providing aspect images for all our releases and the latest development version. Therefore, we do not have to do much support, except from answering questions that maybe arise.
2. The changes to the project are small (see commit below, just one new file to tell Docker how to create an Aspect container). And the (yet missing) documentation of course.
3. If we can convince users to recreate bugs on the docker image, we can be sure to be able to reproduce them on our machines as well. 

If you want to test the docker image, I have uploaded the preliminary image on my docker-hub account. After installing docker (https://docs.docker.com/installation/) type "docker run gassmoeller/aspect" and docker will download and run the necessary image. If docker complains about missing rights, make sure your user is added to the 'docker' group ('usermod -a -G docker $USER' in Ubuntu/Debian), after a logout everything should work as intended. To actually run a parameter file (and not just get aspect's error message complaining about the missing parameter file), you need to set up a shared folder with your host system: "docker run -v $HOST_DIR:$CLIENT_DIR gassmoeller/aspect $CLIENT_DIR/$PARAMETER_FILE". Replace $HOST_DIR with the directory including your parameter file, and $CLIENT_DIR with the directory name it should have inside the container. The output folder in your parameter file also must be specified as $CLIENT_DIR/output_folder. 

Let me know what you think of this. If you think its worth adding/pursuing, I could go ahead and add a section in the manual.