### PR TITLE
Correct changes.h

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -11,11 +11,9 @@
  * property_depends_on() functions. The dependencies of parameters
  * on solution variables are instead handled by a structure in the
  * base class. All included material models have been updated. User
- * written material models will continue to work, unless they have
- * a variable viscosity, in which case they need to set the
- * model_dependence->viscosity. Since there is no solver yet that
- * utilizes the other dependencies, the impact of this change
- * is limited.
+ * written material models will continue to work as before. Since
+ * there is no solver yet that utilizes the other dependencies,
+ * the impact of this change is limited.
  * <br>
  * (Kimberly Moore, Rene Gassmoeller, Wolfgang Bangerth, 2015/08/26)
  *


### PR DESCRIPTION
This is a correction for the changes.h entry of #565. User-written models do not need to change anything, because all dependencies are initialized to `Dependence::uninitialized`, but the stokes_matrix_depends_on_solution() checks for `Dependence::none`. Therefore not setting the viscosity dependence is interpreted as having a dependence, which is a good default value (some user models might now rebuild the preconditioner, although they dont need to, but that is better than not rebuilding, when it is needed).