### PR TITLE
 Include vector_tools.templates.h for deal.II 8.3.0 support

### DIFF
--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -32,6 +32,9 @@
 
 #include <deal.II/numerics/vector_tools.h>
 
+#if DEAL_II_VERSION_GTE(8,3,0)
+#include <deal.II/numerics/vector_tools.templates.h>
+#endif
 
 using namespace dealii;
 

--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -29,7 +29,12 @@
 #include <deal.II/fe/fe_values.h>
 
 #include <deal.II/lac/sparsity_tools.h>
-
+/*
+ * In some instances, using the Mac .dmg package to install deal.II, compilation
+ * fails at the linker stage with an 'ld: symbol(s) not found for architecture x86_64'
+ * error associated to VectorTools::compute_no_normal_flux_constraints. This is not
+ * really understood, but the extra include makes it work for now.
+ */
 #include <deal.II/numerics/vector_tools.h>
 
 #if DEAL_II_VERSION_GTE(8,3,0)

--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -29,14 +29,15 @@
 #include <deal.II/fe/fe_values.h>
 
 #include <deal.II/lac/sparsity_tools.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
 /*
  * In some instances, using the Mac .dmg package to install deal.II, compilation
  * fails at the linker stage with an 'ld: symbol(s) not found for architecture x86_64'
  * error associated to VectorTools::compute_no_normal_flux_constraints. This is not
  * really understood, but the extra include makes it work for now.
  */
-#include <deal.II/numerics/vector_tools.h>
-
 #if DEAL_II_VERSION_GTE(8,3,0)
 #include <deal.II/numerics/vector_tools.templates.h>
 #endif


### PR DESCRIPTION
Aspect doesn't build in Xcode 7.0.1 (Clang-700.0.72) using deal 8.3.0 MacOSX package unless this include is added.