### PR TITLE
fix FPE in vector construction

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -400,7 +400,7 @@ namespace aspect
                                  GeometryInfo<dim>::max_children_per_face * GeometryInfo<dim>::faces_per_cell
                                  :
                                  0),
-                                std::vector<types::global_dof_index>(finite_element.dofs_per_cell,Utilities::signaling_nan<double>()))
+                                std::vector<types::global_dof_index>(finite_element.dofs_per_cell))
         {}
 
 


### PR DESCRIPTION
It doesn't make sense to initialize an array of indices with a NaN
double. In fact, it throws a floating point exception on my machine.