### PR TITLE
reorder assembly terms again

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1712,7 +1712,7 @@ namespace aspect
                 += (
                      (time_step * (conductivity + nu)
                       * (scratch.grad_phi_field[i] * scratch.grad_phi_field[j]))
-                     + ((time_step * (current_u * scratch.phi_field[i] * scratch.grad_phi_field[j]))
+                     + ((time_step * (scratch.phi_field[i] * (current_u * scratch.grad_phi_field[j])))
                         + (factor * scratch.phi_field[i] * scratch.phi_field[j])) *
                      (density_c_P + latent_heat_LHS)
                    )


### PR DESCRIPTION
this is closer to the mathematical notation and will make the 3 tests
work again that broke with PR #388.