### PR TITLE
Avoid the use of unicode characters in the manual.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -278,32 +278,32 @@ to some part using \aspect{}, you cite the following, canonical reference for
 this software:
 \begin{lstlisting}[frame=single,language=tex]
 @Article{KHB12,
-  author = 	 {M. Kronbichler and T. Heister and W. Bangerth},
-  title = 	 {High Accuracy Mantle Convection Simulation through Modern Numerical Methods},
-  journal = 	 {Geophysics Journal International},
-  year = 	 2012,
-  volume = 	 191,
-  pages = 	 {12--29}}
+  author =       {M. Kronbichler and T. Heister and W. Bangerth},
+  title =        {High Accuracy Mantle Convection Simulation through Modern Numerical Methods},
+  journal =      {Geophysics Journal International},
+  year =         2012,
+  volume =       191,
+  pages =        {12--29}}
 \end{lstlisting}
 You can refer to the website by citing the following:
 \begin{lstlisting}[frame=single,language=tex]
 
       @MANUAL{aspectweb,
-        title = {ASPECT: Advanced Solver for Problems in Earth's ConvecTion},
+        title  = {ASPECT: Advanced Solver for Problems in Earth's ConvecTion},
         author = {W. Bangerth and T. Heister and others},
-        year = {2014},
-        note = {\texttt{https://aspect.dealii.org/}},
-        url = {https://aspect.dealii.org/}
+        year   = {2014},
+        note   = {\texttt{https://aspect.dealii.org/}},
+        url    = {https://aspect.dealii.org/}
       }
 \end{lstlisting}
 The manual's proper reference is this:
 \begin{lstlisting}[frame=single,language=tex]
 @Manual{aspectmanual,
         title =        {\textsc{ASPECT}: Advanced Solver for Problems in Earth's
-          ConvecTion},
+                        ConvecTion},
         author =       {W. Bangerth and T. Heister and others},
         organization = {Computational Infrastructure for Geodynamics},
-        year = 	 2014
+        year =         2014
       }
 \end{lstlisting}
 
@@ -2658,11 +2658,11 @@ into the given file. The result is a graphics file similar to the one
 shown in Fig.~\ref{fig:convection-box-stats} on page \pageref{fig:convection-box-stats}.
 
 \note{After setting output to a file, \textit{all} following plot commands will
-	want to write to this file. Thus, if you want to create more plots after
-	the one just created, you need to reset output back to the screen. On Linux,
-	this is done using the command \texttt{set terminal X11}. You can then
-	continue experimenting with plots and when you have the next plot ready,
-	switch back to output to a file.}
+  want to write to this file. Thus, if you want to create more plots after
+  the one just created, you need to reset output back to the screen. On Linux,
+  this is done using the command \texttt{set terminal X11}. You can then
+  continue experimenting with plots and when you have the next plot ready,
+  switch back to output to a file.}
 
 What makes \texttt{Gnuplot} so useful is that it doesn't just allow entering
 all these commands at the prompt. Rather, one can write them all into a file,
@@ -4604,10 +4604,10 @@ In particular, what is necessary is an evaluation function that looks like this:
         { 
           const double z = in.position[i][1];
 
-	  if (z>jump_height)
-	    out.viscosities[i] = eta_U;
-	  else
-	    out.viscosities[i] = eta_L;
+          if (z>jump_height)
+            out.viscosities[i] = eta_U;
+          else
+            out.viscosities[i] = eta_L;
                      
           out.densities[i] = reference_rho*(1.0-thermal_alpha*(in.temperature[i]-reference_T));
           out.thermal_expansion_coefficients[i] = thermal_alpha;
@@ -5033,61 +5033,61 @@ and that were outlined in Section~\ref{sec:cookbooks-overview}, and address them
 one by one:
 \begin{itemize}
   \item \textit{What internal forces act on the medium (the equation)?}
-  	This may in fact be the most difficult to answer part of it all. The real
-  	material in Earth's mantle is certainly no Newtonian fluid where the stress
-  	is a linear function of the strain with a proportionality constant (the
-  	viscosity) $\eta$ that only depends on the temperature. Rather, the
-  	real viscosity almost surely also depends on the pressure and the strain
-  	rate. Because the issue is complicated and the exact material model not
-  	entirely clear, for the next few subsections we will therefore ignore the
-  	issue and start with just using the ``simple'' material model where the
-  	viscosity is constant and most other coefficients depend at most on the
-  	temperature.
+    This may in fact be the most difficult to answer part of it all. The real
+    material in Earth's mantle is certainly no Newtonian fluid where the stress
+    is a linear function of the strain with a proportionality constant (the
+    viscosity) $\eta$ that only depends on the temperature. Rather, the
+    real viscosity almost surely also depends on the pressure and the strain
+    rate. Because the issue is complicated and the exact material model not
+    entirely clear, for the next few subsections we will therefore ignore the
+    issue and start with just using the ``simple'' material model where the
+    viscosity is constant and most other coefficients depend at most on the
+    temperature.
 
   \item \textit{What external forces do we have (the right hand side)}
-  	There are of course other issues: for example, should the model include terms
-  	that describe shear heating? Should it be compressible? Adiabatic heating due
-  	to compression? Most of the terms that pertain to these questions appear on
-  	the right hand sides of the equations, though some (such as the
-  	compressibility) also affect the differential operators on the left. Either
-  	way, for the moment, let us just go with the simplest models and come back to
-  	the more advanced questions in later examples.
+    There are of course other issues: for example, should the model include terms
+    that describe shear heating? Should it be compressible? Adiabatic heating due
+    to compression? Most of the terms that pertain to these questions appear on
+    the right hand sides of the equations, though some (such as the
+    compressibility) also affect the differential operators on the left. Either
+    way, for the moment, let us just go with the simplest models and come back to
+    the more advanced questions in later examples.
 
-  	One right hand side that will certainly be there is that due to gravitational
-  	acceleration. To first order, within the mantle gravity points radially
-  	inward and has a roughly constant magnitude. In reality, of course, the
-  	strength and direction of gravity depends on the distribution and density of
-  	materials in Earth -- and, consequently, on the solution of the model at
-  	every time step. We will discuss some of the associated issues in the
-  	examples below.
+    One right hand side that will certainly be there is that due to gravitational
+    acceleration. To first order, within the mantle gravity points radially
+    inward and has a roughly constant magnitude. In reality, of course, the
+    strength and direction of gravity depends on the distribution and density of
+    materials in Earth -- and, consequently, on the solution of the model at
+    every time step. We will discuss some of the associated issues in the
+    examples below.
 
   \item \textit{What is the domain (geometry)?}
-  	This question is easier to answer. To first order, the domains we want to
-  	simulate are spherical shells, and to second order ellipsoid shells that can
-  	be obtained by considering the isopotential surface of the gravity field of
-  	a homogenous, rotating fluid.
-  	A more accurate description is of course the geoid for which several
-  	parameterizations are available. A complication arises if we ask whether we
-  	want to include the mostly rigid crust in the domain and simply assume that
-  	it is part of the convecting mantle, albeit a rather viscous part due to its
-  	low temperature and the low pressure there, or whether we want to truncate
-  	the computation at the asthenosphere.
+    This question is easier to answer. To first order, the domains we want to
+    simulate are spherical shells, and to second order ellipsoid shells that can
+    be obtained by considering the isopotential surface of the gravity field of
+    a homogenous, rotating fluid.
+    A more accurate description is of course the geoid for which several
+    parameterizations are available. A complication arises if we ask whether we
+    want to include the mostly rigid crust in the domain and simply assume that
+    it is part of the convecting mantle, albeit a rather viscous part due to its
+    low temperature and the low pressure there, or whether we want to truncate
+    the computation at the asthenosphere.
 
   \item \textit{What happens at the boundary for each variable involved
-  (boundary conditions)?}
-  	The mantle has two boundaries: at the bottom where it contacts the outer core
-  	and at the top where it either touches the air or, depending on the outcome
-  	of the discussion of the previous question, where it contacts the
-  	lithospheric crust. At the bottom, a very good approximation of what is
-  	happening is certainly to assume that the velocity field is tangential
-  	(i.e., horizontal) and without friction forces due to the very low viscosity
-  	of the liquid metal in the outer core. Similarly, we can assume that the
-  	outer core is well mixed and at a constant temperature. At the top boundary,
-  	the situation is slightly more complex because in reality the boundary is not
-  	fixed but also allows vertical movement. If we ignore this, we can assume
-  	free tangential flow at the surface or, if we want, prescribe the tangential
-  	velocity as inferred from plate motion models. \aspect{} has a plugin that
-  	allows to query this kind of information from the \texttt{GPlates} program.
+      (boundary conditions)?}
+    The mantle has two boundaries: at the bottom where it contacts the outer core
+    and at the top where it either touches the air or, depending on the outcome
+    of the discussion of the previous question, where it contacts the
+    lithospheric crust. At the bottom, a very good approximation of what is
+    happening is certainly to assume that the velocity field is tangential
+    (i.e., horizontal) and without friction forces due to the very low viscosity
+    of the liquid metal in the outer core. Similarly, we can assume that the
+    outer core is well mixed and at a constant temperature. At the top boundary,
+    the situation is slightly more complex because in reality the boundary is not
+    fixed but also allows vertical movement. If we ignore this, we can assume
+    free tangential flow at the surface or, if we want, prescribe the tangential
+    velocity as inferred from plate motion models. \aspect{} has a plugin that
+    allows to query this kind of information from the \texttt{GPlates} program.
 
   \item \textit{How did it look at the beginning (initial conditions)?}
     This is of course a trick question. Convection in the mantle of earth-like
@@ -5994,7 +5994,7 @@ to \cite{will99}, and in extension to \cite{alht11}.
 
 Brittle failure is approximated by adapting the viscosity to limit the stress 
 that is generated during deformation. 
-This “cap” on the stress level is parameterized in this experiment by the pressure-dependent 
+This ``cap'' on the stress level is parameterized in this experiment by the pressure-dependent 
 Drucker Prager yield criterion  and we therefore make use of the Drucker-Prager 
 material model (see Section \ref{parameters:Material_20model}) in the 
 {\tt cookbooks/crustal\_model\_2D.prm}.
@@ -7093,7 +7093,7 @@ where $f$ is the ratio $\frac{r_{\min}}{r_{\max}}$.
 
 We can put this in terms of heat flux
 \begin{equation*}
-	q_r = -k\frac{\partial T}{\partial r}
+  q_r = -k\frac{\partial T}{\partial r}
 \end{equation*}
 through the inner and outer surfaces,
 where $q_r$ is heat flux in the radial direction. Let $Q$ be the total heat that flows throug a surface,
@@ -7793,11 +7793,11 @@ function of the following kind (a nonsensical but instructive example; see
 Section~\ref{sec:postprocessors} for more details on what postprocessors do
 and how they are implemented):%
 \footnote{For complicated, technical reasons, in the code below we need to
-	access elements of the \href{doc/doxygen/classaspect_1_1SimulatorAccess.html}{SimulatorAccess} class using the notation
-	\texttt{this->get\_solution()}, etc. This is due to the fact that both the
-	current class and the base class are templates. A long description of
-	why it is necessary to use \texttt{this->} can be found in the \dealii{}
-	Frequently Asked Questions.}
+  access elements of the \href{doc/doxygen/classaspect_1_1SimulatorAccess.html}{SimulatorAccess} class using the notation
+  \texttt{this->get\_solution()}, etc. This is due to the fact that both the
+  current class and the base class are templates. A long description of
+  why it is necessary to use \texttt{this->} can be found in the \dealii{}
+  Frequently Asked Questions.}
 \begin{lstlisting}[frame=single,language=C++]
     template <int dim>
     std::pair<std::string,std::string>
@@ -8308,8 +8308,8 @@ explained using an example:
       ... create the coarse mesh ...
 
       coarse_grid.signals.post_refinement.connect
-	(std_cxx1x::bind (&set_boundary_indicators<dim>,
-			  std_cxx1x::ref(coarse_grid)));
+        (std_cxx1x::bind (&set_boundary_indicators<dim>,
+                          std_cxx1x::ref(coarse_grid)));
 
     }
 \end{lstlisting}
@@ -8348,9 +8348,9 @@ function of the \texttt{MyGeometry} class, then the following will work:
       ... create the coarse mesh ...
 
       coarse_grid.signals.post_refinement.connect
-	(std_cxx1x::bind (&MyGeometry<dim>::set_boundary_indicators,
-			  std_cxx1x::cref(*this),
-			  std_cxx1x::ref(coarse_grid)));
+        (std_cxx1x::bind (&MyGeometry<dim>::set_boundary_indicators,
+                          std_cxx1x::cref(*this),
+                          std_cxx1x::ref(coarse_grid)));
     }
 \end{lstlisting}
 Here, like any other member function, \texttt{set\_boundary\_indicators}
@@ -9245,7 +9245,7 @@ void post_constraints_creation (const SimulatorAccess<dim> &simulator_access,
 {
   simulator_access.get_statistics_object()
     .add_value ("number of constraints",
-		        current_constraints.n_constraints());
+                current_constraints.n_constraints());
 }
 \end{lstlisting}
 This will produce, for every time step (because this is how often the signal is


### PR DESCRIPTION
I really only wanted to change the one line where unicode chars appear (line 5997) but then my emacs decided to also change all tabs to spaces -- well, that's probably not terrible either.