### PR TITLE
Fix pressure bounds of steinberger material model.

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -7,5 +7,13 @@
  *
  * <ol>
  *
+ * <li> Fixed: The Steinberger material model had a bug in case a
+ * material table was used that had not the same number of points in
+ * temperature and pressure direction. The table was truncated in pressure
+ * dimension to the number of lines of the temperature dimension. This is
+ * fixed now.
+ * <br>
+ * (Rene Gassmoeller, 2015/01/29)
+ *
  * </ol>
  */

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -90,7 +90,7 @@ namespace aspect
 
 
             max_temp = min_temp + (numtemp-1) * delta_temp;
-            max_press = min_press + (numtemp-1) * delta_press;
+            max_press = min_press + (numpress-1) * delta_press;
 
             density_values.reinit(numtemp,numpress);
             thermal_expansivity_values.reinit(numtemp,numpress);


### PR DESCRIPTION
What a tricky bug. It was in there since over two years and was never catched, because the tests unfortunately use tables with numtemp == numpress. I am a bit hesitant to create another test for this material model though, because it is so sensitive and already the existing tests are causing quite some trouble. Maybe this class can be at some time replaced by an AsciiDataLookup class from #240, when it is finished, so for now I would just fix the bug.