### PR TITLE
Revert "Potential bug in CMakeList.txt in test folder"

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -257,7 +257,7 @@ FOREACH(_test ${_tests})
 	  | egrep -v '^--'
 	  | sed 's\#${ASPECT_BASE_DIR}\#ASPECT_DIR\#g'
 	  > ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}.notime
-	DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}
+	DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output
 		${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}.cmp.notime
       )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -250,6 +250,10 @@ FOREACH(_test ${_tests})
 	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_test}/${_output}
       )
 
+      # While it looks like a typo to depend on screen-output and not on
+      # ${_output}, there is no rule to generate ${_output}. But generating
+      # screen-output will of course generate all output files (including
+      # ${_output}), so this rule will work as expected.
       ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}.notime
 	COMMAND
 	  cat ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}


### PR DESCRIPTION
Reverts geodynamics/aspect#333

I think this was a mistake. Nearly all test are failing on mainline now, see [1]. The reason is that there is no target to generate ${_output}. If we depend on screen-output on the other hand, we will run the test and therefore generate ${_output}.

[1]: http://www.math.clemson.edu/~heister/aspect-logs/bf886f8e63f43dbac73899f346454ca807013884/