### PR TITLE
Add dependencies in postprocessors

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -10,7 +10,17 @@
  * <li> New: There are now postprocessors BoundaryDensities and
  * BoundaryPressures which calculate laterally averaged densities 
  * and pressures at the top and bottom of the domain.
- * (Ian Rose, 2015/05/27)
+ * (Ian Rose, 2015/05/28)
+ *
+ * <li> New: Postprocessor and visualization postprocessor plugins can
+ * now state that they require other postprocessors to run as well,
+ * for example because they want to query information computed
+ * by these other postprocessors in computing their own information.
+ * This is done using the
+ * aspect::Postprocess::Interface::requires_other_postprocessors()
+ * function.
+ * <br>
+ * (Wolfgang Bangerth, 2015/05/28)
  *
  * <li> New: Added cookbook to prescribe initial condition from shear
  * wave velocity model.

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -128,6 +128,29 @@ namespace aspect
         void
         parse_parameters (ParameterHandler &prm);
 
+        /**
+         * A function that is used to indicate to the postprocessor manager which
+         * other postprocessor(s) the current one depends upon. The returned
+         * list contains the names (as strings, as you would write them in
+         * the input file) of the postprocessors it requires. The manager
+         * will ensure that these postprocessors are indeed used, even if
+         * they were not explicitly listed in the input file, and are indeed
+         * run <i>before</i> this postprocessor everytime they are executed.
+         *
+         * The default implementation of this function returns an empty list.
+         *
+         * @note This mechanism is intended to support postprocessors that
+         * do not want to recompute information that other postprocessors
+         * already compute (or could compute, if they were run -- which
+         * we can ensure using the current function). To do so, a postprocessor
+         * of course needs to be able to access these other postprocessors.
+         * This can be done by deriving your postprocessor from
+         * SimulatorAccess, and then using the SimulatorAccess::find_postprocessor()
+         * function.
+         */
+        virtual
+        std::list<std::string>
+        requires_other_postprocessors () const;
 
         /**
          * Save the state of this object to the argument given to this

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -150,7 +150,7 @@ namespace aspect
          */
         virtual
         std::list<std::string>
-        requires_other_postprocessors () const;
+        required_other_postprocessors () const;
 
         /**
          * Save the state of this object to the argument given to this

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -153,7 +153,7 @@ namespace aspect
            */
           virtual
           std::list<std::string>
-          requires_other_postprocessors () const;
+          required_other_postprocessors () const;
 
 
           /**
@@ -307,7 +307,7 @@ namespace aspect
          */
         virtual
         std::list<std::string>
-        requires_other_postprocessors () const;
+        required_other_postprocessors () const;
 
         /**
          * Declare the parameters this class takes through input files.

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -137,6 +137,24 @@ namespace aspect
           void
           parse_parameters (ParameterHandler &prm);
 
+          /**
+           * A function that is used to indicate to the postprocessor manager which
+           * other postprocessor(s) the current one depends upon. The returned
+           * list contains the names (as strings, as you would write them in
+           * the input file) of the postprocessors it requires. The manager
+           * will ensure that these postprocessors are indeed used, even if
+           * they were not explicitly listed in the input file, and are indeed
+           * run <i>before</i> this postprocessor everytime they are executed.
+           *
+           * The postprocessors you can nominate here are of the general
+           * postprocessor class, not visualization postprocessors.
+           *
+           * The default implementation of this function returns an empty list.
+           */
+          virtual
+          std::list<std::string>
+          requires_other_postprocessors () const;
+
 
           /**
            * Save the state of this object to the argument given to this
@@ -279,6 +297,17 @@ namespace aspect
                                               const std::string &description,
                                               void (*declare_parameters_function) (ParameterHandler &),
                                               VisualizationPostprocessors::Interface<dim> *(*factory_function) ());
+
+        /**
+         * A function that is used to indicate to the postprocessor manager which
+         * other postprocessor(s) the current one depends upon.
+         *
+         * For the current class, we simply loop over all of the visualization
+         * postprocessors and collect what they want.
+         */
+        virtual
+        std::list<std::string>
+        requires_other_postprocessors () const;
 
         /**
          * Declare the parameters this class takes through input files.

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -516,7 +516,7 @@ namespace aspect
        * returns a pointer to the postprocessor object of this type. If
        * no postprocessor of this type has been selected in the input
        * file (or, has been required by another postprocessor using the
-       * Postprocess::Interface::requires_other_postprocessors()
+       * Postprocess::Interface::required_other_postprocessors()
        * mechanism), then the function returns a NULL pointer.
        */
       template <typename PostprocessorType>

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -510,8 +510,14 @@ namespace aspect
 
 
       /**
-       * Find a pointer to a certain postprocessor, if not return a NULL
-       * pointer.
+       * This function can be used to find out whether the list of
+       * postprocessors that are run at the end of each time step
+       * contains an object of the given template type. If so, the function
+       * returns a pointer to the postprocessor object of this type. If
+       * no postprocessor of this type has been selected in the input
+       * file (or, has been required by another postprocessor using the
+       * Postprocess::Interface::requires_other_postprocessors()
+       * mechanism), then the function returns a NULL pointer.
        */
       template <typename PostprocessorType>
       PostprocessorType *

--- a/source/postprocess/interface.cc
+++ b/source/postprocess/interface.cc
@@ -55,6 +55,15 @@ namespace aspect
 
 
     template <int dim>
+    std::list<std::string>
+    Interface<dim>::requires_other_postprocessors() const
+    {
+      return std::list<std::string>();
+    }
+
+
+
+    template <int dim>
     void
     Interface<dim>::save (std::map<std::string,std::string> &) const
     {}
@@ -230,6 +239,34 @@ namespace aspect
 
           postprocessors.back()->parse_parameters (prm);
           postprocessors.back()->initialize ();
+
+          // now see if the newly created postprocessor relies on others. if so,
+          // go through the list of the ones we already have and if the required
+          // ones are new, add them to the end of the list we work through
+          const std::list<std::string> additional_postprocessors
+            = postprocessors.back()->requires_other_postprocessors ();
+
+          for (std::list<std::string>::const_iterator p = additional_postprocessors.begin();
+               p != additional_postprocessors.end(); ++p)
+            {
+              AssertThrow (Patterns::Selection(std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ())
+                           .match (*p) == true,
+                           ExcMessage ("Postprocessor <" + postprocessor_names[name] +
+                                       "> states that it depends on another postprocessor, <"
+                                       + *p +
+                                       ">, but the latter is not a valid name."));
+
+              bool already_present = false;
+              for (unsigned int n=0; n<postprocessor_names.size(); ++n)
+                if (postprocessor_names[n] == *p)
+                  {
+                    already_present = true;
+                    break;
+                  }
+
+              if (already_present == false)
+                postprocessor_names.push_back (*p);
+            }
         }
     }
 

--- a/source/postprocess/interface.cc
+++ b/source/postprocess/interface.cc
@@ -56,7 +56,7 @@ namespace aspect
 
     template <int dim>
     std::list<std::string>
-    Interface<dim>::requires_other_postprocessors() const
+    Interface<dim>::required_other_postprocessors() const
     {
       return std::list<std::string>();
     }
@@ -244,7 +244,7 @@ namespace aspect
           // go through the list of the ones we already have and if the required
           // ones are new, add them to the end of the list we work through
           const std::list<std::string> additional_postprocessors
-            = postprocessors.back()->requires_other_postprocessors ();
+            = postprocessors.back()->required_other_postprocessors ();
 
           for (std::list<std::string>::const_iterator p = additional_postprocessors.begin();
                p != additional_postprocessors.end(); ++p)

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -125,7 +125,7 @@ namespace aspect
 
       template <int dim>
       std::list<std::string>
-      Interface<dim>::requires_other_postprocessors () const
+      Interface<dim>::required_other_postprocessors () const
       {
         return std::list<std::string>();
       }
@@ -871,7 +871,7 @@ namespace aspect
 
     template <int dim>
     std::list<std::string>
-    Visualization<dim>::requires_other_postprocessors () const
+    Visualization<dim>::required_other_postprocessors () const
     {
       std::list<std::string> requirements;
 
@@ -882,7 +882,7 @@ namespace aspect
            p = postprocessors.begin();
            p != postprocessors.end(); ++p)
         {
-          const std::list<std::string> this_requirements = (*p)->requires_other_postprocessors();
+          const std::list<std::string> this_requirements = (*p)->required_other_postprocessors();
           requirements.insert (requirements.end(),
                                this_requirements.begin(), this_requirements.end());
         }

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -124,6 +124,15 @@ namespace aspect
 
 
       template <int dim>
+      std::list<std::string>
+      Interface<dim>::requires_other_postprocessors () const
+      {
+        return std::list<std::string>();
+      }
+
+
+
+      template <int dim>
       void
       Interface<dim>::save (std::map<std::string,std::string> &) const
       {}
@@ -857,6 +866,30 @@ namespace aspect
                                                                declare_parameters_function,
                                                                factory_function);
     }
+
+
+
+    template <int dim>
+    std::list<std::string>
+    Visualization<dim>::requires_other_postprocessors () const
+    {
+      std::list<std::string> requirements;
+
+      // loop over all of the viz postprocessors and collect what
+      // they want. don't worry about duplicates, the postprocessor
+      // manager will filter them out
+      for (typename std::list<std_cxx11::shared_ptr<VisualizationPostprocessors::Interface<dim> > >::const_iterator
+           p = postprocessors.begin();
+           p != postprocessors.end(); ++p)
+        {
+          const std::list<std::string> this_requirements = (*p)->requires_other_postprocessors();
+          requirements.insert (requirements.end(),
+                               this_requirements.begin(), this_requirements.end());
+        }
+
+      return requirements;
+    }
+
 
   }
 }

--- a/tests/plugin_dependency.cc
+++ b/tests/plugin_dependency.cc
@@ -1,0 +1,37 @@
+// create a postprocessor that does exactly the same as
+// SolCxPostprocessor, but also requires something else
+
+#include "solcx.cc"
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+     template <int dim>
+     class NewPostprocessor : public aspect::InclusionBenchmark::SolCxPostprocessor<dim>
+     {
+     public:
+       virtual
+       std::list<std::string>
+       requires_other_postprocessors () const
+       {
+	 // select a postprocessor that is not selected in the .prm file
+	 std::list<std::string> deps;
+	 deps.push_back ("velocity statistics");
+	 return deps;
+       }
+     };
+  }
+}
+
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    ASPECT_REGISTER_POSTPROCESSOR(NewPostprocessor,
+                                  "new postprocessor",
+                                  ".")
+  }
+}
+

--- a/tests/plugin_dependency.cc
+++ b/tests/plugin_dependency.cc
@@ -13,7 +13,7 @@ namespace aspect
      public:
        virtual
        std::list<std::string>
-       requires_other_postprocessors () const
+       required_other_postprocessors () const
        {
 	 // select a postprocessor that is not selected in the .prm file
 	 std::list<std::string> deps;

--- a/tests/plugin_dependency.prm
+++ b/tests/plugin_dependency.prm
@@ -1,0 +1,118 @@
+# Test that the way we provide postprocessors to state that they
+# depend on other postprocessors works
+
+set Dimension = 2
+
+
+set CFL number                             = 1.0
+
+set End time                               = 0
+
+
+set Resume computation                     = false
+
+set Start time                             = 0
+
+set Adiabatic surface temperature          = 0
+
+set Surface pressure                       = 0
+
+set Use years in output instead of seconds = false  # default: true
+
+set Nonlinear solver scheme                = Stokes only
+
+subsection Boundary temperature model
+  set Model name = box
+
+end
+
+
+subsection Discretization
+  set Stokes velocity polynomial degree       = 2
+
+  set Temperature polynomial degree           = 2
+
+  set Use locally conservative discretization = false
+
+  subsection Stabilization parameters
+    set alpha = 2
+
+    set beta  = 0.078
+
+    set cR    = 0.5   # default: 0.11
+  end
+
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+
+    set Y extent = 1
+
+    set Z extent = 1
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+end
+
+
+subsection Initial conditions
+  set Model name = perturbed box
+
+end
+
+
+subsection Material model
+  set Model name = SolCxMaterial
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0                       # default: 2
+  set Initial global refinement          = 2                       # default: 2
+
+  set Strategy                           = density, temperature
+end
+
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false # default: true
+
+
+  set Fixed temperature boundary indicators   = 0, 1
+
+  set Prescribed velocity boundary indicators =
+
+  set Tangential velocity boundary indicators = 0,1,2,3
+
+  set Zero velocity boundary indicators       =
+end
+
+
+subsection Postprocess
+  # choose a postprocessor that will in turn require another one
+  # to run as well (here, velocity statistics)
+  set List of postprocessors = new postprocessor
+
+  subsection Depth average
+    set Time between graphical output = 1e8
+  end
+
+  subsection Visualization
+    set Number of grouped files       = 0
+
+    set Output format                 = gnuplot
+
+    set Time between graphical output = 0   # default: 1e8
+  end
+end
+

--- a/tests/plugin_dependency/screen-output
+++ b/tests/plugin_dependency/screen-output
@@ -1,0 +1,40 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.4.pre
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Loading shared library <./libplugin_dependency.so>
+
+Number of active cells: 16 (on 3 levels)
+Number of degrees of freedom: 268 (162+25+81)
+
+*** Timestep 0:  t=0 seconds
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 17 iterations.
+      Nonlinear Stokes residual: 0.0667217
+   Solving Stokes system... 0 iterations.
+      Nonlinear Stokes residual: 4.40627e-09
+
+   Postprocessing:
+     Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174943e-01, 1.069688e-04, 1.192654e-01
+     RMS, max velocity:             0.00125 m/s, 0.00345 m/s
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |    0.0384s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |   0.00287s |       7.5% |
+| Build Stokes preconditioner     |         1 |   0.00558s |        15% |
+| Solve Stokes system             |         2 |   0.00258s |       6.7% |
+| Initialization                  |         2 |    0.0183s |        48% |
+| Postprocessing                  |         1 |   0.00452s |        12% |
+| Setup dof systems               |         1 |   0.00292s |       7.6% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/plugin_dependency_redundant.cc
+++ b/tests/plugin_dependency_redundant.cc
@@ -1,0 +1,3 @@
+// Exactly like plugin_dependency.cc
+
+#include "plugin_dependency.cc"

--- a/tests/plugin_dependency_redundant.prm
+++ b/tests/plugin_dependency_redundant.prm
@@ -1,0 +1,120 @@
+# like plugin_dependency, but also list the required plugin in the
+# .prm file. this is then redundant, and this test ensures that we
+# don't load the plugin twice
+
+set Dimension = 2
+
+
+set CFL number                             = 1.0
+
+set End time                               = 0
+
+
+set Resume computation                     = false
+
+set Start time                             = 0
+
+set Adiabatic surface temperature          = 0
+
+set Surface pressure                       = 0
+
+set Use years in output instead of seconds = false  # default: true
+
+set Nonlinear solver scheme                = Stokes only
+
+subsection Boundary temperature model
+  set Model name = box
+
+end
+
+
+subsection Discretization
+  set Stokes velocity polynomial degree       = 2
+
+  set Temperature polynomial degree           = 2
+
+  set Use locally conservative discretization = false
+
+  subsection Stabilization parameters
+    set alpha = 2
+
+    set beta  = 0.078
+
+    set cR    = 0.5   # default: 0.11
+  end
+
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+
+    set Y extent = 1
+
+    set Z extent = 1
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+end
+
+
+subsection Initial conditions
+  set Model name = perturbed box
+
+end
+
+
+subsection Material model
+  set Model name = SolCxMaterial
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0                       # default: 2
+  set Initial global refinement          = 2                       # default: 2
+
+  set Strategy                           = density, temperature
+end
+
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false # default: true
+
+
+  set Fixed temperature boundary indicators   = 0, 1
+
+  set Prescribed velocity boundary indicators =
+
+  set Tangential velocity boundary indicators = 0,1,2,3
+
+  set Zero velocity boundary indicators       =
+end
+
+
+subsection Postprocess
+  # choose a postprocessor that will in turn require another one
+  # to run as well (here, velocity statistics). check that
+  # redundancy is no problem
+  set List of postprocessors = new postprocessor, velocity statistics
+
+  subsection Depth average
+    set Time between graphical output = 1e8
+  end
+
+  subsection Visualization
+    set Number of grouped files       = 0
+
+    set Output format                 = gnuplot
+
+    set Time between graphical output = 0   # default: 1e8
+  end
+end
+

--- a/tests/plugin_dependency_redundant/screen-output
+++ b/tests/plugin_dependency_redundant/screen-output
@@ -1,0 +1,40 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.4.pre
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Loading shared library <./libplugin_dependency_redundant.so>
+
+Number of active cells: 16 (on 3 levels)
+Number of degrees of freedom: 268 (162+25+81)
+
+*** Timestep 0:  t=0 seconds
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 17 iterations.
+      Nonlinear Stokes residual: 0.0667217
+   Solving Stokes system... 0 iterations.
+      Nonlinear Stokes residual: 4.40627e-09
+
+   Postprocessing:
+     Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174943e-01, 1.069688e-04, 1.192654e-01
+     RMS, max velocity:             0.00125 m/s, 0.00345 m/s
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |    0.0386s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |   0.00297s |       7.7% |
+| Build Stokes preconditioner     |         1 |   0.00557s |        14% |
+| Solve Stokes system             |         2 |   0.00261s |       6.8% |
+| Initialization                  |         2 |    0.0186s |        48% |
+| Postprocessing                  |         1 |   0.00426s |        11% |
+| Setup dof systems               |         1 |   0.00299s |       7.7% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/plugin_dependency_redundant_02.cc
+++ b/tests/plugin_dependency_redundant_02.cc
@@ -1,0 +1,3 @@
+// Exactly like plugin_dependency.cc
+
+#include "plugin_dependency.cc"

--- a/tests/plugin_dependency_redundant_02.prm
+++ b/tests/plugin_dependency_redundant_02.prm
@@ -1,0 +1,119 @@
+# like plugin_dependency_redundant, but list plugins in reverse order. this
+# should still no lead to any redundancy
+
+set Dimension = 2
+
+
+set CFL number                             = 1.0
+
+set End time                               = 0
+
+
+set Resume computation                     = false
+
+set Start time                             = 0
+
+set Adiabatic surface temperature          = 0
+
+set Surface pressure                       = 0
+
+set Use years in output instead of seconds = false  # default: true
+
+set Nonlinear solver scheme                = Stokes only
+
+subsection Boundary temperature model
+  set Model name = box
+
+end
+
+
+subsection Discretization
+  set Stokes velocity polynomial degree       = 2
+
+  set Temperature polynomial degree           = 2
+
+  set Use locally conservative discretization = false
+
+  subsection Stabilization parameters
+    set alpha = 2
+
+    set beta  = 0.078
+
+    set cR    = 0.5   # default: 0.11
+  end
+
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+
+    set Y extent = 1
+
+    set Z extent = 1
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+end
+
+
+subsection Initial conditions
+  set Model name = perturbed box
+
+end
+
+
+subsection Material model
+  set Model name = SolCxMaterial
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0                       # default: 2
+  set Initial global refinement          = 2                       # default: 2
+
+  set Strategy                           = density, temperature
+end
+
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false # default: true
+
+
+  set Fixed temperature boundary indicators   = 0, 1
+
+  set Prescribed velocity boundary indicators =
+
+  set Tangential velocity boundary indicators = 0,1,2,3
+
+  set Zero velocity boundary indicators       =
+end
+
+
+subsection Postprocess
+  # choose a postprocessor that will in turn require another one
+  # to run as well (here, velocity statistics). check that
+  # redundancy is no problem
+  set List of postprocessors = velocity statistics, new postprocessor
+
+  subsection Depth average
+    set Time between graphical output = 1e8
+  end
+
+  subsection Visualization
+    set Number of grouped files       = 0
+
+    set Output format                 = gnuplot
+
+    set Time between graphical output = 0   # default: 1e8
+  end
+end
+

--- a/tests/plugin_dependency_redundant_02/screen-output
+++ b/tests/plugin_dependency_redundant_02/screen-output
@@ -1,0 +1,40 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.4.pre
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Loading shared library <./libplugin_dependency_redundant_02.so>
+
+Number of active cells: 16 (on 3 levels)
+Number of degrees of freedom: 268 (162+25+81)
+
+*** Timestep 0:  t=0 seconds
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 17 iterations.
+      Nonlinear Stokes residual: 0.0667217
+   Solving Stokes system... 0 iterations.
+      Nonlinear Stokes residual: 4.40627e-09
+
+   Postprocessing:
+     RMS, max velocity:             0.00125 m/s, 0.00345 m/s
+     Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174943e-01, 1.069688e-04, 1.192654e-01
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |    0.0386s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |   0.00297s |       7.7% |
+| Build Stokes preconditioner     |         1 |   0.00557s |        14% |
+| Solve Stokes system             |         2 |   0.00261s |       6.8% |
+| Initialization                  |         2 |    0.0186s |        48% |
+| Postprocessing                  |         1 |   0.00426s |        11% |
+| Setup dof systems               |         1 |   0.00299s |       7.7% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/viz_plugin_dependency.cc
+++ b/tests/viz_plugin_dependency.cc
@@ -1,0 +1,74 @@
+// create a visualization postprocessor that requires something else
+//
+// this works just like the plugin_dependency* tests, just that it's a
+// viz postprocessor, not a regular postprocessor that has
+// dependencies
+
+#include "solcx.cc"
+#include <aspect/postprocess/visualization.h>
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    namespace VisualizationPostprocessors
+    {
+      template <int dim>
+      class MyPostprocessor
+        : public DataPostprocessorScalar<dim>,
+          public SimulatorAccess<dim>,
+          public Interface<dim>
+      {
+        public:
+          MyPostprocessor ()
+	    :
+	    DataPostprocessorScalar<dim> ("my_postprocessor",
+					  update_default)
+	  {}
+
+          virtual
+          void
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &,
+                                             const std::vector<Point<dim> >                  &,
+                                             const std::vector<Point<dim> >                  &,
+                                             std::vector<Vector<double> >                    &computed_quantities) const
+	{
+	  Assert (computed_quantities[0].size() == 1, ExcInternalError());
+	  
+	  for (unsigned int q=0; q<computed_quantities.size(); ++q)
+	    {
+	      // not important what we do here :-)
+	      computed_quantities[q](0) = 0;
+	    }
+	}
+
+	virtual
+	std::list<std::string>
+	requires_other_postprocessors () const
+	{
+	  // select a postprocessor that is not selected in the .prm file
+	  std::list<std::string> deps;
+	  deps.push_back ("velocity statistics");
+	  return deps;
+	}
+      };
+    }
+  }
+}
+
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    namespace VisualizationPostprocessors
+    {
+      ASPECT_REGISTER_VISUALIZATION_POSTPROCESSOR(MyPostprocessor,
+						  "my postprocessor",
+						  ".")
+    }
+  }
+}
+

--- a/tests/viz_plugin_dependency.cc
+++ b/tests/viz_plugin_dependency.cc
@@ -46,7 +46,7 @@ namespace aspect
 
 	virtual
 	std::list<std::string>
-	requires_other_postprocessors () const
+	required_other_postprocessors () const
 	{
 	  // select a postprocessor that is not selected in the .prm file
 	  std::list<std::string> deps;

--- a/tests/viz_plugin_dependency.prm
+++ b/tests/viz_plugin_dependency.prm
@@ -1,0 +1,120 @@
+# Test that the way we provide postprocessors to state that they
+# depend on other postprocessors works
+
+set Dimension = 2
+
+
+set CFL number                             = 1.0
+
+set End time                               = 0
+
+
+set Resume computation                     = false
+
+set Start time                             = 0
+
+set Adiabatic surface temperature          = 0
+
+set Surface pressure                       = 0
+
+set Use years in output instead of seconds = false  # default: true
+
+set Nonlinear solver scheme                = Stokes only
+
+subsection Boundary temperature model
+  set Model name = box
+
+end
+
+
+subsection Discretization
+  set Stokes velocity polynomial degree       = 2
+
+  set Temperature polynomial degree           = 2
+
+  set Use locally conservative discretization = false
+
+  subsection Stabilization parameters
+    set alpha = 2
+
+    set beta  = 0.078
+
+    set cR    = 0.5   # default: 0.11
+  end
+
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+
+    set Y extent = 1
+
+    set Z extent = 1
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+end
+
+
+subsection Initial conditions
+  set Model name = perturbed box
+
+end
+
+
+subsection Material model
+  set Model name = SolCxMaterial
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0                       # default: 2
+  set Initial global refinement          = 2                       # default: 2
+
+  set Strategy                           = density, temperature
+end
+
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false # default: true
+
+
+  set Fixed temperature boundary indicators   = 0, 1
+
+  set Prescribed velocity boundary indicators =
+
+  set Tangential velocity boundary indicators = 0,1,2,3
+
+  set Zero velocity boundary indicators       =
+end
+
+
+subsection Postprocess
+  set List of postprocessors = visualization
+
+  subsection Depth average
+    set Time between graphical output = 1e8
+  end
+
+  subsection Visualization
+    # choose a postprocessor that will in turn require another one
+    # to run as well (here, velocity statistics)
+    set List of output variables = my postprocessor
+
+    set Number of grouped files       = 0
+
+    set Output format                 = gnuplot
+
+    set Time between graphical output = 0   # default: 1e8
+  end
+end
+

--- a/tests/viz_plugin_dependency/screen-output
+++ b/tests/viz_plugin_dependency/screen-output
@@ -1,0 +1,40 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.4.pre
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Loading shared library <./libviz_plugin_dependency.so>
+
+Number of active cells: 16 (on 3 levels)
+Number of degrees of freedom: 268 (162+25+81)
+
+*** Timestep 0:  t=0 seconds
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 17 iterations.
+      Nonlinear Stokes residual: 0.0667217
+   Solving Stokes system... 0 iterations.
+      Nonlinear Stokes residual: 4.40627e-09
+
+   Postprocessing:
+     Writing graphical output: output-viz_plugin_dependency/solution-00000
+     RMS, max velocity:        0.00125 m/s, 0.00345 m/s
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |    0.0345s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |   0.00278s |         8% |
+| Build Stokes preconditioner     |         1 |    0.0057s |        17% |
+| Solve Stokes system             |         2 |   0.00246s |       7.1% |
+| Initialization                  |         2 |    0.0179s |        52% |
+| Postprocessing                  |         1 |   0.00126s |       3.7% |
+| Setup dof systems               |         1 |   0.00279s |       8.1% |
++---------------------------------+-----------+------------+------------+
+


### PR DESCRIPTION
Using this, postprocessors can say that they want other postprocessors to run as well, for example because they want to reuse information these other postprocessors have already computed.

Fixes #460 