### PR TITLE
Fix RHS in assembly

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -449,14 +449,15 @@ which it is in fact implemented:
   \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right)
   \\
   &\quad
-  +\alpha T \left( \mathbf u \cdot \nabla p \right)
+  +\alpha \hat{T} \left( \mathbf u \cdot \nabla p \right)
   \notag
   \\
   &\quad
-  + \rho T \Delta S \frac{\partial X}{\partial p} \mathbf u\cdot\nabla p
+  + \rho \hat{T} \Delta S \frac{\partial X}{\partial p} \mathbf u\cdot\nabla p
   & \quad & \textrm{in $\Omega$}.
   \notag
 \end{align}
+where $\hat{T}$ is an extrapolated temperature of the closest previous time steps.
 
 The last of the equations above, equation~\eqref{eq:compositional}, describes
 the evolution of additional fields that are transported along with the
@@ -465,6 +466,20 @@ features of the solution, but that do not diffuse. We call these fields $c_i$
 \textit{compositional fields}, although they can also be used for other
 purposes than just tracking chemical compositions. We will discuss this
 equation in more detail in Section~\ref{sec:compositional}.
+
+Starting with (\ref{eq:temperature-reformulated}) and multiplying on the left by a test function $\phi$ and integrating over the domain yields the weak form:
+\begin{align}
+  \label{eq:weak_form}
+  \left(\rho C_p - \rho T \Delta S \frac{\partial X}{\partial T}\right) 
+  \left( c \left( \phi, T \right) - \mathbf u \Delta t \left( \nabla \phi, T \right) 
+  \right) + k \Delta t \left( \nabla \phi , \nabla T \right)
+  &=
+  \left( \phi , \gamma \right) 
+  +  \left( \phi , q \right) 
+  \notag
+ \hspace{.5cm}  \forall \phi,
+\end{align}
+where $\Delta t$ is the current time step size, $c$ is a factor that depends on the old and current time step size, $\gamma$ is a combination of the internal heat production, friction heating, and adiabatic compression of material, and $q$ is the reaction term. Note that the entire equation was multiplied through by $\Delta t$ from what you would expect. 
 
 \subsubsection{A comment on adiabatic heating}
 Other codes and texts sometimes make a simplification to the adiabatic heating

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1697,12 +1697,14 @@ namespace aspect
         for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
           {
             data.local_rhs(i)
-            += (field_term_for_rhs * scratch.phi_field[i]
+            += (scratch.phi_field[i] * field_term_for_rhs
                 + time_step *
+                scratch.phi_field[i] *
                 gamma
-                * scratch.phi_field[i]
-                + reaction_term
-                * scratch.phi_field[i])
+                +
+                scratch.phi_field[i]) *
+                reaction_term
+
                *
                scratch.finite_element_values.JxW(q);
 

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1702,8 +1702,8 @@ namespace aspect
                 scratch.phi_field[i] *
                 gamma
                 +
-                scratch.phi_field[i]) *
-                reaction_term
+                scratch.phi_field[i] *
+                reaction_term)
 
                *
                scratch.finite_element_values.JxW(q);


### PR DESCRIPTION
In my weak form, the phi is on the left of each term in the RHS in the weak form that I recently proposed to be added, and I think the manual should match the code.  (It was also said that we want the phi to be on the left, which is why I did it the way I did).