### PR TITLE
Provide fallbacks for command line

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -5,6 +5,13 @@
  * 1.3. All entries are signed with the names of the author. </p>
  *
  * <ol>
+ * <li> New: ASPECT no longer relies on the availability of a command-
+ * processor (terminal) at run-time, by providing fallbacks to C
+ * commands. This adds support for architectures that do not offer a
+ * terminal on compute nodes (like IBM BlueGene/Q).
+ * <br>
+ * (Rene Gassmoeller, 2016/02/03)
+ *
  * <li> Changed: The 'depth' function of the 'box' geometry model and
  * the 'two merged boxes' geometry model previously threw an exception
  * when asked for the depth of a point outside of the initial model domain.

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -74,6 +74,22 @@ namespace aspect
     bool fexists(const std::string &filename);
 
     /**
+     * Creates a path as if created by the shell command "mkdir -p", therefore
+     * generating directories from the highest to the lowest level if they are
+     * not already existing.
+     *
+     * @param pathname String that contains the path to create. '/' is used as
+     * directory separator.
+     * @param mode Permissions (mode bits) of the created directories. See the
+     * documentation of the chmod() command for more information.
+     * @return The function returns the error value of the last mkdir call
+     * inside. It returns zero on success. See the man page of mkdir() for
+     * more information.
+     */
+    int
+    mkdirp(std::string pathname, const mode_t mode = 0755);
+
+    /**
      * A namespace defining the cubic spline interpolation that can be used
      * between different spherical layers in the mantle.
      */

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -535,7 +535,7 @@ namespace aspect
       // null pointer. System is guaranteed to return non-zero if it finds
       // a terminal and zero if there is none (like on the compute nodes of
       // some cluster architectures, e.g. IBM BlueGene/Q)
-      if (system((char*)0) != 0)
+      if (system((char *)0) != 0)
         {
           // Try getting the environment variable for the temporary directory
           const char *tmp_filedir = getenv("TMPDIR");

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -531,7 +531,11 @@ namespace aspect
 
       int tmp_file_desc = -1;
 
-      if (system(0) != 0)
+      // Check if a command-processor is available by calling system() with a
+      // null pointer. System is guaranteed to return non-zero if it finds
+      // a terminal and zero if there is none (like on the compute nodes of
+      // some cluster architectures, e.g. IBM BlueGene/Q)
+      if (system((char*)0) != 0)
         {
           // Try getting the environment variable for the temporary directory
           const char *tmp_filedir = getenv("TMPDIR");

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -531,46 +531,49 @@ namespace aspect
 
       int tmp_file_desc = -1;
 
-      {
-        // Try getting the environment variable for the temporary directory
-        const char *tmp_filedir = getenv("TMPDIR");
-        // If we can't, default to /tmp
-        if (tmp_filedir)
-          tmp_filename = tmp_filedir;
-        else
-          tmp_filename = "/tmp";
-        tmp_filename += "/aspect.tmp.XXXXXX";
+      if (system(0) != 0)
+        {
+          // Try getting the environment variable for the temporary directory
+          const char *tmp_filedir = getenv("TMPDIR");
+          // If we can't, default to /tmp
+          if (tmp_filedir)
+            tmp_filename = tmp_filedir;
+          else
+            tmp_filename = "/tmp";
+          tmp_filename += "/aspect.tmp.XXXXXX";
 
-        // Create the temporary file; get at the actual filename
-        // by using a C-style string that mkstemp will then overwrite
-        char *tmp_filename_x = new char[tmp_filename.size()+1];
-        std::strcpy(tmp_filename_x, tmp_filename.c_str());
-        tmp_file_desc = mkstemp(tmp_filename_x);
-        tmp_filename = tmp_filename_x;
-        delete []tmp_filename_x;
+          // Create the temporary file; get at the actual filename
+          // by using a C-style string that mkstemp will then overwrite
+          char *tmp_filename_x = new char[tmp_filename.size()+1];
+          std::strcpy(tmp_filename_x, tmp_filename.c_str());
+          tmp_file_desc = mkstemp(tmp_filename_x);
+          tmp_filename = tmp_filename_x;
+          delete []tmp_filename_x;
 
-        // If we failed to create the temp file, just write directly to the target file.
-        // We also provide a warning about this fact. There are places where
-        // this fails *on every node*, so we will get a lot of warning messages
-        // into the output; in these cases, just writing multiple pieces to
-        // std::cerr will produce an unreadable mass of text; rather, first
-        // assemble the error message completely, and then output it atomically
-        if (tmp_file_desc == -1)
-          {
-            const std::string x = ("***** WARNING: could not create temporary file <"
-                                   +
-                                   tmp_filename
-                                   +
-                                   ">, will output directly to final location. This may negatively "
-                                   "affect performance. (On processor "
-                                   + Utilities::int_to_string(Utilities::MPI::this_mpi_process (MPI_COMM_WORLD))
-                                   + ".)\n");
+          // If we failed to create the temp file, just write directly to the target file.
+          // We also provide a warning about this fact. There are places where
+          // this fails *on every node*, so we will get a lot of warning messages
+          // into the output; in these cases, just writing multiple pieces to
+          // std::cerr will produce an unreadable mass of text; rather, first
+          // assemble the error message completely, and then output it atomically
+          if (tmp_file_desc == -1)
+            {
+              const std::string x = ("***** WARNING: could not create temporary file <"
+                                     +
+                                     tmp_filename
+                                     +
+                                     ">, will output directly to final location. This may negatively "
+                                     "affect performance. (On processor "
+                                     + Utilities::int_to_string(Utilities::MPI::this_mpi_process (MPI_COMM_WORLD))
+                                     + ".)\n");
 
-            std::cerr << x << std::flush;
+              std::cerr << x << std::flush;
 
-            tmp_filename = *filename;
-          }
-      }
+              tmp_filename = *filename;
+            }
+        }
+      else
+        tmp_filename = *filename;
 
       // open the file. if we can't open it, abort if this is the "real"
       // file. re-try with the "real" file if we had tried to write to

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/simulator.h>
+#include <aspect/utilities.h>
 
 #include <deal.II/base/mpi.h>
 #include <deal.II/grid/grid_tools.h>
@@ -39,7 +40,17 @@ namespace aspect
     void move_file (const std::string &old_name,
                     const std::string &new_name)
     {
-      const int error = system (("mv " + old_name + " " + new_name).c_str());
+      int error = system (("mv " + old_name + " " + new_name).c_str());
+
+      // If the above call failed, e.g. because there is no command-line
+      // available, try with internal functions.
+      if (error != 0)
+        {
+          if (Utilities::fexists(new_name))
+            error = remove(new_name.c_str());
+
+          error = rename(old_name.c_str(),new_name.c_str());
+        }
 
       AssertThrow (error == 0, ExcMessage(std::string ("Can't move files: ")
                                           +

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -47,14 +47,18 @@ namespace aspect
       if (error != 0)
         {
           if (Utilities::fexists(new_name))
-            error = remove(new_name.c_str());
+            {
+              error = remove(new_name.c_str());
+              AssertThrow (error == 0, ExcMessage(std::string ("Unable to remove file: "
+                                                               + new_name
+                                                               + ", although it seems to exist.")));
+            }
 
           error = rename(old_name.c_str(),new_name.c_str());
+          AssertThrow (error == 0, ExcMessage(std::string ("Unable to rename files: ")
+                                              +
+                                              old_name + " -> " + new_name));
         }
-
-      AssertThrow (error == 0, ExcMessage(std::string ("Can't move files: ")
-                                          +
-                                          old_name + " -> " + new_name));
     }
   }
 

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -21,6 +21,7 @@
 
 #include <aspect/simulator.h>
 #include <aspect/global.h>
+#include <aspect/utilities.h>
 
 #include <deal.II/base/parameter_handler.h>
 
@@ -764,21 +765,9 @@ namespace aspect
                   << "-----------------------------------------------------------------------------\n\n"
                   << std::endl;
 
-        // Create the directory. We could call the 'mkdir()' function directly, but
-        // this can only create a single level of directories. If someone has specified
-        // a nested subdirectory as output directory, and if multiple parts of the path
-        // do not exist, this would fail. Working around this is easiest by just calling
-        // 'mkdir -p' from the command line.
-        int error = system ((std::string("mkdir -p '") + output_directory + "'").c_str());
+        const int error = Utilities::mkdirp(output_directory, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
 
-        // If no command-line exists (such as on compute nodes of IBM BlueGene/Q), or
-        // mkdir is not available on the command-line, fall back to mkdir().
-        if (error != 0)
-          {
-            error = mkdir(output_directory.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-          }
-
-        AssertThrow (error==0,
+        AssertThrow (error == 0,
                      ExcMessage (std::string("Can't create the output directory at <") + output_directory + ">"));
       }
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -34,6 +34,9 @@
 #include <aspect/geometry_model/chunk.h>
 
 #include <fstream>
+#include <string>
+#include <sys/stat.h>
+#include <errno.h>
 
 namespace aspect
 {
@@ -99,6 +102,36 @@ namespace aspect
     {
       std::ifstream ifile(filename.c_str());
       return static_cast<bool>(ifile); // only in c++11 you can convert to bool directly
+    }
+
+    int
+    mkdirp(std::string pathname,const mode_t mode)
+    {
+      // force trailing / so we can handle everything in loop
+      if (pathname[pathname.size()-1] != '/')
+        {
+          pathname += '/';
+        }
+
+      size_t pre = 0;
+      size_t pos;
+
+      while ((pos = pathname.find_first_of('/',pre)) != std::string::npos)
+        {
+          const std::string subdir = pathname.substr(0,pos++);
+          pre = pos;
+
+          // if leading '/', first string is 0 length
+          if (subdir.size() == 0)
+            continue;
+
+          int mkdir_return_value;
+          if ((mkdir_return_value = mkdir(subdir.c_str(),mode)) && (errno != EEXIST))
+            return mkdir_return_value;
+
+        }
+
+      return 0;
     }
 
     // tk does the cubic spline interpolation that can be used between different spherical layers in the mantle.


### PR DESCRIPTION
A set of patches that should work around some issues that occur, if `system()` (to do something on the command line) does not work for some reason. This is the case for compute nodes on IBM's BlueGene/Q architecture.

The inclusion of the different namespace in Utilities is only coarsely related. It would be nice, if I would not need to rename every `Utilities::something` function into `dealii::Utilities::something` just because I include the `aspect::Utilities` header file. Is this solution ok?