### PR TITLE
Remove a marker that still dates to subversion times.

### DIFF
--- a/AspectConfig.cmake.in
+++ b/AspectConfig.cmake.in
@@ -16,9 +16,6 @@
 # along with ASPECT; see the file doc/COPYING.  If not see
 # <http://www.gnu.org/licenses/>.
 
-#  $Id$
-
-
 
 # This file provides a macro that authors can use to
 # set up a directory with source files that will then be


### PR DESCRIPTION
The marker made sense when we still used svn, but is no longer relevant with git.