### PR TITLE
[WIP] Free surface and prescribed velocity boundary conditions on the vertical boundaries

### DIFF
--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -172,11 +172,27 @@ namespace aspect
       VectorTools::interpolate_boundary_values (free_surface_dof_handler, *p,
                                                 ZeroFunction<dim>(dim), mesh_displacement_constraints);
 
+    std::set<types::boundary_id> vert_free_prescribed_vel;
     //Zero out the displacement for the prescribed velocity
     for (std::map<types::boundary_id, std::pair<std::string, std::string> >::const_iterator p = sim.parameters.prescribed_velocity_boundary_indicators.begin();
          p != sim.parameters.prescribed_velocity_boundary_indicators.end(); ++p)
-      VectorTools::interpolate_boundary_values (free_surface_dof_handler, p->first,
+    {
+     if ((p->second.first.find("z") && dim == 3) || (p->second.first.find("y") && dim == 2) || p->second.first.empty())
+     VectorTools::interpolate_boundary_values (free_surface_dof_handler, p->first,
                                                 ZeroFunction<dim>(dim), mesh_displacement_constraints);
+     else
+    {
+    	 vert_free_prescribed_vel.insert(p->first);
+
+    // In 3D what about the free y component, it could be prescribed
+    }
+    }
+
+    VectorTools::compute_no_normal_flux_constraints (free_surface_dof_handler,
+                                                         /* first_vector_component= */
+                                                         0,
+                                                         vert_free_prescribed_vel,
+                                                         mesh_displacement_constraints, sim.mapping);
 
     //make the tangential boundary indicators no displacement normal to the boundary
     VectorTools::compute_no_normal_flux_constraints (free_surface_dof_handler,

--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -176,23 +176,25 @@ namespace aspect
     //Zero out the displacement for the prescribed velocity
     for (std::map<types::boundary_id, std::pair<std::string, std::string> >::const_iterator p = sim.parameters.prescribed_velocity_boundary_indicators.begin();
          p != sim.parameters.prescribed_velocity_boundary_indicators.end(); ++p)
-    {
-     if ((p->second.first.find("z") && dim == 3) || (p->second.first.find("y") && dim == 2) || p->second.first.empty())
-     VectorTools::interpolate_boundary_values (free_surface_dof_handler, p->first,
-                                                ZeroFunction<dim>(dim), mesh_displacement_constraints);
-     else
-    {
-    	 vert_free_prescribed_vel.insert(p->first);
+      {
+        if (((p->second.first.find("z")!=std::string::npos) && dim == 3) || ((p->second.first.find("y")!=std::string::npos) && dim == 2) || p->second.first.empty())
+          {
+            VectorTools::interpolate_boundary_values (free_surface_dof_handler, p->first,
+                                                      ZeroFunction<dim>(dim), mesh_displacement_constraints);
+          }
+        else
+          {
+            vert_free_prescribed_vel.insert(p->first);
+          }
+      }
 
-    // In 3D what about the free y component, it could be prescribed
-    }
-    }
-
+    //make the prescribed velocity boundaries with a free vertical velocity component no displacement normal to the boundary
+    //TODO: in 3D, what if x and y component are prescribed?
     VectorTools::compute_no_normal_flux_constraints (free_surface_dof_handler,
-                                                         /* first_vector_component= */
-                                                         0,
-                                                         vert_free_prescribed_vel,
-                                                         mesh_displacement_constraints, sim.mapping);
+                                                     /* first_vector_component= */
+                                                     0,
+                                                     vert_free_prescribed_vel,
+                                                     mesh_displacement_constraints, sim.mapping);
 
     //make the tangential boundary indicators no displacement normal to the boundary
     VectorTools::compute_no_normal_flux_constraints (free_surface_dof_handler,


### PR DESCRIPTION
After talking to Sascha who is working with @gassmoeller, I have run some simple 2D models looking at the behaviour of the free surface with a free slip boundary condition on the right vertical boundary. I specified this condition either by listing the boundary under "Tangential velocity boundary indicators" or under "Prescribed velocity boundary indicators" while only prescribing the x-component of velocity to be zero and leaving the vertical component free. The behaviour of the right corner point of the mesh is different (vertical movement vs no movement), I think because the "mesh_displacement_constraints" are set to zero for prescribed velocity boundary conditions. It is not taken into account that not all velocity components need to be prescribed. I've added a few lines such that in 2D vertical motion along the vertical boundary is allowed, but I'm not sure this is the best way to do it and I don't think it covers all combinations of prescribed/free velocity components and boundaries. I'm not very familiar with the free surface yet, so I'm looking for input from @ian-r-rose on this :)