### PR TITLE
Change color of references to blue.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -45,7 +45,7 @@
 % files in the aspect tree without having to specify the
 % location relative to the directory where the pdf actually
 % resides
-\usepackage[colorlinks,linkcolor=blue,urlcolor=blue,baseurl=../]{hyperref}
+\usepackage[colorlinks,linkcolor=blue,urlcolor=blue,citecolor=blue,baseurl=../]{hyperref}
 
 \newcommand{\dealii}{{\textsc{deal.II}}}
 \newcommand{\pfrst}{{\normalfont\textsc{p4est}}}


### PR DESCRIPTION
Previously, section links and URLs in the manual were printed in blue, 
but references in light green. This is neither readable, nor conforming
to widely used styles. Change the color to blue also in that case.