### PR TITLE
improve error if no model selected

### DIFF
--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -98,6 +98,10 @@ namespace aspect
       }
       prm.leave_subsection ();
 
+      AssertThrow(model_name != "",
+                  ExcMessage("You need to select a boundary model for the composition "
+                             "('set Model name' in 'subsection Boundary composition model')."));
+
       return std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                     "Boundary composition model::Model name");
     }

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -98,6 +98,12 @@ namespace aspect
       }
       prm.leave_subsection ();
 
+      // If one sets the model name to an empty string in the input file,
+      // ParameterHandler produces an error while reading the file. However,
+      // if one omits specifying any model name at all (not even setting it to
+      // the empty string) then the value we get here is the empty string. If
+      // we don't catch this case here, we end up with awkward downstream
+      // errors because the value obviously does not conform to the Pattern.
       AssertThrow(model_name != "",
                   ExcMessage("You need to select a boundary model for the composition "
                              "('set Model name' in 'subsection Boundary composition model')."));

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -100,6 +100,12 @@ namespace aspect
       }
       prm.leave_subsection ();
 
+      // If one sets the model name to an empty string in the input file,
+      // ParameterHandler produces an error while reading the file. However,
+      // if one omits specifying any model name at all (not even setting it to
+      // the empty string) then the value we get here is the empty string. If
+      // we don't catch this case here, we end up with awkward downstream
+      // errors because the value obviously does not conform to the Pattern.
       AssertThrow(model_name != "",
                   ExcMessage("You need to select a Boundary model for the temperature "
                              "('set Model name' in 'subsection Boundary temperature model')."));

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -100,6 +100,10 @@ namespace aspect
       }
       prm.leave_subsection ();
 
+      AssertThrow(model_name != "",
+                  ExcMessage("You need to select a Boundary model for the temperature "
+                             "('set Model name' in 'subsection Boundary temperature model')."));
+
       return std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                     "Boundary temperature model::Model name");
     }

--- a/source/geometry_model/interface.cc
+++ b/source/geometry_model/interface.cc
@@ -216,6 +216,10 @@ namespace aspect
       }
       prm.leave_subsection ();
 
+      AssertThrow(model_name != "",
+                  ExcMessage("You need to select a Geometry model "
+                             "('set Model name' in 'subsection Geometry model')."));
+
       return std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                     "Geometry model::model name",
                                                                     prm);

--- a/source/geometry_model/interface.cc
+++ b/source/geometry_model/interface.cc
@@ -216,6 +216,12 @@ namespace aspect
       }
       prm.leave_subsection ();
 
+      // If one sets the model name to an empty string in the input file,
+      // ParameterHandler produces an error while reading the file. However,
+      // if one omits specifying any model name at all (not even setting it to
+      // the empty string) then the value we get here is the empty string. If
+      // we don't catch this case here, we end up with awkward downstream
+      // errors because the value obviously does not conform to the Pattern.
       AssertThrow(model_name != "",
                   ExcMessage("You need to select a Geometry model "
                              "('set Model name' in 'subsection Geometry model')."));

--- a/source/gravity_model/interface.cc
+++ b/source/gravity_model/interface.cc
@@ -98,6 +98,10 @@ namespace aspect
       }
       prm.leave_subsection ();
 
+      AssertThrow(model_name != "",
+                  ExcMessage("You need to select a Gravity model "
+                             "('set Model name' in 'subsection Gravity model')."));
+
       return std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                     "Gravity model::Model name");
     }

--- a/source/gravity_model/interface.cc
+++ b/source/gravity_model/interface.cc
@@ -98,6 +98,12 @@ namespace aspect
       }
       prm.leave_subsection ();
 
+      // If one sets the model name to an empty string in the input file,
+      // ParameterHandler produces an error while reading the file. However,
+      // if one omits specifying any model name at all (not even setting it to
+      // the empty string) then the value we get here is the empty string. If
+      // we don't catch this case here, we end up with awkward downstream
+      // errors because the value obviously does not conform to the Pattern.
       AssertThrow(model_name != "",
                   ExcMessage("You need to select a Gravity model "
                              "('set Model name' in 'subsection Gravity model')."));

--- a/source/initial_conditions/interface.cc
+++ b/source/initial_conditions/interface.cc
@@ -95,6 +95,12 @@ namespace aspect
       }
       prm.leave_subsection ();
 
+      // If one sets the model name to an empty string in the input file,
+      // ParameterHandler produces an error while reading the file. However,
+      // if one omits specifying any model name at all (not even setting it to
+      // the empty string) then the value we get here is the empty string. If
+      // we don't catch this case here, we end up with awkward downstream
+      // errors because the value obviously does not conform to the Pattern.
       AssertThrow(model_name != "",
                   ExcMessage("You need to select initial conditions for the temperature "
                              "('set Model name' in 'subsection Initial conditions')."));

--- a/source/initial_conditions/interface.cc
+++ b/source/initial_conditions/interface.cc
@@ -95,6 +95,10 @@ namespace aspect
       }
       prm.leave_subsection ();
 
+      AssertThrow(model_name != "",
+                  ExcMessage("You need to select initial conditions for the temperature "
+                             "('set Model name' in 'subsection Initial conditions')."));
+
       Interface<dim> *plugin = std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                                       "Initial conditions::Model name");
       return plugin;

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -226,6 +226,12 @@ namespace aspect
       }
       prm.leave_subsection ();
 
+      // If one sets the model name to an empty string in the input file,
+      // ParameterHandler produces an error while reading the file. However,
+      // if one omits specifying any model name at all (not even setting it to
+      // the empty string) then the value we get here is the empty string. If
+      // we don't catch this case here, we end up with awkward downstream
+      // errors because the value obviously does not conform to the Pattern.
       AssertThrow(model_name != "",
                   ExcMessage("You need to select a material model "
                              "('set Model name' in 'subsection Material model')."));

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -226,6 +226,10 @@ namespace aspect
       }
       prm.leave_subsection ();
 
+      AssertThrow(model_name != "",
+                  ExcMessage("You need to select a material model "
+                             "('set Model name' in 'subsection Material model')."));
+
       Interface<dim> *plugin = std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                                       "Material model::Model name");
       return plugin;


### PR DESCRIPTION
The default values for geometry/gravity/material/... model are "", which
creates a rather long and unhelpful error message from deal.II. Catch
this case earlier and provide a helpful error.