### PR TITLE
change heating interface

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,11 @@
  *
  *
  * <ol>
+ * <li> Changed: The specific heating plugin has a new interface now; it gets
+ * the material model inputs and outputs and fills a vector with heating
+ * model outputs for the whole cell.
+ * <br>
+ * (Juliane Dannberg, 2015/05/20)
  *
  * </ol>
  */

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -23,6 +23,7 @@
 #define __aspect__heating_model_interface_h
 
 #include <aspect/plugins.h>
+#include <aspect/material_model/interface.h>
 
 #include <deal.II/base/point.h>
 #include <deal.II/base/parameter_handler.h>
@@ -77,6 +78,19 @@ namespace aspect
         virtual
         void
         update ();
+
+        /**
+         * Function to compute the heating terms in @p heating_outputs given the
+         * inputs in @p material_model_inputs and the outputs of the material
+         * model in @p material_model_outputs.
+         * The default implementation calls specific_heating_rate to make
+         * this implementation backwards compatible.
+         */
+        virtual
+        void
+        execute (const typename aspect::MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
+                 const typename aspect::MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
+                 std::vector<double> &heating_outputs);
 
         /**
          * Return the specific heating rate as a function of position.

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -82,7 +82,9 @@ namespace aspect
         /**
          * Function to compute the heating terms in @p heating_outputs given the
          * inputs in @p material_model_inputs and the outputs of the material
-         * model in @p material_model_outputs.
+         * model in @p material_model_outputs. The @p heating_outputs vector is
+         * filled with the value of the heating rate at each quadrature point as
+         * defined in @p material_model_inputs.
          * The default implementation calls specific_heating_rate to make
          * this implementation backwards compatible.
          */
@@ -90,7 +92,7 @@ namespace aspect
         void
         execute (const typename aspect::MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
                  const typename aspect::MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
-                 std::vector<double> &heating_outputs);
+                 std::vector<double> &heating_outputs) const;
 
         /**
          * Return the specific heating rate as a function of position.
@@ -100,7 +102,7 @@ namespace aspect
         specific_heating_rate (const double temperature,
                                const double pressure,
                                const std::vector<double> &compositional_fields,
-                               const Point<dim> &position) const = 0;
+                               const Point<dim> &position) const DEAL_II_DEPRECATED = 0;
 
         /**
          * Declare the parameters this class takes through input files. The

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -90,9 +90,9 @@ namespace aspect
          */
         virtual
         void
-        execute (const typename aspect::MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
-                 const typename aspect::MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
-                 std::vector<double> &heating_outputs) const;
+        evaluate (const typename aspect::MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
+                  const typename aspect::MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
+                  std::vector<double> &heating_outputs) const;
 
         /**
          * Return the specific heating rate as a function of position.

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -612,6 +612,7 @@ namespace aspect
       double compute_heating_term(const internal::Assembly::Scratch::AdvectionSystem<dim>  &scratch,
                                   typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
                                   typename MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
+                                  const double heating_model_output,
                                   const AdvectionField &advection_field,
                                   const unsigned int q) const;
 

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -602,9 +602,7 @@ namespace aspect
 
       /**
        * Compute the heating term for the advection system index. Currently
-       * the heating term is 0 for compositional fields, but this can be
-       * changed in the future to allow for interactions between compositional
-       * fields.
+       * the heating term is 0 for compositional fields.
        *
        * This function is implemented in
        * <code>source/simulator/assembly.cc</code>.
@@ -612,7 +610,7 @@ namespace aspect
       double compute_heating_term(const internal::Assembly::Scratch::AdvectionSystem<dim>  &scratch,
                                   typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
                                   typename MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
-                                  const double heating_model_output,
+                                  const double specific_heating_rate,
                                   const AdvectionField &advection_field,
                                   const unsigned int q) const;
 

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -53,6 +53,22 @@ namespace aspect
 
     template <int dim>
     void
+    Interface<dim>::execute (const typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
+                             const typename MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
+                             std::vector<double> &heating_outputs)
+    {
+      for (unsigned int i=0; i<heating_outputs.size(); ++i)
+        {
+          heating_outputs[i] = specific_heating_rate(material_model_inputs.temperature[i],
+                                                     material_model_inputs.pressure[i],
+                                                     material_model_inputs.composition[i],
+                                                     material_model_inputs.position[i]);
+        }
+    }
+
+
+    template <int dim>
+    void
     Interface<dim>::
     declare_parameters (dealii::ParameterHandler &)
     {}
@@ -75,7 +91,6 @@ namespace aspect
       internal::Plugins::PluginList<Interface<2> >,
       internal::Plugins::PluginList<Interface<3> > > registered_plugins;
     }
-
 
 
     template <int dim>

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -53,20 +53,18 @@ namespace aspect
 
     template <int dim>
     void
-    Interface<dim>::execute (const typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
-                             const typename MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
-                             std::vector<double> &heating_outputs) const
+    Interface<dim>::evaluate (const typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
+                              const typename MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
+                              std::vector<double> &heating_outputs) const
     {
-      for (unsigned int i=0; i<heating_outputs.size(); ++i)
-        {
-          Assert(heating_outputs.size() == material_model_inputs.position.size(),
-                 ExcMessage ("Heating outputs need to have the same number of entries as the material model inputs."));
+      Assert(heating_outputs.size() == material_model_inputs.position.size(),
+             ExcMessage ("Heating outputs need to have the same number of entries as the material model inputs."));
 
-          heating_outputs[i] = specific_heating_rate(material_model_inputs.temperature[i],
-                                                     material_model_inputs.pressure[i],
-                                                     material_model_inputs.composition[i],
-                                                     material_model_inputs.position[i]);
-        }
+      for (unsigned int q=0; q<heating_outputs.size(); ++q)
+        heating_outputs[q] = specific_heating_rate(material_model_inputs.temperature[q],
+                                                   material_model_inputs.pressure[q],
+                                                   material_model_inputs.composition[q],
+                                                   material_model_inputs.position[q]);
     }
 
 

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -55,10 +55,13 @@ namespace aspect
     void
     Interface<dim>::execute (const typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
                              const typename MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
-                             std::vector<double> &heating_outputs)
+                             std::vector<double> &heating_outputs) const
     {
       for (unsigned int i=0; i<heating_outputs.size(); ++i)
         {
+          Assert(heating_outputs.size() == material_model_inputs.position.size(),
+                 ExcMessage ("Heating outputs need to have the same number of entries as the material model inputs."));
+
           heating_outputs[i] = specific_heating_rate(material_model_inputs.temperature[i],
                                                      material_model_inputs.pressure[i],
                                                      material_model_inputs.composition[i],

--- a/source/postprocess/internal_heating_statistics.cc
+++ b/source/postprocess/internal_heating_statistics.cc
@@ -89,15 +89,17 @@ namespace aspect
 
             this->get_material_model().evaluate(in, out);
 
+            std::vector<double> heating_model_outputs(n_q_points);
+            heating_model.execute(in,
+                                  out,
+                                  heating_model_outputs);
+
             for (unsigned int q=0; q<n_q_points; ++q)
               {
                 for (unsigned c=0; c<this->n_compositional_fields(); c++)
                   in.composition[q][c] = composition_values[c][q];
 
-                local_internal_heating_integrals += heating_model.specific_heating_rate(in.temperature[q],
-                                                                                        in.pressure[q],
-                                                                                        in.composition[q],
-                                                                                        in.position[q])
+                local_internal_heating_integrals += heating_model_outputs[q]
                                                     * out.densities[q] * fe_values.JxW(q);
 
                 local_mass += out.densities[q] * fe_values.JxW(q);

--- a/source/postprocess/internal_heating_statistics.cc
+++ b/source/postprocess/internal_heating_statistics.cc
@@ -56,6 +56,7 @@ namespace aspect
 
       in.strain_rate.resize(0); // we do not need the viscosity
       std::vector<std::vector<double> > composition_values (this->n_compositional_fields(),std::vector<double> (quadrature_formula.size()));
+      std::vector<double> heating_model_outputs(n_q_points);
 
       typename DoFHandler<dim>::active_cell_iterator
       cell = this->get_dof_handler().begin_active(),
@@ -88,17 +89,10 @@ namespace aspect
             in.position = fe_values.get_quadrature_points();
 
             this->get_material_model().evaluate(in, out);
-
-            std::vector<double> heating_model_outputs(n_q_points);
-            heating_model.execute(in,
-                                  out,
-                                  heating_model_outputs);
+            heating_model.evaluate(in, out, heating_model_outputs);
 
             for (unsigned int q=0; q<n_q_points; ++q)
               {
-                for (unsigned c=0; c<this->n_compositional_fields(); c++)
-                  in.composition[q][c] = composition_values[c][q];
-
                 local_internal_heating_integrals += heating_model_outputs[q]
                                                     * out.densities[q] * fe_values.JxW(q);
 

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -610,9 +610,9 @@ namespace aspect
     const unsigned int n_q_points = scratch.old_field_values->size();
 
     std::vector<double> heating_model_outputs(n_q_points);
-    heating_model->execute(scratch.material_model_inputs,
-                           scratch.material_model_outputs,
-                           heating_model_outputs);
+    heating_model->evaluate(scratch.material_model_inputs,
+                            scratch.material_model_outputs,
+                            heating_model_outputs);
 
     for (unsigned int q=0; q < n_q_points; ++q)
       {
@@ -1360,7 +1360,7 @@ namespace aspect
   Simulator<dim>::compute_heating_term(const internal::Assembly::Scratch::AdvectionSystem<dim>  &scratch,
                                        typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
                                        typename MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
-                                       const double heating_model_output,
+                                       const double specific_heating_rate,
                                        const AdvectionField     &advection_field,
                                        const unsigned int q) const
   {
@@ -1388,7 +1388,7 @@ namespace aspect
     gravity = gravity_model->gravity_vector (scratch.finite_element_values.quadrature_point(q));
 
     const double gamma
-      = (heating_model_output * density
+      = (specific_heating_rate * density
          +
          // add the term 2*eta*(eps - 1/3*(tr eps)1):(eps - 1/3*(tr eps)1)
          //
@@ -1580,9 +1580,9 @@ namespace aspect
                                                scratch.material_model_outputs);
 
     std::vector<double> heating_model_outputs(n_q_points);
-    heating_model->execute(scratch.material_model_inputs,
-                           scratch.material_model_outputs,
-                           heating_model_outputs);
+    heating_model->evaluate(scratch.material_model_inputs,
+                            scratch.material_model_outputs,
+                            heating_model_outputs);
 
     if (advection_field.is_temperature())
       {

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -609,6 +609,11 @@ namespace aspect
   {
     const unsigned int n_q_points = scratch.old_field_values->size();
 
+    std::vector<double> heating_model_outputs(n_q_points);
+    heating_model->execute(scratch.material_model_inputs,
+                           scratch.material_model_outputs,
+                           heating_model_outputs);
+
     for (unsigned int q=0; q < n_q_points; ++q)
       {
         const Tensor<1,dim> u = (scratch.old_velocity_values[q] +
@@ -629,10 +634,12 @@ namespace aspect
 
         const double field = ((*scratch.old_field_values)[q] + (*scratch.old_old_field_values)[q]) / 2;
 
+
         const double gamma
           = compute_heating_term(scratch,
                                  scratch.explicit_material_model_inputs,
                                  scratch.explicit_material_model_outputs,
+                                 heating_model_outputs[q],
                                  advection_field,
                                  q);
 
@@ -1353,6 +1360,7 @@ namespace aspect
   Simulator<dim>::compute_heating_term(const internal::Assembly::Scratch::AdvectionSystem<dim>  &scratch,
                                        typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
                                        typename MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
+                                       const double heating_model_output,
                                        const AdvectionField     &advection_field,
                                        const unsigned int q) const
   {
@@ -1369,10 +1377,6 @@ namespace aspect
     const double density              = material_model_outputs.densities[q];
     const double viscosity            = material_model_outputs.viscosities[q];
     const bool is_compressible        = material_model->is_compressible();
-    const double specific_radiogenic_heating_rate = heating_model->specific_heating_rate(material_model_inputs.temperature[q],
-                                                    material_model_inputs.pressure[q],
-                                                    material_model_inputs.composition[q],
-                                                    material_model_inputs.position[q]);
     const double compressibility      = (is_compressible
                                          ?
                                          material_model_outputs.compressibilities[q]
@@ -1384,7 +1388,7 @@ namespace aspect
     gravity = gravity_model->gravity_vector (scratch.finite_element_values.quadrature_point(q));
 
     const double gamma
-      = (specific_radiogenic_heating_rate * density
+      = (heating_model_output * density
          +
          // add the term 2*eta*(eps - 1/3*(tr eps)1):(eps - 1/3*(tr eps)1)
          //
@@ -1575,6 +1579,11 @@ namespace aspect
                                                scratch.finite_element_values.get_mapping(),
                                                scratch.material_model_outputs);
 
+    std::vector<double> heating_model_outputs(n_q_points);
+    heating_model->execute(scratch.material_model_inputs,
+                           scratch.material_model_outputs,
+                           heating_model_outputs);
+
     if (advection_field.is_temperature())
       {
         for (unsigned int q=0; q<n_q_points; ++q)
@@ -1652,6 +1661,7 @@ namespace aspect
         const double gamma = compute_heating_term(scratch,
                                                   scratch.material_model_inputs,
                                                   scratch.material_model_outputs,
+                                                  heating_model_outputs[q],
                                                   advection_field,
                                                   q);
         const double reaction_term =


### PR DESCRIPTION
Change the interface of the heating model plugin so that it gets the material model inputs and outputs. 
This is a first step towards moving all of the heating terms into the heating model. 