### PR TITLE
Improve debugging.

### DIFF
--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -253,6 +253,11 @@ namespace aspect
   const FiniteElement<dim> &
   SimulatorAccess<dim>::get_fe () const
   {
+    Assert (simulator->dof_handler.n_locally_owned_dofs() != 0,
+            ExcMessage("You are trying to access the FiniteElement before the DOFs have been "
+                       "initialized. This may happen when accessing the Simulator from a plugin "
+                       "that gets executed early in some cases (like material models) or from "
+                       "an early point in the core code."));
     return simulator->dof_handler.get_fe();
   }
 


### PR DESCRIPTION
I ran into a case the other day where I wanted to access the FiniteElement object from a material model, and found out that there are cases where the material model is evaluated before the dof_handler object has been initialized (called from AdiabaticConditions::InitialProfile::initialize()). I would have benefited from a more specific error message than the one I got from deal.II.