### PR TITLE
add a new log material averaging option

### DIFF
--- a/include/aspect/material_model/averaging.h
+++ b/include/aspect/material_model/averaging.h
@@ -55,6 +55,10 @@ namespace aspect
     * quadrature point to \f[ \bar x = \max_{1\le q\le Q} x_q \f] where
     * $x_q$ are the values at the $Q$ quadrature points.
     *
+    * - Log average: Set the values of each output quantity at every
+    * quadrature point to \f[ \bar x = 10^{\frac 1Q \sum_{q=1}^Q log10_{x_q}} \f]
+    * where $x_q$ are the values at the $Q$ quadrature points.
+    *
     * - NWD Arithmetic averaging: Set the values of each output quantity at
     * every quadrature point to \f[ \bar x = \frac {\sum_{q=1}^Q W_q * x_q} {\sum_{q=1}^Q W_q} \f]
     * where $x_q$ are the values and $w$ the weights at the $Q$ quadrature points.
@@ -76,6 +80,7 @@ namespace aspect
       harmonic_average,
       geometric_average,
       pick_largest,
+      log_average,
       nwd_arithmetic_average,
       nwd_harmonic_average,
       nwd_geometric_average

--- a/include/aspect/material_model/averaging.h
+++ b/include/aspect/material_model/averaging.h
@@ -56,7 +56,7 @@ namespace aspect
     * $x_q$ are the values at the $Q$ quadrature points.
     *
     * - Log average: Set the values of each output quantity at every
-    * quadrature point to \f[ \bar x = 10^{\frac 1Q \sum_{q=1}^Q log10_{x_q}} \f]
+    * quadrature point to \f[ \bar x = {10}^{\frac 1Q \sum_{q=1}^Q \log_{10} x_q} \f]
     * where $x_q$ are the values at the $Q$ quadrature points.
     *
     * - NWD Arithmetic averaging: Set the values of each output quantity at

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -347,6 +347,10 @@ namespace aspect
        * points and computes the best bi- or trilinear approximation for them.
        * In other words, it projects the values into the $Q_1$ finite element
        * space. It then re-evaluate this projection at the quadrature points.
+       *
+       * - Log average: Set the values of each output quantity at every
+       * quadrature point to \f[ \bar x = 10^{\frac 1Q \sum_{q=1}^Q log10_{x_q}} \f]
+       * where $x_q$ are the values at the $Q$ quadrature points.
        */
       enum AveragingOperation
       {
@@ -355,7 +359,8 @@ namespace aspect
         harmonic_average,
         geometric_average,
         pick_largest,
-        project_to_Q1
+        project_to_Q1,
+        log_average
       };
 
 

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -349,7 +349,7 @@ namespace aspect
        * space. It then re-evaluate this projection at the quadrature points.
        *
        * - Log average: Set the values of each output quantity at every
-       * quadrature point to \f[ \bar x = 10^{\frac 1Q \sum_{q=1}^Q log10_{x_q}} \f]
+       * quadrature point to \f[ \bar x = {10}^{\frac 1Q \sum_{q=1}^Q \log_{10} x_q} \f]
        * where $x_q$ are the values at the $Q$ quadrature points.
        */
       enum AveragingOperation

--- a/source/material_model/averaging.cc
+++ b/source/material_model/averaging.cc
@@ -149,7 +149,7 @@ namespace aspect
             for (unsigned int i=0; i<N; ++i)
               {
                 Assert (values_out[i] >= 0,
-                        ExcMessage ("Computing the geometric average "
+                        ExcMessage ("Computing the log average "
                                     "only makes sense for non-negative "
                                     "quantities."));
                 sum += std::log10(values_out[i]);

--- a/source/material_model/averaging.cc
+++ b/source/material_model/averaging.cc
@@ -45,6 +45,8 @@ namespace aspect
         return geometric_average;
       else if (s == "pick largest")
         return pick_largest;
+      else if (s == "log average")
+        return log_average;
       else if (s == "nwd arithmetic average")
         return nwd_arithmetic_average;
       else if (s == "nwd harmonic average")
@@ -139,6 +141,22 @@ namespace aspect
 
             for (unsigned int i=0; i<N; ++i)
               values_out[i] = max;
+            break;
+          }
+          case log_average:
+          {
+            double sum = 0;
+            for (unsigned int i=0; i<N; ++i)
+              {
+                Assert (values_out[i] >= 0,
+                        ExcMessage ("Computing the geometric average "
+                                    "only makes sense for non-negative "
+                                    "quantities."));
+                sum += std::log10(values_out[i]);
+              }
+            const double log_value_average = std::pow (10.,sum/N);
+            for (unsigned int i=0; i<N; ++i)
+              values_out[i] = log_value_average;
             break;
           }
           case nwd_arithmetic_average:
@@ -327,8 +345,8 @@ namespace aspect
               average (averaging_operation,in.position,out.viscosities);
               average (averaging_operation,in.position,out.densities);
               average (averaging_operation,in.position,out.thermal_expansion_coefficients);
-              average (averaging_operation, in.position,out.specific_heat);
-              average (averaging_operation, in.position,out.compressibilities);
+              average (averaging_operation,in.position,out.specific_heat);
+              average (averaging_operation,in.position,out.compressibilities);
               average (averaging_operation,in.position,out.entropy_derivative_pressure);
               average (averaging_operation,in.position,out.entropy_derivative_temperature);
             }
@@ -351,7 +369,7 @@ namespace aspect
                             "``Material models/Model name'' parameter. See the documentation for "
                             "that for more information.");
           prm.declare_entry ("Averaging operation", "none",
-                             Patterns::Selection ("none|arithmetic average|harmonic average|geometric average|pick largest|nwd arithmetic average|nwd harmonic average|nwd geometric average"),
+                             Patterns::Selection ("none|arithmetic average|harmonic average|geometric average|pick largest|log average|nwd arithmetic average|nwd harmonic average|nwd geometric average"),
                              "Chose the averaging operation to use.");
           prm.declare_entry ("Bell shape limit", "1",
                              Patterns::Double(0),
@@ -468,7 +486,7 @@ namespace aspect
                                    "The user must specify a ``Base model'' from which material properties are "
                                    "derived. Furthermore an averaging operation must be selected, where the "
                                    "Choice should be from the list none|arithmetic average|harmonic average|"
-                                   "geometric average|pick largest|NWD arithmetic average|NWD harmonic average"
+                                   "geometric average|pick largest|log average|NWD arithmetic average|NWD harmonic average"
                                    "|NWD geometric average. "
                                    "\n\n"
                                    "NWD stands for Normalized Weighed Distance. The models with this in front "

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -340,7 +340,7 @@ namespace aspect
     {
       std::string get_averaging_operation_names ()
       {
-        return "none|arithmetic average|harmonic average|geometric average|pick largest|project to Q1";
+        return "none|arithmetic average|harmonic average|geometric average|pick largest|project to Q1|log average";
       }
 
 
@@ -358,6 +358,8 @@ namespace aspect
           return pick_largest;
         else if (s == "project to Q1")
           return project_to_Q1;
+        else if (s == "log average")
+          return log_average;
         else
           AssertThrow (false,
                        ExcMessage ("The value <" + s + "> for a material "
@@ -499,6 +501,23 @@ namespace aspect
                 for (unsigned int i=0; i<N; ++i)
                   values_out[i] = x(i);
 
+                break;
+              }
+
+              case log_average:
+              {
+                double sum = 0;
+                for (unsigned int i=0; i<N; ++i)
+                  {
+                    Assert (values_out[i] >= 0,
+                    ExcMessage ("Computing the geometric average "
+                                    "only makes sense for non-negative "
+                                    "quantities."));
+                    sum += std::log10(values_out[i]);
+                  }
+                const double log_value_average = std::pow (10.,sum/N);
+                for (unsigned int i=0; i<N; ++i)
+                  values_out[i] = log_value_average;
                 break;
               }
 

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -510,9 +510,9 @@ namespace aspect
                 for (unsigned int i=0; i<N; ++i)
                   {
                     Assert (values_out[i] >= 0,
-                    ExcMessage ("Computing the geometric average "
-                                    "only makes sense for non-negative "
-                                    "quantities."));
+                    ExcMessage ("Computing the log average "
+                                "only makes sense for non-negative "
+                                "quantities."));
                     sum += std::log10(values_out[i]);
                   }
                 const double log_value_average = std::pow (10.,sum/N);

--- a/tests/average-log.prm
+++ b/tests/average-log.prm
@@ -1,0 +1,99 @@
+# Variations of the cookbook/sinker-with-averaging/sinker-with-averaging.prm
+# file for the different kinds of averaging operations
+
+set Dimension                              = 2
+set Start time                             = 0
+set End time                               = 0
+
+set Linear solver tolerance                = 1e-7
+set Pressure normalization                 = volume
+
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent  = 1.0000
+    set Y extent  = 1.0000
+  end
+end
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false
+  set Tangential velocity boundary indicators = 
+  set Zero velocity boundary indicators       = left, right, bottom, top
+end
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Viscosity                     = 1
+    set Thermal expansion coefficient = 0
+    set Composition viscosity prefactor = 1e6
+    set Density differential for compositional field 1 = 10
+  end
+
+  set Material averaging = log average
+end
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 1
+  end
+end
+
+
+############### Parameters describing the temperature field
+# Note: The temperature plays no role in this model
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+subsection Initial conditions
+  set Model name = function
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+
+############### Parameters describing the compositional field
+# Note: The compositional field is what drives the flow
+# in this example
+
+subsection Compositional fields
+  set Number of fields = 1
+end
+
+subsection Compositional initial conditions
+  set Model name = function
+  subsection Function
+    set Variable names      = x,y
+    set Function expression = if( (sqrt((x-0.5)^2+(y-0.5)^2)>0.22) , 0 , 1 )
+  end
+end
+
+
+############### Parameters describing the discretization
+
+subsection Mesh refinement
+  set Initial global refinement          = 4
+  set Initial adaptive refinement        = 0
+end
+
+
+
+############### Parameters describing what to do with the solution
+
+subsection Postprocess
+  set List of postprocessors = pressure statistics
+  subsection Visualization
+    set Output format                 = gnuplot
+    set Time between graphical output = 0
+    set List of output variables = density, viscosity
+  end
+end

--- a/tests/average-log/screen-output
+++ b/tests/average-log/screen-output
@@ -1,0 +1,42 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.4.pre
+--     . running in OPTIMIZED mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+12 iterations.
+
+   Postprocessing:
+     Pressure min/avg/max: -1.561 Pa, 7.999e-14 Pa, 1.561 Pa
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.408s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |    0.0348s |       8.5% |
+| Assemble composition system     |         1 |    0.0197s |       4.8% |
+| Assemble temperature system     |         1 |    0.0228s |       5.6% |
+| Build Stokes preconditioner     |         1 |    0.0369s |       9.1% |
+| Build composition preconditioner|         1 |   0.00335s |      0.82% |
+| Build temperature preconditioner|         1 |   0.00502s |       1.2% |
+| Solve Stokes system             |         1 |     0.131s |        32% |
+| Solve composition system        |         1 |  0.000632s |      0.16% |
+| Solve temperature system        |         1 |   0.00124s |       0.3% |
+| Initialization                  |         2 |    0.0646s |        16% |
+| Postprocessing                  |         1 |  0.000853s |      0.21% |
+| Setup dof systems               |         1 |    0.0749s |        18% |
++---------------------------------+-----------+------------+------------+
+


### PR DESCRIPTION
The log material averaging option is added. Similar to other averaging options, the test results have a narrower pressure range than no averaging. The pressure range of log averaging is also close to those of other averaging.