### PR TITLE
Augment comment for checkpoint resume function

### DIFF
--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -57,7 +57,8 @@ namespace aspect
     if (my_id == 0)
       {
         // if we have previously written a snapshot, then keep the last
-        // snapshot in case this one fails to save
+        // snapshot in case this one fails to save. Note: static variables
+        // will only be initialied once per model run.
         static bool previous_snapshot_exists = (parameters.resume_computation == true);
 
         if (previous_snapshot_exists == true)


### PR DESCRIPTION
It seems weird to add a comment on a sort of basic object orientated construct like this, but because that variable looks local I found it nonintuitive that the function doesn't overwrite it every time it executes.