### PR TITLE
Assembler unique ptr

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -89,7 +89,7 @@ namespace aspect
       {
         template <int dim>      class AssemblerBase;
       }
-      template <int dim>      class AssemblerLists;
+      template <int dim>      struct AssemblerLists;
     }
   }
 

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -61,7 +61,7 @@
 
 #include <boost/iostreams/tee.hpp>
 #include <boost/iostreams/stream.hpp>
-
+#include <deal.II/base/std_cxx11/shared_ptr.h>
 
 namespace aspect
 {
@@ -579,7 +579,7 @@ namespace aspect
        * set_assemblers(), and are later destroyed by the destructor
        * of the current class.
        */
-      std::vector<std_cxx11::unique_ptr<internal::Assembly::Assemblers::AssemblerBase<dim> > > assembler_objects;
+      std::vector<std_cxx11::shared_ptr<internal::Assembly::Assemblers::AssemblerBase<dim> > > assembler_objects;
 
       /**
        * Determine, based on the run-time parameters of the current simulation,

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1137,7 +1137,7 @@ namespace aspect
                                 std_cxx11::_3,
                                 std_cxx11::_4,
                                 std_cxx11::_5));
-    assembler_objects.push_back (std_cxx11::unique_ptr<internal::Assembly::Assemblers::AssemblerBase<dim> >
+    assembler_objects.push_back (std_cxx11::shared_ptr<internal::Assembly::Assemblers::AssemblerBase<dim> >
                                  (complete_equation_assembler));
 
 


### PR DESCRIPTION
A unique_ptr (or boost::scoped_ptr, which is used if we don't have
c++11) can only be placed into std::vector if we have c++11. Instead,
use a shared_ptr for now.