### PR TITLE
Rebuild sparsity pattern after rebuilding constraints

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -7,6 +7,11 @@
  *
  * <ol>
  *
+ * <li> Fixed: certain combinations of boundary conditions with a free surface
+ * could result in accessing nonexistent matrix entries. This is fixed.
+ * <br>
+ * (Ian Rose, 2015/09/28)
+ *
  * <li> New: Ability to automatically resume models from a checkpoint
  * if previous checkpoint files exist (Resume computation = auto).
  * <br>

--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -262,7 +262,9 @@ namespace aspect
     CompressedSimpleSparsityPattern sp(mesh_locally_relevant);
 
 #else
-    TrilinosWrappers::SparsityPattern sp (mesh_locally_owned,mesh_locally_owned,
+    TrilinosWrappers::SparsityPattern sp (mesh_locally_owned,
+                                          mesh_locally_owned,
+                                          mesh_locally_relevant,
                                           sim.mpi_communicator);
 #endif
     DoFTools::make_sparsity_pattern (free_surface_dof_handler, sp, mass_matrix_constraints, false,
@@ -377,7 +379,30 @@ namespace aspect
     Vector<double> cell_vector (dofs_per_cell);
     FullMatrix<double> cell_matrix (dofs_per_cell, dofs_per_cell);
 
-    mesh_matrix = 0;
+    mesh_matrix.clear ();
+#ifdef ASPECT_USE_PETSC
+    CompressedSimpleSparsityPattern sp(mesh_locally_relevant);
+#else
+    TrilinosWrappers::SparsityPattern sp (mesh_locally_owned,
+                                          mesh_locally_owned,
+                                          mesh_locally_relevant,
+                                          sim.mpi_communicator);
+#endif
+    DoFTools::make_sparsity_pattern (free_surface_dof_handler,
+                                     sp,
+                                     mesh_displacement_constraints, false,
+                                     Utilities::MPI::
+                                     this_mpi_process(sim.mpi_communicator));
+#ifdef ASPECT_USE_PETSC
+    SparsityTools::distribute_sparsity_pattern(sp,
+                                               free_surface_dof_handler.n_locally_owned_dofs_per_processor(),
+                                               sim.mpi_communicator, mesh_locally_relevant);
+    sp.compress();
+    mesh_matrix.reinit (mesh_locally_owned, mesh_locally_owned, sp, sim.mpi_communicator);
+#else
+    sp.compress();
+    mesh_matrix.reinit (sp);
+#endif
 
     //carry out the solution
     FEValuesExtractors::Vector extract_vel(0);
@@ -572,44 +597,6 @@ namespace aspect
     make_constraints();
 
     // matrix
-    {
-      mesh_matrix.clear ();
-
-      Table<2,DoFTools::Coupling> coupling (dim, dim);
-      coupling.fill(DoFTools::none);
-
-      for (unsigned int c=0; c<dim; ++c)
-        coupling[c][c] = DoFTools::always;
-
-#ifdef ASPECT_USE_PETSC
-      CompressedSimpleSparsityPattern sp(mesh_locally_relevant);
-
-#else
-      TrilinosWrappers::SparsityPattern sp (mesh_locally_owned,mesh_locally_owned,
-                                            sim.mpi_communicator);
-#endif
-
-      DoFTools::make_sparsity_pattern (free_surface_dof_handler,
-                                       coupling, sp,
-                                       mesh_displacement_constraints, false,
-                                       Utilities::MPI::
-                                       this_mpi_process(sim.mpi_communicator));
-
-#ifdef ASPECT_USE_PETSC
-      SparsityTools::distribute_sparsity_pattern(sp,
-                                                 free_surface_dof_handler.n_locally_owned_dofs_per_processor(),
-                                                 sim.mpi_communicator, mesh_locally_relevant);
-
-      sp.compress();
-
-      mesh_matrix.reinit (mesh_locally_owned, mesh_locally_owned, sp, sim.mpi_communicator);
-#else
-      sp.compress();
-
-      mesh_matrix.reinit (sp);
-#endif
-
-    }
 
 
   }

--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -380,6 +380,15 @@ namespace aspect
     FullMatrix<double> cell_matrix (dofs_per_cell, dofs_per_cell);
 
     mesh_matrix.clear ();
+
+    // We are just solving a Laplacian in each spatial direction, so
+    // the degrees of freedom for different dimensions do not couple.
+    Table<2,DoFTools::Coupling> coupling (dim, dim);
+    coupling.fill(DoFTools::none);
+
+    for (unsigned int c=0; c<dim; ++c)
+      coupling[c][c] = DoFTools::always;
+
 #ifdef ASPECT_USE_PETSC
     CompressedSimpleSparsityPattern sp(mesh_locally_relevant);
 #else
@@ -389,7 +398,7 @@ namespace aspect
                                           sim.mpi_communicator);
 #endif
     DoFTools::make_sparsity_pattern (free_surface_dof_handler,
-                                     sp,
+                                     coupling, sp,
                                      mesh_displacement_constraints, false,
                                      Utilities::MPI::
                                      this_mpi_process(sim.mpi_communicator));


### PR DESCRIPTION
This is an attempt to fix #612.

This was a difficult bug to reproduce and track down, so I'd appreciate it if @MFraters could check if this fixes the problem he was seeing. The basic problem was that we are rebuilding the constraints on the mesh motion at every time-step, but only setting up the sparsity pattern for the remeshing matrix after redistributing the mesh. In certain difficult-to-predict cases (especially when tangential constraints are involved) the sparsity pattern can be no longer valid for the computed constraints.

The fix here is just to rebuild the sparsity pattern after rebuilding the constraints object. This should be somewhat less efficient, but I don't think that this step was very expensive to begin with.

Thoughts?