### PR TITLE
Fix Chunk GeometryModel

### DIFF
--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -27,48 +27,6 @@
 #include <deal.II/base/function_lib.h>
 #include <deal.II/grid/grid_out.h>
 
-namespace
-{
-  using namespace dealii;
-
-  /**
-   * A geometry model class that describes a chunk of a spherical shell.
-   * In 2D, this class simulates a sector with inner and outer radius, and
-   * minimum and maximum longitude. Longitude increases anticlockwise
-   * from the positive x-axis, as per the mathematical convention of phi.
-   * In 3D, the class simulates a chunk of a sphere, bounded by arbitrary
-   * lines of longitude, latitude and radius. Boundary indicator names are
-   * west, east, south, north, inner and outer.
-   *
-   * The parameters that describe this geometry and that are read from the
-   * input file are the inner and outer radii of the shell, the minimum
-   * and maximum longitude, minimum and maximum longitude, and the
-   * number of cells initialised in each dimension.
-   */
-
-  /**
-   * ChunkGeometry is a class that implements the interface of
-   * ChartManifold. The function push_forward takes a point
-   * in the reference (lat,long,radius) domain and transforms
-   * it into real space (cartesian). The inverse function
-   * pull_back reverses this operation.
-   */
-
-  template <int dim>
-  class ChunkGeometry : public ChartManifold<dim,dim>
-  {
-    public:
-      virtual
-      Point<dim>
-      pull_back(const Point<dim> &space_point) const;
-
-      virtual
-      Point<dim>
-      push_forward(const Point<dim> &chart_point) const;
-  };
-
-}
-
 namespace aspect
 {
   namespace GeometryModel
@@ -76,9 +34,18 @@ namespace aspect
     using namespace dealii;
 
     /**
-     * A class that describes a piece of a circle/sphere delimited by
-     * minimum and maximum longitude and radius (2D), or
-     * minimum and maximum longitude, latitude and radius (3D)
+     * A geometry model class that describes a chunk of a spherical shell.
+     * In 2D, this class simulates a sector with inner and outer radius, and
+     * minimum and maximum longitude. Longitude increases anticlockwise
+     * from the positive x-axis, as per the mathematical convention of phi.
+     * In 3D, the class simulates a chunk of a sphere, bounded by arbitrary
+     * lines of longitude, latitude and radius. Boundary indicator names are
+     * west, east, south, north, inner and outer.
+     *
+     * The parameters that describe this geometry and that are read from the
+     * input file are the inner and outer radii of the shell, the minimum
+     * and maximum longitude, minimum and maximum longitude, and the
+     * number of cells initialised in each dimension.
      */
     template <int dim>
     class Chunk : public Interface<dim>
@@ -202,9 +169,29 @@ namespace aspect
         unsigned int repetitions[dim];
 
         /**
+         * ChunkGeometry is a class that implements the interface of
+         * ChartManifold. The function push_forward takes a point
+         * in the reference (lat,long,radius) domain and transforms
+         * it into real space (cartesian). The inverse function
+         * pull_back reverses this operation.
+         */
+
+        class ChunkGeometry : public ChartManifold<dim,dim>
+        {
+          public:
+            virtual
+            Point<dim>
+            pull_back(const Point<dim> &space_point) const;
+
+            virtual
+            Point<dim>
+            push_forward(const Point<dim> &chart_point) const;
+        };
+
+        /**
          * An object that describes the geometry.
          */
-        ChunkGeometry<dim> manifold;
+        ChunkGeometry manifold;
 
         static void set_manifold_ids (Triangulation<dim> &triangulation);
         static void clear_manifold_ids (Triangulation<dim> &triangulation);

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -28,72 +28,65 @@
 #include <deal.II/grid/tria_boundary_lib.h>
 #include <deal.II/grid/manifold_lib.h>
 
-namespace
-{
-  using namespace dealii;
-
-  template <int dim>
-  Point<dim>
-  ChunkGeometry<dim>::
-  push_forward(const Point<dim> &input_vertex) const
-  {
-    Point<dim> output_vertex;
-    switch (dim)
-      {
-        case 2:
-        {
-          output_vertex[0] = input_vertex[0]*std::cos(input_vertex[1]); // x=rcosphi
-          output_vertex[1] = input_vertex[0]*std::sin(input_vertex[1]); // z=rsinphi
-          break;
-        }
-        case 3:
-        {
-          output_vertex[0] = input_vertex[0]*std::cos(input_vertex[2])*std::cos(input_vertex[1]); // x=rsinthetacosphi
-          output_vertex[1] = input_vertex[0]*std::cos(input_vertex[2])*std::sin(input_vertex[1]); // y=rsinthetasinphi
-          output_vertex[2] = input_vertex[0]*std::sin(input_vertex[2]); // z=rcostheta
-          break;
-        }
-        default:
-          Assert (false, ExcNotImplemented ());
-      }
-    return output_vertex;
-  }
-
-  template <int dim>
-  Point<dim>
-  ChunkGeometry<dim>::
-  pull_back(const Point<dim> &v) const
-  {
-    Point<dim> output_vertex;
-    switch (dim)
-      {
-        case 2:
-        {
-          output_vertex[1] = std::atan2(v[1], v[0]);
-          output_vertex[0] = v.norm();
-          break;
-        }
-        case 3:
-        {
-          const double radius=v.norm();
-          output_vertex[0] = radius;
-          output_vertex[1] = std::atan2(v[1], v[0]);
-          output_vertex[2] = std::asin(v[2]/radius);
-          break;
-        }
-        default:
-          Assert (false, ExcNotImplemented ());
-      }
-    return output_vertex;
-  }
-
-}
-
 
 namespace aspect
 {
   namespace GeometryModel
   {
+    template <int dim>
+    Point<dim>
+    Chunk<dim>::ChunkGeometry::
+    push_forward(const Point<dim> &input_vertex) const
+    {
+      Point<dim> output_vertex;
+      switch (dim)
+        {
+          case 2:
+          {
+            output_vertex[0] = input_vertex[0]*std::cos(input_vertex[1]); // x=rcosphi
+            output_vertex[1] = input_vertex[0]*std::sin(input_vertex[1]); // z=rsinphi
+            break;
+          }
+          case 3:
+          {
+            output_vertex[0] = input_vertex[0]*std::cos(input_vertex[2])*std::cos(input_vertex[1]); // x=rsinthetacosphi
+            output_vertex[1] = input_vertex[0]*std::cos(input_vertex[2])*std::sin(input_vertex[1]); // y=rsinthetasinphi
+            output_vertex[2] = input_vertex[0]*std::sin(input_vertex[2]); // z=rcostheta
+            break;
+          }
+          default:
+            Assert (false, ExcNotImplemented ());
+        }
+      return output_vertex;
+    }
+
+    template <int dim>
+    Point<dim>
+    Chunk<dim>::ChunkGeometry::
+    pull_back(const Point<dim> &v) const
+    {
+      Point<dim> output_vertex;
+      switch (dim)
+        {
+          case 2:
+          {
+            output_vertex[1] = std::atan2(v[1], v[0]);
+            output_vertex[0] = v.norm();
+            break;
+          }
+          case 3:
+          {
+            const double radius=v.norm();
+            output_vertex[0] = radius;
+            output_vertex[1] = std::atan2(v[1], v[0]);
+            output_vertex[2] = std::asin(v[2]/radius);
+            break;
+          }
+          default:
+            Assert (false, ExcNotImplemented ());
+        }
+      return output_vertex;
+    }
 
     template <int dim>
     void
@@ -109,7 +102,7 @@ namespace aspect
 
 
       // Transform box into spherical chunk
-      GridTools::transform (std_cxx11::bind(&ChunkGeometry<dim>::push_forward,
+      GridTools::transform (std_cxx11::bind(&ChunkGeometry::push_forward,
                                             std_cxx11::cref(manifold),
                                             std_cxx11::_1),
                             coarse_grid);


### PR DESCRIPTION
Intel doesn't like separating declaration and definition of ChunkGeometry
inside an anonymous namespace. Having an anonymous namespace in a .h is weird
anyway, so move it.

Also fix doxygen documentation.