### PR TITLE
Fix warnings gcc 51

### DIFF
--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -88,7 +88,9 @@ namespace dealii
  * auto_ptr in CXX17. We need this to silence deprecation warnings in new
  * compilers.
  */
-#if !DEAL_II_VERSION_GTE(8,3,0)
+#if DEAL_II_VERSION_GTE(8,3,0)
+#include <deal.II/base/std_cxx11/unique_ptr.h>
+#else
 #ifdef DEAL_II_WITH_CXX11
 
 #  include <memory>

--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -133,8 +133,8 @@ namespace dealii
 
         template<class Y>
         explicit unique_ptr (Y *p)
-        :
-        boost::scoped_ptr<T>(p)
+          :
+          boost::scoped_ptr<T>(p)
         {}
     };
 

--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -83,6 +83,67 @@ namespace dealii
 }
 #endif
 
+/*
+ * Unique_ptr functionality that was introduced in deal.II 8.3 and replaces
+ * auto_ptr in CXX17. We need this to silence deprecation warnings in new
+ * compilers.
+ */
+#if !DEAL_II_VERSION_GTE(8,3,0)
+#ifdef DEAL_II_WITH_CXX11
+
+#  include <memory>
+namespace dealii
+{
+  namespace std_cxx11
+  {
+    using std::unique_ptr;
+  }
+}
+
+#else
+
+#include <boost/scoped_ptr.hpp>
+
+namespace dealii
+{
+  namespace std_cxx11
+  {
+    /**
+     * Implementation of a basic replacement for C++11's std::unique_ptr class.
+     *
+     * BOOST does not have a replacement for std::unique_ptr (because unique_ptr
+     * requires move semantics that aren't available unless you have a C++11
+     * compiler -- in which case you also have std::unique_ptr; see for example
+     * http://stackoverflow.com/questions/2953530/unique-ptr-boost-equivalent)
+     *
+     * Consequently, we emulate the class by just wrapping a boost::scoped_ptr
+     * in the cheapest possible way -- by just deriving from it and repeating
+     * the basic constructors. Everything else is inherited from the scoped_ptr
+     * class.
+     *
+     * There is no overhead to this approach: scoped_ptr cannot be copied or
+     * moved. Instances of unique_ptr cannot be copied, and if you do not have a
+     * C++11 compiler, then you cannot move anything anyway.
+     */
+    template <typename T>
+    class unique_ptr : public boost::scoped_ptr<T>
+    {
+      public:
+        unique_ptr () {}
+
+        template<class Y>
+        explicit unique_ptr (Y *p)
+        :
+        boost::scoped_ptr<T>(p)
+        {}
+    };
+
+  }
+}
+
+#endif
+#endif
+
 
 
 #endif

--- a/include/aspect/compositional_initial_conditions/function.h
+++ b/include/aspect/compositional_initial_conditions/function.h
@@ -79,7 +79,7 @@ namespace aspect
         /**
          * A function object representing the compositional fields.
          */
-        std::auto_ptr<Functions::ParsedFunction<dim> > function;
+        std_cxx11::unique_ptr<Functions::ParsedFunction<dim> > function;
     };
   }
 }

--- a/include/aspect/initial_conditions/adiabatic.h
+++ b/include/aspect/initial_conditions/adiabatic.h
@@ -103,7 +103,7 @@ namespace aspect
          * be used as a reference profile for calculating the thermal
          * diffusivity. The function depends only on depth.
          */
-        std::auto_ptr<Functions::ParsedFunction<1> > function;
+        std_cxx11::unique_ptr<Functions::ParsedFunction<1> > function;
     };
   }
 }

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -26,6 +26,7 @@
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/std_cxx11/unique_ptr.h>
 
 #include <deal.II/lac/trilinos_block_vector.h>
 #include <deal.II/lac/trilinos_block_sparse_matrix.h>
@@ -1011,16 +1012,16 @@ namespace aspect
        * @name Variables that describe the physical setup of the problem
        * @{
        */
-      const std::auto_ptr<GeometryModel::Interface<dim> >            geometry_model;
-      const IntermediaryConstructorAction                            post_geometry_model_creation_action;
-      const std::auto_ptr<MaterialModel::Interface<dim> >            material_model;
-      const std::auto_ptr<GravityModel::Interface<dim> >             gravity_model;
-      const std::auto_ptr<BoundaryTemperature::Interface<dim> >      boundary_temperature;
-      const std::auto_ptr<BoundaryComposition::Interface<dim> >      boundary_composition;
-      const std::auto_ptr<InitialConditions::Interface<dim> >        initial_conditions;
-      const std::auto_ptr<PrescribedStokesSolution::Interface<dim> >        prescribed_stokes_solution;
-      const std::auto_ptr<CompositionalInitialConditions::Interface<dim> > compositional_initial_conditions;
-      const std::auto_ptr<AdiabaticConditions::Interface<dim> >      adiabatic_conditions;
+      const std_cxx11::unique_ptr<GeometryModel::Interface<dim> >             geometry_model;
+      const IntermediaryConstructorAction                                     post_geometry_model_creation_action;
+      const std_cxx11::unique_ptr<MaterialModel::Interface<dim> >             material_model;
+      const std_cxx11::unique_ptr<GravityModel::Interface<dim> >              gravity_model;
+      const std_cxx11::unique_ptr<BoundaryTemperature::Interface<dim> >       boundary_temperature;
+      const std_cxx11::unique_ptr<BoundaryComposition::Interface<dim> >       boundary_composition;
+      const std_cxx11::unique_ptr<InitialConditions::Interface<dim> >         initial_conditions;
+      const std_cxx11::unique_ptr<PrescribedStokesSolution::Interface<dim> >  prescribed_stokes_solution;
+      const std_cxx11::unique_ptr<CompositionalInitialConditions::Interface<dim> >                     compositional_initial_conditions;
+      const std_cxx11::unique_ptr<AdiabaticConditions::Interface<dim> >       adiabatic_conditions;
       std::map<types::boundary_id,std_cxx11::shared_ptr<VelocityBoundaryConditions::Interface<dim> > > velocity_boundary_conditions;
       std::map<types::boundary_id,std_cxx11::shared_ptr<TractionBoundaryConditions::Interface<dim> > > traction_boundary_conditions;
 

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -26,7 +26,6 @@
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/symmetric_tensor.h>
-#include <deal.II/base/std_cxx11/unique_ptr.h>
 
 #include <deal.II/lac/trilinos_block_vector.h>
 #include <deal.II/lac/trilinos_block_sparse_matrix.h>

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -23,7 +23,6 @@
 #define __aspect__simulator_access_h
 
 #include <deal.II/base/conditional_ostream.h>
-#include <deal.II/base/std_cxx11/unique_ptr.h>
 #include <deal.II/distributed/tria.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/fe/fe.h>

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -23,6 +23,7 @@
 #define __aspect__simulator_access_h
 
 #include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/std_cxx11/unique_ptr.h>
 #include <deal.II/distributed/tria.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/fe/fe.h>

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -95,7 +95,7 @@ namespace aspect
       //If we are using a free surface, also serialize the mesh vertices vector, which
       //uses its own dof handler
       std::vector<const LinearAlgebra::Vector *> x_fs_system (2);
-      std::auto_ptr<parallel::distributed::SolutionTransfer<dim,LinearAlgebra::Vector> > freesurface_trans;
+      std_cxx11::unique_ptr<parallel::distributed::SolutionTransfer<dim,LinearAlgebra::Vector> > freesurface_trans;
       if (parameters.free_surface_enabled)
         {
           freesurface_trans.reset (new parallel::distributed::SolutionTransfer<dim,LinearAlgebra::Vector>

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1446,7 +1446,7 @@ namespace aspect
     system_trans(dof_handler);
 
     std::vector<const LinearAlgebra::Vector *> x_fs_system (1);
-    std::auto_ptr<parallel::distributed::SolutionTransfer<dim,LinearAlgebra::Vector> >
+    std_cxx11::unique_ptr<parallel::distributed::SolutionTransfer<dim,LinearAlgebra::Vector> >
     freesurface_trans;
 
     if (parameters.free_surface_enabled)


### PR DESCRIPTION
While recompiling aspect with gcc5.1 (our cluster switched its default compilers) I got a lot of deprecation warnings for the use of `auto_ptr`. Since it will be removed in C++17, maybe we can replace it by `unique_ptr` anyway?

Also I got hundreds of warnings for including `deal.II/base/multithread_info.h:64` in `aspect/global.h` that I did not get before (e.g. gcc 4.8 did not output them). Is this an issue in deal.II, or do we have to live with that until this line gets removed (after the release of deal.II 8.4?)?