### PR TITLE
Fix tests and allow for no prescribed boundary temperature.

### DIFF
--- a/source/initial_conditions/adiabatic.cc
+++ b/source/initial_conditions/adiabatic.cc
@@ -53,7 +53,10 @@ namespace aspect
                                                   adiabatic_surface_temperature;
 
       // then, get the temperature at the top and bottom boundary of the model
-      // if no boundary temperature is prescribed simply use the adiabatic
+      // if no boundary temperature is prescribed simply use the adiabatic.
+      // This implementation assumes that the top and bottom boundaries have
+      // prescribed temperatures and minimal_temperature() returns the value
+      // at the surface and maximal_temperature() the value at the bottom.
       const double T_surface = (&this->get_boundary_temperature() != 0)
                                ?
                                    this->get_boundary_temperature().minimal_temperature(

--- a/source/initial_conditions/adiabatic.cc
+++ b/source/initial_conditions/adiabatic.cc
@@ -40,13 +40,7 @@ namespace aspect
       const double age_bottom = (this->convert_output_to_years() ? age_bottom_boundary_layer * year_in_seconds
                                  : age_bottom_boundary_layer);
 
-      // first, get the temperature at the top and bottom boundary of the model
-      const double T_surface = this->get_boundary_temperature().minimal_temperature(
-                                 this->get_fixed_temperature_boundary_indicators());
-      const double T_bottom = this->get_boundary_temperature().maximal_temperature(
-                                this->get_fixed_temperature_boundary_indicators());
-
-      // then, get the temperature of the adiabatic profile at a representative
+      // First, get the temperature of the adiabatic profile at a representative
       // point at the top and bottom boundary of the model
       // if adiabatic heating is switched off, assume a constant profile
       const Point<dim> surface_point = this->get_geometry_model().representative_point(0.0);
@@ -57,6 +51,21 @@ namespace aspect
                                                   this->get_adiabatic_conditions().temperature(bottom_point)
                                                   :
                                                   adiabatic_surface_temperature;
+
+      // then, get the temperature at the top and bottom boundary of the model
+      // if no boundary temperature is prescribed simply use the adiabatic
+      const double T_surface = (&this->get_boundary_temperature() != 0)
+                               ?
+                                   this->get_boundary_temperature().minimal_temperature(
+                                       this->get_fixed_temperature_boundary_indicators())
+                               :
+                                   adiabatic_surface_temperature;
+      const double T_bottom = (&this->get_boundary_temperature() != 0)
+                              ?
+                                  this->get_boundary_temperature().maximal_temperature(
+                                      this->get_fixed_temperature_boundary_indicators())
+                              :
+                                  adiabatic_surface_temperature;
 
       // get a representative profile of the compositional fields as an input
       // for the material model

--- a/source/initial_conditions/solidus.cc
+++ b/source/initial_conditions/solidus.cc
@@ -126,8 +126,13 @@ namespace aspect
       AssertThrow(solidus_curve.is_radius==true,ExcMessage("The solidus curve has to be radius dependent."));
       const GeometryModel::SphericalShell<dim> *spherical_geometry_model=
         dynamic_cast< const GeometryModel::SphericalShell<dim> *>(&this->get_geometry_model());
+
       AssertThrow(spherical_geometry_model!=0,
                   ExcMessage("This initial condition can only be used with spherical shell geometry model."));
+
+      AssertThrow(&this->get_boundary_temperature()!=0,
+                  ExcMessage("This initial condition can only be used with a prescribed boundary temperature."));
+
       T_min=(this->get_boundary_temperature()).minimal_temperature();
 
       // In case of spherical shell calculate spherical coordinates

--- a/source/initial_conditions/spherical_shell.cc
+++ b/source/initial_conditions/spherical_shell.cc
@@ -44,6 +44,13 @@ namespace aspect
                    ExcMessage ("This initial condition can only be used if the geometry "
                                "is a spherical shell."));
 
+      // this initial condition only makes sense if a boundary temperature
+      // is prescribed. verify that it is indeed
+      AssertThrow (&this->get_boundary_temperature()
+                   != 0,
+                   ExcMessage ("This initial condition can only be used if a boundary "
+                               "temperature is prescribed."));
+
       const double R1 = dynamic_cast<const GeometryModel::SphericalShell<dim>&>
                         (this->get_geometry_model()).outer_radius();
 
@@ -158,6 +165,13 @@ namespace aspect
                    != 0,
                    ExcMessage ("This initial condition can only be used if the geometry "
                                "is a spherical shell."));
+
+      // this initial condition only makes sense if a boundary temperature
+      // is prescribed. verify that it is indeed
+      AssertThrow (&this->get_boundary_temperature()
+                   != 0,
+                   ExcMessage ("This initial condition can only be used if a boundary "
+                               "temperature is prescribed."));
       const double
       R0 = dynamic_cast<const GeometryModel::SphericalShell<dim>&> (this->get_geometry_model()).inner_radius(),
       R1 = dynamic_cast<const GeometryModel::SphericalShell<dim>&> (this->get_geometry_model()).outer_radius();

--- a/source/postprocess/basic_statistics.cc
+++ b/source/postprocess/basic_statistics.cc
@@ -46,8 +46,14 @@ namespace aspect
 
               const double h = this->get_geometry_model().maximal_depth();
 
-              const double dT = this->get_boundary_temperature().maximal_temperature(this->get_fixed_temperature_boundary_indicators())
-                                - this->get_boundary_temperature().minimal_temperature(this->get_fixed_temperature_boundary_indicators());
+              // dT is only meaningful if boundary temperatures are prescribed, otherwise it is 0
+              const double dT = (&this->get_boundary_temperature())
+                                ?
+                                    this->get_boundary_temperature().maximal_temperature(this->get_fixed_temperature_boundary_indicators())
+                                    - this->get_boundary_temperature().minimal_temperature(this->get_fixed_temperature_boundary_indicators())
+                                    :
+                                    0;
+
               // we do not compute the compositions but give the functions below the value 0.0 instead
               std::vector<double> composition_values(this->n_compositional_fields(),0.0);
 
@@ -70,7 +76,7 @@ namespace aspect
               this->get_pcout()<< "     Reference thermal expansion (1/K):             "
                                << material_model.reference_thermal_expansion_coefficient()
                                << std::endl;
-              this->get_pcout()<< "     Temperature contrast across model domain (K): "
+              this->get_pcout()<< "     Temperature contrast across model domain (K):  "
                                << dT
                                << std::endl;
               this->get_pcout()<< "     Model domain depth (m):                        "

--- a/source/postprocess/table_heat_flux_statistics.cc
+++ b/source/postprocess/table_heat_flux_statistics.cc
@@ -181,8 +181,14 @@ namespace aspect
           const double R1 = (*geometry).outer_radius();
           const double h = R1-R0;
 
-          const double dT = this->get_boundary_temperature().maximal_temperature(this->get_fixed_temperature_boundary_indicators())
-                            - this->get_boundary_temperature().minimal_temperature(this->get_fixed_temperature_boundary_indicators());
+          // dT is only meaningful if boundary temperatures are prescribed, otherwise it is 0
+          const double dT = (&this->get_boundary_temperature())
+                            ?
+                                this->get_boundary_temperature().maximal_temperature(this->get_fixed_temperature_boundary_indicators())
+                                - this->get_boundary_temperature().minimal_temperature(this->get_fixed_temperature_boundary_indicators())
+                                :
+                                0;
+
           const double conductive_heatflux = dT/h;
           const double nusselt_outer = global_boundary_fluxes[0]/conductive_heatflux;
           const double boundary_curveLength_outer = R0*phi;

--- a/source/postprocess/table_velocity_statistics.cc
+++ b/source/postprocess/table_velocity_statistics.cc
@@ -45,6 +45,7 @@ namespace aspect
               ExcMessage ("This postprocessor can only be used when using "
                           "the MaterialModel::Table implementation of the "
                           "material model interface."));
+
       const MaterialModel::Table<dim> &
       material_model
         = dynamic_cast<const MaterialModel::Table<dim> &>(this->get_material_model());
@@ -160,8 +161,13 @@ namespace aspect
                << " m/s";
       if (this->get_time() == 0e0)
         {
-          double dT = this->get_boundary_temperature().maximal_temperature(this->get_fixed_temperature_boundary_indicators())
-                      - this->get_boundary_temperature().minimal_temperature(this->get_fixed_temperature_boundary_indicators());
+          // dT is only meaningful if boundary temperatures are prescribed, otherwise it is 0
+          const double dT = (&this->get_boundary_temperature())
+                            ?
+                                this->get_boundary_temperature().maximal_temperature(this->get_fixed_temperature_boundary_indicators())
+                                - this->get_boundary_temperature().minimal_temperature(this->get_fixed_temperature_boundary_indicators())
+                                :
+                                0;
           // we do not compute the compositions but give the functions below the value 0.0 instead
           std::vector<double> composition_values(this->n_compositional_fields(),0.0);
 

--- a/tests/no_adiabatic_heating_02/screen-output
+++ b/tests/no_adiabatic_heating_02/screen-output
@@ -29,7 +29,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
      Reference density (kg/m^3):                    1
      Reference gravity (m/s^2):                     10
      Reference thermal expansion (1/K):             0
-     Temperature contrast across model domain (K): 1
+     Temperature contrast across model domain (K):  0
      Model domain depth (m):                        1
      Reference thermal diffusivity (m^2/s):         8e-10
      Reference viscosity (Pas):                     1

--- a/tests/stokes/screen-output
+++ b/tests/stokes/screen-output
@@ -38,11 +38,11 @@ Number of degrees of freedom: 10,726 (6,243+321+2,081+2,081)
      Reference density (kg/m^3):                    3300
      Reference gravity (m/s^2):                     9.81
      Reference thermal expansion (1/K):             2e-05
-     Temperature contrast across model domain (K): 1
+     Temperature contrast across model domain (K):  0
      Model domain depth (m):                        2.89e+06
      Reference thermal diffusivity (m^2/s):         1.13939e-06
      Reference viscosity (Pas):                     1e+22
-     Ra number:                                     1371.62
+     Ra number:                                     0
      k_value:                                       4.7
      reference_cp:                                  1250
      reference_thermal_diffusivity:                 1.13939e-06


### PR DESCRIPTION
This should fix the broken tests introduced in #243 . Some of the plugins now require a boundary temperature to be prescribed, some can guess reasonable values if none is prescribed. Some test output changed, but it was actually wrong or at least meaningless before.
Since I changed the output of the basic_statistics slightly (there was a missing space beforehand) I expect other testcases to fail as well. I will update them accordingly later.