### PR TITLE
Allow free surfaces with positive topography in the box geometry model

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -5,6 +5,15 @@
  * 1.3. All entries are signed with the names of the author. </p>
  *
  * <ol>
+ * <li> Changed: The 'depth' function of the 'box' geometry model and
+ * the 'two merged boxes' geometry model previously threw an exception
+ * when asked for the depth of a point outside of the initial model domain.
+ * This is not longer appropriate for models with free surfaces and therefore
+ * the behaviour was changed to the behaviour of the 'spherical shell' geometry
+ * model, which is a cutoff of the depth to the range (0,maximal_depth).
+ * <br>
+ * (Rene Gassmoeller, Sascha Brune, 2016/01/11)
+ *
  * <li> New: There is now a parameter called 'Additional tangential
  * mesh velocity boundary indicators' that allows to specify boundaries
  * which elements are allowed to deform tangential to the boundary.

--- a/source/geometry_model/box.cc
+++ b/source/geometry_model/box.cc
@@ -153,21 +153,7 @@ namespace aspect
     Box<dim>::depth(const Point<dim> &position) const
     {
       const double d = maximal_depth()-(position(dim-1)-box_origin[dim-1]);
-
-      // if we violate the bounds, check that we do so only very slightly and
-      // then just return maximal or minimal depth
-      if (d < 0)
-        {
-          Assert (d >= -1e-14*std::fabs(maximal_depth()), ExcInternalError());
-          return 0;
-        }
-      if (d > maximal_depth())
-        {
-          Assert (d <= (1.+1e-14)*maximal_depth(), ExcInternalError());
-          return maximal_depth();
-        }
-
-      return d;
+      return std::min (std::max (d, 0.), maximal_depth());
     }
 
 

--- a/source/geometry_model/two_merged_boxes.cc
+++ b/source/geometry_model/two_merged_boxes.cc
@@ -254,21 +254,7 @@ namespace aspect
     TwoMergedBoxes<dim>::depth(const Point<dim> &position) const
     {
       const double d = maximal_depth()-(position(dim-1)-lower_box_origin[dim-1]);
-
-      // if we violate the bounds, check that we do so only very slightly and
-      // then just return maximal or minimal depth
-      if (d < 0)
-        {
-          Assert (d >= -1e-14*std::fabs(maximal_depth()), ExcInternalError());
-          return 0;
-        }
-      if (d > maximal_depth())
-        {
-          Assert (d <= (1.+1e-14)*maximal_depth(), ExcInternalError());
-          return maximal_depth();
-        }
-
-      return d;
+      return std::min (std::max (d, 0.), maximal_depth());
     }
 
 


### PR DESCRIPTION
This addresses #702 and unifies the depth() function boundary handling of the box geometries with the other geometry models that also do a truncation instead of throwing an exception. 
I do not think this will change any behaviour, because previously the cases that are now truncated were throwing exceptions, so there are no models that now behave differently.