### PR TITLE
Replace all occurrences of std_cxx1x by std_cxx11

### DIFF
--- a/include/aspect/initial_conditions/S40RTS_perturbation.h
+++ b/include/aspect/initial_conditions/S40RTS_perturbation.h
@@ -23,7 +23,7 @@
 #define __aspect__initial_conditions_S40RTS_perturbation_h
 
 #include <aspect/simulator_access.h>
-#include <deal.II/base/std_cxx1x/array.h>
+#include <deal.II/base/std_cxx11/array.h>
 
 namespace aspect
 {
@@ -126,13 +126,13 @@ namespace aspect
          * Pointer to an object that reads and processes the spherical
          * harmonics coefficients
          */
-        std_cxx1x::shared_ptr<internal::SphericalHarmonicsLookup> spherical_harmonics_lookup;
+        std_cxx11::shared_ptr<internal::SphericalHarmonicsLookup> spherical_harmonics_lookup;
 
         /**
          * Pointer to an object that reads and processes the depths for the
          * spline knot points.
          */
-        std_cxx1x::shared_ptr<internal::SplineDepthsLookup> spline_depths_lookup;
+        std_cxx11::shared_ptr<internal::SplineDepthsLookup> spline_depths_lookup;
 
     };
 

--- a/include/aspect/material_model/steinberger.h
+++ b/include/aspect/material_model/steinberger.h
@@ -282,19 +282,19 @@ namespace aspect
          * Perplex files. There is one pointer/object per compositional field
          * data provided.
          */
-        std::vector<std_cxx1x::shared_ptr<internal::MaterialLookup> > material_lookup;
+        std::vector<std_cxx11::shared_ptr<internal::MaterialLookup> > material_lookup;
 
         /**
          * Pointer to an object that reads and processes data for the lateral
          * temperature dependency of viscosity.
          */
-        std_cxx1x::shared_ptr<internal::LateralViscosityLookup> lateral_viscosity_lookup;
+        std_cxx11::shared_ptr<internal::LateralViscosityLookup> lateral_viscosity_lookup;
 
         /**
          * Pointer to an object that reads and processes data for the radial
          * viscosity profile.
          */
-        std_cxx1x::shared_ptr<internal::RadialViscosityLookup> radial_viscosity_lookup;
+        std_cxx11::shared_ptr<internal::RadialViscosityLookup> radial_viscosity_lookup;
 
     };
   }

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -26,7 +26,7 @@
 #include <aspect/plugins.h>
 #include <aspect/simulator_access.h>
 
-#include <deal.II/base/std_cxx1x/shared_ptr.h>
+#include <deal.II/base/std_cxx11/shared_ptr.h>
 #include <deal.II/base/table_handler.h>
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/distributed/tria.h>
@@ -260,7 +260,7 @@ namespace aspect
          * A list of mesh refinement objects that have been requested in the
          * parameter file.
          */
-        std::list<std_cxx1x::shared_ptr<Interface<dim> > > mesh_refinement_objects;
+        std::list<std_cxx11::shared_ptr<Interface<dim> > > mesh_refinement_objects;
     };
 
 

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -210,9 +210,9 @@ namespace aspect
          */
         void set_triangulation(const parallel::distributed::Triangulation<dim> *new_tria)
         {
-          //if (triangulation) triangulation->signals.post_refinement.disconnect(std_cxx1x::bind(&World::mesh_changed, std_cxx1x::ref(*this)));
+          //if (triangulation) triangulation->signals.post_refinement.disconnect(std_cxx11::bind(&World::mesh_changed, std_cxx11::ref(*this)));
           triangulation = new_tria;
-          triangulation->signals.post_refinement.connect(std_cxx1x::bind(&World::mesh_changed, std_cxx1x::ref(*this)));
+          triangulation->signals.post_refinement.connect(std_cxx11::bind(&World::mesh_changed, std_cxx11::ref(*this)));
         };
 
         /**

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -24,7 +24,7 @@
 
 
 #include <deal.II/base/parameter_handler.h>
-#include <deal.II/base/std_cxx1x/tuple.h>
+#include <deal.II/base/std_cxx11/tuple.h>
 
 #include <string>
 #include <list>
@@ -105,7 +105,7 @@ namespace aspect
          * - A function that can produce objects of this plugin type.
          */
         typedef
-        std_cxx1x::tuple<std::string,
+        std_cxx11::tuple<std::string,
                   std::string,
                   void ( *) (ParameterHandler &),
                   InterfaceClass *( *) ()>
@@ -239,7 +239,7 @@ namespace aspect
         for (typename std::list<PluginInfo>::const_iterator
              p = plugins->begin();
              p != plugins->end(); ++p)
-          Assert (std_cxx1x::get<0>(*p) != name,
+          Assert (std_cxx11::get<0>(*p) != name,
                   ExcMessage ("A plugin with name <" + name + "> has "
                               "already been registered!"));
 
@@ -266,7 +266,7 @@ namespace aspect
         for (typename std::list<PluginInfo>::const_iterator
              p = plugins->begin();
              p != plugins->end(); ++p)
-          names.insert (std_cxx1x::get<0>(*p));
+          names.insert (std_cxx11::get<0>(*p));
 
         // now create a pattern from all of these sorted names
         std::string pattern_of_names;
@@ -297,7 +297,7 @@ namespace aspect
         for (typename std::list<PluginInfo>::const_iterator
              p = plugins->begin();
              p != plugins->end(); ++p)
-          names_and_descriptions[std_cxx1x::get<0>(*p)] = std_cxx1x::get<1>(*p);;
+          names_and_descriptions[std_cxx11::get<0>(*p)] = std_cxx11::get<1>(*p);;
 
         // then output it all
         typename std::map<std::string,std::string>::const_iterator
@@ -340,7 +340,7 @@ namespace aspect
         for (typename std::list<PluginInfo>::const_iterator
              p = plugins->begin();
              p != plugins->end(); ++p)
-          (std_cxx1x::get<2>(*p))(prm);
+          (std_cxx11::get<2>(*p))(prm);
       }
 
 
@@ -372,9 +372,9 @@ namespace aspect
 
         for (typename std::list<PluginInfo>::const_iterator p = plugins->begin();
              p != plugins->end(); ++p)
-          if (std_cxx1x::get<0>(*p) == name)
+          if (std_cxx11::get<0>(*p) == name)
             {
-              InterfaceClass *i = std_cxx1x::get<3>(*p)();
+              InterfaceClass *i = std_cxx11::get<3>(*p)();
               return i;
             }
 

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -26,7 +26,7 @@
 #include <aspect/plugins.h>
 #include <aspect/simulator_access.h>
 
-#include <deal.II/base/std_cxx1x/shared_ptr.h>
+#include <deal.II/base/std_cxx11/shared_ptr.h>
 #include <deal.II/base/table_handler.h>
 #include <deal.II/base/parameter_handler.h>
 
@@ -280,7 +280,7 @@ namespace aspect
          * A list of postprocessor objects that have been requested in the
          * parameter file.
          */
-        std::list<std_cxx1x::shared_ptr<Interface<dim> > > postprocessors;
+        std::list<std_cxx11::shared_ptr<Interface<dim> > > postprocessors;
     };
 
 
@@ -294,7 +294,7 @@ namespace aspect
       // let all the postprocessors save their data in a map and then
       // serialize that
       std::map<std::string,std::string> saved_text;
-      for (typename std::list<std_cxx1x::shared_ptr<Interface<dim> > >::const_iterator
+      for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
            p = postprocessors.begin();
            p != postprocessors.end(); ++p)
         (*p)->save (saved_text);
@@ -315,7 +315,7 @@ namespace aspect
       std::map<std::string,std::string> saved_text;
       ar &saved_text;
 
-      for (typename std::list<std_cxx1x::shared_ptr<Interface<dim> > >::iterator
+      for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::iterator
            p = postprocessors.begin();
            p != postprocessors.end(); ++p)
         (*p)->load (saved_text);
@@ -334,7 +334,7 @@ namespace aspect
     PostprocessorType *
     Manager<dim>::find_postprocessor () const
     {
-      for (typename std::list<std_cxx1x::shared_ptr<Interface<dim> > >::const_iterator
+      for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
            p = postprocessors.begin();
            p != postprocessors.end(); ++p)
         if (PostprocessorType *x = dynamic_cast<PostprocessorType *> ( (*p).get()) )

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -434,7 +434,7 @@ namespace aspect
          * A list of postprocessor objects that have been requested in the
          * parameter file.
          */
-        std::list<std_cxx1x::shared_ptr<VisualizationPostprocessors::Interface<dim> > > postprocessors;
+        std::list<std_cxx11::shared_ptr<VisualizationPostprocessors::Interface<dim> > > postprocessors;
 
         /**
          * A list of pairs (time, pvtu_filename) that have so far been written

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -493,7 +493,7 @@ namespace aspect
        */
       struct IntermediaryConstructorAction
       {
-        IntermediaryConstructorAction (std_cxx1x::function<void ()> action);
+        IntermediaryConstructorAction (std_cxx11::function<void ()> action);
       };
 
       /**
@@ -606,7 +606,7 @@ namespace aspect
        * <code>source/simulator/assembly.cc</code>.
        */
       void build_advection_preconditioner (const AdvectionField &advection_field,
-                                           std_cxx1x::shared_ptr<aspect::LinearAlgebra::PreconditionILU> &preconditioner);
+                                           std_cxx11::shared_ptr<aspect::LinearAlgebra::PreconditionILU> &preconditioner);
 
       /**
        * Initiate the assembly of the Stokes matrix and right hand side.
@@ -1354,7 +1354,7 @@ namespace aspect
       const std::auto_ptr<InitialConditions::Interface<dim> >        initial_conditions;
       const std::auto_ptr<CompositionalInitialConditions::Interface<dim> > compositional_initial_conditions;
       const std::auto_ptr<AdiabaticConditions::Interface<dim> >      adiabatic_conditions;
-      std::map<types::boundary_id,std_cxx1x::shared_ptr<VelocityBoundaryConditions::Interface<dim> > > velocity_boundary_conditions;
+      std::map<types::boundary_id,std_cxx11::shared_ptr<VelocityBoundaryConditions::Interface<dim> > > velocity_boundary_conditions;
       /**
        * @}
        */
@@ -1454,11 +1454,11 @@ namespace aspect
 
 
 
-      std_cxx1x::shared_ptr<LinearAlgebra::PreconditionAMG>     Amg_preconditioner;
-      std_cxx1x::shared_ptr<LinearAlgebra::PreconditionILU>     Mp_preconditioner;
-      std_cxx1x::shared_ptr<LinearAlgebra::PreconditionILU>     T_preconditioner;
+      std_cxx11::shared_ptr<LinearAlgebra::PreconditionAMG>     Amg_preconditioner;
+      std_cxx11::shared_ptr<LinearAlgebra::PreconditionILU>     Mp_preconditioner;
+      std_cxx11::shared_ptr<LinearAlgebra::PreconditionILU>     T_preconditioner;
 //TODO: use n_compositional_field separate preconditioners
-      std_cxx1x::shared_ptr<LinearAlgebra::PreconditionILU>     C_preconditioner;
+      std_cxx11::shared_ptr<LinearAlgebra::PreconditionILU>     C_preconditioner;
 
       bool                                                      rebuild_stokes_matrix;
       bool                                                      rebuild_stokes_preconditioner;
@@ -1644,7 +1644,7 @@ namespace aspect
        * if we do not need the machinery for doing free surface stuff, we do
        * not even allocate it.
        */
-      std_cxx1x::shared_ptr<FreeSurfaceHandler> free_surface;
+      std_cxx11::shared_ptr<FreeSurfaceHandler> free_surface;
 
       friend class boost::serialization::access;
       friend class SimulatorAccess<dim>;

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -437,7 +437,7 @@ namespace aspect
       /**
        * Return the map of prescribed_velocity_boundary_conditions
        */
-      const std::map<types::boundary_id,std_cxx1x::shared_ptr<VelocityBoundaryConditions::Interface<dim> > >
+      const std::map<types::boundary_id,std_cxx11::shared_ptr<VelocityBoundaryConditions::Interface<dim> > >
       get_prescribed_velocity_boundary_conditions () const;
 
       /**

--- a/include/aspect/termination_criteria/interface.h
+++ b/include/aspect/termination_criteria/interface.h
@@ -25,7 +25,7 @@
 #include <aspect/global.h>
 #include <aspect/plugins.h>
 
-#include <deal.II/base/std_cxx1x/shared_ptr.h>
+#include <deal.II/base/std_cxx11/shared_ptr.h>
 #include <deal.II/base/parameter_handler.h>
 #include <aspect/simulator_access.h>
 
@@ -243,7 +243,7 @@ namespace aspect
          * A list of termination criterion objects that have been requested in
          * the parameter file.
          */
-        std::list<std_cxx1x::shared_ptr<Interface<dim> > > termination_objects;
+        std::list<std_cxx11::shared_ptr<Interface<dim> > > termination_objects;
 
         /**
          * A list of names corresponding to the termination criteria in the

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -24,7 +24,7 @@
 
 #include <aspect/global.h>
 
-#include <deal.II/base/std_cxx1x/array.h>
+#include <deal.II/base/std_cxx11/array.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/conditional_ostream.h>
 
@@ -53,7 +53,7 @@ namespace aspect
      *
      */
     template <int dim>
-    std_cxx1x::array<double,dim>
+    std_cxx11::array<double,dim>
     spherical_coordinates(const Point<dim> &position);
 
     /**
@@ -63,7 +63,7 @@ namespace aspect
      */
     template <int dim>
     Point<dim>
-    cartesian_coordinates(const std_cxx1x::array<double,dim> &scoord);
+    cartesian_coordinates(const std_cxx11::array<double,dim> &scoord);
 
     /**
      * Checks whether a file named filename exists.

--- a/include/aspect/velocity_boundary_conditions/gplates.h
+++ b/include/aspect/velocity_boundary_conditions/gplates.h
@@ -23,7 +23,7 @@
 #define __aspect__velocity_boundary_conditions_gplates_h
 
 #include <aspect/velocity_boundary_conditions/interface.h>
-#include <deal.II/base/std_cxx1x/array.h>
+#include <deal.II/base/std_cxx11/array.h>
 #include <aspect/simulator_access.h>
 
 
@@ -151,7 +151,7 @@ namespace aspect
            * coordinate axes in the order y-x-z (instead of the often used
            * z-x-z)
            */
-          std_cxx1x::array<double,3>
+          std_cxx11::array<double,3>
           angles_from_matrix (const Tensor<2,3> &rotation_matrix) const;
 
           /**
@@ -415,7 +415,7 @@ namespace aspect
          * Pointer to an object that reads and processes data we get from
          * gplates files.
          */
-        std_cxx1x::shared_ptr<internal::GPlatesLookup> lookup;
+        std_cxx11::shared_ptr<internal::GPlatesLookup> lookup;
 
         /**
          * Handles the update of the velocity data in lookup.

--- a/source/adiabatic_conditions/initial_profile.cc
+++ b/source/adiabatic_conditions/initial_profile.cc
@@ -24,7 +24,7 @@
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/box.h>
 
-#include <deal.II/base/std_cxx1x/bind.h>
+#include <deal.II/base/std_cxx11/bind.h>
 
 
 namespace aspect

--- a/source/adiabatic_conditions/interface.cc
+++ b/source/adiabatic_conditions/interface.cc
@@ -23,7 +23,7 @@
 #include <aspect/adiabatic_conditions/interface.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/std_cxx1x/tuple.h>
+#include <deal.II/base/std_cxx11/tuple.h>
 
 #include <list>
 
@@ -66,7 +66,7 @@ namespace aspect
 
     namespace
     {
-      std_cxx1x::tuple
+      std_cxx11::tuple
       <void *,
       void *,
       internal::Plugins::PluginList<Interface<2> >,
@@ -82,7 +82,7 @@ namespace aspect
                                    void (*declare_parameters_function) (ParameterHandler &),
                                    Interface<dim> *(*factory_function) ())
     {
-      std_cxx1x::get<dim>(registered_plugins).register_plugin (name,
+      std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
                                                                declare_parameters_function,
                                                                factory_function);
@@ -100,7 +100,7 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      Interface<dim> *plugin = std_cxx1x::get<dim>(registered_plugins).create_plugin (model_name,
+      Interface<dim> *plugin = std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                                       "Adiabatic Conditions model::Model name");
 
       return plugin;
@@ -117,17 +117,17 @@ namespace aspect
       prm.enter_subsection ("Adiabatic conditions model");
       {
         const std::string pattern_of_names
-          = std_cxx1x::get<dim>(registered_plugins).get_pattern_of_names ();
+          = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
 
         prm.declare_entry ("Model name", "initial profile",
                            Patterns::Selection (pattern_of_names),
                            "Select one of the following models:\n\n"
                            +
-                           std_cxx1x::get<dim>(registered_plugins).get_description_string());
+                           std_cxx11::get<dim>(registered_plugins).get_description_string());
       }
       prm.leave_subsection ();
 
-      std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
+      std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
   }

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -23,7 +23,7 @@
 #include <aspect/boundary_composition/interface.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/std_cxx1x/tuple.h>
+#include <deal.II/base/std_cxx11/tuple.h>
 
 #include <list>
 
@@ -64,7 +64,7 @@ namespace aspect
 
     namespace
     {
-      std_cxx1x::tuple
+      std_cxx11::tuple
       <void *,
       void *,
       internal::Plugins::PluginList<Interface<2> >,
@@ -80,7 +80,7 @@ namespace aspect
                                    void (*declare_parameters_function) (ParameterHandler &),
                                    Interface<dim> *(*factory_function) ())
     {
-      std_cxx1x::get<dim>(registered_plugins).register_plugin (name,
+      std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
                                                                declare_parameters_function,
                                                                factory_function);
@@ -98,7 +98,7 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      return std_cxx1x::get<dim>(registered_plugins).create_plugin (model_name,
+      return std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                     "Boundary composition model::Model name");
     }
 
@@ -112,14 +112,14 @@ namespace aspect
       prm.enter_subsection ("Boundary composition model");
       {
         const std::string pattern_of_names
-          = std_cxx1x::get<dim>(registered_plugins).get_pattern_of_names ();
+          = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
         try
           {
             prm.declare_entry ("Model name", "",
                                Patterns::Selection (pattern_of_names),
                                "Select one of the following models:\n\n"
                                +
-                               std_cxx1x::get<dim>(registered_plugins).get_description_string());
+                               std_cxx11::get<dim>(registered_plugins).get_description_string());
           }
         catch (const ParameterHandler::ExcValueDoesNotMatchPattern &)
           {
@@ -129,7 +129,7 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
+      std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
   }

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -23,7 +23,7 @@
 #include <aspect/boundary_temperature/interface.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/std_cxx1x/tuple.h>
+#include <deal.II/base/std_cxx11/tuple.h>
 
 #include <list>
 
@@ -66,7 +66,7 @@ namespace aspect
 
     namespace
     {
-      std_cxx1x::tuple
+      std_cxx11::tuple
       <void *,
       void *,
       internal::Plugins::PluginList<Interface<2> >,
@@ -82,7 +82,7 @@ namespace aspect
                                    void (*declare_parameters_function) (ParameterHandler &),
                                    Interface<dim> *(*factory_function) ())
     {
-      std_cxx1x::get<dim>(registered_plugins).register_plugin (name,
+      std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
                                                                declare_parameters_function,
                                                                factory_function);
@@ -100,7 +100,7 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      return std_cxx1x::get<dim>(registered_plugins).create_plugin (model_name,
+      return std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                     "Boundary temperature model::Model name");
     }
 
@@ -114,14 +114,14 @@ namespace aspect
       prm.enter_subsection ("Boundary temperature model");
       {
         const std::string pattern_of_names
-          = std_cxx1x::get<dim>(registered_plugins).get_pattern_of_names ();
+          = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
         try
           {
             prm.declare_entry ("Model name", "",
                                Patterns::Selection (pattern_of_names),
                                "Select one of the following models:\n\n"
                                +
-                               std_cxx1x::get<dim>(registered_plugins).get_description_string());
+                               std_cxx11::get<dim>(registered_plugins).get_description_string());
           }
         catch (const ParameterHandler::ExcValueDoesNotMatchPattern &)
           {
@@ -131,7 +131,7 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
+      std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
   }

--- a/source/compositional_initial_conditions/interface.cc
+++ b/source/compositional_initial_conditions/interface.cc
@@ -23,7 +23,7 @@
 #include <aspect/compositional_initial_conditions/interface.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/std_cxx1x/tuple.h>
+#include <deal.II/base/std_cxx11/tuple.h>
 
 #include <list>
 
@@ -61,7 +61,7 @@ namespace aspect
 
     namespace
     {
-      std_cxx1x::tuple
+      std_cxx11::tuple
       <void *,
       void *,
       internal::Plugins::PluginList<Interface<2> >,
@@ -77,7 +77,7 @@ namespace aspect
                                        void (*declare_parameters_function) (ParameterHandler &),
                                        Interface<dim> *(*factory_function) ())
     {
-      std_cxx1x::get<dim>(registered_plugins).register_plugin (name,
+      std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
                                                                declare_parameters_function,
                                                                factory_function);
@@ -105,7 +105,7 @@ namespace aspect
           }
           prm.leave_subsection ();
 
-          Interface<dim> *plugin = std_cxx1x::get<dim>(registered_plugins).create_plugin (model_name,
+          Interface<dim> *plugin = std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                                           "Compositional initial conditions::Model name");
           return plugin;
         }
@@ -121,16 +121,16 @@ namespace aspect
       prm.enter_subsection ("Compositional initial conditions");
       {
         const std::string pattern_of_names
-          = std_cxx1x::get<dim>(registered_plugins).get_pattern_of_names ();
+          = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
         prm.declare_entry ("Model name", "function",
                            Patterns::Selection (pattern_of_names),
                            "Select one of the following models:\n\n"
                            +
-                           std_cxx1x::get<dim>(registered_plugins).get_description_string());
+                           std_cxx11::get<dim>(registered_plugins).get_description_string());
       }
       prm.leave_subsection ();
 
-      std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
+      std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
   }
 }

--- a/source/geometry_model/interface.cc
+++ b/source/geometry_model/interface.cc
@@ -22,7 +22,7 @@
 #include <aspect/global.h>
 #include <aspect/geometry_model/interface.h>
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/std_cxx1x/tuple.h>
+#include <deal.II/base/std_cxx11/tuple.h>
 
 namespace aspect
 {
@@ -182,7 +182,7 @@ namespace aspect
 
     namespace
     {
-      std_cxx1x::tuple
+      std_cxx11::tuple
       <void *,
       void *,
       internal::Plugins::PluginList<Interface<2> >,
@@ -198,7 +198,7 @@ namespace aspect
                              void (*declare_parameters_function) (ParameterHandler &),
                              Interface<dim> *(*factory_function) ())
     {
-      std_cxx1x::get<dim>(registered_plugins).register_plugin (name,
+      std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
                                                                declare_parameters_function,
                                                                factory_function);
@@ -216,7 +216,7 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      return std_cxx1x::get<dim>(registered_plugins).create_plugin (model_name,
+      return std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                     "Geometry model::model name",
                                                                     prm);
     }
@@ -231,14 +231,14 @@ namespace aspect
       prm.enter_subsection ("Geometry model");
       {
         const std::string pattern_of_names
-          = std_cxx1x::get<dim>(registered_plugins).get_pattern_of_names ();
+          = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
         try
           {
             prm.declare_entry ("Model name", "",
                                Patterns::Selection (pattern_of_names),
                                "Select one of the following models:\n\n"
                                +
-                               std_cxx1x::get<dim>(registered_plugins).get_description_string());
+                               std_cxx11::get<dim>(registered_plugins).get_description_string());
           }
         catch (const ParameterHandler::ExcValueDoesNotMatchPattern &)
           {
@@ -248,7 +248,7 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
+      std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
   }

--- a/source/gravity_model/interface.cc
+++ b/source/gravity_model/interface.cc
@@ -23,7 +23,7 @@
 #include <aspect/gravity_model/interface.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/std_cxx1x/tuple.h>
+#include <deal.II/base/std_cxx11/tuple.h>
 
 #include <list>
 
@@ -64,7 +64,7 @@ namespace aspect
 
     namespace
     {
-      std_cxx1x::tuple
+      std_cxx11::tuple
       <void *,
       void *,
       internal::Plugins::PluginList<Interface<2> >,
@@ -80,7 +80,7 @@ namespace aspect
                             void (*declare_parameters_function) (ParameterHandler &),
                             Interface<dim> *(*factory_function) ())
     {
-      std_cxx1x::get<dim>(registered_plugins).register_plugin (name,
+      std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
                                                                declare_parameters_function,
                                                                factory_function);
@@ -98,7 +98,7 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      return std_cxx1x::get<dim>(registered_plugins).create_plugin (model_name,
+      return std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                     "Gravity model::Model name");
     }
 
@@ -112,14 +112,14 @@ namespace aspect
       prm.enter_subsection ("Gravity model");
       {
         const std::string pattern_of_names
-          = std_cxx1x::get<dim>(registered_plugins).get_pattern_of_names ();
+          = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
         try
           {
             prm.declare_entry ("Model name", "",
                                Patterns::Selection (pattern_of_names),
                                "Select one of the following models:\n\n"
                                +
-                               std_cxx1x::get<dim>(registered_plugins).get_description_string());
+                               std_cxx11::get<dim>(registered_plugins).get_description_string());
           }
         catch (const ParameterHandler::ExcValueDoesNotMatchPattern &)
           {
@@ -129,7 +129,7 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
+      std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
   }

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -23,7 +23,7 @@
 #include <aspect/heating_model/interface.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/std_cxx1x/tuple.h>
+#include <deal.II/base/std_cxx11/tuple.h>
 
 #include <list>
 
@@ -69,7 +69,7 @@ namespace aspect
 
     namespace
     {
-      std_cxx1x::tuple
+      std_cxx11::tuple
       <void *,
       void *,
       internal::Plugins::PluginList<Interface<2> >,
@@ -85,7 +85,7 @@ namespace aspect
                             void (*declare_parameters_function) (ParameterHandler &),
                             Interface<dim> *(*factory_function) ())
     {
-      std_cxx1x::get<dim>(registered_plugins).register_plugin (name,
+      std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
                                                                declare_parameters_function,
                                                                factory_function);
@@ -103,7 +103,7 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      Interface<dim> *plugin = std_cxx1x::get<dim>(registered_plugins).create_plugin (model_name,
+      Interface<dim> *plugin = std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                                       "Heating model::Model name");
       return plugin;
     }
@@ -114,7 +114,7 @@ namespace aspect
     std::string
     get_names ()
     {
-      return std_cxx1x::get<dim>(registered_plugins).get_pattern_of_names ();
+      return std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
     }
 
 
@@ -126,14 +126,14 @@ namespace aspect
       prm.enter_subsection ("Heating model");
       {
         const std::string pattern_of_names
-          = std_cxx1x::get<dim>(registered_plugins).get_pattern_of_names ();
+          = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
         try
           {
             prm.declare_entry ("Model name", "constant heating",
                                Patterns::Selection (pattern_of_names),
                                "Select one of the following models:\n\n"
                                +
-                               std_cxx1x::get<dim>(registered_plugins).get_description_string());
+                               std_cxx11::get<dim>(registered_plugins).get_description_string());
           }
         catch (const ParameterHandler::ExcValueDoesNotMatchPattern &)
           {
@@ -143,7 +143,7 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
+      std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
   }
 }

--- a/source/initial_conditions/S40RTS_perturbation.cc
+++ b/source/initial_conditions/S40RTS_perturbation.cc
@@ -23,7 +23,7 @@
 #include <aspect/utilities.h>
 #include <fstream>
 #include <iostream>
-#include <deal.II/base/std_cxx1x/array.h>
+#include <deal.II/base/std_cxx11/array.h>
 
 #include <boost/math/special_functions/spherical_harmonic.hpp>
 
@@ -260,7 +260,7 @@ namespace aspect
         depth_values[i] = rcmb+(rmoho-rcmb)*0.5*(r[i]+1);
 
       // convert coordinates from [x,y,z] to [r, phi, theta]
-      std_cxx1x::array<double,dim> scoord = aspect::Utilities::spherical_coordinates(position);
+      std_cxx11::array<double,dim> scoord = aspect::Utilities::spherical_coordinates(position);
 
       // iterate over all degrees and orders at each depth and sum them all up.
       std::vector<double> spline_values(num_spline_knots,0);

--- a/source/initial_conditions/harmonic_perturbation.cc
+++ b/source/initial_conditions/harmonic_perturbation.cc
@@ -62,7 +62,7 @@ namespace aspect
           spherical_geometry_model = dynamic_cast <const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()))
         {
           // In case of spherical shell calculate spherical coordinates
-          const std_cxx1x::array<double,dim> scoord = aspect::Utilities::spherical_coordinates(position);
+          const std_cxx11::array<double,dim> scoord = aspect::Utilities::spherical_coordinates(position);
 
           if (dim==2)
             {

--- a/source/initial_conditions/interface.cc
+++ b/source/initial_conditions/interface.cc
@@ -23,7 +23,7 @@
 #include <aspect/initial_conditions/interface.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/std_cxx1x/tuple.h>
+#include <deal.II/base/std_cxx11/tuple.h>
 
 #include <list>
 
@@ -61,7 +61,7 @@ namespace aspect
 
     namespace
     {
-      std_cxx1x::tuple
+      std_cxx11::tuple
       <void *,
       void *,
       internal::Plugins::PluginList<Interface<2> >,
@@ -77,7 +77,7 @@ namespace aspect
                                        void (*declare_parameters_function) (ParameterHandler &),
                                        Interface<dim> *(*factory_function) ())
     {
-      std_cxx1x::get<dim>(registered_plugins).register_plugin (name,
+      std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
                                                                declare_parameters_function,
                                                                factory_function);
@@ -95,7 +95,7 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      Interface<dim> *plugin = std_cxx1x::get<dim>(registered_plugins).create_plugin (model_name,
+      Interface<dim> *plugin = std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                                       "Initial conditions::Model name");
       return plugin;
     }
@@ -110,14 +110,14 @@ namespace aspect
       prm.enter_subsection ("Initial conditions");
       {
         const std::string pattern_of_names
-          = std_cxx1x::get<dim>(registered_plugins).get_pattern_of_names ();
+          = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
         try
           {
             prm.declare_entry ("Model name", "",
                                Patterns::Selection (pattern_of_names),
                                "Select one of the following models:\n\n"
                                +
-                               std_cxx1x::get<dim>(registered_plugins).get_description_string());
+                               std_cxx11::get<dim>(registered_plugins).get_description_string());
           }
         catch (const ParameterHandler::ExcValueDoesNotMatchPattern &)
           {
@@ -127,7 +127,7 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
+      std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
   }
 }

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -23,7 +23,7 @@
 #include <aspect/simulator_access.h>
 #include <aspect/material_model/interface.h>
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/std_cxx1x/tuple.h>
+#include <deal.II/base/std_cxx11/tuple.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/fe_q.h>
 
@@ -175,7 +175,7 @@ namespace aspect
 
     namespace
     {
-      std_cxx1x::tuple
+      std_cxx11::tuple
       <void *,
       void *,
       internal::Plugins::PluginList<Interface<2> >,
@@ -191,7 +191,7 @@ namespace aspect
                              void (*declare_parameters_function) (ParameterHandler &),
                              Interface<dim> *(*factory_function) ())
     {
-      std_cxx1x::get<dim>(registered_plugins).register_plugin (name,
+      std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
                                                                declare_parameters_function,
                                                                factory_function);
@@ -209,7 +209,7 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      Interface<dim> *plugin = std_cxx1x::get<dim>(registered_plugins).create_plugin (model_name,
+      Interface<dim> *plugin = std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                                       "Material model::Model name");
       return plugin;
     }
@@ -271,14 +271,14 @@ namespace aspect
       prm.enter_subsection ("Material model");
       {
         const std::string pattern_of_names
-          = std_cxx1x::get<dim>(registered_plugins).get_pattern_of_names ();
+          = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
         try
           {
             prm.declare_entry ("Model name", "",
                                Patterns::Selection (pattern_of_names),
                                "Select one of the following models:\n\n"
                                +
-                               std_cxx1x::get<dim>(registered_plugins).get_description_string());
+                               std_cxx11::get<dim>(registered_plugins).get_description_string());
           }
         catch (const ParameterHandler::ExcValueDoesNotMatchPattern &)
           {
@@ -288,7 +288,7 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
+      std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
 

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -419,7 +419,7 @@ namespace aspect
 
       n_material_data = material_file_names.size();
       for (unsigned i = 0; i < n_material_data; i++)
-        material_lookup.push_back(std_cxx1x::shared_ptr<internal::MaterialLookup>
+        material_lookup.push_back(std_cxx11::shared_ptr<internal::MaterialLookup>
                                   (new internal::MaterialLookup(datadirectory+material_file_names[i],interpolation)));
       lateral_viscosity_lookup.reset(new internal::LateralViscosityLookup(datadirectory+lateral_viscosity_file_name));
       radial_viscosity_lookup.reset(new internal::RadialViscosityLookup(datadirectory+radial_viscosity_file_name));

--- a/source/mesh_refinement/interface.cc
+++ b/source/mesh_refinement/interface.cc
@@ -89,7 +89,7 @@ namespace aspect
       std::vector<Vector<float> > all_error_indicators (mesh_refinement_objects.size(),
                                                         Vector<float>(error_indicators.size()));
       unsigned int index = 0;
-      for (typename std::list<std_cxx1x::shared_ptr<Interface<dim> > >::const_iterator
+      for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
            p = mesh_refinement_objects.begin();
            p != mesh_refinement_objects.end(); ++p, ++index)
         {
@@ -196,7 +196,7 @@ namespace aspect
       // call the tag_additional_cells() functions of all
       // plugins we have here in turns.
       unsigned int index = 0;
-      for (typename std::list<std_cxx1x::shared_ptr<Interface<dim> > >::const_iterator
+      for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
            p = mesh_refinement_objects.begin();
            p != mesh_refinement_objects.end(); ++p, ++index)
         {
@@ -259,7 +259,7 @@ namespace aspect
 
     namespace
     {
-      std_cxx1x::tuple
+      std_cxx11::tuple
       <void *,
       void *,
       internal::Plugins::PluginList<Interface<2> >,
@@ -279,7 +279,7 @@ namespace aspect
         // construct a string for Patterns::MultipleSelection that
         // contains the names of all registered plugins
         const std::string pattern_of_names
-          = std_cxx1x::get<dim>(registered_plugins).get_pattern_of_names ();
+          = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
         prm.declare_entry("Strategy",
                           "thermal energy density",
                           Patterns::MultipleSelection(pattern_of_names),
@@ -292,7 +292,7 @@ namespace aspect
                           "merged through the operation selected in this section.\n\n"
                           "The following criteria are available:\n\n"
                           +
-                          std_cxx1x::get<dim>(registered_plugins).get_description_string());
+                          std_cxx11::get<dim>(registered_plugins).get_description_string());
 
         prm.declare_entry("Normalize individual refinement criteria",
                           "true",
@@ -360,7 +360,7 @@ namespace aspect
 
       // now declare the parameters of each of the registered
       // plugins in turn
-      std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
+      std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
 
@@ -369,7 +369,7 @@ namespace aspect
     void
     Manager<dim>::parse_parameters (ParameterHandler &prm)
     {
-      Assert (std_cxx1x::get<dim>(registered_plugins).plugins != 0,
+      Assert (std_cxx11::get<dim>(registered_plugins).plugins != 0,
               ExcMessage ("No mesh refinement plugins registered!?"));
 
       // find out which plugins are requested and the various other
@@ -408,8 +408,8 @@ namespace aspect
                    ExcMessage ("You need to provide at least one mesh refinement criterion in the input file!"));
       for (unsigned int name=0; name<plugin_names.size(); ++name)
         {
-          mesh_refinement_objects.push_back (std_cxx1x::shared_ptr<Interface<dim> >
-                                             (std_cxx1x::get<dim>(registered_plugins)
+          mesh_refinement_objects.push_back (std_cxx11::shared_ptr<Interface<dim> >
+                                             (std_cxx11::get<dim>(registered_plugins)
                                               .create_plugin (plugin_names[name],
                                                               "Mesh refinement::Refinement criteria merge operation")));
 
@@ -429,7 +429,7 @@ namespace aspect
                                                       void (*declare_parameters_function) (ParameterHandler &),
                                                       Interface<dim> *(*factory_function) ())
     {
-      std_cxx1x::get<dim>(registered_plugins).register_plugin (name,
+      std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
                                                                declare_parameters_function,
                                                                factory_function);

--- a/source/mesh_refinement/maximum_refinement_function.cc
+++ b/source/mesh_refinement/maximum_refinement_function.cc
@@ -58,7 +58,7 @@ namespace aspect
                     }
                   else if (coordinate_system == spherical)
                     {
-                      const std_cxx1x::array<double,dim> spherical_coordinates =
+                      const std_cxx11::array<double,dim> spherical_coordinates =
                         aspect::Utilities::spherical_coordinates(vertex);
 
                       // Conversion to evaluate the spherical coordinates in the maximum

--- a/source/mesh_refinement/minimum_refinement_function.cc
+++ b/source/mesh_refinement/minimum_refinement_function.cc
@@ -58,7 +58,7 @@ namespace aspect
                     }
                   else if (coordinate_system == spherical)
                     {
-                      const std_cxx1x::array<double,dim> spherical_coordinates =
+                      const std_cxx11::array<double,dim> spherical_coordinates =
                         aspect::Utilities::spherical_coordinates(vertex);
 
                       // Conversion to evaluate the spherical coordinates in the minimum

--- a/source/postprocess/interface.cc
+++ b/source/postprocess/interface.cc
@@ -78,7 +78,7 @@ namespace aspect
       // call the execute() functions of all postprocessor objects we have
       // here in turns
       std::list<std::pair<std::string,std::string> > output_list;
-      for (typename std::list<std_cxx1x::shared_ptr<Interface<dim> > >::iterator
+      for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::iterator
            p = postprocessors.begin();
            p != postprocessors.end(); ++p)
         {
@@ -145,7 +145,7 @@ namespace aspect
 
     namespace
     {
-      std_cxx1x::tuple
+      std_cxx11::tuple
       <void *,
       void *,
       internal::Plugins::PluginList<Interface<2> >,
@@ -165,7 +165,7 @@ namespace aspect
         // construct a string for Patterns::MultipleSelection that
         // contains the names of all registered postprocessors
         const std::string pattern_of_names
-          = std_cxx1x::get<dim>(registered_plugins).get_pattern_of_names ();
+          = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
         prm.declare_entry("List of postprocessors",
                           "",
                           Patterns::MultipleSelection(pattern_of_names),
@@ -177,13 +177,13 @@ namespace aspect
                           "postprocessors should be run after each time step.\n\n"
                           "The following postprocessors are available:\n\n"
                           +
-                          std_cxx1x::get<dim>(registered_plugins).get_description_string());
+                          std_cxx11::get<dim>(registered_plugins).get_description_string());
       }
       prm.leave_subsection();
 
       // now declare the parameters of each of the registered
       // postprocessors in turn
-      std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
+      std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
 
@@ -192,7 +192,7 @@ namespace aspect
     void
     Manager<dim>::parse_parameters (ParameterHandler &prm)
     {
-      Assert (std_cxx1x::get<dim>(registered_plugins).plugins != 0,
+      Assert (std_cxx11::get<dim>(registered_plugins).plugins != 0,
               ExcMessage ("No postprocessors registered!?"));
 
       // first find out which postprocessors are requested
@@ -212,17 +212,17 @@ namespace aspect
         {
           postprocessor_names.clear();
           for (typename std::list<typename internal::Plugins::PluginList<Interface<dim> >::PluginInfo>::const_iterator
-               p = std_cxx1x::get<dim>(registered_plugins).plugins->begin();
-               p != std_cxx1x::get<dim>(registered_plugins).plugins->end(); ++p)
-            postprocessor_names.push_back (std_cxx1x::get<0>(*p));
+               p = std_cxx11::get<dim>(registered_plugins).plugins->begin();
+               p != std_cxx11::get<dim>(registered_plugins).plugins->end(); ++p)
+            postprocessor_names.push_back (std_cxx11::get<0>(*p));
         }
 
       // then go through the list, create objects and let them parse
       // their own parameters
       for (unsigned int name=0; name<postprocessor_names.size(); ++name)
         {
-          postprocessors.push_back (std_cxx1x::shared_ptr<Interface<dim> >
-                                    (std_cxx1x::get<dim>(registered_plugins)
+          postprocessors.push_back (std_cxx11::shared_ptr<Interface<dim> >
+                                    (std_cxx11::get<dim>(registered_plugins)
                                      .create_plugin (postprocessor_names[name],
                                                      "Postprocessor plugins")));
           if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(&*postprocessors.back()))
@@ -241,7 +241,7 @@ namespace aspect
                                           void (*declare_parameters_function) (ParameterHandler &),
                                           Interface<dim> *(*factory_function) ())
     {
-      std_cxx1x::get<dim>(registered_plugins).register_plugin (name,
+      std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
                                                                declare_parameters_function,
                                                                factory_function);

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -245,8 +245,8 @@ namespace aspect
       // add the computed quantity as well. keep a list of
       // pointers to data vectors created by cell data visualization
       // postprocessors that will later be deleted
-      std::list<std_cxx1x::shared_ptr<Vector<float> > > cell_data_vectors;
-      for (typename std::list<std_cxx1x::shared_ptr<VisualizationPostprocessors::Interface<dim> > >::const_iterator
+      std::list<std_cxx11::shared_ptr<Vector<float> > > cell_data_vectors;
+      for (typename std::list<std_cxx11::shared_ptr<VisualizationPostprocessors::Interface<dim> > >::const_iterator
            p = postprocessors.begin(); p!=postprocessors.end(); ++p)
         {
           try
@@ -276,7 +276,7 @@ namespace aspect
                                       "on the current processor."));
 
                   // store the pointer, then attach the vector to the DataOut object
-                  cell_data_vectors.push_back (std_cxx1x::shared_ptr<Vector<float> >
+                  cell_data_vectors.push_back (std_cxx11::shared_ptr<Vector<float> >
                                                (cell_data.second));
 
                   data_out.add_data_vector (*cell_data.second,
@@ -590,7 +590,7 @@ namespace aspect
 
     namespace
     {
-      std_cxx1x::tuple
+      std_cxx11::tuple
       <void *,
       void *,
       aspect::internal::Plugins::PluginList<VisualizationPostprocessors::Interface<2> >,
@@ -672,7 +672,7 @@ namespace aspect
           // finally also construct a string for Patterns::MultipleSelection that
           // contains the names of all registered visualization postprocessors
           const std::string pattern_of_names
-            = std_cxx1x::get<dim>(registered_plugins).get_pattern_of_names ();
+            = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
           prm.declare_entry("List of output variables",
                             "",
                             Patterns::MultipleSelection(pattern_of_names),
@@ -689,7 +689,7 @@ namespace aspect
                             "to have in your output file.\n\n"
                             "The following postprocessors are available:\n\n"
                             +
-                            std_cxx1x::get<dim>(registered_plugins).get_description_string());
+                            std_cxx11::get<dim>(registered_plugins).get_description_string());
         }
         prm.leave_subsection();
       }
@@ -697,7 +697,7 @@ namespace aspect
 
       // now declare the parameters of each of the registered
       // visualization postprocessors in turn
-      std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
+      std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
 
@@ -705,7 +705,7 @@ namespace aspect
     void
     Visualization<dim>::parse_parameters (ParameterHandler &prm)
     {
-      Assert (std_cxx1x::get<dim>(registered_plugins).plugins != 0,
+      Assert (std_cxx11::get<dim>(registered_plugins).plugins != 0,
               ExcMessage ("No postprocessors registered!?"));
       std::vector<std::string> viz_names;
 
@@ -732,9 +732,9 @@ namespace aspect
             {
               viz_names.clear();
               for (typename std::list<typename aspect::internal::Plugins::PluginList<VisualizationPostprocessors::Interface<dim> >::PluginInfo>::const_iterator
-                   p = std_cxx1x::get<dim>(registered_plugins).plugins->begin();
-                   p != std_cxx1x::get<dim>(registered_plugins).plugins->end(); ++p)
-                viz_names.push_back (std_cxx1x::get<0>(*p));
+                   p = std_cxx11::get<dim>(registered_plugins).plugins->begin();
+                   p != std_cxx11::get<dim>(registered_plugins).plugins->end(); ++p)
+                viz_names.push_back (std_cxx11::get<0>(*p));
             }
         }
         prm.leave_subsection();
@@ -746,7 +746,7 @@ namespace aspect
       for (unsigned int name=0; name<viz_names.size(); ++name)
         {
           VisualizationPostprocessors::Interface<dim> *
-          viz_postprocessor = std_cxx1x::get<dim>(registered_plugins)
+          viz_postprocessor = std_cxx11::get<dim>(registered_plugins)
                               .create_plugin (viz_names[name],
                                               "Visualization plugins");
 
@@ -763,7 +763,7 @@ namespace aspect
                               "dealii::DataPostprocessor or "
                               "VisualizationPostprocessors::CellDataVectorCreator!?"));
 
-          postprocessors.push_back (std_cxx1x::shared_ptr<VisualizationPostprocessors::Interface<dim> >
+          postprocessors.push_back (std_cxx11::shared_ptr<VisualizationPostprocessors::Interface<dim> >
                                     (viz_postprocessor));
 
           if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(&*postprocessors.back()))
@@ -775,7 +775,7 @@ namespace aspect
       // Finally also set up a listener to check when the mesh changes
       mesh_changed = true;
       this->get_triangulation().signals.post_refinement
-      .connect(std_cxx1x::bind(&Visualization::mesh_changed_signal, std_cxx1x::ref(*this)));
+      .connect(std_cxx11::bind(&Visualization::mesh_changed_signal, std_cxx11::ref(*this)));
     }
 
 
@@ -853,7 +853,7 @@ namespace aspect
                                           void (*declare_parameters_function) (ParameterHandler &),
                                           VisualizationPostprocessors::Interface<dim> *(*factory_function) ())
     {
-      std_cxx1x::get<dim>(registered_plugins).register_plugin (name,
+      std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
                                                                declare_parameters_function,
                                                                factory_function);

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -974,16 +974,16 @@ namespace aspect
                      dof_handler.begin_active()),
          CellFilter (IteratorFilters::LocallyOwnedCell(),
                      dof_handler.end()),
-         std_cxx1x::bind (&Simulator<dim>::
+         std_cxx11::bind (&Simulator<dim>::
                           local_assemble_stokes_preconditioner,
                           this,
-                          std_cxx1x::_1,
-                          std_cxx1x::_2,
-                          std_cxx1x::_3),
-         std_cxx1x::bind (&Simulator<dim>::
+                          std_cxx11::_1,
+                          std_cxx11::_2,
+                          std_cxx11::_3),
+         std_cxx11::bind (&Simulator<dim>::
                           copy_local_to_global_stokes_preconditioner,
                           this,
-                          std_cxx1x::_1),
+                          std_cxx11::_1),
          internal::Assembly::Scratch::
          StokesPreconditioner<dim> (finite_element, quadrature_formula,
                                     mapping,
@@ -1229,16 +1229,16 @@ namespace aspect
                      dof_handler.begin_active()),
          CellFilter (IteratorFilters::LocallyOwnedCell(),
                      dof_handler.end()),
-         std_cxx1x::bind (&Simulator<dim>::
+         std_cxx11::bind (&Simulator<dim>::
                           local_assemble_stokes_system,
                           this,
-                          std_cxx1x::_1,
-                          std_cxx1x::_2,
-                          std_cxx1x::_3),
-         std_cxx1x::bind (&Simulator<dim>::
+                          std_cxx11::_1,
+                          std_cxx11::_2,
+                          std_cxx11::_3),
+         std_cxx11::bind (&Simulator<dim>::
                           copy_local_to_global_stokes_system,
                           this,
-                          std_cxx1x::_1),
+                          std_cxx11::_1),
          internal::Assembly::Scratch::
          StokesSystem<dim> (finite_element, mapping, quadrature_formula,
                             (update_values    |
@@ -1276,7 +1276,7 @@ namespace aspect
   template <int dim>
   void
   Simulator<dim>::build_advection_preconditioner(const AdvectionField &advection_field,
-                                                 std_cxx1x::shared_ptr<aspect::LinearAlgebra::PreconditionILU> &preconditioner)
+                                                 std_cxx11::shared_ptr<aspect::LinearAlgebra::PreconditionILU> &preconditioner)
   {
     switch (advection_field.field_type)
       {
@@ -1706,7 +1706,7 @@ namespace aspect
                      dof_handler.begin_active()),
          CellFilter (IteratorFilters::LocallyOwnedCell(),
                      dof_handler.end()),
-         std_cxx1x::bind (&Simulator<dim>::
+         std_cxx11::bind (&Simulator<dim>::
                           local_assemble_advection_system,
                           this,
                           advection_field,
@@ -1718,13 +1718,13 @@ namespace aspect
                           get_entropy_variation ((global_field_range.first +
                                                   global_field_range.second) / 2,
                                                  advection_field),
-                          std_cxx1x::_1,
-                          std_cxx1x::_2,
-                          std_cxx1x::_3),
-         std_cxx1x::bind (&Simulator<dim>::
+                          std_cxx11::_1,
+                          std_cxx11::_2,
+                          std_cxx11::_3),
+         std_cxx11::bind (&Simulator<dim>::
                           copy_local_to_global_advection_system,
                           this,
-                          std_cxx1x::_1),
+                          std_cxx11::_1),
 
          // we have to assemble the term u.grad phi_i * phi_j, which is
          // of total polynomial degree
@@ -1787,7 +1787,7 @@ namespace aspect
   template void Simulator<dim>::assemble_stokes_system (); \
   template void Simulator<dim>::get_artificial_viscosity (Vector<float> &viscosity_per_cell) const; \
   template void Simulator<dim>::build_advection_preconditioner (const AdvectionField &, \
-                                                                std_cxx1x::shared_ptr<aspect::LinearAlgebra::PreconditionILU> &preconditioner); \
+                                                                std_cxx11::shared_ptr<aspect::LinearAlgebra::PreconditionILU> &preconditioner); \
   template void Simulator<dim>::local_assemble_advection_system ( \
                                                                   const AdvectionField          &advection_field, \
                                                                   const std::pair<double,double> global_field_range, \

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -85,7 +85,7 @@ namespace aspect
    */
   template <int dim>
   Simulator<dim>::IntermediaryConstructorAction::
-  IntermediaryConstructorAction (std_cxx1x::function<void ()> action)
+  IntermediaryConstructorAction (std_cxx11::function<void ()> action)
   {
     action();
   }
@@ -117,10 +117,10 @@ namespace aspect
     // make sure the parameters object gets a chance to
     // parse those parameters that depend on symbolic names
     // for boundary components
-    post_geometry_model_creation_action (std_cxx1x::bind (&Parameters::parse_geometry_dependent_parameters,
-                                                          std_cxx1x::ref(parameters),
-                                                          std_cxx1x::ref(prm),
-                                                          std_cxx1x::cref(*geometry_model))),
+    post_geometry_model_creation_action (std_cxx11::bind (&Parameters::parse_geometry_dependent_parameters,
+                                                          std_cxx11::ref(parameters),
+                                                          std_cxx11::ref(prm),
+                                                          std_cxx11::cref(*geometry_model))),
     material_model (MaterialModel::create_material_model<dim>(prm)),
     heating_model (HeatingModel::create_heating_model<dim>(prm)),
     gravity_model (GravityModel::create_gravity_model<dim>(prm)),
@@ -468,7 +468,7 @@ namespace aspect
          *     of the resulting Function object.
          */
         VectorFunctionFromVelocityFunctionObject (const unsigned int n_components,
-                                                  const std_cxx1x::function<Tensor<1,dim> (const Point<dim> &)> &function_object);
+                                                  const std_cxx11::function<Tensor<1,dim> (const Point<dim> &)> &function_object);
 
         /**
          * Return the value of the
@@ -497,7 +497,7 @@ namespace aspect
          * The function object which we call when this class's value() or
          * value_list() functions are called.
          **/
-        const std_cxx1x::function<Tensor<1,dim> (const Point<dim> &)> function_object;
+        const std_cxx11::function<Tensor<1,dim> (const Point<dim> &)> function_object;
     };
 
 
@@ -505,7 +505,7 @@ namespace aspect
     VectorFunctionFromVelocityFunctionObject<dim>::
     VectorFunctionFromVelocityFunctionObject
     (const unsigned int n_components,
-     const std_cxx1x::function<Tensor<1,dim> (const Point<dim> &)> &function_object)
+     const std_cxx11::function<Tensor<1,dim> (const Point<dim> &)> &function_object)
       :
       Function<dim>(n_components),
       function_object (function_object)
@@ -624,16 +624,16 @@ namespace aspect
     {
       // set the current time and do the interpolation
       // for the prescribed velocity fields
-      for (typename std::map<types::boundary_id,std_cxx1x::shared_ptr<VelocityBoundaryConditions::Interface<dim> > >::iterator
+      for (typename std::map<types::boundary_id,std_cxx11::shared_ptr<VelocityBoundaryConditions::Interface<dim> > >::iterator
            p = velocity_boundary_conditions.begin();
            p != velocity_boundary_conditions.end(); ++p)
         {
           p->second->update ();
           VectorFunctionFromVelocityFunctionObject<dim> vel
           (introspection.n_components,
-           std_cxx1x::bind (&VelocityBoundaryConditions::Interface<dim>::boundary_velocity,
+           std_cxx11::bind (&VelocityBoundaryConditions::Interface<dim>::boundary_velocity,
                             p->second,
-                            std_cxx1x::_1));
+                            std_cxx11::_1));
 
           // here we create a mask for interpolate_boundary_values out of the 'selector'
           std::vector<bool> mask(introspection.component_masks.velocities.size(), false);
@@ -700,11 +700,11 @@ namespace aspect
                   ExcInternalError());
           VectorTools::interpolate_boundary_values (dof_handler,
                                                     *p,
-                                                    VectorFunctionFromScalarFunctionObject<dim>(std_cxx1x::bind (&BoundaryTemperature::Interface<dim>::temperature,
-                                                        std_cxx1x::cref(*boundary_temperature),
-                                                        std_cxx1x::cref(*geometry_model),
+                                                    VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (&BoundaryTemperature::Interface<dim>::temperature,
+                                                        std_cxx11::cref(*boundary_temperature),
+                                                        std_cxx11::cref(*geometry_model),
                                                         *p,
-                                                        std_cxx1x::_1),
+                                                        std_cxx11::_1),
                                                         introspection.component_masks.temperature.first_selected_component(),
                                                         introspection.n_components),
                                                     current_constraints,
@@ -731,11 +731,11 @@ namespace aspect
                     ExcInternalError());
             VectorTools::interpolate_boundary_values (dof_handler,
                                                       *p,
-                                                      VectorFunctionFromScalarFunctionObject<dim>(std_cxx1x::bind (&BoundaryComposition::Interface<dim>::composition,
-                                                          std_cxx1x::cref(*boundary_composition),
-                                                          std_cxx1x::cref(*geometry_model),
+                                                      VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (&BoundaryComposition::Interface<dim>::composition,
+                                                          std_cxx11::cref(*boundary_composition),
+                                                          std_cxx11::cref(*geometry_model),
                                                           *p,
-                                                          std_cxx1x::_1,
+                                                          std_cxx11::_1,
                                                           c),
                                                           introspection.component_masks.compositional_fields[c].first_selected_component(),
                                                           introspection.n_components),

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -207,9 +207,9 @@ namespace aspect
         // solution vector, so create such a function object
         // that is simply zero for all velocity components
         VectorTools::interpolate (mapping, dof_handler,
-                                  VectorFunctionFromScalarFunctionObject<dim> (std_cxx1x::bind (&AdiabaticConditions::Interface<dim>::pressure,
-                                                                               std_cxx1x::cref (*adiabatic_conditions),
-                                                                               std_cxx1x::_1),
+                                  VectorFunctionFromScalarFunctionObject<dim> (std_cxx11::bind (&AdiabaticConditions::Interface<dim>::pressure,
+                                                                               std_cxx11::cref (*adiabatic_conditions),
+                                                                               std_cxx11::_1),
                                                                                introspection.component_indices.pressure,
                                                                                introspection.n_components),
                                   system_tmp);
@@ -250,9 +250,9 @@ namespace aspect
         std::vector<double> rhs_values(n_q_points);
 
         ScalarFunctionFromFunctionObject<dim>
-        adiabatic_pressure (std_cxx1x::bind (&AdiabaticConditions::Interface<dim>::pressure,
-                                             std_cxx1x::cref(*adiabatic_conditions),
-                                             std_cxx1x::_1));
+        adiabatic_pressure (std_cxx11::bind (&AdiabaticConditions::Interface<dim>::pressure,
+                                             std_cxx11::cref(*adiabatic_conditions),
+                                             std_cxx11::_1));
 
 
         typename DoFHandler<dim>::active_cell_iterator

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -317,7 +317,7 @@ namespace aspect
 
 
   template <int dim>
-  const std::map<types::boundary_id,std_cxx1x::shared_ptr<VelocityBoundaryConditions::Interface<dim> > >
+  const std::map<types::boundary_id,std_cxx11::shared_ptr<VelocityBoundaryConditions::Interface<dim> > >
   SimulatorAccess<dim>::get_prescribed_velocity_boundary_conditions () const
   {
     return simulator->velocity_boundary_conditions;

--- a/source/termination_criteria/interface.cc
+++ b/source/termination_criteria/interface.cc
@@ -63,7 +63,7 @@ namespace aspect
     double Manager<dim>::check_for_last_time_step (const double time_step) const
     {
       double new_time_step = time_step;
-      for (typename std::list<std_cxx1x::shared_ptr<Interface<dim> > >::const_iterator
+      for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
            p = termination_objects.begin();
            p != termination_objects.end(); ++p)
         {
@@ -89,7 +89,7 @@ namespace aspect
       // call the execute() functions of all plugins we have
       // here in turns.
       std::list<std::string>::const_iterator  itn = termination_obj_names.begin();;
-      for (typename std::list<std_cxx1x::shared_ptr<Interface<dim> > >::const_iterator
+      for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
            p = termination_objects.begin();
            p != termination_objects.end(); ++p,++itn)
         {
@@ -166,7 +166,7 @@ namespace aspect
 
     namespace
     {
-      std_cxx1x::tuple
+      std_cxx11::tuple
       <void *,
       void *,
       internal::Plugins::PluginList<Interface<2> >,
@@ -191,7 +191,7 @@ namespace aspect
         // construct a string for Patterns::MultipleSelection that
         // contains the names of all registered termination criteria
         const std::string pattern_of_names
-          = std_cxx1x::get<dim>(registered_plugins).get_pattern_of_names ();
+          = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
         prm.declare_entry("Termination criteria",
                           "end time",
                           Patterns::MultipleSelection(pattern_of_names),
@@ -201,13 +201,13 @@ namespace aspect
                           "termination criterion will always be used."
                           "The following termination criteria are available:\n\n"
                           +
-                          std_cxx1x::get<dim>(registered_plugins).get_description_string());
+                          std_cxx11::get<dim>(registered_plugins).get_description_string());
       }
       prm.leave_subsection();
 
       // now declare the parameters of each of the registered
       // plugins in turn
-      std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
+      std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
 
@@ -216,7 +216,7 @@ namespace aspect
     void
     Manager<dim>::parse_parameters (ParameterHandler &prm)
     {
-      Assert (std_cxx1x::get<dim>(registered_plugins).plugins != 0,
+      Assert (std_cxx11::get<dim>(registered_plugins).plugins != 0,
               ExcMessage ("No termination criteria plugins registered!?"));
 
       // first find out which plugins are requested
@@ -238,8 +238,8 @@ namespace aspect
       // their own parameters
       for (unsigned int name=0; name<plugin_names.size(); ++name)
         {
-          termination_objects.push_back (std_cxx1x::shared_ptr<Interface<dim> >
-                                         (std_cxx1x::get<dim>(registered_plugins)
+          termination_objects.push_back (std_cxx11::shared_ptr<Interface<dim> >
+                                         (std_cxx11::get<dim>(registered_plugins)
                                           .create_plugin (plugin_names[name],
                                                           "Termination criteria::Termination criteria")));
           if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(&*termination_objects.back()))
@@ -259,7 +259,7 @@ namespace aspect
                                                   void (*declare_parameters_function) (ParameterHandler &),
                                                   Interface<dim> *(*factory_function) ())
     {
-      std_cxx1x::get<dim>(registered_plugins).register_plugin (name,
+      std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
                                                                declare_parameters_function,
                                                                factory_function);

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -21,7 +21,7 @@
 #include <aspect/global.h>
 #include <aspect/utilities.h>
 
-#include <deal.II/base/std_cxx1x/array.h>
+#include <deal.II/base/std_cxx11/array.h>
 #include <deal.II/base/point.h>
 
 #include <deal.II/base/table.h>
@@ -45,10 +45,10 @@ namespace aspect
     using namespace dealii;
 
     template <int dim>
-    std_cxx1x::array<double,dim>
+    std_cxx11::array<double,dim>
     spherical_coordinates(const Point<dim> &position)
     {
-      std_cxx1x::array<double,dim> scoord;
+      std_cxx11::array<double,dim> scoord;
 
       scoord[0] = position.norm(); // R
       scoord[1] = std::atan2(position(1),position(0)); // Phi
@@ -66,7 +66,7 @@ namespace aspect
 
     template <int dim>
     Point<dim>
-    cartesian_coordinates(const std_cxx1x::array<double,dim> &scoord)
+    cartesian_coordinates(const std_cxx11::array<double,dim> &scoord)
     {
       Point<dim> ccoord;
 
@@ -738,10 +738,10 @@ namespace aspect
     template class AsciiDataInitial<2>;
     template class AsciiDataInitial<3>;
 
-    template Point<2> cartesian_coordinates<2>(const std_cxx1x::array<double,2> &scoord);
-    template Point<3> cartesian_coordinates<3>(const std_cxx1x::array<double,3> &scoord);
+    template Point<2> cartesian_coordinates<2>(const std_cxx11::array<double,2> &scoord);
+    template Point<3> cartesian_coordinates<3>(const std_cxx11::array<double,3> &scoord);
 
-    template std_cxx1x::array<double,2> spherical_coordinates<2>(const Point<2> &position);
-    template std_cxx1x::array<double,3> spherical_coordinates<3>(const Point<3> &position);
+    template std_cxx11::array<double,2> spherical_coordinates<2>(const Point<2> &position);
+    template std_cxx11::array<double,3> spherical_coordinates<3>(const Point<3> &position);
   }
 }

--- a/source/velocity_boundary_conditions/ascii_data.cc
+++ b/source/velocity_boundary_conditions/ascii_data.cc
@@ -38,9 +38,9 @@ namespace aspect
     void
     AsciiData<dim>::initialize ()
     {
-      const std::map<types::boundary_id,std_cxx1x::shared_ptr<VelocityBoundaryConditions::Interface<dim> > >
+      const std::map<types::boundary_id,std_cxx11::shared_ptr<VelocityBoundaryConditions::Interface<dim> > >
       bvs = this->get_prescribed_velocity_boundary_conditions();
-      for (typename std::map<types::boundary_id,std_cxx1x::shared_ptr<VelocityBoundaryConditions::Interface<dim> > >::const_iterator
+      for (typename std::map<types::boundary_id,std_cxx11::shared_ptr<VelocityBoundaryConditions::Interface<dim> > >::const_iterator
            p = bvs.begin();
            p != bvs.end(); ++p)
         {

--- a/source/velocity_boundary_conditions/gplates.cc
+++ b/source/velocity_boundary_conditions/gplates.cc
@@ -132,8 +132,8 @@ namespace aspect
             Tensor<1,3> rotation_axis;
             const double rotation_angle = rotation_axis_from_matrix(rotation_axis,rotation_matrix);
 
-            std_cxx1x::array<double,3> angles = angles_from_matrix(rotation_matrix);
-            std_cxx1x::array<double,3> back_angles = angles_from_matrix(transpose(rotation_matrix));
+            std_cxx11::array<double,3> angles = angles_from_matrix(rotation_matrix);
+            std_cxx11::array<double,3> back_angles = angles_from_matrix(transpose(rotation_matrix));
 
             output << "   Input point 1 spherical coordinates: " << surface_point_one  << std::endl
                    << "   Input point 1 normalized cartesian coordinates: " << point_one  << std::endl
@@ -570,10 +570,10 @@ namespace aspect
         return rotation_angle;
       }
 
-      std_cxx1x::array<double,3>
+      std_cxx11::array<double,3>
       GPlatesLookup::angles_from_matrix(const Tensor<2,3> &rotation_matrix) const
       {
-        std_cxx1x::array<double,3> orientation;
+        std_cxx11::array<double,3> orientation;
 
         /*
          * The following code is part of the VTK project and copied here for
@@ -685,7 +685,7 @@ namespace aspect
       GPlatesLookup::calculate_spatial_index(int *index,
                                              const Tensor<1,3> &position) const
       {
-        const std_cxx1x::array<double,3> scoord =
+        const std_cxx11::array<double,3> scoord =
           ::aspect::Utilities::spherical_coordinates(static_cast<Point<3> > (position));
         index[0] = lround(scoord[2]/delta_theta);
         index[1] = lround(scoord[1]/delta_phi);

--- a/source/velocity_boundary_conditions/interface.cc
+++ b/source/velocity_boundary_conditions/interface.cc
@@ -23,7 +23,7 @@
 #include <aspect/velocity_boundary_conditions/interface.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/std_cxx1x/tuple.h>
+#include <deal.II/base/std_cxx11/tuple.h>
 
 #include <list>
 
@@ -69,7 +69,7 @@ namespace aspect
 
     namespace
     {
-      std_cxx1x::tuple
+      std_cxx11::tuple
       <void *,
       void *,
       internal::Plugins::PluginList<Interface<2> >,
@@ -85,7 +85,7 @@ namespace aspect
                                                  void (*declare_parameters_function) (ParameterHandler &),
                                                  Interface<dim> *(*factory_function) ())
     {
-      std_cxx1x::get<dim>(registered_plugins).register_plugin (name,
+      std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
                                                                declare_parameters_function,
                                                                factory_function);
@@ -96,7 +96,7 @@ namespace aspect
     Interface<dim> *
     create_velocity_boundary_conditions (const std::string &name)
     {
-      Interface<dim> *plugin = std_cxx1x::get<dim>(registered_plugins).create_plugin (name,
+      Interface<dim> *plugin = std_cxx11::get<dim>(registered_plugins).create_plugin (name,
                                                                                       "Velocity boundary conditions");
       return plugin;
     }
@@ -107,7 +107,7 @@ namespace aspect
     std::string
     get_names ()
     {
-      return std_cxx1x::get<dim>(registered_plugins).get_pattern_of_names ();
+      return std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
     }
 
 
@@ -115,7 +115,7 @@ namespace aspect
     void
     declare_parameters (ParameterHandler &prm)
     {
-      std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
+      std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
   }
 }


### PR DESCRIPTION
This has been available since before deal.II 8.2.

This also takes care of a great many Eclipse errors in the code base.