### PR TITLE
Add blankenbach test

### DIFF
--- a/tests/blankenbach.prm
+++ b/tests/blankenbach.prm
@@ -1,0 +1,88 @@
+# Listing of Parameters
+# ---------------------
+# This case is identical to case 1a from the Blankenbach Benchmark
+# (Blankenbach 1989). Cases b and c can be run by changing the 
+# Viscosity to 1e-5 and 1e-6, respectively, which leads to the
+# corresponding change of the Rayleigh number from 1e4 to 1e5 and
+# 1e6. 
+# The relevant output is the vrms velocity and the heat flux through
+# the top boundary, which in this setup is identical to the Nu number. 
+
+set End time                               = 0.002 # 1.0 for full benchmark
+set Use years in output instead of seconds = false
+
+
+subsection Boundary temperature model
+  set Model name = box
+  subsection Box
+    set Bottom temperature = 1
+    set Left temperature   = 0
+    set Right temperature  = 0
+    set Top temperature    = 0
+  end
+end
+
+subsection Geometry model
+  set Model name = box 
+
+
+  subsection Box
+    set X extent = 1
+    set Y extent = 1
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 1e3 
+  end
+end
+
+
+subsection Initial conditions
+  set Model name = function
+  subsection Function
+    set Function constants  = z1=0.102367, z2=0.897633, pi=3.14159265359
+    set Function expression = if(z<z1,0.5+0.5*(z1-z)/z1,if(z>z2,0.5*(1-z)/(1-z2),0.5)) + 0.1 * cos(x*pi) * sin(z*pi)
+    set Variable names      = x,z
+  end
+end
+
+
+subsection Material model
+  set Model name = simple 
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 1
+    set Thermal conductivity          = 1
+    set Thermal expansion coefficient = 1e-3
+    set Viscosity                     = 1e-4
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 5
+  set Time steps between mesh refinement = 0
+end
+
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false 
+  set Prescribed velocity boundary indicators = 
+  set Tangential velocity boundary indicators = left, right, bottom, top
+  set Zero velocity boundary indicators       = 
+  set Fixed temperature boundary indicators   = bottom, top
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics
+
+end

--- a/tests/blankenbach.prm
+++ b/tests/blankenbach.prm
@@ -4,7 +4,9 @@
 # (Blankenbach 1989). Cases b and c can be run by changing the 
 # Viscosity to 1e-5 and 1e-6, respectively, which leads to the
 # corresponding change of the Rayleigh number from 1e4 to 1e5 and
-# 1e6. 
+# 1e6. This test essentially resembles the convection-box cookbook
+# and reproduces its results very closely (a slight difference results
+# from the different refinement levels).
 # The relevant output is the vrms velocity and the heat flux through
 # the top boundary, which in this setup is identical to the Nu number. 
 

--- a/tests/blankenbach/screen-output
+++ b/tests/blankenbach/screen-output
@@ -1,0 +1,57 @@
+
+Number of active cells: 1,024 (on 6 levels)
+Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  17.9 m/s, 25.3 m/s
+     Temperature min/avg/max:            0 K, 0.5 K, 1 K
+     Heat fluxes through boundary parts: -5.912e-06 W, 5.912e-06 W, -4.884 W, 4.884 W
+
+*** Timestep 1:  t=0.00061685 seconds
+   Solving temperature system... 29 iterations.
+   Solving Stokes system... 29 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  17.9 m/s, 25.5 m/s
+     Temperature min/avg/max:            0 K, 0.5 K, 1 K
+     Heat fluxes through boundary parts: -2.651e-06 W, 2.674e-06 W, -4.834 W, 4.834 W
+
+*** Timestep 2:  t=0.00122985 seconds
+   Solving temperature system... 21 iterations.
+   Solving Stokes system... 25 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  18 m/s, 25.7 m/s
+     Temperature min/avg/max:            0 K, 0.5 K, 1 K
+     Heat fluxes through boundary parts: -6.051e-06 W, 6.049e-06 W, -4.727 W, 4.728 W
+
+*** Timestep 3:  t=0.00183783 seconds
+   Solving temperature system... 21 iterations.
+   Solving Stokes system... 25 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  18 m/s, 26 m/s
+     Temperature min/avg/max:            0 K, 0.5 K, 1 K
+     Heat fluxes through boundary parts: -6.346e-06 W, 6.341e-06 W, -4.553 W, 4.554 W
+
+*** Timestep 4:  t=0.002 seconds
+   Solving temperature system... 10 iterations.
+   Solving Stokes system... 22 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  18.1 m/s, 26.1 m/s
+     Temperature min/avg/max:            0 K, 0.5 K, 1 K
+     Heat fluxes through boundary parts: -6.552e-06 W, 6.548e-06 W, -4.496 W, 4.496 W
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/blankenbach/statistics
+++ b/tests/blankenbach/statistics
@@ -1,0 +1,25 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Iterations for temperature solver
+# 7: Iterations for Stokes solver
+# 8: Velocity iterations in Stokes preconditioner
+# 9: Schur complement iterations in Stokes preconditioner
+# 10: Time step size (seconds)
+# 11: RMS velocity (m/s)
+# 12: Max. velocity (m/s)
+# 13: Minimal temperature (K)
+# 14: Average temperature (K)
+# 15: Maximal temperature (K)
+# 16: Average nondimensional temperature (K)
+# 17: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 18: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 19: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 20: Outward heat flux through boundary with indicator 3 ("top") (W)
+0 0.0000e+00 1024 9539 4225  0 32 20  3 6.1685e-04 1.79112171e+01 2.53271834e+01 0.00000000e+00 5.00000000e-01 1.00000000e+00 5.00000000e-01 -5.91160354e-06 5.91160354e-06 -4.88438657e+00 4.88438657e+00 
+1 6.1685e-04 1024 9539 4225 29 29 30 30 6.1300e-04 1.79206256e+01 2.54863248e+01 0.00000000e+00 5.00000205e-01 1.00000000e+00 5.00000205e-01 -2.65071185e-06 2.67371774e-06 -4.83412127e+00 4.83417665e+00 
+2 1.2298e-03 1024 9539 4225 21 25 26 26 6.0798e-04 1.79633151e+01 2.56969062e+01 0.00000000e+00 5.00000636e-01 1.00000000e+00 5.00000636e-01 -6.05122683e-06 6.04881120e-06 -4.72744261e+00 4.72759595e+00 
+3 1.8378e-03 1024 9539 4225 21 25 26 26 1.6217e-04 1.80455161e+01 2.59672456e+01 0.00000000e+00 5.00001125e-01 1.00000000e+00 5.00001125e-01 -6.34580370e-06 6.34076600e-06 -4.55340270e+00 4.55368096e+00 
+4 2.0000e-03 1024 9539 4225 10 22 23 23 5.9976e-04 1.80744508e+01 2.60500583e+01 0.00000000e+00 5.00001257e-01 1.00000000e+00 5.00001257e-01 -6.55199727e-06 6.54769574e-06 -4.49593324e+00 4.49624548e+00 


### PR DESCRIPTION
This a test case that exactly resembles the case 1a of the blankenbach 1989 benchmark paper. @jdannberg is currently doing some work with extensions of this benchmark (so this setup is entirely her work), and they will eventually end up in the benchmark folder as well, but in the meantime I thought it might be nice to have one of them as tests to ensure the results do not change during the development. Since this benchmark is often used (and the parameter file we have in cookbooks/future is apparently broken), this might be a way to provide new users a way to reproduce this benchmark results. By the way, does someone remember what the cookbooks/future/blankenbach.prm file was supposed to do? There is no documentation in there and it triggers an assertion about negative density_cp values.