### PR TITLE
Initialize SimulatorAccess object for compositing material models.

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,9 +6,15 @@
  *
  *
  * <ol>
- * <li> New: The tolerance of the preconditioners of the A and S block 
- * are now available as parameters in the prm file. There is now also 
- * a section added to the manual on how to use these parameters to 
+ * <li> Fixed: Whenever the base models used by either the "depth dependent"
+ * or "averaging" material models depended on anything that requires accessing
+ * the simulator, then this led to segmentation faults. This is now fixed.
+ * <br>
+ * (Wolfgang Bangerth, Shangxin Liu, 2015/11/24)
+ *
+ * <li> New: The tolerance of the preconditioners of the A and S block
+ * are now available as parameters in the prm file. There is now also
+ * a section added to the manual on how to use these parameters to
  * make ASPECT in certain situation faster.
  * <br>
  * (Menno Fraters, 2015/11/08)
@@ -19,8 +25,8 @@
  * <br>
  * (Ian Rose, 2015/11/04)
  *
- * <li> New: Add depth postprocessor which visually outputs the 
- * depth for all points inside the domain, as determined by the 
+ * <li> New: Add depth postprocessor which visually outputs the
+ * depth for all points inside the domain, as determined by the
  * geometry model.
  * <br>
  * (Menno Fraters, 2015/10/15)
@@ -87,26 +93,26 @@
  * <br>
  * (Ian Rose, 2015/08/24)
  *
- * <li> New: There is now a new initial condition in which the temperature field is perturbed 
- * following the SAVANI shear wave velocity model by Auer et al., 2014. The data were 
+ * <li> New: There is now a new initial condition in which the temperature field is perturbed
+ * following the SAVANI shear wave velocity model by Auer et al., 2014. The data were
  * downloaded from http://n.ethz.ch/~auerl/research.html .
  * <br>
  * (Shangxin Liu, 2015/08/20)
- *   
+ *
  * <li> New: A box Geometry Model plugin with additional boundary indicators
- * for the upper part of the box and corresponding Boundary Temperature and 
- * Composition Model plugins. With this plugin, different boundary conditions 
+ * for the upper part of the box and corresponding Boundary Temperature and
+ * Composition Model plugins. With this plugin, different boundary conditions
  * can be prescribed on the upper and lower part of the vertical domain boundaries.
  * <br>
  * (Anne Glerum, 2015/08/14)
  *
- * <li> New: Plugin for visualizing the boundary indicators used by the 
+ * <li> New: Plugin for visualizing the boundary indicators used by the
  * Geometry Model.
  * <br>
  * (Anne Glerum, 2015/08/14)
  *
- * <li> New: There is a new visualization postprocessor which displays 
- * the heat flux in the vertical direction, where upwards heat flux 
+ * <li> New: There is a new visualization postprocessor which displays
+ * the heat flux in the vertical direction, where upwards heat flux
  * is positive.
  * <br>
  * (Ian Rose, 2015/08/12)
@@ -121,10 +127,10 @@
  * <br>
  * (Anne Glerum, 2015/08/03)
  *
- * <li> Fixed: Quasi-implicit stabilization of a free surface had used the 
- * reference density instead of the density as evaluated by the material 
- * model.  Now it uses the actual density of at the surface.  This should 
- * not change much unless the density at the surface is significantly 
+ * <li> Fixed: Quasi-implicit stabilization of a free surface had used the
+ * reference density instead of the density as evaluated by the material
+ * model.  Now it uses the actual density of at the surface.  This should
+ * not change much unless the density at the surface is significantly
  * different from the reference density.
  * <br>
  * (Ian Rose, 2015/07/22)
@@ -133,11 +139,11 @@
  * <br>
  * (Jonathan Perry-Houts, 2015/07/12)
  *
- * <li> New: For free surface computations there is an option to advect the 
- * mesh vertically (in the direction of gravity),  in addition to the old 
- * formulation which advects it in the direction normal to the surface.  
+ * <li> New: For free surface computations there is an option to advect the
+ * mesh vertically (in the direction of gravity),  in addition to the old
+ * formulation which advects it in the direction normal to the surface.
  * This can be enabled by setting "Surface velocity projection" to "vertical"
- * in the "Free surface" section of a parameter file. 
+ * in the "Free surface" section of a parameter file.
  * This scheme can maintain better mesh regularity properties for computations
  * where there is a large deformation, or large curvature.
  * <br>
@@ -148,13 +154,13 @@
  * <br>
  * (Ian Rose, 2015/06/16)
  *
- * <li> New: There are now parameter files and a section in the manual for 
- * reproducing the benchmarks for free surface computations from Crameri et 
+ * <li> New: There are now parameter files and a section in the manual for
+ * reproducing the benchmarks for free surface computations from Crameri et
  * al. (2012).
  * <br>
  * (Ian Rose, 2015/06/14)
  *
- * <li> New: One can now prescribe the traction on a boundary instead of 
+ * <li> New: One can now prescribe the traction on a boundary instead of
  * supplying velocity boundary conditions.
  * This is done in a similar way as for the prescribed velocity boundary conditions:
  * For a given boundary indicator, one can prescribe all or a selection of the
@@ -162,28 +168,28 @@
  * <br>
  * (Wolfgang Bangerth, Anne Glerum, 2015/05/29)
  *
- * <li> Changed: We now use the exact formulation with the 
- * compressible strain rate instead of an approximation 
+ * <li> Changed: We now use the exact formulation with the
+ * compressible strain rate instead of an approximation
  * using the right hand side of the mass conservation equation
  * to calculate the shear heating. This is more accurate in
  * compressible models.
  * <br>
  * (Juliane Dannberg, 2015/05/29)
- * 
+ *
  * <li> New: There is now a new geometry model called chunk, which
  * takes radius, longitude (and latitude) pairs and creates a regional
- * chunk of a spherical shell. Spherical boundary and initial conditions 
+ * chunk of a spherical shell. Spherical boundary and initial conditions
  * have been updated to accept this new model. The conversion conventions
  * between [longitude, latitude and radius], [phi, theta and radius] and
- * Cartesian [x, y, z] are consistent with mathematical convention and 
+ * Cartesian [x, y, z] are consistent with mathematical convention and
  * other models in dealii/ASPECT.
- * This model was based largely on work on deal.ii by D. Sarah Stamps, 
+ * This model was based largely on work on deal.ii by D. Sarah Stamps,
  * Wolfgang Bangerth, and in ASPECT by Menno Fraters.
  * <br>
  * (Bob Myhill, 2015/05/29)
  *
  * <li> New: Added the ability to prescribe internal velocities with an ascii
- * file. 
+ * file.
  * <br>
  * (Scott Tarlow, 2015/05/29)
  *
@@ -195,7 +201,7 @@
  * (Menno Fraters, 2015/05/28)
  *
  * <li> New: There are now postprocessors BoundaryDensities and
- * BoundaryPressures which calculate laterally averaged densities 
+ * BoundaryPressures which calculate laterally averaged densities
  * and pressures at the top and bottom of the domain.
  * <br>
  * (Ian Rose, 2015/05/28)
@@ -217,7 +223,7 @@
  *
  * <li> Changed: The heating models have a new straucture now:
  * Instead of the implementation in the assembly, there is a heating
- * plugin for each model now that can be used both in the assembly 
+ * plugin for each model now that can be used both in the assembly
  * and the postprocessors, and a new heating model manager that
  * combines the plugins by adding the individual heating terms.
  * <br>
@@ -233,12 +239,12 @@
  * <br>
  * (Jonathan Perry-Houts, 2015/05/26)
  *
- * <li> New: There is now a Material model called diffusion dislocation that 
+ * <li> New: There is now a Material model called diffusion dislocation that
  * implements diffusion and dislocation creep viscosity.
  * <br>
  * (Bob Myhill, 2015/05/26)
  *
- * <li> Changed: Modified S40RTS initial condition file to incorporate 
+ * <li> Changed: Modified S40RTS initial condition file to incorporate
  * the option to zero out heterogeneities within a given depth.
  * <br>
  * (Jacqueline Austermann, 2015/05/26)
@@ -247,7 +253,7 @@
  * will come handy to capture shear bands when combined with plasticity.
  * <br>
  * (Cedric Thieulot, 2015/05/26)
- * 
+ *
  * <li> New: There is now a Material model called Depth dependent that implements
  * depth-dependent viscosity through the modification of any other Material model.
  * <br>
@@ -259,7 +265,7 @@
  * (Timo Heister, 2015/05/23)
  *
  * <li> New: There are now a set of global constants defined for physical
- * properties and for radius and gravity parameters relevant to 
+ * properties and for radius and gravity parameters relevant to
  * Earth and Mars.
  * <br>
  * (Bob Myhill, 2015/05/22)
@@ -278,18 +284,18 @@
  * (Wolfgang Bangerth, 2015/05/21)
  *
  * <li> Changed: The free surface handler now detaches internal manifolds
- * for cases when the domain has them, since they are not necessarily a 
+ * for cases when the domain has them, since they are not necessarily a
  * good description of the geometry when there has been large mesh deformation.
  * <br>
  * (Ian Rose, 2015/05/21)
  *
- * <li> Changed: The documentation for nullspace removal is now more 
- * descriptive of what Aspect is actually doing. 
+ * <li> Changed: The documentation for nullspace removal is now more
+ * descriptive of what Aspect is actually doing.
  * <br>
  * (Ian Rose, 2015/05/21)
  *
  * <li> New: There is now a mesh refinement criterion called Slope, intended
- * for use with a free surface, which refines where the topography has a 
+ * for use with a free surface, which refines where the topography has a
  * large slope.
  * <br>
  * (Ian Rose, 2015/05/21)
@@ -300,10 +306,10 @@
  * <br>
  * (Juliane Dannberg, 2015/05/20)
  *
- * <li> New: There is now an (3D) ellipsoidal chunk geometry model where two 
- * of the axis have the same length. The ellipsoidal chunk can be non-coordinate 
- * parallel part of the ellipsoid. 
- * This plugin is a joined effort of Menno Fraters, D Sarah Stamps and Wolfgang 
+ * <li> New: There is now an (3D) ellipsoidal chunk geometry model where two
+ * of the axis have the same length. The ellipsoidal chunk can be non-coordinate
+ * parallel part of the ellipsoid.
+ * This plugin is a joined effort of Menno Fraters, D Sarah Stamps and Wolfgang
  * Bangerth
  * <br>
  * (Menno Fraters, 2015/08/28)

--- a/source/material_model/averaging.cc
+++ b/source/material_model/averaging.cc
@@ -390,7 +390,13 @@ namespace aspect
                   ExcMessage("You may not use ``averaging'' as the base model for "
                              "a averaging model.") );
 
+          // create the base model and initialize its SimulatorAccess base
+          // class; it will get a chance to read its parameters below after we
+          // leave the current section
           base_model.reset(create_material_model<dim>(prm.get("Base model")));
+          if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(base_model.get()))
+            sim->initialize_simulator (this->get_simulator());
+
           averaging_operation = Averaging<dim>::parse_averaging_operation_name(prm.get ("Averaging operation"));
           bell_shape_limit = prm.get_double ("Bell shape limit");
         }

--- a/source/material_model/depth_dependent.cc
+++ b/source/material_model/depth_dependent.cc
@@ -207,7 +207,13 @@ namespace aspect
                        ExcMessage("You may not use ``depth dependent'' as the base model for "
                                   "a depth-dependent model.") );
 
+          // create the base model and initialize its SimulatorAccess base
+          // class; it will get a chance to read its parameters below after we
+          // leave the current section
           base_model.reset(create_material_model<dim>(prm.get("Base model")));
+          if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(base_model.get()))
+            sim->initialize_simulator (this->get_simulator());
+
           if ( prm.get("Depth dependence method") == "Function" )
             viscosity_source = Function;
           else if ( prm.get("Depth dependence method") == "File" )
@@ -279,7 +285,7 @@ namespace aspect
       /* After parsing the parameters for depth dependent, it is essential to parse
       parameters related to the base model. */
       base_model->parse_parameters(prm);
-      this-> model_dependence = base_model->get_model_dependence();
+      this->model_dependence = base_model->get_model_dependence();
     }
 
     template <int dim>


### PR DESCRIPTION
This fixes the fact that compositing material models (specifically the depth dependent
and averaging material models) held pointers to base models that may need to access
the simulator, but never initialized these base models' pointers to the Simulator
object. This patch fixes this by intercepting the initializing call.