### PR TITLE
Skip viscosity calculation for adiabatic IC.

### DIFF
--- a/source/initial_conditions/adiabatic.cc
+++ b/source/initial_conditions/adiabatic.cc
@@ -82,7 +82,7 @@ namespace aspect
       in.pressure[0]=this->get_adiabatic_conditions().pressure(position);
       for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
         in.composition[0][c] = function->value(Point<1>(depth),c);
-      in.strain_rate[0] = SymmetricTensor<2,dim>(); // adiabat has strain=0.
+      in.strain_rate.resize(0); // adiabat has strain=0.
       this->get_material_model().evaluate(in, out);
 
       const double kappa = out.thermal_conductivities[0] / (out.densities[0] * out.specific_heat[0]);


### PR DESCRIPTION
Very small change, but it skips the unnecessary viscosity calculation for the IC, which is useful in some cases (e.g. when the viscosity depends on the lateral average of temperature). There is no effect  on model inputs or outputs so I guess an entry in changes.h is not needed?