### PR TITLE
Avoid a division by zero.

### DIFF
--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1119,8 +1119,10 @@ namespace aspect
           fe_values[field_].get_function_values (solution, velocity_values);
           for (unsigned int q=0; q<output.size(); ++q)
             {
-              Tensor<1,dim> g = gravity_->gravity_vector(in.position[q]);
-              output[q] = std::fabs(std::min(0.0, g*velocity_values[q]/g.norm()))*year_in_seconds;
+              const Tensor<1,dim> g = gravity_->gravity_vector(in.position[q]);
+              const Tensor<1,dim> vertical = (g.norm() > 0 ? g/g.norm() : Tensor<1,dim>());
+
+              output[q] = std::fabs(std::min(0.0, velocity_values[q] * vertical))*year_in_seconds;
             }
         }
 


### PR DESCRIPTION
This can happen if the gravity model happens to return a zero vector at some points.