### PR TITLE
fix tests/terminate_user_request

### DIFF
--- a/tests/terminate_user_request.cc
+++ b/tests/terminate_user_request.cc
@@ -1,0 +1,14 @@
+#include <stdlib.h>
+
+// Create a function that is run upon loading the plugin. We delete the
+// restart.mesh file that is used as a trigger for terminating
+// ASPECT. Otherwise we might have a left over file that triggers termination
+// immediately.
+int f()
+{
+  system ("rm -f output-terminate_user_request/restart.mesh");
+  return 42;
+}
+
+// run this function by initializing a global variable by it
+int i = f();

--- a/tests/terminate_user_request/screen-output
+++ b/tests/terminate_user_request/screen-output
@@ -6,6 +6,8 @@
 --     . using Trilinos
 -----------------------------------------------------------------------------
 
+Loading shared library <./libterminate_user_request.so>
+
 Number of active cells: 1,024 (on 6 levels)
 Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
 


### PR DESCRIPTION
The test terminate_user_request terminates when finding the file
restart.mesh which is generated after a couple of time steps. If this
test is run again from a directory that is not clean, it will fail if
restart.mesh still exists. Fix this deleting this file by loading a
plugin upon loading.