### PR TITLE
Fix sign of default entropy change of melting.

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,14 @@
  *
  *
  * <ol>
+ * <li> Changed: The default values for the latent heat release of melting in
+ * the 'latent heat melt' material model had the wrong sign. This likely
+ * resulted from a change in the latent heat terms in the assembly long ago.
+ * All tests were correctly set up, but the default values were forgotten.
+ * This is fixed now.
+ * <br>
+ * (Rene Gassmoeller, 2015/02/18)
+ *
  * <li> Changed: The unused parameter 'Activation enthalpies' was removed from
  * the 'latent heat' material model. The active parameter for the same purpose
  * is 'Thermal viscosity exponent'. If there are parameter files specifying

--- a/source/material_model/latent_heat_melt.cc
+++ b/source/material_model/latent_heat_melt.cc
@@ -585,7 +585,7 @@ namespace aspect
                              "Exponent of the melting temperature in "
                              "the melt fraction calculation. "
                              "Units: non-dimensional.");
-          prm.declare_entry ("Peridotite melting entropy change", "300",
+          prm.declare_entry ("Peridotite melting entropy change", "-300",
                              Patterns::Double (),
                              "The entropy change for the phase transition "
                              "from solid to melt of peridotite. "
@@ -629,7 +629,7 @@ namespace aspect
                              "in the quadratic function that approximates "
                              "the melt fraction of pyroxenite. "
                              "Units: $°C/(Pa^2)$.");
-          prm.declare_entry ("Pyroxenite melting entropy change", "400",
+          prm.declare_entry ("Pyroxenite melting entropy change", "-400",
                              Patterns::Double (),
                              "The entropy change for the phase transition "
                              "from solid to melt of pyroxenite. "


### PR DESCRIPTION
The sign of the default value for the entropy change of melting in the latent_heat_melt material model is wrong. Apparently, when the signs of the latent heat terms in the equations were changed, the tests were updated (compare `tests/upwelling_melting_peridotite.prm`), but the default values were forgotten. The current formulation leads to heat release on melting, which causes more melting and more heat release ... .