### PR TITLE
Move pressure correction into the assembly.

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,18 @@
  *
  *
  * <ol>
+ * <li> Fixed: To make the right-hand side of the Stokes equation compatible
+ * to the matrix we need to apply a correction for inbalanced in-/outflow
+ * across the model boundaries. This correction was accidentally applied 
+ * twice in the first iteration of the iterated IMPES solver. This does not
+ * change the results, because subsequent iterations will do it correctly,
+ * but it might prevent the model to converge or slow down convergence. 
+ * This is fixed now by applying the correction directly after assembling
+ * the matrix and right-hand side.
+ * <br>
+ * (Rene Gassmoeller, Timo Heister, Juliane Dannberg, 2015/04/14)
+ *
+ * <ol>
  * <li> New: ASPECT can now read the list of input arguments from the
  * default input stdin, instead of a file, by specifying "--" for
  * the name of the input file.

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1245,8 +1245,14 @@ namespace aspect
     system_matrix.compress(VectorOperation::add);
     system_rhs.compress(VectorOperation::add);
 
+    // if the model is compressible then we need to adjust the right hand
+    // side of the equation to make it compatible with the matrix on the
+    // left
     if (do_pressure_rhs_compatibility_modification)
-      pressure_shape_function_integrals.compress(VectorOperation::add);
+      {
+        pressure_shape_function_integrals.compress(VectorOperation::add);
+        make_pressure_rhs_compatible(system_rhs);
+      }
 
 
     // record that we have just rebuilt the matrix

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -898,8 +898,6 @@ namespace aspect
     denormalize_pressure (remap);
     current_constraints.set_zero (remap);
     remap.block (block_p) /= pressure_scaling;
-    if (do_pressure_rhs_compatibility_modification)
-      make_pressure_rhs_compatible(system_rhs);
 
     // we calculate the velocity residual with a zero velocity,
     // computing only the part of the RHS not balanced by the static pressure

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -495,9 +495,6 @@ namespace aspect
           }
         distributed_stokes_solution.compress(VectorOperation::insert);
 
-        if (do_pressure_rhs_compatibility_modification)
-          make_pressure_rhs_compatible(system_rhs);
-
         // we need a temporary vector for the residual (even if we don't care about it)
         LinearAlgebra::Vector residual (introspection.index_sets.stokes_partitioning[0], mpi_communicator);
 
@@ -589,11 +586,6 @@ namespace aspect
     denormalize_pressure (remap);
     current_constraints.set_zero (remap);
     remap.block (block_p) /= pressure_scaling;
-    // if the model is compressible then we need to adjust the right hand
-    // side of the equation to make it compatible with the matrix on the
-    // left
-    if (do_pressure_rhs_compatibility_modification)
-      make_pressure_rhs_compatible(system_rhs);
 
     // (ab)use the distributed solution vector to temporarily put a residual in
     // (we don't care about the residual vector -- all we care about is the


### PR DESCRIPTION
This should fix #298 . Lets see what the tester says about the changes. On my machine all of the iterated IMPES tests are working, and I also saw quite a speed-up compared to the old version, although the iteration count stayed constant. I am testing on battery though, so it might be related to throttling.