### PR TITLE
Secure timestep calculation

### DIFF
--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -347,19 +347,22 @@ namespace aspect
 
               material_model->evaluate(in, out);
 
-              // In the future we may want to evaluate thermal diffusivity at
-              // each point in the mesh, but for now we just use the reference value
+              // Evaluate thermal diffusivity at each quadrature point and
+              // calculate the corresponding conduction timestep, if applicable
               for (unsigned int q=0; q<n_q_points; ++q)
                 {
-                  double k = out.thermal_conductivities[q];
-                  double rho = out.densities[q];
-                  double c_p = out.specific_heat[q];
+                  const double k = out.thermal_conductivities[q];
+                  const double rho = out.densities[q];
+                  const double c_p = out.specific_heat[q];
 
-                  double thermal_diffusivity = k/(rho*c_p);
+                  const double thermal_diffusivity = k/(rho*c_p);
 
-                  min_local_conduction_timestep = std::min(min_local_conduction_timestep,
-                                                           parameters.CFL_number*pow(cell->minimum_vertex_distance(),2)
-                                                           / thermal_diffusivity);
+                  if (thermal_diffusivity > 0)
+                    {
+                      min_local_conduction_timestep = std::min(min_local_conduction_timestep,
+                                                               parameters.CFL_number*pow(cell->minimum_vertex_distance(),2)
+                                                               / thermal_diffusivity);
+                    }
                 }
             }
         }
@@ -371,20 +374,24 @@ namespace aspect
     else
       min_conduction_timestep = std::numeric_limits<double>::max();
 
-    // if the velocity is zero, then it is somewhat arbitrary what time step
-    // we should choose. in that case, do as if the velocity was one
-    if (max_global_speed_over_meshsize == 0 && !parameters.use_conduction_timestep)
-      {
-        new_time_step = (parameters.CFL_number /
-                         (parameters.temperature_degree * 1));
-        convection_dominant = false;
-      }
-    else
+    if ((max_global_speed_over_meshsize != 0.0) ||
+        (min_conduction_timestep < std::numeric_limits<double>::max()))
       {
         new_time_step = std::min(min_conduction_timestep,
                                  (parameters.CFL_number / (parameters.temperature_degree * max_global_speed_over_meshsize)));
         convection_dominant = (new_time_step < min_conduction_timestep);
       }
+    else
+      {
+        // If the velocity is zero and we either do not compute the conduction
+        // timestep or do not have any conduction, then it is somewhat
+        // arbitrary what time step we should choose. In that case, do as if
+        // the velocity was one
+        new_time_step = (parameters.CFL_number /
+                         (parameters.temperature_degree * 1));
+        convection_dominant = false;
+      }
+
 
     return std::make_pair(new_time_step, convection_dominant);
   }

--- a/tests/no-conduction-timestep.prm
+++ b/tests/no-conduction-timestep.prm
@@ -1,0 +1,95 @@
+# This test checks that we do not divide by zero when computing
+# the conduction timestep in a model, where the thermal conductivity is
+# set to zero. We simply use the convection timestep in this case
+# (or fall back to the original default, when the velocity is zero as well).
+# Otherwise this test is identical to constant-composition-convergence.prm
+
+set Dimension                              = 2
+set End time                               = 2e8
+set Use years in output instead of seconds = true
+set Use conduction timestep                = true
+
+set Adiabatic surface temperature          = 1600
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 400000
+    set Y extent = 400000
+  end
+end
+
+subsection Model settings
+  set Fixed temperature boundary indicators   =
+  set Fixed composition boundary indicators   = 
+  set Zero velocity boundary indicators       = 
+  set Tangential velocity boundary indicators = 0, 1, 2 ,3
+  set Prescribed velocity boundary indicators = 
+
+  set Include shear heating = false
+  set Include adiabatic heating = false
+end
+
+subsection Boundary temperature model
+  set Model name = initial temperature
+end
+
+subsection Boundary composition model
+  set Model name = initial composition
+end
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+end
+
+subsection Initial conditions
+  set Model name = function
+
+  subsection Function
+    set Variable names      = x,z
+    set Function constants  = pi=3.1415926
+    set Function expression = 1600 + 100*sin(x*pi/200000.0)
+  end
+end
+
+subsection Compositional initial conditions
+  set Model name = function
+  
+  subsection Function
+    set Function expression = 0.5
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 1
+end
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density                = 3000
+    set Thermal conductivity             = 0
+    set Thermal expansion coefficient    = 4e-5
+    set Viscosity                        = 1e23
+    set Reference temperature            = 1600
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 3
+  set Time steps between mesh refinement = 0
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics
+end
+
+

--- a/tests/no-conduction-timestep/screen-output
+++ b/tests/no-conduction-timestep/screen-output
@@ -1,0 +1,61 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.3.pre
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 1,237 (578+81+289+289)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 17 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.000119 m/year, 0.000189 m/year
+     Temperature min/avg/max: 1500 K, 1600 K, 1700 K
+
+*** Timestep 1:  t=1.3162e+08 years
+   Solving temperature system... 13 iterations.
+   Solving C_1 system ... 0 iterations.
+   Solving Stokes system... 17 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.000117 m/year, 0.000185 m/year
+     Temperature min/avg/max: 1501 K, 1600 K, 1699 K
+
+*** Timestep 2:  t=2e+08 years
+   Solving temperature system... 8 iterations.
+   Solving C_1 system ... 0 iterations.
+   Solving Stokes system... 15 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0.000116 m/year, 0.000182 m/year
+     Temperature min/avg/max: 1502 K, 1600 K, 1698 K
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.145s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         3 |    0.0217s |        15% |
+| Assemble composition system     |         3 |    0.0178s |        12% |
+| Assemble temperature system     |         3 |    0.0211s |        15% |
+| Build Stokes preconditioner     |         1 |    0.0229s |        16% |
+| Build composition preconditioner|         3 |   0.00155s |       1.1% |
+| Build temperature preconditioner|         3 |   0.00177s |       1.2% |
+| Solve Stokes system             |         3 |    0.0148s |        10% |
+| Solve composition system        |         3 |   0.00077s |      0.53% |
+| Solve temperature system        |         3 |   0.00184s |       1.3% |
+| Initialization                  |         2 |    0.0217s |        15% |
+| Postprocessing                  |         3 |   0.00236s |       1.6% |
+| Setup dof systems               |         1 |    0.0112s |       7.8% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/no-conduction-timestep/statistics
+++ b/tests/no-conduction-timestep/statistics
@@ -1,0 +1,20 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Number of degrees of freedom for all compositions
+# 7: Iterations for temperature solver
+# 8: Iterations for composition solver 1
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Time step size (years)
+# 13: RMS velocity (m/year)
+# 14: Max. velocity (m/year)
+# 15: Minimal temperature (K)
+# 16: Average temperature (K)
+# 17: Maximal temperature (K)
+0 0.0000e+00 64 659 289 289  0 0 17 18 17 1.3162e+08 1.18882864e-04 1.88957196e-04 1.50000000e+03 1.60000000e+03 1.70000000e+03 
+1 1.3162e+08 64 659 289 289 13 0 17 18 18 6.8380e+07 1.17035168e-04 1.85133345e-04 1.50118274e+03 1.59999793e+03 1.69881398e+03 
+2 2.0000e+08 64 659 289 289  8 0 15 16 16 1.3739e+08 1.15769831e-04 1.82312577e-04 1.50179942e+03 1.59999681e+03 1.69819671e+03 


### PR DESCRIPTION
If we calculate the conduction timestep, but the conductivity is set to zero we currently produce a division-by-zero floating point exception. This change prevents this, and also updates some outdated comments.
Now, the logic for cases with a velocity and conduction of 0 is also handling this case correctly.
The problem should only happen in artificial testcases, therefore I do not think anybody will ever notice this change (apart from the cleaner code).