### PR TITLE
remove some lines that are not needed anywhere

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -870,25 +870,6 @@ namespace aspect
         scratch.finite_element_values[solution_field].get_function_laplacians (old_old_solution,
                                                                                scratch.old_old_field_laplacians);
 
-        compute_material_model_input_values (current_linearization_point,
-                                             scratch.finite_element_values,
-                                             cell,
-                                             true,
-                                             scratch.material_model_inputs);
-        material_model->evaluate(scratch.material_model_inputs,scratch.material_model_outputs);
-        if (advection_field.is_temperature()==true)
-          {
-            MaterialModel::MaterialAveraging::average (parameters.material_averaging,
-                                                       cell,
-                                                       scratch.finite_element_values.get_quadrature(),
-                                                       scratch.finite_element_values.get_mapping(),
-                                                       scratch.material_model_outputs);
-            HeatingModel::HeatingModelOutputs heating_model_outputs(n_q_points, parameters.n_compositional_fields);
-            heating_model_manager.evaluate(scratch.material_model_inputs,
-                                           scratch.material_model_outputs,
-                                           heating_model_outputs);
-          }
-
         for (unsigned int q=0; q<n_q_points; ++q)
           {
             scratch.explicit_material_model_inputs.temperature[q] = (scratch.old_temperature_values[q] + scratch.old_old_temperature_values[q]) / 2;

--- a/tests/cell_reference/screen-output
+++ b/tests/cell_reference/screen-output
@@ -1,10 +1,3 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Loading shared library <./libcell_reference.so>
 
@@ -13,12 +6,8 @@ Number of degrees of freedom: 84 (50+9+25)
 
 *** Timestep 0:  t=0 seconds
 Level: 1 Index: 0
-Level: 1 Index: 0
-Level: 1 Index: 1
 Level: 1 Index: 1
 Level: 1 Index: 2
-Level: 1 Index: 2
-Level: 1 Index: 3
 Level: 1 Index: 3
 Level: 1 Index: 0
 Level: 1 Index: 0
@@ -58,18 +47,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |    0.0294s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |  0.000718s |       2.4% |
-| Assemble temperature system     |         1 |   0.00143s |       4.9% |
-| Build Stokes preconditioner     |         1 |    0.0033s |        11% |
-| Build temperature preconditioner|         1 |  0.000215s |      0.73% |
-| Solve Stokes system             |         1 |   0.00136s |       4.6% |
-| Solve temperature system        |         1 |  0.000197s |      0.67% |
-| Initialization                  |         2 |    0.0164s |        56% |
-| Postprocessing                  |         1 |   0.00199s |       6.8% |
-| Setup dof systems               |         1 |   0.00243s |       8.3% |
 +---------------------------------+-----------+------------+------------+
 


### PR DESCRIPTION
We computed the material model inputs and outputs in the `get_artificial_viscosity()` function in the `assembly.cc`, but they weren't used anywhere.  