### PR TITLE
Add option to auto resume models

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -7,6 +7,11 @@
  *
  * <ol>
  *
+ * <li> New: Ability to automatically resume models from a checkpoint
+ * if previous checkpoint files exist (Resume computation = auto).
+ * <br>
+ * (Jonathan Perry-Houts, 2015/09/25)
+ *
  * <li> Changed: the user can now select a subset of the laterally-
  * averaged quantities to be computed in the DepthAverage postprocessor.
  * <br>

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -69,9 +69,11 @@ namespace aspect
                        "library.");
 
     prm.declare_entry ("Resume computation", "false",
-                       Patterns::Bool (),
+                       Patterns::Selection ("true|false|auto"),
                        "A flag indicating whether the computation should be resumed from "
-                       "a previously saved state (if true) or start from scratch (if false).");
+                       "a previously saved state (if true) or start from scratch (if false). "
+                       "If auto is selected, models will be resumed if there is an existing "
+                       "checkpoint file, otherwise started from scratch.");
 
     prm.declare_entry ("Max nonlinear iterations", "10",
                        Patterns::Integer (0),
@@ -690,14 +692,6 @@ namespace aspect
     AssertThrow (prm.get_integer("Dimension") == dim,
                  ExcInternalError());
 
-    resume_computation      = prm.get_bool ("Resume computation");
-#ifndef DEAL_II_WITH_ZLIB
-    AssertThrow (resume_computation == false,
-                 ExcMessage ("You need to have deal.II configured with the 'libz' "
-                             "option if you want to resume a computation from a checkpoint, but deal.II "
-                             "did not detect its presence when you called 'cmake'."));
-#endif
-
     CFL_number              = prm.get_double ("CFL number");
     use_conduction_timestep = prm.get_bool ("Use conduction timestep");
     convert_to_years        = prm.get_bool ("Use years in output instead of seconds");
@@ -759,6 +753,25 @@ namespace aspect
         AssertThrow (error==0,
                      ExcMessage (std::string("Can't create the output directory at <") + output_directory + ">"));
       }
+
+    if (prm.get ("Resume computation") == "true")
+      resume_computation = true;
+    else if (prm.get ("Resume computation") == "false")
+      resume_computation = false;
+    else if (prm.get ("Resume computation") == "auto")
+      {
+        std::fstream check_file((output_directory+"restart.mesh").c_str());
+        resume_computation = check_file.is_open();
+        check_file.close();
+      }
+    else
+      AssertThrow (false, ExcMessage ("Resume computation parameter must be either 'true', 'false', or 'auto'."));
+#ifndef DEAL_II_WITH_ZLIB
+    AssertThrow (resume_computation == false,
+                 ExcMessage ("You need to have deal.II configured with the 'libz' "
+                             "option if you want to resume a computation from a checkpoint, but deal.II "
+                             "did not detect its presence when you called 'cmake'."));
+#endif
 
     surface_pressure              = prm.get_double ("Surface pressure");
     adiabatic_surface_temperature = prm.get_double ("Adiabatic surface temperature");


### PR DESCRIPTION
This patch adds the ability to set "Resume computation = auto" which checks on startup whether a resume file exists, and uses it if so. Otherwise it starts the model from scratch. "true" and "false" are still valid options, and the default behavior is unchanged. I don't know if the ParameterHandler::get_bool() function handles other inputs (like "yes"/"no"). If so, those cases will not work with this patch.