### PR TITLE
Replace unsigned ints with types::global_dof_index

### DIFF
--- a/source/mesh_refinement/nonadiabatic_temperature.cc
+++ b/source/mesh_refinement/nonadiabatic_temperature.cc
@@ -49,7 +49,7 @@ namespace aspect
                                                   this->get_mpi_communicator());
 
       const Quadrature<dim> quadrature(this->get_fe().base_element(this->introspection().base_elements.temperature).get_unit_support_points());
-      std::vector<unsigned int> local_dof_indices (this->get_fe().dofs_per_cell);
+      std::vector<types::global_dof_index> local_dof_indices (this->get_fe().dofs_per_cell);
       FEValues<dim> fe_values (this->get_mapping(),
                                this->get_fe(),
                                quadrature,

--- a/source/mesh_refinement/viscosity.cc
+++ b/source/mesh_refinement/viscosity.cc
@@ -53,7 +53,7 @@ namespace aspect
                                                   this->get_mpi_communicator());
 
       const Quadrature<dim> quadrature(this->get_fe().base_element(this->introspection().base_elements.temperature).get_unit_support_points());
-      std::vector<unsigned int> local_dof_indices (this->get_fe().dofs_per_cell);
+      std::vector<types::global_dof_index> local_dof_indices (this->get_fe().dofs_per_cell);
       FEValues<dim> fe_values (this->get_mapping(),
                                this->get_fe(),
                                quadrature,

--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -237,7 +237,7 @@ namespace aspect
                        dofs_per_cell = fs_fe_face_values.dofs_per_cell;
 
     //stuff for assembling system
-    std::vector<unsigned int> cell_dof_indices (dofs_per_cell);
+    std::vector<types::global_dof_index> cell_dof_indices (dofs_per_cell);
     Vector<double> cell_vector (dofs_per_cell);
     FullMatrix<double> cell_matrix (dofs_per_cell, dofs_per_cell);
 
@@ -372,7 +372,7 @@ namespace aspect
                        dofs_per_face = sim.finite_element.dofs_per_face,
                        n_q_points    = fe_values.n_quadrature_points;
 
-    std::vector<unsigned int> cell_dof_indices (dofs_per_cell);
+    std::vector<types::global_dof_index> cell_dof_indices (dofs_per_cell);
     std::vector<unsigned int> face_dof_indices (dofs_per_face);
     Vector<double> cell_vector (dofs_per_cell);
     FullMatrix<double> cell_matrix (dofs_per_cell, dofs_per_cell);
@@ -471,7 +471,7 @@ namespace aspect
     const unsigned int n_q_points = fe_values.n_quadrature_points,
                        dofs_per_cell = fe_values.dofs_per_cell;
 
-    std::vector<unsigned int> cell_dof_indices (dofs_per_cell);
+    std::vector<types::global_dof_index> cell_dof_indices (dofs_per_cell);
     FEValuesExtractors::Vector extract_vel(0);
     std::vector<Tensor<1,dim> > velocity_values(n_q_points);
 
@@ -546,7 +546,7 @@ namespace aspect
           = free_surface_fe.base_element(0).get_unit_support_points();
         FEValues<dim> mesh_points (sim.mapping, free_surface_fe,
                                    mesh_support_points, update_quadrature_points);
-        std::vector<unsigned int> cell_dof_indices (free_surface_fe.dofs_per_cell);
+        std::vector<types::global_dof_index> cell_dof_indices (free_surface_fe.dofs_per_cell);
 
         typename DoFHandler<dim>::active_cell_iterator cell = free_surface_dof_handler.begin_active(),
                                                        endc = free_surface_dof_handler.end();

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -501,7 +501,7 @@ namespace aspect
     Assert(introspection.block_indices.velocities == 0, ExcNotImplemented());
     const std::vector<Point<dim> > mesh_support_points = finite_element.base_element(introspection.base_elements.velocities).get_unit_support_points();
     FEValues<dim> mesh_points (mapping, finite_element, mesh_support_points, update_quadrature_points);
-    std::vector<unsigned int> cell_dof_indices (finite_element.dofs_per_cell);
+    std::vector<types::global_dof_index> cell_dof_indices (finite_element.dofs_per_cell);
 
     typename DoFHandler<dim>::active_cell_iterator cell = dof_handler.begin_active(),
                                                    endc = dof_handler.end();


### PR DESCRIPTION
This should address #611. It compiles and tests seem to run fine (except for the usual deviations in number of iterations, etc.). I stumbled over this, because I think we can use the same typedef for the tracer indices in #411. The number of tracers will likely reach similar number as the number of dofs, so using the same type seems reasonable to me.