### PR TITLE
Add assembler properties

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1089,7 +1089,7 @@ namespace aspect
        */
       void
       compute_material_model_input_values (const LinearAlgebra::BlockVector                            &input_solution,
-                                           const FEValues<dim,dim>                                     &input_finite_element_values,
+                                           const FEValuesBase<dim,dim>                                 &input_finite_element_values,
                                            const typename DoFHandler<dim>::active_cell_iterator        &cell,
                                            const bool                                                   compute_strainrate,
                                            MaterialModel::MaterialModelInputs<dim> &material_model_inputs) const;

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -697,6 +697,14 @@ namespace aspect
            * boundary faces.
            */
           bool need_face_material_model_data;
+
+          /**
+           * A list of FEValues UpdateFlags that are necessary for
+           * a given operation. Assembler objects may add to this list
+           * as necessary; it will be initialized with a set of
+           * "default" flags that will always be set.
+           */
+          UpdateFlags needed_update_flags;
         };
 
         /**

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
+  Copyright (C) 2011 - 2016 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -661,6 +661,52 @@ namespace aspect
                                       const bool,
                                       internal::Assembly::Scratch::StokesSystem<dim>       &,
                                       internal::Assembly::CopyData::StokesSystem<dim>      &)> local_assemble_stokes_system_on_boundary_face;
+
+        /**
+         * A structure that describes what information an assembler function
+         * (listed as one of the signals/slots above) may need to operate.
+         *
+         * There are a number of pieces of information that are always
+         * assumed to be needed. For example, the Stokes and advection
+         * assemblers will always need to have access to the material
+         * model outputs. But the Stokes assembler may or may not need
+         * access to material model output for quadrature points on faces.
+         *
+         * These properties are all preset in a conservative way
+         * (i.e., disabled) in the constructor of this class, but can
+         * be enabled in Simulator::set_assemblers() when adding
+         * individual assemblers. Functions such as
+         * Simulator::local_assemble_stokes_preconditioner(),
+         * Simulator::local_assemble_stokes_system() will then query
+         * these flags to determine whether something has to be
+         * initialized for at least one of the assemblers they call.
+         */
+        struct Properties
+        {
+          /**
+           * Constructor. Disable all properties as described in the
+           * class documentation.
+           */
+          Properties ();
+
+          /**
+           * Whether or not at least one of the the assembler slots in
+           * a signal require the initialization and re-computation of
+           * a MaterialModelOutputs object for each face. This
+           * property is only relevant to assemblers that operate on
+           * boundary faces.
+           */
+          bool need_face_material_model_data;
+        };
+
+        /**
+         * A list of properties of the various types of assemblers.
+         * These property lists are set in Simulator::set_assemblers()
+         * where we add individual functions to the signals above.
+         */
+        Properties stokes_preconditioner_assembler_properties;
+        Properties stokes_system_assembler_properties;
+        Properties stokes_system_assembler_on_boundary_face_properties;
       };
 
       /**

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
+  Copyright (C) 2011 - 2016 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -981,6 +981,14 @@ namespace aspect
 
     material_model_inputs.cell = &cell;
   }
+
+
+
+  template <int dim>
+  Simulator<dim>::Assemblers::Properties::Properties ()
+    :
+    need_face_material_model_data (false)
+  {}
 
 
 
@@ -2051,6 +2059,7 @@ namespace aspect
 namespace aspect
 {
 #define INSTANTIATE(dim) \
+  template struct Simulator<dim>::Assemblers::Properties; \
   template void Simulator<dim>::set_assemblers (); \
   template void Simulator<dim>::local_assemble_stokes_preconditioner ( \
                                                                        const DoFHandler<dim>::active_cell_iterator &cell, \

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -67,6 +67,10 @@ namespace aspect
           std::vector<SymmetricTensor<2,dim> > strain_rates;
           std::vector<std::vector<double> >     composition_values;
 
+          /**
+           * Material model inputs and outputs computed at the current
+           * linearization point.
+           */
           MaterialModel::MaterialModelInputs<dim> material_model_inputs;
           MaterialModel::MaterialModelOutputs<dim> material_model_outputs;
         };
@@ -147,6 +151,17 @@ namespace aspect
           std::vector<SymmetricTensor<2,dim> > grads_phi_u;
           std::vector<double>                  div_phi_u;
           std::vector<Tensor<1,dim> >          velocity_values;
+
+          /**
+           * Material model inputs and outputs computed at the current
+           * linearization point.
+           *
+           * In contrast to the variables above, the following two
+           * variables are used in the assembly at quadrature points
+           * on faces, not on cells.
+           */
+          MaterialModel::MaterialModelInputs<dim> face_material_model_inputs;
+          MaterialModel::MaterialModelOutputs<dim> face_material_model_outputs;
         };
 
 
@@ -173,7 +188,9 @@ namespace aspect
           phi_u (finite_element.dofs_per_cell, Utilities::signaling_nan<Tensor<1,dim> >()),
           grads_phi_u (finite_element.dofs_per_cell, Utilities::signaling_nan<SymmetricTensor<2,dim> >()),
           div_phi_u (finite_element.dofs_per_cell, Utilities::signaling_nan<double>()),
-          velocity_values (quadrature.size(), Utilities::signaling_nan<Tensor<1,dim> >())
+          velocity_values (quadrature.size(), Utilities::signaling_nan<Tensor<1,dim> >()),
+          face_material_model_inputs(face_quadrature.size(), n_compositional_fields),
+          face_material_model_outputs(face_quadrature.size(), n_compositional_fields)
         {}
 
 
@@ -192,7 +209,9 @@ namespace aspect
           phi_u (scratch.phi_u),
           grads_phi_u (scratch.grads_phi_u),
           div_phi_u (scratch.div_phi_u),
-          velocity_values (scratch.velocity_values)
+          velocity_values (scratch.velocity_values),
+          face_material_model_inputs(scratch.face_material_model_inputs),
+          face_material_model_outputs(scratch.face_material_model_outputs)
         {}
 
 
@@ -253,9 +272,18 @@ namespace aspect
           std::vector<SymmetricTensor<2,dim> > current_strain_rates;
           std::vector<std::vector<double> > current_composition_values;
 
+          /**
+           * Material model inputs and outputs computed at the current
+           * linearization point.
+           */
           MaterialModel::MaterialModelInputs<dim> material_model_inputs;
           MaterialModel::MaterialModelOutputs<dim> material_model_outputs;
 
+          /**
+           * Material model inputs and outputs computed at a previous
+           * time step's solution, or an extrapolation from previous
+           * time steps.
+           */
           MaterialModel::MaterialModelInputs<dim> explicit_material_model_inputs;
           MaterialModel::MaterialModelOutputs<dim> explicit_material_model_outputs;
         };
@@ -936,7 +964,7 @@ namespace aspect
   void
   Simulator<dim>::
   compute_material_model_input_values (const LinearAlgebra::BlockVector                            &input_solution,
-                                       const FEValues<dim>                                         &input_finite_element_values,
+                                       const FEValuesBase<dim>                                     &input_finite_element_values,
                                        const typename DoFHandler<dim>::active_cell_iterator        &cell,
                                        const bool                                                   compute_strainrate,
                                        MaterialModel::MaterialModelInputs<dim> &material_model_inputs) const
@@ -1544,8 +1572,7 @@ namespace aspect
     if (do_pressure_rhs_compatibility_modification)
       data.local_pressure_shape_function_integrals = 0;
 
-    // we only need the strain rates for the viscosity,
-    // which we only need when rebuilding the matrix
+    // initialize the material model data on the cell
     compute_material_model_input_values (current_linearization_point,
                                          scratch.finite_element_values,
                                          cell,
@@ -1568,12 +1595,36 @@ namespace aspect
     assemblers.local_assemble_stokes_system(cell, pressure_scaling, rebuild_stokes_matrix,
                                             scratch, data);
 
-    // then also work on possible face terms
+    // then also work on possible face terms. if necessary, initialize
+    // the material model data on faces
     for (unsigned int face_no=0; face_no<GeometryInfo<dim>::faces_per_cell; ++face_no)
       if (cell->at_boundary(face_no))
-        assemblers.local_assemble_stokes_system_on_boundary_face(cell, face_no,
-                                                                 pressure_scaling, rebuild_stokes_matrix,
-                                                                 scratch, data);
+        {
+          scratch.face_finite_element_values.reinit (cell, face_no);
+
+          if (assemblers.stokes_system_assembler_on_boundary_face_properties.need_face_material_model_data)
+            {
+              compute_material_model_input_values (current_linearization_point,
+                                                   scratch.face_finite_element_values,
+                                                   cell,
+                                                   rebuild_stokes_matrix,
+                                                   scratch.face_material_model_inputs);
+
+              material_model->evaluate(scratch.face_material_model_inputs,
+                                       scratch.face_material_model_outputs);
+//TODO: the following doesn't currently compile because the get_quadrature() call returns
+//  a dim-1 dimensional quadrature
+              // MaterialModel::MaterialAveraging::average (parameters.material_averaging,
+              //                                            cell,
+              //                                            scratch.face_finite_element_values.get_quadrature(),
+              //                                            scratch.face_finite_element_values.get_mapping(),
+              //                                            scratch.face_material_model_outputs);
+            }
+
+          assemblers.local_assemble_stokes_system_on_boundary_face(cell, face_no,
+                                                                   pressure_scaling, rebuild_stokes_matrix,
+                                                                   scratch, data);
+        }
 
 
     cell->get_dof_indices (data.local_dof_indices);
@@ -1624,42 +1675,47 @@ namespace aspect
     FilteredIterator<typename DoFHandler<dim>::active_cell_iterator>
     CellFilter;
 
-    WorkStream::
-    run (CellFilter (IteratorFilters::LocallyOwnedCell(),
-                     dof_handler.begin_active()),
-         CellFilter (IteratorFilters::LocallyOwnedCell(),
-                     dof_handler.end()),
-         std_cxx11::bind (&Simulator<dim>::
-                          local_assemble_stokes_system,
-                          this,
-                          std_cxx11::_1,
-                          std_cxx11::_2,
-                          std_cxx11::_3),
-         std_cxx11::bind (&Simulator<dim>::
-                          copy_local_to_global_stokes_system,
-                          this,
-                          std_cxx11::_1),
-         internal::Assembly::Scratch::
-         StokesSystem<dim> (finite_element, mapping, quadrature_formula,
-                            face_quadrature_formula,
-                            (update_values    |
-                             update_gradients |
-                             update_quadrature_points  |
-                             update_JxW_values),
-                            // see if we need to assemble traction boundary conditions.
-                            // only if so do we actually need to have an FEFaceValues object
-                            (parameters.prescribed_traction_boundary_indicators.size() > 0
-                             ?
-                             update_values |
-                             update_quadrature_points |
-                             update_normal_vectors |
-                             update_JxW_values
-                             :
-                             UpdateFlags(0)),
-                            parameters.n_compositional_fields),
-         internal::Assembly::CopyData::
-         StokesSystem<dim> (finite_element,
-                            do_pressure_rhs_compatibility_modification));
+    const UpdateFlags cell_update_flags
+      = (update_values    |
+         update_gradients |
+         update_quadrature_points  |
+         update_JxW_values);
+    // see if we need to assemble traction boundary conditions.
+    // only if so do we actually need to have an FEFaceValues object
+    const UpdateFlags face_update_flags
+      = (parameters.prescribed_traction_boundary_indicators.size() > 0
+         ?
+         update_values |
+         update_quadrature_points |
+         update_normal_vectors |
+         update_JxW_values
+         :
+         UpdateFlags(0));
+
+        WorkStream::
+        run (CellFilter (IteratorFilters::LocallyOwnedCell(),
+                         dof_handler.begin_active()),
+             CellFilter (IteratorFilters::LocallyOwnedCell(),
+                         dof_handler.end()),
+             std_cxx11::bind (&Simulator<dim>::
+                              local_assemble_stokes_system,
+                              this,
+                              std_cxx11::_1,
+                              std_cxx11::_2,
+                              std_cxx11::_3),
+             std_cxx11::bind (&Simulator<dim>::
+                              copy_local_to_global_stokes_system,
+                              this,
+                              std_cxx11::_1),
+             internal::Assembly::Scratch::
+             StokesSystem<dim> (finite_element, mapping, quadrature_formula,
+                                face_quadrature_formula,
+                                cell_update_flags,
+                                face_update_flags,
+                                parameters.n_compositional_fields),
+             internal::Assembly::CopyData::
+             StokesSystem<dim> (finite_element,
+                                do_pressure_rhs_compatibility_modification));
 
     system_matrix.compress(VectorOperation::add);
     system_rhs.compress(VectorOperation::add);
@@ -2091,7 +2147,7 @@ namespace aspect
   template void Simulator<dim>::copy_local_to_global_advection_system ( \
                                                                         const internal::Assembly::CopyData::AdvectionSystem<dim> &data); \
   template void Simulator<dim>::assemble_advection_system (const AdvectionField     &advection_field); \
-   
+
 
 
   ASPECT_INSTANTIATE(INSTANTIATE)


### PR DESCRIPTION
This isn't used right now, but it will enable us to define things only
some of the assemblers require.

This patch is on top of what's already proposed in #722. The only commit relevant for now is the last one (the first two are duplicated from #722).

@jdannberg -- would something like this allow you to determine in `local_assemble_stokes_system` that one needs to initialize face material outputs? I don't currently do that because I don't know what fields you need in the scratch data.