### PR TITLE
Remove an unnecessary include file.

### DIFF
--- a/include/aspect/material_model/simpler.h
+++ b/include/aspect/material_model/simpler.h
@@ -23,7 +23,6 @@
 #define __aspect__model_simpler_h
 
 #include <aspect/material_model/interface.h>
-#include <aspect/simulator_access.h>
 
 namespace aspect
 {


### PR DESCRIPTION
As reported by Rene at the hackathon, this #include file is not actually necessary.