### PR TITLE
Create the assembler object early.

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1316,9 +1316,6 @@ namespace aspect
   Simulator<dim>::
   set_assemblers ()
   {
-    // allocate the object that holds information about all of the assemblers
-    assemblers.reset (new internal::Assembly::AssemblerLists<dim>());
-
     // create an object for the complete equations assembly; add its
     // member functions to the signals and add the object the list
     // of assembler objects

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -99,6 +99,7 @@ namespace aspect
   Simulator<dim>::Simulator (const MPI_Comm mpi_communicator_,
                              ParameterHandler &prm)
     :
+    assemblers (new internal::Assembly::AssemblerLists<dim>()),
     parameters (prm, mpi_communicator_),
     introspection (parameters),
     mpi_communicator (Utilities::MPI::duplicate_communicator (mpi_communicator_)),


### PR DESCRIPTION
This way, whoever comes along can already subscribe their own assembler
contribution. This way it doesn't all have to happen in set_assemblers().