### PR TITLE
fix bug if test .prm does not end with newline

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -170,6 +170,8 @@ FOREACH(_test ${_tests})
     ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm
       COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/${_test}.prm
 		 ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm
+      COMMAND echo ''
+		 >> ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm
       COMMAND echo 'set Output directory = output-${_test}'
 		 >> ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm
       COMMAND echo '${_testlib}'


### PR DESCRIPTION
If a test .prm ends without a newline, the "output directory" line we
add before running won't take effect. This causes weird test failures
about missing output files. Work around this by inserting a newline.