### PR TITLE
Detach manifolds for free surface computations

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1310,6 +1310,19 @@ namespace aspect
                                     FullMatrix<double> &local_matrix);
 
           /**
+           * If a geometry model uses manifolds for the refinement behavior
+           * it can produce nonsensical meshes on refinement when using a
+           * free surface, since the free surface may deform the mesh to the
+           * point where the manifold is no longer a good description of the
+           * domain.  However, it can still be useful to have the manifold
+           * description for producing a nice starting mesh with the initial
+           * refinements (that is to say, before timestepping).  This detaches
+           * manifolds from cells, and is called after the initial refinements
+           * of the domain.
+           */
+          void detach_manifolds();
+
+          /**
            * Declare parameters for the free surface handling.
            */
           static

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1941,6 +1941,12 @@ namespace aspect
             goto start_time_iteration;
           }
 
+        // as soon as the mesh starts deforming with a free surface, a manifold
+        // description and boundary shape are no longer guaranteed to be any good.
+        // Here we detach those manifolds and boundaries.
+        if ( timestep_number == 0 && parameters.free_surface_enabled == true )
+          free_surface->detach_manifolds();
+
         postprocess ();
 
         // see if this is a time step where additional refinement is requested

--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -669,7 +669,21 @@ namespace aspect
 
   }
 
+  template <int dim>
+  void
+  Simulator<dim>::FreeSurfaceHandler::detach_manifolds()
+  {
+    //remove manifold ids for all cells
+    for (typename Triangulation<dim>::active_cell_iterator
+         cell = sim.triangulation.begin_active();
+         cell != sim.triangulation.end(); ++cell)
+      cell->set_all_manifold_ids (numbers::invalid_manifold_id);
 
+    //also remove boundary description for the free surface indicators
+    std::set<types::boundary_id>::iterator id = sim.parameters.free_surface_boundary_indicators.begin();
+    for (; id != sim.parameters.free_surface_boundary_indicators.end(); ++id)
+      sim.triangulation.set_boundary( *id );
+  }
 }
 
 


### PR DESCRIPTION
The idea here is that the internal manifolds are not necessarily a good way to refine cells when there is a free surface.  For significant deformations, the calculation of new mesh points could be very wrong.  However, the calculation of a nice starting mesh, as is done with the spherical shells model, is still nice.  So here I allow the initial refinements to happen as usual, but then detach the manifold indicators when the timestepping starts.