### PR TITLE
update boundary interfaces

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -5,7 +5,16 @@
  * 1.3. All entries are signed with the names of the author. </p>
  *
  * <ol>
- * <li> New: A new mesh refinement plugin was added that refines cells
+ * <li> Changed: The interfaces of the boundary composition and boundary
+ * temperature plugins have been deprecated. Their replacements not longer 
+ * contain references to the geometry model, which was a leftover from an
+ * earlier development stage. Users should derive their plugins from
+ * SimulatorAccess if they need access to the geometry model. The
+ * deprecated functions will be removed in a future ASPECT release.
+ * <br>
+ * (Rene Gassmoeller, 2016/01/04)
+ *
+  * <li> New: A new mesh refinement plugin was added that refines cells
  * according to the density of particles in that cell.
  * <br>
  * (Rene Gassmoeller, 2015/12/19)

--- a/include/aspect/boundary_composition/ascii_data.h
+++ b/include/aspect/boundary_composition/ascii_data.h
@@ -73,10 +73,9 @@ namespace aspect
          * current class, this function returns value from the text files.
          */
         double
-        composition (const GeometryModel::Interface<dim> &geometry_model,
-                     const types::boundary_id             boundary_indicator,
-                     const Point<dim>                    &position,
-                     const unsigned int                   compositional_field) const;
+        boundary_composition (const types::boundary_id             boundary_indicator,
+                              const Point<dim>                    &position,
+                              const unsigned int                   compositional_field) const;
 
 
         /**

--- a/include/aspect/boundary_composition/ascii_data.h
+++ b/include/aspect/boundary_composition/ascii_data.h
@@ -71,12 +71,13 @@ namespace aspect
         /**
          * Return the boundary composition as a function of position. For the
          * current class, this function returns value from the text files.
+         *
+         * @copydoc aspect::BoundaryComposition::Interface::boundary_composition()
          */
         double
-        boundary_composition (const types::boundary_id             boundary_indicator,
-                              const Point<dim>                    &position,
-                              const unsigned int                   compositional_field) const;
-
+        boundary_composition (const types::boundary_id boundary_indicator,
+                              const Point<dim> &position,
+                              const unsigned int compositional_field) const;
 
         /**
          * Declare the parameters this class takes through input files.

--- a/include/aspect/boundary_composition/box.h
+++ b/include/aspect/boundary_composition/box.h
@@ -37,8 +37,7 @@ namespace aspect
      * @ingroup BoundaryCompositions
      */
     template <int dim>
-    class Box : public Interface<dim>,
-      public SimulatorAccess<dim>
+    class Box : public Interface<dim>, public SimulatorAccess<dim>
     {
       public:
         /**
@@ -48,10 +47,9 @@ namespace aspect
          * @copydoc aspect::BoundaryComposition::Interface::composition()
          */
         virtual
-        double composition (const GeometryModel::Interface<dim> &geometry_model,
-                            const types::boundary_id             boundary_indicator,
-                            const Point<dim>                    &location,
-                            const unsigned int                   compositional_field) const;
+        double boundary_composition (const types::boundary_id             boundary_indicator,
+                                     const Point<dim>                    &location,
+                                     const unsigned int                   compositional_field) const;
 
         /**
          * Declare the parameters this class takes through input files. This

--- a/include/aspect/boundary_composition/box.h
+++ b/include/aspect/boundary_composition/box.h
@@ -41,15 +41,15 @@ namespace aspect
     {
       public:
         /**
-         * This function returns constant compositions at the left and right
+         * This function returns user-defined constant compositions at the
          * boundaries.
          *
-         * @copydoc aspect::BoundaryComposition::Interface::composition()
+         * @copydoc aspect::BoundaryComposition::Interface::boundary_composition()
          */
         virtual
-        double boundary_composition (const types::boundary_id             boundary_indicator,
-                                     const Point<dim>                    &location,
-                                     const unsigned int                   compositional_field) const;
+        double boundary_composition (const types::boundary_id boundary_indicator,
+                                     const Point<dim> &location,
+                                     const unsigned int compositional_field) const;
 
         /**
          * Declare the parameters this class takes through input files. This

--- a/include/aspect/boundary_composition/initial_composition.h
+++ b/include/aspect/boundary_composition/initial_composition.h
@@ -23,7 +23,7 @@
 #define __aspect__boundary_composition_initial_composition_h
 
 #include <aspect/boundary_composition/interface.h>
-#include <aspect/simulator.h>
+#include <aspect/simulator_access.h>
 
 
 namespace aspect
@@ -39,7 +39,7 @@ namespace aspect
      * @ingroup BoundaryCompositions
      */
     template <int dim>
-    class InitialComposition : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    class InitialComposition : public Interface<dim>, public SimulatorAccess<dim>
     {
       public:
         /**
@@ -49,10 +49,9 @@ namespace aspect
          * @copydoc aspect::BoundaryComposition::Interface::composition()
          */
         virtual
-        double composition (const GeometryModel::Interface<dim> &geometry_model,
-                            const types::boundary_id             boundary_indicator,
-                            const Point<dim>                    &location,
-                            const unsigned int                   compositional_field) const;
+        double boundary_composition (const types::boundary_id             boundary_indicator,
+                                     const Point<dim>                    &location,
+                                     const unsigned int                   compositional_field) const;
 
         /**
          * Return the minimal composition on that part of the boundary on

--- a/include/aspect/boundary_composition/initial_composition.h
+++ b/include/aspect/boundary_composition/initial_composition.h
@@ -43,22 +43,19 @@ namespace aspect
     {
       public:
         /**
-         * This function returns the constant compositions read from the
-         * parameter file for the inner and outer boundaries.
+         * This function returns the boundary compositions that are defined
+         * by the initial conditions.
          *
-         * @copydoc aspect::BoundaryComposition::Interface::composition()
+         * @copydoc aspect::BoundaryComposition::Interface::boundary_composition()
          */
         virtual
-        double boundary_composition (const types::boundary_id             boundary_indicator,
-                                     const Point<dim>                    &location,
-                                     const unsigned int                   compositional_field) const;
+        double boundary_composition (const types::boundary_id boundary_indicator,
+                                     const Point<dim> &location,
+                                     const unsigned int compositional_field) const;
 
         /**
          * Return the minimal composition on that part of the boundary on
          * which Dirichlet conditions are posed.
-         *
-         * This value is used in computing dimensionless numbers such as the
-         * Nusselt number indicating heat flux.
          */
         virtual
         double minimal_composition (const std::set<types::boundary_id> &fixed_boundary_ids) const;
@@ -66,9 +63,6 @@ namespace aspect
         /**
          * Return the maximal composition on that part of the boundary on
          * which Dirichlet conditions are posed.
-         *
-         * This value is used in computing dimensionless numbers such as the
-         * Nusselt number indicating heat flux.
          */
         virtual
         double maximal_composition (const std::set<types::boundary_id> &fixed_boundary_ids) const;

--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -124,9 +124,9 @@ namespace aspect
          */
         virtual
         double
-        boundary_composition (const types::boundary_id             boundary_indicator,
-                              const Point<dim>                    &position,
-                              const unsigned int                   compositional_field) const;
+        boundary_composition (const types::boundary_id boundary_indicator,
+                              const Point<dim> &position,
+                              const unsigned int compositional_field) const;
 
         /**
          * Declare the parameters this class takes through input files. The

--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -79,7 +79,7 @@ namespace aspect
         update ();
 
         /**
-         * Return the composition that is to hold at a particular location on
+         * Return the composition that is to hold at a particular position on
          * the boundary of the domain.
          *
          * @param geometry_model The geometry model that describes the domain.
@@ -88,18 +88,45 @@ namespace aspect
          * @param boundary_indicator The boundary indicator of the part of the
          * boundary of the domain on which the point is located at which we
          * are requesting the composition.
-         * @param location The location of the point at which we ask for the
+         * @param position The position of the point at which we ask for the
          * composition.
-         * @param compositional_field The number of the compositional field
-         * for which we are requesting the composition.
          * @param compositional_field The index of the compositional field
          * between 0 and @p parameters.n_compositional_fields.
+         * @return Boundary value of the compositional field @p
+         * compositional_field at the position @p position.
+         *
+         * @deprecated Use <code>composition(const types::boundary_id
+         * boundary_indicator,const Point<dim> &position, const unsigned
+         * int compositional_field) const</code> instead. The reference to
+         * the geometry model can be reached by deriving plugins from
+         * aspect::SimulatorAccess<dim>.
          */
         virtual
-        double composition (const GeometryModel::Interface<dim> &geometry_model,
-                            const types::boundary_id             boundary_indicator,
-                            const Point<dim>                    &location,
-                            const unsigned int                   compositional_field) const = 0;
+        double
+        composition (const GeometryModel::Interface<dim> &geometry_model,
+                     const types::boundary_id             boundary_indicator,
+                     const Point<dim>                    &position,
+                     const unsigned int                   compositional_field) const DEAL_II_DEPRECATED;
+
+        /**
+         * Return the composition that is to hold at a particular position on
+         * the boundary of the domain.
+         *
+         * @param boundary_indicator The boundary indicator of the part of the
+         * boundary of the domain on which the point is located at which we
+         * are requesting the composition.
+         * @param position The position of the point at which we ask for the
+         * composition.
+         * @param compositional_field The index of the compositional field
+         * between 0 and @p parameters.n_compositional_fields.
+         * @return Boundary value of the compositional field @p
+         * compositional_field at the position @p position.
+         */
+        virtual
+        double
+        boundary_composition (const types::boundary_id             boundary_indicator,
+                              const Point<dim>                    &position,
+                              const unsigned int                   compositional_field) const;
 
         /**
          * Declare the parameters this class takes through input files. The

--- a/include/aspect/boundary_composition/spherical_constant.h
+++ b/include/aspect/boundary_composition/spherical_constant.h
@@ -47,19 +47,16 @@ namespace aspect
          * This function returns the constant compositions read from the
          * parameter file for the inner and outer boundaries.
          *
-         * @copydoc aspect::BoundaryComposition::Interface::composition()
+         * @copydoc aspect::BoundaryComposition::Interface::boundary_composition()
          */
         virtual
-        double boundary_composition (const types::boundary_id             boundary_indicator,
-                                     const Point<dim>                    &location,
-                                     const unsigned int                   compositional_field) const;
+        double boundary_composition (const types::boundary_id boundary_indicator,
+                                     const Point<dim> &location,
+                                     const unsigned int compositional_field) const;
 
         /**
          * Return the minimal composition on that part of the boundary on
          * which Dirichlet conditions are posed.
-         *
-         * This value is used in computing dimensionless numbers such as the
-         * Nusselt number indicating heat flux.
          */
         virtual
         double minimal_composition (const std::set<types::boundary_id> &fixed_boundary_ids) const;
@@ -67,9 +64,6 @@ namespace aspect
         /**
          * Return the maximal composition on that part of the boundary on
          * which Dirichlet conditions are posed.
-         *
-         * This value is used in computing dimensionless numbers such as the
-         * Nusselt number indicating heat flux.
          */
         virtual
         double maximal_composition (const std::set<types::boundary_id> &fixed_boundary_ids) const;

--- a/include/aspect/boundary_composition/spherical_constant.h
+++ b/include/aspect/boundary_composition/spherical_constant.h
@@ -24,6 +24,8 @@
 
 #include <aspect/boundary_composition/interface.h>
 
+#include <aspect/simulator_access.h>
+
 
 namespace aspect
 {
@@ -38,7 +40,7 @@ namespace aspect
      * @ingroup BoundaryCompositions
      */
     template <int dim>
-    class SphericalConstant : public Interface<dim>
+    class SphericalConstant : public Interface<dim>, public SimulatorAccess<dim>
     {
       public:
         /**
@@ -48,10 +50,9 @@ namespace aspect
          * @copydoc aspect::BoundaryComposition::Interface::composition()
          */
         virtual
-        double composition (const GeometryModel::Interface<dim> &geometry_model,
-                            const types::boundary_id             boundary_indicator,
-                            const Point<dim>                    &location,
-                            const unsigned int                   compositional_field) const;
+        double boundary_composition (const types::boundary_id             boundary_indicator,
+                                     const Point<dim>                    &location,
+                                     const unsigned int                   compositional_field) const;
 
         /**
          * Return the minimal composition on that part of the boundary on

--- a/include/aspect/boundary_composition/two_merged_boxes.h
+++ b/include/aspect/boundary_composition/two_merged_boxes.h
@@ -38,8 +38,7 @@ namespace aspect
      * @ingroup BoundaryCompositions
      */
     template <int dim>
-    class TwoMergedBoxes : public Interface<dim>,
-      public SimulatorAccess<dim>
+    class TwoMergedBoxes : public Interface<dim>, public SimulatorAccess<dim>
     {
       public:
         /**
@@ -48,10 +47,9 @@ namespace aspect
          * @copydoc aspect::BoundaryComposition::Interface::composition()
          */
         virtual
-        double composition (const GeometryModel::Interface<dim> &geometry_model,
-                            const types::boundary_id             boundary_indicator,
-                            const Point<dim>                    &location,
-                            const unsigned int                   compositional_field) const;
+        double boundary_composition (const types::boundary_id             boundary_indicator,
+                                     const Point<dim>                    &location,
+                                     const unsigned int                   compositional_field) const;
 
         /**
          * Declare the parameters this class takes through input files. This

--- a/include/aspect/boundary_composition/two_merged_boxes.h
+++ b/include/aspect/boundary_composition/two_merged_boxes.h
@@ -44,12 +44,12 @@ namespace aspect
         /**
          * This function returns constant compositions at the boundaries.
          *
-         * @copydoc aspect::BoundaryComposition::Interface::composition()
+         * @copydoc aspect::BoundaryComposition::Interface::boundary_composition()
          */
         virtual
-        double boundary_composition (const types::boundary_id             boundary_indicator,
-                                     const Point<dim>                    &location,
-                                     const unsigned int                   compositional_field) const;
+        double boundary_composition (const types::boundary_id boundary_indicator,
+                                     const Point<dim> &location,
+                                     const unsigned int compositional_field) const;
 
         /**
          * Declare the parameters this class takes through input files. This

--- a/include/aspect/boundary_temperature/ascii_data.h
+++ b/include/aspect/boundary_temperature/ascii_data.h
@@ -70,9 +70,11 @@ namespace aspect
         /**
          * Return the boundary temperature as a function of position. For the
          * current class, this function returns value from the text files.
+         *
+         * @copydoc aspect::BoundaryTemperature::Interface::boundary_temperature()
          */
         double
-        boundary_temperature (const types::boundary_id             boundary_indicator,
+        boundary_temperature (const types::boundary_id boundary_indicator,
                               const Point<dim> &position) const;
 
         /**

--- a/include/aspect/boundary_temperature/ascii_data.h
+++ b/include/aspect/boundary_temperature/ascii_data.h
@@ -72,9 +72,8 @@ namespace aspect
          * current class, this function returns value from the text files.
          */
         double
-        temperature (const GeometryModel::Interface<dim> &geometry_model,
-                     const types::boundary_id             boundary_indicator,
-                     const Point<dim> &position) const;
+        boundary_temperature (const types::boundary_id             boundary_indicator,
+                              const Point<dim> &position) const;
 
         /**
          * Return the minimal the temperature on that part of the boundary on

--- a/include/aspect/boundary_temperature/box.h
+++ b/include/aspect/boundary_temperature/box.h
@@ -23,6 +23,7 @@
 #define __aspect__boundary_temperature_box_h
 
 #include <aspect/boundary_temperature/interface.h>
+#include <aspect/simulator_access.h>
 
 
 namespace aspect
@@ -36,7 +37,7 @@ namespace aspect
      * @ingroup BoundaryTemperatures
      */
     template <int dim>
-    class Box : public Interface<dim>
+    class Box : public Interface<dim>, public SimulatorAccess<dim>
     {
       public:
         /**
@@ -44,9 +45,6 @@ namespace aspect
          * the boundary of the domain. This function returns constant
          * temperatures at the left and right boundaries.
          *
-         * @param geometry_model The geometry model that describes the domain.
-         * This may be used to determine whether the boundary temperature
-         * model is implemented for this geometry.
          * @param boundary_indicator The boundary indicator of the part of the
          * boundary of the domain on which the point is located at which we
          * are requesting the temperature.
@@ -54,9 +52,8 @@ namespace aspect
          * temperature.
          */
         virtual
-        double temperature (const GeometryModel::Interface<dim> &geometry_model,
-                            const types::boundary_id             boundary_indicator,
-                            const Point<dim>                    &location) const;
+        double boundary_temperature (const types::boundary_id             boundary_indicator,
+                                     const Point<dim>                    &location) const;
 
         /**
          * Return the minimal the temperature on that part of the boundary on

--- a/include/aspect/boundary_temperature/box.h
+++ b/include/aspect/boundary_temperature/box.h
@@ -41,19 +41,14 @@ namespace aspect
     {
       public:
         /**
-         * Return the temperature that is to hold at a particular location on
-         * the boundary of the domain. This function returns constant
-         * temperatures at the left and right boundaries.
+         * This function returns user-defined constant temperatures at the
+         * boundaries.
          *
-         * @param boundary_indicator The boundary indicator of the part of the
-         * boundary of the domain on which the point is located at which we
-         * are requesting the temperature.
-         * @param location The location of the point at which we ask for the
-         * temperature.
+         * @copydoc aspect::BoundaryTemperature::Interface::boundary_temperature()
          */
         virtual
-        double boundary_temperature (const types::boundary_id             boundary_indicator,
-                                     const Point<dim>                    &location) const;
+        double boundary_temperature (const types::boundary_id boundary_indicator,
+                                     const Point<dim> &location) const;
 
         /**
          * Return the minimal the temperature on that part of the boundary on

--- a/include/aspect/boundary_temperature/constant.h
+++ b/include/aspect/boundary_temperature/constant.h
@@ -44,19 +44,14 @@ namespace aspect
     {
       public:
         /**
-         * Return the temperature that is to hold at a particular location on
-         * the boundary of the domain. This function returns the constant
-         * temperatures read from the parameter file.
+         * This function returns user-defined constant temperatures at the
+         * boundaries of arbitrary geometries.
          *
-         * @param boundary_indicator The boundary indicator of the part of the
-         * boundary of the domain on which the point is located at which we
-         * are requesting the temperature.
-         * @param location The location of the point at which we ask for the
-         * temperature.
+         * @copydoc aspect::BoundaryTemperature::Interface::boundary_temperature()
          */
         virtual
-        double boundary_temperature (const types::boundary_id             boundary_indicator,
-                                     const Point<dim>                    &location) const;
+        double boundary_temperature (const types::boundary_id boundary_indicator,
+                                     const Point<dim> &location) const;
 
         /**
          * Return the minimal the temperature on that part of the boundary on

--- a/include/aspect/boundary_temperature/constant.h
+++ b/include/aspect/boundary_temperature/constant.h
@@ -48,9 +48,6 @@ namespace aspect
          * the boundary of the domain. This function returns the constant
          * temperatures read from the parameter file.
          *
-         * @param geometry_model The geometry model that describes the domain.
-         * This may be used to determine whether the boundary temperature
-         * model is implemented for this geometry.
          * @param boundary_indicator The boundary indicator of the part of the
          * boundary of the domain on which the point is located at which we
          * are requesting the temperature.
@@ -58,9 +55,8 @@ namespace aspect
          * temperature.
          */
         virtual
-        double temperature (const GeometryModel::Interface<dim> &geometry_model,
-                            const types::boundary_id             boundary_indicator,
-                            const Point<dim>                    &location) const;
+        double boundary_temperature (const types::boundary_id             boundary_indicator,
+                                     const Point<dim>                    &location) const;
 
         /**
          * Return the minimal the temperature on that part of the boundary on

--- a/include/aspect/boundary_temperature/function.h
+++ b/include/aspect/boundary_temperature/function.h
@@ -53,9 +53,8 @@ namespace aspect
          */
         virtual
         double
-        temperature (const GeometryModel::Interface<dim> &geometry_model,
-                     const types::boundary_id             boundary_indicator,
-                     const Point<dim>                    &position) const;
+        boundary_temperature (const types::boundary_id             boundary_indicator,
+                              const Point<dim>                    &position) const;
 
         /**
          * A function that is called at the beginning of each time step to

--- a/include/aspect/boundary_temperature/function.h
+++ b/include/aspect/boundary_temperature/function.h
@@ -50,11 +50,13 @@ namespace aspect
 
         /**
          * Return the boundary temperature as a function of position and time.
+         *
+         * @copydoc aspect::BoundaryTemperature::Interface::boundary_temperature()
          */
         virtual
         double
-        boundary_temperature (const types::boundary_id             boundary_indicator,
-                              const Point<dim>                    &position) const;
+        boundary_temperature (const types::boundary_id boundary_indicator,
+                              const Point<dim> &position) const;
 
         /**
          * A function that is called at the beginning of each time step to

--- a/include/aspect/boundary_temperature/initial_temperature.h
+++ b/include/aspect/boundary_temperature/initial_temperature.h
@@ -46,9 +46,6 @@ namespace aspect
          * temperatures read from the parameter file for the inner and outer
          * boundaries.
          *
-         * @param geometry_model The geometry model that describes the domain.
-         * This may be used to determine whether the boundary temperature
-         * model is implemented for this geometry.
          * @param boundary_indicator The boundary indicator of the part of the
          * boundary of the domain on which the point is located at which we
          * are requesting the temperature.
@@ -56,9 +53,8 @@ namespace aspect
          * temperature.
          */
         virtual
-        double temperature (const GeometryModel::Interface<dim> &geometry_model,
-                            const types::boundary_id             boundary_indicator,
-                            const Point<dim>                    &location) const;
+        double boundary_temperature (const types::boundary_id             boundary_indicator,
+                                     const Point<dim>                    &location) const;
 
         /**
          * Return the minimal the temperature on that part of the boundary on

--- a/include/aspect/boundary_temperature/initial_temperature.h
+++ b/include/aspect/boundary_temperature/initial_temperature.h
@@ -23,7 +23,7 @@
 #define __aspect__boundary_temperature_initial_temperature_h
 
 #include <aspect/boundary_temperature/interface.h>
-#include <aspect/simulator.h>
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {
@@ -41,20 +41,14 @@ namespace aspect
     {
       public:
         /**
-         * Return the temperature that is to hold at a particular location on
-         * the boundary of the domain. This function returns the constant
-         * temperatures read from the parameter file for the inner and outer
-         * boundaries.
+         * This function returns the boundary temperatures that are defined
+         * by the initial conditions.
          *
-         * @param boundary_indicator The boundary indicator of the part of the
-         * boundary of the domain on which the point is located at which we
-         * are requesting the temperature.
-         * @param location The location of the point at which we ask for the
-         * temperature.
+         * @copydoc aspect::BoundaryTemperature::Interface::boundary_temperature()
          */
         virtual
-        double boundary_temperature (const types::boundary_id             boundary_indicator,
-                                     const Point<dim>                    &location) const;
+        double boundary_temperature (const types::boundary_id boundary_indicator,
+                                     const Point<dim> &location) const;
 
         /**
          * Return the minimal the temperature on that part of the boundary on

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -97,11 +97,10 @@ namespace aspect
          * @param position The position of the point at which we ask for the
          * temperature.
          * @return Boundary temperature at position @p position.
-         *
          */
         virtual
-        double boundary_temperature (const types::boundary_id             boundary_indicator,
-                                     const Point<dim>                    &position) const;
+        double boundary_temperature (const types::boundary_id boundary_indicator,
+                                     const Point<dim> &position) const;
 
         /**
          * Return the minimal the temperature on that part of the boundary on

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -64,7 +64,7 @@ namespace aspect
         virtual void initialize ();
 
         /**
-         * Return the temperature that is to hold at a particular location on
+         * Return the temperature that is to hold at a particular position on
          * the boundary of the domain.
          *
          * @param geometry_model The geometry model that describes the domain.
@@ -73,13 +73,35 @@ namespace aspect
          * @param boundary_indicator The boundary indicator of the part of the
          * boundary of the domain on which the point is located at which we
          * are requesting the temperature.
-         * @param location The location of the point at which we ask for the
+         * @param position The position of the point at which we ask for the
          * temperature.
+         * @return Boundary temperature at position @p position.
+         *
+         * @deprecated Use <code>temperature(const types::boundary_id
+         * boundary_indicator,const Point<dim> &position) const</code> instead.
+         * The reference to the geometry model can be reached by deriving
+         * plugins from aspect::SimulatorAccess<dim>.
          */
         virtual
         double temperature (const GeometryModel::Interface<dim> &geometry_model,
                             const types::boundary_id             boundary_indicator,
-                            const Point<dim>                    &location) const = 0;
+                            const Point<dim>                    &position) const DEAL_II_DEPRECATED;
+
+        /**
+         * Return the temperature that is to hold at a particular position on
+         * the boundary of the domain.
+         *
+         * @param boundary_indicator The boundary indicator of the part of the
+         * boundary of the domain on which the point is located at which we
+         * are requesting the temperature.
+         * @param position The position of the point at which we ask for the
+         * temperature.
+         * @return Boundary temperature at position @p position.
+         *
+         */
+        virtual
+        double boundary_temperature (const types::boundary_id             boundary_indicator,
+                                     const Point<dim>                    &position) const;
 
         /**
          * Return the minimal the temperature on that part of the boundary on

--- a/include/aspect/boundary_temperature/spherical_constant.h
+++ b/include/aspect/boundary_temperature/spherical_constant.h
@@ -43,20 +43,14 @@ namespace aspect
     {
       public:
         /**
-         * Return the temperature that is to hold at a particular location on
-         * the boundary of the domain. This function returns the constant
-         * temperatures read from the parameter file for the inner and outer
-         * boundaries.
+         * This function returns the constant compositions read from the
+         * parameter file for the inner and outer boundaries.
          *
-         * @param boundary_indicator The boundary indicator of the part of the
-         * boundary of the domain on which the point is located at which we
-         * are requesting the temperature.
-         * @param location The location of the point at which we ask for the
-         * temperature.
+         * @copydoc aspect::BoundaryTemperature::Interface::boundary_temperature()
          */
         virtual
-        double boundary_temperature (const types::boundary_id             boundary_indicator,
-                                     const Point<dim>                    &location) const;
+        double boundary_temperature (const types::boundary_id boundary_indicator,
+                                     const Point<dim> &location) const;
 
         /**
          * Return the minimal the temperature on that part of the boundary on

--- a/include/aspect/boundary_temperature/spherical_constant.h
+++ b/include/aspect/boundary_temperature/spherical_constant.h
@@ -24,6 +24,7 @@
 
 #include <aspect/boundary_temperature/interface.h>
 
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {
@@ -38,7 +39,7 @@ namespace aspect
      * @ingroup BoundaryTemperatures
      */
     template <int dim>
-    class SphericalConstant : public Interface<dim>
+    class SphericalConstant : public Interface<dim>, public SimulatorAccess<dim>
     {
       public:
         /**
@@ -47,9 +48,6 @@ namespace aspect
          * temperatures read from the parameter file for the inner and outer
          * boundaries.
          *
-         * @param geometry_model The geometry model that describes the domain.
-         * This may be used to determine whether the boundary temperature
-         * model is implemented for this geometry.
          * @param boundary_indicator The boundary indicator of the part of the
          * boundary of the domain on which the point is located at which we
          * are requesting the temperature.
@@ -57,9 +55,8 @@ namespace aspect
          * temperature.
          */
         virtual
-        double temperature (const GeometryModel::Interface<dim> &geometry_model,
-                            const types::boundary_id             boundary_indicator,
-                            const Point<dim>                    &location) const;
+        double boundary_temperature (const types::boundary_id             boundary_indicator,
+                                     const Point<dim>                    &location) const;
 
         /**
          * Return the minimal the temperature on that part of the boundary on

--- a/include/aspect/boundary_temperature/two_merged_boxes.h
+++ b/include/aspect/boundary_temperature/two_merged_boxes.h
@@ -24,6 +24,8 @@
 
 #include <aspect/boundary_temperature/interface.h>
 
+#include <aspect/simulator_access.h>
+
 
 namespace aspect
 {
@@ -37,7 +39,7 @@ namespace aspect
      * @ingroup BoundaryTemperatures
      */
     template <int dim>
-    class TwoMergedBoxes : public Interface<dim>
+    class TwoMergedBoxes : public Interface<dim>, public SimulatorAccess<dim>
     {
       public:
         /**
@@ -45,9 +47,6 @@ namespace aspect
          * the boundary of the domain. This function returns constant
          * temperatures at the boundaries.
          *
-         * @param geometry_model The geometry model that describes the domain.
-         * This may be used to determine whether the boundary temperature
-         * model is implemented for this geometry.
          * @param boundary_indicator The boundary indicator of the part of the
          * boundary of the domain on which the point is located at which we
          * are requesting the temperature.
@@ -55,9 +54,8 @@ namespace aspect
          * temperature.
          */
         virtual
-        double temperature (const GeometryModel::Interface<dim> &geometry_model,
-                            const types::boundary_id             boundary_indicator,
-                            const Point<dim>                    &location) const;
+        double boundary_temperature (const types::boundary_id             boundary_indicator,
+                                     const Point<dim>                    &location) const;
 
         /**
          * Return the minimal the temperature on that part of the boundary on

--- a/include/aspect/boundary_temperature/two_merged_boxes.h
+++ b/include/aspect/boundary_temperature/two_merged_boxes.h
@@ -43,19 +43,13 @@ namespace aspect
     {
       public:
         /**
-         * Return the temperature that is to hold at a particular location on
-         * the boundary of the domain. This function returns constant
-         * temperatures at the boundaries.
+         * This function returns constant compositions at the boundaries.
          *
-         * @param boundary_indicator The boundary indicator of the part of the
-         * boundary of the domain on which the point is located at which we
-         * are requesting the temperature.
-         * @param location The location of the point at which we ask for the
-         * temperature.
+         * @copydoc aspect::BoundaryTemperature::Interface::boundary_temperature()
          */
         virtual
-        double boundary_temperature (const types::boundary_id             boundary_indicator,
-                                     const Point<dim>                    &location) const;
+        double boundary_temperature (const types::boundary_id boundary_indicator,
+                                     const Point<dim> &location) const;
 
         /**
          * Return the minimal the temperature on that part of the boundary on

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -45,6 +45,7 @@ namespace aspect
   namespace Utilities
   {
     using namespace dealii;
+    using namespace dealii::Utilities;
 
     /**
      * Returns spherical coordinates of a cartesian point. The returned array

--- a/source/boundary_composition/ascii_data.cc
+++ b/source/boundary_composition/ascii_data.cc
@@ -57,10 +57,9 @@ namespace aspect
     template <int dim>
     double
     AsciiData<dim>::
-    composition (const GeometryModel::Interface<dim> &,
-                 const types::boundary_id             boundary_indicator,
-                 const Point<dim>                    &position,
-                 const unsigned int                   compositional_field) const
+    boundary_composition (const types::boundary_id             boundary_indicator,
+                          const Point<dim>                    &position,
+                          const unsigned int                   compositional_field) const
     {
       return Utilities::AsciiDataBoundary<dim>::get_data_component(boundary_indicator,
                                                                    position,

--- a/source/boundary_composition/ascii_data.cc
+++ b/source/boundary_composition/ascii_data.cc
@@ -57,9 +57,9 @@ namespace aspect
     template <int dim>
     double
     AsciiData<dim>::
-    boundary_composition (const types::boundary_id             boundary_indicator,
-                          const Point<dim>                    &position,
-                          const unsigned int                   compositional_field) const
+    boundary_composition (const types::boundary_id boundary_indicator,
+                          const Point<dim> &position,
+                          const unsigned int compositional_field) const
     {
       return Utilities::AsciiDataBoundary<dim>::get_data_component(boundary_indicator,
                                                                    position,

--- a/source/boundary_composition/box.cc
+++ b/source/boundary_composition/box.cc
@@ -35,9 +35,9 @@ namespace aspect
     template <int dim>
     double
     Box<dim>::
-    boundary_composition (const types::boundary_id             boundary_indicator,
-                          const Point<dim> &,
-                          const unsigned int                   compositional_field) const
+    boundary_composition (const types::boundary_id boundary_indicator,
+                          const Point<dim> &/*position*/,
+                          const unsigned int compositional_field) const
     {
       // verify that the geometry is in fact a box since only
       // for this geometry do we know for sure what boundary indicators it

--- a/source/boundary_composition/box.cc
+++ b/source/boundary_composition/box.cc
@@ -35,17 +35,14 @@ namespace aspect
     template <int dim>
     double
     Box<dim>::
-    composition (const GeometryModel::Interface<dim> &geometry_model,
-                 const types::boundary_id             boundary_indicator,
-                 const Point<dim> &,
-                 const unsigned int                   compositional_field) const
+    boundary_composition (const types::boundary_id             boundary_indicator,
+                          const Point<dim> &,
+                          const unsigned int                   compositional_field) const
     {
-      (void)geometry_model;
-
       // verify that the geometry is in fact a box since only
       // for this geometry do we know for sure what boundary indicators it
       // uses and what they mean
-      Assert (dynamic_cast<const GeometryModel::Box<dim>*>(&geometry_model)
+      Assert (dynamic_cast<const GeometryModel::Box<dim>*>(&this->get_geometry_model())
               != 0,
               ExcMessage ("This boundary model is only implemented if the geometry is "
                           "in fact a box."));

--- a/source/boundary_composition/initial_composition.cc
+++ b/source/boundary_composition/initial_composition.cc
@@ -20,8 +20,6 @@
 
 
 #include <aspect/boundary_composition/initial_composition.h>
-#include <aspect/simulator_access.h>
-
 
 namespace aspect
 {
@@ -32,10 +30,9 @@ namespace aspect
     template <int dim>
     double
     InitialComposition<dim>::
-    composition (const GeometryModel::Interface<dim> &,
-                 const types::boundary_id             ,
-                 const Point<dim>                    &location,
-                 const unsigned int                   compositional_field) const
+    boundary_composition (const types::boundary_id             ,
+                          const Point<dim>                    &location,
+                          const unsigned int                   compositional_field) const
     {
       return this->get_compositional_initial_conditions().initial_composition(location, compositional_field);
     }

--- a/source/boundary_composition/initial_composition.cc
+++ b/source/boundary_composition/initial_composition.cc
@@ -30,9 +30,9 @@ namespace aspect
     template <int dim>
     double
     InitialComposition<dim>::
-    boundary_composition (const types::boundary_id             ,
-                          const Point<dim>                    &location,
-                          const unsigned int                   compositional_field) const
+    boundary_composition (const types::boundary_id /*boundary_indicator*/,
+                          const Point<dim> &location,
+                          const unsigned int compositional_field) const
     {
       return this->get_compositional_initial_conditions().initial_composition(location, compositional_field);
     }

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -22,6 +22,8 @@
 #include <aspect/global.h>
 #include <aspect/boundary_composition/interface.h>
 
+#include <aspect/utilities.h>
+
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/std_cxx11/tuple.h>
 
@@ -45,6 +47,32 @@ namespace aspect
     void
     Interface<dim>::initialize ()
     {}
+
+    template <int dim>
+    double
+    Interface<dim>::composition (const GeometryModel::Interface<dim> &/*geometry_model*/,
+                                 const types::boundary_id             boundary_indicator,
+                                 const Point<dim>                    &position,
+                                 const unsigned int                   compositional_field) const
+    {
+      /**
+       * Call the new-style function without the geometry model
+       * to maintain backwards compatibility. Normally the derived class should
+       * override the called function, but if it overrides this function, the
+       * new interface will not be used.
+       */
+
+      return boundary_composition(boundary_indicator,position,compositional_field);
+    }
+
+    template <int dim>
+    double
+    Interface<dim>::boundary_composition (const types::boundary_id             /*boundary_indicator*/,
+                                          const Point<dim>                    &/*position*/,
+                                          const unsigned int                   /*compositional_field*/) const
+    {
+      return std::numeric_limits<double>::quiet_NaN();
+    }
 
     template <int dim>
     void

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -71,8 +71,9 @@ namespace aspect
                                           const unsigned int       /*compositional_field*/) const
     {
       AssertThrow(false,
-                  ExcMessage("The boundary composition plugin has to implement a function called boundary_composition "
-                             "with either three or four arguments. The function with four arguments is deprecated and will "
+                  ExcMessage("The boundary composition plugin has to implement a function called 'composition' "
+                             "with four arguments or a function 'boundary_composition' with three arguments. "
+                             "The function with four arguments is deprecated and will "
                              "be removed in a later version of ASPECT."));
       return Utilities::signaling_nan<double>();
     }

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -57,9 +57,8 @@ namespace aspect
     {
       /**
        * Call the new-style function without the geometry model
-       * to maintain backwards compatibility. Normally the derived class should
-       * override the called function, but if it overrides this function, the
-       * new interface will not be used.
+       * to maintain backwards compatibility. After removal of this deprecated
+       * function the new function will be called directly by Simulator.
        */
 
       return boundary_composition(boundary_indicator,position,compositional_field);
@@ -71,7 +70,11 @@ namespace aspect
                                           const Point<dim>                    &/*position*/,
                                           const unsigned int                   /*compositional_field*/) const
     {
-      return std::numeric_limits<double>::quiet_NaN();
+      AssertThrow(false,
+          ExcMessage("The boundary composition plugin has to implement a function called boundary_composition "
+              "with either three or four arguments. The function with four arguments is deprecated and will "
+              "be removed in a later version of ASPECT."));
+      return Utilities::signaling_nan<double>();
     }
 
     template <int dim>

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -66,14 +66,14 @@ namespace aspect
 
     template <int dim>
     double
-    Interface<dim>::boundary_composition (const types::boundary_id             /*boundary_indicator*/,
-                                          const Point<dim>                    &/*position*/,
-                                          const unsigned int                   /*compositional_field*/) const
+    Interface<dim>::boundary_composition (const types::boundary_id /*boundary_indicator*/,
+                                          const Point<dim>        &/*position*/,
+                                          const unsigned int       /*compositional_field*/) const
     {
       AssertThrow(false,
-          ExcMessage("The boundary composition plugin has to implement a function called boundary_composition "
-              "with either three or four arguments. The function with four arguments is deprecated and will "
-              "be removed in a later version of ASPECT."));
+                  ExcMessage("The boundary composition plugin has to implement a function called boundary_composition "
+                             "with either three or four arguments. The function with four arguments is deprecated and will "
+                             "be removed in a later version of ASPECT."));
       return Utilities::signaling_nan<double>();
     }
 

--- a/source/boundary_composition/spherical_constant.cc
+++ b/source/boundary_composition/spherical_constant.cc
@@ -22,6 +22,7 @@
 #include <aspect/boundary_composition/spherical_constant.h>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/chunk.h>
+#include <aspect/geometry_model/ellipsoidal_chunk.h>
 
 #include <utility>
 #include <limits>
@@ -36,22 +37,21 @@ namespace aspect
     template <int dim>
     double
     SphericalConstant<dim>::
-    composition (const GeometryModel::Interface<dim> &geometry_model,
-                 const types::boundary_id             boundary_indicator,
-                 const Point<dim> &,
-                 const unsigned int                   ) const
+    boundary_composition (const types::boundary_id             boundary_indicator,
+                          const Point<dim> &,
+                          const unsigned int                   ) const
     {
-      (void)geometry_model;
-
-      // verify that the geometry is a spherical shell or a chunk since only
-      // for geometries based on spherical shells do we know which boundary indicators are
-      // used and what they mean
-      Assert ((dynamic_cast<const GeometryModel::SphericalShell<dim>*>(&geometry_model) != 0
-               || dynamic_cast<const GeometryModel::Chunk<dim>*>(&geometry_model) != 0),
+      // verify that the geometry is a spherical shell, a chunk, or an
+      // ellipsoidal chunk since only for geometries based on spherical shells
+      // do we know which boundary indicators are used and what they mean
+      const GeometryModel::Interface<dim> *geometry_model = &this->get_geometry_model();
+      Assert ((dynamic_cast<const GeometryModel::SphericalShell<dim>*>(geometry_model) != 0
+               || dynamic_cast<const GeometryModel::Chunk<dim>*>(geometry_model) != 0
+               || dynamic_cast<const GeometryModel::EllipsoidalChunk<dim>*>(geometry_model) != 0),
               ExcMessage ("This boundary model is only implemented if the geometry "
                           "is a spherical shell or chunk."));
 
-      const std::string boundary_name = geometry_model.translate_id_to_symbol_name(boundary_indicator);
+      const std::string boundary_name = geometry_model->translate_id_to_symbol_name(boundary_indicator);
 
       if (boundary_name == "inner")
         return inner_composition;

--- a/source/boundary_composition/spherical_constant.cc
+++ b/source/boundary_composition/spherical_constant.cc
@@ -37,9 +37,9 @@ namespace aspect
     template <int dim>
     double
     SphericalConstant<dim>::
-    boundary_composition (const types::boundary_id             boundary_indicator,
-                          const Point<dim> &,
-                          const unsigned int                   ) const
+    boundary_composition (const types::boundary_id boundary_indicator,
+                          const Point<dim> &/*position*/,
+                          const unsigned int /*compositional_field*/) const
     {
       // verify that the geometry is a spherical shell, a chunk, or an
       // ellipsoidal chunk since only for geometries based on spherical shells

--- a/source/boundary_composition/two_merged_boxes.cc
+++ b/source/boundary_composition/two_merged_boxes.cc
@@ -34,9 +34,9 @@ namespace aspect
     template <int dim>
     double
     TwoMergedBoxes<dim>::
-    boundary_composition (const types::boundary_id             boundary_indicator,
-                          const Point<dim> &,
-                          const unsigned int                   compositional_field) const
+    boundary_composition (const types::boundary_id boundary_indicator,
+                          const Point<dim> &/*position*/,
+                          const unsigned int compositional_field) const
     {
       // verify that the geometry is in fact a box since only
       // for this geometry do we know for sure what boundary indicators it

--- a/source/boundary_composition/two_merged_boxes.cc
+++ b/source/boundary_composition/two_merged_boxes.cc
@@ -34,17 +34,14 @@ namespace aspect
     template <int dim>
     double
     TwoMergedBoxes<dim>::
-    composition (const GeometryModel::Interface<dim> &geometry_model,
-                 const types::boundary_id             boundary_indicator,
-                 const Point<dim> &,
-                 const unsigned int                   compositional_field) const
+    boundary_composition (const types::boundary_id             boundary_indicator,
+                          const Point<dim> &,
+                          const unsigned int                   compositional_field) const
     {
-      (void)geometry_model;
-
       // verify that the geometry is in fact a box since only
       // for this geometry do we know for sure what boundary indicators it
       // uses and what they mean
-      Assert (dynamic_cast<const GeometryModel::TwoMergedBoxes<dim>*>(&geometry_model)
+      Assert (dynamic_cast<const GeometryModel::TwoMergedBoxes<dim>*>(&this->get_geometry_model())
               != 0,
               ExcMessage ("This boundary model is only useful if the geometry is "
                           "in fact a box with additional lithosphere boundary indicators."));

--- a/source/boundary_temperature/ascii_data.cc
+++ b/source/boundary_temperature/ascii_data.cc
@@ -56,9 +56,8 @@ namespace aspect
 
     template <int dim>
     double
-    AsciiData<dim>::temperature (const GeometryModel::Interface<dim> &,
-                                 const types::boundary_id             boundary_indicator,
-                                 const Point<dim>                    &position) const
+    AsciiData<dim>::boundary_temperature (const types::boundary_id             boundary_indicator,
+                                          const Point<dim>                    &position) const
     {
       return Utilities::AsciiDataBoundary<dim>::get_data_component(boundary_indicator,
                                                                    position,

--- a/source/boundary_temperature/ascii_data.cc
+++ b/source/boundary_temperature/ascii_data.cc
@@ -56,8 +56,8 @@ namespace aspect
 
     template <int dim>
     double
-    AsciiData<dim>::boundary_temperature (const types::boundary_id             boundary_indicator,
-                                          const Point<dim>                    &position) const
+    AsciiData<dim>::boundary_temperature (const types::boundary_id boundary_indicator,
+                                          const Point<dim> &position) const
     {
       return Utilities::AsciiDataBoundary<dim>::get_data_component(boundary_indicator,
                                                                    position,

--- a/source/boundary_temperature/box.cc
+++ b/source/boundary_temperature/box.cc
@@ -35,8 +35,8 @@ namespace aspect
     template <int dim>
     double
     Box<dim>::
-    boundary_temperature (const types::boundary_id             boundary_indicator,
-                          const Point<dim> &) const
+    boundary_temperature (const types::boundary_id boundary_indicator,
+                          const Point<dim> &/*position*/) const
     {
       // verify that the geometry is in fact a box since only
       // for this geometry do we know for sure what boundary indicators it

--- a/source/boundary_temperature/box.cc
+++ b/source/boundary_temperature/box.cc
@@ -35,16 +35,13 @@ namespace aspect
     template <int dim>
     double
     Box<dim>::
-    temperature (const GeometryModel::Interface<dim> &geometry_model,
-                 const types::boundary_id             boundary_indicator,
-                 const Point<dim> &) const
+    boundary_temperature (const types::boundary_id             boundary_indicator,
+                          const Point<dim> &) const
     {
-      (void)geometry_model;
-
       // verify that the geometry is in fact a box since only
       // for this geometry do we know for sure what boundary indicators it
       // uses and what they mean
-      Assert (dynamic_cast<const GeometryModel::Box<dim>*>(&geometry_model)
+      Assert (dynamic_cast<const GeometryModel::Box<dim>*>(&this->get_geometry_model())
               != 0,
               ExcMessage ("This boundary model is only implemented if the geometry is "
                           "in fact a box."));

--- a/source/boundary_temperature/constant.cc
+++ b/source/boundary_temperature/constant.cc
@@ -33,9 +33,8 @@ namespace aspect
     template <int dim>
     double
     Constant<dim>::
-    temperature (const GeometryModel::Interface<dim> &,
-                 const types::boundary_id             boundary_indicator,
-                 const Point<dim> &) const
+    boundary_temperature (const types::boundary_id             boundary_indicator,
+                          const Point<dim> &) const
     {
       const std::map<types::boundary_id, double>::const_iterator it = boundary_temperatures.find(boundary_indicator);
       if (it != boundary_temperatures.end())

--- a/source/boundary_temperature/constant.cc
+++ b/source/boundary_temperature/constant.cc
@@ -33,8 +33,8 @@ namespace aspect
     template <int dim>
     double
     Constant<dim>::
-    boundary_temperature (const types::boundary_id             boundary_indicator,
-                          const Point<dim> &) const
+    boundary_temperature (const types::boundary_id boundary_indicator,
+                          const Point<dim> &/*position*/) const
     {
       const std::map<types::boundary_id, double>::const_iterator it = boundary_temperatures.find(boundary_indicator);
       if (it != boundary_temperatures.end())

--- a/source/boundary_temperature/function.cc
+++ b/source/boundary_temperature/function.cc
@@ -37,9 +37,8 @@ namespace aspect
     template <int dim>
     double
     Function<dim>::
-    temperature (const GeometryModel::Interface<dim> &,
-                 const types::boundary_id             ,
-                 const Point<dim>                    &position) const
+    boundary_temperature (const types::boundary_id             ,
+                          const Point<dim>                    &position) const
     {
       return boundary_temperature_function.value(position);
     }

--- a/source/boundary_temperature/function.cc
+++ b/source/boundary_temperature/function.cc
@@ -37,8 +37,8 @@ namespace aspect
     template <int dim>
     double
     Function<dim>::
-    boundary_temperature (const types::boundary_id             ,
-                          const Point<dim>                    &position) const
+    boundary_temperature (const types::boundary_id /*boundary_indicator*/,
+                          const Point<dim> &position) const
     {
       return boundary_temperature_function.value(position);
     }

--- a/source/boundary_temperature/initial_temperature.cc
+++ b/source/boundary_temperature/initial_temperature.cc
@@ -32,9 +32,8 @@ namespace aspect
     template <int dim>
     double
     InitialTemperature<dim>::
-    temperature (const GeometryModel::Interface<dim> &,
-                 const types::boundary_id             ,
-                 const Point<dim>                    &location) const
+    boundary_temperature (const types::boundary_id             ,
+                          const Point<dim>                    &location) const
     {
       return this->get_initial_conditions().initial_temperature(location);
     }

--- a/source/boundary_temperature/initial_temperature.cc
+++ b/source/boundary_temperature/initial_temperature.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/boundary_temperature/initial_temperature.h>
-#include <aspect/simulator_access.h>
 
 
 namespace aspect
@@ -32,8 +31,8 @@ namespace aspect
     template <int dim>
     double
     InitialTemperature<dim>::
-    boundary_temperature (const types::boundary_id             ,
-                          const Point<dim>                    &location) const
+    boundary_temperature (const types::boundary_id,
+                          const Point<dim> &location) const
     {
       return this->get_initial_conditions().initial_temperature(location);
     }

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -57,9 +57,8 @@ namespace aspect
     {
       /**
        * Call the new-style function without the geometry model
-       * to maintain backwards compatibility. Normally the derived class should
-       * override the called function, but if it overrides this function, the
-       * new interface will not be used.
+       * to maintain backwards compatibility. After removal of this deprecated
+       * function the new function will be called directly by Simulator.
        */
 
       return this->boundary_temperature(boundary_indicator,position);
@@ -70,8 +69,11 @@ namespace aspect
     Interface<dim>::boundary_temperature (const types::boundary_id             /*boundary_indicator*/,
                                           const Point<dim>                    &/*position*/) const
     {
-      return std::numeric_limits<double>::quiet_NaN();
-    }
+      AssertThrow(false,
+          ExcMessage("The boundary composition plugin has to implement a function called boundary_composition "
+              "with either three or four arguments. The function with four arguments is deprecated and will "
+              "be removed in a later version of ASPECT."));
+      return Utilities::signaling_nan<double>();    }
 
 
     template <int dim>

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -70,8 +70,9 @@ namespace aspect
                                           const Point<dim>        &/*position*/) const
     {
       AssertThrow(false,
-                  ExcMessage("The boundary composition plugin has to implement a function called boundary_composition "
-                             "with either three or four arguments. The function with four arguments is deprecated and will "
+                  ExcMessage("The boundary temperature plugin has to implement a function called 'temperature' "
+                             "with three arguments or a function 'boundary_temperature' with two arguments. "
+                             "The function with three arguments is deprecated and will "
                              "be removed in a later version of ASPECT."));
       return Utilities::signaling_nan<double>();
     }

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -22,6 +22,8 @@
 #include <aspect/global.h>
 #include <aspect/boundary_temperature/interface.h>
 
+#include <aspect/utilities.h>
+
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/std_cxx11/tuple.h>
 
@@ -46,6 +48,30 @@ namespace aspect
     void
     Interface<dim>::initialize ()
     {}
+
+    template <int dim>
+    double
+    Interface<dim>::temperature (const GeometryModel::Interface<dim> &/*geometry_model*/,
+                                 const types::boundary_id             boundary_indicator,
+                                 const Point<dim>                    &position) const
+    {
+      /**
+       * Call the new-style function without the geometry model
+       * to maintain backwards compatibility. Normally the derived class should
+       * override the called function, but if it overrides this function, the
+       * new interface will not be used.
+       */
+
+      return this->boundary_temperature(boundary_indicator,position);
+    }
+
+    template <int dim>
+    double
+    Interface<dim>::boundary_temperature (const types::boundary_id             /*boundary_indicator*/,
+                                          const Point<dim>                    &/*position*/) const
+    {
+      return std::numeric_limits<double>::quiet_NaN();
+    }
 
 
     template <int dim>

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -66,14 +66,15 @@ namespace aspect
 
     template <int dim>
     double
-    Interface<dim>::boundary_temperature (const types::boundary_id             /*boundary_indicator*/,
-                                          const Point<dim>                    &/*position*/) const
+    Interface<dim>::boundary_temperature (const types::boundary_id /*boundary_indicator*/,
+                                          const Point<dim>        &/*position*/) const
     {
       AssertThrow(false,
-          ExcMessage("The boundary composition plugin has to implement a function called boundary_composition "
-              "with either three or four arguments. The function with four arguments is deprecated and will "
-              "be removed in a later version of ASPECT."));
-      return Utilities::signaling_nan<double>();    }
+                  ExcMessage("The boundary composition plugin has to implement a function called boundary_composition "
+                             "with either three or four arguments. The function with four arguments is deprecated and will "
+                             "be removed in a later version of ASPECT."));
+      return Utilities::signaling_nan<double>();
+    }
 
 
     template <int dim>

--- a/source/boundary_temperature/spherical_constant.cc
+++ b/source/boundary_temperature/spherical_constant.cc
@@ -37,22 +37,20 @@ namespace aspect
     template <int dim>
     double
     SphericalConstant<dim>::
-    temperature (const GeometryModel::Interface<dim> &geometry_model,
-                 const types::boundary_id             boundary_indicator,
-                 const Point<dim> &) const
+    boundary_temperature (const types::boundary_id             boundary_indicator,
+                          const Point<dim> &) const
     {
-      (void)geometry_model;
-
-      // verify that the geometry is a spherical shell or a chunk since only
-      // for geometries based on spherical shells do we know which boundary indicators are
-      // used and what they mean
-      Assert ((dynamic_cast<const GeometryModel::SphericalShell<dim>*>(&geometry_model) != 0
-               || dynamic_cast<const GeometryModel::Chunk<dim>*>(&geometry_model) != 0
-               || dynamic_cast<const GeometryModel::EllipsoidalChunk<dim>*>(&geometry_model) != 0),
+      // verify that the geometry is a spherical shell, a chunk, or an
+      // ellipsoidal chunk since only for geometries based on spherical shells
+      // do we know which boundary indicators are used and what they mean
+      const GeometryModel::Interface<dim> *geometry_model = &this->get_geometry_model();
+      Assert ((dynamic_cast<const GeometryModel::SphericalShell<dim>*>(geometry_model) != 0
+               || dynamic_cast<const GeometryModel::Chunk<dim>*>(geometry_model) != 0
+               || dynamic_cast<const GeometryModel::EllipsoidalChunk<dim>*>(geometry_model) != 0),
               ExcMessage ("This boundary model is only implemented if the geometry "
                           "is a spherical shell, ellipsoidal chunk or chunk."));
 
-      const std::string boundary_name = geometry_model.translate_id_to_symbol_name(boundary_indicator);
+      const std::string boundary_name = geometry_model->translate_id_to_symbol_name(boundary_indicator);
 
       if (boundary_name == "inner")
         return inner_temperature;

--- a/source/boundary_temperature/spherical_constant.cc
+++ b/source/boundary_temperature/spherical_constant.cc
@@ -37,7 +37,7 @@ namespace aspect
     template <int dim>
     double
     SphericalConstant<dim>::
-    boundary_temperature (const types::boundary_id             boundary_indicator,
+    boundary_temperature (const types::boundary_id boundary_indicator,
                           const Point<dim> &) const
     {
       // verify that the geometry is a spherical shell, a chunk, or an

--- a/source/boundary_temperature/two_merged_boxes.cc
+++ b/source/boundary_temperature/two_merged_boxes.cc
@@ -34,16 +34,13 @@ namespace aspect
     template <int dim>
     double
     TwoMergedBoxes<dim>::
-    temperature (const GeometryModel::Interface<dim> &geometry_model,
-                 const types::boundary_id             boundary_indicator,
-                 const Point<dim> &) const
+    boundary_temperature (const types::boundary_id             boundary_indicator,
+                          const Point<dim> &) const
     {
-      (void)geometry_model;
-
       // verify that the geometry is in fact a box since only
       // for this geometry do we know for sure what boundary indicators it
       // uses and what they mean
-      Assert (dynamic_cast<const GeometryModel::TwoMergedBoxes<dim>*>(&geometry_model)!=0,
+      Assert (dynamic_cast<const GeometryModel::TwoMergedBoxes<dim>*>(&this->get_geometry_model()) != 0,
               ExcMessage ("This boundary model is only useful if the geometry is "
                           "in fact a box with additional boundary indicators."));
 

--- a/source/boundary_temperature/two_merged_boxes.cc
+++ b/source/boundary_temperature/two_merged_boxes.cc
@@ -34,7 +34,7 @@ namespace aspect
     template <int dim>
     double
     TwoMergedBoxes<dim>::
-    boundary_temperature (const types::boundary_id             boundary_indicator,
+    boundary_temperature (const types::boundary_id boundary_indicator,
                           const Point<dim> &) const
     {
       // verify that the geometry is in fact a box since only

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -21,8 +21,6 @@
 
 #include <aspect/simulator.h>
 #include <aspect/global.h>
-#include <aspect/utilities.h>
-
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/quadrature_lib.h>
@@ -851,46 +849,17 @@ namespace aspect
         {
           Assert (is_element (*p, geometry_model->get_used_boundary_indicators()),
                   ExcInternalError());
-
-          if (std::isnan(boundary_temperature->boundary_temperature(*p,geometry_model->representative_point(0.0))))
-            {
-              if (timestep_number == 0)
-                pcout << "WARNING: Your selected boundary temperature plugin uses the deprecated "
-                      << "interface function 'temperature(geometry_model,boundary_indicator,position)'. "
-                      << "This function will be removed in a future ASPECT "
-                      << "release. Please update your plugin NOW to the new interface "
-                      << "'boundary_temperature(boundary_indicator,position) "
-                      << "instead, and derive it from SimulatorAccess, if you need access to the "
-                      << "geometry model." << std::endl;
-
-              VectorTools::interpolate_boundary_values (dof_handler,
+          VectorTools::interpolate_boundary_values (dof_handler,
+                                                    *p,
+                                                    VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (&BoundaryTemperature::Interface<dim>::temperature,
+                                                        std_cxx11::cref(*boundary_temperature),
+                                                        std_cxx11::cref(*geometry_model),
                                                         *p,
-                                                        VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (static_cast<double (BoundaryTemperature::Interface<dim>::*)(const GeometryModel::Interface<dim> &,
-                                                            const types::boundary_id,
-                                                            const Point<dim> &) const> (&BoundaryTemperature::Interface<dim>::temperature),
-                                                            std_cxx11::cref(*boundary_temperature),
-                                                            std_cxx11::cref(*geometry_model),
-                                                            *p,
-                                                            std_cxx11::_1),
-                                                            introspection.component_masks.temperature.first_selected_component(),
-                                                            introspection.n_components),
-                                                        current_constraints,
-                                                        introspection.component_masks.temperature);
-            }
-          else
-            {
-              VectorTools::interpolate_boundary_values (dof_handler,
-                                                        *p,
-                                                        VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (static_cast<double (BoundaryTemperature::Interface<dim>::*)(const types::boundary_id,
-                                                            const Point<dim> &) const> (&BoundaryTemperature::Interface<dim>::boundary_temperature),
-                                                            std_cxx11::cref(*boundary_temperature),
-                                                            *p,
-                                                            std_cxx11::_1),
-                                                            introspection.component_masks.temperature.first_selected_component(),
-                                                            introspection.n_components),
-                                                        current_constraints,
-                                                        introspection.component_masks.temperature);
-            }
+                                                        std_cxx11::_1),
+                                                        introspection.component_masks.temperature.first_selected_component(),
+                                                        introspection.n_components),
+                                                    current_constraints,
+                                                    introspection.component_masks.temperature);
         }
     }
 
@@ -911,50 +880,18 @@ namespace aspect
           {
             Assert (is_element (*p, geometry_model->get_used_boundary_indicators()),
                     ExcInternalError());
-
-            if (boundary_composition->boundary_composition(*p,geometry_model->representative_point(0.0),0) == Utilities::signaling_nan<double>())
-              {
-                if (timestep_number == 0)
-                  pcout << "WARNING: Your selected boundary composition plugin uses the deprecated "
-                        << "interface function 'composition(geometry_model,boundary_indicator,position,"
-                        << "compositional_field)'. This function will be removed in a future ASPECT "
-                        << "release. Please update your plugin NOW to the new interface "
-                        << "'boundary_composition(boundary_indicator,position,compositional_field) "
-                        << "instead, and derive it from SimulatorAccess, if you need access to the "
-                        << "geometry model." << std::endl;
-
-                VectorTools::interpolate_boundary_values (dof_handler,
+            VectorTools::interpolate_boundary_values (dof_handler,
+                                                      *p,
+                                                      VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (&BoundaryComposition::Interface<dim>::composition,
+                                                          std_cxx11::cref(*boundary_composition),
+                                                          std_cxx11::cref(*geometry_model),
                                                           *p,
-                                                          VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (static_cast<double (BoundaryComposition::Interface<dim>::*)(const GeometryModel::Interface<dim> &,
-                                                              const types::boundary_id,
-                                                              const Point<dim> &,
-                                                              const unsigned int) const> (&BoundaryComposition::Interface<dim>::composition),
-                                                              std_cxx11::cref(*boundary_composition),
-                                                              std_cxx11::cref(*geometry_model),
-                                                              *p,
-                                                              std_cxx11::_1,
-                                                              c),
-                                                              introspection.component_masks.compositional_fields[c].first_selected_component(),
-                                                              introspection.n_components),
-                                                          current_constraints,
-                                                          introspection.component_masks.compositional_fields[c]);
-              }
-            else
-              {
-                VectorTools::interpolate_boundary_values (dof_handler,
-                                                          *p,
-                                                          VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (static_cast<double (BoundaryComposition::Interface<dim>::*)(const types::boundary_id,
-                                                              const Point<dim> &,
-                                                              const unsigned int) const> (&BoundaryComposition::Interface<dim>::boundary_composition),
-                                                              std_cxx11::cref(*boundary_composition),
-                                                              *p,
-                                                              std_cxx11::_1,
-                                                              c),
-                                                              introspection.component_masks.compositional_fields[c].first_selected_component(),
-                                                              introspection.n_components),
-                                                          current_constraints,
-                                                          introspection.component_masks.compositional_fields[c]);
-              }
+                                                          std_cxx11::_1,
+                                                          c),
+                                                          introspection.component_masks.compositional_fields[c].first_selected_component(),
+                                                          introspection.n_components),
+                                                      current_constraints,
+                                                      introspection.component_masks.compositional_fields[c]);
           }
     }
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -21,6 +21,8 @@
 
 #include <aspect/simulator.h>
 #include <aspect/global.h>
+#include <aspect/utilities.h>
+
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/quadrature_lib.h>
@@ -849,17 +851,46 @@ namespace aspect
         {
           Assert (is_element (*p, geometry_model->get_used_boundary_indicators()),
                   ExcInternalError());
-          VectorTools::interpolate_boundary_values (dof_handler,
-                                                    *p,
-                                                    VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (&BoundaryTemperature::Interface<dim>::temperature,
-                                                        std_cxx11::cref(*boundary_temperature),
-                                                        std_cxx11::cref(*geometry_model),
+
+          if (std::isnan(boundary_temperature->boundary_temperature(*p,geometry_model->representative_point(0.0))))
+            {
+              if (timestep_number == 0)
+                pcout << "WARNING: Your selected boundary temperature plugin uses the deprecated "
+                      << "interface function 'temperature(geometry_model,boundary_indicator,position)'. "
+                      << "This function will be removed in a future ASPECT "
+                      << "release. Please update your plugin NOW to the new interface "
+                      << "'boundary_temperature(boundary_indicator,position) "
+                      << "instead, and derive it from SimulatorAccess, if you need access to the "
+                      << "geometry model." << std::endl;
+
+              VectorTools::interpolate_boundary_values (dof_handler,
                                                         *p,
-                                                        std_cxx11::_1),
-                                                        introspection.component_masks.temperature.first_selected_component(),
-                                                        introspection.n_components),
-                                                    current_constraints,
-                                                    introspection.component_masks.temperature);
+                                                        VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (static_cast<double (BoundaryTemperature::Interface<dim>::*)(const GeometryModel::Interface<dim> &,
+                                                            const types::boundary_id,
+                                                            const Point<dim> &) const> (&BoundaryTemperature::Interface<dim>::temperature),
+                                                            std_cxx11::cref(*boundary_temperature),
+                                                            std_cxx11::cref(*geometry_model),
+                                                            *p,
+                                                            std_cxx11::_1),
+                                                            introspection.component_masks.temperature.first_selected_component(),
+                                                            introspection.n_components),
+                                                        current_constraints,
+                                                        introspection.component_masks.temperature);
+            }
+          else
+            {
+              VectorTools::interpolate_boundary_values (dof_handler,
+                                                        *p,
+                                                        VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (static_cast<double (BoundaryTemperature::Interface<dim>::*)(const types::boundary_id,
+                                                            const Point<dim> &) const> (&BoundaryTemperature::Interface<dim>::boundary_temperature),
+                                                            std_cxx11::cref(*boundary_temperature),
+                                                            *p,
+                                                            std_cxx11::_1),
+                                                            introspection.component_masks.temperature.first_selected_component(),
+                                                            introspection.n_components),
+                                                        current_constraints,
+                                                        introspection.component_masks.temperature);
+            }
         }
     }
 
@@ -880,18 +911,50 @@ namespace aspect
           {
             Assert (is_element (*p, geometry_model->get_used_boundary_indicators()),
                     ExcInternalError());
-            VectorTools::interpolate_boundary_values (dof_handler,
-                                                      *p,
-                                                      VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (&BoundaryComposition::Interface<dim>::composition,
-                                                          std_cxx11::cref(*boundary_composition),
-                                                          std_cxx11::cref(*geometry_model),
+
+            if (boundary_composition->boundary_composition(*p,geometry_model->representative_point(0.0),0) == Utilities::signaling_nan<double>())
+              {
+                if (timestep_number == 0)
+                  pcout << "WARNING: Your selected boundary composition plugin uses the deprecated "
+                        << "interface function 'composition(geometry_model,boundary_indicator,position,"
+                        << "compositional_field)'. This function will be removed in a future ASPECT "
+                        << "release. Please update your plugin NOW to the new interface "
+                        << "'boundary_composition(boundary_indicator,position,compositional_field) "
+                        << "instead, and derive it from SimulatorAccess, if you need access to the "
+                        << "geometry model." << std::endl;
+
+                VectorTools::interpolate_boundary_values (dof_handler,
                                                           *p,
-                                                          std_cxx11::_1,
-                                                          c),
-                                                          introspection.component_masks.compositional_fields[c].first_selected_component(),
-                                                          introspection.n_components),
-                                                      current_constraints,
-                                                      introspection.component_masks.compositional_fields[c]);
+                                                          VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (static_cast<double (BoundaryComposition::Interface<dim>::*)(const GeometryModel::Interface<dim> &,
+                                                              const types::boundary_id,
+                                                              const Point<dim> &,
+                                                              const unsigned int) const> (&BoundaryComposition::Interface<dim>::composition),
+                                                              std_cxx11::cref(*boundary_composition),
+                                                              std_cxx11::cref(*geometry_model),
+                                                              *p,
+                                                              std_cxx11::_1,
+                                                              c),
+                                                              introspection.component_masks.compositional_fields[c].first_selected_component(),
+                                                              introspection.n_components),
+                                                          current_constraints,
+                                                          introspection.component_masks.compositional_fields[c]);
+              }
+            else
+              {
+                VectorTools::interpolate_boundary_values (dof_handler,
+                                                          *p,
+                                                          VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (static_cast<double (BoundaryComposition::Interface<dim>::*)(const types::boundary_id,
+                                                              const Point<dim> &,
+                                                              const unsigned int) const> (&BoundaryComposition::Interface<dim>::boundary_composition),
+                                                              std_cxx11::cref(*boundary_composition),
+                                                              *p,
+                                                              std_cxx11::_1,
+                                                              c),
+                                                              introspection.component_masks.compositional_fields[c].first_selected_component(),
+                                                              introspection.n_components),
+                                                          current_constraints,
+                                                          introspection.component_masks.compositional_fields[c]);
+              }
           }
     }
 

--- a/tests/find_postprocess.cc
+++ b/tests/find_postprocess.cc
@@ -23,7 +23,6 @@
 #include <aspect/geometry_model/box.h>
 #include <aspect/postprocess/heat_flux_statistics.h>
 #include <aspect/postprocess/pressure_statistics.h>
-#include <aspect/simulator_access.h>
 #include <aspect/simulator.h>
 
 #include <utility>
@@ -35,7 +34,7 @@ namespace aspect
   namespace BoundaryTemperature
   {
     template <int dim>
-    class Box2 : public Box<dim>, public aspect::SimulatorAccess<dim>
+    class Box2 : public Box<dim>
     {
       public:
         virtual void update();

--- a/tests/tangurnis.cc
+++ b/tests/tangurnis.cc
@@ -462,7 +462,7 @@ namespace aspect
    * @ingroup BoundaryTemperatures
    */
   template <int dim>
-  class TanGurnisBoundary : public BoundaryTemperature::Interface<dim>
+  class TanGurnisBoundary : public BoundaryTemperature::Interface<dim>, public SimulatorAccess<dim>
   {
     public:
       /**
@@ -470,9 +470,6 @@ namespace aspect
        * the boundary of the domain. This function returns constant
        * temperatures at the left and right boundaries.
        *
-       * @param geometry_model The geometry model that describes the domain.
-       * This may be used to determine whether the boundary temperature
-       * model is implemented for this geometry.
        * @param boundary_indicator The boundary indicator of the part of the
        * boundary of the domain on which the point is located at which we
        * are requesting the temperature.
@@ -480,8 +477,7 @@ namespace aspect
        * temperature.
        */
       virtual
-      double temperature (const GeometryModel::Interface<dim> &geometry_model,
-                          const types::boundary_id             boundary_indicator,
+      double temperature (const types::boundary_id             boundary_indicator,
                           const Point<dim>                    &location) const;
 
       /**
@@ -508,14 +504,13 @@ namespace aspect
   template <int dim>
   double
   TanGurnisBoundary<dim>::
-  temperature (const GeometryModel::Interface<dim> &geometry_model,
-               const types::boundary_id             boundary_indicator,
+  temperature (const types::boundary_id             boundary_indicator,
                const Point<dim>                    &location) const
   {
     // verify that the geometry is in fact a box since only
     // for this geometry do we know for sure what boundary indicators it
     // uses and what they mean
-    Assert (dynamic_cast<const GeometryModel::Box<dim>*>(&geometry_model)
+    Assert (dynamic_cast<const GeometryModel::Box<dim>*>(&this->get_geometry_model())
             != 0,
             ExcMessage ("This boundary model is only implemented if the geometry is "
                         "in fact a box."));

--- a/tests/tangurnis.cc
+++ b/tests/tangurnis.cc
@@ -466,19 +466,14 @@ namespace aspect
   {
     public:
       /**
-       * Return the temperature that is to hold at a particular location on
-       * the boundary of the domain. This function returns constant
-       * temperatures at the left and right boundaries.
+       * This plugin prescribes the setup of the Tan Gurnis Benchmark at all
+       * boundaries.
        *
-       * @param boundary_indicator The boundary indicator of the part of the
-       * boundary of the domain on which the point is located at which we
-       * are requesting the temperature.
-       * @param location The location of the point at which we ask for the
-       * temperature.
+       * @copydoc aspect::BoundaryTemperature::Interface::boundary_temperature()
        */
       virtual
-      double temperature (const types::boundary_id             boundary_indicator,
-                          const Point<dim>                    &location) const;
+      double boundary_temperature (const types::boundary_id boundary_indicator,
+                                   const Point<dim> &position) const;
 
       /**
        * Return the minimal the temperature on that part of the boundary on
@@ -504,8 +499,8 @@ namespace aspect
   template <int dim>
   double
   TanGurnisBoundary<dim>::
-  temperature (const types::boundary_id             boundary_indicator,
-               const Point<dim>                    &location) const
+  boundary_temperature (const types::boundary_id boundary_indicator,
+                        const Point<dim> &position) const
   {
     // verify that the geometry is in fact a box since only
     // for this geometry do we know for sure what boundary indicators it
@@ -516,7 +511,7 @@ namespace aspect
                         "in fact a box."));
 
     double wavenumber=1;
-    return sin(numbers::PI*location(dim-1))*cos(numbers::PI*wavenumber*location(0));
+    return sin(numbers::PI*position(dim-1))*cos(numbers::PI*wavenumber*position(0));
   }
 
 

--- a/tests/time_dependent_temperature_bc.cc
+++ b/tests/time_dependent_temperature_bc.cc
@@ -45,9 +45,6 @@ namespace aspect
          * the boundary of the domain. This function returns constant
          * temperatures at the left and right boundaries.
          *
-         * @param geometry_model The geometry model that describes the domain.
-         * This may be used to determine whether the boundary temperature
-         * model is implemented for this geometry.
          * @param boundary_indicator The boundary indicator of the part of the
          * boundary of the domain on which the point is located at which we
          * are requesting the temperature.
@@ -55,8 +52,7 @@ namespace aspect
          * temperature.
          */
         virtual
-        double temperature (const GeometryModel::Interface<dim> &geometry_model,
-                            const types::boundary_id             boundary_indicator,
+        double temperature (const types::boundary_id             boundary_indicator,
                             const Point<dim>                    &location) const;
 
         /**
@@ -117,14 +113,13 @@ namespace aspect
     template <int dim>
     double
     Time_Dep_Box<dim>::
-    temperature (const GeometryModel::Interface<dim> &geometry_model,
-                 const types::boundary_id             boundary_indicator,
+    temperature (const types::boundary_id             boundary_indicator,
                  const Point<dim>                    &location) const
     {
       // verify that the geometry is in fact a time_dep_box since only
       // for this geometry do we know for sure what boundary indicators it
       // uses and what they mean
-      Assert (dynamic_cast<const GeometryModel::Box<dim>*>(&geometry_model)
+      Assert (dynamic_cast<const GeometryModel::Box<dim>*>(&this->get_geometry_model())
               != 0,
               ExcMessage ("This boundary model is only implemented if the geometry is "
                           "in fact a time_dep_box."));

--- a/tests/time_dependent_temperature_bc.cc
+++ b/tests/time_dependent_temperature_bc.cc
@@ -41,19 +41,13 @@ namespace aspect
     {
       public:
         /**
-         * Return the temperature that is to hold at a particular location on
-         * the boundary of the domain. This function returns constant
-         * temperatures at the left and right boundaries.
+         * This plugin prescribes time dependent temperatures for all boundaries.
          *
-         * @param boundary_indicator The boundary indicator of the part of the
-         * boundary of the domain on which the point is located at which we
-         * are requesting the temperature.
-         * @param location The location of the point at which we ask for the
-         * temperature.
+         * @copydoc aspect::BoundaryTemperature::Interface::boundary_temperature()
          */
         virtual
-        double temperature (const types::boundary_id             boundary_indicator,
-                            const Point<dim>                    &location) const;
+        double boundary_temperature (const types::boundary_id boundary_indicator,
+                                     const Point<dim> &position) const;
 
         /**
          * Return the minimal the temperature on that part of the boundary on
@@ -113,8 +107,8 @@ namespace aspect
     template <int dim>
     double
     Time_Dep_Box<dim>::
-    temperature (const types::boundary_id             boundary_indicator,
-                 const Point<dim>                    &location) const
+    boundary_temperature (const types::boundary_id boundary_indicator,
+                          const Point<dim> &position) const
     {
       // verify that the geometry is in fact a time_dep_box since only
       // for this geometry do we know for sure what boundary indicators it


### PR DESCRIPTION
This continues the work of #671 and extends it to the boundary composition and boundary temperature by removing a leftover parameter and unifying the function names. We need a different approach than for the boundary velocity though, because we a *removing* a parameter from the interface that is not known by the interface, therefore we can not implement a new interface function that by default calls the old (deprecated) one, and we do not want to derive the interface from SimulatorAccess to be able to do so. Therefore in this version the Simulator checks if the new function is implemented and outputs a run-time warning if not. It would be nice if somebody could take a look at `core.cc` and say if this is a thing worth pursuing or if there is a cleaner possibility. We can remove the deprecation code in core.cc after the next release or so.