### PR TITLE
More assembly work

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1251,7 +1251,7 @@ namespace aspect
            * assemly of the system matrix.
            */
           void apply_stabilization (const typename DoFHandler<dim>::active_cell_iterator &cell,
-                                    FullMatrix<double> &local_matrix);
+                                    internal::Assembly::CopyData::StokesSystem<dim>      &data);
 
           /**
            * If a geometry model uses manifolds for the refinement behavior

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1410,6 +1410,18 @@ namespace aspect
            */
           std::set<types::boundary_id> tangential_mesh_boundary_indicators;
 
+          /**
+           * A handle on the connection that connects the Stokes assembler
+           * signal of the main simulator object to the apply_stabilization()
+           * function. We keep track of this connection because we need to
+           * break it once the current free surface handler object goes out
+           * of scope.
+           *
+           * With the current variable, the connection is broken once the
+           * scoped_connection goes out of scope, i.e., when the surrounding
+           * class is destroyed.
+           */
+          boost::signals2::scoped_connection assembler_connection;
 
           friend class Simulator<dim>;
           friend class SimulatorAccess<dim>;

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1088,17 +1088,6 @@ namespace aspect
               }
           }
       }
-
-
-
-      template <int dim>
-      void
-      free_boundary_stokes_contribution (const typename DoFHandler<dim>::active_cell_iterator &cell,
-                                         typename Simulator<dim>::FreeSurfaceHandler          &free_surface,
-                                         internal::Assembly::CopyData::StokesSystem<dim>      &data)
-      {
-        free_surface.apply_stabilization(cell, data.local_matrix);
-      }
     }
   }
 
@@ -1151,17 +1140,6 @@ namespace aspect
                               // discard rebuild_stokes_matrix,
                               std_cxx11::_5,
                               std_cxx11::_6));
-
-    // and, if necessary, the function that computes stabilization terms for free boundaries
-    if (parameters.free_surface_enabled)
-      assemblers->local_assemble_stokes_system
-      .connect (std_cxx11::bind(&aspect::Assemblers::OtherTerms::free_boundary_stokes_contribution<dim>,
-                                std_cxx11::_1,
-                                std_cxx11::ref(*free_surface.get()),
-                                // discard pressure_scaling,
-                                // discard rebuild_stokes_matrix,
-                                // discard scratch object,
-                                std_cxx11::_5));
 
     // add the terms necessary to normalize the pressure
     if (do_pressure_rhs_compatibility_modification)

--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -56,14 +56,16 @@ namespace aspect
       free_surface_dof_handler (sim.triangulation)
   {
     parse_parameters(prm);
-    sim.assemblers->local_assemble_stokes_system
-    .connect (std_cxx11::bind(&Simulator<dim>::FreeSurfaceHandler::apply_stabilization,
-                              std_cxx11::ref(*this),
-                              std_cxx11::_1,
-                              // discard pressure_scaling,
-                              // discard rebuild_stokes_matrix,
-                              // discard scratch object,
-                              std_cxx11::_5));
+
+    assembler_connection =
+      sim.assemblers->local_assemble_stokes_system
+      .connect (std_cxx11::bind(&Simulator<dim>::FreeSurfaceHandler::apply_stabilization,
+                                std_cxx11::ref(*this),
+                                std_cxx11::_1,
+                                // discard pressure_scaling,
+                                // discard rebuild_stokes_matrix,
+                                // discard scratch object,
+                                std_cxx11::_5));
 
   }
 

--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -21,6 +21,7 @@
 
 #include <aspect/simulator.h>
 #include <aspect/global.h>
+#include <aspect/assembly.h>
 
 #include <deal.II/dofs/dof_renumbering.h>
 #include <deal.II/dofs/dof_accessor.h>
@@ -48,14 +49,37 @@ using namespace dealii;
 namespace aspect
 {
 
+  namespace
+  {
+
+    template <int dim>
+    void
+    free_boundary_stokes_contribution (const typename DoFHandler<dim>::active_cell_iterator &cell,
+                                       typename Simulator<dim>::FreeSurfaceHandler          &free_surface,
+                                       internal::Assembly::CopyData::StokesSystem<dim>      &data)
+    {
+      free_surface.apply_stabilization(cell, data.local_matrix);
+    }
+  }
+
+
   template <int dim>
-  Simulator<dim>::FreeSurfaceHandler::FreeSurfaceHandler( Simulator<dim> &simulator,
+  Simulator<dim>::FreeSurfaceHandler::FreeSurfaceHandler (Simulator<dim> &simulator,
                                                           ParameterHandler &prm)
     : sim(simulator),  //reference to the simulator that owns the FreeSurfaceHandler
       free_surface_fe (FE_Q<dim>(1),dim), //Q1 elements which describe the mesh geometry
       free_surface_dof_handler (sim.triangulation)
   {
     parse_parameters(prm);
+    sim.assemblers->local_assemble_stokes_system
+    .connect (std_cxx11::bind(&free_boundary_stokes_contribution<dim>,
+                              std_cxx11::_1,
+                              std_cxx11::ref(*this),
+                              // discard pressure_scaling,
+                              // discard rebuild_stokes_matrix,
+                              // discard scratch object,
+                              std_cxx11::_5));
+
   }
 
   template <int dim>


### PR DESCRIPTION
This PR simplifies code in that it lets the `FreeSurfaceHandler` class add its assembler itself, rather than putting this into `Simulator::set_assemblers()`. It also removes, in the process, a helper function.