### PR TITLE
Potential bug in CMakeList.txt in test folder

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -257,7 +257,7 @@ FOREACH(_test ${_tests})
 	  | egrep -v '^--'
 	  | sed 's\#${ASPECT_BASE_DIR}\#ASPECT_DIR\#g'
 	  > ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}.notime
-	DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output
+	DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}
 		${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}.cmp.notime
       )
 


### PR DESCRIPTION
When I ran ctest on my computer it was passing some test even though the statistics files were different.  Upon investigation, Timo and I believe we found a bug in the CMakeLists.txt file in the test directory.