### PR TITLE
Use mapping for output interpolation

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -5,6 +5,14 @@
  * 1.3. All entries are signed with the names of the author. </p>
  *
  * <ol>
+ * <li> Improved: The option to increase the output resolution by linear
+ * interpolation of the quadratic elements now correctly uses the mapping of
+ * curved geometries to interpolate cells. This increases output accuracy for
+ * models that use curved geometries and use 'Set Interpolate output = true'.
+ * The simulation itself is not affected.
+ * <br>
+ * (Rene Gassmoeller, 2016/02/08)
+ *
  * <li> Changed: The GPlates plugin is restructured in the style of the
  * AsciiData Plugin. The major difference is that the interpolation is now
  * performed in spherical coordinates instead of Cartesian coordinates. Note

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -381,12 +381,21 @@ namespace aspect
 
         }
 
-      // now build the patches and see how we can output these
-      data_out.build_patches ((interpolate_output) ?
-                              this->get_stokes_velocity_degree()
-                              :
-                              0);
+      // Now build the patches. If selected, increase the output resolution.
+      if (interpolate_output)
+        {
+          data_out.build_patches (this->get_mapping(),
+                                  this->get_stokes_velocity_degree(),
+                                  this->get_geometry_model().has_curved_elements()
+                                  ?
+                                  DataOut<dim>::curved_inner_cells
+                                  :
+                                  DataOut<dim>::no_curved_cells);
+        }
+      else
+        data_out.build_patches();
 
+      // Now prepare everything for writing the output and choose output format
       std::string solution_file_prefix = "solution-" + Utilities::int_to_string (output_file_number, 5);
       std::string mesh_file_prefix = "mesh-" + Utilities::int_to_string (output_file_number, 5);
       const double time_in_years_or_seconds = (this->convert_output_to_years() ?


### PR DESCRIPTION
This improves output quality of the interpolated output mesh. So far the 'real' mesh cells followed the mapping, but the additional interpolated output cells used a Q1 mapping, which puzzled me a bit when looking at the output in detail. It is not affecting any solution, but this new way looks nicer and creates a more consistent mesh.