### PR TITLE
include headers for QtCreator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ MESSAGE("====================================================")
 # Set the name of the project and target:
 SET(TARGET "aspect")
 
-FILE(GLOB_RECURSE TARGET_SRC  "source/*.cc")
+FILE(GLOB_RECURSE TARGET_SRC  "source/*.cc" "include/*.h")
 INCLUDE_DIRECTORIES(include)
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.8)


### PR DESCRIPTION
QtCreator uses the cmake output to generate the project file and doesn't
list the headers unless we add them as "source files" inside cmake. It
looks like compilation is not affected by this change.