### PR TITLE
Avoid floating point problems

### DIFF
--- a/include/aspect/material_model/diffusion_dislocation.h
+++ b/include/aspect/material_model/diffusion_dislocation.h
@@ -110,6 +110,11 @@ namespace aspect
       private:
 
         double reference_T;
+
+        /**
+         * Defining a minimum strain rate stabilizes the viscosity calculation,
+         * which involves a division by the strain rate. Units: $1/s$.
+         */
         double min_strain_rate;
         double min_visc;
         double max_visc;

--- a/source/material_model/diffusion_dislocation.cc
+++ b/source/material_model/diffusion_dislocation.cc
@@ -138,11 +138,11 @@ namespace aspect
       // experience the same strain rate (isostrain).
 
       // If strain rate is zero (like during the first time step) set it to some very small number
-      const double edot_ii = (strain_rate.norm() == 0.0
-                              ?
-                              2.0*std::numeric_limits<double>::min()
-                              :
-                              std::sqrt(abs(second_invariant(strain_rate))));
+      // to prevent a division-by-zero, and a floating point exception.
+      // Otherwise, calculate the square-root of the norm of the second invariant of the deviatoric-
+      // strain rate (often simplified as epsilondot_ii)
+      const double edot_ii = std::max(std::sqrt(std::fabs(second_invariant(deviator(strain_rate)))),
+                                      min_strain_rate * min_strain_rate);
 
 
       // Find effective viscosities for each of the individual phases

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -37,23 +37,24 @@ namespace aspect
                const SymmetricTensor<2,dim> &strain_rate,
                const Point<dim> &/*position*/) const
     {
-      // For the very first time this function is called,
-      // we prescribe a representative reference strain rate,
-      // instead of using the input strain rate which
-      // is a zero tensor. This avoids division by zero and produces
+      // For the very first time this function is called
+      // (the first iteration of the first timestep), this function is called
+      // with a zero input strain rate. We provide a representative reference
+      // strain rate for this case, which avoids division by zero and produces
       // a representative first guess of the viscosities.
-      // Otherwise we calculate the second moment invariant
-      // of the deviatoric strain rate tensor.
+      // In later iterations and timesteps we calculate the second moment
+      // invariant of the deviatoric strain rate tensor.
       // This is equal to the negative of the second principle
       // invariant calculated with the function second_invariant.
-
       const double strain_rate_dev_inv2 = ( (this->get_timestep_number() == 0 && strain_rate.norm() <= std::numeric_limits<double>::min())
                                             ?
                                             reference_strain_rate * reference_strain_rate
                                             :
                                             std::fabs(second_invariant(deviator(strain_rate))));
 
-      // Prevent floating-point exceptions for very small strain rates
+      // In later timesteps, we still need to care about cases of very small
+      // strain rates. We expect the viscosity to approach the maximum_viscosity
+      // in these cases. This check prevents a division-by-zero.
       if (std::sqrt(strain_rate_dev_inv2) <= std::numeric_limits<double>::min())
         return maximum_viscosity;
 

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -47,13 +47,15 @@ namespace aspect
       // This is equal to the negative of the second principle
       // invariant calculated with the function second_invariant.
 
-      const SymmetricTensor<2,dim> strain_rate_dev = deviator(strain_rate);
-
-      const double strain_rate_dev_inv2 = ( (this->get_timestep_number() == 0 && strain_rate.norm() == 0.0)
+      const double strain_rate_dev_inv2 = ( (this->get_timestep_number() == 0 && strain_rate.norm() <= std::numeric_limits<double>::min())
                                             ?
                                             reference_strain_rate * reference_strain_rate
                                             :
-                                            -second_invariant(strain_rate_dev) );
+                                            std::fabs(second_invariant(deviator(strain_rate))));
+
+      // Prevent floating-point exceptions for very small strain rates
+      if (std::sqrt(strain_rate_dev_inv2) <= std::numeric_limits<double>::min())
+        return maximum_viscosity;
 
       // To avoid negative yield strengths and eventually viscosities,
       // we make sure the pressure is not negative

--- a/tests/diffusion_dislocation/screen-output
+++ b/tests/diffusion_dislocation/screen-output
@@ -2,7 +2,7 @@
 -- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
 --     . version 1.4.pre
 --     . running in DEBUG mode
---     . running with 4 MPI processes
+--     . running with 1 MPI process
 --     . using Trilinos
 -----------------------------------------------------------------------------
 
@@ -22,16 +22,16 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
    Solving depleted_lithosphere system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8 iterations.
-      Nonlinear residuals: 231496, 5.96195e-06, 1.18673e+11
-      Total relative nonlinear residual: 0.0007332
+      Nonlinear residuals: 231496, 5.96195e-06, 1.18735e+11
+      Total relative nonlinear residual: 0.000733713
 
 
    Solving temperature system... 0 iterations.
    Solving depleted_lithosphere system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3 iterations.
-      Nonlinear residuals: 231496, 5.96195e-06, 1.95168e+07
-      Total relative nonlinear residual: 1.20406e-07
+      Nonlinear residuals: 231496, 5.96195e-06, 3.12547e+07
+      Total relative nonlinear residual: 1.93137e-07
 
 
 
@@ -41,21 +41,21 @@ Termination requested by criterion: end step
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.351s |            |
+| Total wallclock time elapsed since start    |     0.412s |            |
 |                                             |            |            |
 | Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         3 |    0.0427s |        12% |
-| Assemble composition system     |         3 |    0.0241s |       6.9% |
-| Assemble temperature system     |         3 |    0.0243s |       6.9% |
-| Build Stokes preconditioner     |         3 |    0.0625s |        18% |
-| Build composition preconditioner|         3 |   0.00142s |      0.41% |
-| Build temperature preconditioner|         3 |   0.00172s |      0.49% |
-| Solve Stokes system             |         3 |    0.0968s |        28% |
-| Solve composition system        |         3 |   0.00443s |       1.3% |
-| Solve temperature system        |         3 |   0.00824s |       2.3% |
-| Initialization                  |         2 |    0.0502s |        14% |
-| Postprocessing                  |         1 |  0.000154s |     0.044% |
-| Setup dof systems               |         1 |    0.0223s |       6.4% |
+| Assemble Stokes system          |         3 |     0.106s |        26% |
+| Assemble composition system     |         3 |    0.0584s |        14% |
+| Assemble temperature system     |         3 |    0.0913s |        22% |
+| Build Stokes preconditioner     |         3 |    0.0967s |        23% |
+| Build composition preconditioner|         3 |   0.00126s |      0.31% |
+| Build temperature preconditioner|         3 |   0.00175s |      0.43% |
+| Solve Stokes system             |         3 |   0.00867s |       2.1% |
+| Solve composition system        |         3 |  0.000663s |      0.16% |
+| Solve temperature system        |         3 |  0.000926s |      0.22% |
+| Initialization                  |         2 |    0.0274s |       6.6% |
+| Postprocessing                  |         1 |   9.3e-05s |     0.023% |
+| Setup dof systems               |         1 |    0.0108s |       2.6% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/diffusion_dislocation/statistics
+++ b/tests/diffusion_dislocation/statistics
@@ -10,6 +10,6 @@
 # 10: Velocity iterations in Stokes preconditioner
 # 11: Schur complement iterations in Stokes preconditioner
 # 12: Time step size (years)
-0 0.0000e+00 64 659 289 289 0 0 18  19  18 0.0000e+00 
-0 0.0000e+00  0   0   0   0 0 0  8   9   9 0.0000e+00 
-0 0.0000e+00  0   0   0   0 0 0  3   4   4 1.7058e+06 
+0 0.0000e+00 64 659 289 289 0 0 18 19 18 0.0000e+00 
+0 0.0000e+00  0   0   0   0 0 0  8  9  9 0.0000e+00 
+0 0.0000e+00  0   0   0   0 0 0  3  4  4 1.7057e+06 


### PR DESCRIPTION
I tried to combine these two material models into a new one for a different purpose. During that I noticed that they are extremely unstable, throwing floating-point exceptions in many models. Additionally, they do more or less the same thing, but it is quite differently implemented. So I tried to unify the look, and make them more robust. The tests change marginally, but I think the new version is preferable.

I have a question for @anne-glerum and @bobmyhill, before merging: Drucker-prager currently uses the second invariant of the deviatoric strain rate, while diffusion-dislocation uses the second invariant of the full strain rate. Is this correct, or should we look into unifying this?