### PR TITLE
Produce a compile time error if libz was not detected.

### DIFF
--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -128,7 +128,10 @@ namespace aspect
           f.write((char *)&compressed_data[0], compressed_data_length);
         }
 #else
-#  error "You need to have deal.II configured with the 'libz' option to support checkpoint/restart, but deal.II did not detect its presence when you called 'cmake'."
+      AssertThrow (false,
+                   ExcMessage ("You need to have deal.II configured with the 'libz' "
+                               "option to support checkpoint/restart, but deal.II "
+                               "did not detect its presence when you called 'cmake'."));
 #endif
 
     }
@@ -233,7 +236,10 @@ namespace aspect
           ia >> (*this);
         }
 #else
-	// no need to repeat the #error directive from above -- the error is still the same
+        AssertThrow (false,
+                     ExcMessage ("You need to have deal.II configured with the 'libz' "
+                                 "option to support checkpoint/restart, but deal.II "
+                                 "did not detect its presence when you called 'cmake'."));
 #endif
       }
     catch (std::exception &e)

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -25,7 +25,9 @@
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/distributed/solution_transfer.h>
 
-#include <zlib.h>
+#ifdef DEAL_II_WITH_ZLIB
+#  include <zlib.h>
+#endif
 
 namespace aspect
 {
@@ -100,6 +102,7 @@ namespace aspect
       oa << (*this);
 
       // compress with zlib and write to file on the root processor
+#ifdef DEAL_II_WITH_ZLIB
       if (my_id == 0)
         {
           uLongf compressed_data_length = compressBound (oss.str().length());
@@ -124,6 +127,9 @@ namespace aspect
           f.write((const char *)compression_header, 4 * sizeof(compression_header[0]));
           f.write((char *)&compressed_data[0], compressed_data_length);
         }
+#else
+#  error "You need to have deal.II configured with the 'libz' option to support checkpoint/restart, but deal.II did not detect its presence when you called 'cmake'."
+#endif
 
     }
     pcout << "*** Snapshot created!" << std::endl << std::endl;
@@ -199,6 +205,7 @@ namespace aspect
     // read zlib compressed resume.z
     try
       {
+#ifdef DEAL_II_WITH_ZLIB
         std::ifstream ifs ((parameters.output_directory + "restart.resume.z").c_str());
         AssertThrow(ifs.is_open(),
                     ExcMessage("Cannot open snapshot resume file."));
@@ -225,6 +232,9 @@ namespace aspect
           aspect::iarchive ia (ss);
           ia >> (*this);
         }
+#else
+	// no need to repeat the #error directive from above -- the error is still the same
+#endif
       }
     catch (std::exception &e)
       {

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -72,6 +72,13 @@ namespace aspect
                        "A flag indicating whether the computation should be resumed from "
                        "a previously saved state (if true) or start from scratch (if false).");
 
+#ifndef DEAL_II_WITH_ZLIB
+    AssertThrow (resume_computation == false,
+                 ExcMessage ("You need to have deal.II configured with the 'libz' "
+                             "option if you want to resume a computation from a checkpoint, but deal.II "
+                             "did not detect its presence when you called 'cmake'."));
+#endif
+
     prm.declare_entry ("Max nonlinear iterations", "10",
                        Patterns::Integer (0),
                        "The maximal number of nonlinear iterations to be performed.");
@@ -806,6 +813,15 @@ namespace aspect
     {
       checkpoint_time_secs = prm.get_integer ("Time between checkpoint");
       checkpoint_steps     = prm.get_integer ("Steps between checkpoint");
+
+#ifndef DEAL_II_WITH_ZLIB
+      AssertThrow ((checkpoint_time_secs == 0)
+                   &&
+                   (checkpoint_steps == 0),
+                   ExcMessage ("You need to have deal.II configured with the 'libz' "
+                               "option if you want to generate checkpoints, but deal.II "
+                               "did not detect its presence when you called 'cmake'."));
+#endif
     }
     prm.leave_subsection ();
 


### PR DESCRIPTION
This is better than creating the link-time error that a bunch of symbols are undefined.