### PR TITLE
Switched i and j in assembly

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1712,7 +1712,7 @@ namespace aspect
                 += (
                      (time_step * (conductivity + nu)
                       * (scratch.grad_phi_field[i] * scratch.grad_phi_field[j]))
-                     + ((time_step * (current_u * scratch.grad_phi_field[j] * scratch.phi_field[i]))
+                     + ((time_step * (current_u * scratch.phi_field[i] * scratch.grad_phi_field[j]))
                         + (factor * scratch.phi_field[i] * scratch.phi_field[j])) *
                      (density_c_P + latent_heat_LHS)
                    )


### PR DESCRIPTION
Switched a term in the assembly to match how Wolfgang said it should be.