### PR TITLE
Add an update() function for prescribed stokes solution

### DIFF
--- a/include/aspect/prescribed_stokes_solution/interface.h
+++ b/include/aspect/prescribed_stokes_solution/interface.h
@@ -71,6 +71,20 @@ namespace aspect
         initialize ();
 
         /**
+         * A function that is called at the beginning of each time step. The
+         * default implementation of the function does nothing, but derived
+         * classes that need more elaborate setups for a given time step may
+         * overload the function.
+         *
+         * The point of this function is to allow complex prescribed Stokes
+         * solutions to do an initialization step once at the beginning of each
+         * time step. An example would be a time-dependent prescribed velocity.
+         */
+        virtual
+        void
+        update ();
+
+        /**
          * Given a position @p p, fill in desired velocity and pressure at
          * that point into @p value, which will have dim+1 components. In @p
          * value, the velocity components come first, followed by the pressure

--- a/source/prescribed_stokes_solution/interface.cc
+++ b/source/prescribed_stokes_solution/interface.cc
@@ -39,6 +39,12 @@ namespace aspect
 
     template <int dim>
     void
+    Interface<dim>::update ()
+    {}
+
+
+    template <int dim>
+    void
     Interface<dim>::
     declare_parameters (dealii::ParameterHandler &/*prm*/)
     {}

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -713,7 +713,7 @@ namespace aspect
     heating_model_manager.update();
     adiabatic_conditions->update();
 
-    if(prescribed_stokes_solution.get())
+    if (prescribed_stokes_solution.get())
       prescribed_stokes_solution->update();
 
     // do the same for the traction boundary conditions and other things

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -713,6 +713,9 @@ namespace aspect
     heating_model_manager.update();
     adiabatic_conditions->update();
 
+    if(prescribed_stokes_solution.get())
+      prescribed_stokes_solution->update();
+
     // do the same for the traction boundary conditions and other things
     // that end up in the bilinear form. we update those that end up in
     // the constraints object when calling compute_current_constraints()


### PR DESCRIPTION
This allows time-dependent prescribed stokes solutions. The prescribed_stokes_solution/function plugin allows this already (copy-paste from another function plugin), but we never prepared core.cc and the interface class for this behaviour. We currently want to use this feature to make convergence tests for particle integrators.