### PR TITLE
Increase limit for the number of inner iterations.

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,12 @@
  *
  *
  * <ol>
+ * <li> New: The parameters for the inner Algebraic Multigrid preconditioner
+ * used in the Stokes solve have been tuned to achieve a speedup of the solver
+ * phase by a factor between 1.2 and 2, depending on application.
+ * <br>
+ * (Wolfgang Bangerth, 2014/12/05)
+ *
  *<li> New:  There is now the option to specify an origin when using the box
  * goemetry model.
  * <br>
@@ -19,7 +25,6 @@
  * output time step will produce output. Old checkpoint files will continue
  * to work, only with a possible short gap in visualization output right
  * after restart.
- * 
  * <br>
  * (Rene Gassmoeller, 2014/12/03)
  *

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1027,6 +1027,16 @@ namespace aspect
     Amg_data.constant_modes = constant_modes;
     Amg_data.elliptic = true;
     Amg_data.higher_order_elements = true;
+
+    // set the AMG parameters in a way that minimizes the run
+    // time. compared to some of the deal.II tutorial programs, we
+    // found that it pays off to set the aggregration threshold to
+    // zero, especially for ill-conditioned problems with large
+    // variations in the viscosity
+    //
+    // for extensive benchmarking of various settings of these
+    // parameters and others, see
+    // https://github.com/geodynamics/aspect/pull/234
     Amg_data.smoother_sweeps = 2;
     Amg_data.aggregation_threshold = 0.001;
 #endif

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011 - 2014 by the authors of the ASPECT code.
+  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -1028,7 +1028,7 @@ namespace aspect
     Amg_data.elliptic = true;
     Amg_data.higher_order_elements = true;
     Amg_data.smoother_sweeps = 2;
-    Amg_data.aggregation_threshold = 0.02;
+    Amg_data.aggregation_threshold = 0.001;
 #endif
 
     /*  The stabilization term for the free surface (Kaus et. al., 2010)

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -320,7 +320,7 @@ namespace aspect
       // iterations of our two-stage outer GMRES iteration)
       if (do_solve_A == true)
         {
-          SolverControl solver_control(1000, utmp.l2_norm()*1e-2);
+          SolverControl solver_control(10000, utmp.l2_norm()*1e-2);
 #ifdef ASPECT_USE_PETSC
           SolverCG<LinearAlgebra::Vector> solver(solver_control);
 #else


### PR DESCRIPTION
This is apparently necessary for some very ill-conditioned models. Specifically,
I have been running a model by Sarah Stamps with very large variations of the
viscosity, and it takes more than 2000 inner iterations to converge in this
place. Maybe not surprisingly, the run time profile looks rather unfamiliar:

+---------------------------------------------+------------+------------+
| Total wallclock time elapsed since start    |  4.37e+05s |            |
|                                             |            |            |
| Section                         | no. calls |  wall time | % of total |
+---------------------------------+-----------+------------+------------+
| Assemble Stokes system          |         2 |      82.4s |     0.019% |
| Assemble temperature system     |         1 |      44.5s |      0.01% |
| Build Stokes preconditioner     |         1 |      97.3s |     0.022% |
| Build temperature preconditioner|         1 |      2.77s |   0.00063% |
| Solve Stokes system             |         2 |  4.35e+05s |     1e+02% |
| Solve temperature system        |         1 |      6.15s |    0.0014% |
| Initialization                  |         2 |        18s |    0.0041% |
| Postprocessing                  |         1 |  1.71e+03s |      0.39% |
| Setup dof systems               |         1 |      60.4s |     0.014% |
+---------------------------------+-----------+------------+------------+

Note that we spend 99.5% of the time in the Stokes solver.