### PR TITLE
Do not check that compositions are initialized to positive values.

### DIFF
--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -112,10 +112,6 @@ namespace aspect
                      compositional_initial_conditions->initial_composition(fe_values.quadrature_point(i),n-1));
                   initial_solution(local_dof_indices[system_local_dof]) = value;
 
-                  if (!advf.is_temperature())
-                    Assert (value >= 0,
-                            ExcMessage("Invalid initial conditions: Composition is negative"));
-
                   // if it is specified in the parameter file that the sum of all compositional fields
                   // must not exceed one, this should be checked
                   if (parameters.normalized_fields.size()>0 && n == 1)


### PR DESCRIPTION
At `source/simulator/initial_conditions.cc:117` there is an assert that checks that all compositional fields are initialized to positive values. There are cases where I'd like to use compositional fields to track things (like vector components) where negative values are permissible.

Is there a fundamental reason why this assert is necessary, or is it only there on the assumption that a negative value must be a mistake on the users part?

Would anyone be opposed to removing this assert?