### PR TITLE
[WIP] testing: move diff reporting to shell script

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,9 +67,9 @@ SET_IF_EMPTY(TEST_TIME_LIMIT 600)
 ADD_CUSTOM_TARGET(tests)
 
 #
-# We need a diff tool, preferably numdiff:
+# We need a diff tool, preferably numdiff otherwise diff. Let the user
+# override it by specifying TEST_DIFF.
 #
-
 FIND_PROGRAM(DIFF_EXECUTABLE
   NAMES diff
   HINTS ${DIFF_DIR}
@@ -86,14 +86,9 @@ MARK_AS_ADVANCED(DIFF_EXECUTABLE NUMDIFF_EXECUTABLE)
 
 IF("${TEST_DIFF}" STREQUAL "")
   #
-  # No TEST_DIFF is set, specify one:
-  #
 
   IF(NOT NUMDIFF_EXECUTABLE MATCHES "-NOTFOUND")
-    SET(TEST_DIFF ${NUMDIFF_EXECUTABLE} -a 1e-6 -r 1e-8 -s ' \\t\\n:,')
-    IF(DIFF_EXECUTABLE MATCHES "-NOTFOUND")
-      SET(DIFF_EXECUTABLE ${NUMDIFF_EXECUTABLE})
-    ENDIF()
+    SET(TEST_DIFF ${NUMDIFF_EXECUTABLE})
   ELSEIF(NOT DIFF_EXECUTABLE MATCHES "-NOTFOUND")
     SET(TEST_DIFF ${DIFF_EXECUTABLE})
   ELSE()
@@ -114,6 +109,9 @@ FOREACH(_test ${_tests})
   CHECK_LINEAR_ALGEBRA(${CMAKE_CURRENT_SOURCE_DIR}/${_test}.prm)
 
   IF("${_use_test}" STREQUAL "1")
+
+    # main target for this test:
+    ADD_CUSTOM_TARGET(tests.${_test})
 
     MATH(EXPR _n_tests "${_n_tests} + 1")
 
@@ -214,13 +212,6 @@ FOREACH(_test ${_tests})
     ENDIF()
 
 
-    # The final target for this test
-    ADD_CUSTOM_TARGET(${_test}.run
-      DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output
-      )
-
-
-    ADD_CUSTOM_TARGET(tests.${_test})
 
 
     # for each of the output files saved in the source directory for
@@ -268,20 +259,11 @@ FOREACH(_test ${_tests})
       # create the target that compares the .notime with the saved file
       ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}.diff
 	COMMAND
-	  if (${TEST_DIFF} ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}.cmp.notime
-		${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}.notime
-	      > ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}.diff) \; then
-	    : \;
-	  else
-	    mv ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}.diff
-	       ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}.diff.failed \;
-	    echo "******* Error during diffing output results for ${_test}/${_output}" \;
-	    echo "******* Results are stored in ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}.diff.failed" \;
-	    echo "******* Check: ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output} ${CMAKE_CURRENT_SOURCE_DIR}/${_test}/${_output}" \;
-	    echo "******* Diffs are:" \;
-	    cat ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}.diff.failed \;
-	    false \;
-	  fi
+	    ${CMAKE_CURRENT_SOURCE_DIR}/diff_test.sh 
+		${TEST_DIFF}
+		${_test}/${_output}
+		${CMAKE_CURRENT_SOURCE_DIR}
+		${CMAKE_CURRENT_BINARY_DIR}
 	DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}.cmp.notime
 		${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/${_output}.notime
       )

--- a/tests/diff_test.sh
+++ b/tests/diff_test.sh
@@ -10,12 +10,12 @@
 DIFF_EXE=$1
 
 # 2. short name of the reference file: "testname/filename"
-PRETTY_FILENAME=$2
+PRETTY_TEST_AND_FILENAME=$2
 
-# 3.
+# 3. absolute cmake source directory
 CMAKE_CURRENT_SOURCE_DIR=$3
 
-# 4.
+# 4. absolute cmake binary directory
 CMAKE_CURRENT_BINARY_DIR=$4
 
 
@@ -24,19 +24,19 @@ CMAKE_CURRENT_BINARY_DIR=$4
 #
 
 # the reference file to compare with: "filename.cmp.notime"
-REF_FILE=${CMAKE_CURRENT_BINARY_DIR}/output-${PRETTY_FILENAME}.cmp.notime
+REF_FILE=${CMAKE_CURRENT_BINARY_DIR}/output-${PRETTY_TEST_AND_FILENAME}.cmp.notime
 
 # filename to compare: "filename.notime"
-GEN_FILE=${CMAKE_CURRENT_BINARY_DIR}/output-${PRETTY_FILENAME}.notime
+GEN_FILE=${CMAKE_CURRENT_BINARY_DIR}/output-${PRETTY_TEST_AND_FILENAME}.notime
 
 # filename to write the diff output into: "filename.diff"
-DIFF_OUTPUT=${CMAKE_CURRENT_BINARY_DIR}/output-${PRETTY_FILENAME}.diff
+DIFF_OUTPUT=${CMAKE_CURRENT_BINARY_DIR}/output-${PRETTY_TEST_AND_FILENAME}.diff
 
 # full path of the original (unprocessed reference file)
-ORIGINAL_REF_FULL_PATH=${CMAKE_CURRENT_SOURCE_DIR}/${PRETTY_FILENAME}
+ORIGINAL_REF_FULL_PATH=${CMAKE_CURRENT_SOURCE_DIR}/${PRETTY_TEST_AND_FILENAME}
 
 # full path of the generated filename (without .notime)
-ORIGINAL_GEN_FULL_PATH=${CMAKE_CURRENT_BINARY_DIR}/output-${PRETTY_FILENAME}
+ORIGINAL_GEN_FULL_PATH=${CMAKE_CURRENT_BINARY_DIR}/output-${PRETTY_TEST_AND_FILENAME}
 
 
 #
@@ -57,7 +57,7 @@ esac
 
 if [ $? -ne 0 ]; then
   mv ${DIFF_OUTPUT}.tmp ${DIFF_OUTPUT}.failed
-  echo "******* Error during diffing output results for ${PRETTY_FILENAME}"
+  echo "******* Error during diffing output results for ${PRETTY_TEST_AND_FILENAME}"
   echo "******* Results are stored in ${DIFF_OUTPUT}.failed"
   echo "******* Check ${ORIGINAL_GEN_FULL_PATH} ${ORIGINAL_REF_FULL_PATH}"
   echo "******* 50 lines of diffs are:"

--- a/tests/diff_test.sh
+++ b/tests/diff_test.sh
@@ -40,31 +40,31 @@ ORIGINAL_GEN_FULL_PATH=${CMAKE_CURRENT_BINARY_DIR}/output-${PRETTY_FILENAME}
 
 
 #
-# finally do the work
+# Finally do the work.
 #
 
-rm -f ${DIFF_OUTPUT}.failed
-
-echo "HELLO ${DIFF_EXE}"
+rm -f ${DIFF_OUTPUT}.failed ${DIFF_OUTPUT}
 
 case ${DIFF_EXE} in
     *numdiff)
 	${DIFF_EXE} -a 1e-6 -r 1e-8 -s ' \t\n:<>=,;' \
-	    ${REF_FILE} ${GEN_FILE} > ${DIFF_OUTPUT}
+	    ${REF_FILE} ${GEN_FILE} > ${DIFF_OUTPUT}.tmp
 	;;
     *)
 	"${DIFF_EXE}" \
-	    ${REF_FILE} ${GEN_FILE} > ${DIFF_OUTPUT}
+	    ${REF_FILE} ${GEN_FILE} > ${DIFF_OUTPUT}.tmp
 esac
 
 if [ $? -ne 0 ]; then
-  mv ${DIFF_OUTPUT} ${DIFF_OUTPUT}.failed
+  mv ${DIFF_OUTPUT}.tmp ${DIFF_OUTPUT}.failed
   echo "******* Error during diffing output results for ${PRETTY_FILENAME}"
   echo "******* Results are stored in ${DIFF_OUTPUT}.failed"
   echo "******* Check ${ORIGINAL_GEN_FULL_PATH} ${ORIGINAL_REF_FULL_PATH}"
   echo "******* 50 lines of diffs are:"
   head -n 50 ${DIFF_OUTPUT}.failed
   exit 1
+else
+  mv ${DIFF_OUTPUT}.tmp ${DIFF_OUTPUT}
 fi
 
 exit 0

--- a/tests/diff_test.sh
+++ b/tests/diff_test.sh
@@ -1,0 +1,70 @@
+# Script for diffing a certain output file of a test and printing nice output
+#
+# While we could put this code into CMakeLists.txt, cmake prints the whole
+# command that failed, which will be really long and ugly. This way, only the
+# line executing this script will show up.
+
+# Call this script with 4 parameters:
+
+# 1. name/path of diff executable
+DIFF_EXE=$1
+
+# 2. short name of the reference file: "testname/filename"
+PRETTY_FILENAME=$2
+
+# 3.
+CMAKE_CURRENT_SOURCE_DIR=$3
+
+# 4.
+CMAKE_CURRENT_BINARY_DIR=$4
+
+
+#
+# now generate filenames with full paths
+#
+
+# the reference file to compare with: "filename.cmp.notime"
+REF_FILE=${CMAKE_CURRENT_BINARY_DIR}/output-${PRETTY_FILENAME}.cmp.notime
+
+# filename to compare: "filename.notime"
+GEN_FILE=${CMAKE_CURRENT_BINARY_DIR}/output-${PRETTY_FILENAME}.notime
+
+# filename to write the diff output into: "filename.diff"
+DIFF_OUTPUT=${CMAKE_CURRENT_BINARY_DIR}/output-${PRETTY_FILENAME}.diff
+
+# full path of the original (unprocessed reference file)
+ORIGINAL_REF_FULL_PATH=${CMAKE_CURRENT_SOURCE_DIR}/${PRETTY_FILENAME}
+
+# full path of the generated filename (without .notime)
+ORIGINAL_GEN_FULL_PATH=${CMAKE_CURRENT_BINARY_DIR}/output-${PRETTY_FILENAME}
+
+
+#
+# finally do the work
+#
+
+rm -f ${DIFF_OUTPUT}.failed
+
+echo "HELLO ${DIFF_EXE}"
+
+case ${DIFF_EXE} in
+    *numdiff)
+	${DIFF_EXE} -a 1e-6 -r 1e-8 -s ' \t\n:<>=,;' \
+	    ${REF_FILE} ${GEN_FILE} > ${DIFF_OUTPUT}
+	;;
+    *)
+	"${DIFF_EXE}" \
+	    ${REF_FILE} ${GEN_FILE} > ${DIFF_OUTPUT}
+esac
+
+if [ $? -ne 0 ]; then
+  mv ${DIFF_OUTPUT} ${DIFF_OUTPUT}.failed
+  echo "******* Error during diffing output results for ${PRETTY_FILENAME}"
+  echo "******* Results are stored in ${DIFF_OUTPUT}.failed"
+  echo "******* Check ${ORIGINAL_GEN_FULL_PATH} ${ORIGINAL_REF_FULL_PATH}"
+  echo "******* 50 lines of diffs are:"
+  head -n 50 ${DIFF_OUTPUT}.failed
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This is similar to how we do it in deal.II. The advantage is that the
output is a lot cleaner because cmake reports the whole command that
fails (which is now just referencing the shell script).

Also remove some weird logic and an unused target.