### PR TITLE
Fix data out

### DIFF
--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -29,6 +29,7 @@
 #include <deal.II/base/thread_management.h>
 #include <deal.II/numerics/data_postprocessor.h>
 #include <deal.II/base/data_out_base.h>
+#include <deal.II/numerics/data_out.h>
 
 namespace aspect
 {
@@ -420,11 +421,13 @@ namespace aspect
          * is a <code>.visit</code> file per time step and one for all time
          * steps.
          *
+         * @param data_out The DataOut object that was used to write the solutions.
          * @param solution_file_prefix The stem of the filename to be written.
          * @param filenames List of filenames for the current output from all
          * processors.
          */
-        void write_master_files (const std::string &solution_file_prefix,
+        void write_master_files (DataOut<dim> &data_out,
+                                 const std::string &solution_file_prefix,
                                  const std::vector<std::string> &filenames);
 
         /**

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -426,7 +426,7 @@ namespace aspect
          * @param filenames List of filenames for the current output from all
          * processors.
          */
-        void write_master_files (DataOut<dim> &data_out,
+        void write_master_files (const DataOut<dim> &data_out,
                                  const std::string &solution_file_prefix,
                                  const std::vector<std::string> &filenames);
 

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -169,7 +169,7 @@ namespace aspect
 
     template <int dim>
     void
-    Visualization<dim>::write_master_files (DataOut<dim> &data_out,
+    Visualization<dim>::write_master_files (const DataOut<dim> &data_out,
                                             const std::string &solution_file_prefix,
                                             const std::vector<std::string> &filenames)
     {

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -169,10 +169,10 @@ namespace aspect
 
     template <int dim>
     void
-    Visualization<dim>::write_master_files (const std::string &solution_file_prefix,
+    Visualization<dim>::write_master_files (DataOut<dim> &data_out,
+                                            const std::string &solution_file_prefix,
                                             const std::vector<std::string> &filenames)
     {
-      DataOut<dim> data_out;
       const double time_in_years_or_seconds = (this->convert_output_to_years() ?
                                                this->get_time() / year_in_seconds :
                                                this->get_time());
@@ -398,7 +398,7 @@ namespace aspect
                                        + "." + Utilities::int_to_string(i, 4)
                                        + ".vtu");
               }
-              write_master_files (solution_file_prefix, filenames);
+              write_master_files (data_out, solution_file_prefix, filenames);
             }
         }
       else
@@ -432,7 +432,7 @@ namespace aspect
                                      DataOutBase::default_suffix
                                      (DataOutBase::parse_output_format(output_format)));
 
-              write_master_files (solution_file_prefix, filenames);
+              write_master_files (data_out, solution_file_prefix, filenames);
             }
 
           const std::string *filename

--- a/tests/parallel_output_group_0/solution-00000.pvtu
+++ b/tests/parallel_output_group_0/solution-00000.pvtu
@@ -5,6 +5,9 @@
 <VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <PUnstructuredGrid GhostLevel="0">
     <PPointData Scalars="scalars">
+    <PDataArray type="Float64" Name="velocity" NumberOfComponents="3" format="ascii"/>
+    <PDataArray type="Float64" Name="p" format="ascii"/>
+    <PDataArray type="Float64" Name="T" format="ascii"/>
     </PPointData>
     <PPoints>
       <PDataArray type="Float64" NumberOfComponents="3"/>

--- a/tests/parallel_output_group_0/solution-00001.pvtu
+++ b/tests/parallel_output_group_0/solution-00001.pvtu
@@ -5,6 +5,9 @@
 <VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <PUnstructuredGrid GhostLevel="0">
     <PPointData Scalars="scalars">
+    <PDataArray type="Float64" Name="velocity" NumberOfComponents="3" format="ascii"/>
+    <PDataArray type="Float64" Name="p" format="ascii"/>
+    <PDataArray type="Float64" Name="T" format="ascii"/>
     </PPointData>
     <PPoints>
       <PDataArray type="Float64" NumberOfComponents="3"/>

--- a/tests/parallel_output_group_1/solution-00000.pvtu
+++ b/tests/parallel_output_group_1/solution-00000.pvtu
@@ -5,6 +5,9 @@
 <VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <PUnstructuredGrid GhostLevel="0">
     <PPointData Scalars="scalars">
+    <PDataArray type="Float64" Name="velocity" NumberOfComponents="3" format="ascii"/>
+    <PDataArray type="Float64" Name="p" format="ascii"/>
+    <PDataArray type="Float64" Name="T" format="ascii"/>
     </PPointData>
     <PPoints>
       <PDataArray type="Float64" NumberOfComponents="3"/>

--- a/tests/parallel_output_group_1/solution-00001.pvtu
+++ b/tests/parallel_output_group_1/solution-00001.pvtu
@@ -5,6 +5,9 @@
 <VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <PUnstructuredGrid GhostLevel="0">
     <PPointData Scalars="scalars">
+    <PDataArray type="Float64" Name="velocity" NumberOfComponents="3" format="ascii"/>
+    <PDataArray type="Float64" Name="p" format="ascii"/>
+    <PDataArray type="Float64" Name="T" format="ascii"/>
     </PPointData>
     <PPoints>
       <PDataArray type="Float64" NumberOfComponents="3"/>

--- a/tests/parallel_output_group_2/solution-00000.pvtu
+++ b/tests/parallel_output_group_2/solution-00000.pvtu
@@ -5,6 +5,9 @@
 <VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <PUnstructuredGrid GhostLevel="0">
     <PPointData Scalars="scalars">
+    <PDataArray type="Float64" Name="velocity" NumberOfComponents="3" format="ascii"/>
+    <PDataArray type="Float64" Name="p" format="ascii"/>
+    <PDataArray type="Float64" Name="T" format="ascii"/>
     </PPointData>
     <PPoints>
       <PDataArray type="Float64" NumberOfComponents="3"/>

--- a/tests/parallel_output_group_2/solution-00001.pvtu
+++ b/tests/parallel_output_group_2/solution-00001.pvtu
@@ -5,6 +5,9 @@
 <VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <PUnstructuredGrid GhostLevel="0">
     <PPointData Scalars="scalars">
+    <PDataArray type="Float64" Name="velocity" NumberOfComponents="3" format="ascii"/>
+    <PDataArray type="Float64" Name="p" format="ascii"/>
+    <PDataArray type="Float64" Name="T" format="ascii"/>
     </PPointData>
     <PPoints>
       <PDataArray type="Float64" NumberOfComponents="3"/>


### PR DESCRIPTION
It turns out we need the current DataOut object for writing pvtu files
so we can write out the names of the fields. 