### PR TITLE
[Do not merge] Allow weighted repartitioning for tracer handling

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -150,7 +150,11 @@ namespace aspect
                    typename Triangulation<dim>::MeshSmoothing
                    (Triangulation<dim>::smoothing_on_refinement |
                     Triangulation<dim>::smoothing_on_coarsening),
-                   parallel::distributed::Triangulation<dim>::mesh_reconstruction_after_repartitioning),
+                   typename parallel::distributed::Triangulation<dim>::Settings (parallel::distributed::Triangulation<dim>::mesh_reconstruction_after_repartitioning
+#if DEAL_II_VERSION_GTE(8,4,0)
+                                                                                 | parallel::distributed::Triangulation<dim>::no_automatic_repartitioning
+#endif
+                                                                                )),
 
     //Fourth order mapping doesn't really make sense for free surface
     //calculations (we disable curved boundaries) or we we only have straight
@@ -1463,6 +1467,10 @@ namespace aspect
       freesurface_trans->prepare_for_coarsening_and_refinement(x_fs_system);
 
     triangulation.execute_coarsening_and_refinement ();
+#if DEAL_II_VERSION_GTE(8,4,0)
+    triangulation.repartition();
+#endif
+
     computing_timer.exit_section();
 
     setup_dofs ();
@@ -2012,6 +2020,9 @@ namespace aspect
 
             mesh_refinement_manager.tag_additional_cells ();
             triangulation.execute_coarsening_and_refinement();
+#if DEAL_II_VERSION_GTE(8,4,0)
+            triangulation.repartition();
+#endif
           }
 
         global_volume = GridTools::volume (triangulation, mapping);


### PR DESCRIPTION
I am currently thinking about how to implement the load balancing discussed in #411. My idea was to set the `parallel::distributed::Triangulation<dim>::no_automatic_repartitioning` flag and then introduce a signal between `execute_coarsening_and_refinement()` and `repartition(weights)` to allow plugins to specify their weights.
However, already this example without signal breaks, because both functions call `parallel::distributed::Triangulation<dim>::attach_mesh_data()` and apparently that is not allowed, although the error message I get is very crude (essentially an invalid index deep within block_indices.h). I would like to avoid the trouble of having to transfer the solution twice (from the old mesh to the refined one, and then from the refined one to the repartitioned one). 
Because one could want to repartition the mesh less often than doing the refinement, simply omitting `attach_mesh_data` in `execute_coarsening_and_refinement()` when `no_automatic_repartitioning` is set is also no option. Would it be possible to have an input parameter for `repartition` that indicates whether `attach_mesh_data` should be called, with a default set to true?