### PR TITLE
Update S40RTS_perturbation.cc

### DIFF
--- a/source/initial_conditions/S40RTS_perturbation.cc
+++ b/source/initial_conditions/S40RTS_perturbation.cc
@@ -263,7 +263,13 @@ namespace aspect
       // iterate over all degrees and orders at each depth and sum them all up.
       std::vector<double> spline_values(num_spline_knots,0);
       double prefact;
-      int ind = 0;
+      
+      // option to not include the sin and cos coefficients of degree zero
+      int ind = (zero_out_degree_0
+                  ?
+                  1
+                  :
+                  0);
 
       // option to not include degree zero in summation
       const unsigned int starting_degree = (zero_out_degree_0


### PR DESCRIPTION
There is a small bug in S40RTS spherical harmonics computation. We should not only determine whether to include degree 0 item, but also set an option to remove the corresponding degree 0 cos/sin coefficients or not.