### PR TITLE
remove an unwanted loop

### DIFF
--- a/source/material_model/averaging.cc
+++ b/source/material_model/averaging.cc
@@ -334,22 +334,21 @@ namespace aspect
       base_model -> evaluate(in,out);
 
       /**
-       * Check if the size of the viscosities (and thereby all the other vectors) has been filled.
-       * If it hasn't been filled yet, it will have size 1.
+       * Check if the size of the viscosities (and thereby all the other vectors) is larger
+       * than one. Averaging over one or zero points does not make a difference anyway,
+       * and the normalized weighted distance averaging schemes need the distance between
+       * the points and can not handle a distance of zero.
        */
       if (out.viscosities.size() > 1)
         {
-          /* Average the base model values value based on the chosen average */
-          for (unsigned int i=0; i < out.viscosities.size(); ++i)
-            {
-              average (averaging_operation,in.position,out.viscosities);
-              average (averaging_operation,in.position,out.densities);
-              average (averaging_operation,in.position,out.thermal_expansion_coefficients);
-              average (averaging_operation,in.position,out.specific_heat);
-              average (averaging_operation,in.position,out.compressibilities);
-              average (averaging_operation,in.position,out.entropy_derivative_pressure);
-              average (averaging_operation,in.position,out.entropy_derivative_temperature);
-            }
+          /* Average the base model values based on the chosen average */
+          average (averaging_operation,in.position,out.viscosities);
+          average (averaging_operation,in.position,out.densities);
+          average (averaging_operation,in.position,out.thermal_expansion_coefficients);
+          average (averaging_operation,in.position,out.specific_heat);
+          average (averaging_operation,in.position,out.compressibilities);
+          average (averaging_operation,in.position,out.entropy_derivative_pressure);
+          average (averaging_operation,in.position,out.entropy_derivative_temperature);
         }
     }
 

--- a/tests/average-nwd-arithmetic/screen-output
+++ b/tests/average-nwd-arithmetic/screen-output
@@ -1,7 +1,7 @@
 -----------------------------------------------------------------------------
 -- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
 --     . version 1.4.pre
---     . running in DEBUG mode
+--     . running in OPTIMIZED mode
 --     . running with 1 MPI process
 --     . using Trilinos
 -----------------------------------------------------------------------------
@@ -13,15 +13,30 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
    Solving temperature system... 0 iterations.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 30+14 iterations.
+   Solving Stokes system... 30+33 iterations.
 
    Postprocessing:
-     Pressure min/avg/max: -1.634 Pa, 7.624e-14 Pa, 1.634 Pa
+     Pressure min/avg/max: -3.003 Pa, 8.717e-14 Pa, 3.003 Pa
 
 Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      1.23s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |    0.0185s |       1.5% |
+| Assemble composition system     |         1 |    0.0132s |       1.1% |
+| Assemble temperature system     |         1 |    0.0285s |       2.3% |
+| Build Stokes preconditioner     |         1 |     0.229s |        19% |
+| Build composition preconditioner|         1 |   0.00127s |       0.1% |
+| Build temperature preconditioner|         1 |     0.043s |       3.5% |
+| Solve Stokes system             |         1 |     0.136s |        11% |
+| Solve composition system        |         1 |  0.000259s |     0.021% |
+| Solve temperature system        |         1 |    0.0364s |         3% |
+| Initialization                  |         2 |     0.228s |        18% |
+| Postprocessing                  |         1 |  0.000343s |     0.028% |
+| Setup dof systems               |         1 |     0.326s |        26% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/average-nwd-geometric/screen-output
+++ b/tests/average-nwd-geometric/screen-output
@@ -1,7 +1,7 @@
 -----------------------------------------------------------------------------
 -- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
 --     . version 1.4.pre
---     . running in DEBUG mode
+--     . running in OPTIMIZED mode
 --     . running with 1 MPI process
 --     . using Trilinos
 -----------------------------------------------------------------------------
@@ -13,15 +13,30 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
    Solving temperature system... 0 iterations.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 30+13 iterations.
+   Solving Stokes system... 30+25 iterations.
 
    Postprocessing:
-     Pressure min/avg/max: -1.556 Pa, 8.71e-14 Pa, 1.556 Pa
+     Pressure min/avg/max: -1.827 Pa, 7.893e-14 Pa, 1.827 Pa
 
 Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |       0.3s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |      0.02s |       6.6% |
+| Assemble composition system     |         1 |    0.0153s |       5.1% |
+| Assemble temperature system     |         1 |    0.0156s |       5.2% |
+| Build Stokes preconditioner     |         1 |    0.0169s |       5.6% |
+| Build composition preconditioner|         1 |   0.00129s |      0.43% |
+| Build temperature preconditioner|         1 |   0.00144s |      0.48% |
+| Solve Stokes system             |         1 |     0.197s |        65% |
+| Solve composition system        |         1 |  0.000267s |     0.089% |
+| Solve temperature system        |         1 |   0.00036s |      0.12% |
+| Initialization                  |         2 |    0.0188s |       6.3% |
+| Postprocessing                  |         1 |  0.000334s |      0.11% |
+| Setup dof systems               |         1 |    0.0113s |       3.8% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/average-nwd-harmonic/screen-output
+++ b/tests/average-nwd-harmonic/screen-output
@@ -1,7 +1,7 @@
 -----------------------------------------------------------------------------
 -- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
 --     . version 1.4.pre
---     . running in DEBUG mode
+--     . running in OPTIMIZED mode
 --     . running with 1 MPI process
 --     . using Trilinos
 -----------------------------------------------------------------------------
@@ -13,15 +13,30 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
    Solving temperature system... 0 iterations.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 30+10 iterations.
+   Solving Stokes system... 30+15 iterations.
 
    Postprocessing:
-     Pressure min/avg/max: -1.59 Pa, 8.714e-14 Pa, 1.59 Pa
+     Pressure min/avg/max: -1.6 Pa, 7.929e-14 Pa, 1.6 Pa
 
 Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.169s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |    0.0171s |        10% |
+| Assemble composition system     |         1 |      0.01s |         6% |
+| Assemble temperature system     |         1 |   0.00999s |       5.9% |
+| Build Stokes preconditioner     |         1 |     0.015s |       8.9% |
+| Build composition preconditioner|         1 |   0.00151s |      0.89% |
+| Build temperature preconditioner|         1 |   0.00141s |      0.84% |
+| Solve Stokes system             |         1 |    0.0801s |        47% |
+| Solve composition system        |         1 |  0.000381s |      0.23% |
+| Solve temperature system        |         1 |  0.000329s |      0.19% |
+| Initialization                  |         2 |     0.019s |        11% |
+| Postprocessing                  |         1 |  0.000329s |      0.19% |
+| Setup dof systems               |         1 |    0.0114s |       6.7% |
 +---------------------------------+-----------+------------+------------+
 


### PR DESCRIPTION
I think we do not need this loop (as we already do the loop over all quadrature points within the individual averaging functions), and in the case of the averaging schemes that do not generate one average for all of the points in one cell, but calculate position-dependent, different values for every point, this even generates different results (because we average several times). 
Please correct me if I am wrong!