### PR TITLE
Be less strict in which types of exceptions we catch.

### DIFF
--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -292,7 +292,7 @@ namespace aspect
             // if the solver fails, report the error from processor 0 with some additional
             // information about its location, and throw a quiet exception on all other
             // processors
-            catch (const SolverControl::NoConvergence &exc)
+            catch (const std::exception &exc)
               {
                 if (Utilities::MPI::this_mpi_process(src.block(0).get_mpi_communicator()) == 0)
                   AssertThrow (false,


### PR DESCRIPTION
Using the change, we can also catch exceptions that do not just
indicate that the solver has run out of iterations, but also
exceptions that state that the underlying AztecOO solver from
Trilinos has failed with this matrix.