### PR TITLE
Use MPI_Bcast for input data

### DIFF
--- a/include/aspect/initial_conditions/solidus.h
+++ b/include/aspect/initial_conditions/solidus.h
@@ -42,7 +42,8 @@ namespace aspect
         /**
          * Read the data file into the class.
          */
-        void read(const std::string &filename);
+        void read(const std::string &filename,
+                  const MPI_Comm &comm);
 
         /**
          * Get the melting temperature.

--- a/include/aspect/material_model/depth_dependent.h
+++ b/include/aspect/material_model/depth_dependent.h
@@ -110,7 +110,8 @@ namespace aspect
          * for File depth dependence method
          */
         void
-        read_viscosity_file(const std::string &filename);
+        read_viscosity_file(const std::string &filename,
+                            const MPI_Comm &comm);
 
         /**
          * Data structures to store depth and viscosity lookup tables as well as interpolating

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -74,21 +74,18 @@ namespace aspect
     bool fexists(const std::string &filename);
 
     /**
-     * Loads the content of the ascii file @param filename on process 0 and
-     * distribute the content by MPI_Bcast to all processes. After the call
-     * @param datastream contains the content of the file on all processes.
+     * Reads the content of the ascii file @param filename on process 0 and
+     * distributes the content by MPI_Bcast to all processes. The function
+     * returns the content of the file on all processes.
      *
      * @param [in] filename The name of the ascii file to load.
      * @param [in] comm The MPI communicator in which the content is
      * distributed.
-     * @param [in,out] datastream A string which is resized and overwritten
-     * by the filecontent in @param filename. After the call the string has
-     * the same content on all processes in @param comm.
+     * @return A string which contains the data in @param filename.
      */
-    void
-    load_and_distribute_file_content(const std::string &filename,
-                                     const MPI_Comm &comm,
-                                     std::stringstream &datastream);
+    std::string
+    read_and_distribute_file_content(const std::string &filename,
+                                     const MPI_Comm &comm);
 
     /**
      * Creates a path as if created by the shell command "mkdir -p", therefore

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -74,6 +74,23 @@ namespace aspect
     bool fexists(const std::string &filename);
 
     /**
+     * Loads the content of the ascii file @param filename on process 0 and
+     * distribute the content by MPI_Bcast to all processes. After the call
+     * @param datastream contains the content of the file on all processes.
+     *
+     * @param [in] filename The name of the ascii file to load.
+     * @param [in] comm The MPI communicator in which the content is
+     * distributed.
+     * @param [in,out] datastream A string which is resized and overwritten
+     * by the filecontent in @param filename. After the call the string has
+     * the same content on all processes in @param comm.
+     */
+    void
+    load_and_distribute_file_content(const std::string &filename,
+                                     const MPI_Comm &comm,
+                                     std::stringstream &datastream);
+
+    /**
      * Creates a path as if created by the shell command "mkdir -p", therefore
      * generating directories from the highest to the lowest level if they are
      * not already existing.
@@ -281,7 +298,8 @@ namespace aspect
          * changes over model runtime.
          */
         void
-        load_file(const std::string &filename);
+        load_file(const std::string &filename,
+                  const MPI_Comm &communicator);
 
         /**
          * Returns the computed data (velocity, temperature, etc. - according

--- a/include/aspect/velocity_boundary_conditions/gplates.h
+++ b/include/aspect/velocity_boundary_conditions/gplates.h
@@ -65,7 +65,8 @@ namespace aspect
            * Loads a gplates .gpml velocity file. Throws an exception if the
            * file does not exist.
            */
-          void load_file(const std::string &filename);
+          void load_file(const std::string &filename,
+                         const MPI_Comm &comm);
 
           /**
            * Returns the computed surface velocity in cartesian coordinates.

--- a/source/initial_conditions/S40RTS_perturbation.cc
+++ b/source/initial_conditions/S40RTS_perturbation.cc
@@ -48,8 +48,7 @@ namespace aspect
             {
               std::string temp;
               // Read data from disk and distribute among processes
-              std::stringstream in;
-              Utilities::load_and_distribute_file_content(filename, comm, in);
+              std::istringstream in(Utilities::read_and_distribute_file_content(filename, comm));
 
               in >> order;
               getline(in,temp);  // throw away the rest of the line
@@ -127,8 +126,7 @@ namespace aspect
             {
               std::string temp;
               // Read data from disk and distribute among processes
-              std::stringstream in;
-              Utilities::load_and_distribute_file_content(filename, comm, in);
+              std::istringstream in(Utilities::read_and_distribute_file_content(filename, comm));
 
               getline(in,temp);  // throw away the rest of the line
               getline(in,temp);  // throw away the rest of the line

--- a/source/initial_conditions/S40RTS_perturbation.cc
+++ b/source/initial_conditions/S40RTS_perturbation.cc
@@ -43,12 +43,13 @@ namespace aspect
         class SphericalHarmonicsLookup
         {
           public:
-            SphericalHarmonicsLookup(const std::string &filename)
+            SphericalHarmonicsLookup(const std::string &filename,
+                                     const MPI_Comm &comm)
             {
               std::string temp;
-              std::ifstream in(filename.c_str(), std::ios::in);
-              AssertThrow (in,
-                           ExcMessage (std::string("Could not open file <") + filename + ">."));
+              // Read data from disk and distribute among processes
+              std::stringstream in;
+              Utilities::load_and_distribute_file_content(filename, comm, in);
 
               in >> order;
               getline(in,temp);  // throw away the rest of the line
@@ -121,12 +122,13 @@ namespace aspect
         class SplineDepthsLookup
         {
           public:
-            SplineDepthsLookup(const std::string &filename)
+            SplineDepthsLookup(const std::string &filename,
+                               const MPI_Comm &comm)
             {
               std::string temp;
-              std::ifstream in(filename.c_str(), std::ios::in);
-              AssertThrow (in,
-                           ExcMessage (std::string("Could not open file <") + filename + ">."));
+              // Read data from disk and distribute among processes
+              std::stringstream in;
+              Utilities::load_and_distribute_file_content(filename, comm, in);
 
               getline(in,temp);  // throw away the rest of the line
               getline(in,temp);  // throw away the rest of the line
@@ -158,8 +160,8 @@ namespace aspect
     void
     S40RTSPerturbation<dim>::initialize()
     {
-      spherical_harmonics_lookup.reset(new internal::S40RTS::SphericalHarmonicsLookup(datadirectory+harmonics_coeffs_file_name));
-      spline_depths_lookup.reset(new internal::S40RTS::SplineDepthsLookup(datadirectory+spline_depth_file_name));
+      spherical_harmonics_lookup.reset(new internal::S40RTS::SphericalHarmonicsLookup(datadirectory+harmonics_coeffs_file_name,this->get_mpi_communicator()));
+      spline_depths_lookup.reset(new internal::S40RTS::SplineDepthsLookup(datadirectory+spline_depth_file_name,this->get_mpi_communicator()));
     }
 
     // NOTE: this module uses the Boost spherical harmonics package which is not designed

--- a/source/initial_conditions/SAVANI_perturbation.cc
+++ b/source/initial_conditions/SAVANI_perturbation.cc
@@ -48,8 +48,7 @@ namespace aspect
             {
               std::string temp;
               // Read data from disk and distribute among processes
-              std::stringstream in;
-              Utilities::load_and_distribute_file_content(filename, comm, in);
+              std::istringstream in(Utilities::read_and_distribute_file_content(filename, comm));
 
               in >> order;
               getline(in,temp);  // throw away the rest of the line
@@ -129,8 +128,7 @@ namespace aspect
             {
               std::string temp;
               // Read data from disk and distribute among processes
-              std::stringstream in;
-              Utilities::load_and_distribute_file_content(filename, comm, in);
+              std::istringstream in(Utilities::read_and_distribute_file_content(filename, comm));
 
               getline(in,temp);  // throw away the rest of the line
               getline(in,temp);  // throw away the rest of the line

--- a/source/initial_conditions/SAVANI_perturbation.cc
+++ b/source/initial_conditions/SAVANI_perturbation.cc
@@ -43,12 +43,13 @@ namespace aspect
         class SphericalHarmonicsLookup
         {
           public:
-            SphericalHarmonicsLookup(const std::string &filename)
+            SphericalHarmonicsLookup(const std::string &filename,
+                                     const MPI_Comm &comm)
             {
               std::string temp;
-              std::ifstream in(filename.c_str(), std::ios::in);
-              AssertThrow (in,
-                           ExcMessage (std::string("Could not open file <") + filename + ">."));
+              // Read data from disk and distribute among processes
+              std::stringstream in;
+              Utilities::load_and_distribute_file_content(filename, comm, in);
 
               in >> order;
               getline(in,temp);  // throw away the rest of the line
@@ -123,12 +124,13 @@ namespace aspect
         class SplineDepthsLookup
         {
           public:
-            SplineDepthsLookup(const std::string &filename)
+            SplineDepthsLookup(const std::string &filename,
+                               const MPI_Comm &comm)
             {
               std::string temp;
-              std::ifstream in(filename.c_str(), std::ios::in);
-              AssertThrow (in,
-                           ExcMessage (std::string("Could not open file <") + filename + ">."));
+              // Read data from disk and distribute among processes
+              std::stringstream in;
+              Utilities::load_and_distribute_file_content(filename, comm, in);
 
               getline(in,temp);  // throw away the rest of the line
               getline(in,temp);  // throw away the rest of the line
@@ -159,8 +161,8 @@ namespace aspect
     void
     SAVANIPerturbation<dim>::initialize()
     {
-      spherical_harmonics_lookup.reset(new internal::SAVANI::SphericalHarmonicsLookup(datadirectory+harmonics_coeffs_file_name));
-      spline_depths_lookup.reset(new internal::SAVANI::SplineDepthsLookup(datadirectory+spline_depth_file_name));
+      spherical_harmonics_lookup.reset(new internal::SAVANI::SphericalHarmonicsLookup(datadirectory+harmonics_coeffs_file_name,this->get_mpi_communicator()));
+      spline_depths_lookup.reset(new internal::SAVANI::SplineDepthsLookup(datadirectory+spline_depth_file_name,this->get_mpi_communicator()));
     }
 
     // NOTE: this module uses the Boost spherical harmonics package which is not designed

--- a/source/initial_conditions/solidus.cc
+++ b/source/initial_conditions/solidus.cc
@@ -36,8 +36,7 @@ namespace aspect
     {
       data_filename=filename;
       // Read data from disk and distribute among processes
-      std::stringstream in;
-      Utilities::load_and_distribute_file_content(filename, comm, in);
+      std::istringstream in(Utilities::read_and_distribute_file_content(filename, comm));
 
       std::string dummy;
 

--- a/source/initial_conditions/solidus.cc
+++ b/source/initial_conditions/solidus.cc
@@ -19,22 +19,25 @@
 */
 
 
-//#define _USE_MATH_DEFINES
-#include <cmath>
 #include <aspect/initial_conditions/solidus.h>
+#include <aspect/utilities.h>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/boundary_temperature/interface.h>
+
 #include <boost/math/special_functions/spherical_harmonic.hpp>
+#include <cmath>
 
 namespace aspect
 {
   namespace InitialConditions
   {
-    void MeltingCurve::read(const std::string &filename)
+    void MeltingCurve::read(const std::string &filename,
+                            const MPI_Comm &comm)
     {
       data_filename=filename;
-      std::ifstream in(data_filename.c_str(), std::ios::in);
-      AssertThrow (in, ExcMessage (std::string("Can't read file <") + filename + ">"));
+      // Read data from disk and distribute among processes
+      std::stringstream in;
+      Utilities::load_and_distribute_file_content(filename, comm, in);
 
       std::string dummy;
 
@@ -293,7 +296,7 @@ namespace aspect
             }
 
             // then actually read the file
-            solidus_curve.read(solidus_filename);
+            solidus_curve.read(solidus_filename,this->get_mpi_communicator());
           }
           prm.leave_subsection();
         }

--- a/source/material_model/depth_dependent.cc
+++ b/source/material_model/depth_dependent.cc
@@ -39,8 +39,7 @@ namespace aspect
     {
       /* This method is used for the Table method of depth dependent viscosity */
       // Read data from disk and distribute among processes
-      std::stringstream in;
-      Utilities::load_and_distribute_file_content(filename, comm, in);
+      std::istringstream in(Utilities::read_and_distribute_file_content(filename, comm));
 
       double min_depth=std::numeric_limits<double>::max();
       double max_depth=-std::numeric_limits<double>::max();

--- a/source/material_model/depth_dependent.cc
+++ b/source/material_model/depth_dependent.cc
@@ -18,8 +18,11 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <deal.II/base/std_cxx11/array.h>
 #include <aspect/material_model/depth_dependent.h>
+#include <aspect/utilities.h>
+
+#include <deal.II/base/std_cxx11/array.h>
+
 #include <utility>
 #include <limits>
 
@@ -31,12 +34,13 @@ namespace aspect
   {
     template <int dim>
     void
-    DepthDependent<dim>::read_viscosity_file(const std::string &filename)
+    DepthDependent<dim>::read_viscosity_file(const std::string &filename,
+                                             const MPI_Comm &comm)
     {
       /* This method is used for the Table method of depth dependent viscosity */
-      std::ifstream in(filename.c_str(), std::ios::in);
-      AssertThrow (in,
-                   ExcMessage (std::string("Could not open file <") + filename + ">."));
+      // Read data from disk and distribute among processes
+      std::stringstream in;
+      Utilities::load_and_distribute_file_content(filename, comm, in);
 
       double min_depth=std::numeric_limits<double>::max();
       double max_depth=-std::numeric_limits<double>::max();
@@ -258,7 +262,7 @@ namespace aspect
                                        datadirectory.begin()+position+subst_text.size(),
                                        ASPECT_SOURCE_DIR);
               /* If using the File method for depth-dependence, initialize the lookup table */
-              read_viscosity_file(datadirectory+radial_viscosity_file_name);
+              read_viscosity_file(datadirectory+radial_viscosity_file_name,this->get_mpi_communicator());
             }
 
           prm.enter_subsection("Viscosity depth function");

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -20,8 +20,9 @@
 
 
 #include <aspect/material_model/steinberger.h>
-#include <aspect/simulator_access.h>
+#include <aspect/utilities.h>
 #include <aspect/lateral_averaging.h>
+
 #include <deal.II/base/table.h>
 #include <fstream>
 #include <iostream>
@@ -41,7 +42,8 @@ namespace aspect
       {
         public:
           MaterialLookup(const std::string &filename,
-                         const bool interpol)
+                         const bool interpol,
+                         const MPI_Comm &comm)
           {
 
             /* Initializing variables */
@@ -54,9 +56,9 @@ namespace aspect
             numpress=0;
 
             std::string temp;
-            std::ifstream in(filename.c_str(), std::ios::in);
-            AssertThrow (in,
-                         ExcMessage (std::string("Could not open file <") + filename + ">."));
+            // Read data from disk and distribute among processes
+            std::stringstream in;
+            Utilities::load_and_distribute_file_content(filename, comm, in);
 
             getline(in, temp); // eat first line
             getline(in, temp); // eat next line
@@ -303,12 +305,13 @@ namespace aspect
       class LateralViscosityLookup
       {
         public:
-          LateralViscosityLookup(const std::string &filename)
+          LateralViscosityLookup(const std::string &filename,
+                                 const MPI_Comm &comm)
           {
             std::string temp;
-            std::ifstream in(filename.c_str(), std::ios::in);
-            AssertThrow (in,
-                         ExcMessage (std::string("Could not open file <") + filename + ">."));
+            // Read data from disk and distribute among processes
+            std::stringstream in;
+            Utilities::load_and_distribute_file_content(filename, comm, in);
 
             getline(in, temp); // eat first line
 
@@ -361,12 +364,13 @@ namespace aspect
       class RadialViscosityLookup
       {
         public:
-          RadialViscosityLookup(const std::string &filename)
+          RadialViscosityLookup(const std::string &filename,
+                                const MPI_Comm &comm)
           {
             std::string temp;
-            std::ifstream in(filename.c_str(), std::ios::in);
-            AssertThrow (in,
-                         ExcMessage (std::string("Could not open file <") + filename + ">."));
+            // Read data from disk and distribute among processes
+            std::stringstream in;
+            Utilities::load_and_distribute_file_content(filename, comm, in);
 
             min_depth=1e20;
             max_depth=-1;
@@ -420,9 +424,9 @@ namespace aspect
       n_material_data = material_file_names.size();
       for (unsigned i = 0; i < n_material_data; i++)
         material_lookup.push_back(std_cxx11::shared_ptr<internal::MaterialLookup>
-                                  (new internal::MaterialLookup(datadirectory+material_file_names[i],interpolation)));
-      lateral_viscosity_lookup.reset(new internal::LateralViscosityLookup(datadirectory+lateral_viscosity_file_name));
-      radial_viscosity_lookup.reset(new internal::RadialViscosityLookup(datadirectory+radial_viscosity_file_name));
+                                  (new internal::MaterialLookup(datadirectory+material_file_names[i],interpolation,this->get_mpi_communicator())));
+      lateral_viscosity_lookup.reset(new internal::LateralViscosityLookup(datadirectory+lateral_viscosity_file_name,this->get_mpi_communicator()));
+      radial_viscosity_lookup.reset(new internal::RadialViscosityLookup(datadirectory+radial_viscosity_file_name,this->get_mpi_communicator()));
       avg_temp.resize(lateral_viscosity_lookup->get_nslices());
     }
 

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -57,8 +57,7 @@ namespace aspect
 
             std::string temp;
             // Read data from disk and distribute among processes
-            std::stringstream in;
-            Utilities::load_and_distribute_file_content(filename, comm, in);
+            std::istringstream in(Utilities::read_and_distribute_file_content(filename, comm));
 
             getline(in, temp); // eat first line
             getline(in, temp); // eat next line
@@ -310,8 +309,7 @@ namespace aspect
           {
             std::string temp;
             // Read data from disk and distribute among processes
-            std::stringstream in;
-            Utilities::load_and_distribute_file_content(filename, comm, in);
+            std::istringstream in(Utilities::read_and_distribute_file_content(filename, comm));
 
             getline(in, temp); // eat first line
 
@@ -369,8 +367,7 @@ namespace aspect
           {
             std::string temp;
             // Read data from disk and distribute among processes
-            std::stringstream in;
-            Utilities::load_and_distribute_file_content(filename, comm, in);
+            std::istringstream in(Utilities::read_and_distribute_file_content(filename, comm));
 
             min_depth=1e20;
             max_depth=-1;

--- a/source/particle/generator/ascii_file.cc
+++ b/source/particle/generator/ascii_file.cc
@@ -35,8 +35,7 @@ namespace aspect
         const std::string filename = data_directory+data_filename;
 
         // Read data from disk and distribute among processes
-        std::stringstream in;
-        Utilities::load_and_distribute_file_content(filename, this->get_mpi_communicator(), in);
+        std::istringstream in(Utilities::read_and_distribute_file_content(filename, this->get_mpi_communicator()));
 
         // Skip header lines
         while (in.peek() == '#')

--- a/source/particle/generator/ascii_file.cc
+++ b/source/particle/generator/ascii_file.cc
@@ -19,6 +19,7 @@
  */
 
 #include <aspect/particle/generator/ascii_file.h>
+#include <aspect/utilities.h>
 
 
 namespace aspect
@@ -32,13 +33,10 @@ namespace aspect
       AsciiFile<dim>::generate_particles(std::multimap<types::LevelInd, Particle<dim> > &particles)
       {
         const std::string filename = data_directory+data_filename;
-        std::ifstream in(filename.c_str(), std::ios::in);
-        AssertThrow (in,
-                     ExcMessage (std::string("Could not open data file <"
-                                             +
-                                             filename
-                                             +
-                                             ">.")));
+
+        // Read data from disk and distribute among processes
+        std::stringstream in;
+        Utilities::load_and_distribute_file_content(filename, this->get_mpi_communicator(), in);
 
         // Skip header lines
         while (in.peek() == '#')

--- a/source/velocity_boundary_conditions/gplates.cc
+++ b/source/velocity_boundary_conditions/gplates.cc
@@ -144,22 +144,17 @@ namespace aspect
 
       template <int dim>
       void
-      GPlatesLookup<dim>::load_file(const std::string &filename)
+      GPlatesLookup<dim>::load_file(const std::string &filename,
+                                    const MPI_Comm &comm)
       {
+        // Read data from disk and distribute among processes
+        std::stringstream filecontent;
+        Utilities::load_and_distribute_file_content(filename, comm, filecontent);
+
         boost::property_tree::ptree pt;
 
-        // Check whether file exists, we do not want to throw
-        // an exception in case it does not, because it could be by purpose
-        // (i.e. the end of the boundary condition is reached)
-        AssertThrow (Utilities::fexists(filename),
-                     ExcMessage (std::string("GPlates file <")
-                                 +
-                                 filename
-                                 +
-                                 "> not found!"));
-
         // populate tree structure pt
-        read_xml(filename, pt);
+        read_xml(filecontent, pt);
 
         const unsigned int n_points = pt.get_child("gpml:FeatureCollection.gml:featureMember.gpml:VelocityField.gml:domainSet.gml:MultiPoint").size();
 
@@ -592,7 +587,7 @@ namespace aspect
 
       const std::string filename (create_filename (current_file_number));
       if (Utilities::fexists(filename))
-        lookup->load_file(filename);
+        lookup->load_file(filename,this->get_mpi_communicator());
       else
         AssertThrow(false,
                     ExcMessage (std::string("GPlates data file <")
@@ -617,7 +612,7 @@ namespace aspect
           if (Utilities::fexists(filename))
             {
               lookup.swap(old_lookup);
-              lookup->load_file(filename);
+              lookup->load_file(filename,this->get_mpi_communicator());
             }
           else
             end_time_dependence ();
@@ -704,7 +699,7 @@ namespace aspect
           if (Utilities::fexists(filename))
             {
               lookup.swap(old_lookup);
-              lookup->load_file(filename);
+              lookup->load_file(filename,this->get_mpi_communicator());
             }
 
           // If loading current_time_step failed, end time dependent part with old_file_number.
@@ -725,7 +720,7 @@ namespace aspect
       if (Utilities::fexists(filename))
         {
           lookup.swap(old_lookup);
-          lookup->load_file(filename);
+          lookup->load_file(filename,this->get_mpi_communicator());
         }
 
       // If next file does not exist, end time dependent part with current_time_step.

--- a/source/velocity_boundary_conditions/gplates.cc
+++ b/source/velocity_boundary_conditions/gplates.cc
@@ -148,8 +148,8 @@ namespace aspect
                                     const MPI_Comm &comm)
       {
         // Read data from disk and distribute among processes
-        std::stringstream filecontent;
-        Utilities::load_and_distribute_file_content(filename, comm, filecontent);
+        std::istringstream filecontent(
+          Utilities::read_and_distribute_file_content(filename, comm));
 
         boost::property_tree::ptree pt;
 


### PR DESCRIPTION
While working on #752 I noticed that there was an issue with the file input in ASPECT that I wanted to address since my last computing time proposal: We handle file output very carefully in terms of avoiding unnecessary IO accesses and slowdowns, but every file input is handled very simple and duplicated by letting every MPI process read a file from disk. While input files are usually smaller than output files they can still reach several MB size, and I even had some models with a one GB material table once. This way, even with small input data files, models with several hundreds to a thousand processes can generate as much input file traffic (with many accesses in very short time) as output traffic.
We should handle this more elegantly and with this PR, all file input operations are bundled in one utility function. It currently reads the file on process 0 and distributes the content via MPI_Bcast to other processes. While for small models and files the new approach might be slightly slower (there is more copying of data involved, and a global MPI communication), it should not matter much, because the file input is very fast in that case anyway.
In principle there is an alternative approach in using MPI I/O for the input operation, but for now I am not sure it will be faster than the current implementation. In case it will become necessary we might still do a benchmark later on and just change the newly created utility function then. At least now every file access is handled by the same function.
What do you think about this issue?