### PR TITLE
Add refinement critereon based on boundary indicator

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -7,17 +7,17 @@
  *
  * <ol>
  *
- * <li> New: There is now a mesh refinement criterion based on
- * refining near a user-specified list of boundary indicators.
- * <br>
- * (Ian Rose, 2015/05/12)
- *
  * <li> Fixed: We now use the correct residual to calculate the stabilization
  * for the advection of temperature and compositional fields. Both the latent
  * heat term for the temperature and the reaction terms for the compositional
  * fields were missing.
  * <br>
  * (Juliane Dannberg, 2015/05/13)
+ *
+ * <li> New: There is now a mesh refinement criterion called Boundary
+ * based on refining near a user-specified list of boundary indicators.
+ * <br>
+ * (Ian Rose, 2015/05/12)
  *
  * <li> Fixed: The advection solver had problems converging for 
  * constant compositional fields in timestep 1. This is fixed now.

--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -7,6 +7,11 @@
  *
  * <ol>
  *
+ * <li> New: There is now a mesh refinement criterion based on
+ * refining near a user-specified list of boundary indicators.
+ * <br>
+ * (Ian Rose, 2015/05/12)
+ *
  * <li> Fixed: We now use the correct residual to calculate the stabilization
  * for the advection of temperature and compositional fields. Both the latent
  * heat term for the temperature and the reaction terms for the compositional

--- a/include/aspect/mesh_refinement/boundary.h
+++ b/include/aspect/mesh_refinement/boundary.h
@@ -46,6 +46,18 @@ namespace aspect
       public:
 
         /**
+         * Execute this mesh refinement criterion.
+         *
+         * @param[out] error_indicators A vector that for every active cell of
+         * the current mesh (which may be a partition of a distributed mesh)
+         * provides an error indicator. This vector will already have the
+         * correct size when the function is called.
+         */
+        virtual
+        void
+        execute (Vector<float> &error_indicators) const;
+
+        /**
          * Declare the parameters this class takes through input files.
          */
         static
@@ -58,18 +70,6 @@ namespace aspect
         virtual
         void
         parse_parameters (ParameterHandler &prm);
-
-        /**
-         * Execute this mesh refinement criterion.
-         *
-         * @param[out] error_indicators A vector that for every active cell of
-         * the current mesh (which may be a partition of a distributed mesh)
-         * provides an error indicator. This vector will already have the
-         * correct size when the function is called.
-         */
-        virtual
-        void
-        execute (Vector<float> &error_indicators) const;
 
       private:
         /**

--- a/include/aspect/mesh_refinement/boundary.h
+++ b/include/aspect/mesh_refinement/boundary.h
@@ -1,0 +1,83 @@
+/*
+  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef __aspect__mesh_refinement_boundary_h
+#define __aspect__mesh_refinement_boundary_h
+
+#include <aspect/mesh_refinement/interface.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+  namespace MeshRefinement
+  {
+
+    /**
+     * A class that implements a mesh refinement criterion that refines the
+     * mesh on selected boundaries. This is useful for cases where one wants
+     * to accurately model processes at a boundary.  Frequently, there are
+     * also strong temperature or compositional gradients at boundaries, so
+     * this refinement criterion can be redundant.
+     *
+     * @ingroup MeshRefinement
+     */
+    template <int dim>
+    class Boundary : public Interface<dim>,
+      public SimulatorAccess<dim>
+    {
+      public:
+
+        /**
+         * Declare the parameters this class takes through input files.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         */
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
+
+        /**
+         * Execute this mesh refinement criterion.
+         *
+         * @param[out] error_indicators A vector that for every active cell of
+         * the current mesh (which may be a partition of a distributed mesh)
+         * provides an error indicator. This vector will already have the
+         * correct size when the function is called.
+         */
+        virtual
+        void
+        execute (Vector<float> &error_indicators) const;
+
+      private:
+        /**
+         * A set of boundary indicators marked for refinement
+         */
+        std::set<types::boundary_id> boundary_refinement_indicators;
+    };
+  }
+}
+
+#endif

--- a/source/mesh_refinement/boundary.cc
+++ b/source/mesh_refinement/boundary.cc
@@ -27,6 +27,41 @@ namespace aspect
   {
     template <int dim>
     void
+    Boundary<dim>::execute(Vector<float> &indicators) const
+    {
+      indicators = 0;
+
+      // iterate over all of the cells and choose the ones at the indicated
+      // boundaries for refinement (assign the largest error to them)
+
+      typename DoFHandler<dim>::active_cell_iterator
+      cell = this->get_dof_handler().begin_active(),
+      endc = this->get_dof_handler().end();
+
+      unsigned int i=0;
+      for (; cell!=endc; ++cell, ++i)
+        if (cell->is_locally_owned() && cell->at_boundary())
+          for (unsigned int face_no=0; face_no<GeometryInfo<dim>::faces_per_cell; ++face_no)
+            if (cell->face(face_no)->at_boundary())
+              {
+                const types::boundary_id boundary_indicator
+#if DEAL_II_VERSION_GTE(8,3,0)
+                  = cell->face(face_no)->boundary_id();
+#else
+                  = cell->face(face_no)->boundary_indicator();
+#endif
+                if ( boundary_refinement_indicators.find(boundary_indicator) !=
+                     boundary_refinement_indicators.end() )
+                  {
+                    indicators(i) = 1.0;
+                    break;  //no need to loop over the rest of the faces
+                  }
+              }
+
+    }
+
+    template <int dim>
+    void
     Boundary<dim>::
     declare_parameters (ParameterHandler &prm)
     {
@@ -72,37 +107,6 @@ namespace aspect
       prm.leave_subsection();
     }
 
-    template <int dim>
-    void
-    Boundary<dim>::execute(Vector<float> &indicators) const
-    {
-      indicators = 0;
-
-      // iterate over all of the cells and choose the ones at the indicated
-      // boundaries for refinement (assign the largest error to them)
-
-      typename DoFHandler<dim>::active_cell_iterator
-      cell = this->get_dof_handler().begin_active(),
-      endc = this->get_dof_handler().end();
-
-      unsigned int i=0;
-      for (; cell!=endc; ++cell, ++i)
-        if (cell->is_locally_owned() && cell->at_boundary())
-          for (unsigned int face_no=0; face_no<GeometryInfo<dim>::faces_per_cell; ++face_no)
-            if (cell->face(face_no)->at_boundary())
-              {
-                const types::boundary_id boundary_indicator
-#if DEAL_II_VERSION_GTE(8,3,0)
-                  = cell->face(face_no)->boundary_id();
-#else
-                  = cell->face(face_no)->boundary_indicator();
-#endif
-                if ( boundary_refinement_indicators.find(boundary_indicator) !=
-                     boundary_refinement_indicators.end() )
-                  indicators(i) = 1.0;
-              }
-
-    }
   }
 }
 

--- a/source/mesh_refinement/boundary.cc
+++ b/source/mesh_refinement/boundary.cc
@@ -1,0 +1,126 @@
+/*
+  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/mesh_refinement/boundary.h>
+
+namespace aspect
+{
+  namespace MeshRefinement
+  {
+    template <int dim>
+    void
+    Boundary<dim>::
+    declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Mesh refinement");
+      {
+        prm.enter_subsection("Boundary");
+        {
+          prm.declare_entry ("Boundary refinement indicators", "",
+                             Patterns::List (Patterns::Anything()),
+                             "A comma separated list of names denoting those boundaries "
+                             "where there should be mesh refinement."
+                             "\n\n"
+                             "The names of the boundaries listed here can either be "
+                             "numbers (in which case they correspond to the numerical "
+                             "boundary indicators assigned by the geometry object), or they "
+                             "can correspond to any of the symbolic names the geometry object "
+                             "may have provided for each part of the boundary. You may want "
+                             "to compare this with the documentation of the geometry model you "
+                             "use in your model.");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+    template <int dim>
+    void
+    Boundary<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Mesh refinement");
+      {
+        prm.enter_subsection("Boundary");
+        {
+          const std::vector<types::boundary_id> x_boundary_refinement_indicators
+            = this->get_geometry_model().translate_symbolic_boundary_names_to_ids(Utilities::split_string_list
+                                                                                  (prm.get ("Boundary refinement indicators")));
+          boundary_refinement_indicators
+            = std::set<types::boundary_id> (x_boundary_refinement_indicators.begin(),
+                                            x_boundary_refinement_indicators.end());
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+    template <int dim>
+    void
+    Boundary<dim>::execute(Vector<float> &indicators) const
+    {
+      indicators = 0;
+
+      // iterate over all of the cells and choose the ones at the indicated
+      // boundaries for refinement (assign the largest error to them)
+
+      typename DoFHandler<dim>::active_cell_iterator
+      cell = this->get_dof_handler().begin_active(),
+      endc = this->get_dof_handler().end();
+
+      unsigned int i=0;
+      for (; cell!=endc; ++cell, ++i)
+        if (cell->is_locally_owned() && cell->at_boundary())
+          for (unsigned int face_no=0; face_no<GeometryInfo<dim>::faces_per_cell; ++face_no)
+            if (cell->face(face_no)->at_boundary())
+              {
+                const types::boundary_id boundary_indicator
+#if DEAL_II_VERSION_GTE(8,3,0)
+                  = cell->face(face_no)->boundary_id();
+#else
+                  = cell->face(face_no)->boundary_indicator();
+#endif
+                if ( boundary_refinement_indicators.find(boundary_indicator) !=
+                     boundary_refinement_indicators.end() )
+                  indicators(i) = 1.0;
+              }
+
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace MeshRefinement
+  {
+    ASPECT_REGISTER_MESH_REFINEMENT_CRITERION(Boundary,
+                                              "boundary",
+                                              "A class that implements a mesh refinement criterion which "
+                                              "always flags all cells on specified boundaries for refinement. "
+                                              "This is useful to provide high accuracy for processes at or "
+                                              "close to the edge of the model domain."
+                                              "\n\n"
+                                              "To use this refinement criterion, you may want to combine "
+                                              "it with other refinement criteria, setting the 'Normalize "
+                                              "individual refinement criteria' flag and using the 'max' "
+                                              "setting for 'Refinement criteria merge operation'.")
+  }
+}

--- a/tests/refinement_boundary.prm
+++ b/tests/refinement_boundary.prm
@@ -1,0 +1,109 @@
+# Test that we indeed refine the boundaries when using the
+# 'boundary' mesh refinement criterion
+#
+# As far as output is concerned, all we care about is the number
+# of cells, which is always printed by default.
+
+set Dimension = 2
+
+
+set CFL number                             = 1.0
+
+set End time                               = 0
+
+
+set Resume computation                     = false
+
+set Start time                             = 0
+
+set Adiabatic surface temperature          = 0
+
+set Surface pressure                       = 0
+
+set Use years in output instead of seconds = false  # default: true
+
+set Nonlinear solver scheme                = IMPES
+
+subsection Boundary temperature model
+  set Model name = box
+
+end
+
+
+subsection Discretization
+  set Stokes velocity polynomial degree       = 2
+
+  set Temperature polynomial degree           = 2
+
+  set Use locally conservative discretization = false
+
+  subsection Stabilization parameters
+    set alpha = 2
+
+    set beta  = 0.078
+
+    set cR    = 0.5   # default: 0.11
+  end
+
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+
+    set Y extent = 1
+
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+end
+
+
+subsection Initial conditions
+  set Model name = perturbed box
+
+end
+
+
+subsection Material model
+  set Model name = simple
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 3
+  set Initial global refinement          = 2
+
+  set Strategy                           = boundary
+  subsection Boundary
+    set Boundary refinement indicators = top, bottom, left, right
+  end
+end
+
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false # default: true
+
+
+  set Fixed temperature boundary indicators   = 0, 1
+
+  set Prescribed velocity boundary indicators =
+
+  set Tangential velocity boundary indicators = 0,1,2,3
+
+  set Zero velocity boundary indicators       =
+end
+
+
+subsection Postprocess
+  set List of postprocessors =
+end
+

--- a/tests/refinement_boundary/screen-output
+++ b/tests/refinement_boundary/screen-output
@@ -1,0 +1,63 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.3.pre
+--     . running in OPTIMIZED mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Number of active cells: 16 (on 3 levels)
+Number of degrees of freedom: 268 (162+25+81)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 17 iterations.
+
+Number of active cells: 52 (on 4 levels)
+Number of degrees of freedom: 844 (514+73+257)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 17 iterations.
+
+Number of active cells: 136 (on 5 levels)
+Number of degrees of freedom: 2,204 (1,346+185+673)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 16 iterations.
+
+Number of active cells: 316 (on 6 levels)
+Number of degrees of freedom: 5,132 (3,138+425+1,569)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.196s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         4 |     0.026s |        13% |
+| Assemble temperature system     |         4 |    0.0165s |       8.4% |
+| Build Stokes preconditioner     |         4 |     0.035s |        18% |
+| Build temperature preconditioner|         4 |   0.00367s |       1.9% |
+| Solve Stokes system             |         4 |    0.0437s |        22% |
+| Solve temperature system        |         4 |   0.00106s |      0.54% |
+| Initialization                  |         5 |    0.0294s |        15% |
+| Postprocessing                  |         1 |   3.6e-05s |     0.018% |
+| Refine mesh structure, part 1   |         3 |   0.00306s |       1.6% |
+| Refine mesh structure, part 2   |         3 |   0.00215s |       1.1% |
+| Setup dof systems               |         4 |    0.0314s |        16% |
++---------------------------------+-----------+------------+------------+
+


### PR DESCRIPTION
Similar to the topography refinement strategy, but the user gives a list of boundary indicators for refinement.  Sometimes the user may want refinement at the boundaries, even if there are no strong gradients there to trip other refinement criteria.