### PR TITLE
Use 'struct' consistently for all declarations.

### DIFF
--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011, 2012 by the authors of the ASPECT code.
+  Copyright (C) 2011, 2012, 2015 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -50,7 +50,7 @@ namespace aspect
 
   // forward declaration
   template <int dim> class Simulator;
-  template <int dim> class SimulatorSignals;
+  template <int dim> struct SimulatorSignals;
   template <int dim> class LateralAveraging;
   namespace HeatingModel
   {


### PR DESCRIPTION
This includes forward declaration. Fixes a warning posted by Luca Heltai.