### PR TITLE
Allow tangential mesh movement at boundaries were velocity is prescribed orthogonal

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -5,6 +5,18 @@
  * 1.3. All entries are signed with the names of the author. </p>
  *
  * <ol>
+ * <li> New: There is now a parameter called 'Additional tangential
+ * mesh velocity boundary indicators' that allows to specify boundaries
+ * which elements are allowed to deform tangential to the boundary.
+ * This can be useful in models with free surface and a prescribed
+ * material in-/outflow at the sides. Previously in this case the
+ * uppermost element became distorted over time, now the whole
+ * boundary mesh adjusts according to the deformation. This change
+ * also fixes the handling of traction boundary conditions in models
+ * with free surface.
+ * <br>
+ * (Anne Glerum, Rene Gassmoeller, Ian Rose, 2016/01/11)
+ *
  * <li> Changed: The interfaces of the boundary composition and boundary
  * temperature plugins have been deprecated. Their replacements not longer 
  * contain references to the geometry model, which was a leftover from an
@@ -14,7 +26,7 @@
  * <br>
  * (Rene Gassmoeller, 2016/01/04)
  *
-  * <li> New: A new mesh refinement plugin was added that refines cells
+ * <li> New: A new mesh refinement plugin was added that refines cells
  * according to the density of particles in that cell.
  * <br>
  * (Rene Gassmoeller, 2015/12/19)

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1357,6 +1357,18 @@ namespace aspect
           typename SurfaceAdvection::Direction advection_direction;
 
 
+          /**
+           * A set of boundary indicators that denote those boundaries that are
+           * allowed to move their mesh tangential to the boundary. All
+           * boundaries that have tangential material velocity boundary
+           * conditions are in this set by default, but it can be extended by
+           * open boundaries, boundaries with traction boundary conditions, or
+           * boundaries with prescribed material velocities if requested in
+           * the parameter file.
+           */
+          std::set<types::boundary_id> tangential_mesh_boundary_indicators;
+
+
           friend class Simulator<dim>;
           friend class SimulatorAccess<dim>;
       };

--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -88,15 +88,13 @@ namespace aspect
                          "allows to generate mesh movements along other boundaries that are "
                          "open, or have prescribed material velocities or tractions."
                          "\n\n"
-                         "The names of the boundaries listed here can either by "
-                         "numeric numbers (in which case they correspond to the numerical "
+                         "The names of the boundaries listed here can either be "
+                         "numbers (in which case they correspond to the numerical "
                          "boundary indicators assigned by the geometry object), or they "
                          "can correspond to any of the symbolic names the geometry object "
                          "may have provided for each part of the boundary. You may want "
                          "to compare this with the documentation of the geometry model you "
-                         "use in your model. Names that occur in the <Model settings/Tangential "
-                         "velocity boundary indicators> list are not allowed to appear here "
-                         "again.");
+                         "use in your model.");
     }
     prm.leave_subsection ();
   }
@@ -116,11 +114,13 @@ namespace aspect
       else
         AssertThrow(false, ExcMessage("The surface velocity projection must be ``normal'' or ``vertical''."));
 
+
+      // Create the list of tangential mesh movement boundary indicators
       try
         {
           const std::vector<types::boundary_id> x_additional_tangential_mesh_boundary_indicators
             = sim.geometry_model->translate_symbolic_boundary_names_to_ids(Utilities::split_string_list
-                                                                      (prm.get ("Additional tangential mesh velocity boundary indicators")));
+                                                                           (prm.get ("Additional tangential mesh velocity boundary indicators")));
 
           tangential_mesh_boundary_indicators = sim.parameters.tangential_velocity_boundary_indicators;
           tangential_mesh_boundary_indicators.insert(x_additional_tangential_mesh_boundary_indicators.begin(),
@@ -129,9 +129,7 @@ namespace aspect
       catch (const std::string &error)
         {
           AssertThrow (false, ExcMessage ("While parsing the entry <Free surface/Additional tangential "
-                                          "mesh velocity boundary indicators>, there was an error. Maybe you "
-                                          "specified one of the <Model settings/Tangential velocity boundary indicators> "
-                                          "again, which is unncecessary? Specifically, "
+                                          "mesh velocity boundary indicators>, there was an error. Specifically, "
                                           "the conversion function complained as follows: "
                                           + error));
         }

--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -172,11 +172,27 @@ namespace aspect
       VectorTools::interpolate_boundary_values (free_surface_dof_handler, *p,
                                                 ZeroFunction<dim>(dim), mesh_displacement_constraints);
 
+    std::set<types::boundary_id> vert_free_prescribed_vel;
     //Zero out the displacement for the prescribed velocity
     for (std::map<types::boundary_id, std::pair<std::string, std::string> >::const_iterator p = sim.parameters.prescribed_velocity_boundary_indicators.begin();
          p != sim.parameters.prescribed_velocity_boundary_indicators.end(); ++p)
-      VectorTools::interpolate_boundary_values (free_surface_dof_handler, p->first,
+    {
+     if ((p->second.first.find("z") && dim == 3) || (p->second.first.find("y") && dim == 2) || p->second.first.empty())
+     VectorTools::interpolate_boundary_values (free_surface_dof_handler, p->first,
                                                 ZeroFunction<dim>(dim), mesh_displacement_constraints);
+     else
+    {
+    	 vert_free_prescribed_vel.insert(p->first);
+
+    // In 3D what about the free y component, it could be prescribed
+    }
+    }
+
+    VectorTools::compute_no_normal_flux_constraints (free_surface_dof_handler,
+                                                         /* first_vector_component= */
+                                                         0,
+                                                         vert_free_prescribed_vel,
+                                                         mesh_displacement_constraints, sim.mapping);
 
     //make the tangential boundary indicators no displacement normal to the boundary
     VectorTools::compute_no_normal_flux_constraints (free_surface_dof_handler,

--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -176,23 +176,25 @@ namespace aspect
     //Zero out the displacement for the prescribed velocity
     for (std::map<types::boundary_id, std::pair<std::string, std::string> >::const_iterator p = sim.parameters.prescribed_velocity_boundary_indicators.begin();
          p != sim.parameters.prescribed_velocity_boundary_indicators.end(); ++p)
-    {
-     if ((p->second.first.find("z") && dim == 3) || (p->second.first.find("y") && dim == 2) || p->second.first.empty())
-     VectorTools::interpolate_boundary_values (free_surface_dof_handler, p->first,
-                                                ZeroFunction<dim>(dim), mesh_displacement_constraints);
-     else
-    {
-    	 vert_free_prescribed_vel.insert(p->first);
+      {
+        if (((p->second.first.find("z")!=std::string::npos) && dim == 3) || ((p->second.first.find("y")!=std::string::npos) && dim == 2) || p->second.first.empty())
+          {
+            VectorTools::interpolate_boundary_values (free_surface_dof_handler, p->first,
+                                                      ZeroFunction<dim>(dim), mesh_displacement_constraints);
+          }
+        else
+          {
+            vert_free_prescribed_vel.insert(p->first);
+          }
+      }
 
-    // In 3D what about the free y component, it could be prescribed
-    }
-    }
-
+    //make the prescribed velocity boundaries with a free vertical velocity component no displacement normal to the boundary
+    //TODO: in 3D, what if x and y component are prescribed?
     VectorTools::compute_no_normal_flux_constraints (free_surface_dof_handler,
-                                                         /* first_vector_component= */
-                                                         0,
-                                                         vert_free_prescribed_vel,
-                                                         mesh_displacement_constraints, sim.mapping);
+                                                     /* first_vector_component= */
+                                                     0,
+                                                     vert_free_prescribed_vel,
+                                                     mesh_displacement_constraints, sim.mapping);
 
     //make the tangential boundary indicators no displacement normal to the boundary
     VectorTools::compute_no_normal_flux_constraints (free_surface_dof_handler,

--- a/tests/free_surface_tangential_mesh_velocity.prm
+++ b/tests/free_surface_tangential_mesh_velocity.prm
@@ -1,0 +1,86 @@
+set Dimension                              = 2
+set End time                               = 1e6
+set Use years in output instead of seconds = true
+set Output directory                       = output
+set Adiabatic surface temperature          = 1613
+set CFL number                             = 1.0
+set Pressure normalization                 = no
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 2e5
+    set X repetitions = 2
+    set Y extent = 1e5
+  end
+end
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = bottom, top
+  set Zero velocity boundary indicators       = 
+  set Tangential velocity boundary indicators = bottom
+  set Prescribed velocity boundary indicators = left x: function, right x: function
+  set Free surface boundary indicators        = top
+end
+
+
+subsection Boundary temperature model
+  set Model name = function
+
+  # box prescribes a constant temp, function is for a function
+  subsection Function
+    set Function expression = if(y<5e4,1613,273)
+  end
+end
+
+# The velocity along the top boundary models a spreading
+# center
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = if(x>0, 1e-2 , -1e-2); 0
+  end
+end
+
+subsection Free surface
+  set Free surface stabilization theta = 0.5
+  set Additional tangential mesh velocity boundary indicators = left,right
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 9.8
+  end
+end
+
+
+subsection Initial conditions
+  set Model name = adiabatic
+end
+
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density     = 3300
+    set Thermal conductivity  = 3.3
+    set Thermal expansion coefficient  = 3e-5
+    set Reference specific heat        = 1200
+    set Viscosity             = 1e21
+    set Reference temperature = 1600
+  end
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 4
+  set Time steps between mesh refinement = 0
+  set Strategy                           = strain rate, topography
+end
+
+subsection Postprocess
+  set List of postprocessors = topography
+end

--- a/tests/free_surface_tangential_mesh_velocity/screen-output
+++ b/tests/free_surface_tangential_mesh_velocity/screen-output
@@ -1,0 +1,86 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.4.0-pre
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Number of active cells: 512 (on 5 levels)
+Number of degrees of freedom: 6,996 (4,290+561+2,145)
+
+Number of free surface degrees of freedom: 1122
+*** Timestep 0:  t=0 years
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+     Topography min/max: 0 m, 0 m, 
+
+*** Timestep 1:  t=220971 years
+   Solving mesh velocity system... 1 iterations.
+   Solving temperature system... 13 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+     Topography min/max: -2210 m, -2210 m, 
+
+*** Timestep 2:  t=439388 years
+   Solving mesh velocity system... 1 iterations.
+   Solving temperature system... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 28 iterations.
+
+   Postprocessing:
+     Topography min/max: -4347 m, -4345 m, 
+
+*** Timestep 3:  t=655320 years
+   Solving mesh velocity system... 1 iterations.
+   Solving temperature system... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 23 iterations.
+
+   Postprocessing:
+     Topography min/max: -6414 m, -6409 m, 
+
+*** Timestep 4:  t=868786 years
+   Solving mesh velocity system... 1 iterations.
+   Solving temperature system... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 23 iterations.
+
+   Postprocessing:
+     Topography min/max: -8413 m, -8406 m, 
+
+*** Timestep 5:  t=1e+06 years
+   Solving mesh velocity system... 1 iterations.
+   Solving temperature system... 8 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 27 iterations.
+
+   Postprocessing:
+     Topography min/max: -9615 m, -9608 m, 
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      3.81s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         6 |      1.33s |        35% |
+| Assemble temperature system     |         6 |     0.857s |        23% |
+| Build Stokes preconditioner     |         6 |     0.716s |        19% |
+| Build temperature preconditioner|         6 |    0.0412s |       1.1% |
+| Solve Stokes system             |         6 |     0.314s |       8.2% |
+| Solve temperature system        |         6 |    0.0138s |      0.36% |
+| FreeSurface                     |         6 |     0.211s |       5.5% |
+| Initialization                  |         2 |    0.0722s |       1.9% |
+| Postprocessing                  |         6 |  0.000918s |     0.024% |
+| Setup dof systems               |         1 |     0.077s |         2% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/free_surface_tangential_mesh_velocity/statistics
+++ b/tests/free_surface_tangential_mesh_velocity/statistics
@@ -1,0 +1,18 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Iterations for temperature solver
+# 7: Iterations for Stokes solver
+# 8: Velocity iterations in Stokes preconditioner
+# 9: Schur complement iterations in Stokes preconditioner
+# 10: Time step size (years)
+# 11: Minimum topography (m)
+# 12: Maximum topography (m)
+0 0.0000e+00 512 4851 2145  0 32 21  3 2.2097e+05  0.00000000e+00  0.00000000e+00 
+1 2.2097e+05 512 4851 2145 13 32 18  3 2.1842e+05 -2.20970873e+03 -2.20970850e+03 
+2 4.3939e+05 512 4851 2145 10 28 29 29 2.1593e+05 -4.34705993e+03 -4.34456123e+03 
+3 6.5532e+05 512 4851 2145 10 23 24 24 2.1347e+05 -6.41385746e+03 -6.40915861e+03 
+4 8.6879e+05 512 4851 2145 10 23 24 24 1.3121e+05 -8.41256533e+03 -8.40631084e+03 
+5 1.0000e+06 512 4851 2145  8 27 28 28 2.0948e+05 -9.61474629e+03 -9.60779976e+03 


### PR DESCRIPTION
I think this supersedes #642. I have worked a bit more with Sascha these days and this solution seems to fit our needs best (@anne-glerum you solution was already working for him, but only for box models as we discussed in #642). This PR introduces a new parameter in the Free Surface section called `Additional tangential mesh velocity boundary indicators`, which can be set by the user to allow the mesh to change tangential to the boundary at boundaries where tractions or velocities are prescribed. If anyone has a nicer name for the parameter let me know, I am not quite happy with it.