### PR TITLE
Fix cookbooks so they can run on odd Macs as well.

### DIFF
--- a/cookbooks/latent-heat.prm
+++ b/cookbooks/latent-heat.prm
@@ -67,7 +67,7 @@ end
 subsection Initial conditions
   set Model name = function
   subsection Function
-    set Function expression = 1000.0
+    set Function expression = 1.0e3
     set Variable names      = x,y
   end
 end

--- a/cookbooks/shell_simple_3d.prm
+++ b/cookbooks/shell_simple_3d.prm
@@ -51,7 +51,7 @@ end
 subsection Initial conditions
   set Model name = function
   subsection Function
-    set Function expression = 1473
+    set Function expression = 1.473e3
   end
 end
 

--- a/cookbooks/stokes.prm
+++ b/cookbooks/stokes.prm
@@ -96,7 +96,7 @@ subsection Compositional initial conditions
 
   subsection Function
     set Variable names      = x,y,z
-    set Function constants  = r=200000,p=1445000
+    set Function constants  = r=2e5, p=1.445e6
     set Function expression = if(sqrt((x-p)*(x-p)+(y-p)*(y-p)+(z-p)*(z-p)) > r, 0, 1)
   end
 end


### PR DESCRIPTION
For reasons that are beyond a solid understanding, the function parser
thinks that 4 or more digits are not a number on some Mac OS X
systems. The problem is that it thinks that the locale *requires*,
not just allows, the use of commas as thousands separators. It then
thinks that such numbers are obviously names, and complains that
the symbol has not been assigned a numerical value. Very awkward to
make sense of.

This only appears to be a problem inside the function parser. All other
parameters that are not treated as function expressions are ok.