### PR TITLE
Generalize constitutive law with optional tensor

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -1138,6 +1138,54 @@ all sorts of components of models that go beyond the simple Stokes plus
 temperature set of equations. Play with them!
 
 
+\subsection{Constitutive laws}
+
+Equation \eqref{eq:stokes-1} describes buoyancy-driven flow in an isotropic
+fluid where strain rate is related to stress by a scalar (possibly spatially variable)
+multiplier, $\eta$. For some material models it is useful to generalize this
+relationship to anisotropic materials, or other exotic constitutive laws.
+For these cases \aspect{} can optionally include a generalized, fourth-order
+tensor field as a material model state variable which changes equation
+\eqref{eq:stokes-1} to
+\begin{align}
+  \label{eq:stokes-1-anisotropic}
+  -\nabla \cdot \left[2\eta \left(C \varepsilon(\mathbf u)
+                                  - \frac{1}{3}(tr(C \varepsilon(\mathbf u)))\mathbf 1\right)
+                \right] + \nabla p &=
+  \rho \mathbf g
+  & \qquad
+  & \textrm{in $\Omega$}
+\end{align}
+and the shear heating term in equation \eqref{eq:temperature} to
+\begin{align}
+  \label {eq:temperature-anisotropic}
+  \dots
+  \notag
+  \\
+  + 2 \eta
+  \left(C \varepsilon(\mathbf u) - \frac{1}{3}(tr(C \varepsilon(\mathbf u)))\mathbf 1\right)
+  :
+  \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right)
+  \\
+  \dots
+  \notag
+\end{align}
+where $C = C_{ijkl}$ is defined by the material model. For physical reasons, $C$ needs
+to be a symmetric rank-4 tensor: i.e., when multiplied by a symmetric (strain rate)
+tensor of rank 2 it needs to return another symmetric tensor of rank 2. In mathematical
+terms this, this means that $C_{ijkl}=C_{jikl}=C_{ijlk}=C_{jilk}$. Energy considerations
+also require that $C$ is positive definite: i.e., for any $\varepsilon \neq 0$, the
+scalar $\varepsilon : (C \varepsilon)$ must be positive.
+
+This functionality can be optionally invoked by any material model that chooses to
+define a $C$ field, and falls back to the default case ($C=\mathbb I$) if no such
+field is defined. It should be noted that $\eta$ still appears in equations
+\eqref{eq:stokes-1-anisotropic} and \eqref{eq:temperature-anisotropic}. $C$ is
+therefore intended to be thought of as a ``director'' tensor rather than a
+replacement for the viscosity field, although in practice either interpretation
+is okay.
+
+
 \subsection{Numerical methods}
 
 There is no shortage in the literature for methods to solve the equations

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -274,6 +274,20 @@ namespace aspect
       std::vector<double> viscosities;
 
       /**
+       * Stress-strain "director" tensors at the given positions. This
+       * variable can be used to implement exotic rheologies such as
+       * anisotropic viscosity.
+       *
+       * @note The strain rate term in equation (1) of the manual will be
+       * multiplied by this tensor *and* the viscosity scalar ($\eta$), as
+       * described in the manual secion titled "Constitutive laws". This
+       * variable is assigned the rank-four identity tensor by default.
+       * This leaves the isotropic constitutive law unchanged if the material
+       * model does not explicitly assign a value.
+       */
+      std::vector<SymmetricTensor<4,dim> > stress_strain_directors;
+
+      /**
        * Density values at the given positions.
        */
       std::vector<double> densities;
@@ -567,6 +581,13 @@ namespace aspect
          * Specifically, the reference viscosity appears in the factor scaling
          * the pressure against the velocity. It is also used in computing
          * dimension-less quantities.
+         *
+         * @note The reference viscosity should take into account the complete
+         * constitutive relationship, defined as the scalar viscosity times the
+         * constitutive tensor. In most cases, the constitutive tensor will simply
+         * be the identity tensor (this is the default case), but this may become
+         * important for material models with anisotropic viscosities, if the
+         * constitutive tensor is not normalized.
          */
         virtual double reference_viscosity () const = 0;
 

--- a/source/heating_model/shear_heating.cc
+++ b/source/heating_model/shear_heating.cc
@@ -41,15 +41,30 @@ namespace aspect
 
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
         {
-          const SymmetricTensor<2,dim> compressible_strain_rate
-            = (this->get_material_model().is_compressible()
-               ?
-               material_model_inputs.strain_rate[q] - 1./3. * trace(material_model_inputs.strain_rate[q]) * unit_symmetric_tensor<dim>()
-               :
-               material_model_inputs.strain_rate[q]);
+          const SymmetricTensor<4,dim> &C = material_model_outputs.stress_strain_directors[q];
+          const SymmetricTensor<2,dim> &directed_strain_rate = ((C == dealii::identity_tensor<dim> ())
+                                                                ?
+                                                                C * material_model_inputs.strain_rate[q]
+                                                                :
+                                                                material_model_inputs.strain_rate[q]);
 
-          heating_model_outputs.heating_source_terms[q] = 2.0 * material_model_outputs.viscosities[q] *
-                                                          compressible_strain_rate * compressible_strain_rate;
+          const SymmetricTensor<2,dim> stress =
+            2 * material_model_outputs.viscosities[q] *
+            (this->get_material_model().is_compressible()
+             ?
+             directed_strain_rate - 1./3. * trace(directed_strain_rate) * unit_symmetric_tensor<dim>()
+             :
+             directed_strain_rate);
+
+          const SymmetricTensor<2,dim> compressible_strain_rate =
+            (this->get_material_model().is_compressible()
+             ?
+             material_model_inputs.strain_rate[q]
+             - 1./3. * trace(material_model_inputs.strain_rate[q]) * unit_symmetric_tensor<dim>()
+             :
+             material_model_inputs.strain_rate[q]);
+
+          heating_model_outputs.heating_source_terms[q] = stress * compressible_strain_rate;
 
           heating_model_outputs.lhs_latent_heat_terms[q] = 0.0;
         }

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -285,6 +285,7 @@ namespace aspect
                                                     const unsigned int n_comp)
     {
       viscosities.resize(n_points, aspect::Utilities::signaling_nan<double>());
+      stress_strain_directors.resize(n_points, dealii::identity_tensor<dim> ());
       densities.resize(n_points, aspect::Utilities::signaling_nan<double>());
       thermal_expansion_coefficients.resize(n_points, aspect::Utilities::signaling_nan<double>());
       specific_heat.resize(n_points, aspect::Utilities::signaling_nan<double>());

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -997,14 +997,19 @@ namespace aspect
 
         const double eta = scratch.material_model_outputs.viscosities[q];
 
+        const SymmetricTensor<4,dim> &stress_strain_director =
+          scratch.material_model_outputs.stress_strain_directors[q];
+        const bool use_tensor = (stress_strain_director != dealii::identity_tensor<dim> ());
+
         for (unsigned int i=0; i<dofs_per_cell; ++i)
           for (unsigned int j=0; j<dofs_per_cell; ++j)
             if (finite_element.system_to_component_index(i).first
                 ==
                 finite_element.system_to_component_index(j).first)
-              data.local_matrix(i,j) += (eta *
-                                         (scratch.grads_phi_u[i] *
-                                          scratch.grads_phi_u[j])
+              data.local_matrix(i,j) += ((use_tensor ?
+                                          eta * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
+                                          :
+                                          eta * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
                                          +
                                          (1./eta) *
                                          pressure_scaling *
@@ -1197,11 +1202,16 @@ namespace aspect
               }
           }
 
+        // Viscosity scalar
         const double eta = (rebuild_stokes_matrix
                             ?
                             scratch.material_model_outputs.viscosities[q]
                             :
                             std::numeric_limits<double>::quiet_NaN());
+
+        const SymmetricTensor<4,dim> &stress_strain_director =
+          scratch.material_model_outputs.stress_strain_directors[q];
+        const bool use_tensor = (stress_strain_director !=  dealii::identity_tensor<dim> ());
 
         const Tensor<1,dim>
         gravity = gravity_model->gravity_vector (scratch.finite_element_values.quadrature_point(q));
@@ -1217,10 +1227,17 @@ namespace aspect
         if (rebuild_stokes_matrix)
           for (unsigned int i=0; i<dofs_per_cell; ++i)
             for (unsigned int j=0; j<dofs_per_cell; ++j)
-              data.local_matrix(i,j) += ( eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j])
+              data.local_matrix(i,j) += ( (use_tensor ?
+                                           eta * 2.0 * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
+                                           :
+                                           eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
                                           - (is_compressible
                                              ?
-                                             eta * 2.0/3.0 * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
+                                             (use_tensor ?
+                                              eta * 2.0/3.0 * (scratch.div_phi_u[i] * trace(stress_strain_director * scratch.grads_phi_u[j]))
+                                              :
+                                              eta * 2.0/3.0 * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
+                                             )
                                              :
                                              0)
                                           - (pressure_scaling *

--- a/tests/anisotropic_viscosity.cc
+++ b/tests/anisotropic_viscosity.cc
@@ -1,0 +1,161 @@
+#include <aspect/material_model/simple.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    using namespace dealii;
+
+    template <int dim>
+    class Anisotropic : public MaterialModel::Simple<dim>
+    {
+      public:
+
+        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                              MaterialModel::MaterialModelOutputs<dim> &out) const;
+        static void declare_parameters(ParameterHandler &prm);
+        virtual void parse_parameters(ParameterHandler &prm);
+
+        /**
+          * Return true if the compressibility() function returns something that
+          * is not zero.
+          */
+        virtual bool
+        is_compressible () const;
+
+      private:
+        SymmetricTensor<4,dim> C; // Constitutive tensor
+    };
+
+  }
+}
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+
+    template <int dim>
+    void
+    Anisotropic<dim>::
+    evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+             MaterialModel::MaterialModelOutputs<dim> &out) const
+    {
+      Simple<dim>::evaluate(in, out);
+      Point<dim> center;
+      center[0] = 0.5;
+      center[1] = 0.5;
+      if (dim == 3)
+        center[2] = 0.5;
+      for (unsigned int i=0; i < in.position.size(); ++i)
+        {
+          const double pressure = in.pressure[i];
+          out.densities[i] = 1.0 + pressure;
+          out.compressibilities[i] = 1.0 / (1. + pressure);
+          if ((in.position[i]-center).norm() < 0.25)
+            {
+              out.stress_strain_directors[i] = C;
+            }
+        }
+    }
+
+    template <int dim>
+    bool
+    Anisotropic<dim>::
+    is_compressible () const
+    {
+      return true;
+    }
+
+    template <int dim>
+    void
+    Anisotropic<dim>::
+    declare_parameters (ParameterHandler &prm)
+    {
+      Simple<dim>::declare_parameters (prm);
+      prm.enter_subsection ("Material model");
+      {
+        prm.enter_subsection ("Anisotropic");
+        {
+          if (dim == 2)
+            prm.declare_entry ("Viscosity tensor",
+                               "1, 0, 0,"
+                               "0, 1, 0,"
+                               "0, 0,.5",
+                               Patterns::List(Patterns::Double()),
+                               "Viscosity-scaling tensor in Voigt notation.");
+          else
+            prm.declare_entry ("Viscosity tensor",
+                               "1, 0, 0, 0, 0, 0,"
+                               "0, 1, 0, 0, 0, 0,"
+                               "0, 0, 1, 0, 0, 0,"
+                               "0, 0, 0,.5, 0, 0,"
+                               "0, 0, 0, 0,.5, 0,"
+                               "0, 0, 0, 0, 0,.5",
+                               Patterns::List(Patterns::Double()),
+                               "Viscosity-scaling tensor in Voigt notation.");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+    template <int dim>
+    void
+    Anisotropic<dim>::
+    parse_parameters (ParameterHandler &prm)
+    {
+      Simple<dim>::parse_parameters (prm);
+      prm.enter_subsection ("Material model");
+      {
+        prm.enter_subsection ("Anisotropic");
+        {
+          const int size_voigt = (dim == 3 ? 6 : 3);
+          const std::vector<double> tmp_tensor =
+            Utilities::string_to_double(Utilities::split_string_list(prm.get ("Viscosity tensor")));
+          Assert(tmp_tensor.size() == size_voigt*size_voigt,
+                 ExcMessage("Constitutive voigt matrix must have 9 components in 2D, or 36 components in 3d"));
+
+          std::vector<std::vector<double> > voigt_visc_tensor (size_voigt);
+          for (unsigned int i=0; i<size_voigt; ++i)
+            {
+              voigt_visc_tensor[i].resize(size_voigt);
+              for (unsigned int j=0; j<size_voigt; ++j)
+                voigt_visc_tensor[i][j] = tmp_tensor[i*size_voigt+j];
+            }
+
+          // Voigt indices (For mapping back to real tensor)
+          const unsigned int vi3d0[] = {0, 1, 2, 1, 0, 0};
+          const unsigned int vi3d1[] = {0, 1, 2, 2, 2, 1};
+          const unsigned int vi2d0[] = {0, 1, 0};
+          const unsigned int vi2d1[] = {0, 1, 1};
+
+          // Fill the constitutive tensor with values from the Voigt tensor
+          for (unsigned int i=0; i<size_voigt; ++i)
+            for (unsigned int j=0; j<size_voigt; ++j)
+              if (dim == 2)
+                C[vi2d0[i]][vi2d1[i]][vi2d0[j]][vi2d1[j]] = voigt_visc_tensor[i][j];
+              else
+                C[vi3d0[i]][vi3d1[i]][vi3d0[j]][vi3d1[j]] = voigt_visc_tensor[i][j];
+        }
+        prm.leave_subsection ();
+      }
+      prm.leave_subsection ();
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    ASPECT_REGISTER_MATERIAL_MODEL(Anisotropic,
+                                   "anisotropic",
+                                   "A simple material model that is like the "
+                                   "'Simple' model, but has a non-zero compressibility "
+                                   "and always has a blob of anisotropic material in "
+                                   "the center.")
+  }
+}

--- a/tests/anisotropic_viscosity.prm
+++ b/tests/anisotropic_viscosity.prm
@@ -1,0 +1,92 @@
+set Dimension = 2
+set CFL number                             = 1.0
+set End time                               = 0
+set Start time                             = 0
+set Adiabatic surface temperature          = 0
+set Surface pressure                       = 0
+set Use years in output instead of seconds = false  # default: true
+
+set Nonlinear solver scheme                = Stokes only
+set Max nonlinear iterations               = 1
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+subsection Gravity model
+  set Model name = vertical
+end
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+    set Y extent = 1
+    set Z extent = 1
+  end
+end
+
+# temperature field doesn't matter. set it to zero
+subsection Initial conditions
+  set Model name = function
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+# no gravity. the pressure will equal just the dynamic component
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 1.0
+  end
+end
+
+subsection Material model
+  set Model name = anisotropic
+
+  subsection Anisotropic
+    # n = (1,1); eta_s/eta_n = 0.001
+    set Viscosity tensor = 0.501, 0.499, 0.0, \
+                           0.499, 0.501, 0.0, \
+                           0.0,   0.0,   0.5
+  end
+
+  subsection Simple model
+    set Reference density             = 1    # default: 3300
+    set Reference specific heat       = 1250
+    set Reference temperature         = 0    # default: 293
+    set Thermal conductivity          = 1e-6 # default: 4.7
+    set Thermal expansion coefficient = 0
+    set Viscosity                     = 1    # default: 5e24
+  end
+end
+
+subsection Heating model
+  set List of model names = shear heating
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 5
+end
+
+subsection Model settings
+  set Fixed temperature boundary indicators   =
+  set Tangential velocity boundary indicators = 0, 1
+  set Zero velocity boundary indicators       =
+  set Prescribed velocity boundary indicators = 2: function
+  set Include shear heating = false
+end
+
+subsection Boundary velocity model
+  subsection Function
+    set Variable names = x,y
+    set Function expression = 1;1
+  end
+end
+
+subsection Postprocess
+  set List of postprocessors = heating statistics, viscous dissipation statistics, velocity statistics
+end

--- a/tests/anisotropic_viscosity/screen-output
+++ b/tests/anisotropic_viscosity/screen-output
@@ -1,0 +1,39 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.4.pre
+--     . running in OPTIMIZED mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Loading shared library <./libanisotropic_viscosity.so>
+
+Number of active cells: 1,024 (on 6 levels)
+Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
+
+*** Timestep 0:  t=0 seconds
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+15 iterations.
+      Nonlinear Stokes residual: 21.6582
+
+   Postprocessing:
+     Heating rate (average/total):  35.92 W/kg, 47.23 W
+     Total viscous dissipation:     47.3 W
+     RMS, max velocity:             1.22 m/s, 2.05 m/s
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      1.47s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |    0.0987s |       6.7% |
+| Build Stokes preconditioner     |         1 |    0.0504s |       3.4% |
+| Solve Stokes system             |         1 |      1.13s |        77% |
+| Initialization                  |         2 |     0.121s |       8.3% |
+| Postprocessing                  |         1 |    0.0149s |         1% |
+| Setup dof systems               |         1 |    0.0424s |       2.9% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/anisotropic_viscosity/statistics
+++ b/tests/anisotropic_viscosity/statistics
@@ -1,0 +1,15 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Iterations for Stokes solver
+# 7: Velocity iterations in Stokes preconditioner
+# 8: Schur complement iterations in Stokes preconditioner
+# 9: Time step size (seconds)
+# 10: Average shear heating rate (W/kg) 
+# 11: Total shear heating rate (W) 
+# 12: Total viscous dissipation (W)
+# 13: RMS velocity (m/s)
+# 14: Max. velocity (m/s)
+0 0.0000e+00 1024 9539 4225 45 1106 16 7.6305e-03 3.59169534e+01 4.72261510e+01 4.72697927e+01 1.22476546e+00 2.04950484e+00 


### PR DESCRIPTION
Still a work in progress.

Is backwards compatible with isotropic material models: per Timo's suggestion the original viscosity paramter is still used and the optional viscosity tensor is set to the identity by default.

Also, could someone clarify to me how the divergence of u term for the compressible case works in the bilinear form? Does it need to get multiplied by the trace of the viscosity tensor? I think this happens implicitly when viscosity is isotropic, but I've managed to confuse myself about it.