### PR TITLE
Fixed order of RHS terms

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1716,10 +1716,10 @@ namespace aspect
             data.local_rhs(i)
             += (field_term_for_rhs * scratch.phi_field[i]
                 + time_step *
-                gamma
-                * scratch.phi_field[i]
-                + reaction_term
-                * scratch.phi_field[i])
+                scratch.phi_field[i]
+                * gamma
+                + scratch.phi_field[i]
+                * reaction_term)
                *
                scratch.finite_element_values.JxW(q);
 


### PR DESCRIPTION
Fixed the order of terms in the RHS so that it follows our idea of multiplying with the test function on the left (This will also eventually match the weak form I am putting in the manual).

(Wait to see if this breaks anything.)