### PR TITLE
Velocity and Cell Reference in material interface

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -153,7 +153,9 @@ namespace aspect
       /**
        * Velocity values at the points given in the #position vector.
        * This value is mostly important in the case of determining
-       * whether material crossed a certain region (e.g. a phase boundary)
+       * whether material crossed a certain region (e.g. a phase boundary).
+       * The timestep that is needed for this check can be requested from
+       * SimulatorAccess.
        */
       std::vector<Tensor<1,dim> > velocity;
 
@@ -181,10 +183,12 @@ namespace aspect
       /**
        * Optional reference to the cell that contains these quadrature
        * points. This allows for evaluating properties at the cell vertices
-       * and interpolating to the quadrature points. Note that not all
-       * calling functions can set this reference, so make sure that
-       * your material model either fails with a proper error message in
-       * these cases or provide an alternative calculation for these cases.
+       * and interpolating to the quadrature points, or to query the cell for
+       * material ids, neighbors, or other information that is not available
+       * solely from the locations. Note that not all calling functions can set
+       * this reference. In these cases it will be a NULL pointer, so make sure
+       * that your material model either fails with a proper error message
+       * or provide an alternative calculation for these cases.
        */
       const typename DoFHandler<dim>::active_cell_iterator *cell;
     };

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011, 2012, 2013, 2014, 2015 by the authors of the ASPECT code.
+  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -28,6 +28,7 @@
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/fe/mapping.h>
 
 namespace aspect
@@ -150,6 +151,13 @@ namespace aspect
       std::vector<double> pressure;
 
       /**
+       * Velocity values at the points given in the #position vector.
+       * This value is mostly important in the case of determining
+       * whether material crossed a certain region (e.g. a phase boundary)
+       */
+      std::vector<Tensor<1,dim> > velocity;
+
+      /**
        * Values of the compositional fields at the points given in the
        * #position vector: composition[i][c] is the compositional field c at
        * point i.
@@ -169,6 +177,16 @@ namespace aspect
        * u^T) - \frac 13 \nabla \cdot \mathbf u \mathbf 1$.
        */
       std::vector<SymmetricTensor<2,dim> > strain_rate;
+
+      /**
+       * Optional reference to the cell that contains these quadrature
+       * points. This allows for evaluating properties at the cell vertices
+       * and interpolating to the quadrature points. Note that not all
+       * calling functions can set this reference, so make sure that
+       * your material model either fails with a proper error message in
+       * these cases or provide an alternative calculation for these cases.
+       */
+      const typename DoFHandler<dim>::active_cell_iterator *cell;
     };
 
 

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1016,7 +1016,7 @@ namespace aspect
        * <code>source/simulator/assembly.cc</code>.
        */
       void
-      compute_material_model_input_values (const LinearAlgebra::BlockVector                    &input_solution,
+      compute_material_model_input_values (const LinearAlgebra::BlockVector                            &input_solution,
                                            const FEValues<dim,dim>                                     &input_finite_element_values,
                                            const bool                                                   compute_strainrate,
                                            typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs) const;

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1018,6 +1018,7 @@ namespace aspect
       void
       compute_material_model_input_values (const LinearAlgebra::BlockVector                            &input_solution,
                                            const FEValues<dim,dim>                                     &input_finite_element_values,
+                                           const typename DoFHandler<dim>::active_cell_iterator        &cell,
                                            const bool                                                   compute_strainrate,
                                            typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs) const;
 

--- a/source/adiabatic_conditions/initial_profile.cc
+++ b/source/adiabatic_conditions/initial_profile.cc
@@ -72,6 +72,7 @@ namespace aspect
           in.position[0] = representative_point;
           in.temperature[0] = temperatures[i-1];
           in.pressure[0] = pressures[i-1];
+          in.velocity[0] = Tensor <1,dim> ();
 
           for (unsigned int c=0; c<n_compositional_fields; ++c)
             in.composition[0][c] = this->get_compositional_initial_conditions().initial_composition(representative_point, c);

--- a/source/initial_conditions/adiabatic.cc
+++ b/source/initial_conditions/adiabatic.cc
@@ -80,6 +80,7 @@ namespace aspect
       in.position[0]=position;
       in.temperature[0]=this->get_adiabatic_conditions().temperature(position);
       in.pressure[0]=this->get_adiabatic_conditions().pressure(position);
+      in.velocity[0]= Tensor<1,dim> ();
       for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
         in.composition[0][c] = function->value(Point<1>(depth),c);
       in.strain_rate.resize(0); // adiabat has strain=0.

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -317,10 +317,12 @@ namespace aspect
       position.resize(n_points);
       temperature.resize(n_points);
       pressure.resize(n_points);
+      velocity.resize(n_points);
       composition.resize(n_points);
       for (unsigned int q=0; q<n_points; ++q)
         composition[q].resize(n_comp);
       strain_rate.resize(n_points);
+      cell = 0;
     }
 
 

--- a/source/mesh_refinement/density.cc
+++ b/source/mesh_refinement/density.cc
@@ -81,6 +81,8 @@ namespace aspect
                                                                                       in.pressure);
             fe_values[this->introspection().extractors.temperature].get_function_values (this->get_solution(),
                                                                                          in.temperature);
+            fe_values[this->introspection().extractors.velocities].get_function_values (this->get_solution(),
+                                                                                        in.velocity);
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
               fe_values[this->introspection().extractors.compositional_fields[c]].get_function_values (this->get_solution(),
                   prelim_composition_values[c]);
@@ -92,6 +94,8 @@ namespace aspect
                 for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
                   in.composition[i][c] = prelim_composition_values[c][i];
               }
+            in.cell = &cell;
+
             this->get_material_model().evaluate(in, out);
 
             cell->get_dof_indices (local_dof_indices);

--- a/source/mesh_refinement/thermal_energy_density.cc
+++ b/source/mesh_refinement/thermal_energy_density.cc
@@ -56,6 +56,7 @@ namespace aspect
                                update_quadrature_points | update_values);
       std::vector<double> pressure_values(quadrature.size());
       std::vector<double> temperature_values(quadrature.size());
+      std::vector<Tensor<1,dim> > velocity_values(quadrature.size());
 
       // the values of the compositional fields are stored as blockvectors for each field
       // we have to extract them in this structure
@@ -78,6 +79,8 @@ namespace aspect
                                                                                       pressure_values);
             fe_values[this->introspection().extractors.temperature].get_function_values (this->get_solution(),
                                                                                          temperature_values);
+            fe_values[this->introspection().extractors.velocities].get_function_values (this->get_solution(),
+                                                                                        velocity_values);
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
               fe_values[this->introspection().extractors.compositional_fields[c]].get_function_values (this->get_solution(),
                   prelim_composition_values[c]);
@@ -92,6 +95,8 @@ namespace aspect
                 for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
                   in.composition[i][c] = prelim_composition_values[c][i];
               }
+            in.cell = &cell;
+
             this->get_material_model().evaluate(in, out);
 
             // for each temperature dof, write into the output

--- a/source/mesh_refinement/thermal_energy_density.cc
+++ b/source/mesh_refinement/thermal_energy_density.cc
@@ -54,16 +54,11 @@ namespace aspect
                                this->get_fe(),
                                quadrature,
                                update_quadrature_points | update_values);
-      std::vector<double> pressure_values(quadrature.size());
-      std::vector<double> temperature_values(quadrature.size());
-      std::vector<Tensor<1,dim> > velocity_values(quadrature.size());
 
       // the values of the compositional fields are stored as blockvectors for each field
       // we have to extract them in this structure
       std::vector<std::vector<double> > prelim_composition_values (this->n_compositional_fields(),
                                                                    std::vector<double> (quadrature.size()));
-      std::vector<std::vector<double> > composition_values (quadrature.size(),
-                                                            std::vector<double> (this->n_compositional_fields()));
 
       typename MaterialModel::Interface<dim>::MaterialModelInputs in(quadrature.size(), this->n_compositional_fields());
       typename MaterialModel::Interface<dim>::MaterialModelOutputs out(quadrature.size(), this->n_compositional_fields());
@@ -76,11 +71,11 @@ namespace aspect
           {
             fe_values.reinit(cell);
             fe_values[this->introspection().extractors.pressure].get_function_values (this->get_solution(),
-                                                                                      pressure_values);
+                                                                                      in.pressure);
             fe_values[this->introspection().extractors.temperature].get_function_values (this->get_solution(),
-                                                                                         temperature_values);
+                                                                                         in.temperature);
             fe_values[this->introspection().extractors.velocities].get_function_values (this->get_solution(),
-                                                                                        velocity_values);
+                                                                                        in.velocity);
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
               fe_values[this->introspection().extractors.compositional_fields[c]].get_function_values (this->get_solution(),
                   prelim_composition_values[c]);
@@ -90,8 +85,6 @@ namespace aspect
             in.strain_rate.resize(0);// we are not reading the viscosity
             for (unsigned int i=0; i<quadrature.size(); ++i)
               {
-                in.temperature[i] = temperature_values[i];
-                in.pressure[i] = pressure_values[i];
                 for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
                   in.composition[i][c] = prelim_composition_values[c][i];
               }
@@ -110,7 +103,7 @@ namespace aspect
 
                 vec_distributed(local_dof_indices[system_local_dof])
                   = out.densities[i]
-                    * temperature_values[i]
+                    * in.temperature[i]
                     * out.specific_heat[i];
               }
           }

--- a/source/mesh_refinement/viscosity.cc
+++ b/source/mesh_refinement/viscosity.cc
@@ -83,7 +83,8 @@ namespace aspect
                                                                                          in.temperature);
             fe_values[this->introspection().extractors.velocities].get_function_symmetric_gradients (this->get_solution(),
                 in.strain_rate);
-
+            fe_values[this->introspection().extractors.velocities].get_function_values (this->get_solution(),
+                                                                                        in.velocity);
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
               fe_values[this->introspection().extractors.compositional_fields[c]].get_function_values (this->get_solution(),
                   prelim_composition_values[c]);
@@ -94,6 +95,8 @@ namespace aspect
                 for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
                   in.composition[i][c] = prelim_composition_values[c][i];
               }
+            in.cell = &cell;
+
             this->get_material_model().evaluate(in, out);
 
             cell->get_dof_indices (local_dof_indices);

--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -96,6 +96,8 @@ namespace aspect
               fe_values[this->introspection().extractors.pressure]
               .get_function_values (this->get_solution(), in.pressure);
               fe_values[this->introspection().extractors.velocities]
+              .get_function_values (this->get_solution(), in.velocity);
+              fe_values[this->introspection().extractors.velocities]
               .get_function_symmetric_gradients (this->get_solution(), in.strain_rate);
 
 
@@ -110,6 +112,7 @@ namespace aspect
                   for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
                     in.composition[i][c] = composition_values[c][i];
                 }
+              in.cell = &cell;
 
               this->get_material_model().evaluate(in, out);
 

--- a/source/postprocess/heat_flux_statistics.cc
+++ b/source/postprocess/heat_flux_statistics.cc
@@ -92,6 +92,8 @@ namespace aspect
                     in.temperature);
                 fe_face_values[this->introspection().extractors.pressure].get_function_values (this->get_solution(),
                                                                                                in.pressure);
+                fe_face_values[this->introspection().extractors.velocities].get_function_values (this->get_solution(),
+                    in.velocity);
                 for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
                   fe_face_values[this->introspection().extractors.compositional_fields[c]].get_function_values(this->get_solution(),
                       composition_values[c]);
@@ -110,6 +112,7 @@ namespace aspect
                     for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
                       in.composition[i][c] = composition_values[c][i];
                   }
+                in.cell = &cell;
 
                 this->get_material_model().evaluate(in, out);
 

--- a/source/postprocess/internal_heating_statistics.cc
+++ b/source/postprocess/internal_heating_statistics.cc
@@ -76,6 +76,9 @@ namespace aspect
             fe_values[this->introspection().extractors.pressure]
             .get_function_values (this->get_solution(),
                                   in.pressure);
+            fe_values[this->introspection().extractors.velocities]
+            .get_function_values (this->get_solution(),
+                                  in.velocity);
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
               fe_values[this->introspection().extractors.compositional_fields[c]]
               .get_function_values(this->get_solution(),
@@ -87,6 +90,7 @@ namespace aspect
               }
 
             in.position = fe_values.get_quadrature_points();
+            in.cell = &cell;
 
             this->get_material_model().evaluate(in, out);
             heating_model.evaluate(in, out, heating_model_outputs);

--- a/source/postprocess/mass_flux_statistics.cc
+++ b/source/postprocess/mass_flux_statistics.cc
@@ -122,6 +122,7 @@ namespace aspect
                     for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
                       in.composition[i][c] = composition_values[c][i];
                   }
+                in.cell = &cell;
 
                 this->get_material_model().evaluate(in, out);
 

--- a/source/postprocess/mass_flux_statistics.cc
+++ b/source/postprocess/mass_flux_statistics.cc
@@ -71,7 +71,6 @@ namespace aspect
                                         update_normal_vectors |
                                         update_q_points       | update_JxW_values);
 
-      std::vector<Tensor<1,dim> > velocities (quadrature_formula.size());
       std::vector<std::vector<double> > composition_values (this->n_compositional_fields(),std::vector<double> (quadrature_formula.size()));
 
       std::map<types::boundary_id, double> local_boundary_fluxes;
@@ -99,7 +98,7 @@ namespace aspect
               {
                 fe_face_values.reinit (cell, f);
                 fe_face_values[this->introspection().extractors.velocities].get_function_values (this->get_solution(),
-                    velocities);
+                    in.velocity);
                 fe_face_values[this->introspection().extractors.temperature].get_function_values (this->get_solution(),
                     in.temperature);
                 fe_face_values[this->introspection().extractors.pressure].get_function_values (this->get_solution(),
@@ -133,7 +132,7 @@ namespace aspect
                     local_normal_flux
                     +=
                       out.densities[q]
-                      * (velocities[q] * fe_face_values.normal_vector(q))
+                      * (in.velocity[q] * fe_face_values.normal_vector(q))
                       * fe_face_values.JxW(q);
                   }
 

--- a/source/postprocess/table_heat_flux_statistics.cc
+++ b/source/postprocess/table_heat_flux_statistics.cc
@@ -97,6 +97,8 @@ namespace aspect
                     in.temperature);
                 fe_face_values[this->introspection().extractors.pressure].get_function_values (this->get_solution(),
                                                                                                in.pressure);
+                fe_face_values[this->introspection().extractors.velocities].get_function_values (this->get_solution(),
+                    in.velocity);
                 for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
                   fe_face_values[this->introspection().extractors.compositional_fields[c]].get_function_values(this->get_solution(),
                       composition_values[c]);
@@ -108,6 +110,7 @@ namespace aspect
                     for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
                       in.composition[i][c] = composition_values[c][i];
                   }
+                in.cell = &cell;
 
                 this->get_material_model().evaluate(in, out);
 

--- a/source/postprocess/viscous_dissipation_statistics.cc
+++ b/source/postprocess/viscous_dissipation_statistics.cc
@@ -78,6 +78,8 @@ namespace aspect
                                                                                       in.pressure);
             fe_values[this->introspection().extractors.temperature].get_function_values (this->get_solution(),
                                                                                          in.temperature);
+            fe_values[this->introspection().extractors.velocities].get_function_values (this->get_solution(),
+                                                                                        in.velocity);
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
               fe_values[this->introspection().extractors.compositional_fields[c]].get_function_values
               (this->get_solution(),prelim_composition_values[c]);
@@ -90,6 +92,7 @@ namespace aspect
 
             fe_values[this->introspection().extractors.velocities].get_function_symmetric_gradients (this->get_solution(),
                 in.strain_rate);
+            in.cell = &cell;
 
             // get the viscosity from the material model
             this->get_material_model().evaluate(in, out);

--- a/source/postprocess/visualization/density.cc
+++ b/source/postprocess/visualization/density.cc
@@ -66,6 +66,8 @@ namespace aspect
           {
             in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
             in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            for (unsigned int i = 0; i < dim; ++i)
+              in.velocity[q][i]=uh[q][this->introspection().component_indices.velocities[i]];
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
               in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];

--- a/source/postprocess/visualization/dynamic_topography.cc
+++ b/source/postprocess/visualization/dynamic_topography.cc
@@ -101,6 +101,8 @@ namespace aspect
                 fe_values[this->introspection().extractors.pressure]
                 .get_function_values (this->get_solution(), in.pressure);
                 fe_values[this->introspection().extractors.velocities]
+                .get_function_values (this->get_solution(), in.velocity);
+                fe_values[this->introspection().extractors.velocities]
                 .get_function_symmetric_gradients (this->get_solution(), in.strain_rate);
 
 

--- a/source/postprocess/visualization/friction_heating.cc
+++ b/source/postprocess/visualization/friction_heating.cc
@@ -71,6 +71,8 @@ namespace aspect
 
             in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
             in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            for (unsigned int i = 0; i < dim; ++i)
+              in.velocity[q][i]=uh[q][this->introspection().component_indices.velocities[i]];
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
               in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];

--- a/source/postprocess/visualization/material_properties.cc
+++ b/source/postprocess/visualization/material_properties.cc
@@ -112,7 +112,11 @@ namespace aspect
           {
             Tensor<2,dim> grad_u;
             for (unsigned int d=0; d<dim; ++d)
-              grad_u[d] = duh[q][d];
+              {
+                grad_u[d] = duh[q][d];
+                in.velocity[q][d] = uh[q][this->introspection().component_indices.velocities[d]];
+              }
+
             in.strain_rate[q] = symmetrize (grad_u);
 
             in.pressure[q]=uh[q][this->introspection().component_indices.pressure];

--- a/source/postprocess/visualization/specific_heat.cc
+++ b/source/postprocess/visualization/specific_heat.cc
@@ -66,6 +66,8 @@ namespace aspect
           {
             in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
             in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            for (unsigned int i = 0; i < dim; ++i)
+              in.velocity[q][i]=uh[q][this->introspection().component_indices.velocities[i]];
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
               in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];

--- a/source/postprocess/visualization/thermal_expansivity.cc
+++ b/source/postprocess/visualization/thermal_expansivity.cc
@@ -67,6 +67,8 @@ namespace aspect
             //in.strain_rate[q] =
             in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
             in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            for (unsigned int i = 0; i < dim; ++i)
+              in.velocity[q][i]=uh[q][this->introspection().component_indices.velocities[i]];
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
               in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];

--- a/source/postprocess/visualization/viscosity.cc
+++ b/source/postprocess/visualization/viscosity.cc
@@ -71,6 +71,8 @@ namespace aspect
 
             in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
             in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            for (unsigned int i = 0; i < dim; ++i)
+              in.velocity[q][i]=uh[q][this->introspection().component_indices.velocities[i]];
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
               in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -866,6 +866,7 @@ namespace aspect
 
         compute_material_model_input_values (current_linearization_point,
                                              scratch.finite_element_values,
+                                             cell,
                                              true,
                                              scratch.material_model_inputs);
         material_model->evaluate(scratch.material_model_inputs,scratch.material_model_outputs);
@@ -881,6 +882,7 @@ namespace aspect
               scratch.explicit_material_model_inputs.composition[q][c] = (scratch.old_composition_values[c][q] + scratch.old_old_composition_values[c][q]) / 2;
             scratch.explicit_material_model_inputs.strain_rate[q] = (scratch.old_strain_rates[q] + scratch.old_old_strain_rates[q]) / 2;
           }
+        scratch.explicit_material_model_inputs.cell = &cell;
 
         material_model->evaluate(scratch.explicit_material_model_inputs,scratch.explicit_material_model_outputs);
 
@@ -903,6 +905,7 @@ namespace aspect
   Simulator<dim>::
   compute_material_model_input_values (const LinearAlgebra::BlockVector                            &input_solution,
                                        const FEValues<dim>                                         &input_finite_element_values,
+                                       const typename DoFHandler<dim>::active_cell_iterator        &cell,
                                        const bool                                                   compute_strainrate,
                                        typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs) const
   {
@@ -942,10 +945,7 @@ namespace aspect
       for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
         material_model_inputs.composition[q][c] = composition_values[c][q];
 
-    typename Triangulation<dim>::active_cell_iterator cell = input_finite_element_values.get_cell();
-    typename DoFHandler<dim>::active_cell_iterator dof_cell(&triangulation,cell->level(),cell->index(),&dof_handler);
-
-    material_model_inputs.cell = &dof_cell;
+    material_model_inputs.cell = &cell;
   }
 
 
@@ -965,6 +965,7 @@ namespace aspect
 
     compute_material_model_input_values (current_linearization_point,
                                          scratch.finite_element_values,
+                                         cell,
                                          true,
                                          scratch.material_model_inputs);
 
@@ -1158,6 +1159,7 @@ namespace aspect
     // which we only need when rebuilding the matrix
     compute_material_model_input_values (current_linearization_point,
                                          scratch.finite_element_values,
+                                         cell,
                                          rebuild_stokes_matrix,
                                          scratch.material_model_inputs);
 
@@ -1579,6 +1581,7 @@ namespace aspect
 
     compute_material_model_input_values (current_linearization_point,
                                          scratch.finite_element_values,
+                                         cell,
                                          true,
                                          scratch.material_model_inputs);
     material_model->evaluate(scratch.material_model_inputs,
@@ -1601,6 +1604,8 @@ namespace aspect
             scratch.explicit_material_model_inputs.temperature[q] = (scratch.old_temperature_values[q] + scratch.old_old_temperature_values[q]) / 2;
             scratch.explicit_material_model_inputs.position[q] = scratch.finite_element_values.quadrature_point(q);
             scratch.explicit_material_model_inputs.pressure[q] = (scratch.old_pressure[q] + scratch.old_old_pressure[q]) / 2;
+            scratch.explicit_material_model_inputs.velocity[q] = (scratch.old_velocity_values[q] + scratch.old_old_velocity_values[q]) / 2;
+
             for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
               scratch.explicit_material_model_inputs.composition[q][c] = (scratch.old_composition_values[c][q] + scratch.old_old_composition_values[c][q]) / 2;
             scratch.explicit_material_model_inputs.strain_rate[q] = (scratch.old_strain_rates[q] + scratch.old_old_strain_rates[q]) / 2;

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -335,9 +335,11 @@ namespace aspect
                   in.position[q] = fe_values.quadrature_point(q);
                   in.temperature[q] = temperature_values[q];
                   in.pressure[q] = pressure_values[q];
+                  in.velocity[q] = velocity_values[q];
                   for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
                     in.composition[q][c] = composition_values_at_q_point[c];
                 }
+              in.cell = &cell;
 
               material_model->evaluate(in, out);
 
@@ -977,6 +979,8 @@ namespace aspect
                                                                                 in.pressure);
               fe_values[introspection.extractors.temperature].get_function_values (this->solution,
                                                                                    in.temperature);
+              fe_values[introspection.extractors.velocities].get_function_values (this->solution,
+                                                                                  in.velocity);
               fe_values[introspection.extractors.velocities].get_function_symmetric_gradients (this->solution,
                   in.strain_rate);
               for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
@@ -989,6 +993,8 @@ namespace aspect
                   for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
                     in.composition[i][c] = composition_values[c][i];
                 }
+              in.cell = &cell;
+
               material_model->evaluate(in, out);
             }
 

--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -446,6 +446,8 @@ namespace aspect
             {
               fe[introspection.extractors.pressure].get_function_values (relevant_dst, in.pressure);
               fe[introspection.extractors.temperature].get_function_values (relevant_dst, in.temperature);
+              in.velocity=velocities;
+
               for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
                 fe[introspection.extractors.compositional_fields[c]].get_function_values(relevant_dst,
                                                                                          composition_values[c]);
@@ -456,6 +458,8 @@ namespace aspect
                   for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
                     in.composition[i][c] = composition_values[c][i];
                 }
+              in.cell = &cell;
+
               material_model->evaluate(in, out);
             }
 

--- a/tests/cell_reference.cc
+++ b/tests/cell_reference.cc
@@ -1,0 +1,40 @@
+#include <aspect/simulator_access.h>
+#include <aspect/global.h>
+#include <aspect/material_model/simpler.h>
+
+using namespace dealii;
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+
+    template <int dim>
+    class CellMaterial :
+        public aspect::MaterialModel::Simpler<dim>, aspect::SimulatorAccess<dim>
+    {
+      public:
+        void
+        evaluate(const typename Interface<dim>::MaterialModelInputs &in, typename Interface<dim>::MaterialModelOutputs &out) const
+        {
+          Simpler<dim>::evaluate(in,out);
+
+          if (in.cell)
+            {
+              std::cout << "Level: " << (*in.cell)->level() << " Index: " << (*in.cell)->index() << std::endl;
+            }
+        }
+    };
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    ASPECT_REGISTER_MATERIAL_MODEL(CellMaterial,
+                                   "cell",
+                                   "")
+  }
+}

--- a/tests/cell_reference.prm
+++ b/tests/cell_reference.prm
@@ -56,7 +56,7 @@ end
 
 subsection Mesh refinement
   set Initial adaptive refinement        = 0
-  set Initial global refinement          = 3
+  set Initial global refinement          = 1
 end
 
 

--- a/tests/cell_reference.prm
+++ b/tests/cell_reference.prm
@@ -1,0 +1,78 @@
+# This is a copy of simpler-box.prm test,
+# with a slightly modified material model that outputs the
+# cell level and index to check that the cell reference is working
+
+
+set Dimension = 2
+set CFL number                             = 1.0
+set End time                               = 0
+set Start time                             = 0
+set Adiabatic surface temperature          = 0
+set Surface pressure                       = 0
+set Use years in output instead of seconds = false  # default: true
+set Nonlinear solver scheme                = IMPES
+
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+
+
+subsection Gravity model
+  set Model name = vertical
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1.2 # default: 1
+    set Y extent = 1
+    set Z extent = 1
+  end
+end
+
+
+subsection Initial conditions
+  set Model name = perturbed box
+end
+
+
+subsection Material model
+  set Model name = cell
+
+  subsection Simpler model
+    set Reference density             = 1    # default: 3300
+    set Reference specific heat       = 1250
+    set Reference temperature         = 1    # default: 293
+    set Thermal conductivity          = 1e-6 # default: 4.7
+    set Thermal expansion coefficient = 2e-5
+    set Viscosity                     = 1    # default: 5e24
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 3
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = 0, 1
+  set Prescribed velocity boundary indicators =
+  set Tangential velocity boundary indicators = 1
+  set Zero velocity boundary indicators       = 0, 2, 3
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, velocity statistics, basic statistics,  temperature statistics, heat flux statistics
+
+   
+  subsection Visualization
+    set List of output variables      = density, viscosity
+  end
+end
+

--- a/tests/cell_reference/screen-output
+++ b/tests/cell_reference/screen-output
@@ -8,324 +8,60 @@
 
 Loading shared library <./libcell_reference.so>
 
-Number of active cells: 64 (on 4 levels)
-Number of degrees of freedom: 948 (578+81+289)
+Number of active cells: 4 (on 2 levels)
+Number of degrees of freedom: 84 (50+9+25)
 
 *** Timestep 0:  t=0 seconds
-Level: 3 Index: 0
-Level: 3 Index: 0
-Level: 3 Index: 1
-Level: 3 Index: 1
-Level: 3 Index: 2
-Level: 3 Index: 2
-Level: 3 Index: 3
-Level: 3 Index: 3
-Level: 3 Index: 4
-Level: 3 Index: 4
-Level: 3 Index: 5
-Level: 3 Index: 5
-Level: 3 Index: 6
-Level: 3 Index: 6
-Level: 3 Index: 7
-Level: 3 Index: 7
-Level: 3 Index: 8
-Level: 3 Index: 8
-Level: 3 Index: 9
-Level: 3 Index: 9
-Level: 3 Index: 10
-Level: 3 Index: 10
-Level: 3 Index: 11
-Level: 3 Index: 11
-Level: 3 Index: 12
-Level: 3 Index: 12
-Level: 3 Index: 13
-Level: 3 Index: 13
-Level: 3 Index: 14
-Level: 3 Index: 14
-Level: 3 Index: 15
-Level: 3 Index: 15
-Level: 3 Index: 16
-Level: 3 Index: 16
-Level: 3 Index: 17
-Level: 3 Index: 17
-Level: 3 Index: 18
-Level: 3 Index: 18
-Level: 3 Index: 19
-Level: 3 Index: 19
-Level: 3 Index: 20
-Level: 3 Index: 20
-Level: 3 Index: 21
-Level: 3 Index: 21
-Level: 3 Index: 22
-Level: 3 Index: 22
-Level: 3 Index: 23
-Level: 3 Index: 23
-Level: 3 Index: 24
-Level: 3 Index: 24
-Level: 3 Index: 25
-Level: 3 Index: 25
-Level: 3 Index: 26
-Level: 3 Index: 26
-Level: 3 Index: 27
-Level: 3 Index: 27
-Level: 3 Index: 28
-Level: 3 Index: 28
-Level: 3 Index: 29
-Level: 3 Index: 29
-Level: 3 Index: 30
-Level: 3 Index: 30
-Level: 3 Index: 31
-Level: 3 Index: 31
-Level: 3 Index: 32
-Level: 3 Index: 32
-Level: 3 Index: 33
-Level: 3 Index: 33
-Level: 3 Index: 34
-Level: 3 Index: 34
-Level: 3 Index: 35
-Level: 3 Index: 35
-Level: 3 Index: 36
-Level: 3 Index: 36
-Level: 3 Index: 37
-Level: 3 Index: 37
-Level: 3 Index: 38
-Level: 3 Index: 38
-Level: 3 Index: 39
-Level: 3 Index: 39
-Level: 3 Index: 40
-Level: 3 Index: 40
-Level: 3 Index: 41
-Level: 3 Index: 41
-Level: 3 Index: 42
-Level: 3 Index: 42
-Level: 3 Index: 43
-Level: 3 Index: 43
-Level: 3 Index: 44
-Level: 3 Index: 44
-Level: 3 Index: 45
-Level: 3 Index: 45
-Level: 3 Index: 46
-Level: 3 Index: 46
-Level: 3 Index: 47
-Level: 3 Index: 47
-Level: 3 Index: 48
-Level: 3 Index: 48
-Level: 3 Index: 49
-Level: 3 Index: 49
-Level: 3 Index: 50
-Level: 3 Index: 50
-Level: 3 Index: 51
-Level: 3 Index: 51
-Level: 3 Index: 52
-Level: 3 Index: 52
-Level: 3 Index: 53
-Level: 3 Index: 53
-Level: 3 Index: 54
-Level: 3 Index: 54
-Level: 3 Index: 55
-Level: 3 Index: 55
-Level: 3 Index: 56
-Level: 3 Index: 56
-Level: 3 Index: 57
-Level: 3 Index: 57
-Level: 3 Index: 58
-Level: 3 Index: 58
-Level: 3 Index: 59
-Level: 3 Index: 59
-Level: 3 Index: 60
-Level: 3 Index: 60
-Level: 3 Index: 61
-Level: 3 Index: 61
-Level: 3 Index: 62
-Level: 3 Index: 62
-Level: 3 Index: 63
-Level: 3 Index: 63
+Level: 1 Index: 0
+Level: 1 Index: 0
+Level: 1 Index: 1
+Level: 1 Index: 1
+Level: 1 Index: 2
+Level: 1 Index: 2
+Level: 1 Index: 3
+Level: 1 Index: 3
    Solving temperature system... 0 iterations.
-Level: 3 Index: 0
-Level: 3 Index: 1
-Level: 3 Index: 2
-Level: 3 Index: 3
-Level: 3 Index: 4
-Level: 3 Index: 5
-Level: 3 Index: 6
-Level: 3 Index: 7
-Level: 3 Index: 8
-Level: 3 Index: 9
-Level: 3 Index: 10
-Level: 3 Index: 11
-Level: 3 Index: 12
-Level: 3 Index: 13
-Level: 3 Index: 14
-Level: 3 Index: 15
-Level: 3 Index: 16
-Level: 3 Index: 17
-Level: 3 Index: 18
-Level: 3 Index: 19
-Level: 3 Index: 20
-Level: 3 Index: 21
-Level: 3 Index: 22
-Level: 3 Index: 23
-Level: 3 Index: 24
-Level: 3 Index: 25
-Level: 3 Index: 26
-Level: 3 Index: 27
-Level: 3 Index: 28
-Level: 3 Index: 29
-Level: 3 Index: 30
-Level: 3 Index: 31
-Level: 3 Index: 32
-Level: 3 Index: 33
-Level: 3 Index: 34
-Level: 3 Index: 35
-Level: 3 Index: 36
-Level: 3 Index: 37
-Level: 3 Index: 38
-Level: 3 Index: 39
-Level: 3 Index: 40
-Level: 3 Index: 41
-Level: 3 Index: 42
-Level: 3 Index: 43
-Level: 3 Index: 44
-Level: 3 Index: 45
-Level: 3 Index: 46
-Level: 3 Index: 47
-Level: 3 Index: 48
-Level: 3 Index: 49
-Level: 3 Index: 50
-Level: 3 Index: 51
-Level: 3 Index: 52
-Level: 3 Index: 53
-Level: 3 Index: 54
-Level: 3 Index: 55
-Level: 3 Index: 56
-Level: 3 Index: 57
-Level: 3 Index: 58
-Level: 3 Index: 59
-Level: 3 Index: 60
-Level: 3 Index: 61
-Level: 3 Index: 62
-Level: 3 Index: 63
-   Rebuilding Stokes preconditioner...Level: 3 Index: 0
-Level: 3 Index: 1
-Level: 3 Index: 2
-Level: 3 Index: 3
-Level: 3 Index: 4
-Level: 3 Index: 5
-Level: 3 Index: 6
-Level: 3 Index: 7
-Level: 3 Index: 8
-Level: 3 Index: 9
-Level: 3 Index: 10
-Level: 3 Index: 11
-Level: 3 Index: 12
-Level: 3 Index: 13
-Level: 3 Index: 14
-Level: 3 Index: 15
-Level: 3 Index: 16
-Level: 3 Index: 17
-Level: 3 Index: 18
-Level: 3 Index: 19
-Level: 3 Index: 20
-Level: 3 Index: 21
-Level: 3 Index: 22
-Level: 3 Index: 23
-Level: 3 Index: 24
-Level: 3 Index: 25
-Level: 3 Index: 26
-Level: 3 Index: 27
-Level: 3 Index: 28
-Level: 3 Index: 29
-Level: 3 Index: 30
-Level: 3 Index: 31
-Level: 3 Index: 32
-Level: 3 Index: 33
-Level: 3 Index: 34
-Level: 3 Index: 35
-Level: 3 Index: 36
-Level: 3 Index: 37
-Level: 3 Index: 38
-Level: 3 Index: 39
-Level: 3 Index: 40
-Level: 3 Index: 41
-Level: 3 Index: 42
-Level: 3 Index: 43
-Level: 3 Index: 44
-Level: 3 Index: 45
-Level: 3 Index: 46
-Level: 3 Index: 47
-Level: 3 Index: 48
-Level: 3 Index: 49
-Level: 3 Index: 50
-Level: 3 Index: 51
-Level: 3 Index: 52
-Level: 3 Index: 53
-Level: 3 Index: 54
-Level: 3 Index: 55
-Level: 3 Index: 56
-Level: 3 Index: 57
-Level: 3 Index: 58
-Level: 3 Index: 59
-Level: 3 Index: 60
-Level: 3 Index: 61
-Level: 3 Index: 62
-Level: 3 Index: 63
+Level: 1 Index: 0
+Level: 1 Index: 1
+Level: 1 Index: 2
+Level: 1 Index: 3
+   Rebuilding Stokes preconditioner...Level: 1 Index: 0
+Level: 1 Index: 1
+Level: 1 Index: 2
+Level: 1 Index: 3
 
-   Solving Stokes system... 30+3 iterations.
+   Solving Stokes system... 12 iterations.
 
    Postprocessing:
-Level: 3 Index: 0
-Level: 3 Index: 0
-Level: 3 Index: 1
-Level: 3 Index: 2
-Level: 3 Index: 4
-Level: 3 Index: 5
-Level: 3 Index: 8
-Level: 3 Index: 10
-Level: 3 Index: 16
-Level: 3 Index: 17
-Level: 3 Index: 20
-Level: 3 Index: 21
-Level: 3 Index: 21
-Level: 3 Index: 23
-Level: 3 Index: 29
-Level: 3 Index: 31
-Level: 3 Index: 32
-Level: 3 Index: 34
-Level: 3 Index: 40
-Level: 3 Index: 42
-Level: 3 Index: 42
-Level: 3 Index: 43
-Level: 3 Index: 46
-Level: 3 Index: 47
-Level: 3 Index: 53
-Level: 3 Index: 55
-Level: 3 Index: 58
-Level: 3 Index: 59
-Level: 3 Index: 61
-Level: 3 Index: 62
-Level: 3 Index: 63
-Level: 3 Index: 63
+Level: 1 Index: 0
+Level: 1 Index: 0
+Level: 1 Index: 1
+Level: 1 Index: 1
+Level: 1 Index: 2
+Level: 1 Index: 2
+Level: 1 Index: 3
+Level: 1 Index: 3
      Writing graphical output:           output-cell_reference/solution-00000
-     RMS, max velocity:                  1.96e-08 m/s, 7.74e-08 m/s
-     Temperature min/avg/max:            0 K, 1.02 K, 1.1 K
-     Heat fluxes through boundary parts: 1.688e-07 W, 2.017e-05 W, 2.43e-07 W, 2.43e-07 W
+     RMS, max velocity:                  5.88e-08 m/s, 1.41e-07 m/s
+     Temperature min/avg/max:            0 K, 0.9574 K, 1.1 K
+     Heat fluxes through boundary parts: 1.944e-07 W, 5.194e-06 W, 2.8e-07 W, 2.8e-07 W
 
 Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.094s |            |
+| Total wallclock time elapsed since start    |    0.0294s |            |
 |                                             |            |            |
 | Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0116s |        12% |
-| Assemble temperature system     |         1 |   0.00594s |       6.3% |
-| Build Stokes preconditioner     |         1 |    0.0174s |        19% |
-| Build temperature preconditioner|         1 |  0.000696s |      0.74% |
-| Solve Stokes system             |         1 |    0.0113s |        12% |
-| Solve temperature system        |         1 |   0.00034s |      0.36% |
-| Initialization                  |         2 |    0.0223s |        24% |
-| Postprocessing                  |         1 |   0.00905s |       9.6% |
-| Setup dof systems               |         1 |      0.01s |        11% |
+| Assemble Stokes system          |         1 |  0.000718s |       2.4% |
+| Assemble temperature system     |         1 |   0.00143s |       4.9% |
+| Build Stokes preconditioner     |         1 |    0.0033s |        11% |
+| Build temperature preconditioner|         1 |  0.000215s |      0.73% |
+| Solve Stokes system             |         1 |   0.00136s |       4.6% |
+| Solve temperature system        |         1 |  0.000197s |      0.67% |
+| Initialization                  |         2 |    0.0164s |        56% |
+| Postprocessing                  |         1 |   0.00199s |       6.8% |
+| Setup dof systems               |         1 |   0.00243s |       8.3% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/cell_reference/screen-output
+++ b/tests/cell_reference/screen-output
@@ -1,0 +1,331 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.4.pre
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Loading shared library <./libcell_reference.so>
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 948 (578+81+289)
+
+*** Timestep 0:  t=0 seconds
+Level: 3 Index: 0
+Level: 3 Index: 0
+Level: 3 Index: 1
+Level: 3 Index: 1
+Level: 3 Index: 2
+Level: 3 Index: 2
+Level: 3 Index: 3
+Level: 3 Index: 3
+Level: 3 Index: 4
+Level: 3 Index: 4
+Level: 3 Index: 5
+Level: 3 Index: 5
+Level: 3 Index: 6
+Level: 3 Index: 6
+Level: 3 Index: 7
+Level: 3 Index: 7
+Level: 3 Index: 8
+Level: 3 Index: 8
+Level: 3 Index: 9
+Level: 3 Index: 9
+Level: 3 Index: 10
+Level: 3 Index: 10
+Level: 3 Index: 11
+Level: 3 Index: 11
+Level: 3 Index: 12
+Level: 3 Index: 12
+Level: 3 Index: 13
+Level: 3 Index: 13
+Level: 3 Index: 14
+Level: 3 Index: 14
+Level: 3 Index: 15
+Level: 3 Index: 15
+Level: 3 Index: 16
+Level: 3 Index: 16
+Level: 3 Index: 17
+Level: 3 Index: 17
+Level: 3 Index: 18
+Level: 3 Index: 18
+Level: 3 Index: 19
+Level: 3 Index: 19
+Level: 3 Index: 20
+Level: 3 Index: 20
+Level: 3 Index: 21
+Level: 3 Index: 21
+Level: 3 Index: 22
+Level: 3 Index: 22
+Level: 3 Index: 23
+Level: 3 Index: 23
+Level: 3 Index: 24
+Level: 3 Index: 24
+Level: 3 Index: 25
+Level: 3 Index: 25
+Level: 3 Index: 26
+Level: 3 Index: 26
+Level: 3 Index: 27
+Level: 3 Index: 27
+Level: 3 Index: 28
+Level: 3 Index: 28
+Level: 3 Index: 29
+Level: 3 Index: 29
+Level: 3 Index: 30
+Level: 3 Index: 30
+Level: 3 Index: 31
+Level: 3 Index: 31
+Level: 3 Index: 32
+Level: 3 Index: 32
+Level: 3 Index: 33
+Level: 3 Index: 33
+Level: 3 Index: 34
+Level: 3 Index: 34
+Level: 3 Index: 35
+Level: 3 Index: 35
+Level: 3 Index: 36
+Level: 3 Index: 36
+Level: 3 Index: 37
+Level: 3 Index: 37
+Level: 3 Index: 38
+Level: 3 Index: 38
+Level: 3 Index: 39
+Level: 3 Index: 39
+Level: 3 Index: 40
+Level: 3 Index: 40
+Level: 3 Index: 41
+Level: 3 Index: 41
+Level: 3 Index: 42
+Level: 3 Index: 42
+Level: 3 Index: 43
+Level: 3 Index: 43
+Level: 3 Index: 44
+Level: 3 Index: 44
+Level: 3 Index: 45
+Level: 3 Index: 45
+Level: 3 Index: 46
+Level: 3 Index: 46
+Level: 3 Index: 47
+Level: 3 Index: 47
+Level: 3 Index: 48
+Level: 3 Index: 48
+Level: 3 Index: 49
+Level: 3 Index: 49
+Level: 3 Index: 50
+Level: 3 Index: 50
+Level: 3 Index: 51
+Level: 3 Index: 51
+Level: 3 Index: 52
+Level: 3 Index: 52
+Level: 3 Index: 53
+Level: 3 Index: 53
+Level: 3 Index: 54
+Level: 3 Index: 54
+Level: 3 Index: 55
+Level: 3 Index: 55
+Level: 3 Index: 56
+Level: 3 Index: 56
+Level: 3 Index: 57
+Level: 3 Index: 57
+Level: 3 Index: 58
+Level: 3 Index: 58
+Level: 3 Index: 59
+Level: 3 Index: 59
+Level: 3 Index: 60
+Level: 3 Index: 60
+Level: 3 Index: 61
+Level: 3 Index: 61
+Level: 3 Index: 62
+Level: 3 Index: 62
+Level: 3 Index: 63
+Level: 3 Index: 63
+   Solving temperature system... 0 iterations.
+Level: 3 Index: 0
+Level: 3 Index: 1
+Level: 3 Index: 2
+Level: 3 Index: 3
+Level: 3 Index: 4
+Level: 3 Index: 5
+Level: 3 Index: 6
+Level: 3 Index: 7
+Level: 3 Index: 8
+Level: 3 Index: 9
+Level: 3 Index: 10
+Level: 3 Index: 11
+Level: 3 Index: 12
+Level: 3 Index: 13
+Level: 3 Index: 14
+Level: 3 Index: 15
+Level: 3 Index: 16
+Level: 3 Index: 17
+Level: 3 Index: 18
+Level: 3 Index: 19
+Level: 3 Index: 20
+Level: 3 Index: 21
+Level: 3 Index: 22
+Level: 3 Index: 23
+Level: 3 Index: 24
+Level: 3 Index: 25
+Level: 3 Index: 26
+Level: 3 Index: 27
+Level: 3 Index: 28
+Level: 3 Index: 29
+Level: 3 Index: 30
+Level: 3 Index: 31
+Level: 3 Index: 32
+Level: 3 Index: 33
+Level: 3 Index: 34
+Level: 3 Index: 35
+Level: 3 Index: 36
+Level: 3 Index: 37
+Level: 3 Index: 38
+Level: 3 Index: 39
+Level: 3 Index: 40
+Level: 3 Index: 41
+Level: 3 Index: 42
+Level: 3 Index: 43
+Level: 3 Index: 44
+Level: 3 Index: 45
+Level: 3 Index: 46
+Level: 3 Index: 47
+Level: 3 Index: 48
+Level: 3 Index: 49
+Level: 3 Index: 50
+Level: 3 Index: 51
+Level: 3 Index: 52
+Level: 3 Index: 53
+Level: 3 Index: 54
+Level: 3 Index: 55
+Level: 3 Index: 56
+Level: 3 Index: 57
+Level: 3 Index: 58
+Level: 3 Index: 59
+Level: 3 Index: 60
+Level: 3 Index: 61
+Level: 3 Index: 62
+Level: 3 Index: 63
+   Rebuilding Stokes preconditioner...Level: 3 Index: 0
+Level: 3 Index: 1
+Level: 3 Index: 2
+Level: 3 Index: 3
+Level: 3 Index: 4
+Level: 3 Index: 5
+Level: 3 Index: 6
+Level: 3 Index: 7
+Level: 3 Index: 8
+Level: 3 Index: 9
+Level: 3 Index: 10
+Level: 3 Index: 11
+Level: 3 Index: 12
+Level: 3 Index: 13
+Level: 3 Index: 14
+Level: 3 Index: 15
+Level: 3 Index: 16
+Level: 3 Index: 17
+Level: 3 Index: 18
+Level: 3 Index: 19
+Level: 3 Index: 20
+Level: 3 Index: 21
+Level: 3 Index: 22
+Level: 3 Index: 23
+Level: 3 Index: 24
+Level: 3 Index: 25
+Level: 3 Index: 26
+Level: 3 Index: 27
+Level: 3 Index: 28
+Level: 3 Index: 29
+Level: 3 Index: 30
+Level: 3 Index: 31
+Level: 3 Index: 32
+Level: 3 Index: 33
+Level: 3 Index: 34
+Level: 3 Index: 35
+Level: 3 Index: 36
+Level: 3 Index: 37
+Level: 3 Index: 38
+Level: 3 Index: 39
+Level: 3 Index: 40
+Level: 3 Index: 41
+Level: 3 Index: 42
+Level: 3 Index: 43
+Level: 3 Index: 44
+Level: 3 Index: 45
+Level: 3 Index: 46
+Level: 3 Index: 47
+Level: 3 Index: 48
+Level: 3 Index: 49
+Level: 3 Index: 50
+Level: 3 Index: 51
+Level: 3 Index: 52
+Level: 3 Index: 53
+Level: 3 Index: 54
+Level: 3 Index: 55
+Level: 3 Index: 56
+Level: 3 Index: 57
+Level: 3 Index: 58
+Level: 3 Index: 59
+Level: 3 Index: 60
+Level: 3 Index: 61
+Level: 3 Index: 62
+Level: 3 Index: 63
+
+   Solving Stokes system... 30+3 iterations.
+
+   Postprocessing:
+Level: 3 Index: 0
+Level: 3 Index: 0
+Level: 3 Index: 1
+Level: 3 Index: 2
+Level: 3 Index: 4
+Level: 3 Index: 5
+Level: 3 Index: 8
+Level: 3 Index: 10
+Level: 3 Index: 16
+Level: 3 Index: 17
+Level: 3 Index: 20
+Level: 3 Index: 21
+Level: 3 Index: 21
+Level: 3 Index: 23
+Level: 3 Index: 29
+Level: 3 Index: 31
+Level: 3 Index: 32
+Level: 3 Index: 34
+Level: 3 Index: 40
+Level: 3 Index: 42
+Level: 3 Index: 42
+Level: 3 Index: 43
+Level: 3 Index: 46
+Level: 3 Index: 47
+Level: 3 Index: 53
+Level: 3 Index: 55
+Level: 3 Index: 58
+Level: 3 Index: 59
+Level: 3 Index: 61
+Level: 3 Index: 62
+Level: 3 Index: 63
+Level: 3 Index: 63
+     Writing graphical output:           output-cell_reference/solution-00000
+     RMS, max velocity:                  1.96e-08 m/s, 7.74e-08 m/s
+     Temperature min/avg/max:            0 K, 1.02 K, 1.1 K
+     Heat fluxes through boundary parts: 1.688e-07 W, 2.017e-05 W, 2.43e-07 W, 2.43e-07 W
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.094s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |    0.0116s |        12% |
+| Assemble temperature system     |         1 |   0.00594s |       6.3% |
+| Build Stokes preconditioner     |         1 |    0.0174s |        19% |
+| Build temperature preconditioner|         1 |  0.000696s |      0.74% |
+| Solve Stokes system             |         1 |    0.0113s |        12% |
+| Solve temperature system        |         1 |   0.00034s |      0.36% |
+| Initialization                  |         2 |    0.0223s |        24% |
+| Postprocessing                  |         1 |   0.00905s |       9.6% |
+| Setup dof systems               |         1 |      0.01s |        11% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/cell_reference/statistics
+++ b/tests/cell_reference/statistics
@@ -1,0 +1,22 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Iterations for temperature solver
+# 7: Iterations for Stokes solver
+# 8: Velocity iterations in Stokes preconditioner
+# 9: Schur complement iterations in Stokes preconditioner
+# 10: Time step size (seconds)
+# 11: Visualization file name
+# 12: RMS velocity (m/s)
+# 13: Max. velocity (m/s)
+# 14: Minimal temperature (K)
+# 15: Average temperature (K)
+# 16: Maximal temperature (K)
+# 17: Average nondimensional temperature (K)
+# 18: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 19: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 20: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 21: Outward heat flux through boundary with indicator 3 ("top") (W)
+0 0.0000e+00 64 659 289 0 33 12 4 7.4833e+05 output-cell_reference/solution-00000 1.95891774e-08 7.73882627e-08 0.00000000e+00 1.01969581e+00 1.10000000e+00 1.01969581e+00 1.68781124e-07 2.01687811e-05 2.43044819e-07 2.43044819e-07 

--- a/tests/cell_reference/statistics
+++ b/tests/cell_reference/statistics
@@ -19,4 +19,4 @@
 # 19: Outward heat flux through boundary with indicator 1 ("right") (W)
 # 20: Outward heat flux through boundary with indicator 2 ("bottom") (W)
 # 21: Outward heat flux through boundary with indicator 3 ("top") (W)
-0 0.0000e+00 64 659 289 0 33 12 4 7.4833e+05 output-cell_reference/solution-00000 1.95891774e-08 7.73882627e-08 0.00000000e+00 1.01969581e+00 1.10000000e+00 1.01969581e+00 1.68781124e-07 2.01687811e-05 2.43044819e-07 2.43044819e-07 
+0 0.0000e+00 4 59 25 0 12 13 12 1.2127e+06 output-cell_reference/solution-00000 5.87731488e-08 1.40992996e-07 0.00000000e+00 9.57380151e-01 1.10000000e+00 9.57380151e-01 1.94444444e-07 5.19444444e-06 2.80000000e-07 2.80000000e-07 


### PR DESCRIPTION
This pull request adds a velocity and a cell reference to the material model inputs. The cell reference is useful for evaluating material properties at points different from the quadrature points (e.g. the cell midpoint), and we use the velocity to determine if material has crossed a certain region. Additionally, the velocity is needed for the extended heating model (to compute the adiabatic heating).

If you prefer, I can keep the huge test out of the PR, this is just exactly what we used the cell reference for, so I will keep it on a private branch for myself then. Unfortunately for this purpose the testdata can not be smaller than this.