### PR TITLE
manual: fix CIG acknowledgement

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -321,9 +321,16 @@ which \aspect{} builds heavily have been supported through many other grants
 that are equally gratefully acknowledged.
 
 Please acknowledge CIG as follows:
-\begin{lstlisting}[frame=single,language=tex]
-ASPECT is hosted by the Computational Infrastructure for Geodynamics (CIG) which is supported by the National Science Foundation award NSF-094946.
-\end{lstlisting}
+{\parindent0pt
+  \begin{center}
+    \shadowbox{
+      \begin{minipage}[c]{0.9\linewidth}
+ASPECT is hosted by the Computational Infrastructure for Geodynamics (CIG)
+which is supported by the National Science Foundation award NSF-094946.
+      \end{minipage}
+    }
+  \end{center}
+}
 
 \section{Equations, models, coefficients}
 \label{sec:models}


### PR DESCRIPTION
- had no line breaks and went off the page
- tex listing environment is not as pretty as a fancybox with shadows