### PR TITLE
Replace #include to <simulator.h> with <simulator_access.h>.

### DIFF
--- a/include/aspect/adiabatic_conditions/initial_profile.h
+++ b/include/aspect/adiabatic_conditions/initial_profile.h
@@ -24,7 +24,7 @@
 
 
 #include <aspect/adiabatic_conditions/interface.h>
-#include <aspect/simulator.h>
+#include <aspect/simulator_access.h>
 #include <deal.II/base/point.h>
 
 

--- a/include/aspect/gravity_model/radial.h
+++ b/include/aspect/gravity_model/radial.h
@@ -22,7 +22,7 @@
 #ifndef __aspect__gravity_model_radial_h
 #define __aspect__gravity_model_radial_h
 
-#include <aspect/simulator.h>
+#include <aspect/simulator_access.h>
 #include <aspect/gravity_model/interface.h>
 
 namespace aspect

--- a/include/aspect/initial_conditions/adiabatic.h
+++ b/include/aspect/initial_conditions/adiabatic.h
@@ -23,7 +23,7 @@
 #define __aspect__initial_conditions_adiabatic_h
 
 #include <aspect/initial_conditions/interface.h>
-#include <aspect/simulator.h>
+#include <aspect/simulator_access.h>
 
 #include <deal.II/base/parsed_function.h>
 

--- a/include/aspect/initial_conditions/box.h
+++ b/include/aspect/initial_conditions/box.h
@@ -23,7 +23,7 @@
 #define __aspect__initial_conditions_box_h
 
 #include <aspect/initial_conditions/interface.h>
-#include <aspect/simulator.h>
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {

--- a/include/aspect/initial_conditions/harmonic_perturbation.h
+++ b/include/aspect/initial_conditions/harmonic_perturbation.h
@@ -23,7 +23,7 @@
 #define __aspect__initial_conditions_harmonic_perturbation_h
 
 #include <aspect/initial_conditions/interface.h>
-#include <aspect/simulator.h>
+#include <aspect/simulator_access.h>
 
 
 namespace aspect

--- a/include/aspect/initial_conditions/solidus.h
+++ b/include/aspect/initial_conditions/solidus.h
@@ -24,7 +24,7 @@
 #define __aspect__initial_conditions_solidus_h
 
 #include <aspect/initial_conditions/interface.h>
-#include <aspect/simulator.h>
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {

--- a/include/aspect/initial_conditions/spherical_shell.h
+++ b/include/aspect/initial_conditions/spherical_shell.h
@@ -23,7 +23,7 @@
 #define __aspect__initial_conditions_spherical_shell_h
 
 #include <aspect/initial_conditions/interface.h>
-#include <aspect/simulator.h>
+#include <aspect/simulator_access.h>
 
 
 namespace aspect

--- a/include/aspect/postprocess/topography.h
+++ b/include/aspect/postprocess/topography.h
@@ -23,7 +23,7 @@
 #define __aspect__postprocess_topography_h
 
 #include <aspect/postprocess/interface.h>
-#include <aspect/simulator.h>
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {

--- a/include/aspect/termination_criteria/end_step.h
+++ b/include/aspect/termination_criteria/end_step.h
@@ -22,7 +22,7 @@
 #define __aspect__termination_criteria_end_step_h
 
 #include <aspect/termination_criteria/interface.h>
-#include <aspect/simulator.h>
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {

--- a/include/aspect/termination_criteria/end_time.h
+++ b/include/aspect/termination_criteria/end_time.h
@@ -23,7 +23,7 @@
 #define __aspect__termination_criteria_end_time_h
 
 #include <aspect/termination_criteria/interface.h>
-#include <aspect/simulator.h>
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {

--- a/include/aspect/termination_criteria/steady_rms_velocity.h
+++ b/include/aspect/termination_criteria/steady_rms_velocity.h
@@ -23,7 +23,7 @@
 #define __aspect__termination_criteria_steady_rms_velocity_h
 
 #include <aspect/termination_criteria/interface.h>
-#include <aspect/simulator.h>
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {

--- a/include/aspect/termination_criteria/user_request.h
+++ b/include/aspect/termination_criteria/user_request.h
@@ -23,7 +23,7 @@
 #define __aspect__termination_criteria_user_request_h
 
 #include <aspect/termination_criteria/interface.h>
-#include <aspect/simulator.h>
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {


### PR DESCRIPTION
No plugin should ever need to #include <simulator.h>. Rather, all of them should
be content with just knowing about the <simulator_access.h> class. Replacing
these includes therefore increases modularity, and decreases compile
time. It also makes it a lot simpler to make changes to simulator.h
itself, because it vastly reduces the number of files affected by such
changes.