### PR TITLE
Fix heating deprecation warnings

### DIFF
--- a/include/aspect/heating_model/constant_heating.h
+++ b/include/aspect/heating_model/constant_heating.h
@@ -40,15 +40,14 @@ namespace aspect
     {
       public:
         /**
-         * Return the specific heating rate. For the current class, this
+         * Return the heating terms. For the current class, this
          * function obviously simply returns a constant value.
          */
         virtual
-        double
-        specific_heating_rate (const double,
-                               const double,
-                               const std::vector<double> &,
-                               const Point<dim> &) const;
+        void
+        evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+                  const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
+                  HeatingModel::HeatingModelOutputs &heating_model_outputs) const;
 
         /**
          * @name Functions used in dealing with run-time parameters

--- a/include/aspect/heating_model/function.h
+++ b/include/aspect/heating_model/function.h
@@ -53,11 +53,10 @@ namespace aspect
          * object.
          */
         virtual
-        double
-        specific_heating_rate (const double,
-                               const double,
-                               const std::vector<double> &,
-                               const Point<dim> &) const;
+        void
+        evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+                  const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
+                  HeatingModel::HeatingModelOutputs &heating_model_outputs) const;
 
         /**
          * A function that is called at the beginning of each time step to

--- a/include/aspect/heating_model/radioactive_decay.h
+++ b/include/aspect/heating_model/radioactive_decay.h
@@ -53,11 +53,10 @@ namespace aspect
          * decay.
          */
         virtual
-        double
-        specific_heating_rate (const double,
-                               const double,
-                               const std::vector<double> &composition,
-                               const Point<dim> &position) const;
+        void
+        evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+                  const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
+                  HeatingModel::HeatingModelOutputs &heating_model_outputs) const;
 
         /**
          * Declare the parameters this class takes through input files.

--- a/source/heating_model/constant_heating.cc
+++ b/source/heating_model/constant_heating.cc
@@ -27,16 +27,21 @@ namespace aspect
   namespace HeatingModel
   {
     template <int dim>
-    double
+    void
     ConstantHeating<dim>::
-    specific_heating_rate (const double,
-                           const double,
-                           const std::vector<double> &,
-                           const Point<dim> &) const
+    evaluate (const MaterialModel::MaterialModelInputs<dim> &/*material_model_inputs*/,
+              const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
+              HeatingModel::HeatingModelOutputs &heating_model_outputs) const
     {
-      // return a constant value
-      return radiogenic_heating_rate;
+      for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
+        {
+          // return a constant value
+          heating_model_outputs.heating_source_terms[q] = radiogenic_heating_rate
+                                                          * material_model_outputs.densities[q];
+        }
     }
+
+
 
     template <int dim>
     void

--- a/source/heating_model/function.cc
+++ b/source/heating_model/function.cc
@@ -33,16 +33,20 @@ namespace aspect
     {}
 
 
-
     template <int dim>
-    double
+    void
     Function<dim>::
-    specific_heating_rate (const double,
-                           const double,
-                           const std::vector<double> &,
-                           const Point<dim> &p) const
+    evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+              const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
+              HeatingModel::HeatingModelOutputs &heating_model_outputs) const
     {
-      return heating_model_function.value(p);
+      for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
+        {
+          // return a constant value
+          const Point<dim> position = material_model_inputs.position[q];
+          heating_model_outputs.heating_source_terms[q] = heating_model_function.value(position)
+                                                          * material_model_outputs.densities[q];
+        }
     }
 
 

--- a/source/heating_model/radioactive_decay.cc
+++ b/source/heating_model/radioactive_decay.cc
@@ -43,35 +43,35 @@ namespace aspect
       AssertThrow(crust_composition_num < material_model_inputs.composition[0].size(),
                   ExcMessage("The composition number of crust is larger than number of composition fields."));
 
-      for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
+      for (unsigned int q = 0; q < heating_model_outputs.heating_source_terms.size(); ++q)
         {
-          double time = this->get_time();
-          // we get time passed as seconds (always) but may want
-          // to reinterpret it in years
-          if (this->convert_output_to_years())
-            time/=year_in_seconds;
-          double timedependent_radioactive_heating_rates=0;
+          double timedependent_radioactive_heating_rates = 0;
 
-          if (n_radio_heating_elements!=0)
+          if (n_radio_heating_elements != 0)
             {
-              double crust_fraction=0;
+              double crust_fraction = 0;
+
               if (is_crust_defined_by_composition)
                 {
-                  crust_fraction=material_model_inputs.composition[q][crust_composition_num];
-                  if (crust_fraction<0)crust_fraction=0;
-                  if (crust_fraction>1)crust_fraction=1;
+                  crust_fraction = material_model_inputs.composition[q][crust_composition_num];
+
+                  if (crust_fraction < 0.0)
+                    crust_fraction = 0;
+                  if (crust_fraction > 1.0)
+                    crust_fraction = 1;
                 }
               else if ((this->get_geometry_model()).depth(material_model_inputs.position[q]) < crust_depth)
-                crust_fraction=1.;
+                crust_fraction = 1;
 
-              for (unsigned i_radio=0; i_radio<n_radio_heating_elements; i_radio++)
-                timedependent_radioactive_heating_rates+=
-                  radioactive_heating_rates[i_radio]
-                  *(radioactive_initial_concentrations_mantle[i_radio]*(1-crust_fraction)
-                    +radioactive_initial_concentrations_crust[i_radio]*crust_fraction)*1e-6
-                  //1e-6 above is used to change concentration from ppm
-                  *std::pow(0.5,time/half_decay_times[i_radio]);
+              for (unsigned element = 0; element < n_radio_heating_elements; ++element)
+                {
+                  timedependent_radioactive_heating_rates += radioactive_heating_rates[element]
+                                                             * (radioactive_initial_concentrations_mantle[element] * (1-crust_fraction)
+                                                                + radioactive_initial_concentrations_crust[element] * crust_fraction)
+                                                             * std::pow(0.5,this->get_time()/half_decay_times[element]);
+                }
             }
+
           heating_model_outputs.heating_source_terms[q] = timedependent_radioactive_heating_rates
                                                           * material_model_outputs.densities[q];
         }
@@ -128,38 +128,53 @@ namespace aspect
         prm.enter_subsection("Radioactive decay");
         {
 
-          n_radio_heating_elements= prm.get_integer ("Number of elements");
-          radioactive_heating_rates=Utilities::string_to_double
-                                    (Utilities::split_string_list
-                                     (prm.get("Heating rates")));
-          AssertThrow(radioactive_heating_rates.size()==n_radio_heating_elements,
-                      ExcMessage("Number of heating rate entities does not match "
-                                 "the number of radioactive elements."));
+          n_radio_heating_elements  = prm.get_integer ("Number of elements");
 
-          half_decay_times=Utilities::string_to_double
-                           (Utilities::split_string_list
-                            (prm.get("Half decay times")));
-          AssertThrow(half_decay_times.size()==n_radio_heating_elements,
-                      ExcMessage("Number of half decay time entities does not match "
-                                 "the number of radioactive elements."));
+          radioactive_heating_rates = Utilities::string_to_double
+                                      (Utilities::split_string_list
+                                       (prm.get("Heating rates")));
 
-          radioactive_initial_concentrations_crust=Utilities::string_to_double
-                                                   (Utilities::split_string_list
-                                                    (prm.get("Initial concentrations crust")));
-          AssertThrow(radioactive_initial_concentrations_crust.size()==n_radio_heating_elements,
-                      ExcMessage("Number of initial concentration entities in crust "
-                                 "does not match the number of radioactive elements."));
+          half_decay_times          = Utilities::string_to_double
+                                      (Utilities::split_string_list
+                                       (prm.get("Half decay times")));
 
-          radioactive_initial_concentrations_mantle=Utilities::string_to_double
-                                                    (Utilities::split_string_list
-                                                     (prm.get("Initial concentrations mantle")));
-          AssertThrow(radioactive_initial_concentrations_mantle.size()==n_radio_heating_elements,
-                      ExcMessage("Number of initial concentration entities in mantle "
-                                 "does not match the number of radioactive elements."));
+          radioactive_initial_concentrations_crust  = Utilities::string_to_double
+                                                      (Utilities::split_string_list
+                                                       (prm.get("Initial concentrations crust")));
+
+          radioactive_initial_concentrations_mantle = Utilities::string_to_double
+                                                      (Utilities::split_string_list
+                                                       (prm.get("Initial concentrations mantle")));
 
           is_crust_defined_by_composition = prm.get_bool    ("Crust defined by composition");
           crust_depth                     = prm.get_double  ("Crust depth");
           crust_composition_num           = prm.get_integer ("Crust composition number");
+
+
+          AssertThrow(radioactive_heating_rates.size() == n_radio_heating_elements,
+                      ExcMessage("Number of heating rate entities does not match "
+                                 "the number of radioactive elements."));
+          AssertThrow(half_decay_times.size() == n_radio_heating_elements,
+                      ExcMessage("Number of half decay time entities does not match "
+                                 "the number of radioactive elements."));
+          AssertThrow(radioactive_initial_concentrations_crust.size() == n_radio_heating_elements,
+                      ExcMessage("Number of initial concentration entities in crust "
+                                 "does not match the number of radioactive elements."));
+          AssertThrow(radioactive_initial_concentrations_mantle.size() == n_radio_heating_elements,
+                      ExcMessage("Number of initial concentration entities in mantle "
+                                 "does not match the number of radioactive elements."));
+
+          // if we get half_decay_times passed as years convert it to seconds
+          if (this->convert_output_to_years())
+            for (unsigned int i = 0; i < n_radio_heating_elements; ++i)
+              half_decay_times[i] *= year_in_seconds;
+
+          // Convert ppm to SI concentrations
+          for (unsigned int i = 0; i < n_radio_heating_elements; ++i)
+            {
+              radioactive_initial_concentrations_crust[i] *= 1e-6;
+              radioactive_initial_concentrations_mantle[i] *= 1e-6;
+            }
         }
         prm.leave_subsection();
       }


### PR DESCRIPTION
This patch was my attempt to fix the remaining deprecation warnings in the heating model with gcc 5.1 (mentioned in #668). It will replace the implementation of the specific_heating_rate function by the new evaluate function in all plugins that still use it. Unfortunately it did not fulfill its purpose, I guess because of the following bug in gcc 5.1: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65974. It seems like we have to live with deprecation warnings, for everybody using gcc 5.1 and 5.2 for now. Still the patch itself is valid and improves the code, so we should merge it anyway.