### PR TITLE
Improve timestep logic

### DIFF
--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -280,14 +280,18 @@ namespace aspect
   {
     const QIterated<dim> quadrature_formula (QTrapez<1>(),
                                              parameters.stokes_velocity_degree);
+
+    FEValues<dim> fe_values (mapping,
+                             finite_element,
+                             quadrature_formula,
+                             update_values |
+                             update_gradients |
+                             (parameters.use_conduction_timestep ? update_quadrature_points : update_default));
+
     const unsigned int n_q_points = quadrature_formula.size();
 
-    FEValues<dim> fe_values (mapping, finite_element, quadrature_formula, update_values | update_gradients | (parameters.use_conduction_timestep ? update_quadrature_points : update_default));
     std::vector<Tensor<1,dim> > velocity_values(n_q_points);
-    std::vector<double> pressure_values(n_q_points), temperature_values(n_q_points);
-    std::vector<Tensor<1,dim> > pressure_gradients(n_q_points);
     std::vector<std::vector<double> > composition_values (parameters.n_compositional_fields,std::vector<double> (n_q_points));
-    std::vector<double> composition_values_at_q_point (parameters.n_compositional_fields);
 
     double max_local_speed_over_meshsize = 0;
     double min_local_conduction_timestep = std::numeric_limits<double>::max();
@@ -312,35 +316,31 @@ namespace aspect
                                                    cell->minimum_vertex_distance());
           if (parameters.use_conduction_timestep)
             {
+              MaterialModel::MaterialModelInputs<dim> in(n_q_points, parameters.n_compositional_fields);
+              MaterialModel::MaterialModelOutputs<dim> out(n_q_points, parameters.n_compositional_fields);
+
+              in.strain_rate.resize(0); // we do not need the viscosity
+              in.position = fe_values.get_quadrature_points();
+              in.cell = &cell;
+
               fe_values[introspection.extractors.pressure].get_function_values (solution,
-                                                                                pressure_values);
+                                                                                in.pressure);
               fe_values[introspection.extractors.temperature].get_function_values (solution,
-                                                                                   temperature_values);
+                                                                                   in.temperature);
               fe_values[introspection.extractors.pressure].get_function_gradients (solution,
-                                                                                   pressure_gradients);
+                                                                                   in.pressure_gradient);
+
               for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
                 fe_values[introspection.extractors.compositional_fields[c]].get_function_values (solution,
                     composition_values[c]);
 
-              MaterialModel::MaterialModelInputs<dim> in(n_q_points, parameters.n_compositional_fields);
-              MaterialModel::MaterialModelOutputs<dim> out(n_q_points, parameters.n_compositional_fields);
-
-              in.strain_rate.resize(0);// we are not reading the viscosity
-
-              for (unsigned int q=0; q<n_q_points; ++q)
+              for (unsigned int q=0; q<fe_values.n_quadrature_points; ++q)
                 {
-                  for (unsigned int k=0; k < composition_values_at_q_point.size(); ++k)
-                    composition_values_at_q_point[k] = composition_values[k][q];
-
-                  in.position[q] = fe_values.quadrature_point(q);
-                  in.temperature[q] = temperature_values[q];
-                  in.pressure[q] = pressure_values[q];
-                  in.velocity[q] = velocity_values[q];
-                  in.pressure_gradient[q] = pressure_gradients[q];
                   for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
-                    in.composition[q][c] = composition_values_at_q_point[c];
+                    in.composition[q][c] = composition_values[c][q];
+
+                  in.velocity[q] = velocity_values[q];
                 }
-              in.cell = &cell;
 
               material_model->evaluate(in, out);
 
@@ -352,9 +352,9 @@ namespace aspect
                   const double rho = out.densities[q];
                   const double c_p = out.specific_heat[q];
 
-                  Assert(rho*c_p > 0,
+                  Assert(rho * c_p > 0,
                          ExcMessage ("The product of density and c_P needs to be a "
-                                                     "non-negative quantity."));
+                                     "non-negative quantity."));
 
                   const double thermal_diffusivity = k/(rho*c_p);
 
@@ -372,10 +372,10 @@ namespace aspect
       = Utilities::MPI::max (max_local_speed_over_meshsize, mpi_communicator);
 
     double min_convection_timestep = std::numeric_limits<double>::max();
+    double min_conduction_timestep = std::numeric_limits<double>::max();
+
     if (max_global_speed_over_meshsize != 0.0)
       min_convection_timestep = parameters.CFL_number / (parameters.temperature_degree * max_global_speed_over_meshsize);
-
-    double min_conduction_timestep = std::numeric_limits<double>::max();
 
     if (parameters.use_conduction_timestep)
       MPI_Allreduce (&min_local_conduction_timestep, &min_conduction_timestep, 1, MPI_DOUBLE, MPI_MIN, mpi_communicator);

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -378,7 +378,7 @@ namespace aspect
       min_convection_timestep = parameters.CFL_number / (parameters.temperature_degree * max_global_speed_over_meshsize);
 
     if (parameters.use_conduction_timestep)
-      MPI_Allreduce (&min_local_conduction_timestep, &min_conduction_timestep, 1, MPI_DOUBLE, MPI_MIN, mpi_communicator);
+      min_conduction_timestep = - Utilities::MPI::max (-min_local_conduction_timestep, mpi_communicator);
 
     double new_time_step = std::min(min_convection_timestep,min_conduction_timestep);
     bool convection_dominant = (min_convection_timestep < min_conduction_timestep);


### PR DESCRIPTION
I stumbled over the `compute_time_step` function while investigating #293. The logic at the end did throw a floating point exception when `max_global_speed_over_meshsize == 0 && min_conduction_timestep < std::numeric_limits<double>::max()`. Additionally filling the material model inputs was inefficient and creating FEValues did not follow our usual line break convention. This PR should fix these minor things, it does not fix #293 however.