### PR TITLE
Update composition boundaries

### DIFF
--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -64,6 +64,21 @@ namespace aspect
         virtual void initialize ();
 
         /**
+         * A function that is called at the beginning of each time step. The
+         * default implementation of the function does nothing, but derived
+         * classes that need more elaborate setups for a given time step may
+         * overload the function.
+         *
+         * The point of this function is to allow complex boundary composition
+         * models to do an initialization step once at the beginning of each
+         * time step. An example would be a model that needs to call an
+         * external program to compute composition changes at sides.
+         */
+        virtual
+        void
+        update ();
+
+        /**
          * Return the composition that is to hold at a particular location on
          * the boundary of the domain.
          *

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -38,6 +38,11 @@ namespace aspect
 
     template <int dim>
     void
+    Interface<dim>::update ()
+    {}
+
+    template <int dim>
+    void
     Interface<dim>::initialize ()
     {}
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -666,7 +666,7 @@ namespace aspect
     // do the same for the temperature variable: evaluate the current boundary temperature
     // and add these constraints as well
     {
-      //Update the temperature boundary conditon.
+      //Update the temperature boundary condition.
       boundary_temperature->update();
 
       // obtain the boundary indicators that belong to Dirichlet-type
@@ -692,6 +692,12 @@ namespace aspect
         }
 
       // now do the same for the composition variable:
+
+      // If there are fixed boundary compositions,
+      // update the composition boundary condition.
+      if (boundary_composition.get())
+        boundary_composition->update();
+
       // obtain the boundary indicators that belong to Dirichlet-type
       // composition boundary conditions and interpolate the composition
       // there


### PR DESCRIPTION
This is an improvement we need for #240 . So far boundary conditions for compositions had no update() function in their interface. This is necessary for loading new data or implementing complex time-dependent boundary conditions. 

At the same time I noticed that the boundary  condition for composition is handled differently than the one for temperature in core.cc. So far, if one prescribes no composition boundary condition we do not care and just make sure to not try to access it. But if one prescribes no fixed temperature boundary condition, simulator tries to access a null pointer and crashes without useful error messages. I see a few options to improve this:

1. I unified the handling of the two in the second patch. Boundary temperature will not longer be constructed and not longer called if no fixed_boundary_temperature_ids are present. This solution is not fully satisfactory either, since some other plugins rely on the existence of fixed boundary temperatures, and do not check, whether they actually exist (they call minimal_temperature and maximal_temperature, e.g. basic_statistics.cc or adiabatic.cc).

2. We could instead enforce the user to select a boundary temperature plugin even if no fixed temperature boundary ids were selected but that feels a bit  weird either. 

3. Another solution would be to go through every plugin, look for calls to boundary temperature and add error checks that deal with the case when boundary temperature is not constructed.

4. Leave it as before, but add an Assertion that returns a proper error message, if one does not set a boundary temperature model.

Any opinions? If you do not have a particular preference, I would go with the attached option 1, it at least improves the current behaviour.