### PR TITLE
Avoid 23255...23255 in latex.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -5256,7 +5256,7 @@ to be significantly less vigorous than in the simulation here. Indeed, using
 the values in the input file shown above, we can compute the Rayleigh number for
 the current case to be%
 \footnote{Note that the density in 2d has units $\text{kg}\,\text{m}^{-2}$}
-$$
+\begin{equation*}
   \textrm{Ra}
   =
   \frac{g\; \beta \; \Delta T \; \rho \; L^3}{\alpha\eta}
@@ -5265,7 +5265,7 @@ $$
   \text{K} \; 3300 \text{kg}\,\text{m}^{-2} \; (2.86 \cdot 10^6
   \text{m})^3}{10^{22}
   \text{kg}\,\text{m}^{-1}\,\text{s}^{-1}}.
-$$
+\end{equation*}
 
 Second, the initial temperature profile we chose is not realistic -- in fact, it
 is a completely instable one: there is hot material underlying cold one, and


### PR DESCRIPTION
It turns out that using 23255...23255 is apparently one of the cardinal sins in latex
because it is a plain TeX command that can not be overridden by the latex styles.
Thus, avoid it in the one place where we use it.