### PR TITLE
Fix grammar and style of a number of error messages.

### DIFF
--- a/source/initial_conditions/S40RTS_perturbation.cc
+++ b/source/initial_conditions/S40RTS_perturbation.cc
@@ -48,7 +48,7 @@ namespace aspect
               std::string temp;
               std::ifstream in(filename.c_str(), std::ios::in);
               AssertThrow (in,
-                           ExcMessage (std::string("Couldn't open file <") + filename));
+                           ExcMessage (std::string("Could not open file <") + filename + ">."));
 
               in >> order;
               getline(in,temp);  // throw away the rest of the line
@@ -126,7 +126,7 @@ namespace aspect
               std::string temp;
               std::ifstream in(filename.c_str(), std::ios::in);
               AssertThrow (in,
-                           ExcMessage (std::string("Couldn't open file <") + filename));
+                           ExcMessage (std::string("Could not open file <") + filename + ">."));
 
               getline(in,temp);  // throw away the rest of the line
               getline(in,temp);  // throw away the rest of the line

--- a/source/initial_conditions/SAVANI_perturbation.cc
+++ b/source/initial_conditions/SAVANI_perturbation.cc
@@ -48,7 +48,7 @@ namespace aspect
               std::string temp;
               std::ifstream in(filename.c_str(), std::ios::in);
               AssertThrow (in,
-                           ExcMessage (std::string("Couldn't open file <") + filename));
+                           ExcMessage (std::string("Could not open file <") + filename + ">."));
 
               in >> order;
               getline(in,temp);  // throw away the rest of the line
@@ -128,7 +128,7 @@ namespace aspect
               std::string temp;
               std::ifstream in(filename.c_str(), std::ios::in);
               AssertThrow (in,
-                           ExcMessage (std::string("Couldn't open file <") + filename));
+                           ExcMessage (std::string("Could not open file <") + filename + ">."));
 
               getline(in,temp);  // throw away the rest of the line
               getline(in,temp);  // throw away the rest of the line

--- a/source/material_model/depth_dependent.cc
+++ b/source/material_model/depth_dependent.cc
@@ -36,7 +36,7 @@ namespace aspect
       /* This method is used for the Table method of depth dependent viscosity */
       std::ifstream in(filename.c_str(), std::ios::in);
       AssertThrow (in,
-                   ExcMessage (std::string("Couldn't open file <") + filename + std::string(">")));
+                   ExcMessage (std::string("Could not open file <") + filename + ">."));
 
       double min_depth=std::numeric_limits<double>::max();
       double max_depth=-std::numeric_limits<double>::max();

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -56,7 +56,7 @@ namespace aspect
             std::string temp;
             std::ifstream in(filename.c_str(), std::ios::in);
             AssertThrow (in,
-                         ExcMessage (std::string("Couldn't open file <") + filename));
+                         ExcMessage (std::string("Could not open file <") + filename + ">."));
 
             getline(in, temp); // eat first line
             getline(in, temp); // eat next line
@@ -308,7 +308,7 @@ namespace aspect
             std::string temp;
             std::ifstream in(filename.c_str(), std::ios::in);
             AssertThrow (in,
-                         ExcMessage (std::string("Couldn't open file <") + filename));
+                         ExcMessage (std::string("Could not open file <") + filename + ">."));
 
             getline(in, temp); // eat first line
 
@@ -366,7 +366,7 @@ namespace aspect
             std::string temp;
             std::ifstream in(filename.c_str(), std::ios::in);
             AssertThrow (in,
-                         ExcMessage (std::string("Couldn't open file <") + filename));
+                         ExcMessage (std::string("Could not open file <") + filename + ">."));
 
             min_depth=1e20;
             max_depth=-1;

--- a/source/particle/generator.cc
+++ b/source/particle/generator.cc
@@ -170,7 +170,7 @@ namespace aspect
                       }
                     num_tries++;
                   }
-                AssertThrow (num_tries < 100, ExcMessage ("Couldn't generate particle (unusual cell shape?)."));
+                AssertThrow (num_tries < 100, ExcMessage ("Could not generate particle (unusual cell shape?)."));
 
                 // Add the generated particle to the set
                 T new_particle(pt, cur_id);

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -549,7 +549,7 @@ namespace aspect
       {
         std::ofstream prm_out ((parameters.output_directory + "parameters.prm").c_str());
         AssertThrow (prm_out,
-                     ExcMessage (std::string("Couldn't open file <") +
+                     ExcMessage (std::string("Could not open file <") +
                                  parameters.output_directory + "parameters.prm>."));
         prm.print_parameters(prm_out, ParameterHandler::Text);
       }
@@ -557,7 +557,7 @@ namespace aspect
       {
         std::ofstream prm_out ((parameters.output_directory + "parameters.tex").c_str());
         AssertThrow (prm_out,
-                     ExcMessage (std::string("Couldn't open file <") +
+                     ExcMessage (std::string("Could not open file <") +
                                  parameters.output_directory + "parameters.tex>."));
         prm.print_parameters(prm_out, ParameterHandler::LaTeX);
       }

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -376,7 +376,7 @@ namespace aspect
     {
       std::ifstream in(filename.c_str(), std::ios::in);
       AssertThrow (in,
-                   ExcMessage (std::string("Couldn't open data file <"
+                   ExcMessage (std::string("Could not open data file <"
                                            +
                                            filename
                                            +

--- a/source/velocity_boundary_conditions/gplates.cc
+++ b/source/velocity_boundary_conditions/gplates.cc
@@ -210,7 +210,7 @@ namespace aspect
         std::string velos = pt.get<std::string>("gpml:FeatureCollection.gml:featureMember.gpml:VelocityField.gml:rangeSet.gml:DataBlock.gml:tupleList");
         std::stringstream in(velos, std::ios::in);
         AssertThrow (in,
-                     ExcMessage (std::string("Couldn't find velocities. Is file native gpml format for velocities?")));
+                     ExcMessage (std::string("Could not find velocities. Is this file in native gpml format for the velocities?")));
 
         // The lat-lon mesh has changed its starting longitude in gplates1.4
         // correct for this while reading in the velocity data


### PR DESCRIPTION
Specifically, in error messages that report about files that can't be opened, do
(i) use the words 'could not' instead of 'couldn't', and (ii) do not forget to
close the '>' tag after the name of the file that could not be opened.