### PR TITLE
Add maximum nonlinear iterations for the prerefinement

### DIFF
--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -175,7 +175,7 @@ namespace aspect
     bool                           use_direct_stokes_solver;
     double                         linear_stokes_solver_tolerance;
     unsigned int                   max_nonlinear_iterations;
-    int                            max_nonlinear_iterations_in_prerefinment;
+    unsigned int                   max_nonlinear_iterations_in_prerefinment;
     unsigned int                   n_cheap_stokes_solver_steps;
     double                         temperature_solver_tolerance;
     double                         composition_solver_tolerance;

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -175,6 +175,7 @@ namespace aspect
     bool                           use_direct_stokes_solver;
     double                         linear_stokes_solver_tolerance;
     unsigned int                   max_nonlinear_iterations;
+    int                            max_nonlinear_iterations_in_prerefinment;
     unsigned int                   n_cheap_stokes_solver_steps;
     double                         temperature_solver_tolerance;
     double                         composition_solver_tolerance;

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1151,6 +1151,7 @@ namespace aspect
       double                                                    time_step;
       double                                                    old_time_step;
       unsigned int                                              timestep_number;
+      unsigned int                                              pre_refinement_step;
       /**
        * @}
        */

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -273,6 +273,7 @@ namespace aspect
     ar &time_step;
     ar &old_time_step;
     ar &timestep_number;
+    ar &pre_refinement_step;
 
     ar &postprocess_manager &statistics;
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1699,7 +1699,7 @@ namespace aspect
             }
           while (! ((iteration >= parameters.max_nonlinear_iterations) // regular timestep
                     ||
-                    ((pre_refinement_step <= parameters.initial_adaptive_refinement) // pre-refinement
+                    ((pre_refinement_step < parameters.initial_adaptive_refinement) // pre-refinement
                      &&
                      (iteration >= parameters.max_nonlinear_iterations_in_prerefinment))));
           break;
@@ -1798,7 +1798,7 @@ namespace aspect
             }
           while (! ((iteration >= parameters.max_nonlinear_iterations) // regular timestep
                     ||
-                    ((pre_refinement_step <= parameters.initial_adaptive_refinement) // pre-refinement
+                    ((pre_refinement_step < parameters.initial_adaptive_refinement) // pre-refinement
                      &&
                      (iteration >= parameters.max_nonlinear_iterations_in_prerefinment))));
 
@@ -1838,7 +1838,7 @@ namespace aspect
           double initial_stokes_residual = 0;
           for (unsigned int i=0; (! ((i >= parameters.max_nonlinear_iterations) // regular timestep
                                      ||
-                                     ((pre_refinement_step <= parameters.initial_adaptive_refinement) // pre-refinement
+                                     ((pre_refinement_step < parameters.initial_adaptive_refinement) // pre-refinement
                                       &&
                                       (i >= parameters.max_nonlinear_iterations_in_prerefinment)))); ++i)
             {

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1697,7 +1697,11 @@ namespace aspect
 
               ++iteration;
             }
-          while (iteration < parameters.max_nonlinear_iterations);
+          while (iteration < parameters.max_nonlinear_iterations
+              && 
+              (iteration < parameters.max_nonlinear_iterations_in_prerefinment 
+              || 
+              parameters.initial_adaptive_refinement <= pre_refinement_step));
           break;
         }
 
@@ -1792,7 +1796,11 @@ namespace aspect
               ++iteration;
 //TODO: terminate here if the number of iterations is too large and we see no convergence
             }
-          while (iteration < parameters.max_nonlinear_iterations);
+          while (iteration < parameters.max_nonlinear_iterations
+              && 
+              (iteration < parameters.max_nonlinear_iterations_in_prerefinment 
+              || 
+              parameters.initial_adaptive_refinement <= pre_refinement_step));
 
           break;
         }
@@ -1828,7 +1836,11 @@ namespace aspect
 
           // ...and then iterate the solution of the Stokes system
           double initial_stokes_residual = 0;
-          for (unsigned int i=0; i< parameters.max_nonlinear_iterations; ++i)
+          for (unsigned int i=0; i< parameters.max_nonlinear_iterations
+               && 
+               (i < parameters.max_nonlinear_iterations_in_prerefinment 
+               || 
+               parameters.initial_adaptive_refinement <= pre_refinement_step); ++i)
             {
               // rebuild the matrix if it actually depends on the solution
               // of the previous iteration.
@@ -1927,7 +1939,7 @@ namespace aspect
   {
     unsigned int max_refinement_level = parameters.initial_global_refinement +
                                         parameters.initial_adaptive_refinement;
-    unsigned int pre_refinement_step = 0;
+    pre_refinement_step = 0;
 
     // if we want to resume a computation from an earlier point
     // then reload it from a snapshot. otherwise do the basic

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1698,10 +1698,10 @@ namespace aspect
               ++iteration;
             }
           while (iteration < parameters.max_nonlinear_iterations
-              && 
-              (iteration < parameters.max_nonlinear_iterations_in_prerefinment 
-              || 
-              parameters.initial_adaptive_refinement <= pre_refinement_step));
+                 &&
+                 (iteration < parameters.max_nonlinear_iterations_in_prerefinment
+                  ||
+                  parameters.initial_adaptive_refinement <= pre_refinement_step));
           break;
         }
 
@@ -1797,10 +1797,10 @@ namespace aspect
 //TODO: terminate here if the number of iterations is too large and we see no convergence
             }
           while (iteration < parameters.max_nonlinear_iterations
-              && 
-              (iteration < parameters.max_nonlinear_iterations_in_prerefinment 
-              || 
-              parameters.initial_adaptive_refinement <= pre_refinement_step));
+                 &&
+                 (iteration < parameters.max_nonlinear_iterations_in_prerefinment
+                  ||
+                  parameters.initial_adaptive_refinement <= pre_refinement_step));
 
           break;
         }
@@ -1837,10 +1837,10 @@ namespace aspect
           // ...and then iterate the solution of the Stokes system
           double initial_stokes_residual = 0;
           for (unsigned int i=0; i< parameters.max_nonlinear_iterations
-               && 
-               (i < parameters.max_nonlinear_iterations_in_prerefinment 
-               || 
-               parameters.initial_adaptive_refinement <= pre_refinement_step); ++i)
+               &&
+               (i < parameters.max_nonlinear_iterations_in_prerefinment
+                ||
+                parameters.initial_adaptive_refinement <= pre_refinement_step); ++i)
             {
               // rebuild the matrix if it actually depends on the solution
               // of the previous iteration.

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -2050,8 +2050,8 @@ namespace aspect
 
         // invalidate the value of pre_refinement_step since it will no longer be used from here on
         if ( timestep_number == 0 )
-        pre_refinement_step = std::numeric_limits<unsigned int>::max();
-        
+          pre_refinement_step = std::numeric_limits<unsigned int>::max();
+
         // as soon as the mesh starts deforming with a free surface, a manifold
         // description and boundary shape are no longer guaranteed to be any good.
         // Here we detach those manifolds and boundaries.

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1697,11 +1697,11 @@ namespace aspect
 
               ++iteration;
             }
-          while (iteration < parameters.max_nonlinear_iterations
-                 &&
-                 (iteration < parameters.max_nonlinear_iterations_in_prerefinment
-                  ||
-                  parameters.initial_adaptive_refinement <= pre_refinement_step));
+          while (! ((iteration >= parameters.max_nonlinear_iterations) // regular timestep
+                    ||
+                    ((pre_refinement_step <= parameters.initial_adaptive_refinement) // pre-refinement
+                     &&
+                     (iteration >= parameters.max_nonlinear_iterations_in_prerefinment))));
           break;
         }
 
@@ -1796,11 +1796,11 @@ namespace aspect
               ++iteration;
 //TODO: terminate here if the number of iterations is too large and we see no convergence
             }
-          while (iteration < parameters.max_nonlinear_iterations
-                 &&
-                 (iteration < parameters.max_nonlinear_iterations_in_prerefinment
-                  ||
-                  parameters.initial_adaptive_refinement <= pre_refinement_step));
+          while (! ((iteration >= parameters.max_nonlinear_iterations) // regular timestep
+                    ||
+                    ((pre_refinement_step <= parameters.initial_adaptive_refinement) // pre-refinement
+                     &&
+                     (iteration >= parameters.max_nonlinear_iterations_in_prerefinment))));
 
           break;
         }
@@ -1836,11 +1836,11 @@ namespace aspect
 
           // ...and then iterate the solution of the Stokes system
           double initial_stokes_residual = 0;
-          for (unsigned int i=0; i< parameters.max_nonlinear_iterations
-               &&
-               (i < parameters.max_nonlinear_iterations_in_prerefinment
-                ||
-                parameters.initial_adaptive_refinement <= pre_refinement_step); ++i)
+          for (unsigned int i=0; (! ((i >= parameters.max_nonlinear_iterations) // regular timestep
+                                     ||
+                                     ((pre_refinement_step <= parameters.initial_adaptive_refinement) // pre-refinement
+                                      &&
+                                      (i >= parameters.max_nonlinear_iterations_in_prerefinment)))); ++i)
             {
               // rebuild the matrix if it actually depends on the solution
               // of the previous iteration.

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -2048,6 +2048,10 @@ namespace aspect
             goto start_time_iteration;
           }
 
+        // invalidate the value of pre_refinement_step since it will no longer be used from here on
+        if ( timestep_number == 0 )
+        pre_refinement_step = std::numeric_limits<unsigned int>::max();
+        
         // as soon as the mesh starts deforming with a free surface, a manifold
         // description and boundary shape are no longer guaranteed to be any good.
         // Here we detach those manifolds and boundaries.

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -75,7 +75,13 @@ namespace aspect
     prm.declare_entry ("Max nonlinear iterations", "10",
                        Patterns::Integer (0),
                        "The maximal number of nonlinear iterations to be performed.");
-
+    
+    prm.declare_entry ("Max nonlinear iterations in pre-refinment", "-1",
+                       Patterns::Integer (-1),
+                       "The maximal number of nonlinear iterations to be performed in the pre-refinment "
+                       "steps. This does not include the last refinment step before moving to timestep 1. "
+                       "The value -1 means that the value of the max nonlinear iteraions should be used.");
+    
     prm.declare_entry ("Start time", "0",
                        Patterns::Double (),
                        "The start time of the simulation. Units: Years if the "
@@ -717,6 +723,10 @@ namespace aspect
     nonlinear_tolerance = prm.get_double("Nonlinear solver tolerance");
 
     max_nonlinear_iterations = prm.get_integer ("Max nonlinear iterations");
+    max_nonlinear_iterations_in_prerefinment = prm.get_integer ("Max nonlinear iterations in pre-refinment");
+    if(max_nonlinear_iterations_in_prerefinment == -1)
+      max_nonlinear_iterations_in_prerefinment = max_nonlinear_iterations;
+    
     start_time              = prm.get_double ("Start time");
     if (convert_to_years == true)
       start_time *= year_in_seconds;

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -26,6 +26,7 @@
 
 #include <dirent.h>
 #include <stdlib.h>
+#include <boost/lexical_cast.hpp>
 
 
 namespace aspect
@@ -76,11 +77,11 @@ namespace aspect
                        Patterns::Integer (0),
                        "The maximal number of nonlinear iterations to be performed.");
 
-    prm.declare_entry ("Max nonlinear iterations in pre-refinement", "-1",
-                       Patterns::Integer (-1),
+    prm.declare_entry ("Max nonlinear iterations in pre-refinement", boost::lexical_cast<std::string>(std::numeric_limits<unsigned int>::max()),
+                       Patterns::Integer (0),
                        "The maximal number of nonlinear iterations to be performed in the pre-refinement "
                        "steps. This does not include the last refinement step before moving to timestep 1. "
-                       "The value -1 means that the value of the max nonlinear iterations should be used.");
+                       "When this parameter has a larger value than max nonlinear iterations, the latter is used.");
 
     prm.declare_entry ("Start time", "0",
                        Patterns::Double (),
@@ -724,8 +725,6 @@ namespace aspect
 
     max_nonlinear_iterations = prm.get_integer ("Max nonlinear iterations");
     max_nonlinear_iterations_in_prerefinment = prm.get_integer ("Max nonlinear iterations in pre-refinment");
-    if (max_nonlinear_iterations_in_prerefinment == -1)
-      max_nonlinear_iterations_in_prerefinment = max_nonlinear_iterations;
 
     start_time              = prm.get_double ("Start time");
     if (convert_to_years == true)

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -76,11 +76,11 @@ namespace aspect
                        Patterns::Integer (0),
                        "The maximal number of nonlinear iterations to be performed.");
 
-    prm.declare_entry ("Max nonlinear iterations in pre-refinment", "-1",
+    prm.declare_entry ("Max nonlinear iterations in pre-refinement", "-1",
                        Patterns::Integer (-1),
-                       "The maximal number of nonlinear iterations to be performed in the pre-refinment "
-                       "steps. This does not include the last refinment step before moving to timestep 1. "
-                       "The value -1 means that the value of the max nonlinear iteraions should be used.");
+                       "The maximal number of nonlinear iterations to be performed in the pre-refinement "
+                       "steps. This does not include the last refinement step before moving to timestep 1. "
+                       "The value -1 means that the value of the max nonlinear iterations should be used.");
 
     prm.declare_entry ("Start time", "0",
                        Patterns::Double (),

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -75,13 +75,13 @@ namespace aspect
     prm.declare_entry ("Max nonlinear iterations", "10",
                        Patterns::Integer (0),
                        "The maximal number of nonlinear iterations to be performed.");
-    
+
     prm.declare_entry ("Max nonlinear iterations in pre-refinment", "-1",
                        Patterns::Integer (-1),
                        "The maximal number of nonlinear iterations to be performed in the pre-refinment "
                        "steps. This does not include the last refinment step before moving to timestep 1. "
                        "The value -1 means that the value of the max nonlinear iteraions should be used.");
-    
+
     prm.declare_entry ("Start time", "0",
                        Patterns::Double (),
                        "The start time of the simulation. Units: Years if the "
@@ -724,9 +724,9 @@ namespace aspect
 
     max_nonlinear_iterations = prm.get_integer ("Max nonlinear iterations");
     max_nonlinear_iterations_in_prerefinment = prm.get_integer ("Max nonlinear iterations in pre-refinment");
-    if(max_nonlinear_iterations_in_prerefinment == -1)
+    if (max_nonlinear_iterations_in_prerefinment == -1)
       max_nonlinear_iterations_in_prerefinment = max_nonlinear_iterations;
-    
+
     start_time              = prm.get_double ("Start time");
     if (convert_to_years == true)
       start_time *= year_in_seconds;

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -724,7 +724,7 @@ namespace aspect
     nonlinear_tolerance = prm.get_double("Nonlinear solver tolerance");
 
     max_nonlinear_iterations = prm.get_integer ("Max nonlinear iterations");
-    max_nonlinear_iterations_in_prerefinment = prm.get_integer ("Max nonlinear iterations in pre-refinment");
+    max_nonlinear_iterations_in_prerefinment = prm.get_integer ("Max nonlinear iterations in pre-refinement");
 
     start_time              = prm.get_double ("Start time");
     if (convert_to_years == true)

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -77,7 +77,7 @@ namespace aspect
                        Patterns::Integer (0),
                        "The maximal number of nonlinear iterations to be performed.");
 
-    prm.declare_entry ("Max nonlinear iterations in pre-refinement", boost::lexical_cast<std::string>(std::numeric_limits<unsigned int>::max()),
+    prm.declare_entry ("Max nonlinear iterations in pre-refinement", boost::lexical_cast<std::string>(std::numeric_limits<int>::max()),
                        Patterns::Integer (0),
                        "The maximal number of nonlinear iterations to be performed in the pre-refinement "
                        "steps. This does not include the last refinement step before moving to timestep 1. "


### PR DESCRIPTION
For the model I use it is usually unnecessary to calculate the stokes solution (in much detail) for the pre-refinment steps (the steps before the last timestep 0). These changes allow you to set the amount of nonlinear iterations of these pre-refinment steps. The default value (-1) means that the value is set to be the same as the Max nonlinear iterations parameter. These changes have been implemented in all the solvers which support nonlinear iterations: stokes only, iterated IMPES and iterated stokes.