### PR TITLE
Correct the type used to indicator boundary_ids.

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,16 @@
  *
  *
  * <ol>
+ *
+ * <li> Changed: ASPECT accidentally used the type <code>unsigned int</code>
+ * in denoting boundary indicators in BoundaryComposition::Interface::composition()
+ * and BoundaryTemperature::Interface::temperature(), as well as derived
+ * classes' corresponding functions. It should have been the deal.II type
+ * types::boundary_id. This is now fixed. It may require fixing user plugins that
+ * overload these functions.
+ * <br>
+ * (Wolfgang Bangerth, 2015/04/30)
+ *
  * <li> New: ASPECT can now average material properties between the
  * quadrature points of a cell. This greatly increases the stability
  * of solutions in simulations with spatially varying coefficients,

--- a/include/aspect/boundary_composition/ascii_data.h
+++ b/include/aspect/boundary_composition/ascii_data.h
@@ -71,7 +71,7 @@ namespace aspect
          */
         double
         composition (const GeometryModel::Interface<dim> &geometry_model,
-                     const unsigned int                   boundary_indicator,
+                     const types::boundary_id             boundary_indicator,
                      const Point<dim>                    &position,
                      const unsigned int                   compositional_field) const;
 

--- a/include/aspect/boundary_composition/box.h
+++ b/include/aspect/boundary_composition/box.h
@@ -49,7 +49,7 @@ namespace aspect
          */
         virtual
         double composition (const GeometryModel::Interface<dim> &geometry_model,
-                            const unsigned int                   boundary_indicator,
+                            const types::boundary_id             boundary_indicator,
                             const Point<dim>                    &location,
                             const unsigned int                   compositional_field) const;
 

--- a/include/aspect/boundary_composition/initial_composition.h
+++ b/include/aspect/boundary_composition/initial_composition.h
@@ -50,7 +50,7 @@ namespace aspect
          */
         virtual
         double composition (const GeometryModel::Interface<dim> &geometry_model,
-                            const unsigned int                   boundary_indicator,
+                            const types::boundary_id             boundary_indicator,
                             const Point<dim>                    &location,
                             const unsigned int                   compositional_field) const;
 

--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -97,7 +97,7 @@ namespace aspect
          */
         virtual
         double composition (const GeometryModel::Interface<dim> &geometry_model,
-                            const unsigned int                   boundary_indicator,
+                            const types::boundary_id             boundary_indicator,
                             const Point<dim>                    &location,
                             const unsigned int                   compositional_field) const = 0;
 

--- a/include/aspect/boundary_composition/spherical_constant.h
+++ b/include/aspect/boundary_composition/spherical_constant.h
@@ -49,7 +49,7 @@ namespace aspect
          */
         virtual
         double composition (const GeometryModel::Interface<dim> &geometry_model,
-                            const unsigned int                   boundary_indicator,
+                            const types::boundary_id             boundary_indicator,
                             const Point<dim>                    &location,
                             const unsigned int                   compositional_field) const;
 

--- a/include/aspect/boundary_temperature/ascii_data.h
+++ b/include/aspect/boundary_temperature/ascii_data.h
@@ -70,7 +70,7 @@ namespace aspect
          */
         double
         temperature (const GeometryModel::Interface<dim> &geometry_model,
-                     const unsigned int                   boundary_indicator,
+                     const types::boundary_id             boundary_indicator,
                      const Point<dim> &position) const;
 
         /**

--- a/include/aspect/boundary_temperature/box.h
+++ b/include/aspect/boundary_temperature/box.h
@@ -55,7 +55,7 @@ namespace aspect
          */
         virtual
         double temperature (const GeometryModel::Interface<dim> &geometry_model,
-                            const unsigned int                   boundary_indicator,
+                            const types::boundary_id             boundary_indicator,
                             const Point<dim>                    &location) const;
 
         /**

--- a/include/aspect/boundary_temperature/constant.h
+++ b/include/aspect/boundary_temperature/constant.h
@@ -59,7 +59,7 @@ namespace aspect
          */
         virtual
         double temperature (const GeometryModel::Interface<dim> &geometry_model,
-                            const unsigned int                   boundary_indicator,
+                            const types::boundary_id             boundary_indicator,
                             const Point<dim>                    &location) const;
 
         /**

--- a/include/aspect/boundary_temperature/function.h
+++ b/include/aspect/boundary_temperature/function.h
@@ -54,7 +54,7 @@ namespace aspect
         virtual
         double
         temperature (const GeometryModel::Interface<dim> &geometry_model,
-                     const unsigned int                   boundary_indicator,
+                     const types::boundary_id             boundary_indicator,
                      const Point<dim>                    &position) const;
 
         /**

--- a/include/aspect/boundary_temperature/initial_temperature.h
+++ b/include/aspect/boundary_temperature/initial_temperature.h
@@ -57,7 +57,7 @@ namespace aspect
          */
         virtual
         double temperature (const GeometryModel::Interface<dim> &geometry_model,
-                            const unsigned int                   boundary_indicator,
+                            const types::boundary_id             boundary_indicator,
                             const Point<dim>                    &location) const;
 
         /**

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -78,7 +78,7 @@ namespace aspect
          */
         virtual
         double temperature (const GeometryModel::Interface<dim> &geometry_model,
-                            const unsigned int                   boundary_indicator,
+                            const types::boundary_id             boundary_indicator,
                             const Point<dim>                    &location) const = 0;
 
         /**

--- a/include/aspect/boundary_temperature/spherical_constant.h
+++ b/include/aspect/boundary_temperature/spherical_constant.h
@@ -58,7 +58,7 @@ namespace aspect
          */
         virtual
         double temperature (const GeometryModel::Interface<dim> &geometry_model,
-                            const unsigned int                   boundary_indicator,
+                            const types::boundary_id             boundary_indicator,
                             const Point<dim>                    &location) const;
 
         /**

--- a/source/boundary_composition/ascii_data.cc
+++ b/source/boundary_composition/ascii_data.cc
@@ -58,7 +58,7 @@ namespace aspect
     double
     AsciiData<dim>::
     composition (const GeometryModel::Interface<dim> &,
-                 const unsigned int                   boundary_indicator,
+                 const types::boundary_id             boundary_indicator,
                  const Point<dim>                    &position,
                  const unsigned int                   compositional_field) const
     {

--- a/source/boundary_composition/ascii_data.cc
+++ b/source/boundary_composition/ascii_data.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011 - 2014 by the authors of the ASPECT code.
+  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -62,8 +62,7 @@ namespace aspect
                  const Point<dim>                    &position,
                  const unsigned int                   compositional_field) const
     {
-      const types::boundary_id boundary_id(boundary_indicator);
-      return Utilities::AsciiDataBoundary<dim>::get_data_component(boundary_id,
+      return Utilities::AsciiDataBoundary<dim>::get_data_component(boundary_indicator,
                                                                    position,
                                                                    compositional_field);
     }

--- a/source/boundary_composition/box.cc
+++ b/source/boundary_composition/box.cc
@@ -36,7 +36,7 @@ namespace aspect
     double
     Box<dim>::
     composition (const GeometryModel::Interface<dim> &geometry_model,
-                 const unsigned int                   boundary_indicator,
+                 const types::boundary_id             boundary_indicator,
                  const Point<dim> &,
                  const unsigned int                   compositional_field) const
     {

--- a/source/boundary_composition/initial_composition.cc
+++ b/source/boundary_composition/initial_composition.cc
@@ -33,7 +33,7 @@ namespace aspect
     double
     InitialComposition<dim>::
     composition (const GeometryModel::Interface<dim> &,
-                 const unsigned int                   ,
+                 const types::boundary_id             ,
                  const Point<dim>                    &location,
                  const unsigned int                   compositional_field) const
     {

--- a/source/boundary_composition/spherical_constant.cc
+++ b/source/boundary_composition/spherical_constant.cc
@@ -36,7 +36,7 @@ namespace aspect
     double
     SphericalConstant<dim>::
     composition (const GeometryModel::Interface<dim> &geometry_model,
-                 const unsigned int                   boundary_indicator,
+                 const types::boundary_id             boundary_indicator,
                  const Point<dim> &,
                  const unsigned int                   ) const
     {

--- a/source/boundary_temperature/ascii_data.cc
+++ b/source/boundary_temperature/ascii_data.cc
@@ -57,7 +57,7 @@ namespace aspect
     template <int dim>
     double
     AsciiData<dim>::temperature (const GeometryModel::Interface<dim> &,
-                                 const unsigned int                   boundary_indicator,
+                                 const types::boundary_id             boundary_indicator,
                                  const Point<dim>                    &position) const
     {
       const types::boundary_id boundary_id(boundary_indicator);

--- a/source/boundary_temperature/ascii_data.cc
+++ b/source/boundary_temperature/ascii_data.cc
@@ -60,8 +60,7 @@ namespace aspect
                                  const types::boundary_id             boundary_indicator,
                                  const Point<dim>                    &position) const
     {
-      const types::boundary_id boundary_id(boundary_indicator);
-      return Utilities::AsciiDataBoundary<dim>::get_data_component(boundary_id,
+      return Utilities::AsciiDataBoundary<dim>::get_data_component(boundary_indicator,
                                                                    position,
                                                                    0);
     }

--- a/source/boundary_temperature/box.cc
+++ b/source/boundary_temperature/box.cc
@@ -36,7 +36,7 @@ namespace aspect
     double
     Box<dim>::
     temperature (const GeometryModel::Interface<dim> &geometry_model,
-                 const unsigned int                   boundary_indicator,
+                 const types::boundary_id             boundary_indicator,
                  const Point<dim> &) const
     {
       (void)geometry_model;

--- a/source/boundary_temperature/constant.cc
+++ b/source/boundary_temperature/constant.cc
@@ -34,7 +34,7 @@ namespace aspect
     double
     Constant<dim>::
     temperature (const GeometryModel::Interface<dim> &,
-                 const unsigned int                   boundary_indicator,
+                 const types::boundary_id             boundary_indicator,
                  const Point<dim> &) const
     {
       const std::map<types::boundary_id, double>::const_iterator it = boundary_temperatures.find(boundary_indicator);

--- a/source/boundary_temperature/function.cc
+++ b/source/boundary_temperature/function.cc
@@ -38,7 +38,7 @@ namespace aspect
     double
     Function<dim>::
     temperature (const GeometryModel::Interface<dim> &,
-                 const unsigned int                   ,
+                 const types::boundary_id             ,
                  const Point<dim>                    &position) const
     {
       return boundary_temperature_function.value(position);

--- a/source/boundary_temperature/initial_temperature.cc
+++ b/source/boundary_temperature/initial_temperature.cc
@@ -33,7 +33,7 @@ namespace aspect
     double
     InitialTemperature<dim>::
     temperature (const GeometryModel::Interface<dim> &,
-                 const unsigned int                   ,
+                 const types::boundary_id             ,
                  const Point<dim>                    &location) const
     {
       return this->get_initial_conditions().initial_temperature(location);

--- a/source/boundary_temperature/spherical_constant.cc
+++ b/source/boundary_temperature/spherical_constant.cc
@@ -36,7 +36,7 @@ namespace aspect
     double
     SphericalConstant<dim>::
     temperature (const GeometryModel::Interface<dim> &geometry_model,
-                 const unsigned int                   boundary_indicator,
+                 const types::boundary_id             boundary_indicator,
                  const Point<dim> &) const
     {
       (void)geometry_model;

--- a/tests/tangurnis.cc
+++ b/tests/tangurnis.cc
@@ -562,7 +562,7 @@ namespace aspect
        */
       virtual
       double temperature (const GeometryModel::Interface<dim> &geometry_model,
-                          const unsigned int                   boundary_indicator,
+                          const types::boundary_id             boundary_indicator,
                           const Point<dim>                    &location) const;
 
       /**
@@ -590,7 +590,7 @@ namespace aspect
   double
   TanGurnisBoundary<dim>::
   temperature (const GeometryModel::Interface<dim> &geometry_model,
-               const unsigned int                   boundary_indicator,
+               const types::boundary_id             boundary_indicator,
                const Point<dim>                    &location) const
   {
     // verify that the geometry is in fact a box since only

--- a/tests/time-dependent-temperature-bc.cc
+++ b/tests/time-dependent-temperature-bc.cc
@@ -56,7 +56,7 @@ namespace aspect
          */
         virtual
         double temperature (const GeometryModel::Interface<dim> &geometry_model,
-                            const unsigned int                   boundary_indicator,
+                            const types::boundary_id             boundary_indicator,
                             const Point<dim>                    &location) const;
 
         /**
@@ -118,7 +118,7 @@ namespace aspect
     double
     Time_Dep_Box<dim>::
     temperature (const GeometryModel::Interface<dim> &geometry_model,
-                 const unsigned int                   boundary_indicator,
+                 const types::boundary_id             boundary_indicator,
                  const Point<dim>                    &location) const
     {
       // verify that the geometry is in fact a time_dep_box since only


### PR DESCRIPTION
This addresses #310.