### PR TITLE
Revert part of the changes which included MaterialModelInputs<dim>

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -384,7 +384,6 @@ namespace aspect
                     const typename DoFHandler<dim>::active_cell_iterator &cell,
                     const Quadrature<dim>         &quadrature_formula,
                     const Mapping<dim>            &mapping,
-                    const MaterialModelInputs<dim>  &values_in,
                     MaterialModelOutputs<dim>          &values_out);
     }
 

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -372,11 +372,9 @@ namespace aspect
         // Do the requested averaging operation for one array. The
         // projection matrix argument is only used if the operation
         // chosen is project_to_Q1
-        template <int dim>
         void average (const AveragingOperation  operation,
                       const FullMatrix<double>      &projection_matrix,
                       const FullMatrix<double>      &expansion_matrix,
-                      const std::vector<Point<dim> > &,
                       std::vector<double>           &values_out)
         {
           // if an output field has not been filled (because it was
@@ -601,7 +599,6 @@ namespace aspect
                     const typename DoFHandler<dim>::active_cell_iterator &cell,
                     const Quadrature<dim>         &quadrature_formula,
                     const Mapping<dim>            &mapping,
-                    const MaterialModelInputs<dim>  &values_in,
                     MaterialModelOutputs<dim>          &values_out)
       {
         FullMatrix<double> projection_matrix;
@@ -618,20 +615,19 @@ namespace aspect
                                        expansion_matrix);
           }
 
+        average (operation, projection_matrix, expansion_matrix, values_out.viscosities);
         average (operation, projection_matrix, expansion_matrix,
-                 values_in.position,values_out.viscosities);
+                 values_out.densities);
         average (operation, projection_matrix, expansion_matrix,
-                 values_in.position,values_out.densities);
+                 values_out.thermal_expansion_coefficients);
         average (operation, projection_matrix, expansion_matrix,
-                 values_in.position,values_out.thermal_expansion_coefficients);
+                 values_out.specific_heat);
         average (operation, projection_matrix, expansion_matrix,
-                 values_in.position,values_out.specific_heat);
+                 values_out.compressibilities);
         average (operation, projection_matrix, expansion_matrix,
-                 values_in.position,values_out.compressibilities);
+                 values_out.entropy_derivative_pressure);
         average (operation, projection_matrix, expansion_matrix,
-                 values_in.position,values_out.entropy_derivative_pressure);
-        average (operation, projection_matrix, expansion_matrix,
-                 values_in.position,values_out.entropy_derivative_temperature);
+                 values_out.entropy_derivative_temperature);
 
         // the reaction terms are unfortunately stored in reverse
         // indexing. it's also not quite clear whether these should
@@ -700,7 +696,6 @@ namespace aspect
                   const DoFHandler<dim>::active_cell_iterator &cell, \
                   const Quadrature<dim>     &quadrature_formula, \
                   const Mapping<dim>        &mapping, \
-                  const MaterialModelInputs<dim>  &values_in,\
                   MaterialModelOutputs<dim>      &values_out); \
   }
 

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -982,7 +982,6 @@ namespace aspect
                                                cell,
                                                scratch.finite_element_values.get_quadrature(),
                                                scratch.finite_element_values.get_mapping(),
-                                               scratch.material_model_inputs,
                                                scratch.material_model_outputs);
 
     for (unsigned int q=0; q<n_q_points; ++q)
@@ -1177,7 +1176,6 @@ namespace aspect
                                                cell,
                                                scratch.finite_element_values.get_quadrature(),
                                                scratch.finite_element_values.get_mapping(),
-                                               scratch.material_model_inputs,
                                                scratch.material_model_outputs);
 
     scratch.finite_element_values[introspection.extractors.velocities].get_function_values(current_linearization_point,
@@ -1489,7 +1487,6 @@ namespace aspect
                                                cell,
                                                scratch.finite_element_values.get_quadrature(),
                                                scratch.finite_element_values.get_mapping(),
-                                               scratch.material_model_inputs,
                                                scratch.material_model_outputs);
 
     HeatingModel::HeatingModelOutputs heating_model_outputs(n_q_points, parameters.n_compositional_fields);
@@ -1519,7 +1516,6 @@ namespace aspect
                                                  cell,
                                                  scratch.finite_element_values.get_quadrature(),
                                                  scratch.finite_element_values.get_mapping(),
-                                                 scratch.explicit_material_model_inputs,
                                                  scratch.explicit_material_model_outputs);
     }
 


### PR DESCRIPTION
into the interface of the averaging of the material model interface.
Because the new averaging schemes are implemented as material models,
these interfaces are not required anymore.