### PR TITLE
Implement that postprocessor plugins are run in proper order.

### DIFF
--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -303,7 +303,7 @@ namespace aspect
          * A list of postprocessor objects that have been requested in the
          * parameter file.
          */
-        std::list<std_cxx11::shared_ptr<Interface<dim> > > postprocessors;
+        std::vector<std_cxx11::shared_ptr<Interface<dim> > > postprocessors;
     };
 
 
@@ -317,7 +317,7 @@ namespace aspect
       // let all the postprocessors save their data in a map and then
       // serialize that
       std::map<std::string,std::string> saved_text;
-      for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
+      for (typename std::vector<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
            p = postprocessors.begin();
            p != postprocessors.end(); ++p)
         (*p)->save (saved_text);
@@ -338,7 +338,7 @@ namespace aspect
       std::map<std::string,std::string> saved_text;
       ar &saved_text;
 
-      for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::iterator
+      for (typename std::vector<std_cxx11::shared_ptr<Interface<dim> > >::iterator
            p = postprocessors.begin();
            p != postprocessors.end(); ++p)
         (*p)->load (saved_text);
@@ -357,7 +357,7 @@ namespace aspect
     PostprocessorType *
     Manager<dim>::find_postprocessor () const
     {
-      for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
+      for (typename std::vector<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
            p = postprocessors.begin();
            p != postprocessors.end(); ++p)
         if (PostprocessorType *x = dynamic_cast<PostprocessorType *> ( (*p).get()) )

--- a/source/postprocess/interface.cc
+++ b/source/postprocess/interface.cc
@@ -87,7 +87,7 @@ namespace aspect
       // call the execute() functions of all postprocessor objects we have
       // here in turns
       std::list<std::pair<std::string,std::string> > output_list;
-      for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::iterator
+      for (typename std::vector<std_cxx11::shared_ptr<Interface<dim> > >::iterator
            p = postprocessors.begin();
            p != postprocessors.end(); ++p)
         {
@@ -268,6 +268,97 @@ namespace aspect
                 postprocessor_names.push_back (*p);
             }
         }
+      Assert (postprocessor_names.size() == postprocessors.size(),
+              ExcInternalError());
+
+      // we now have matching lists 'postprocessors' and 'postprocessor_names'
+      // that define which postprocessors we have. we just need to bring them
+      // into an order so that dependencies run first, and dependents after
+      // them. the algorithm for creating a sorted list for this works as follows:
+      //
+      // while there are postprocessors not yet added to the sorted list:
+      // - go through the list
+      // - if we encounter a postprocessor that has not yet been added yet:
+      //   . if all of its dependencies are in the list, add it to the end
+      //   . if at least one of its dependencies are not yet in the list,
+      //     skip it
+      //
+      // if we go through a loop where we do not add a postprocessor to the list
+      // but there are still ones that haven't been added to the list, then we
+      // have found a cycle in the dependencies and that is clearly a problem
+      std::vector<bool> already_assigned (postprocessors.size(), false);
+      std::vector<std::string> sorted_names;
+      std::vector<std_cxx11::shared_ptr<Interface<dim> > > sorted_postprocessors;
+      while (sorted_names.size() < postprocessors.size())
+        {
+          bool at_least_one_element_added = false;
+
+          {
+            typename std::vector<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
+            pp = postprocessors.begin();
+            for (unsigned int i=0; i<postprocessor_names.size(); ++i, ++pp)
+              if (already_assigned[i] == false)
+                {
+                  // for this postprocessor, check if all of its dependencies
+                  // are already in the list
+                  const std::list<std::string> deps = (*pp)->required_other_postprocessors();
+                  bool unmet_dependencies = false;
+                  for (std::list<std::string>::const_iterator p = deps.begin();
+                       p != deps.end(); ++p)
+                    if (std::find (sorted_names.begin(),
+                                   sorted_names.end(),
+                                   *p) == sorted_names.end())
+                      {
+                        unmet_dependencies = true;
+                        break;
+                      }
+
+                  // if we have unmet dependencies, there is nothing we can do
+                  // right now for this postprocessor (but we will come back for it)
+                  //
+                  // if there are none, add this postprocessor
+                  if (unmet_dependencies == false)
+                    {
+                      sorted_names.push_back (postprocessor_names[i]);
+                      sorted_postprocessors.push_back (postprocessors[i]);
+                      already_assigned[i] = true;
+                      at_least_one_element_added = true;
+                    }
+                }
+          }
+
+          // check that we have added at least one element; if not, there is a cycle
+          if (at_least_one_element_added == false)
+            {
+              std::ostringstream out;
+              out << "While sorting postprocessors by their dependencies, "
+                  "ASPECT encountered a cycle in dependencies. The following "
+                  "postprocessors are involved:\n";
+              typename std::vector<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
+              pp = postprocessors.begin();
+              for (unsigned int i=0; i<postprocessor_names.size(); ++i, ++pp)
+                if (already_assigned[i] == false)
+                  {
+                    out << "  " << postprocessor_names[i] << " -> ";
+                    const std::list<std::string> deps = (*pp)->required_other_postprocessors();
+                    for (std::list<std::string>::const_iterator p = deps.begin();
+                         p != deps.end(); ++p)
+                      out << "'" << *p << "' ";
+                    out << std::endl;
+                  }
+              AssertThrow (false, ExcMessage(out.str()));
+            }
+        }
+      Assert (postprocessor_names.size() == sorted_names.size(),
+              ExcInternalError());
+      Assert (sorted_postprocessors.size() == sorted_names.size(),
+              ExcInternalError());
+      Assert (std::find (already_assigned.begin(), already_assigned.end(), false) == already_assigned.end(),
+              ExcInternalError());
+
+      // finally swap the unsorted list with the sorted list and only
+      // keep the latter
+      postprocessors.swap (sorted_postprocessors);
     }
 
 

--- a/tests/plugin_dependency/screen-output
+++ b/tests/plugin_dependency/screen-output
@@ -19,22 +19,22 @@ Number of degrees of freedom: 268 (162+25+81)
       Nonlinear Stokes residual: 4.40627e-09
 
    Postprocessing:
-     Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174943e-01, 1.069688e-04, 1.192654e-01
      RMS, max velocity:             0.00125 m/s, 0.00345 m/s
+     Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174943e-01, 1.069688e-04, 1.192654e-01
 
 Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |    0.0384s |            |
+| Total wallclock time elapsed since start    |    0.0375s |            |
 |                                             |            |            |
 | Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |   0.00287s |       7.5% |
-| Build Stokes preconditioner     |         1 |   0.00558s |        15% |
-| Solve Stokes system             |         2 |   0.00258s |       6.7% |
-| Initialization                  |         2 |    0.0183s |        48% |
-| Postprocessing                  |         1 |   0.00452s |        12% |
-| Setup dof systems               |         1 |   0.00292s |       7.6% |
+| Assemble Stokes system          |         2 |   0.00291s |       7.8% |
+| Build Stokes preconditioner     |         1 |   0.00541s |        14% |
+| Solve Stokes system             |         2 |   0.00245s |       6.5% |
+| Initialization                  |         2 |    0.0182s |        48% |
+| Postprocessing                  |         1 |   0.00414s |        11% |
+| Setup dof systems               |         1 |   0.00279s |       7.4% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/plugin_dependency_redundant/screen-output
+++ b/tests/plugin_dependency_redundant/screen-output
@@ -19,22 +19,22 @@ Number of degrees of freedom: 268 (162+25+81)
       Nonlinear Stokes residual: 4.40627e-09
 
    Postprocessing:
-     Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174943e-01, 1.069688e-04, 1.192654e-01
      RMS, max velocity:             0.00125 m/s, 0.00345 m/s
+     Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174943e-01, 1.069688e-04, 1.192654e-01
 
 Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |    0.0386s |            |
+| Total wallclock time elapsed since start    |    0.0437s |            |
 |                                             |            |            |
 | Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |   0.00297s |       7.7% |
-| Build Stokes preconditioner     |         1 |   0.00557s |        14% |
-| Solve Stokes system             |         2 |   0.00261s |       6.8% |
-| Initialization                  |         2 |    0.0186s |        48% |
-| Postprocessing                  |         1 |   0.00426s |        11% |
-| Setup dof systems               |         1 |   0.00299s |       7.7% |
+| Assemble Stokes system          |         2 |   0.00333s |       7.6% |
+| Build Stokes preconditioner     |         1 |   0.00639s |        15% |
+| Solve Stokes system             |         2 |   0.00294s |       6.7% |
+| Initialization                  |         2 |    0.0211s |        48% |
+| Postprocessing                  |         1 |    0.0047s |        11% |
+| Setup dof systems               |         1 |   0.00319s |       7.3% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/viz_plugin_dependency/screen-output
+++ b/tests/viz_plugin_dependency/screen-output
@@ -19,22 +19,22 @@ Number of degrees of freedom: 268 (162+25+81)
       Nonlinear Stokes residual: 4.40627e-09
 
    Postprocessing:
-     Writing graphical output: output-viz_plugin_dependency/solution-00000
      RMS, max velocity:        0.00125 m/s, 0.00345 m/s
+     Writing graphical output: output-viz_plugin_dependency/solution-00000
 
 Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |    0.0345s |            |
+| Total wallclock time elapsed since start    |    0.0392s |            |
 |                                             |            |            |
 | Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |   0.00278s |         8% |
-| Build Stokes preconditioner     |         1 |    0.0057s |        17% |
-| Solve Stokes system             |         2 |   0.00246s |       7.1% |
-| Initialization                  |         2 |    0.0179s |        52% |
-| Postprocessing                  |         1 |   0.00126s |       3.7% |
-| Setup dof systems               |         1 |   0.00279s |       8.1% |
+| Assemble Stokes system          |         2 |   0.00359s |       9.2% |
+| Build Stokes preconditioner     |         1 |   0.00614s |        16% |
+| Solve Stokes system             |         2 |   0.00287s |       7.3% |
+| Initialization                  |         2 |    0.0205s |        52% |
+| Postprocessing                  |         1 |   0.00109s |       2.8% |
+| Setup dof systems               |         1 |   0.00313s |         8% |
 +---------------------------------+-----------+------------+------------+
 


### PR DESCRIPTION
This requires building a list that orders postprocessors so that dependencies come before
dependents.