### PR TITLE
Add tracer refinement criterion

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -5,6 +5,11 @@
  * 1.3. All entries are signed with the names of the author. </p>
  *
  * <ol>
+ * <li> New: A new mesh refinement plugin was added that refines cells
+ * according to the density of particles in that cell.
+ * <br>
+ * (Rene Gassmoeller, 2015/12/19)
+ *
  * <li> Changed: The boundary_velocity(const Point<dim> &position) const 
  * function has now been deprecated in favor of the new function 
  * boundary_velocity (const types::boundary_id boundary_indicator, 

--- a/include/aspect/mesh_refinement/particle_density.h
+++ b/include/aspect/mesh_refinement/particle_density.h
@@ -32,7 +32,8 @@ namespace aspect
 
     /**
      * A class that implements a mesh refinement criterion based on the
-     * density of particles.
+     * density of particles. The mesh refinement indicator equals the areal
+     * (in 2d) or volumetric (in 3d) particle density in this cell.
      *
      * @ingroup MeshRefinement
      */

--- a/include/aspect/mesh_refinement/particle_density.h
+++ b/include/aspect/mesh_refinement/particle_density.h
@@ -1,0 +1,59 @@
+/*
+  Copyright (C) 2015 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef __aspect__mesh_refinement_particle_density_h
+#define __aspect__mesh_refinement_particle_density_h
+
+#include <aspect/mesh_refinement/interface.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+  namespace MeshRefinement
+  {
+
+    /**
+     * A class that implements a mesh refinement criterion based on the
+     * density of particles.
+     *
+     * @ingroup MeshRefinement
+     */
+    template <int dim>
+    class ParticleDensity : public Interface<dim>,
+      public SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * Execute this mesh refinement criterion.
+         *
+         * @param[out] error_indicators A vector that for every active cell of
+         * the current mesh (which may be a partition of a distributed mesh)
+         * provides an error indicator. This vector will already have the
+         * correct size when the function is called.
+         */
+        virtual
+        void
+        execute (Vector<float> &error_indicators) const;
+    };
+  }
+}
+
+#endif

--- a/source/mesh_refinement/particle_density.cc
+++ b/source/mesh_refinement/particle_density.cc
@@ -1,0 +1,74 @@
+/*
+  Copyright (C) 2015 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/mesh_refinement/particle_density.h>
+
+#include <aspect/postprocess/tracers.h>
+#include <aspect/simulator.h>
+
+namespace aspect
+{
+  namespace MeshRefinement
+  {
+    template <int dim>
+    void
+    ParticleDensity<dim>::execute(Vector<float> &indicators) const
+    {
+      const Postprocess::Tracers<dim> *tracer_postprocessor = this->template find_postprocessor<Postprocess::Tracers<dim> >();
+
+      AssertThrow(tracer_postprocessor != 0,
+                  ExcMessage("The mesh refinement plugin 'tracer distribution' requires the "
+                      "postprocessor plugin 'tracers' to be selected. Please activate the "
+                      "tracers or deactivate this mesh refinement plugin."));
+
+      const std::multimap<Particle::types::LevelInd, Particle::Particle<dim> > *particles = &tracer_postprocessor->get_particle_world().get_particles();
+
+      unsigned int i = 0;
+      typename DoFHandler<dim>::active_cell_iterator
+      cell = this->get_dof_handler().begin_active(),
+      endc = this->get_dof_handler().end();
+      for (; cell!=endc; ++cell,++i)
+        if (cell->is_locally_owned())
+          {
+            const Particle::types::LevelInd cell_index (cell->level(),cell->index());
+            const unsigned int n_tracers = particles->count(cell_index);
+
+            // Note that measure() only gives a linear approximation of the cell's volume.
+            // This is unaccurate for curved cells, but the exact measure is likely not
+            // important for this plugin since the cell distortion is usually small.
+            indicators(i) = n_tracers / cell->measure();
+          }
+      return;
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace MeshRefinement
+  {
+    ASPECT_REGISTER_MESH_REFINEMENT_CRITERION(ParticleDensity,
+                                              "particle density",
+                                              "A mesh refinement criterion that computes "
+                                              "refinement indicators from the density of particles.")
+  }
+}

--- a/source/mesh_refinement/particle_density.cc
+++ b/source/mesh_refinement/particle_density.cc
@@ -36,8 +36,8 @@ namespace aspect
 
       AssertThrow(tracer_postprocessor != 0,
                   ExcMessage("The mesh refinement plugin 'tracer distribution' requires the "
-                      "postprocessor plugin 'tracers' to be selected. Please activate the "
-                      "tracers or deactivate this mesh refinement plugin."));
+                             "postprocessor plugin 'tracers' to be selected. Please activate the "
+                             "tracers or deactivate this mesh refinement plugin."));
 
       const std::multimap<Particle::types::LevelInd, Particle::Particle<dim> > *particles = &tracer_postprocessor->get_particle_world().get_particles();
 
@@ -69,6 +69,7 @@ namespace aspect
     ASPECT_REGISTER_MESH_REFINEMENT_CRITERION(ParticleDensity,
                                               "particle density",
                                               "A mesh refinement criterion that computes "
-                                              "refinement indicators from the density of particles.")
+                                              "refinement indicators that equal the areal (in 2d) "
+                                              "or volumetric (in 3d) density of particles in this cell.")
   }
 }

--- a/tests/particle_load_balancing_refinement.prm
+++ b/tests/particle_load_balancing_refinement.prm
@@ -1,0 +1,114 @@
+# A test for the 'tracer distribution' refinement plugin.
+# The cell are refined based on the numbers of particles they
+# contain.
+
+set Dimension                              = 2
+set End time                               = 100
+set Use years in output instead of seconds = false
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent  = 1.0000
+    set Y extent  = 1.0000
+  end
+end
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false
+  set Tangential velocity boundary indicators = left, right
+  set Zero velocity boundary indicators       = bottom, top
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Reference density             = 1010
+    set Viscosity                     = 1e2
+    set Thermal expansion coefficient = 0
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+############### Parameters describing the temperature field
+# Note: The temperature plays no role in this model
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+subsection Initial conditions
+  set Model name = function
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+
+############### Parameters describing the compositional field
+# Note: The compositional field is what drives the flow
+# in this example
+
+subsection Compositional fields
+  set Number of fields = 1
+end
+
+subsection Compositional initial conditions
+  set Model name = function
+  subsection Function
+    set Variable names      = x,z
+    set Function constants  = pi=3.1415926
+    set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
+  end
+end
+
+subsection Material model
+  subsection Simple model
+    set Density differential for compositional field 1 = -10
+  end
+end
+
+
+############### Parameters describing the discretization
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Strategy                           = particle density
+  set Initial global refinement          = 3
+  set Time steps between mesh refinement = 1
+  set Coarsening fraction                = 0.05
+  set Refinement fraction                = 0.3
+end
+
+
+
+############### Parameters describing what to do with the solution
+
+subsection Postprocess
+  set List of postprocessors = tracers
+
+  subsection Tracers
+    set Number of tracers = 10
+    set Time between data output = 100
+    set Load balancing strategy = none
+    set Data output format = ascii
+    set Integration scheme = euler
+    set Particle generator name = probability density function
+
+    subsection Generator
+      subsection Probability density function
+        set Variable names      = x,z
+        set Function expression = x*x*z
+      end
+    end
+  end
+end

--- a/tests/particle_load_balancing_refinement/screen-output
+++ b/tests/particle_load_balancing_refinement/screen-output
@@ -1,0 +1,59 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.4.pre
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 1,237 (578+81+289+289)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 24 iterations.
+
+   Postprocessing:
+     Writing particle output:  output-particle_load_balancing_refinement/particle-00000
+
+Number of active cells: 25 (on 4 levels)
+Number of degrees of freedom: 554 (258+38+129+129)
+
+*** Timestep 1:  t=100 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 24 iterations.
+
+   Postprocessing:
+     Writing particle output:  output-particle_load_balancing_refinement/particle-00001
+
+Number of active cells: 25 (on 4 levels)
+Number of degrees of freedom: 554 (258+38+129+129)
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.182s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |    0.0363s |        20% |
+| Assemble composition system     |         2 |   0.00961s |       5.3% |
+| Assemble temperature system     |         2 |   0.00942s |       5.2% |
+| Build Stokes preconditioner     |         2 |    0.0253s |        14% |
+| Build composition preconditioner|         2 |  0.000568s |      0.31% |
+| Build temperature preconditioner|         2 |  0.000712s |      0.39% |
+| Solve Stokes system             |         2 |   0.00856s |       4.7% |
+| Solve composition system        |         2 |   0.00053s |      0.29% |
+| Solve temperature system        |         2 |  0.000456s |      0.25% |
+| Initialization                  |         2 |    0.0243s |        13% |
+| Postprocessing                  |         2 |   0.00129s |      0.71% |
+| Refine mesh structure, part 1   |         2 |   0.00462s |       2.5% |
+| Refine mesh structure, part 2   |         2 |  0.000594s |      0.33% |
+| Setup dof systems               |         3 |    0.0558s |        31% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/particle_load_balancing_refinement/statistics
+++ b/tests/particle_load_balancing_refinement/statistics
@@ -1,0 +1,16 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Number of degrees of freedom for all compositions
+# 7: Iterations for temperature solver
+# 8: Iterations for composition solver 1
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Time step size (seconds)
+# 13: Number of advected particles
+# 14: Particle file name
+0 0.0000e+00 64 659 289 289 0  0 24 25 24 1.0000e+02 10 output-particle_load_balancing_refinement/output-particle_load_balancing_refinement/particle-00000 
+1 1.0000e+02 25 296 129 129 0 10 24 25 93 1.7394e+02 10 output-particle_load_balancing_refinement/output-particle_load_balancing_refinement/particle-00001 


### PR DESCRIPTION
The entry in changes.h says it all. This PR adds a mesh refinement plugin that refines cells based on the density of tracers in that cell. It can be used to balance the load between cells and particles more effectively, as long as one is fine with synchronizing particle density and cell size.