### PR TITLE
fix hdf5 output after resume

### DIFF
--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -153,7 +153,8 @@ namespace aspect
       // initialize this to a nonsensical value; set it to the actual time
       // the first time around we get to check it
       last_output_time (std::numeric_limits<double>::quiet_NaN()),
-      output_file_number (0)
+      output_file_number (0),
+      mesh_changed (true)
     {}
 
 
@@ -795,10 +796,15 @@ namespace aspect
       & output_file_number
       & times_and_pvtu_names
       & output_file_names_by_timestep
-      & mesh_changed
       & last_mesh_file_name
       & xdmf_entries
       ;
+
+      // We do not serialize mesh_changed but use the default (true) from our
+      // constructor. This will result in a new mesh file the first time we
+      // create visualization output after resuming from a snapshot. Otherwise
+      // we might get corrupted graphical output, because the ordering of
+      // vertices can be different after resuming.
     }
 
 


### PR DESCRIPTION
Bug reported by Siqi Zhang on the ASPECT mailing list. HDF5 output might
be corrupted after resuming from a snapshot when the mesh file is not
written. This is likely happening because the ordering of vertices or
some other data structure can be different when we reconstruct the mesh
after resuming.
Fix this by writing the mesh data after we resume from a snapshot.