### PR TITLE
Remove unused parameter.

### DIFF
--- a/cookbooks/latent-heat.prm
+++ b/cookbooks/latent-heat.prm
@@ -113,7 +113,6 @@ subsection Material model
     set Viscosity                                      = 8.44e21
     set Viscosity prefactors                           = 1.0, 1.0
     set Composition viscosity prefactor                = 1.0
-    set Activation enthalpies                          = 3.9473e-3, 3.9473e-3 
   end
 end
 

--- a/doc/manual/cookbooks/benchmarks/latent-heat/material.part.prm
+++ b/doc/manual/cookbooks/benchmarks/latent-heat/material.part.prm
@@ -38,6 +38,5 @@ subsection Material model
     set Viscosity                                      = 8.44e21 
     set Viscosity prefactors                           = 1.0, 1.0 
     set Composition viscosity prefactor                = 1.0 
-    set Activation enthalpies                          = 3.9473e-3, 3.9473e-3  
   end
 end

--- a/doc/manual/cookbooks/benchmarks/latent-heat/material.part.prm.out
+++ b/doc/manual/cookbooks/benchmarks/latent-heat/material.part.prm.out
@@ -38,6 +38,5 @@ subsection %%\hyperref[parameters:Material_20model]{Material model}%
     set %%\hyperref[parameters:Material model/Latent heat/Viscosity]{Viscosity}%                                      = 8.44e21 %% \index[prmindex]{Viscosity} \index[prmindexfull]{Material model!Latent heat!Viscosity} %
     set %%\hyperref[parameters:Material model/Latent heat/Viscosity prefactors]{Viscosity prefactors}%                           = 1.0, 1.0 %% \index[prmindex]{Viscosity prefactors} \index[prmindexfull]{Material model!Latent heat!Viscosity prefactors} %
     set %%\hyperref[parameters:Material model/Latent heat/Composition viscosity prefactor]{Composition viscosity prefactor}%                = 1.0 %% \index[prmindex]{Composition viscosity prefactor} \index[prmindexfull]{Material model!Latent heat!Composition viscosity prefactor} %
-    set %%\hyperref[parameters:Material model/Latent heat/Activation enthalpies]{Activation enthalpies}%                          = 3.9473e-3, 3.9473e-3  %% \index[prmindex]{Activation enthalpies} \index[prmindexfull]{Material model!Latent heat!Activation enthalpies} %
   end
 end

--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,13 @@
  *
  *
  * <ol>
+ * <li> Changed: The unused parameter 'Activation enthalpies' was removed from
+ * the 'latent heat' material model. The active parameter for the same purpose
+ * is 'Thermal viscosity exponent'. If there are parameter files specifying
+ * the removed parameter it is safe to just remove the line.
+ * <br>
+ * (Rene Gassmoeller, 2015/02/16)
+ *
  * <li> Fixed: The compressibility in the 'latent heat' and 'latent heat melt'
  * material models was used incorrectly to calculate the density. This did only
  * affect compressible models with these material models and is fixed now.

--- a/include/aspect/material_model/latent_heat.h
+++ b/include/aspect/material_model/latent_heat.h
@@ -239,7 +239,6 @@ namespace aspect
         std::vector<double> density_jumps;
         std::vector<int> transition_phases;
         std::vector<double> phase_prefactors;
-        std::vector<double> activation_enthalpies;
     };
 
   }

--- a/source/material_model/latent_heat.cc
+++ b/source/material_model/latent_heat.cc
@@ -517,12 +517,6 @@ namespace aspect
                              "viscosity for each phase. "
                              "List must have one more entry than Phase transition depths. "
                              "Units: non-dimensional.");
-          prm.declare_entry ("Activation enthalpies", "",
-                             Patterns::List (Patterns::Double(0)),
-                             "A list of activation enthalpies for the temperature dependence of the "
-                             "viscosity of each phase. "
-                             "List must have one more entry than Phase transition depths. "
-                             "Units: $1/K$.");
         }
         prm.leave_subsection();
       }
@@ -564,16 +558,13 @@ namespace aspect
                               (Utilities::split_string_list(prm.get ("Corresponding phase for density jump")));
           phase_prefactors = Utilities::string_to_double
                              (Utilities::split_string_list(prm.get ("Viscosity prefactors")));
-          activation_enthalpies = Utilities::string_to_double
-                                  (Utilities::split_string_list(prm.get ("Activation enthalpies")));
 
           if (transition_widths.size() != transition_depths.size() ||
               transition_temperatures.size() != transition_depths.size() ||
               transition_slopes.size() != transition_depths.size() ||
               density_jumps.size() != transition_depths.size() ||
               transition_phases.size() != transition_depths.size() ||
-              phase_prefactors.size() != transition_depths.size()+1 ||
-              activation_enthalpies.size() != transition_depths.size()+1)
+              phase_prefactors.size() != transition_depths.size()+1)
             AssertThrow(false, ExcMessage("Error: At least one list that gives input parameters for the phase transitions has the wrong size."));
 
           if (thermal_viscosity_exponent!=0.0 && reference_T == 0.0)

--- a/tests/direct_solver_1.prm
+++ b/tests/direct_solver_1.prm
@@ -116,7 +116,6 @@ subsection Material model
     set Viscosity                                      = 8.44e21
     set Viscosity prefactors                           = 1.0, 1.0
     set Composition viscosity prefactor                = 1.0
-    set Activation enthalpies                          = 3.9473e-3, 3.9473e-3 
   end
 end
 

--- a/tests/direct_solver_2.prm
+++ b/tests/direct_solver_2.prm
@@ -115,7 +115,6 @@ subsection Material model
     set Viscosity                                      = 8.44e21
     set Viscosity prefactors                           = 1.0, 1.0
     set Composition viscosity prefactor                = 1.0
-    set Activation enthalpies                          = 3.9473e-3, 3.9473e-3 
   end
 end
 

--- a/tests/latent_heat.prm
+++ b/tests/latent_heat.prm
@@ -112,7 +112,6 @@ subsection Material model
     set Viscosity                                      = 8.44e21
     set Viscosity prefactors                           = 1.0, 1.0
     set Composition viscosity prefactor                = 1.0
-    set Activation enthalpies                          = 3.9473e-3, 3.9473e-3 
   end
 end
 


### PR DESCRIPTION
This parameter is never used anywhere, and in fact there is another parameter who does, what this one suggests to do. The test results should not change (they pass on my machine), but there is a part in the manual that cites the cookbook parameter file. @tjhei: is the doc/manual/cookbooks/benchmarks/latent-heat/material.part.prm file updated automatically by some script, or should I update it manually?