### PR TITLE
Fix potential divide by zero error.

### DIFF
--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -50,7 +50,7 @@ namespace aspect
 
       const SymmetricTensor<2,dim> strain_rate_dev = deviator(strain_rate);
 
-      const double strain_rate_dev_inv2 = ( (this->get_timestep_number() == 0 && strain_rate.norm() == 0.0)
+      const double strain_rate_dev_inv2 = ( (this->get_timestep_number() == 0 || strain_rate.norm() == 0.0)
                                             ?
                                             reference_strain_rate * reference_strain_rate
                                             :


### PR DESCRIPTION
Looking for input from @anne-glerum here.  I get a floating point exception in debug mode with the crustal deformation cookbook.  Is this what is intended in the viscosity calculation for the Drucker Prager model?