### PR TITLE
Make the preconditioning tolerances of the A and S block available as parameters.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2868,6 +2868,38 @@ start with a small value and then increase the tolerance until you come to a
 point where the output quantities start to change significantly. This is the
 point where you will want to stop.
 
+\subsubsection{Adjusting solver preconditioner tolerances} To solve the Stokes 
+equations it is necessary to lower the condition number of the
+Stokes matrix by preconditioning  it. In \aspect{} a right preconditioner $Y^{-1} = 
+\begin{pmatrix}
+\widetilde{A^{-1}} & -\widetilde{A^{-1}}B^{T}\widetilde{S^{-1}} \\
+0 & \widetilde{S^{-1}}
+\end{pmatrix}$ is used to precondition the system, where $\widetilde{A^{-1}}$ is 
+the approximate inverse of the A block and $\widetilde{S^{-1}}$ is the approximate 
+inverse of the Schur complement matrix. Matrix $\widetilde{A^{-1}}$ and 
+$\widetilde{S^{-1}}$ are calculated through a CG solve, which requires a tolerance 
+to be set. In comparison with the solver tolerances of the previous section, these 
+parameters are relatively safe to use, since they only change the preconditioner, 
+but can speed up or slow down solving the Stokes system considerably. 
+
+In practice $\widetilde{A^{-1}}$ takes by far the most time to compute, but is 
+also very important in conditioning the system. The accuracy of the computation 
+of $\widetilde{A^{-1}}$ is controlled by the parameter \texttt{Linear solver A 
+block tolerance} which has a default value of $1e-2$. Setting this tolerance 
+to a less strict value will result in more outer iterations, since the 
+preconditioner is not as good, but the amount of time to compute 
+$\widetilde{A^{-1}}$ can drop significantly resulting in a reduced total solve 
+time. The cookbook crustal deformation (Section 
+\ref{sec:cookbooks-crustal-deformation}) for example can be computed much faster 
+by setting the \texttt{Linear solver A block tolerance} to $5e-1$. The 
+calculation of $\widetilde{S^{-1}}$ is usually much faster and the 
+conditioning of the system is less sensitive to the parameter \texttt{Linear 
+solver S block tolerance}, but for some problems it might be worth it to 
+investigate.
+\index[prmindex]{Linear solver A block tolerance}
+\index[prmindexfull]{Linear solver A block tolerance}
+\index[prmindex]{Linear solver S block tolerance}
+\index[prmindexfull]{Linear solver S block tolerance}
 
 \subsubsection{Using lower order elements for the temperature/compositional discretization}
 The default settings of \aspect{} use quadratic finite elements for the

--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,13 @@
  *
  *
  * <ol>
+ * <li> New: The tolerance of the preconditioners of the A and S block 
+ * are now available as parameters in the prm file. There is now also 
+ * a section added to the manual on how to use these parameters to 
+ * make ASPECT in certain situation faster.
+ * <br>
+ * (Menno Fraters, 2015/11/08)
+ *
  * <li> Changed: The DynamicTopography postprocessor and visualization
  * plugins now use the more accurate Gaussian quadrature rule for evaluating
  * cell averages of the surface stress.

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -174,6 +174,8 @@ namespace aspect
     unsigned int                   timing_output_frequency;
     bool                           use_direct_stokes_solver;
     double                         linear_stokes_solver_tolerance;
+    double                         linear_solver_A_block_tolerance;
+    double                         linear_solver_S_block_tolerance;
     unsigned int                   max_nonlinear_iterations;
     unsigned int                   max_nonlinear_iterations_in_prerefinement;
     unsigned int                   n_cheap_stokes_solver_steps;

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -257,6 +257,20 @@ namespace aspect
                        "if you make it larger, they do. For most cases, the default "
                        "value should be sufficient. In fact, a tolerance of 1e-4 "
                        "might be accurate enough.");
+
+    prm.declare_entry ("Linear solver A block tolerance", "1e-2",
+                       Patterns::Double(0,1),
+                       "A relative tolerance up to which the approximate inverse of the A block "
+                       "of the Stokes system is computed. This approximate A is used in the "
+                       "preconditioning used in the GMRES solver.");
+
+    prm.declare_entry ("Linear solver S block tolerance", "1e-6",
+                       Patterns::Double(0,1),
+                       "A relative tolerance up to which the approximate inverse of the S block "
+                       "(Schur complement matrix, $S = BA^{-1}B^{T}$) of the Stokes system is computed. "
+                       "This approximate inverse of the S block is used in the preconditioning "
+                       "used in the GMRES solver.");
+
     prm.declare_entry ("Number of cheap Stokes solver steps", "30",
                        Patterns::Integer(0),
                        "As explained in the ASPECT paper (Kronbichler, Heister, and Bangerth, "
@@ -773,25 +787,27 @@ namespace aspect
                              "did not detect its presence when you called 'cmake'."));
 #endif
 
-    surface_pressure              = prm.get_double ("Surface pressure");
-    adiabatic_surface_temperature = prm.get_double ("Adiabatic surface temperature");
-    pressure_normalization        = prm.get("Pressure normalization");
+    surface_pressure                = prm.get_double ("Surface pressure");
+    adiabatic_surface_temperature   = prm.get_double ("Adiabatic surface temperature");
+    pressure_normalization          = prm.get("Pressure normalization");
 
-    use_direct_stokes_solver      = prm.get_bool("Use direct solver for Stokes system");
-    linear_stokes_solver_tolerance= prm.get_double ("Linear solver tolerance");
-    n_cheap_stokes_solver_steps   = prm.get_integer ("Number of cheap Stokes solver steps");
-    temperature_solver_tolerance  = prm.get_double ("Temperature solver tolerance");
-    composition_solver_tolerance  = prm.get_double ("Composition solver tolerance");
+    use_direct_stokes_solver        = prm.get_bool("Use direct solver for Stokes system");
+    linear_stokes_solver_tolerance  = prm.get_double ("Linear solver tolerance");
+    linear_solver_A_block_tolerance = prm.get_double ("Linear solver A block tolerance");
+    linear_solver_S_block_tolerance = prm.get_double ("Linear solver S block tolerance");
+    n_cheap_stokes_solver_steps     = prm.get_integer ("Number of cheap Stokes solver steps");
+    temperature_solver_tolerance    = prm.get_double ("Temperature solver tolerance");
+    composition_solver_tolerance    = prm.get_double ("Composition solver tolerance");
 
     prm.enter_subsection ("Mesh refinement");
     {
-      initial_global_refinement   = prm.get_integer ("Initial global refinement");
-      initial_adaptive_refinement = prm.get_integer ("Initial adaptive refinement");
+      initial_global_refinement    = prm.get_integer ("Initial global refinement");
+      initial_adaptive_refinement  = prm.get_integer ("Initial adaptive refinement");
 
-      adaptive_refinement_interval= prm.get_integer ("Time steps between mesh refinement");
-      refinement_fraction         = prm.get_double ("Refinement fraction");
-      coarsening_fraction         = prm.get_double ("Coarsening fraction");
-      min_grid_level              = prm.get_integer ("Minimum refinement level");
+      adaptive_refinement_interval = prm.get_integer ("Time steps between mesh refinement");
+      refinement_fraction          = prm.get_double ("Refinement fraction");
+      coarsening_fraction          = prm.get_double ("Coarsening fraction");
+      min_grid_level               = prm.get_integer ("Minimum refinement level");
 
       AssertThrow(refinement_fraction >= 0 && coarsening_fraction >= 0,
                   ExcMessage("Refinement/coarsening fractions must be positive."));


### PR DESCRIPTION
This pull request makes the preconditioning tolerances of the A and S block available as parameters and add a section in the manual in the section on make aspect run faster where advice is given on how to use these parameters.