### PR TITLE
harden floating point exception check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,16 @@ IF (_HAVE_LINK_H)
   ENDFOREACH()
 ENDIF()
 
+INCLUDE (CheckCXXSymbolExists)
+CHECK_CXX_SYMBOL_EXISTS("feenableexcept" "fenv.h" _HAVE_FPE_EXCEPTIONS)
+IF (_HAVE_FPE_EXCEPTIONS)
+  FOREACH(_source_file ${TARGET_SRC})
+    SET_PROPERTY(SOURCE ${_source_file}
+      APPEND PROPERTY COMPILE_DEFINITIONS ASPECT_HAVE_FPE_EXCEPTIONS=1)
+  ENDFOREACH()
+ELSE()
+  MESSAGE(STATUS "No support for feenableexcept(), disabling runtime floating point exception checks...")
+ENDIF()
 
 DEAL_II_INVOKE_AUTOPILOT()
 

--- a/source/main.cc
+++ b/source/main.cc
@@ -25,7 +25,9 @@
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/multithread_info.h>
 
-#include <cfenv>
+#ifdef ASPECT_HAVE_FPE_EXCEPTIONS
+#include <fenv.h>
+#endif
 
 #if ASPECT_USE_SHARED_LIBS==1
 #  include <dlfcn.h>
@@ -378,8 +380,10 @@ int main (int argc, char *argv[])
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, /*n_threads =*/ 1);
 
 #ifdef DEBUG
+#ifdef ASPECT_HAVE_FPE_EXCEPTIONS
   // enable floating point exceptions
   feenableexcept(FE_DIVBYZERO|FE_INVALID);
+#endif
 #endif
 
   try


### PR DESCRIPTION
Do a configure check to ensure we have feenableexcept. Also switch to
the c version of the header because the cxx version would require c++11.