### PR TITLE
fix quick test with old cmake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,11 @@ CONFIGURE_FILE(
   ${CMAKE_BINARY_DIR}/CTestCustom.ctest
   @ONLY
 )
+CONFIGURE_FILE(
+  ${CMAKE_SOURCE_DIR}/tests/print_test_info.sh
+  ${CMAKE_BINARY_DIR}/print_test_info.sh
+  @ONLY
+)
 
 ADD_CUSTOM_TARGET(setup_tests
   COMMAND echo "Enabling all tests ..."

--- a/tests/CTestCustom.ctest.in
+++ b/tests/CTestCustom.ctest.in
@@ -5,19 +5,5 @@
 SET(RUN_ALL_TESTS @ASPECT_RUN_ALL_TESTS@)
 
 IF(NOT RUN_ALL_TESTS)
-  SET(CTEST_CUSTOM_POST_TEST
-      "echo ''"
-      "echo ''"
-      "echo '--------------------------------------------------------------'"
-      "echo 'Completed running the minimal testsuite. Please check the test'"
-      "echo 'results above. To run the complete testsuite, reconfigure your'"
-      "echo 'project with the option ASPECT_RUN_ALL_TESTS=ON or by running'"
-      "echo '    make setup_tests'"
-      "echo 'Be aware that installing the 'numdiff' tools is strongly'"
-      "echo 'recommended before running the full testsuite. Even then, the'"
-      "echo 'output is likely different on your machine due to configuration'"
-      "echo 'differences, so do not expect all tests to succeed on your'"
-      "echo 'machine.'"
-      "echo '--------------------------------------------------------------'"
-    )
+  SET(CTEST_CUSTOM_POST_TEST "./print_test_info.sh")
 ENDIF()

--- a/tests/print_test_info.sh
+++ b/tests/print_test_info.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script is executed by ctest when ASPECT_RUN_ALL_TESTS is disabled. Due
+# to a bug in cmake we can not print this info directly inside
+# CTestCustom.ctest if you are running cmake 2.8.11.x
+
+echo ""
+echo ""
+echo "---------------------------------------------------------------"
+echo "Completed running the minimal testsuite. Please check the test"
+echo "results above. To run the complete testsuite, reconfigure your"
+echo "project with the option ASPECT_RUN_ALL_TESTS=ON or by running"
+echo "    make setup_tests"
+echo "Be aware that installing the 'numdiff' tools is strongly"
+echo "recommended before running the full testsuite. Even then, the"
+echo "output is likely different on your machine due to configuration"
+echo "differences, so do not expect all tests to succeed on your"
+echo "machine."
+echo "---------------------------------------------------------------"


### PR DESCRIPTION
It turns out cmake 2.8.11 can not deal with function arguments in CTestCustom.ctest so ```echo 'bla'``` doesn't work. :-(