### PR TITLE
Advect in the vertical direction for this cookbook

### DIFF
--- a/cookbooks/crustal_model_2D.prm
+++ b/cookbooks/crustal_model_2D.prm
@@ -3,7 +3,7 @@
 
 set Dimension                              = 2
 set Start time                             = 0
-set End time                               = 5e5
+set End time                               = 1e6
 set Use years in output instead of seconds = true
 set Linear solver tolerance                = 1e-9
 set Nonlinear solver scheme                = iterated Stokes
@@ -34,6 +34,13 @@ subsection Model settings
   set Free surface boundary indicators        = top
 end
 
+
+# Advecting the free surface vertically rather than
+# in the surface normal direction can result in a
+# more stable mesh when the deformation is large
+subsection Free surface
+  set Surface velocity projection = vertical
+end
 
 subsection Material model
 #  set Model name = viscoplastic 

--- a/cookbooks/crustal_model_3D.prm
+++ b/cookbooks/crustal_model_3D.prm
@@ -37,6 +37,14 @@ subsection Model settings
 end
 
 
+# Advecting the free surface vertically rather than
+# in the surface normal direction can result in a
+# more stable mesh when the deformation is large
+subsection Free surface
+  set Surface velocity projection = vertical
+end
+
+
 subsection Material model
   set Model name = drucker prager
   subsection Drucker Prager

--- a/doc/manual/cookbooks/crustal_deformation/crustal_model_2D_part3.prm
+++ b/doc/manual/cookbooks/crustal_deformation/crustal_model_2D_part3.prm
@@ -1,10 +1,3 @@
-subsection Mesh refinement
-  set Initial adaptive refinement        = 1
-  set Initial global refinement          = 3
-  set Refinement fraction                = 0.95
-  set Strategy                           = strain rate 
-  set Coarsening fraction                = 0.05
-  set Time steps between mesh refinement = 1
-  set Run postprocessors on initial refinement = true
+subsection Free surface
+  set Surface velocity projection = vertical
 end
-

--- a/doc/manual/cookbooks/crustal_deformation/crustal_model_2D_part3.prm.out
+++ b/doc/manual/cookbooks/crustal_deformation/crustal_model_2D_part3.prm.out
@@ -1,10 +1,3 @@
-subsection %%\hyperref[parameters:Mesh_20refinement]{Mesh refinement}%
-  set %%\hyperref[parameters:Mesh refinement/Initial adaptive refinement]{Initial adaptive refinement}%        = 1%% \index[prmindex]{Initial adaptive refinement} \index[prmindexfull]{Mesh refinement!Initial adaptive refinement} %
-  set %%\hyperref[parameters:Mesh refinement/Initial global refinement]{Initial global refinement}%          = 3%% \index[prmindex]{Initial global refinement} \index[prmindexfull]{Mesh refinement!Initial global refinement} %
-  set %%\hyperref[parameters:Mesh refinement/Refinement fraction]{Refinement fraction}%                = 0.95%% \index[prmindex]{Refinement fraction} \index[prmindexfull]{Mesh refinement!Refinement fraction} %
-  set %%\hyperref[parameters:Mesh refinement/Strategy]{Strategy}%                           = strain rate %% \index[prmindex]{Strategy} \index[prmindexfull]{Mesh refinement!Strategy} %
-  set %%\hyperref[parameters:Mesh refinement/Coarsening fraction]{Coarsening fraction}%                = 0.05%% \index[prmindex]{Coarsening fraction} \index[prmindexfull]{Mesh refinement!Coarsening fraction} %
-  set %%\hyperref[parameters:Mesh refinement/Time steps between mesh refinement]{Time steps between mesh refinement}% = 1%% \index[prmindex]{Time steps between mesh refinement} \index[prmindexfull]{Mesh refinement!Time steps between mesh refinement} %
-  set %%\hyperref[parameters:Mesh refinement/Run postprocessors on initial refinement]{Run postprocessors on initial refinement}% = true%% \index[prmindex]{Run postprocessors on initial refinement} \index[prmindexfull]{Mesh refinement!Run postprocessors on initial refinement} %
+subsection %%\hyperref[parameters:Free_20surface]{Free surface}%
+  set %%\hyperref[parameters:Free surface/Surface velocity projection]{Surface velocity projection}% = vertical%% \index[prmindex]{Surface velocity projection} \index[prmindexfull]{Free surface!Surface velocity projection} %
 end
-

--- a/doc/manual/cookbooks/crustal_deformation/crustal_model_2D_part4.prm
+++ b/doc/manual/cookbooks/crustal_deformation/crustal_model_2D_part4.prm
@@ -1,0 +1,10 @@
+subsection Mesh refinement
+  set Initial adaptive refinement        = 1
+  set Initial global refinement          = 3
+  set Refinement fraction                = 0.95
+  set Strategy                           = strain rate 
+  set Coarsening fraction                = 0.05
+  set Time steps between mesh refinement = 1
+  set Run postprocessors on initial refinement = true
+end
+

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -5920,9 +5920,19 @@ to the following boundary conditions:
 
 Note that compressive boundary conditions are simply achieved by reversing  
 the sign of the imposed velocity.
-We also make use of the strain rate-based mesh refinement plugin:
+
+The free surface will be advected up and down according to the solution of the Stokes solve.
+We have a choice whether to advect the free surface in the direction of the surface normal
+or in the direction of the local vertical (i.e., in the direction of gravity).
+For small deformations, these directions are almost the same, but in this example the deformations 
+are quite large. We have found that when the deformation is large, advecting the surface vertically 
+results in a better behaved mesh, so we set the following in the free surface subsection:
 
 \lstinputlisting[language=prmfile]{cookbooks/crustal_deformation/crustal_model_2D_part3.prm}
+
+We also make use of the strain rate-based mesh refinement plugin:
+
+\lstinputlisting[language=prmfile]{cookbooks/crustal_deformation/crustal_model_2D_part4.prm}
 
 Setting 
 {\tt   set Initial adaptive refinement        = 4}


### PR DESCRIPTION
I believe this goes a long way towards addressing #526.  The fix was introduced in #537, but I am now applying it to the cookbook.

For large deformations advection of the free surface in the surface-normal direction can go unstable. Advecting in the direction of the local vertical seems to do a better job.  Here are some images of the 2D crustal deformation cookbook after 1 Myr:

Before:
![project_normal](https://cloud.githubusercontent.com/assets/5728311/9455911/38a0c51e-4a85-11e5-8a6a-b68f1442e01c.png)
Note the instabilities forming where there are changes in slope.

After:
![project_vertical](https://cloud.githubusercontent.com/assets/5728311/9455920/56480fc8-4a85-11e5-80f7-8640780dc617.png)
Much more stable, it seems.

