### PR TITLE
avoid using MaterialModel*puts typedefs

### DIFF
--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -90,8 +90,8 @@ namespace aspect
          */
         virtual
         void
-        evaluate (const typename aspect::MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
-                  const typename aspect::MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
+        evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+                  const MaterialModel::MaterialModelOutputs &material_model_outputs,
                   std::vector<double> &heating_outputs) const;
 
         /**

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -778,8 +778,8 @@ namespace aspect
          * inputs in @p in. If MaterialModelInputs.strain_rate has the length
          * 0, then the viscosity does not need to be computed.
          */
-        virtual void evaluate(const MaterialModelInputs &in,
-                              MaterialModelOutputs &out) const = 0;
+        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                              MaterialModel::MaterialModelOutputs &out) const = 0;
 
         /**
          * @name Functions used in dealing with run-time parameters
@@ -989,8 +989,8 @@ namespace aspect
          * @param in
          * @param out
          */
-        void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
-                      typename Interface<dim>::MaterialModelOutputs &out) const;
+        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                              MaterialModel::MaterialModelOutputs &out) const;
     };
 
 

--- a/include/aspect/material_model/morency_doin.h
+++ b/include/aspect/material_model/morency_doin.h
@@ -79,11 +79,11 @@ namespace aspect
     {
       public:
 
-        typedef typename aspect::MaterialModel::Interface<dim>::MaterialModelInputs MaterialModelInputs;
-        typedef typename aspect::MaterialModel::Interface<dim>::MaterialModelOutputs MaterialModelOutputs;
-
-        virtual void evaluate(const MaterialModelInputs &in, MaterialModelOutputs &out) const;
-
+        /**
+         * Evaluate material properties.
+         */
+        virtual void evaluate(const MaterialModelInputs<dim> &in,
+                              MaterialModelOutputs &out) const;
 
         /**
          * Return true if the viscosity() function returns something that may

--- a/include/aspect/material_model/simpler.h
+++ b/include/aspect/material_model/simpler.h
@@ -66,8 +66,8 @@ namespace aspect
 
         virtual double reference_density () const;
 
-        virtual void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
-                              typename Interface<dim>::MaterialModelOutputs &out) const;
+        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                              MaterialModel::MaterialModelOutputs &out) const;
 
 
         /**

--- a/include/aspect/material_model/steinberger.h
+++ b/include/aspect/material_model/steinberger.h
@@ -192,8 +192,8 @@ namespace aspect
          */
         virtual
         void
-        evaluate(const typename Interface<dim>::MaterialModelInputs &in,
-                 typename Interface<dim>::MaterialModelOutputs &out) const;
+        evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                 MaterialModel::MaterialModelOutputs &out) const;
 
         /**
          * @name Functions used in dealing with run-time parameters

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -608,8 +608,8 @@ namespace aspect
        * <code>source/simulator/assembly.cc</code>.
        */
       double compute_heating_term(const internal::Assembly::Scratch::AdvectionSystem<dim>  &scratch,
-                                  typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
-                                  typename MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
+                                  MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+                                  MaterialModel::MaterialModelOutputs &material_model_outputs,
                                   const double specific_heating_rate,
                                   const AdvectionField &advection_field,
                                   const unsigned int q) const;
@@ -680,8 +680,8 @@ namespace aspect
        *     void setup(const unsigned int q_points);
        *
        *     // fill @p output for each quadrature point
-       *     void operator()(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
-       *        const typename MaterialModel::Interface<dim>::MaterialModelOutputs &out,
+       *     void operator()(const MaterialModel::MaterialModelInputs<dim> &in,
+       *        const MaterialModel::MaterialModelOutputs &out,
        *        FEValues<dim> &fe_values,
        *        const LinearAlgebra::BlockVector &solution,
        *        std::vector<double> &output);
@@ -1020,7 +1020,7 @@ namespace aspect
                                            const FEValues<dim,dim>                                     &input_finite_element_values,
                                            const typename DoFHandler<dim>::active_cell_iterator        &cell,
                                            const bool                                                   compute_strainrate,
-                                           typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs) const;
+                                           MaterialModel::MaterialModelInputs<dim> &material_model_inputs) const;
 
 
       /**

--- a/source/adiabatic_conditions/initial_profile.cc
+++ b/source/adiabatic_conditions/initial_profile.cc
@@ -67,8 +67,8 @@ namespace aspect
 
           const Point<dim> representative_point = this->get_geometry_model().representative_point (z);
 
-          typename MaterialModel::Interface<dim>::MaterialModelInputs in(1, n_compositional_fields);
-          typename MaterialModel::Interface<dim>::MaterialModelOutputs out(1, n_compositional_fields);
+          MaterialModel::MaterialModelInputs<dim> in(1, n_compositional_fields);
+          MaterialModel::MaterialModelOutputs out(1, n_compositional_fields);
           in.position[0] = representative_point;
           in.temperature[0] = temperatures[i-1];
           in.pressure[0] = pressures[i-1];

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -53,8 +53,8 @@ namespace aspect
 
     template <int dim>
     void
-    Interface<dim>::evaluate (const typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
-                              const typename MaterialModel::Interface<dim>::MaterialModelOutputs & /*material_model_outputs*/,
+    Interface<dim>::evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+                              const MaterialModel::MaterialModelOutputs & /*material_model_outputs*/,
                               std::vector<double> &heating_outputs) const
     {
       Assert(heating_outputs.size() == material_model_inputs.position.size(),

--- a/source/initial_conditions/adiabatic.cc
+++ b/source/initial_conditions/adiabatic.cc
@@ -75,8 +75,8 @@ namespace aspect
       const double depth = this->get_geometry_model().depth(position);
 
       // look up material properties
-      typename MaterialModel::Interface<dim>::MaterialModelInputs in(1, this->n_compositional_fields());
-      typename MaterialModel::Interface<dim>::MaterialModelOutputs out(1, this->n_compositional_fields());
+      MaterialModel::MaterialModelInputs<dim> in(1, this->n_compositional_fields());
+      MaterialModel::MaterialModelOutputs out(1, this->n_compositional_fields());
       in.position[0]=position;
       in.temperature[0]=this->get_adiabatic_conditions().temperature(position);
       in.pressure[0]=this->get_adiabatic_conditions().pressure(position);

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -412,8 +412,8 @@ namespace aspect
 
     template <int dim>
     void
-    InterfaceCompatibility<dim>::evaluate(const typename Interface<dim>::MaterialModelInputs &in,
-                                          typename Interface<dim>::MaterialModelOutputs &out) const
+    InterfaceCompatibility<dim>::evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                                          MaterialModel::MaterialModelOutputs &out) const
     {
       for (unsigned int i=0; i < in.temperature.size(); ++i)
         {

--- a/source/material_model/morency_doin.cc
+++ b/source/material_model/morency_doin.cc
@@ -62,7 +62,7 @@ namespace aspect
     template <int dim>
     void
     MorencyDoin<dim>::
-    evaluate(const MaterialModelInputs &in,
+    evaluate(const MaterialModelInputs<dim> &in,
              MaterialModelOutputs &out) const
     {
       const double R = 8.32; // J mol-1 K-1

--- a/source/material_model/simpler.cc
+++ b/source/material_model/simpler.cc
@@ -97,7 +97,8 @@ namespace aspect
     template <int dim>
     void
     Simpler<dim>::
-    evaluate(const typename Interface<dim>::MaterialModelInputs &in, typename Interface<dim>::MaterialModelOutputs &out) const
+    evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+             MaterialModel::MaterialModelOutputs &out) const
     {
       for (unsigned int i=0; i<in.position.size(); ++i)
         {

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -850,8 +850,8 @@ namespace aspect
 
     template <int dim>
     void
-    Steinberger<dim>::evaluate(const typename Interface<dim>::MaterialModelInputs &in,
-                               typename Interface<dim>::MaterialModelOutputs &out) const
+    Steinberger<dim>::evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                               MaterialModel::MaterialModelOutputs &out) const
     {
 
       Assert ((n_material_data <= in.composition[0].size()) || (n_material_data == 1),

--- a/source/mesh_refinement/density.cc
+++ b/source/mesh_refinement/density.cc
@@ -64,10 +64,10 @@ namespace aspect
       std::vector<std::vector<double> > prelim_composition_values (this->n_compositional_fields(),
                                                                    std::vector<double> (quadrature.size()));
 
-      typename MaterialModel::Interface<dim>::MaterialModelInputs in(quadrature.size(),
-                                                                     this->n_compositional_fields());
-      typename MaterialModel::Interface<dim>::MaterialModelOutputs out(quadrature.size(),
-                                                                       this->n_compositional_fields());
+      MaterialModel::MaterialModelInputs<dim> in(quadrature.size(),
+                                                 this->n_compositional_fields());
+      MaterialModel::MaterialModelOutputs out(quadrature.size(),
+                                              this->n_compositional_fields());
 
       typename DoFHandler<dim>::active_cell_iterator
       cell = this->get_dof_handler().begin_active(),

--- a/source/mesh_refinement/nonadiabatic_temperature.cc
+++ b/source/mesh_refinement/nonadiabatic_temperature.cc
@@ -55,8 +55,8 @@ namespace aspect
                                quadrature,
                                update_quadrature_points | update_values);
 
-      typename MaterialModel::Interface<dim>::MaterialModelInputs in(quadrature.size(),
-                                                                     this->n_compositional_fields());
+      MaterialModel::MaterialModelInputs<dim> in(quadrature.size(),
+                                                 this->n_compositional_fields());
 
       // the values of the compositional fields are stored as blockvectors for each field
       // we have to extract them in this structure

--- a/source/mesh_refinement/thermal_energy_density.cc
+++ b/source/mesh_refinement/thermal_energy_density.cc
@@ -60,8 +60,8 @@ namespace aspect
       std::vector<std::vector<double> > prelim_composition_values (this->n_compositional_fields(),
                                                                    std::vector<double> (quadrature.size()));
 
-      typename MaterialModel::Interface<dim>::MaterialModelInputs in(quadrature.size(), this->n_compositional_fields());
-      typename MaterialModel::Interface<dim>::MaterialModelOutputs out(quadrature.size(), this->n_compositional_fields());
+      MaterialModel::MaterialModelInputs<dim> in(quadrature.size(), this->n_compositional_fields());
+      MaterialModel::MaterialModelOutputs out(quadrature.size(), this->n_compositional_fields());
 
       typename DoFHandler<dim>::active_cell_iterator
       cell = this->get_dof_handler().begin_active(),

--- a/source/mesh_refinement/viscosity.cc
+++ b/source/mesh_refinement/viscosity.cc
@@ -64,10 +64,10 @@ namespace aspect
       std::vector<std::vector<double> > prelim_composition_values (this->n_compositional_fields(),
                                                                    std::vector<double> (quadrature.size()));
 
-      typename MaterialModel::Interface<dim>::MaterialModelInputs in(quadrature.size(),
-                                                                     this->n_compositional_fields());
-      typename MaterialModel::Interface<dim>::MaterialModelOutputs out(quadrature.size(),
-                                                                       this->n_compositional_fields());
+      MaterialModel::MaterialModelInputs<dim> in(quadrature.size(),
+                                                 this->n_compositional_fields());
+      MaterialModel::MaterialModelOutputs out(quadrature.size(),
+                                              this->n_compositional_fields());
 
       typename DoFHandler<dim>::active_cell_iterator
       cell = this->get_dof_handler().begin_active(),

--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -50,8 +50,8 @@ namespace aspect
                                         quadrature_formula_face,
                                         update_JxW_values);
 
-      typename MaterialModel::Interface<dim>::MaterialModelInputs in(fe_values.n_quadrature_points, this->n_compositional_fields());
-      typename MaterialModel::Interface<dim>::MaterialModelOutputs out(fe_values.n_quadrature_points, this->n_compositional_fields());
+      MaterialModel::MaterialModelInputs<dim> in(fe_values.n_quadrature_points, this->n_compositional_fields());
+      MaterialModel::MaterialModelOutputs out(fe_values.n_quadrature_points, this->n_compositional_fields());
 
       std::vector<std::vector<double> > composition_values (this->n_compositional_fields(),std::vector<double> (quadrature_formula.size()));
 

--- a/source/postprocess/heat_flux_statistics.cc
+++ b/source/postprocess/heat_flux_statistics.cc
@@ -68,8 +68,8 @@ namespace aspect
       cell = this->get_dof_handler().begin_active(),
       endc = this->get_dof_handler().end();
 
-      typename MaterialModel::Interface<dim>::MaterialModelInputs in(fe_face_values.n_quadrature_points, this->n_compositional_fields());
-      typename MaterialModel::Interface<dim>::MaterialModelOutputs out(fe_face_values.n_quadrature_points, this->n_compositional_fields());
+      MaterialModel::MaterialModelInputs<dim> in(fe_face_values.n_quadrature_points, this->n_compositional_fields());
+      MaterialModel::MaterialModelOutputs out(fe_face_values.n_quadrature_points, this->n_compositional_fields());
 
       // for every surface face on which it makes sense to compute a
       // heat flux and that is owned by this processor,

--- a/source/postprocess/internal_heating_statistics.cc
+++ b/source/postprocess/internal_heating_statistics.cc
@@ -51,8 +51,8 @@ namespace aspect
                                update_quadrature_points |
                                update_JxW_values);
 
-      typename MaterialModel::Interface<dim>::MaterialModelInputs in(fe_values.n_quadrature_points, this->n_compositional_fields());
-      typename MaterialModel::Interface<dim>::MaterialModelOutputs out(fe_values.n_quadrature_points, this->n_compositional_fields());
+      MaterialModel::MaterialModelInputs<dim> in(fe_values.n_quadrature_points, this->n_compositional_fields());
+      MaterialModel::MaterialModelOutputs out(fe_values.n_quadrature_points, this->n_compositional_fields());
 
       in.strain_rate.resize(0); // we do not need the viscosity
       std::vector<std::vector<double> > composition_values (this->n_compositional_fields(),std::vector<double> (quadrature_formula.size()));

--- a/source/postprocess/mass_flux_statistics.cc
+++ b/source/postprocess/mass_flux_statistics.cc
@@ -79,8 +79,8 @@ namespace aspect
       cell = this->get_dof_handler().begin_active(),
       endc = this->get_dof_handler().end();
 
-      typename MaterialModel::Interface<dim>::MaterialModelInputs in(fe_face_values.n_quadrature_points, this->n_compositional_fields());
-      typename MaterialModel::Interface<dim>::MaterialModelOutputs out(fe_face_values.n_quadrature_points, this->n_compositional_fields());
+      MaterialModel::MaterialModelInputs<dim> in(fe_face_values.n_quadrature_points, this->n_compositional_fields());
+      MaterialModel::MaterialModelOutputs out(fe_face_values.n_quadrature_points, this->n_compositional_fields());
 
       // for every surface face on which it makes sense to compute a
       // mass flux and that is owned by this processor,

--- a/source/postprocess/table_heat_flux_statistics.cc
+++ b/source/postprocess/table_heat_flux_statistics.cc
@@ -67,10 +67,10 @@ namespace aspect
         = this->get_geometry_model().get_used_boundary_indicators ();
       std::map<types::boundary_id, double> local_boundary_fluxes;
 
-      typename MaterialModel::Interface<dim>::MaterialModelInputs in(quadrature.size(),
-                                                                     this->n_compositional_fields());
-      typename MaterialModel::Interface<dim>::MaterialModelOutputs out(quadrature.size(),
-                                                                       this->n_compositional_fields());
+      MaterialModel::MaterialModelInputs<dim> in(quadrature.size(),
+                                                 this->n_compositional_fields());
+      MaterialModel::MaterialModelOutputs out(quadrature.size(),
+                                              this->n_compositional_fields());
 
       typename DoFHandler<dim>::active_cell_iterator
       cell = this->get_dof_handler().begin_active(),

--- a/source/postprocess/viscous_dissipation_statistics.cc
+++ b/source/postprocess/viscous_dissipation_statistics.cc
@@ -60,10 +60,10 @@ namespace aspect
       std::vector<std::vector<double> > prelim_composition_values (this->n_compositional_fields(),
                                                                    std::vector<double> (n_q_points));
 
-      typename MaterialModel::Interface<dim>::MaterialModelInputs in(n_q_points,
-                                                                     this->n_compositional_fields());
-      typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_q_points,
-                                                                       this->n_compositional_fields());
+      MaterialModel::MaterialModelInputs<dim> in(n_q_points,
+                                                 this->n_compositional_fields());
+      MaterialModel::MaterialModelOutputs out(n_q_points,
+                                              this->n_compositional_fields());
 
       typename DoFHandler<dim>::active_cell_iterator
       cell = this->get_dof_handler().begin_active(),

--- a/source/postprocess/visualization/density.cc
+++ b/source/postprocess/visualization/density.cc
@@ -55,10 +55,10 @@ namespace aspect
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
         Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
 
-        typename MaterialModel::Interface<dim>::MaterialModelInputs in(n_quadrature_points,
-                                                                       this->n_compositional_fields());
-        typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_quadrature_points,
-                                                                         this->n_compositional_fields());
+        MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
+                                                   this->n_compositional_fields());
+        MaterialModel::MaterialModelOutputs out(n_quadrature_points,
+                                                this->n_compositional_fields());
 
         in.position = evaluation_points;
         in.strain_rate.resize(0); // we do not need the viscosity

--- a/source/postprocess/visualization/dynamic_topography.cc
+++ b/source/postprocess/visualization/dynamic_topography.cc
@@ -58,8 +58,8 @@ namespace aspect
                                           quadrature_formula_face,
                                           update_JxW_values);
 
-        typename MaterialModel::Interface<dim>::MaterialModelInputs in(fe_values.n_quadrature_points, this->n_compositional_fields());
-        typename MaterialModel::Interface<dim>::MaterialModelOutputs out(fe_values.n_quadrature_points, this->n_compositional_fields());
+        MaterialModel::MaterialModelInputs<dim> in(fe_values.n_quadrature_points, this->n_compositional_fields());
+        MaterialModel::MaterialModelOutputs out(fe_values.n_quadrature_points, this->n_compositional_fields());
 
         std::vector<std::vector<double> > composition_values (this->n_compositional_fields(),std::vector<double> (quadrature_formula.size()));
 

--- a/source/postprocess/visualization/friction_heating.cc
+++ b/source/postprocess/visualization/friction_heating.cc
@@ -56,10 +56,10 @@ namespace aspect
         Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
         Assert (duh[0].size() == this->introspection().n_components,          ExcInternalError());
 
-        typename MaterialModel::Interface<dim>::MaterialModelInputs in(n_quadrature_points,
-                                                                       this->n_compositional_fields());
-        typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_quadrature_points,
-                                                                         this->n_compositional_fields());
+        MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
+                                                   this->n_compositional_fields());
+        MaterialModel::MaterialModelOutputs out(n_quadrature_points,
+                                                this->n_compositional_fields());
 
         in.position = evaluation_points;
         for (unsigned int q=0; q<n_quadrature_points; ++q)

--- a/source/postprocess/visualization/internal_heating.cc
+++ b/source/postprocess/visualization/internal_heating.cc
@@ -57,8 +57,8 @@ namespace aspect
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
         Assert (uh[0].size() == this->introspection().n_components, ExcInternalError());
 
-        typename MaterialModel::Interface<dim>::MaterialModelInputs in(n_quadrature_points, this->n_compositional_fields());
-        typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_quadrature_points, this->n_compositional_fields());
+        MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points, this->n_compositional_fields());
+        MaterialModel::MaterialModelOutputs out(n_quadrature_points, this->n_compositional_fields());
 
         in.strain_rate.resize(0); // we do not need the viscosity
         std::vector<std::vector<double> > composition_values (this->n_compositional_fields(),std::vector<double> (n_quadrature_points));

--- a/source/postprocess/visualization/material_properties.cc
+++ b/source/postprocess/visualization/material_properties.cc
@@ -102,10 +102,10 @@ namespace aspect
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
 
-        typename MaterialModel::Interface<dim>::MaterialModelInputs in(n_quadrature_points,
-                                                                       this->n_compositional_fields());
-        typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_quadrature_points,
-                                                                         this->n_compositional_fields());
+        MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
+                                                   this->n_compositional_fields());
+        MaterialModel::MaterialModelOutputs out(n_quadrature_points,
+                                                this->n_compositional_fields());
 
         in.position = evaluation_points;
         for (unsigned int q=0; q<n_quadrature_points; ++q)

--- a/source/postprocess/visualization/shear_stress.cc
+++ b/source/postprocess/visualization/shear_stress.cc
@@ -47,10 +47,10 @@ namespace aspect
         Assert (uh[0].size() == this->introspection().n_components,   ExcInternalError());
         Assert (duh[0].size() == this->introspection().n_components,  ExcInternalError());
 
-        typename MaterialModel::Interface<dim>::MaterialModelInputs in(n_quadrature_points,
-                                                                       this->n_compositional_fields());
-        typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_quadrature_points,
-                                                                         this->n_compositional_fields());
+        MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
+                                                   this->n_compositional_fields());
+        MaterialModel::MaterialModelOutputs out(n_quadrature_points,
+                                                this->n_compositional_fields());
 
         // collect input information to compute the viscosity at every evaluation point
         in.position = evaluation_points;

--- a/source/postprocess/visualization/specific_heat.cc
+++ b/source/postprocess/visualization/specific_heat.cc
@@ -55,10 +55,10 @@ namespace aspect
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
         Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
 
-        typename MaterialModel::Interface<dim>::MaterialModelInputs in(n_quadrature_points,
-                                                                       this->n_compositional_fields());
-        typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_quadrature_points,
-                                                                         this->n_compositional_fields());
+        MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
+                                                   this->n_compositional_fields());
+        MaterialModel::MaterialModelOutputs out(n_quadrature_points,
+                                                this->n_compositional_fields());
 
         in.position = evaluation_points;
         in.strain_rate.resize(0); // we do not need the viscosity

--- a/source/postprocess/visualization/stress.cc
+++ b/source/postprocess/visualization/stress.cc
@@ -47,10 +47,10 @@ namespace aspect
         Assert (uh[0].size() == this->introspection().n_components,   ExcInternalError());
         Assert (duh[0].size() == this->introspection().n_components,  ExcInternalError());
 
-        typename MaterialModel::Interface<dim>::MaterialModelInputs in(n_quadrature_points,
-                                                                       this->n_compositional_fields());
-        typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_quadrature_points,
-                                                                         this->n_compositional_fields());
+        MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
+                                                   this->n_compositional_fields());
+        MaterialModel::MaterialModelOutputs out(n_quadrature_points,
+                                                this->n_compositional_fields());
 
         // collect input information to compute the viscosity at every evaluation point
         in.position = evaluation_points;

--- a/source/postprocess/visualization/thermal_expansivity.cc
+++ b/source/postprocess/visualization/thermal_expansivity.cc
@@ -55,10 +55,10 @@ namespace aspect
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
         Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
 
-        typename MaterialModel::Interface<dim>::MaterialModelInputs in(n_quadrature_points,
-                                                                       this->n_compositional_fields());
-        typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_quadrature_points,
-                                                                         this->n_compositional_fields());
+        MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
+                                                   this->n_compositional_fields());
+        MaterialModel::MaterialModelOutputs out(n_quadrature_points,
+                                                this->n_compositional_fields());
 
         in.position = evaluation_points;
         in.strain_rate.resize(0); // we do not need the viscosity

--- a/source/postprocess/visualization/viscosity.cc
+++ b/source/postprocess/visualization/viscosity.cc
@@ -56,10 +56,10 @@ namespace aspect
         Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
         Assert (duh[0].size() == this->introspection().n_components,          ExcInternalError());
 
-        typename MaterialModel::Interface<dim>::MaterialModelInputs in(n_quadrature_points,
-                                                                       this->n_compositional_fields());
-        typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_quadrature_points,
-                                                                         this->n_compositional_fields());
+        MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
+                                                   this->n_compositional_fields());
+        MaterialModel::MaterialModelOutputs out(n_quadrature_points,
+                                                this->n_compositional_fields());
 
         in.position = evaluation_points;
         for (unsigned int q=0; q<n_quadrature_points; ++q)

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -64,8 +64,8 @@ namespace aspect
           std::vector<SymmetricTensor<2,dim> > strain_rates;
           std::vector<std::vector<double> >     composition_values;
 
-          typename MaterialModel::Interface<dim>::MaterialModelInputs material_model_inputs;
-          typename MaterialModel::Interface<dim>::MaterialModelOutputs material_model_outputs;
+          MaterialModel::MaterialModelInputs<dim> material_model_inputs;
+          MaterialModel::MaterialModelOutputs material_model_outputs;
         };
 
 
@@ -233,11 +233,11 @@ namespace aspect
           std::vector<Tensor<1,dim> > current_pressure_gradients;
           std::vector<std::vector<double> > current_composition_values;
 
-          typename MaterialModel::Interface<dim>::MaterialModelInputs material_model_inputs;
-          typename MaterialModel::Interface<dim>::MaterialModelOutputs material_model_outputs;
+          MaterialModel::MaterialModelInputs<dim> material_model_inputs;
+          MaterialModel::MaterialModelOutputs material_model_outputs;
 
-          typename MaterialModel::Interface<dim>::MaterialModelInputs explicit_material_model_inputs;
-          typename MaterialModel::Interface<dim>::MaterialModelOutputs explicit_material_model_outputs;
+          MaterialModel::MaterialModelInputs<dim> explicit_material_model_inputs;
+          MaterialModel::MaterialModelOutputs explicit_material_model_outputs;
         };
 
 
@@ -907,7 +907,7 @@ namespace aspect
                                        const FEValues<dim>                                         &input_finite_element_values,
                                        const typename DoFHandler<dim>::active_cell_iterator        &cell,
                                        const bool                                                   compute_strainrate,
-                                       typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs) const
+                                       MaterialModel::MaterialModelInputs<dim> &material_model_inputs) const
   {
     const unsigned int n_q_points = material_model_inputs.temperature.size();
 
@@ -1370,8 +1370,8 @@ namespace aspect
   template <int dim>
   double
   Simulator<dim>::compute_heating_term(const internal::Assembly::Scratch::AdvectionSystem<dim>  &scratch,
-                                       typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
-                                       typename MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
+                                       MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+                                       MaterialModel::MaterialModelOutputs &material_model_outputs,
                                        const double specific_heating_rate,
                                        const AdvectionField     &advection_field,
                                        const unsigned int q) const

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -322,8 +322,8 @@ namespace aspect
                 fe_values[introspection.extractors.compositional_fields[c]].get_function_values (solution,
                     composition_values[c]);
 
-              typename MaterialModel::Interface<dim>::MaterialModelInputs in(n_q_points, parameters.n_compositional_fields);
-              typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_q_points, parameters.n_compositional_fields);
+              MaterialModel::MaterialModelInputs<dim> in(n_q_points, parameters.n_compositional_fields);
+              MaterialModel::MaterialModelOutputs out(n_q_points, parameters.n_compositional_fields);
 
               in.strain_rate.resize(0);// we are not reading the viscosity
 
@@ -962,10 +962,10 @@ namespace aspect
     cell = dof_handler.begin_active(),
     endc = dof_handler.end();
 
-    typename MaterialModel::Interface<dim>::MaterialModelInputs in(n_q_points,
-                                                                   parameters.n_compositional_fields);
-    typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_q_points,
-                                                                     parameters.n_compositional_fields);
+    MaterialModel::MaterialModelInputs<dim> in(n_q_points,
+                                               parameters.n_compositional_fields);
+    MaterialModel::MaterialModelOutputs out(n_q_points,
+                                            parameters.n_compositional_fields);
 
     fctr.setup(quadrature_formula.size());
 
@@ -1038,8 +1038,8 @@ namespace aspect
         {
         }
 
-        void operator()(const typename MaterialModel::Interface<dim>::MaterialModelInputs &,
-                        const typename MaterialModel::Interface<dim>::MaterialModelOutputs &,
+        void operator()(const MaterialModel::MaterialModelInputs<dim> &,
+                        const MaterialModel::MaterialModelOutputs &,
                         FEValues<dim> &fe_values,
                         const LinearAlgebra::BlockVector &solution,
                         std::vector<double> &output)
@@ -1081,8 +1081,8 @@ namespace aspect
         void setup(const unsigned int)
         {}
 
-        void operator()(const typename MaterialModel::Interface<dim>::MaterialModelInputs &,
-                        const typename MaterialModel::Interface<dim>::MaterialModelOutputs &out,
+        void operator()(const MaterialModel::MaterialModelInputs<dim> &,
+                        const MaterialModel::MaterialModelOutputs &out,
                         FEValues<dim> &,
                         const LinearAlgebra::BlockVector &,
                         std::vector<double> &output)
@@ -1119,8 +1119,8 @@ namespace aspect
           velocity_values.resize(q_points);
         }
 
-        void operator()(const typename MaterialModel::Interface<dim>::MaterialModelInputs &,
-                        const typename MaterialModel::Interface<dim>::MaterialModelOutputs &,
+        void operator()(const MaterialModel::MaterialModelInputs<dim> &,
+                        const MaterialModel::MaterialModelOutputs &,
                         FEValues<dim> &fe_values,
                         const LinearAlgebra::BlockVector &solution,
                         std::vector<double> &output)
@@ -1163,8 +1163,8 @@ namespace aspect
           velocity_values.resize(q_points);
         }
 
-        void operator()(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
-                        const typename MaterialModel::Interface<dim>::MaterialModelOutputs &,
+        void operator()(const MaterialModel::MaterialModelInputs<dim> &in,
+                        const MaterialModel::MaterialModelOutputs &,
                         FEValues<dim> &fe_values,
                         const LinearAlgebra::BlockVector &solution,
                         std::vector<double> &output)
@@ -1211,8 +1211,8 @@ namespace aspect
         void setup(const unsigned int)
         {}
 
-        void operator()(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
-                        const typename MaterialModel::Interface<dim>::MaterialModelOutputs &,
+        void operator()(const MaterialModel::MaterialModelInputs<dim> &in,
+                        const MaterialModel::MaterialModelOutputs &,
                         FEValues<dim> &,
                         const LinearAlgebra::BlockVector &,
                         std::vector<double> &output)

--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -320,10 +320,10 @@ namespace aspect
           fe[introspection.extractors.velocities].get_function_values (relevant_dst, velocities);
 
           // get the density at each quadrature point if necessary
-          typename MaterialModel::Interface<dim>::MaterialModelInputs in(n_q_points,
-                                                                         parameters.n_compositional_fields);
-          typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_q_points,
-                                                                           parameters.n_compositional_fields);
+          MaterialModel::MaterialModelInputs<dim> in(n_q_points,
+                                                     parameters.n_compositional_fields);
+          MaterialModel::MaterialModelOutputs out(n_q_points,
+                                                  parameters.n_compositional_fields);
           if ( ! use_constant_density)
             {
               fe[introspection.extractors.pressure].get_function_values (relevant_dst, in.pressure);
@@ -433,10 +433,10 @@ namespace aspect
           const std::vector<Point<dim> > &q_points = fe.get_quadrature_points();
 
           // get the density at each quadrature point if necessary
-          typename MaterialModel::Interface<dim>::MaterialModelInputs in(n_q_points,
-                                                                         parameters.n_compositional_fields);
-          typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_q_points,
-                                                                           parameters.n_compositional_fields);
+          MaterialModel::MaterialModelInputs<dim> in(n_q_points,
+                                                     parameters.n_compositional_fields);
+          MaterialModel::MaterialModelOutputs out(n_q_points,
+                                                  parameters.n_compositional_fields);
 
           //Get the velocity at each quadrature point
           fe[introspection.extractors.velocities].get_function_values (relevant_dst, in.velocity);


### PR DESCRIPTION
Instead of using the deprecated
MaterialModel::Interface<dim>::MaterialModel{In|Out}puts typedefs, use
the new names of the structs: MaterialModel::MaterialModel{In|Out}puts.