### PR TITLE
new generate_reference_output target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,10 @@ IF(EXISTS ${CMAKE_SOURCE_DIR}/tests/CMakeLists.txt)
 ENDIF()
 
 
+ADD_CUSTOM_TARGET(generate_reference_output
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/cmake/generate_reference_output.sh 
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 # Depending on whether we link statically or allow for shared libs,
 # we can or can not load plugins via external shared libs. Pass this
 # down during compilation so we can disable it in the code

--- a/cmake/generate_reference_output.sh
+++ b/cmake/generate_reference_output.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This script is being executed by the make target
+# 'generate_reference_output'. The script executes all tests and overwrites
+# the reference output in the source directory for all failing
+# outputs. Finally, a file changes.diff is generated in the build directory
+# with the diffs. The current directory is assumed to be the build directory,
+# while the path of this script needs to be inside the source cmake/
+# directory.
+
+echo "Overwriting test output with reference output ..."
+
+SRC_PATH=`dirname $0`
+SRC_PATH=`cd $SRC_PATH/..;pwd`
+OUT=$PWD/changes.diff
+ASPECT_GENERATE_REFERENCE_OUTPUT=1 ctest -j 4 >/dev/null
+
+cd $SRC_PATH
+git diff tests/ >$OUT
+if [ -s $OUT ]; then 
+  echo "generated patch file: $OUT"; 
+  echo "modified files:"
+  git diff --name-only tests/
+else
+  echo "no reference file changed."
+fi

--- a/tests/cmake/diff_test.sh
+++ b/tests/cmake/diff_test.sh
@@ -21,6 +21,16 @@ CMAKE_CURRENT_SOURCE_DIR=$3
 CMAKE_CURRENT_BINARY_DIR=$4
 
 
+# Grab ASPECT_GENERATE_REFERENCE_OUTPUT from the environment. If set to "1",
+# do not run tests normally but generate reference output instead. Also see
+# the generate_reference_output make target and the file
+# ./cmake/generate_reference_output.sh
+GENERATE_REFERENCE_OUTPUT=0
+if [ "$ASPECT_GENERATE_REFERENCE_OUTPUT" -eq "1" ]; then
+  GENERATE_REFERENCE_OUTPUT=1
+  echo "generating reference output" 1>&2
+fi
+
 #
 # now generate filenames with full paths
 #
@@ -58,6 +68,13 @@ case ${DIFF_EXE} in
 esac
 
 if [ $? -ne 0 ]; then
+
+  if [ "$GENERATE_REFERENCE_OUTPUT" -eq 1 ]; then
+    echo "modifying $ORIGINAL_REF_FULL_PATH"
+    cp ${GEN_FILE} $ORIGINAL_REF_FULL_PATH
+    exit 0
+  fi
+
   mv ${DIFF_OUTPUT}.tmp ${DIFF_OUTPUT}.failed
   echo "******* Error during diffing output results for ${PRETTY_TEST_AND_FILENAME}"
   echo "******* Results are stored in ${DIFF_OUTPUT}.failed"


### PR DESCRIPTION
- add environment variable ASPECT_GENERATE_REFERENCE_OUTPUT to change
ctest to copy failed test output to the reference directory instead
- add script to run ctest this way and generate a patch file
- add generate_reference_output make target to do this in a user-friendly way