### PR TITLE
rework floating point exception configure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,34 +165,33 @@ IF (_HAVE_LINK_H)
   ENDFOREACH()
 ENDIF()
 
+DEAL_II_INVOKE_AUTOPILOT()
 
+
+# Check if we can raise floating point exceptions.
+#
+# Note that some library we link with in ASPECT on some platforms will trigger
+# floating point exceptions when converting -numeric_limits<double>::max to a
+# string. The only thing we can do is a configure check and disable the
+# exceptions. This is done here:
 SET(ASPECT_USE_FP_EXCEPTIONS ON CACHE BOOL "If ON, floating point exception are raised in debug mode.")
 
-IF (ASPECT_USE_FP_EXCEPTIONS 
-    AND CMAKE_CXX_COMPILER_ID MATCHES "Intel"
-    AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "15"
-    )
-  # deal.II is triggering floating point exception in Pattern::Double() so disable them
-  MESSAGE("Runtime floating point checks not supported on Intel compiler. Disabling...")
-  SET(ASPECT_USE_FP_EXCEPTIONS OFF CACHE BOOL "" FORCE)
-ENDIF()
+IF (ASPECT_USE_FP_EXCEPTIONS)
+  INCLUDE(${CMAKE_SOURCE_DIR}/cmake/fpe_check.cmake)
 
-INCLUDE (CheckCXXSymbolExists)
-CHECK_CXX_SYMBOL_EXISTS("feenableexcept" "fenv.h" _HAVE_FP_EXCEPTIONS)
-IF (_HAVE_FP_EXCEPTIONS AND ASPECT_USE_FP_EXCEPTIONS)
-  MESSAGE(STATUS "Runtime floating point checks enabled.")
-  FOREACH(_source_file ${TARGET_SRC})
-    SET_PROPERTY(SOURCE ${_source_file}
-      APPEND PROPERTY COMPILE_DEFINITIONS ASPECT_USE_FP_EXCEPTIONS=1)
-  ENDFOREACH()
-ELSE()
-  IF (ASPECT_USE_FP_EXCEPTIONS)
+  IF (HAVE_FP_EXCEPTIONS)
+    MESSAGE(STATUS "Runtime floating point checks enabled.")
+    FOREACH(_source_file ${TARGET_SRC})
+      SET_PROPERTY(SOURCE ${_source_file}
+        APPEND PROPERTY COMPILE_DEFINITIONS ASPECT_USE_FP_EXCEPTIONS=1)
+    ENDFOREACH()
+  ELSE()
     SET(ASPECT_USE_FP_EXCEPTIONS OFF CACHE BOOL "" FORCE)
     MESSAGE(STATUS "No support for feenableexcept(), disabling runtime floating point exception checks.")
   ENDIF()
 ENDIF()
 
-DEAL_II_INVOKE_AUTOPILOT()
+
 
 MESSAGE(STATUS "Writing config into detailed.log...")
 LIST(APPEND CMAKE_MODULE_PATH

--- a/cmake/fpe_check.cmake
+++ b/cmake/fpe_check.cmake
@@ -1,0 +1,42 @@
+# Check that we can use feenableexcept. Sets HAVE_FP_EXCEPTIONS.
+
+# The test is a bit more complicated because we want to check that no garbage
+# exception is thrown if we convert -std::numeric_limits<double>::max to a
+# string. Sadly, this bug only triggers if we link with all the deal.II
+# libraries.
+
+INCLUDE (CheckCXXSourceRuns)
+
+SET(_backup_libs ${CMAKE_REQUIRED_LIBRARIES})
+SET(_backup_includes ${CMAKE_REQUIRED_LIBRARIES})
+SET(_build "RELEASE")
+STRING(TOLOWER "${CMAKE_BUILD_TYPE}" _cmake_build_type)
+IF("${_cmake_build_type}" MATCHES "debug")
+  SET(_build "DEBUG")
+ENDIF()
+
+LIST(APPEND CMAKE_REQUIRED_LIBRARIES ${DEAL_II_TARGET_${_build}})
+LIST(APPEND CMAKE_REQUIRED_INCLUDES ${DEAL_II_INCLUDE_DIRS})
+
+CHECK_CXX_SOURCE_RUNS("
+#include <fenv.h>
+#include <limits>
+#include <sstream>
+
+#include <deal.II/base/utilities.h>
+
+int main()
+{
+  feenableexcept(FE_DIVBYZERO|FE_INVALID);
+  std::ostringstream description;
+  const double lower_bound = -std::numeric_limits<double>::max();
+
+  description << lower_bound;
+  description << dealii::Utilities::string_to_int (\"1\");
+
+  return 0;
+}
+" HAVE_FP_EXCEPTIONS)
+
+SET(CMAKE_REQUIRED_LIBRARIES ${_backup_libs})
+SET(CMAKE_REQUIRED_INCLUDES ${_backup_includes})


### PR DESCRIPTION
Note that some library we link with in ASPECT on some platforms will
trigger floating point exceptions when converting
-numeric_limits<double>::max to a string. The only thing we can do is a
configure check and disable the exceptions.