### PR TITLE
Always create a visualization output after restart if interval is set to 0

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,7 +6,19 @@
  *
  *
  * <ol>
- *<li> New: There is now the possibility to interpolate the visualization
+ * <li> Changed: The behaviour when one changed the visualization
+ * output_interval during a checkpoint restart was previously undefined, 
+ * and working in slightly unexpected ways like never writing output for 
+ * the first timestep after the restart. This now works as one would expect,
+ * e.g. every timestep that ends more than output_interval after the last 
+ * output time step will produce output. Old checkpoint files will continue
+ * to work, only with a possible short gap in visualization output right
+ * after restart.
+ * 
+ * <br>
+ * (Rene Gassmoeller, 2014/12/03)
+ *
+ * <li> New: There is now the possibility to interpolate the visualization
  * output to a refined output mesh. This accounts for the fact that most
  * visualization software only offers linear interpolation between grid points
  * and therefore the output file is a very coarse representation of the actual

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -325,19 +325,14 @@ namespace aspect
          * Interval between the generation of graphical output. This parameter
          * is read from the input file and consequently is not part of the
          * state that needs to be saved and restored.
-         *
-         * For technical reasons, this value is stored as given in the input
-         * file and upon use is either interpreted as seconds or years,
-         * depending on how the global flag in the input parameter file is
-         * set.
          */
         double output_interval;
 
         /**
-         * A time (in years) after which the next time step should produce
-         * graphical output again.
+         * A time (in seconds) at which the last graphical output was supposed
+         * to be produced. Used to check for the next necessary output time.
          */
-        double next_output_time;
+        double last_output_time;
 
         /**
          * Consecutively counted number indicating the how-manyth time we will
@@ -372,13 +367,14 @@ namespace aspect
         bool interpolate_output;
 
         /**
-         * Compute the next output time from the current one. In the simplest
-         * case, this is simply the previous next output time plus the
-         * interval, but in general we'd like to ensure that it is larger than
-         * the current time to avoid falling behind with next_output_time and
-         * having to catch up once the time step becomes larger.
+         * Set the time output was supposed to be written. In the simplest
+         * case, this is the previous last output time plus the interval, but
+         * in general we'd like to ensure that it is the largest supposed
+         * output time, which is smaller than the current time, to avoid
+         * falling behind with last_output_time and having to catch up once
+         * the time step becomes larger. This is done after every output.
          */
-        void set_next_output_time (const double current_time);
+        void set_last_output_time (const double current_time);
 
         /**
          * Record that the mesh changed. This helps some output writers avoid


### PR DESCRIPTION
I have a slight issue with the way the visualization output works after restarting a model. Currently, we save the next_output_time for the visualization plugin when checkpointing. I have a model where I want to restart the model for a single timestep and get a new visualization output (with different postprocessors / material model). Since the next_output_time is read in from the previous model run and the set_next_output_time() function is always called when restarting, I do not get a visualization output, independent of the value I set for "Time between graphical output". If I set "Time between graphical output" to 0, set_next_output_time() does nothing, and no output is written until the model time is larger than the next_output_time that was loaded from the checkpoint. If I set "Time between graphical output" to a small value (smaller than the next time step size), set_next_output_time() is called before postprocessing and prevents any visualization output for this first timestep after the restart. 

This PR creates a visualization output in every timestep (even after restarting) if the interval is set to 0. 

Would it be a more expected behaviour to simply not save the next output time, and therefore always write a visualization output after restart independent of the newly set interval (like we do in a normal model start)? 
