### PR TITLE
Improve an error message.

### DIFF
--- a/source/boundary_temperature/function.cc
+++ b/source/boundary_temperature/function.cc
@@ -116,7 +116,9 @@ namespace aspect
             std::cerr << "ERROR: FunctionParser failed to parse\n"
                       << "\t'Boundary temperature model.Function'\n"
                       << "with expression\n"
-                      << "\t'" << prm.get("Function expression") << "'";
+                      << "\t'" << prm.get("Function expression") << "'"
+                      << "More information about the cause of the parse error \n"
+                      << "is shown below.\n";
             throw;
           }
         min_temperature = prm.get_double ("Minimal temperature");

--- a/source/compositional_initial_conditions/function.cc
+++ b/source/compositional_initial_conditions/function.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
+  Copyright (C) 2011 - 2016 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -80,7 +80,9 @@ namespace aspect
             std::cerr << "ERROR: FunctionParser failed to parse\n"
                       << "\t'Compositional initial conditions.Function'\n"
                       << "with expression\n"
-                      << "\t'" << prm.get("Function expression") << "'";
+                      << "\t'" << prm.get("Function expression") << "'\n"
+                      << "More information about the cause of the parse error \n"
+                      << "is shown below.\n";
             throw;
           }
 

--- a/source/gravity_model/function.cc
+++ b/source/gravity_model/function.cc
@@ -74,7 +74,9 @@ namespace aspect
             std::cerr << "ERROR: FunctionParser failed to parse\n"
                       << "\t'Gravity Model.Function'\n"
                       << "with expression\n"
-                      << "\t'" << prm.get("Function expression") << "'";
+                      << "\t'" << prm.get("Function expression") << "'"
+                      << "More information about the cause of the parse error \n"
+                      << "is shown below.\n";
             throw;
           }
         prm.leave_subsection();

--- a/source/heating_model/function.cc
+++ b/source/heating_model/function.cc
@@ -96,7 +96,9 @@ namespace aspect
             std::cerr << "ERROR: FunctionParser failed to parse\n"
                       << "\t'Heating model.Function'\n"
                       << "with expression\n"
-                      << "\t'" << prm.get("Function expression") << "'";
+                      << "\t'" << prm.get("Function expression") << "'"
+                      << "More information about the cause of the parse error \n"
+                      << "is shown below.\n";
             throw;
           }
         {

--- a/source/initial_conditions/adiabatic.cc
+++ b/source/initial_conditions/adiabatic.cc
@@ -307,9 +307,11 @@ namespace aspect
               catch (...)
                 {
                   std::cerr << "ERROR: FunctionParser failed to parse\n"
-                            << "\t<Initial conditions/Adiabatic/Function>\n"
+                            << "\t'Initial conditions.Adiabatic.Function'\n"
                             << "with expression\n"
-                            << "\t<" << prm.get("Function expression") << ">";
+                            << "\t'" << prm.get("Function expression") << "'"
+                            << "More information about the cause of the parse error \n"
+                            << "is shown below.\n";
                   throw;
                 }
 

--- a/source/initial_conditions/function.cc
+++ b/source/initial_conditions/function.cc
@@ -71,7 +71,9 @@ namespace aspect
             std::cerr << "ERROR: FunctionParser failed to parse\n"
                       << "\t'Initial conditions.Function'\n"
                       << "with expression\n"
-                      << "\t'" << prm.get("Function expression") << "'";
+                      << "\t'" << prm.get("Function expression") << "'"
+                      << "More information about the cause of the parse error \n"
+                      << "is shown below.\n";
             throw;
           }
         prm.leave_subsection();

--- a/source/mesh_refinement/maximum_refinement_function.cc
+++ b/source/mesh_refinement/maximum_refinement_function.cc
@@ -157,7 +157,9 @@ namespace aspect
               std::cerr << "ERROR: FunctionParser failed to parse\n"
                         << "\t'Mesh refinement.Maximum refinement function'\n"
                         << "with expression\n"
-                        << "\t'" << prm.get("Function expression") << "'";
+                        << "\t'" << prm.get("Function expression") << "'"
+                        << "More information about the cause of the parse error \n"
+                        << "is shown below.\n";
               throw;
             }
         }

--- a/source/mesh_refinement/minimum_refinement_function.cc
+++ b/source/mesh_refinement/minimum_refinement_function.cc
@@ -157,7 +157,9 @@ namespace aspect
               std::cerr << "ERROR: FunctionParser failed to parse\n"
                         << "\t'Mesh refinement.Minimum refinement function'\n"
                         << "with expression\n"
-                        << "\t'" << prm.get("Function expression") << "'";
+                        << "\t'" << prm.get("Function expression") << "'"
+                        << "More information about the cause of the parse error \n"
+                        << "is shown below.\n";
               throw;
             }
         }

--- a/source/prescribed_stokes_solution/function.cc
+++ b/source/prescribed_stokes_solution/function.cc
@@ -98,9 +98,11 @@ namespace aspect
         catch (...)
           {
             std::cerr << "ERROR: FunctionParser failed to parse\n"
-                      << "\t'Initial conditions.Function'\n"
+                      << "\t'Initial conditions.Function.Velocity function'\n"
                       << "with expression\n"
-                      << "\t'" << prm.get("Function expression") << "'";
+                      << "\t'" << prm.get("Function expression") << "'"
+                      << "More information about the cause of the parse error \n"
+                      << "is shown below.\n";
             throw;
           }
         prm.leave_subsection();
@@ -112,9 +114,11 @@ namespace aspect
         catch (...)
           {
             std::cerr << "ERROR: FunctionParser failed to parse\n"
-                      << "\t'Initial conditions.Function'\n"
+                      << "\t'Initial conditions.Function.Pressure function'\n"
                       << "with expression\n"
-                      << "\t'" << prm.get("Function expression") << "'";
+                      << "\t'" << prm.get("Function expression") << "'"
+                      << "More information about the cause of the parse error \n"
+                      << "is shown below.\n";
             throw;
           }
         prm.leave_subsection();

--- a/source/traction_boundary_conditions/function.cc
+++ b/source/traction_boundary_conditions/function.cc
@@ -93,7 +93,9 @@ namespace aspect
             std::cerr << "ERROR: FunctionParser failed to parse\n"
                       << "\t'Boundary traction model.Function'\n"
                       << "with expression\n"
-                      << "\t'" << prm.get("Function expression") << "'";
+                      << "\t'" << prm.get("Function expression") << "'"
+                      << "More information about the cause of the parse error \n"
+                      << "is shown below.\n";
             throw;
           }
         prm.leave_subsection();

--- a/source/velocity_boundary_conditions/function.cc
+++ b/source/velocity_boundary_conditions/function.cc
@@ -104,7 +104,9 @@ namespace aspect
             std::cerr << "ERROR: FunctionParser failed to parse\n"
                       << "\t'Boundary velocity model.Function'\n"
                       << "with expression\n"
-                      << "\t'" << prm.get("Function expression") << "'";
+                      << "\t'" << prm.get("Function expression") << "'"
+                      << "More information about the cause of the parse error \n"
+                      << "is shown below.\n";
             throw;
           }
         prm.leave_subsection();


### PR DESCRIPTION
If we can't parse a function expression provided in the input file, the
previous error message simply said that there was an error but nothing
more. What was easy to miss was that there is actually more below, since
we re-throw the original error message. The improvement made here simply
points out that there is more about what caused the error below the first
error message. This now looks like this:

```
ERROR: FunctionParser failed to parse
        'Compositional initial conditions.Function'
with expression
        '1'
More information about the cause of the parse error 
is shown below.


----------------------------------------------------
Exception on processing: 

--------------------------------------------------------
An error occurred in line <76> of file </home/bangerth/p/deal.II/1/dealii/source/base/function_parser.cc> in function
    void dealii::FunctionParser<dim>::initialize(const string&, const std::vector<std::basic_string<char> >&, const std::map<std::basic_string<char>, double>&, bool) [with int dim = 3; std::string = std::basic_string<char>]
The violated condition was: 
    this->n_components == expressions.size()
The name and call sequence of the exception was:
    ExcInvalidExpressionSize(this->n_components, expressions.size())
Additional Information: 
The number of components (2) is not equal to the number of expressions (1).
--------------------------------------------------------
```


The commit also makes a couple of places more consistent.