### PR TITLE
Add documentation & split domain and boundary integration

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -599,9 +599,37 @@ namespace aspect
        */
       struct Assemblers
       {
+        /**
+         * A signal that is called from Simulator::local_assemble_stokes_preconditioner()
+         * and whose slots are supposed to assemble terms that together form the
+         * Stokes preconditioner matrix.
+         *
+         * The arguments to the slots are as follows:
+         * - The Simulator::pressure_scaling value used to scale velocity
+         *   and pressure components against each other.
+         * - The scratch object in which temporary data is stored that
+         *   assemblers may need.
+         * - The copy object into which assemblers add up their contributions.
+         */
         boost::signals2::signal<void (const double,
                                       internal::Assembly::Scratch::StokesPreconditioner<dim>  &,
                                       internal::Assembly::CopyData::StokesPreconditioner<dim> &)> local_assemble_stokes_preconditioner;
+
+        /**
+         * A signal that is called from Simulator::local_assemble_stokes_system()
+         * and whose slots are supposed to assemble terms that together form the
+         * Stokes system matrix and right hand side.
+         *
+         * The arguments to the slots are as follows:
+         * - The cell on which we currently assemble.
+         * - The Simulator::pressure_scaling value used to scale velocity
+         *   and pressure components against each other.
+         * - Whether or not to actually assemble the matrix. If @p false,
+         *   then only assemble the right hand side of the Stokes system.
+         * - The scratch object in which temporary data is stored that
+         *   assemblers may need.
+         * - The copy object into which assemblers add up their contributions.
+         */
         boost::signals2::signal<void (const typename DoFHandler<dim>::active_cell_iterator &,
                                       const double,
                                       const bool,

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -635,6 +635,32 @@ namespace aspect
                                       const bool,
                                       internal::Assembly::Scratch::StokesSystem<dim>       &,
                                       internal::Assembly::CopyData::StokesSystem<dim>      &)> local_assemble_stokes_system;
+
+        /**
+         * A signal that is called from Simulator::local_assemble_stokes_system()
+         * and whose slots are supposed to assemble terms that together form the
+         * Stokes system matrix and right hand side. This signal is called
+         * once for each boundary face.
+         *
+         * The arguments to the slots are as follows:
+         * - The cell on which we currently assemble.
+         * - The number of the face on which we intend to assemble. This
+         *   face (of the current cell) will be at the boundary of the
+         *   domain.
+         * - The Simulator::pressure_scaling value used to scale velocity
+         *   and pressure components against each other.
+         * - Whether or not to actually assemble the matrix. If @p false,
+         *   then only assemble the right hand side of the Stokes system.
+         * - The scratch object in which temporary data is stored that
+         *   assemblers may need.
+         * - The copy object into which assemblers add up their contributions.
+         */
+        boost::signals2::signal<void (const typename DoFHandler<dim>::active_cell_iterator &,
+                                      const unsigned int,
+                                      const double,
+                                      const bool,
+                                      internal::Assembly::Scratch::StokesSystem<dim>       &,
+                                      internal::Assembly::CopyData::StokesSystem<dim>      &)> local_assemble_stokes_system_on_boundary_face;
       };
 
       /**


### PR DESCRIPTION
This PR adds a bit of documentation in the first commit, relative to the splitting of assemblers developed in #718.

The second patch splits the assembly of Stokes domain and boundary terms into separate signals. This allows the implementation of individual boundary terms to only deal with one face at a time, rather than having to loop over all faces of a cell. I do this for two reasons:
* If we have multiple slots to this signal, then they will all work on the first face, then all on the second face, rather than interleaving their work. This should make data locality better.
* More importantly, if we these face assemblers need an initialized `MaterialModelOutputs` for each face, we want to reuse this for *all* assemblers on one face before moving to the next face, rather than have each assembler initialize it in turns for each face it looks at, and then let the next assembler do it all over again for each face.

I hope this description makes sense...