### PR TITLE
[WIP] Modularize assembly

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -546,9 +546,61 @@ namespace aspect
        */
 
       /**
-       * @name Functions used in the assembly of linear systems
+       * @name Functions, classes, and variables used in the assembly of linear systems
        * @{
        */
+
+      /**
+       * A structure that consists of member variables representing
+       * each one or more functions that need to be called when
+       * assembling right hand side vectors, matrices, or complete linear
+       * systems. We use this approach in order to support the following
+       * cases:
+       * - Assembling different formulations: When assembling either the
+       *   full equations or only the Boussinesq approximation (to give just
+       *   two examples), one needs different terms. This could be achieved
+       *   using a large number of <code>switch</code> or <code>if</code>
+       *   statements in the code, or one could encapsulate each equation
+       *   or approximation into a collection of functions for this particular
+       *   purpose. The approach chosen here in essence allows the
+       *   implementation of each set of equations in its own scope, and we
+       *   then just need to store a pointer to the function that
+       *   assembles the Stokes system (for example) for the selected
+       *   approximation. The pointer to this function is stored in the
+       *   appropriate member variable of this class.
+       * - Sometimes, we want to assemble a number of terms that build on
+       *   each other. An example is the addition of free boundary terms
+       *   to the Stokes matrix. Rather than having to "know" in one
+       *   place about all of the terms that need to be assembled,
+       *   we simply add the function that computes these terms as
+       *   another "slot" to the appropriate "signal" declared in this
+       *   class.
+       */
+      struct Assemblers
+      {
+        boost::signals2::signal<void (const double,
+                                      internal::Assembly::Scratch::StokesPreconditioner<dim>  &,
+                                      internal::Assembly::CopyData::StokesPreconditioner<dim> &)> local_assemble_stokes_preconditioner;
+        boost::signals2::signal<void (const double,
+                                      const bool,
+                                      internal::Assembly::Scratch::StokesSystem<dim> &,
+                                      internal::Assembly::CopyData::StokesSystem<dim> &)> local_assemble_stokes_system;
+      };
+
+      /**
+       * A member variable that stores, for the current simulation, what
+       * functions need to be called in order to assemble linear systems,
+       * matrices, and right hand side vectors.
+       */
+      Assemblers assemblers;
+
+      /**
+       * Determine, based on the run-time parameters of the current simulation,
+       * which functions need to be called in order to assemble linear systems,
+       * matrices, and right hand side vectors.
+       */
+      void set_assemblers ();
+
       /**
        * Initiate the assembly of the preconditioner for the Stokes system.
        *
@@ -614,7 +666,6 @@ namespace aspect
                                        const typename DoFHandler<dim>::active_cell_iterator &cell,
                                        internal::Assembly::Scratch::AdvectionSystem<dim>  &scratch,
                                        internal::Assembly::CopyData::AdvectionSystem<dim> &data);
-
 
       /**
        * Copy the contribution to the advection system from a single cell into
@@ -961,6 +1012,7 @@ namespace aspect
        */
       double
       compute_initial_stokes_residual();
+
       /**
        * @}
        */

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -83,7 +83,28 @@ namespace aspect
         template <int dim>      struct StokesPreconditioner;
         template <int dim>      struct StokesSystem;
         template <int dim>      struct AdvectionSystem;
+      }
 
+      namespace Assemblers
+      {
+        /**
+         * A base class for objects that implement assembly
+         * operations. This base class does not provide a whole lot
+         * of functionality other than the fact that its destructor
+         * is virtual.
+         *
+         * The point of this class is primarily so that we can store
+         * pointers to such objects in a list. The objects are created
+         * in Simulator::set_assemblers() (which is the only place where
+         * we know their actual type) and destroyed in the destructor of
+         * class Simulation.
+         */
+        template <int dim>
+        class AssemblerBase
+        {
+          public:
+            virtual ~AssemblerBase () {}
+        };
       }
     }
   }
@@ -593,6 +614,18 @@ namespace aspect
        * matrices, and right hand side vectors.
        */
       Assemblers assemblers;
+
+      /**
+       * A collection of objects that implement member functions that may
+       * appear in the assembler signal lists. What the objects do is not
+       * actually important, but individual assembler objects may encapsulate
+       * data that is used by concrete assemblers.
+       *
+       * The objects pointed to by this vector are created in
+       * set_assemblers(), and are later destroyed by the destructor
+       * of the current class.
+       */
+      std::vector<std_cxx11::unique_ptr<internal::Assembly::Assemblers::AssemblerBase<dim> > > assembler_objects;
 
       /**
        * Determine, based on the run-time parameters of the current simulation,

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1246,6 +1246,7 @@ namespace aspect
        * @}
        */
 
+    public:
       /**
        * A member class that isolates the functions and variables that deal
        * with the free surface implementation.  If there are no free surface
@@ -1457,6 +1458,8 @@ namespace aspect
           friend class Simulator<dim>;
           friend class SimulatorAccess<dim>;
       };
+
+    private:
 
       /**
        * Shared pointer for an instance of the FreeSurfaceHandler. this way,

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -602,10 +602,11 @@ namespace aspect
         boost::signals2::signal<void (const double,
                                       internal::Assembly::Scratch::StokesPreconditioner<dim>  &,
                                       internal::Assembly::CopyData::StokesPreconditioner<dim> &)> local_assemble_stokes_preconditioner;
-        boost::signals2::signal<void (const double,
+        boost::signals2::signal<void (const typename DoFHandler<dim>::active_cell_iterator &,
+                                      const double,
                                       const bool,
-                                      internal::Assembly::Scratch::StokesSystem<dim> &,
-                                      internal::Assembly::CopyData::StokesSystem<dim> &)> local_assemble_stokes_system;
+                                      internal::Assembly::Scratch::StokesSystem<dim>       &,
+                                      internal::Assembly::CopyData::StokesSystem<dim>      &)> local_assemble_stokes_system;
       };
 
       /**

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -947,8 +947,6 @@ namespace aspect
                   }
           }
       }
-
-
   }
 
 
@@ -1004,6 +1002,277 @@ namespace aspect
   }
 
 
+
+  /**
+   * A namespace for the definition of sub-namespaces in which we
+   * implement assemblers for the various terms in the linear systems
+   * ASPECT solves.
+   */
+  namespace Assemblers
+  {
+    /**
+     * A namespace for the definition of functions that implement the
+     * linear system terms for the *complete* compressible or
+     * incompressible equations.
+     */
+    namespace CompleteEquations
+    {
+      template <int dim>
+      void
+      local_assemble_stokes_preconditioner (const SimulatorAccess<dim>                              &simulator_access,
+                                            const double                                             pressure_scaling,
+                                            internal::Assembly::Scratch::StokesPreconditioner<dim>  &scratch,
+                                            internal::Assembly::CopyData::StokesPreconditioner<dim> &data)
+      {
+        const Introspection<dim> &introspection = simulator_access.introspection();
+        const FiniteElement<dim> &fe = scratch.finite_element_values.get_fe();
+        const unsigned int   dofs_per_cell   = fe.dofs_per_cell;
+        const unsigned int   n_q_points      = scratch.finite_element_values.n_quadrature_points;
+
+        for (unsigned int q = 0; q < n_q_points; ++q)
+          {
+            for (unsigned int k = 0; k < dofs_per_cell; ++k)
+              {
+                scratch.grads_phi_u[k] =
+                  scratch.finite_element_values[introspection.extractors
+                                                .velocities].symmetric_gradient(k, q);
+                scratch.phi_p[k] = scratch.finite_element_values[introspection
+                                                                 .extractors.pressure].value(k, q);
+              }
+            const double eta = scratch.material_model_outputs.viscosities[q];
+            const SymmetricTensor<4, dim> &stress_strain_director = scratch
+                                                                    .material_model_outputs.stress_strain_directors[q];
+            const bool use_tensor = (stress_strain_director
+                                     != dealii::identity_tensor<dim>());
+            for (unsigned int i = 0; i < dofs_per_cell; ++i)
+              for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                if (fe.system_to_component_index(i).first ==
+                    fe.system_to_component_index(j).first)
+                  data.local_matrix(i, j) += ((
+                                                use_tensor ?
+                                                eta * (scratch.grads_phi_u[i]
+                                                       * stress_strain_director
+                                                       * scratch.grads_phi_u[j]) :
+                                                eta * (scratch.grads_phi_u[i]
+                                                       * scratch.grads_phi_u[j]))
+                                              + (1. / eta) * pressure_scaling
+                                              * pressure_scaling
+                                              * (scratch.phi_p[i] * scratch
+                                                 .phi_p[j]))
+                                             * scratch.finite_element_values.JxW(
+                                               q);
+          }
+      }
+
+
+
+      template <int dim>
+      void
+      local_assemble_stokes_system_compressible (const SimulatorAccess<dim>                      &simulator_access,
+                                                 const double                                     pressure_scaling,
+                                                 const bool                                       rebuild_stokes_matrix,
+                                                 internal::Assembly::Scratch::StokesSystem<dim>  &scratch,
+                                                 internal::Assembly::CopyData::StokesSystem<dim> &data)
+      {
+        const Introspection<dim> &introspection = simulator_access.introspection();
+        const unsigned int dofs_per_cell = scratch.finite_element_values.get_fe().dofs_per_cell;
+        const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
+
+        for (unsigned int q=0; q<n_q_points; ++q)
+          {
+            for (unsigned int k=0; k<dofs_per_cell; ++k)
+              {
+                scratch.phi_u[k] = scratch.finite_element_values[introspection.extractors.velocities].value (k,q);
+                scratch.phi_p[k] = scratch.finite_element_values[introspection.extractors.pressure].value (k, q);
+                if (rebuild_stokes_matrix)
+                  {
+                    scratch.grads_phi_u[k] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(k,q);
+                    scratch.div_phi_u[k]   = scratch.finite_element_values[introspection.extractors.velocities].divergence (k, q);
+                  }
+              }
+
+            // Viscosity scalar
+            const double eta = (rebuild_stokes_matrix
+                                ?
+                                scratch.material_model_outputs.viscosities[q]
+                                :
+                                std::numeric_limits<double>::quiet_NaN());
+
+            const SymmetricTensor<4,dim> &stress_strain_director =
+              scratch.material_model_outputs.stress_strain_directors[q];
+            const bool use_tensor = (stress_strain_director !=  dealii::identity_tensor<dim> ());
+
+            const Tensor<1,dim>
+            gravity = simulator_access.get_gravity_model().gravity_vector (scratch.finite_element_values.quadrature_point(q));
+
+            const double compressibility
+              = scratch.material_model_outputs.compressibilities[q];
+            const double density = scratch.material_model_outputs.densities[q];
+
+            if (rebuild_stokes_matrix)
+              for (unsigned int i=0; i<dofs_per_cell; ++i)
+                for (unsigned int j=0; j<dofs_per_cell; ++j)
+                  data.local_matrix(i,j) += ( (use_tensor ?
+                                               eta * 2.0 * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
+                                               :
+                                               eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
+                                              - (use_tensor ?
+                                                 eta * 2.0/3.0 * (scratch.div_phi_u[i] * trace(stress_strain_director * scratch.grads_phi_u[j]))
+                                                 :
+                                                 eta * 2.0/3.0 * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
+                                                )
+                                              - (pressure_scaling *
+                                                 scratch.div_phi_u[i] * scratch.phi_p[j])
+                                              // finally the term -div(u). note the negative sign to make this
+                                              // operator adjoint to the grad(p) term
+                                              - (pressure_scaling *
+                                                 scratch.phi_p[i] * scratch.div_phi_u[j]))
+                                            * scratch.finite_element_values.JxW(q);
+
+            for (unsigned int i=0; i<dofs_per_cell; ++i)
+              data.local_rhs(i) += (
+                                     (density * gravity * scratch.phi_u[i])
+                                     +
+                                     // add the term that results from the compressibility. compared
+                                     // to the manual, this term seems to have the wrong sign, but this
+                                     // is because we negate the entire equation to make sure we get
+                                     // -div(u) as the adjoint operator of grad(p) (see above where
+                                     // we assemble the matrix)
+                                     (pressure_scaling *
+                                      compressibility * density *
+                                      (scratch.velocity_values[q] * gravity) *
+                                      scratch.phi_p[i])
+                                   )
+                                   * scratch.finite_element_values.JxW(q);
+          }
+      }
+
+
+
+      template <int dim>
+      void
+      local_assemble_stokes_system_incompressible (const SimulatorAccess<dim>                      &simulator_access,
+                                                   const double                                     pressure_scaling,
+                                                   const bool                                       rebuild_stokes_matrix,
+                                                   internal::Assembly::Scratch::StokesSystem<dim>  &scratch,
+                                                   internal::Assembly::CopyData::StokesSystem<dim> &data)
+      {
+        const Introspection<dim> &introspection = simulator_access.introspection();
+        const unsigned int dofs_per_cell = scratch.finite_element_values.get_fe().dofs_per_cell;
+        const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
+
+        for (unsigned int q=0; q<n_q_points; ++q)
+          {
+            for (unsigned int k=0; k<dofs_per_cell; ++k)
+              {
+                scratch.phi_u[k] = scratch.finite_element_values[introspection.extractors.velocities].value (k,q);
+                scratch.phi_p[k] = scratch.finite_element_values[introspection.extractors.pressure].value (k, q);
+                if (rebuild_stokes_matrix)
+                  {
+                    scratch.grads_phi_u[k] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(k,q);
+                    scratch.div_phi_u[k]   = scratch.finite_element_values[introspection.extractors.velocities].divergence (k, q);
+                  }
+              }
+
+            // Viscosity scalar
+            const double eta = (rebuild_stokes_matrix
+                                ?
+                                scratch.material_model_outputs.viscosities[q]
+                                :
+                                std::numeric_limits<double>::quiet_NaN());
+
+            const SymmetricTensor<4,dim> &stress_strain_director =
+              scratch.material_model_outputs.stress_strain_directors[q];
+            const bool use_tensor = (stress_strain_director !=  dealii::identity_tensor<dim> ());
+
+            const Tensor<1,dim>
+            gravity = simulator_access.get_gravity_model().gravity_vector (scratch.finite_element_values.quadrature_point(q));
+
+            const double density = scratch.material_model_outputs.densities[q];
+
+            if (rebuild_stokes_matrix)
+              for (unsigned int i=0; i<dofs_per_cell; ++i)
+                for (unsigned int j=0; j<dofs_per_cell; ++j)
+                  data.local_matrix(i,j) += ( (use_tensor ?
+                                               eta * 2.0 * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
+                                               :
+                                               eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
+                                              - (pressure_scaling *
+                                                 scratch.div_phi_u[i] * scratch.phi_p[j])
+                                              // finally the term -div(u). note the negative sign to make this
+                                              // operator adjoint to the grad(p) term
+                                              - (pressure_scaling *
+                                                 scratch.phi_p[i] * scratch.div_phi_u[j]))
+                                            * scratch.finite_element_values.JxW(q);
+
+            for (unsigned int i=0; i<dofs_per_cell; ++i)
+              data.local_rhs(i) += (density * gravity * scratch.phi_u[i])
+                                   * scratch.finite_element_values.JxW(q);
+          }
+      }
+    }
+
+
+    /**
+     * A namespace for the definition of functions that implement various
+     * other terms that need to occasionally or always be assembled.
+     */
+    namespace OtherTerms
+    {
+      template <int dim>
+      void
+      pressure_rhs_compatibility_modification (const SimulatorAccess<dim>                      &simulator_access,
+                                               internal::Assembly::Scratch::StokesSystem<dim>  &scratch,
+                                               internal::Assembly::CopyData::StokesSystem<dim> &data)
+      {
+        const Introspection<dim> &introspection = simulator_access.introspection();
+
+        const unsigned int dofs_per_cell = scratch.finite_element_values.get_fe().dofs_per_cell;
+        const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
+
+        for (unsigned int q=0; q<n_q_points; ++q)
+          for (unsigned int i=0; i<dofs_per_cell; ++i)
+            {
+              scratch.phi_p[i] = scratch.finite_element_values[introspection.extractors.pressure].value (i, q);
+              data.local_pressure_shape_function_integrals(i) += scratch.phi_p[i] * scratch.finite_element_values.JxW(q);
+            }
+      }
+    }
+  }
+
+
+  template <int dim>
+  void
+  Simulator<dim>::
+  set_assemblers ()
+  {
+    assemblers.local_assemble_stokes_preconditioner
+    .connect (std_cxx11::bind(&aspect::Assemblers::CompleteEquations::local_assemble_stokes_preconditioner<dim>,
+                              SimulatorAccess<dim>(*this),
+                              std_cxx11::_1, std_cxx11::_2, std_cxx11::_3));
+
+    if (material_model->is_compressible())
+      assemblers.local_assemble_stokes_system
+      .connect (std_cxx11::bind(&aspect::Assemblers::CompleteEquations::local_assemble_stokes_system_compressible<dim>,
+                                SimulatorAccess<dim>(*this),
+                                std_cxx11::_1, std_cxx11::_2, std_cxx11::_3, std_cxx11::_4));
+    else
+      assemblers.local_assemble_stokes_system
+      .connect (std_cxx11::bind(&aspect::Assemblers::CompleteEquations::local_assemble_stokes_system_incompressible<dim>,
+                                SimulatorAccess<dim>(*this),
+                                std_cxx11::_1, std_cxx11::_2, std_cxx11::_3, std_cxx11::_4));
+
+
+    if (do_pressure_rhs_compatibility_modification)
+      assemblers.local_assemble_stokes_system
+      .connect (std_cxx11::bind(&aspect::Assemblers::OtherTerms::pressure_rhs_compatibility_modification<dim>,
+                                SimulatorAccess<dim>(*this),
+                                // discard pressure_scaling and rebuild_stokes_matrix,
+                                std_cxx11::_3, std_cxx11::_4));
+  }
+
+
+
   template <int dim>
   void
   Simulator<dim>::
@@ -1011,9 +1280,6 @@ namespace aspect
                                         internal::Assembly::Scratch::StokesPreconditioner<dim> &scratch,
                                         internal::Assembly::CopyData::StokesPreconditioner<dim> &data)
   {
-    const unsigned int   dofs_per_cell   = finite_element.dofs_per_cell;
-    const unsigned int   n_q_points      = scratch.finite_element_values.n_quadrature_points;
-
     scratch.finite_element_values.reinit (cell);
 
     data.local_matrix = 0;
@@ -1032,36 +1298,9 @@ namespace aspect
                                                scratch.finite_element_values.get_mapping(),
                                                scratch.material_model_outputs);
 
-    for (unsigned int q=0; q<n_q_points; ++q)
-      {
-        for (unsigned int k=0; k<dofs_per_cell; ++k)
-          {
-            scratch.grads_phi_u[k] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(k,q);
-            scratch.phi_p[k]       = scratch.finite_element_values[introspection.extractors.pressure].value (k, q);
-          }
-
-        const double eta = scratch.material_model_outputs.viscosities[q];
-
-        const SymmetricTensor<4,dim> &stress_strain_director =
-          scratch.material_model_outputs.stress_strain_directors[q];
-        const bool use_tensor = (stress_strain_director != dealii::identity_tensor<dim> ());
-
-        for (unsigned int i=0; i<dofs_per_cell; ++i)
-          for (unsigned int j=0; j<dofs_per_cell; ++j)
-            if (finite_element.system_to_component_index(i).first
-                ==
-                finite_element.system_to_component_index(j).first)
-              data.local_matrix(i,j) += ((use_tensor ?
-                                          eta * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
-                                          :
-                                          eta * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
-                                         +
-                                         (1./eta) *
-                                         pressure_scaling *
-                                         pressure_scaling *
-                                         (scratch.phi_p[i] * scratch.phi_p[j]))
-                                        * scratch.finite_element_values.JxW(q);
-      }
+    // trigger the invocation of the various functions that actually do
+    // all of the assembling
+    assemblers.local_assemble_stokes_preconditioner(pressure_scaling, scratch, data);
 
     cell->get_dof_indices (data.local_dof_indices);
   }
@@ -1203,10 +1442,6 @@ namespace aspect
                                 internal::Assembly::Scratch::StokesSystem<dim> &scratch,
                                 internal::Assembly::CopyData::StokesSystem<dim> &data)
   {
-    const unsigned int dofs_per_cell = scratch.finite_element_values.get_fe().dofs_per_cell;
-    const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
-    const bool is_compressible = material_model->is_compressible();
-
     scratch.finite_element_values.reinit (cell);
 
     if (rebuild_stokes_matrix)
@@ -1234,89 +1469,11 @@ namespace aspect
     scratch.finite_element_values[introspection.extractors.velocities].get_function_values(current_linearization_point,
         scratch.velocity_values);
 
-    for (unsigned int q=0; q<n_q_points; ++q)
-      {
-        for (unsigned int k=0; k<dofs_per_cell; ++k)
-          {
-            scratch.phi_u[k] = scratch.finite_element_values[introspection.extractors.velocities].value (k,q);
-            scratch.phi_p[k] = scratch.finite_element_values[introspection.extractors.pressure].value (k, q);
-            if (rebuild_stokes_matrix)
-              {
-                scratch.grads_phi_u[k] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(k,q);
-                scratch.div_phi_u[k]   = scratch.finite_element_values[introspection.extractors.velocities].divergence (k, q);
-              }
-          }
+    // trigger the invocation of the various functions that actually do
+    // all of the assembling
+    assemblers.local_assemble_stokes_system(pressure_scaling, rebuild_stokes_matrix,
+                                            scratch, data);
 
-        // Viscosity scalar
-        const double eta = (rebuild_stokes_matrix
-                            ?
-                            scratch.material_model_outputs.viscosities[q]
-                            :
-                            std::numeric_limits<double>::quiet_NaN());
-
-        const SymmetricTensor<4,dim> &stress_strain_director =
-          scratch.material_model_outputs.stress_strain_directors[q];
-        const bool use_tensor = (stress_strain_director !=  dealii::identity_tensor<dim> ());
-
-        const Tensor<1,dim>
-        gravity = gravity_model->gravity_vector (scratch.finite_element_values.quadrature_point(q));
-
-        const double compressibility
-          = (is_compressible
-             ?
-             scratch.material_model_outputs.compressibilities[q]
-             :
-             std::numeric_limits<double>::quiet_NaN() );
-        const double density = scratch.material_model_outputs.densities[q];
-
-        if (rebuild_stokes_matrix)
-          for (unsigned int i=0; i<dofs_per_cell; ++i)
-            for (unsigned int j=0; j<dofs_per_cell; ++j)
-              data.local_matrix(i,j) += ( (use_tensor ?
-                                           eta * 2.0 * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
-                                           :
-                                           eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
-                                          - (is_compressible
-                                             ?
-                                             (use_tensor ?
-                                              eta * 2.0/3.0 * (scratch.div_phi_u[i] * trace(stress_strain_director * scratch.grads_phi_u[j]))
-                                              :
-                                              eta * 2.0/3.0 * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
-                                             )
-                                             :
-                                             0)
-                                          - (pressure_scaling *
-                                             scratch.div_phi_u[i] * scratch.phi_p[j])
-                                          // finally the term -div(u). note the negative sign to make this
-                                          // operator adjoint to the grad(p) term
-                                          - (pressure_scaling *
-                                             scratch.phi_p[i] * scratch.div_phi_u[j]))
-                                        * scratch.finite_element_values.JxW(q);
-
-        for (unsigned int i=0; i<dofs_per_cell; ++i)
-          data.local_rhs(i) += (
-                                 (density * gravity * scratch.phi_u[i])
-                                 +
-                                 // add the term that results from the compressibility. compared
-                                 // to the manual, this term seems to have the wrong sign, but this
-                                 // is because we negate the entire equation to make sure we get
-                                 // -div(u) as the adjoint operator of grad(p) (see above where
-                                 // we assemble the matrix)
-                                 (is_compressible
-                                  ?
-                                  (pressure_scaling *
-                                   compressibility * density *
-                                   (scratch.velocity_values[q] * gravity) *
-                                   scratch.phi_p[i])
-                                  :
-                                  0)
-                               )
-                               * scratch.finite_element_values.JxW(q);
-
-        if (do_pressure_rhs_compatibility_modification)
-          for (unsigned int i=0; i<dofs_per_cell; ++i)
-            data.local_pressure_shape_function_integrals(i) += scratch.phi_p[i] * scratch.finite_element_values.JxW(q);
-      }
 
     // add stabilization terms for free boundaries if necessary.
     if (parameters.free_surface_enabled)
@@ -1324,6 +1481,7 @@ namespace aspect
 
     // see if any of the faces are traction boundaries for which
     // we need to assemble force terms for the right hand side
+    const unsigned int dofs_per_cell = scratch.finite_element_values.get_fe().dofs_per_cell;
     for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
       if (cell->at_boundary(f))
         if (traction_boundary_conditions
@@ -1841,6 +1999,7 @@ namespace aspect
 namespace aspect
 {
 #define INSTANTIATE(dim) \
+  template void Simulator<dim>::set_assemblers (); \
   template void Simulator<dim>::local_assemble_stokes_preconditioner ( \
                                                                        const DoFHandler<dim>::active_cell_iterator &cell, \
                                                                        internal::Assembly::Scratch::StokesPreconditioner<dim> &scratch, \

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1236,6 +1236,7 @@ namespace aspect
       }
 
 
+
       template <int dim>
       void
       traction_boundary_conditions (const SimulatorAccess<dim>                           &simulator_access,
@@ -1284,6 +1285,16 @@ namespace aspect
               }
       }
 
+
+
+      template <int dim>
+      void
+      free_boundary_stokes_contribution (const typename DoFHandler<dim>::active_cell_iterator &cell,
+                                         typename Simulator<dim>::FreeSurfaceHandler          &free_surface,
+                                         internal::Assembly::CopyData::StokesSystem<dim>      &data)
+      {
+        free_surface.apply_stabilization(cell, data.local_matrix);
+      }
     }
   }
 
@@ -1335,6 +1346,17 @@ namespace aspect
                               // discard rebuild_stokes_matrix,
                               std_cxx11::_4,
                               std_cxx11::_5));
+
+    // and, if necessary, the function that computes stabilization terms for free boundaries
+    if (parameters.free_surface_enabled)
+      assemblers.local_assemble_stokes_system
+      .connect (std_cxx11::bind(&aspect::Assemblers::OtherTerms::free_boundary_stokes_contribution<dim>,
+                                std_cxx11::_1,
+                                std_cxx11::ref(*free_surface.get()),
+                                // discard pressure_scaling,
+                                // discard rebuild_stokes_matrix,
+                                // discard scratch object,
+                                std_cxx11::_5));
 
     // add the terms necessary to normalize the pressure
     if (do_pressure_rhs_compatibility_modification)
@@ -1556,11 +1578,6 @@ namespace aspect
     // all of the assembling
     assemblers.local_assemble_stokes_system(cell, pressure_scaling, rebuild_stokes_matrix,
                                             scratch, data);
-
-
-    // add stabilization terms for free boundaries if necessary.
-    if (parameters.free_surface_enabled)
-      free_surface->apply_stabilization(cell, data.local_matrix);
 
     cell->get_dof_indices (data.local_dof_indices);
   }

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -537,6 +537,10 @@ namespace aspect
                                                   &&
                                                   (open_velocity_boundary_indicators.size() == 0));
 
+    // now that all member variables have been set up, also
+    // connect the functions that will actually do the assembly
+    set_assemblers();
+
     // make sure that we don't have to fill every column of the statistics
     // object in each time step.
     statistics.set_auto_fill_mode(true);


### PR DESCRIPTION
This is my second try, following #695.

The idea here is to introduce a structure that contains signals that point to functions that do the actual assembly loop. The setup of scratch objects etc continues to happen at an outer level, but on every cell we then simply call each slot in the signal, and thereby add up terms as appropriate for an equation or approximation.

The current patch is simply a strawman that just does this for the Stokes preconditioner and assembly. It seems to pass the first few tests on my machine, but that's not the point right now. 

Points to discuss:

* Right now, the assembler functions are free functions in a namespace. This makes it relatively easy to add other, similar implementations. It has the disadvantage that the functions do not readily have access to member variables, and so one has to pass a `SimulatorAccess` object to them. I worry that if we create more complex assemblers, that they need more than what they get right now. On the other hand, this probably encourages a clean design where we use as little information as we can. What are people's opinions on free functions? I could as well declare a class `CompleteEquations` (rather than a namespace) which we could then derive from `SimulatorAccess`. I'm not really sure we'd save very much this way, though.

* The signals are declared with only those arguments that differ from invocation to invocation. The functions have other arguments such as the `SimulatorAccess` or `Introspection` argument. I simply `std::bind` them in `set_assemblers()`. This style allows me to define these functions with interfaces that differ by additional `const` arguments that are known at the time `set_assemblers()` is run. 

* Completion of the conversion by doing the same for the temperature/advection system assembly as well as residual assembly, remains to be done. I wanted to have something out for discussion first, before doing the entire conversion.