### PR TITLE
[WIP] update gitattributes and release tasklist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+doc/bump_version.sh export-ignore
+doc/filter export-ignore
+doc/release-tasklist export-ignore
+doc/manual/ export-ignore
+doc/release-tasklist export-ignore
+doc/update_parameters.sh export-ignore

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,16 +6,17 @@ aspect-files      = $(shell echo ../include/aspect/*.h \
                             ../include/aspect/*/*h     \
                             ../include/aspect/*/*/*h   \
                             modules/*h)
-aspect-manual-pix = $(shell find manual/cookbooks/ -name \*.png)
+aspect-manual-pix = $(shell find manual/cookbooks/ -name \*.png 2>/dev/null)
 
 
-aspect-prms = $(shell find manual/cookbooks/ -name \*.prm)
+aspect-prms = $(shell find manual/cookbooks/ -name \*.prm 2>/dev/null)
 aspect-prms-out = $(aspect-prms:=.out)
 
-test:
-	@echo "prms: ${aspect-prms}"
-	@echo "prm-out: ${aspect-prms-out}"
-
+default:
+	@echo "make targets:"
+	@echo "  aspect.tag  - generates doxygen documentation into doxygen/"
+	@echo "  manual.pdf  - generates manual.pdf"
+	@echo "  all         - generates both"
 
 all: aspect.tag manual.pdf
 
@@ -75,6 +76,17 @@ manual.pdf: manual/manual.tex manual/manual.bib manual/parameters.tex \
 	  echo "------------------------------------------------------" ; \
 	  false ; \
 	 fi
+
+# This rule will only trigger if the file is missing, which happens if the
+# user has a release tarball.
+manual/manual.tex:
+	@echo "------------------------------------------------------"
+	@echo "Error: Can not generate manual.pdf without the source"
+	@echo "files in manual/. If you are currently using a release"
+	@echo "of ASPECT, download the latest development version of"
+	@echo "ASPECT instead."
+	@echo "------------------------------------------------------"
+	@false
 
 clean:
 	-rm -f aspect.dox aspect.tag

--- a/doc/release-tasklist
+++ b/doc/release-tasklist
@@ -43,13 +43,13 @@
   . make sure the .prm and .xml files we ship match the default values of
     parameters
   . Tag the release:
-      git tag -a v$VER -m 'tag version $VER'
+      git tag -a v$VER -m "tag version $VER"
   . create a tar file:
       git archive --format=tar.gz --prefix=aspect-$VER/ v$VER >aspect-$VER.tar.gz
   . make public (branch and tag):
       git push cig aspect-$VER
       git push cig v$VER
-  . create a release on github
+  . create a release on github, upload tarball
   . link it on download.html, update version info etc.
   . ask Eric to update http://geodynamics.org/cig/software/aspect/
   . announce on


### PR DESCRIPTION
- Use gitattributes to exclude files from the release tarball: scripts
and doc/manual/, which is used to generate manual.pdf.
- Update release tasks.- Use gitattributes to exclude files from the release tarball: scripts
and doc/manual/, which is used to generate manual.pdf.
- Update release tasks.
- doc/Makefile: better default target, cleanup, and nice error message if manual/ is missing.