### PR TITLE
[WIP] Modularize assembly

### DIFF
--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -38,6 +38,7 @@
 #include <aspect/initial_conditions/interface.h>
 #include <aspect/compositional_initial_conditions/interface.h>
 #include <aspect/velocity_boundary_conditions/interface.h>
+#include <aspect/traction_boundary_conditions/interface.h>
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/postprocess/interface.h>
 #include <aspect/heating_model/interface.h>
@@ -128,20 +129,27 @@ namespace aspect
       introspection () const;
 
       /**
-       * Returns a reference to the Simulator itself. Note that you can not
+       * Return a reference to the Simulator itself. Note that you can not
        * access any members or functions of the Simulator. This function
        * exists so that any class with SimulatorAccess can create other
        * objects with SimulatorAccess (because initializing them requires a
        * reference to the Simulator).
        */
       const Simulator<dim> &
-      get_simulator() const;
+      get_simulator () const;
 
+      /**
+       * Return a reference to the parameters object that describes all run-time
+       * parameters used in the current simulation.
+       */
+      const Parameters<dim> &
+      get_parameters () const;
 
       /**
        * Get Access to the structure containing the signals of the simulator.
        */
-      SimulatorSignals<dim> &get_signals() const;
+      SimulatorSignals<dim> &
+      get_signals() const;
 
       /**
        * Return the MPI communicator for this simulation.
@@ -308,6 +316,17 @@ namespace aspect
       get_old_solution () const;
 
       /**
+       * Return a reference to the vector that has the solution of the entire
+       * system at the second-to-last time step. This vector is associated with the
+       * DoFHandler object returned by get_stokes_dof_handler().
+       *
+       * @note In general the vector is a distributed vector; however, it
+       * contains ghost elements for all locally relevant degrees of freedom.
+       */
+      const LinearAlgebra::BlockVector &
+      get_old_old_solution () const;
+
+      /**
        * Return a reference to the vector that has the mesh velocity for
        * simulations with a free surface.
        *
@@ -379,11 +398,18 @@ namespace aspect
       bool has_boundary_temperature () const;
 
       /**
-       * Return a pointer to the object that describes the temperature
+       * Return a reference to the object that describes the temperature
        * boundary values.
        */
       const BoundaryTemperature::Interface<dim> &
       get_boundary_temperature () const;
+
+      /**
+       * Return a reference to the object that traction temperature
+       * boundary values.
+       */
+      const std::map<types::boundary_id,std_cxx11::shared_ptr<TractionBoundaryConditions::Interface<dim> > > &
+      get_traction_boundary_conditions () const;
 
       /**
        * Return a pointer to the object that describes the temperature initial

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -152,6 +152,13 @@ namespace aspect
       get_signals() const;
 
       /**
+       * Return a reference to the free surface handler object (if one
+       * exists in the simulation, otherwise an exception will be thrown).
+       */
+      const typename Simulator<dim>::FreeSurfaceHandler &
+      get_free_surface_handler () const;
+
+      /**
        * Return the MPI communicator for this simulation.
        */
       MPI_Comm

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -448,6 +448,13 @@ namespace aspect
     adiabatic_conditions->initialize ();
 
 
+    // now also create and initialize an object that can assemble linear systems
+    // TODO: select which object to choose based on run-time parameters
+    local_equation_assembler.reset (new internal::Assembly::CompleteEquationsAssembler<dim>());
+    if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(local_equation_assembler.get()))
+      sim->initialize_simulator (*this);
+
+
     // Initialize the free surface handler
     if (parameters.free_surface_enabled)
       {

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -48,12 +48,23 @@ namespace aspect
     simulator = &simulator_object;
   }
 
+
+
   template <int dim>
   const Simulator<dim> &
   SimulatorAccess<dim>::get_simulator() const
   {
     return *simulator;
   }
+
+
+  template <int dim>
+  const Parameters<dim> &
+  SimulatorAccess<dim>::get_parameters() const
+  {
+    return simulator->parameters;
+  }
+
 
   template <int dim>
   SimulatorSignals<dim> &
@@ -237,21 +248,27 @@ namespace aspect
 
   template <int dim>
   const LinearAlgebra::BlockVector &
+  SimulatorAccess<dim>::get_old_solution () const
+  {
+    return simulator->old_solution;
+  }
+
+  template <int dim>
+  const LinearAlgebra::BlockVector &
+  SimulatorAccess<dim>::get_old_old_solution () const
+  {
+    return simulator->old_old_solution;
+  }
+
+
+  template <int dim>
+  const LinearAlgebra::BlockVector &
   SimulatorAccess<dim>::get_mesh_velocity () const
   {
     Assert( simulator->parameters.free_surface_enabled,
             ExcMessage("You cannot get the mesh velocity with no free surface."));
     return simulator->free_surface->mesh_velocity;
   }
-
-
-  template <int dim>
-  const LinearAlgebra::BlockVector &
-  SimulatorAccess<dim>::get_old_solution () const
-  {
-    return simulator->old_solution;
-  }
-
 
 
   template <int dim>
@@ -283,6 +300,15 @@ namespace aspect
     Assert (simulator->material_model.get() != 0,
             ExcMessage("You can not call this function if no such model is actually available."));
     return *simulator->material_model.get();
+  }
+
+
+
+  template <int dim>
+  const std::map<types::boundary_id,std_cxx11::shared_ptr<TractionBoundaryConditions::Interface<dim> > > &
+  SimulatorAccess<dim>::get_traction_boundary_conditions () const
+  {
+    return simulator->traction_boundary_conditions;
   }
 
 

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -77,6 +77,16 @@ namespace aspect
 
 
   template <int dim>
+  const typename Simulator<dim>::FreeSurfaceHandler &
+  SimulatorAccess<dim>::get_free_surface_handler () const
+  {
+    Assert (simulator->parameters.free_surface_enabled,
+            ExcMessage("You cannot get the free surface handler with no free surface."));
+    return simulator->free_surface;
+  }
+
+
+  template <int dim>
   const Introspection<dim> &
   SimulatorAccess<dim>::introspection () const
   {


### PR DESCRIPTION
This is the work we discussed today. It turns out that it requires a lot of work around the seems, and it's not finished nor currently compiles (and won't get finished today because it's already late), but I wanted to put it out there for comment anyway.

What this patch does, in essence, is declare a hierarchy of classes for the assembly of linear systems (currently at the top of `simulator.h`) and implement them in `assembly.cc`. The changes in `assembly.cc` look massive but in reality they just pertain to moving existing functions out of `Simulator` and modifying them in such ways that they can stand alone and access what they need via `SimulatorAccess` -- there really is no magic here at all, it's just moving code around. The only other interesting piece is the creation of these objects in `core.cc`. 

In essence, `simulator.h` and `core.cc` are the only interesting pieces of the patch.