### PR TITLE
Fix petsc calls

### DIFF
--- a/source/mesh_refinement/density.cc
+++ b/source/mesh_refinement/density.cc
@@ -114,7 +114,8 @@ namespace aspect
 
       // now create a vector with the requisite ghost elements
       // and use it for estimating the gradients
-      LinearAlgebra::BlockVector vec (this->introspection().index_sets.system_relevant_partitioning,
+      LinearAlgebra::BlockVector vec (this->introspection().index_sets.system_partitioning,
+                                      this->introspection().index_sets.system_relevant_partitioning,
                                       this->get_mpi_communicator());
       vec = vec_distributed;
 

--- a/source/mesh_refinement/nonadiabatic_temperature.cc
+++ b/source/mesh_refinement/nonadiabatic_temperature.cc
@@ -88,6 +88,8 @@ namespace aspect
               }
           }
 
+      vec_distributed.compress(VectorOperation::insert);
+
       // now create a vector with the requisite ghost elements
       // and use it for estimating the gradients
       LinearAlgebra::BlockVector vec (this->introspection().index_sets.system_relevant_partitioning,

--- a/source/mesh_refinement/nonadiabatic_temperature.cc
+++ b/source/mesh_refinement/nonadiabatic_temperature.cc
@@ -92,7 +92,8 @@ namespace aspect
 
       // now create a vector with the requisite ghost elements
       // and use it for estimating the gradients
-      LinearAlgebra::BlockVector vec (this->introspection().index_sets.system_relevant_partitioning,
+      LinearAlgebra::BlockVector vec (this->introspection().index_sets.system_partitioning,
+                                      this->introspection().index_sets.system_relevant_partitioning,
                                       this->get_mpi_communicator());
       vec = vec_distributed;
 

--- a/source/mesh_refinement/thermal_energy_density.cc
+++ b/source/mesh_refinement/thermal_energy_density.cc
@@ -114,7 +114,8 @@ namespace aspect
 
       // now create a vector with the requisite ghost elements
       // and use it for estimating the gradients
-      LinearAlgebra::BlockVector vec (this->introspection().index_sets.system_relevant_partitioning,
+      LinearAlgebra::BlockVector vec (this->introspection().index_sets.system_partitioning,
+                                      this->introspection().index_sets.system_relevant_partitioning,
                                       this->get_mpi_communicator());
       vec = vec_distributed;
 

--- a/source/mesh_refinement/thermal_energy_density.cc
+++ b/source/mesh_refinement/thermal_energy_density.cc
@@ -110,6 +110,8 @@ namespace aspect
               }
           }
 
+      vec_distributed.compress(VectorOperation::insert);
+
       // now create a vector with the requisite ghost elements
       // and use it for estimating the gradients
       LinearAlgebra::BlockVector vec (this->introspection().index_sets.system_relevant_partitioning,

--- a/source/mesh_refinement/viscosity.cc
+++ b/source/mesh_refinement/viscosity.cc
@@ -116,7 +116,8 @@ namespace aspect
 
       // now create a vector with the requisite ghost elements
       // and use it for estimating the gradients
-      LinearAlgebra::BlockVector vec (this->introspection().index_sets.system_relevant_partitioning,
+      LinearAlgebra::BlockVector vec (this->introspection().index_sets.system_partitioning,
+                                      this->introspection().index_sets.system_relevant_partitioning,
                                       this->get_mpi_communicator());
       vec = vec_distributed;
 

--- a/source/mesh_refinement/viscosity.cc
+++ b/source/mesh_refinement/viscosity.cc
@@ -112,6 +112,8 @@ namespace aspect
               }
           }
 
+      vec_distributed.compress(VectorOperation::insert);
+
       // now create a vector with the requisite ghost elements
       // and use it for estimating the gradients
       LinearAlgebra::BlockVector vec (this->introspection().index_sets.system_relevant_partitioning,


### PR DESCRIPTION
Several of the mesh refinement modules were not working when Aspect is compiled with PETSc.  This fixes them.