### PR TITLE
Restructure advection face assembly

### DIFF
--- a/include/aspect/assembly.h
+++ b/include/aspect/assembly.h
@@ -211,6 +211,7 @@ namespace aspect
            * enabled heating mechanism contributions.
            */
           HeatingModel::HeatingModelOutputs heating_model_outputs;
+          HeatingModel::HeatingModelOutputs face_heating_model_outputs;
         };
 
 
@@ -520,6 +521,28 @@ namespace aspect
                                                               ResidualWeightSum<std::vector<double> > > compute_advection_system_residual;
 
         /**
+         * A signal that is called from Simulator::local_assemble_advection_system()
+         * and whose slots are supposed to assemble terms that together form the
+         * boundary contribution of the Advection system matrix and right hand side. This signal is called
+         * once for each boundary face.
+         *
+         * The arguments to the slots are as follows:
+         * - The cell on which we currently assemble.
+         * - The number of the face on which we intend to assemble. This
+         *   face (of the current cell) will be at the boundary of the
+         *   domain.
+         * - The advection field that is currently assembled.
+         * - The scratch object in which temporary data is stored that
+         *   assemblers may need.
+         * - The copy object into which assemblers add up their contributions.
+         */
+        boost::signals2::signal<void (const typename DoFHandler<dim>::active_cell_iterator &,
+                                      const unsigned int,
+                                      const typename Simulator<dim>::AdvectionField &,
+                                      internal::Assembly::Scratch::AdvectionSystem<dim>       &,
+                                      internal::Assembly::CopyData::AdvectionSystem<dim>      &)> local_assemble_advection_system_on_boundary_face;
+
+        /**
          * A structure that describes what information an assembler function
          * (listed as one of the signals/slots above) may need to operate.
          *
@@ -572,6 +595,9 @@ namespace aspect
         Properties stokes_preconditioner_assembler_properties;
         Properties stokes_system_assembler_properties;
         Properties stokes_system_assembler_on_boundary_face_properties;
+        Properties advection_system_assembler_properties;
+        Properties advection_system_assembler_on_boundary_face_properties;
+
       };
 
     }

--- a/include/aspect/assembly.h
+++ b/include/aspect/assembly.h
@@ -543,6 +543,27 @@ namespace aspect
                                       internal::Assembly::CopyData::AdvectionSystem<dim>      &)> local_assemble_advection_system_on_boundary_face;
 
         /**
+         * A signal that is called from Simulator::local_assemble_advection_system()
+         * and whose slots are supposed to assemble terms that together form the
+         * interior face contribution of the Advection system matrix and right
+         * hand side. This signal is called once for each interior face.
+         *
+         * The arguments to the slots are as follows:
+         * - The cell on which we currently assemble.
+         * - The number of the face (of the current cell) on which we intend to
+         *  assemble.
+         * - The advection field that is currently assembled.
+         * - The scratch object in which temporary data is stored that
+         *   assemblers may need.
+         * - The copy object into which assemblers add up their contributions.
+         */
+        boost::signals2::signal<void (const typename DoFHandler<dim>::active_cell_iterator &,
+                                      const unsigned int,
+                                      const typename Simulator<dim>::AdvectionField &,
+                                      internal::Assembly::Scratch::AdvectionSystem<dim>       &,
+                                      internal::Assembly::CopyData::AdvectionSystem<dim>      &)> local_assemble_advection_system_on_interior_face;
+
+        /**
          * A structure that describes what information an assembler function
          * (listed as one of the signals/slots above) may need to operate.
          *
@@ -596,7 +617,7 @@ namespace aspect
         Properties stokes_system_assembler_properties;
         Properties stokes_system_assembler_on_boundary_face_properties;
         Properties advection_system_assembler_properties;
-        Properties advection_system_assembler_on_boundary_face_properties;
+        Properties advection_system_assembler_on_face_properties;
 
       };
 

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -231,7 +231,8 @@ namespace aspect
         is_temperature () const;
 
         /**
-         * Return whether this object refers to a field discretized by discontinuous finite elements.
+         * Return whether this object refers to a field discretized by
+         * discontinuous finite elements.
          */
         bool
         is_discontinuous (const Introspection<dim> &introspection) const;

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -35,6 +35,7 @@
 #include <aspect/geometry_model/interface.h>
 #include <aspect/gravity_model/interface.h>
 #include <aspect/boundary_temperature/interface.h>
+#include <aspect/boundary_composition/interface.h>
 #include <aspect/initial_conditions/interface.h>
 #include <aspect/compositional_initial_conditions/interface.h>
 #include <aspect/velocity_boundary_conditions/interface.h>
@@ -291,6 +292,19 @@ namespace aspect
       /** @name Accessing variables that identify the solution of the problem */
       /** @{ */
 
+      /**
+       * Return a reference to the vector that has the current linearization
+       * point of the entire system, i.e. the velocity and pressure variables
+       * as well as the temperature and compositional fields. This vector is
+       * associated with the DoFHandler object returned by get_dof_handler().
+       * This vector is only different from the one returned by get_solution()
+       * during the solver phase.
+       *
+       * @note In general the vector is a distributed vector; however, it
+       * contains ghost elements for all locally relevant degrees of freedom.
+       */
+      const LinearAlgebra::BlockVector &
+      get_current_linearization_point () const;
 
       /**
        * Return a reference to the vector that has the current solution of the
@@ -368,6 +382,17 @@ namespace aspect
       get_material_model () const;
 
       /**
+       * This function simply calls Simulator<dim>::compute_material_model_input_values()
+       * with the given arguments.
+       */
+      void
+      compute_material_model_input_values (const LinearAlgebra::BlockVector                            &input_solution,
+                                           const FEValuesBase<dim,dim>                                 &input_finite_element_values,
+                                           const typename DoFHandler<dim>::active_cell_iterator        &cell,
+                                           const bool                                                   compute_strainrate,
+                                           MaterialModel::MaterialModelInputs<dim> &material_model_inputs) const;
+
+      /**
        * Return a pointer to the gravity model description.
        */
       const GravityModel::Interface<dim> &
@@ -403,6 +428,23 @@ namespace aspect
        */
       const BoundaryTemperature::Interface<dim> &
       get_boundary_temperature () const;
+
+      /**
+       * Return whether the current model has a boundary composition object
+       * set. This is useful because a simulation does not actually have to
+       * declare any boundary composition model, for example if all
+       * boundaries are insulating. In such cases, there is no
+       * boundary composition model that can provide, for example,
+       * a minimal and maximal temperature on the boundary.
+       */
+      bool has_boundary_composition () const;
+
+      /**
+       * Return a reference to the object that describes the composition
+       * boundary values.
+       */
+      const BoundaryComposition::Interface<dim> &
+      get_boundary_composition () const;
 
       /**
        * Return a reference to the object that describes traction

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -433,7 +433,7 @@ namespace aspect
        * Return whether the current model has a boundary composition object
        * set. This is useful because a simulation does not actually have to
        * declare any boundary composition model, for example if all
-       * boundaries are insulating. In such cases, there is no
+       * boundaries are reflecting. In such cases, there is no
        * boundary composition model that can provide, for example,
        * a minimal and maximal temperature on the boundary.
        */

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -239,7 +239,8 @@ namespace aspect
           neighbor_face_material_model_outputs(face_quadrature.size(), n_compositional_fields),
           explicit_material_model_inputs(quadrature.size(), n_compositional_fields),
           explicit_material_model_outputs(quadrature.size(), n_compositional_fields),
-          heating_model_outputs(quadrature.size(), n_compositional_fields)
+          heating_model_outputs(quadrature.size(), n_compositional_fields),
+          face_heating_model_outputs(quadrature.size(), n_compositional_fields)
         {}
 
 
@@ -294,7 +295,8 @@ namespace aspect
           neighbor_face_material_model_outputs(scratch.neighbor_face_material_model_outputs),
           explicit_material_model_inputs(scratch.explicit_material_model_inputs),
           explicit_material_model_outputs(scratch.explicit_material_model_outputs),
-          heating_model_outputs(scratch.heating_model_outputs)
+          heating_model_outputs(scratch.heating_model_outputs),
+          face_heating_model_outputs(scratch.face_heating_model_outputs)
         {}
 
       }
@@ -1207,7 +1209,7 @@ namespace aspect
         compute_advection_system_residual(const typename Simulator<dim>::AdvectionField     &advection_field,
                                           internal::Assembly::Scratch::AdvectionSystem<dim> &scratch) const
         {
-          const unsigned int n_q_points = scratch.old_field_values->size();
+          const unsigned int n_q_points = scratch.finite_element_values.n_quadrature_points;
           std::vector<double> residuals(n_q_points);
 
           HeatingModel::HeatingModelOutputs heating_model_outputs(n_q_points, this->get_parameters().n_compositional_fields);
@@ -1262,6 +1264,840 @@ namespace aspect
                            - dreaction_term_dt);
             }
           return residuals;
+        }
+
+        void
+        local_assemble_advection_face_terms(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                                            const unsigned int face_no,
+                                            const typename Simulator<dim>::AdvectionField &advection_field,
+                                            internal::Assembly::Scratch::AdvectionSystem<dim> &scratch,
+                                            internal::Assembly::CopyData::AdvectionSystem<dim> &data) const
+        {
+          const Parameters<dim> &parameters = this->get_parameters();
+          const Introspection<dim> &introspection = this->introspection();
+          const unsigned int n_q_points    = scratch.face_finite_element_values->n_quadrature_points;
+
+          const double time_step = this->get_timestep();
+
+          // also have the number of dofs that correspond just to the element for
+          // the system we are currently trying to assemble
+          const unsigned int advection_dofs_per_cell = data.local_dof_indices.size();
+
+          Assert (advection_field.is_discontinuous(introspection),
+                  ExcMessage("Face terms only need assembling in the case of discontinuous temperature or compositional discretization."));
+
+          Assert (advection_dofs_per_cell < scratch.face_finite_element_values->get_fe().dofs_per_cell, ExcInternalError());
+          Assert (scratch.face_grad_phi_field.size() == advection_dofs_per_cell, ExcInternalError());
+          Assert (scratch.face_phi_field.size() == advection_dofs_per_cell, ExcInternalError());
+
+          const unsigned int solution_component = advection_field.component_index(introspection);
+
+          const FEValuesExtractors::Scalar solution_field
+            = (advection_field.is_temperature()
+               ?
+               introspection.extractors.temperature
+               :
+               introspection.extractors.compositional_fields[advection_field.compositional_variable]
+              );
+
+          typename DoFHandler<dim>::face_iterator face = cell->face (face_no);
+
+          if (face->at_boundary())
+            {
+              if (((parameters.fixed_temperature_boundary_indicators.find(
+#if DEAL_II_VERSION_GTE(8,3,0)
+                      cell->face(face_no)->boundary_id()
+#else
+                      cell->face(face_no)->boundary_indicator()
+#endif
+                    )
+                    != parameters.fixed_temperature_boundary_indicators.end())
+                   && (advection_field.is_temperature()))
+                  ||
+                  (( parameters.fixed_composition_boundary_indicators.find(
+#if DEAL_II_VERSION_GTE(8,3,0)
+                       cell->face(face_no)->boundary_id()
+#else
+                       cell->face(face_no)->boundary_indicator()
+#endif
+                     )
+                     != parameters.fixed_composition_boundary_indicators.end())
+                   && (!advection_field.is_temperature())))
+                {
+                  /*
+                   * We are in the case of a Dirichlet temperature or composition boundary.
+                   * In the temperature case, impose the Dirichlet value weakly using a matrix term
+                   * and RHS term. In the composition case, Dirichlet conditions can only be imposed
+                   * on inflow boundaries, and we only have the flow-dependent terms, so we only
+                   * assemble the corresponding flow-dependent and matrix and RHS terms
+                   * if we are on an inflow boundary.
+                   */
+
+                  for (unsigned int q=0; q<n_q_points; ++q)
+                    {
+                      // precompute the values of shape functions and their gradients.
+                      // We only need to look up values of shape functions if they
+                      // belong to 'our' component. They are zero otherwise anyway.
+                      // Note that we later only look at the values that we do set here.
+                      for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
+                        {
+                          scratch.face_grad_phi_field[k] = (*scratch.face_finite_element_values)[solution_field].gradient (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                          scratch.face_phi_field[k]      = (*scratch.face_finite_element_values)[solution_field].value (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                        }
+                      const double density_c_P              =
+                        ((advection_field.is_temperature())
+                         ?
+                         scratch.face_material_model_outputs.densities[q] *
+                         scratch.face_material_model_outputs.specific_heat[q]
+                         :
+                         1.0);
+
+                      Assert (density_c_P >= 0,
+                              ExcMessage ("The product of density and c_P needs to be a "
+                                          "non-negative quantity."));
+
+                      const double conductivity =
+                        ((advection_field.is_temperature())
+                         ?
+                         scratch.face_material_model_outputs.thermal_conductivities[q]
+                         :
+                         0.0);
+                      const double latent_heat_LHS =
+                        ((advection_field.is_temperature())
+                         ?
+                         scratch.face_heating_model_outputs.lhs_latent_heat_terms[q]
+                         :
+                         0.0);
+                      Assert (density_c_P + latent_heat_LHS >= 0,
+                              ExcMessage ("The sum of density times c_P and the latent heat contribution "
+                                          "to the left hand side needs to be a non-negative quantity."));
+
+                      const double penalty = (advection_field.is_temperature()
+                                              ?
+                                              parameters.discontinuous_penalty
+                                              * parameters.temperature_degree
+                                              * parameters.temperature_degree
+                                              / face->measure()
+                                              * conductivity
+                                              / (density_c_P + latent_heat_LHS)
+                                              :
+                                              0.0);
+
+                      const double dirichlet_value = (advection_field.is_temperature()
+                                                      ?
+                                                      this->get_boundary_temperature().boundary_temperature(
+#if DEAL_II_VERSION_GTE(8,3,0)
+                                                        cell->face(face_no)->boundary_id(),
+#else
+                                                        cell->face(face_no)->boundary_indicator(),
+#endif
+                                                        scratch.face_finite_element_values->quadrature_point(q))
+                                                      :
+                                                      this->get_boundary_composition().boundary_composition(
+#if DEAL_II_VERSION_GTE(8,3,0)
+                                                        cell->face(face_no)->boundary_id(),
+#else
+                                                        cell->face(face_no)->boundary_indicator(),
+#endif
+                                                        scratch.face_finite_element_values->quadrature_point(q),
+                                                        advection_field.compositional_variable));
+
+                      Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
+                      //Subtract off the mesh velocity for ALE corrections if necessary
+                      if (parameters.free_surface_enabled)
+                        current_u -= scratch.face_mesh_velocity_values[q];
+
+                      /**
+                       * The discontinuous Galerkin method uses 2 types of jumps over edges:
+                       * undirected and directed jumps. Undirected jumps are dependent only
+                       * on the order of the numbering of cells. Directed jumps are dependent
+                       * on the direction of the flow. Thus the flow-dependent terms below are
+                       * only calculated if the edge is an inflow edge.
+                       */
+                      const bool inflow = ((current_u * scratch.face_finite_element_values->normal_vector(q)) < 0.);
+
+                      for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+                        {
+                          data.local_rhs(i)
+                          += (- time_step *  conductivity
+                              * scratch.face_grad_phi_field[i]
+                              * scratch.face_finite_element_values->normal_vector(q)
+                              * dirichlet_value
+
+                              + time_step
+                              * (density_c_P + latent_heat_LHS)
+                              * penalty
+                              * scratch.face_phi_field[i]
+                              * dirichlet_value
+
+                              + (inflow
+                                 ?
+                                 - (density_c_P + latent_heat_LHS)
+                                 * time_step
+                                 * (current_u
+                                    * scratch.face_finite_element_values->normal_vector(q))
+                                 * dirichlet_value
+                                 * scratch.face_phi_field[i]
+                                 :
+                                 0.)
+                             )
+                             *
+                             scratch.face_finite_element_values->JxW(q);
+
+                          // local_matrix terms
+                          for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
+                            {
+                              data.local_matrix(i,j)
+                              += (- time_step *  conductivity
+                                  * scratch.face_grad_phi_field[i]
+                                  * scratch.face_finite_element_values->normal_vector(q)
+                                  * scratch.face_phi_field[j]
+
+                                  - time_step *  conductivity
+                                  * scratch.face_grad_phi_field[j]
+                                  * scratch.face_finite_element_values->normal_vector(q)
+                                  * scratch.face_phi_field[i]
+
+                                  + time_step
+                                  * (density_c_P + latent_heat_LHS)
+                                  * penalty
+                                  * scratch.face_phi_field[i]
+                                  * scratch.face_phi_field[j]
+
+                                  + (inflow
+                                     ?
+                                     - (density_c_P + latent_heat_LHS)
+                                     * time_step
+                                     * (current_u
+                                        * scratch.face_finite_element_values->normal_vector(q))
+                                     * scratch.face_phi_field[i]
+                                     * scratch.face_phi_field[j]
+                                     :
+                                     0.)
+                                 )
+                                 * scratch.face_finite_element_values->JxW(q);
+                            }
+                        }
+                    }
+                }
+              else
+                {
+                  //Neumann temperature term - no non-zero contribution as only homogeneous Neumann boundary conditions are implemented elsewhere for temperature
+                }
+            }
+          else
+            {
+              //interior face - no contribution on RHS
+              Assert (cell->neighbor(face_no).state() == IteratorState::valid,
+                      ExcInternalError());
+              const typename DoFHandler<dim>::cell_iterator neighbor = cell->neighbor(face_no); //note: NOT active_cell_iterator, so this includes cells that are refined.
+
+              if (!(face->has_children()))
+                {
+                  if (!cell->neighbor_is_coarser(face_no) &&
+                      (((neighbor->is_locally_owned()) && (cell->index() < neighbor->index()))
+                       ||
+                       ((!neighbor->is_locally_owned()) && (cell->subdomain_id() < neighbor->subdomain_id()))))
+                    {
+                      Assert (cell->is_locally_owned(), ExcInternalError());
+                      //cell and neighbor are equal-sized, and cell has been chosen to assemble this face, so calculate from cell
+
+                      //how does the neighbor talk about this cell?
+                      const unsigned int neighbor2=cell->neighbor_of_neighbor(face_no);
+
+                      //set up neighbor values
+                      scratch.neighbor_face_finite_element_values->reinit (neighbor, neighbor2);
+
+                      this->compute_material_model_input_values (this->get_current_linearization_point(),
+                                                                 *scratch.neighbor_face_finite_element_values,
+                                                                 neighbor,
+                                                                 true,
+                                                                 scratch.neighbor_face_material_model_inputs);
+                      this->get_material_model().evaluate(scratch.neighbor_face_material_model_inputs,
+                                                          scratch.neighbor_face_material_model_outputs);
+
+                      HeatingModel::HeatingModelOutputs neighbor_face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
+                      this->get_heating_model_manager().evaluate(scratch.neighbor_face_material_model_inputs,
+                                                                 scratch.neighbor_face_material_model_outputs,
+                                                                 neighbor_face_heating_model_outputs);
+
+                      std::vector<types::global_dof_index> neighbor_dof_indices (scratch.face_finite_element_values->get_fe().dofs_per_cell);
+                      // get all dof indices on the neighbor, then extract those
+                      // that correspond to the solution_field we are interested in
+                      neighbor->get_dof_indices (neighbor_dof_indices);
+                      for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+                        data.neighbor_dof_indices[face_no * GeometryInfo<dim>::max_children_per_face][i] = neighbor_dof_indices[scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, i)];
+                      data.assembled_matrices[face_no * GeometryInfo<dim>::max_children_per_face] = true;
+
+                      for (unsigned int q=0; q<n_q_points; ++q)
+                        {
+                          // precompute the values of shape functions and their gradients.
+                          // We only need to look up values of shape functions if they
+                          // belong to 'our' component. They are zero otherwise anyway.
+                          // Note that we later only look at the values that we do set here.
+                          for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
+                            {
+                              scratch.face_grad_phi_field[k]          = (*scratch.face_finite_element_values)[solution_field].gradient (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                              scratch.face_phi_field[k]               = (*scratch.face_finite_element_values)[solution_field].value (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                              scratch.neighbor_face_grad_phi_field[k] = (*scratch.neighbor_face_finite_element_values)[solution_field].gradient (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                              scratch.neighbor_face_phi_field[k]      = (*scratch.neighbor_face_finite_element_values)[solution_field].value (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                            }
+
+                          const double density_c_P              =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.face_material_model_outputs.densities[q] *
+                             scratch.face_material_model_outputs.specific_heat[q]
+                             :
+                             1.0);
+
+                          Assert (density_c_P >= 0,
+                                  ExcMessage ("The product of density and c_P needs to be a "
+                                              "non-negative quantity."));
+
+                          const double conductivity =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.face_material_model_outputs.thermal_conductivities[q]
+                             :
+                             0.0);
+                          const double latent_heat_LHS =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.face_heating_model_outputs.lhs_latent_heat_terms[q]
+                             :
+                             0.0);
+                          Assert (density_c_P + latent_heat_LHS >= 0,
+                                  ExcMessage ("The sum of density times c_P and the latent heat contribution "
+                                              "to the left hand side needs to be a non-negative quantity."));
+
+                          const double penalty = (advection_field.is_temperature()
+                                                  ?
+                                                  parameters.discontinuous_penalty
+                                                  * parameters.temperature_degree
+                                                  * parameters.temperature_degree
+                                                  / face->measure()
+                                                  * conductivity
+                                                  / (density_c_P + latent_heat_LHS)
+                                                  :
+                                                  0.0);
+
+                          Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
+                          //Subtract off the mesh velocity for ALE corrections if necessary
+                          if (parameters.free_surface_enabled)
+                            current_u -= scratch.face_mesh_velocity_values[q];
+
+                          const double neighbor_density_c_P              =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.neighbor_face_material_model_outputs.densities[q] *
+                             scratch.neighbor_face_material_model_outputs.specific_heat[q]
+                             :
+                             1.0);
+
+                          Assert (neighbor_density_c_P >= 0,
+                                  ExcMessage ("The product of density and c_P on the neighbor needs to be a "
+                                              "non-negative quantity."));
+
+                          const double neighbor_conductivity =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.neighbor_face_material_model_outputs.thermal_conductivities[q]
+                             :
+                             0.0);
+                          const double neighbor_latent_heat_LHS =
+                            ((advection_field.is_temperature())
+                             ?
+                             neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
+                             :
+                             0.0);
+                          Assert (neighbor_density_c_P + neighbor_latent_heat_LHS >= 0,
+                                  ExcMessage ("The sum of density times c_P and the latent heat contribution "
+                                              "to the left hand side on the neighbor needs to be a non-negative quantity."));
+
+                          const double neighbor_penalty = (advection_field.is_temperature()
+                                                           ?
+                                                           parameters.discontinuous_penalty
+                                                           * parameters.temperature_degree
+                                                           * parameters.temperature_degree
+                                                           / neighbor->face(neighbor2)->measure()
+                                                           * neighbor_conductivity
+                                                           / (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                                           :
+                                                           0.0);
+
+                          const double max_penalty = std::max(penalty, neighbor_penalty);
+
+                          const double max_density_c_P_and_latent_heat =
+                            std::max(density_c_P + latent_heat_LHS,
+                                     neighbor_density_c_P + neighbor_latent_heat_LHS);
+
+                          Assert (numbers::is_finite(max_density_c_P_and_latent_heat),
+                                  ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a finite quantity."));
+                          Assert (max_density_c_P_and_latent_heat >= 0,
+                                  ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a "
+                                              "non-negative quantity."));
+
+                          /**
+                           * The discontinuous Galerkin method uses 2 types of jumps over edges:
+                           * undirected and directed jumps. Undirected jumps are dependent only
+                           * on the order of the numbering of cells. Directed jumps are dependent
+                           * on the direction of the flow. Thus the flow-dependent terms below are
+                           * only calculated if the edge is an inflow edge.
+                           */
+                          const bool inflow = ((current_u * scratch.face_finite_element_values->normal_vector(q)) < 0.);
+
+                          for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+                            {
+                              for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
+                                {
+                                  data.local_matrix(i,j)
+                                  += (- 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[i]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[j]
+
+                                      - 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[j]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[i]
+
+                                      + time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.face_phi_field[i]
+                                      * scratch.face_phi_field[j]
+
+                                      - (inflow
+                                         ?
+                                         (density_c_P + latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.face_finite_element_values->normal_vector(q))
+                                         * scratch.face_phi_field[i]
+                                         * scratch.face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.face_finite_element_values->JxW(q);
+
+                                  data.local_matrices_int_ext[face_no * GeometryInfo<dim>::max_children_per_face](i,j)
+                                  += (- 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[j]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[i]
+
+                                      + 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[i]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[j]
+
+                                      - time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.neighbor_face_phi_field[j]
+                                      * scratch.face_phi_field[i]
+
+                                      + (inflow
+                                         ?
+                                         (density_c_P + latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.face_finite_element_values->normal_vector(q))
+                                         * scratch.face_phi_field[i]
+                                         * scratch.neighbor_face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.face_finite_element_values->JxW(q);
+
+                                  data.local_matrices_ext_int[face_no * GeometryInfo<dim>::max_children_per_face](i,j)
+                                  += (+ 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[j]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[i]
+
+                                      - 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[i]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[j]
+
+                                      - time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.face_phi_field[j]
+                                      * scratch.neighbor_face_phi_field[i]
+
+                                      - (!inflow
+                                         ?
+                                         (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.face_finite_element_values->normal_vector(q))
+                                         * scratch.neighbor_face_phi_field[i]
+                                         * scratch.face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.face_finite_element_values->JxW(q);
+
+                                  data.local_matrices_ext_ext[face_no * GeometryInfo<dim>::max_children_per_face](i,j)
+                                  += (+ 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[i]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[j]
+
+                                      + 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[j]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[i]
+
+                                      + time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.neighbor_face_phi_field[i]
+                                      * scratch.neighbor_face_phi_field[j]
+
+                                      + (!inflow
+                                         ?
+                                         (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.face_finite_element_values->normal_vector(q))
+                                         * scratch.neighbor_face_phi_field[i]
+                                         * scratch.neighbor_face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.face_finite_element_values->JxW(q);
+                                }
+                            }
+                        }
+                    }
+                  else
+                    {
+                      /* neighbor is taking responsibility for assembly of this face, because
+                       * either (1) neighbor is coarser, or
+                       *        (2) neighbor is equally-sized and
+                       *           (a) neighbor is on a different subdomain, with lower subdmain_id(), or
+                       *           (b) neighbor is on the same subdomain and has lower index().
+                      */
+                    }
+                }
+              else //face->has_children(), so always assemble from here.
+                {
+                  //how does the neighbor talk about this cell?
+                  const unsigned int neighbor2 = cell->neighbor_face_no(face_no);
+
+                  //loop over subfaces
+                  for (unsigned int subface_no=0; subface_no<face->number_of_children(); ++subface_no)
+                    {
+                      const typename DoFHandler<dim>::active_cell_iterator neighbor_child
+                        = cell->neighbor_child_on_subface (face_no, subface_no);
+
+                      //set up subface values
+                      scratch.subface_finite_element_values->reinit (cell, face_no, subface_no);
+
+                      //subface->face
+                      (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(this->get_current_linearization_point(),
+                          scratch.face_current_velocity_values);
+
+                      //get the mesh velocity, as we need to subtract it off of the advection systems
+                      if (parameters.free_surface_enabled)
+                        (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(this->get_mesh_velocity(),
+                            scratch.face_mesh_velocity_values);
+
+                      //get the mesh velocity, as we need to subtract it off of the advection systems
+                      if (parameters.free_surface_enabled)
+                        (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(this->get_mesh_velocity(),
+                            scratch.face_mesh_velocity_values);
+
+                      this->compute_material_model_input_values (this->get_current_linearization_point(),
+                                                                 *scratch.subface_finite_element_values,
+                                                                 cell,
+                                                                 true,
+                                                                 scratch.face_material_model_inputs);
+                      this->get_material_model().evaluate(scratch.face_material_model_inputs,
+                                                          scratch.face_material_model_outputs);
+
+                      HeatingModel::HeatingModelOutputs face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
+                      this->get_heating_model_manager().evaluate(scratch.face_material_model_inputs,
+                                                                 scratch.face_material_model_outputs,
+                                                                 face_heating_model_outputs);
+
+                      //set up neighbor values
+                      scratch.neighbor_face_finite_element_values->reinit (neighbor_child, neighbor2);
+
+                      this->compute_material_model_input_values (this->get_current_linearization_point(),
+                                                                 *scratch.neighbor_face_finite_element_values,
+                                                                 neighbor_child,
+                                                                 true,
+                                                                 scratch.neighbor_face_material_model_inputs);
+                      this->get_material_model().evaluate(scratch.neighbor_face_material_model_inputs,
+                                                          scratch.neighbor_face_material_model_outputs);
+
+                      HeatingModel::HeatingModelOutputs neighbor_face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
+                      this->get_heating_model_manager().evaluate(scratch.neighbor_face_material_model_inputs,
+                                                                 scratch.neighbor_face_material_model_outputs,
+                                                                 neighbor_face_heating_model_outputs);
+
+                      std::vector<types::global_dof_index> neighbor_dof_indices (scratch.face_finite_element_values->get_fe().dofs_per_cell);
+                      // get all dof indices on the neighbor, then extract those
+                      // that correspond to the solution_field we are interested in
+                      neighbor_child->get_dof_indices (neighbor_dof_indices);
+                      for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+                        data.neighbor_dof_indices[face_no * GeometryInfo<dim>::max_children_per_face + subface_no][i] = neighbor_dof_indices[scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, i)];
+                      data.assembled_matrices[face_no * GeometryInfo<dim>::max_children_per_face + subface_no] = true;
+
+                      for (unsigned int q=0; q<n_q_points; ++q)
+                        {
+                          // precompute the values of shape functions and their gradients.
+                          // We only need to look up values of shape functions if they
+                          // belong to 'our' component. They are zero otherwise anyway.
+                          // Note that we later only look at the values that we do set here.
+                          for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
+                            {
+                              scratch.face_grad_phi_field[k]          = (*scratch.subface_finite_element_values)[solution_field].gradient (scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                              scratch.face_phi_field[k]               = (*scratch.subface_finite_element_values)[solution_field].value (scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                              scratch.neighbor_face_grad_phi_field[k] = (*scratch.neighbor_face_finite_element_values)[solution_field].gradient (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                              scratch.neighbor_face_phi_field[k]      = (*scratch.neighbor_face_finite_element_values)[solution_field].value (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                            }
+
+                          const double density_c_P              =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.face_material_model_outputs.densities[q] *
+                             scratch.face_material_model_outputs.specific_heat[q]
+                             :
+                             1.0);
+
+                          Assert (density_c_P >= 0,
+                                  ExcMessage ("The product of density and c_P needs to be a "
+                                              "non-negative quantity."));
+
+                          const double conductivity =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.face_material_model_outputs.thermal_conductivities[q]
+                             :
+                             0.0);
+                          const double latent_heat_LHS =
+                            ((advection_field.is_temperature())
+                             ?
+                             face_heating_model_outputs.lhs_latent_heat_terms[q]
+                             :
+                             0.0);
+                          Assert (density_c_P + latent_heat_LHS >= 0,
+                                  ExcMessage ("The sum of density times c_P and the latent heat contribution "
+                                              "to the left hand side needs to be a non-negative quantity."));
+
+                          const double penalty = (advection_field.is_temperature()
+                                                  ?
+                                                  parameters.discontinuous_penalty
+                                                  * parameters.temperature_degree
+                                                  * parameters.temperature_degree
+                                                  / face->measure()
+                                                  * conductivity
+                                                  / (density_c_P + latent_heat_LHS)
+                                                  :
+                                                  0.0);
+
+                          Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
+                          //Subtract off the mesh velocity for ALE corrections if necessary
+                          if (parameters.free_surface_enabled)
+                            current_u -= scratch.face_mesh_velocity_values[q];
+
+                          const double neighbor_density_c_P              =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.neighbor_face_material_model_outputs.densities[q] *
+                             scratch.neighbor_face_material_model_outputs.specific_heat[q]
+                             :
+                             1.0);
+
+                          Assert (neighbor_density_c_P >= 0,
+                                  ExcMessage ("The product of density and c_P on the neighbor needs to be a "
+                                              "non-negative quantity."));
+
+                          const double neighbor_conductivity =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.neighbor_face_material_model_outputs.thermal_conductivities[q]
+                             :
+                             0.0);
+                          const double neighbor_latent_heat_LHS =
+                            ((advection_field.is_temperature())
+                             ?
+                             neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
+                             :
+                             0.0);
+                          Assert (neighbor_density_c_P + neighbor_latent_heat_LHS >= 0,
+                                  ExcMessage ("The sum of density times c_P and the latent heat contribution "
+                                              "to the left hand side on the neighbor needs to be a non-negative quantity."));
+
+                          const double neighbor_penalty = (advection_field.is_temperature()
+                                                           ?
+                                                           parameters.discontinuous_penalty
+                                                           * parameters.temperature_degree
+                                                           * parameters.temperature_degree
+                                                           / neighbor_child->face(neighbor2)->measure()
+                                                           * neighbor_conductivity
+                                                           / (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                                           :
+                                                           0.0);
+
+                          const double max_penalty = std::max(penalty, neighbor_penalty);
+
+                          const double max_density_c_P_and_latent_heat =
+                            std::max(density_c_P + latent_heat_LHS,
+                                     neighbor_density_c_P + neighbor_latent_heat_LHS);
+
+                          Assert (numbers::is_finite(max_density_c_P_and_latent_heat),
+                                  ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a finite quantity."));
+                          Assert (max_density_c_P_and_latent_heat >= 0,
+                                  ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a "
+                                              "non-negative quantity."));
+
+                          /**
+                           * The discontinuous Galerkin method uses 2 types of jumps over edges:
+                           * undirected and directed jumps. Undirected jumps are dependent only
+                           * on the order of the numbering of cells. Directed jumps are dependent
+                           * on the direction of the flow. Thus the flow-dependent terms below are
+                           * only calculated if the edge is an inflow edge.
+                           */
+                          const bool inflow = ((current_u * scratch.subface_finite_element_values->normal_vector(q)) < 0.);
+
+                          for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+                            {
+                              for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
+                                {
+                                  data.local_matrix(i,j)
+                                  += (- 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[i]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[j]
+
+                                      - 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[j]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[i]
+
+                                      + time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.face_phi_field[i]
+                                      * scratch.face_phi_field[j]
+
+                                      - (inflow
+                                         ?
+                                         (density_c_P + latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.subface_finite_element_values->normal_vector(q))
+                                         * scratch.face_phi_field[i]
+                                         * scratch.face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.subface_finite_element_values->JxW(q);
+
+                                  data.local_matrices_int_ext[face_no * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
+                                  += (- 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[j]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[i]
+
+                                      + 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[i]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[j]
+
+                                      - time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.neighbor_face_phi_field[j]
+                                      * scratch.face_phi_field[i]
+
+                                      + (inflow
+                                         ?
+                                         (density_c_P + latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.subface_finite_element_values->normal_vector(q))
+                                         * scratch.face_phi_field[i]
+                                         * scratch.neighbor_face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.subface_finite_element_values->JxW(q);
+
+                                  data.local_matrices_ext_int[face_no * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
+                                  += (+ 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[j]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[i]
+
+                                      - 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[i]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[j]
+
+                                      - time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.face_phi_field[j]
+                                      * scratch.neighbor_face_phi_field[i]
+
+                                      - (!inflow
+                                         ?
+                                         (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.subface_finite_element_values->normal_vector(q))
+                                         * scratch.neighbor_face_phi_field[i]
+                                         * scratch.face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.subface_finite_element_values->JxW(q);
+
+                                  data.local_matrices_ext_ext[face_no * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
+                                  += (+ 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[i]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[j]
+
+                                      + 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[j]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[i]
+
+                                      + time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.neighbor_face_phi_field[i]
+                                      * scratch.neighbor_face_phi_field[j]
+
+                                      + (!inflow
+                                         ?
+                                         (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.subface_finite_element_values->normal_vector(q))
+                                         * scratch.neighbor_face_phi_field[i]
+                                         * scratch.neighbor_face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.subface_finite_element_values->JxW(q);
+                                }
+                            }
+
+                        }
+                    }
+
+                }
+            }
         }
     };
 
@@ -1436,6 +2272,21 @@ namespace aspect
                               // discard cell,
                               std_cxx11::_2,
                               std_cxx11::_3));
+
+    if (parameters.use_discontinuous_temperature_discretization ||
+        parameters.use_discontinuous_composition_discretization)
+      {
+        assemblers->local_assemble_advection_system_on_boundary_face
+        .connect(std_cxx11::bind(&aspect::Assemblers::CompleteEquations<dim>::local_assemble_advection_face_terms,
+                                 std_cxx11::cref (*complete_equation_assembler),
+                                 std_cxx11::_1,
+                                 std_cxx11::_2,
+                                 std_cxx11::_3,
+                                 std_cxx11::_4,
+                                 std_cxx11::_5));
+
+        assemblers->advection_system_assembler_on_boundary_face_properties.need_face_material_model_data = true;
+      }
 
     // allow other assemblers to add themselves or modify the existing ones by firing the signal
     this->signals.set_assemblers(*this, *assemblers, assembler_objects);
@@ -1842,898 +2693,6 @@ namespace aspect
     computing_timer.exit_section();
   }
 
-  template <int dim>
-  void Simulator<dim>::
-  local_assemble_advection_face_terms(const AdvectionField     &advection_field,
-                                      const typename DoFHandler<dim>::active_cell_iterator &cell,
-                                      internal::Assembly::Scratch::AdvectionSystem<dim> &scratch,
-                                      internal::Assembly::CopyData::AdvectionSystem<dim> &data)
-  {
-    const bool use_bdf2_scheme = (timestep_number > 1);
-
-    const unsigned int n_q_points    = scratch.face_finite_element_values->n_quadrature_points;
-
-    // also have the number of dofs that correspond just to the element for
-    // the system we are currently trying to assemble
-    const unsigned int advection_dofs_per_cell = data.local_dof_indices.size();
-
-    Assert (advection_field.is_discontinuous(introspection),
-            ExcMessage("Face terms only need assembling in the case of discontinuous temperature or compositional discretization."));
-
-    Assert (advection_dofs_per_cell < scratch.face_finite_element_values->get_fe().dofs_per_cell, ExcInternalError());
-    Assert (scratch.face_grad_phi_field.size() == advection_dofs_per_cell, ExcInternalError());
-    Assert (scratch.face_phi_field.size() == advection_dofs_per_cell, ExcInternalError());
-
-    const unsigned int solution_component = advection_field.component_index(introspection);
-
-    const FEValuesExtractors::Scalar solution_field
-      = (advection_field.is_temperature()
-         ?
-         introspection.extractors.temperature
-         :
-         introspection.extractors.compositional_fields[advection_field.compositional_variable]
-        );
-
-    //loop over all possible subfaces of the cell, and reset their matrices.
-    for (unsigned int f = 0; f < GeometryInfo<dim>::max_children_per_face * GeometryInfo<dim>::faces_per_cell; ++f)
-      {
-        data.local_matrices_ext_int[f] = 0;
-        data.local_matrices_int_ext[f] = 0;
-        data.local_matrices_ext_ext[f] = 0;
-        data.assembled_matrices[f] = false;
-      }
-
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
-      {
-        typename DoFHandler<dim>::face_iterator face = cell->face (f);
-
-        if (face->at_boundary())
-          {
-            if (((parameters.fixed_temperature_boundary_indicators.find(
-#if DEAL_II_VERSION_GTE(8,3,0)
-                    cell->face(f)->boundary_id()
-#else
-                    cell->face(f)->boundary_indicator()
-#endif
-                  )
-                  != parameters.fixed_temperature_boundary_indicators.end())
-                 && (advection_field.is_temperature()))
-                ||
-                (( parameters.fixed_composition_boundary_indicators.find(
-#if DEAL_II_VERSION_GTE(8,3,0)
-                     cell->face(f)->boundary_id()
-#else
-                     cell->face(f)->boundary_indicator()
-#endif
-                   )
-                   != parameters.fixed_composition_boundary_indicators.end())
-                 && (!advection_field.is_temperature())))
-              {
-                /*
-                 * We are in the case of a Dirichlet temperature or composition boundary.
-                 * In the temperature case, impose the Dirichlet value weakly using a matrix term
-                 * and RHS term. In the composition case, Dirichlet conditions can only be imposed
-                 * on inflow boundaries, and we only have the flow-dependent terms, so we only
-                 * assemble the corresponding flow-dependent and matrix and RHS terms
-                 * if we are on an inflow boundary.
-                 */
-
-                scratch.face_finite_element_values->reinit (cell, f);
-
-                (*scratch.face_finite_element_values)[introspection.extractors.velocities].get_function_values(current_linearization_point,
-                    scratch.face_current_velocity_values);
-
-                //get the mesh velocity, as we need to subtract it off of the advection systems
-                if (parameters.free_surface_enabled)
-                  (*scratch.face_finite_element_values)[introspection.extractors.velocities].get_function_values(free_surface->mesh_velocity,
-                      scratch.face_mesh_velocity_values);
-
-                compute_material_model_input_values (current_linearization_point,
-                                                     *scratch.face_finite_element_values,
-                                                     cell,
-                                                     true,
-                                                     scratch.face_material_model_inputs);
-                material_model->evaluate(scratch.face_material_model_inputs,
-                                         scratch.face_material_model_outputs);
-
-                HeatingModel::HeatingModelOutputs face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
-                heating_model_manager.evaluate(scratch.face_material_model_inputs,
-                                               scratch.face_material_model_outputs,
-                                               face_heating_model_outputs);
-
-                for (unsigned int q=0; q<n_q_points; ++q)
-                  {
-                    // precompute the values of shape functions and their gradients.
-                    // We only need to look up values of shape functions if they
-                    // belong to 'our' component. They are zero otherwise anyway.
-                    // Note that we later only look at the values that we do set here.
-                    for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
-                      {
-                        scratch.face_grad_phi_field[k] = (*scratch.face_finite_element_values)[solution_field].gradient (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                        scratch.face_phi_field[k]      = (*scratch.face_finite_element_values)[solution_field].value (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                      }
-                    const double density_c_P              =
-                      ((advection_field.is_temperature())
-                       ?
-                       scratch.face_material_model_outputs.densities[q] *
-                       scratch.face_material_model_outputs.specific_heat[q]
-                       :
-                       1.0);
-
-                    Assert (density_c_P >= 0,
-                            ExcMessage ("The product of density and c_P needs to be a "
-                                        "non-negative quantity."));
-
-                    const double conductivity =
-                      ((advection_field.is_temperature())
-                       ?
-                       scratch.face_material_model_outputs.thermal_conductivities[q]
-                       :
-                       0.0);
-                    const double latent_heat_LHS =
-                      ((advection_field.is_temperature())
-                       ?
-                       face_heating_model_outputs.lhs_latent_heat_terms[q]
-                       :
-                       0.0);
-                    Assert (density_c_P + latent_heat_LHS >= 0,
-                            ExcMessage ("The sum of density times c_P and the latent heat contribution "
-                                        "to the left hand side needs to be a non-negative quantity."));
-
-                    const double penalty = (advection_field.is_temperature()
-                                            ?
-                                            parameters.discontinuous_penalty
-                                            * parameters.temperature_degree
-                                            * parameters.temperature_degree
-                                            / face->measure()
-                                            * conductivity
-                                            / (density_c_P + latent_heat_LHS)
-                                            :
-                                            0.0);
-
-                    const double dirichlet_value = (advection_field.is_temperature()
-                                                    ?
-                                                    boundary_temperature->temperature(*geometry_model,
-#if DEAL_II_VERSION_GTE(8,3,0)
-                                                                                      cell->face(f)->boundary_id(),
-#else
-                                                                                      cell->face(f)->boundary_indicator(),
-#endif
-                                                                                      scratch.face_finite_element_values->quadrature_point(q))
-                                                    :
-                                                    boundary_composition->composition(*geometry_model,
-#if DEAL_II_VERSION_GTE(8,3,0)
-                                                                                      cell->face(f)->boundary_id(),
-#else
-                                                                                      cell->face(f)->boundary_indicator(),
-#endif
-                                                                                      scratch.face_finite_element_values->quadrature_point(q),
-                                                                                      advection_field.compositional_variable));
-
-                    Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
-                    //Subtract off the mesh velocity for ALE corrections if necessary
-                    if (parameters.free_surface_enabled)
-                      current_u -= scratch.face_mesh_velocity_values[q];
-
-                    /**
-                     * The discontinuous Galerkin method uses 2 types of jumps over edges:
-                     * undirected and directed jumps. Undirected jumps are dependent only
-                     * on the order of the numbering of cells. Directed jumps are dependent
-                     * on the direction of the flow. Thus the flow-dependent terms below are
-                     * only calculated if the edge is an inflow edge.
-                     */
-                    const bool inflow = ((current_u * scratch.face_finite_element_values->normal_vector(q)) < 0.);
-
-                    for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
-                      {
-                        data.local_rhs(i)
-                        += (- time_step *  conductivity
-                            * scratch.face_grad_phi_field[i]
-                            * scratch.face_finite_element_values->normal_vector(q)
-                            * dirichlet_value
-
-                            + time_step
-                            * (density_c_P + latent_heat_LHS)
-                            * penalty
-                            * scratch.face_phi_field[i]
-                            * dirichlet_value
-
-                            + (inflow
-                               ?
-                               - (density_c_P + latent_heat_LHS)
-                               * time_step
-                               * (current_u
-                                  * scratch.face_finite_element_values->normal_vector(q))
-                               * dirichlet_value
-                               * scratch.face_phi_field[i]
-                               :
-                               0.)
-                           )
-                           *
-                           scratch.face_finite_element_values->JxW(q);
-
-                        // local_matrix terms
-                        for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
-                          {
-                            data.local_matrix(i,j)
-                            += (- time_step *  conductivity
-                                * scratch.face_grad_phi_field[i]
-                                * scratch.face_finite_element_values->normal_vector(q)
-                                * scratch.face_phi_field[j]
-
-                                - time_step *  conductivity
-                                * scratch.face_grad_phi_field[j]
-                                * scratch.face_finite_element_values->normal_vector(q)
-                                * scratch.face_phi_field[i]
-
-                                + time_step
-                                * (density_c_P + latent_heat_LHS)
-                                * penalty
-                                * scratch.face_phi_field[i]
-                                * scratch.face_phi_field[j]
-
-                                + (inflow
-                                   ?
-                                   - (density_c_P + latent_heat_LHS)
-                                   * time_step
-                                   * (current_u
-                                      * scratch.face_finite_element_values->normal_vector(q))
-                                   * scratch.face_phi_field[i]
-                                   * scratch.face_phi_field[j]
-                                   :
-                                   0.)
-                               )
-                               * scratch.face_finite_element_values->JxW(q);
-
-                          }
-                      }
-                  }
-              }
-            else
-              {
-                //Neumann temperature term - no non-zero contribution as only homogeneous Neumann boundary conditions are implemented elsewhere for temperature
-              }
-          }
-        else
-          {
-            //interior face - no contribution on RHS
-            Assert (cell->neighbor(f).state() == IteratorState::valid,
-                    ExcInternalError());
-            const typename DoFHandler<dim>::cell_iterator neighbor = cell->neighbor(f); //note: NOT active_cell_iterator, so this includes cells that are refined.
-
-            if (!(face->has_children()))
-              {
-                if (!cell->neighbor_is_coarser(f) &&
-                    (((neighbor->is_locally_owned()) && (cell->index() < neighbor->index()))
-                     ||
-                     ((!neighbor->is_locally_owned()) && (cell->subdomain_id() < neighbor->subdomain_id()))))
-                  {
-                    Assert (cell->is_locally_owned(), ExcInternalError());
-                    //cell and neighbor are equal-sized, and cell has been chosen to assemble this face, so calculate from cell
-
-                    //how does the neighbor talk about this cell?
-                    const unsigned int neighbor2=cell->neighbor_of_neighbor(f);
-
-                    //set up face values
-                    scratch.face_finite_element_values->reinit (cell, f);
-
-                    (*scratch.face_finite_element_values)[introspection.extractors.velocities].get_function_values(current_linearization_point,
-                        scratch.face_current_velocity_values);
-
-                    //get the mesh velocity, as we need to subtract it off of the advection systems
-                    if (parameters.free_surface_enabled)
-                      (*scratch.face_finite_element_values)[introspection.extractors.velocities].get_function_values(free_surface->mesh_velocity,
-                          scratch.face_mesh_velocity_values);
-
-                    compute_material_model_input_values (current_linearization_point,
-                                                         *scratch.face_finite_element_values,
-                                                         cell,
-                                                         true,
-                                                         scratch.face_material_model_inputs);
-                    material_model->evaluate(scratch.face_material_model_inputs,
-                                             scratch.face_material_model_outputs);
-
-                    HeatingModel::HeatingModelOutputs face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
-                    heating_model_manager.evaluate(scratch.face_material_model_inputs,
-                                                   scratch.face_material_model_outputs,
-                                                   face_heating_model_outputs);
-
-
-                    //set up neighbor values
-                    scratch.neighbor_face_finite_element_values->reinit (neighbor, neighbor2);
-
-                    compute_material_model_input_values (current_linearization_point,
-                                                         *scratch.neighbor_face_finite_element_values,
-                                                         neighbor,
-                                                         true,
-                                                         scratch.neighbor_face_material_model_inputs);
-                    material_model->evaluate(scratch.neighbor_face_material_model_inputs,
-                                             scratch.neighbor_face_material_model_outputs);
-
-                    HeatingModel::HeatingModelOutputs neighbor_face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
-                    heating_model_manager.evaluate(scratch.neighbor_face_material_model_inputs,
-                                                   scratch.neighbor_face_material_model_outputs,
-                                                   neighbor_face_heating_model_outputs);
-
-                    std::vector<types::global_dof_index> neighbor_dof_indices (scratch.face_finite_element_values->get_fe().dofs_per_cell);
-                    // get all dof indices on the neighbor, then extract those
-                    // that correspond to the solution_field we are interested in
-                    neighbor->get_dof_indices (neighbor_dof_indices);
-                    for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
-                      data.neighbor_dof_indices[f * GeometryInfo<dim>::max_children_per_face][i] = neighbor_dof_indices[scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, i)];
-                    data.assembled_matrices[f * GeometryInfo<dim>::max_children_per_face] = true;
-
-                    for (unsigned int q=0; q<n_q_points; ++q)
-                      {
-                        // precompute the values of shape functions and their gradients.
-                        // We only need to look up values of shape functions if they
-                        // belong to 'our' component. They are zero otherwise anyway.
-                        // Note that we later only look at the values that we do set here.
-                        for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
-                          {
-                            scratch.face_grad_phi_field[k]          = (*scratch.face_finite_element_values)[solution_field].gradient (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                            scratch.face_phi_field[k]               = (*scratch.face_finite_element_values)[solution_field].value (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                            scratch.neighbor_face_grad_phi_field[k] = (*scratch.neighbor_face_finite_element_values)[solution_field].gradient (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                            scratch.neighbor_face_phi_field[k]      = (*scratch.neighbor_face_finite_element_values)[solution_field].value (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                          }
-
-                        const double density_c_P              =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.face_material_model_outputs.densities[q] *
-                           scratch.face_material_model_outputs.specific_heat[q]
-                           :
-                           1.0);
-
-                        Assert (density_c_P >= 0,
-                                ExcMessage ("The product of density and c_P needs to be a "
-                                            "non-negative quantity."));
-
-                        const double conductivity =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.face_material_model_outputs.thermal_conductivities[q]
-                           :
-                           0.0);
-                        const double latent_heat_LHS =
-                          ((advection_field.is_temperature())
-                           ?
-                           face_heating_model_outputs.lhs_latent_heat_terms[q]
-                           :
-                           0.0);
-                        Assert (density_c_P + latent_heat_LHS >= 0,
-                                ExcMessage ("The sum of density times c_P and the latent heat contribution "
-                                            "to the left hand side needs to be a non-negative quantity."));
-
-                        const double penalty = (advection_field.is_temperature()
-                                                ?
-                                                parameters.discontinuous_penalty
-                                                * parameters.temperature_degree
-                                                * parameters.temperature_degree
-                                                / face->measure()
-                                                * conductivity
-                                                / (density_c_P + latent_heat_LHS)
-                                                :
-                                                0.0);
-
-                        Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
-                        //Subtract off the mesh velocity for ALE corrections if necessary
-                        if (parameters.free_surface_enabled)
-                          current_u -= scratch.face_mesh_velocity_values[q];
-
-                        const double neighbor_density_c_P              =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.neighbor_face_material_model_outputs.densities[q] *
-                           scratch.neighbor_face_material_model_outputs.specific_heat[q]
-                           :
-                           1.0);
-
-                        Assert (neighbor_density_c_P >= 0,
-                                ExcMessage ("The product of density and c_P on the neighbor needs to be a "
-                                            "non-negative quantity."));
-
-                        const double neighbor_conductivity =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.neighbor_face_material_model_outputs.thermal_conductivities[q]
-                           :
-                           0.0);
-                        const double neighbor_latent_heat_LHS =
-                          ((advection_field.is_temperature())
-                           ?
-                           neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
-                           :
-                           0.0);
-                        Assert (neighbor_density_c_P + neighbor_latent_heat_LHS >= 0,
-                                ExcMessage ("The sum of density times c_P and the latent heat contribution "
-                                            "to the left hand side on the neighbor needs to be a non-negative quantity."));
-
-                        const double neighbor_penalty = (advection_field.is_temperature()
-                                                         ?
-                                                         parameters.discontinuous_penalty
-                                                         * parameters.temperature_degree
-                                                         * parameters.temperature_degree
-                                                         / neighbor->face(neighbor2)->measure()
-                                                         * neighbor_conductivity
-                                                         / (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                                         :
-                                                         0.0);
-
-                        const double max_penalty = std::max(penalty, neighbor_penalty);
-
-                        const double max_density_c_P_and_latent_heat =
-                          std::max(density_c_P + latent_heat_LHS,
-                                   neighbor_density_c_P + neighbor_latent_heat_LHS);
-
-                        Assert (numbers::is_finite(max_density_c_P_and_latent_heat),
-                                ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a finite quantity."));
-                        Assert (max_density_c_P_and_latent_heat >= 0,
-                                ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a "
-                                            "non-negative quantity."));
-
-                        /**
-                         * The discontinuous Galerkin method uses 2 types of jumps over edges:
-                         * undirected and directed jumps. Undirected jumps are dependent only
-                         * on the order of the numbering of cells. Directed jumps are dependent
-                         * on the direction of the flow. Thus the flow-dependent terms below are
-                         * only calculated if the edge is an inflow edge.
-                         */
-                        const bool inflow = ((current_u * scratch.face_finite_element_values->normal_vector(q)) < 0.);
-
-                        for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
-                          {
-                            for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
-                              {
-                                data.local_matrix(i,j)
-                                += (- 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[i]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[j]
-
-                                    - 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[j]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[i]
-
-                                    + time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.face_phi_field[i]
-                                    * scratch.face_phi_field[j]
-
-                                    - (inflow
-                                       ?
-                                       (density_c_P + latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.face_finite_element_values->normal_vector(q))
-                                       * scratch.face_phi_field[i]
-                                       * scratch.face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.face_finite_element_values->JxW(q);
-
-                                data.local_matrices_int_ext[f * GeometryInfo<dim>::max_children_per_face](i,j)
-                                += (- 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[j]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[i]
-
-                                    + 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[i]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[j]
-
-                                    - time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.neighbor_face_phi_field[j]
-                                    * scratch.face_phi_field[i]
-
-                                    + (inflow
-                                       ?
-                                       (density_c_P + latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.face_finite_element_values->normal_vector(q))
-                                       * scratch.face_phi_field[i]
-                                       * scratch.neighbor_face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.face_finite_element_values->JxW(q);
-
-                                data.local_matrices_ext_int[f * GeometryInfo<dim>::max_children_per_face](i,j)
-                                += (+ 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[j]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[i]
-
-                                    - 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[i]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[j]
-
-                                    - time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.face_phi_field[j]
-                                    * scratch.neighbor_face_phi_field[i]
-
-                                    - (!inflow
-                                       ?
-                                       (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.face_finite_element_values->normal_vector(q))
-                                       * scratch.neighbor_face_phi_field[i]
-                                       * scratch.face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.face_finite_element_values->JxW(q);
-
-                                data.local_matrices_ext_ext[f * GeometryInfo<dim>::max_children_per_face](i,j)
-                                += (+ 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[i]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[j]
-
-                                    + 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[j]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[i]
-
-                                    + time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.neighbor_face_phi_field[i]
-                                    * scratch.neighbor_face_phi_field[j]
-
-                                    + (!inflow
-                                       ?
-                                       (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.face_finite_element_values->normal_vector(q))
-                                       * scratch.neighbor_face_phi_field[i]
-                                       * scratch.neighbor_face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.face_finite_element_values->JxW(q);
-                              }
-                          }
-                      }
-                  }
-                else
-                  {
-                    /* neighbor is taking responsibility for assembly of this face, because
-                     * either (1) neighbor is coarser, or
-                     *        (2) neighbor is equally-sized and
-                     *           (a) neighbor is on a different subdomain, with lower subdmain_id(), or
-                     *           (b) neighbor is on the same subdomain and has lower index().
-                    */
-                  }
-              }
-            else //face->has_children(), so always assemble from here.
-              {
-                //how does the neighbor talk about this cell?
-                const unsigned int neighbor2 = cell->neighbor_face_no(f);
-
-                //loop over subfaces
-                for (unsigned int subface_no=0; subface_no<face->number_of_children(); ++subface_no)
-                  {
-                    const typename DoFHandler<dim>::active_cell_iterator neighbor_child
-                      = cell->neighbor_child_on_subface (f, subface_no);
-
-                    //set up subface values
-                    scratch.subface_finite_element_values->reinit (cell, f, subface_no);
-
-                    //subface->face
-                    (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(current_linearization_point,
-                        scratch.face_current_velocity_values);
-
-                    //get the mesh velocity, as we need to subtract it off of the advection systems
-                    if (parameters.free_surface_enabled)
-                      (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(free_surface->mesh_velocity,
-                          scratch.face_mesh_velocity_values);
-
-                    //get the mesh velocity, as we need to subtract it off of the advection systems
-                    if (parameters.free_surface_enabled)
-                      (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(free_surface->mesh_velocity,
-                          scratch.face_mesh_velocity_values);
-
-                    compute_material_model_input_values (current_linearization_point,
-                                                         *scratch.subface_finite_element_values,
-                                                         cell,
-                                                         true,
-                                                         scratch.face_material_model_inputs);
-                    material_model->evaluate(scratch.face_material_model_inputs,
-                                             scratch.face_material_model_outputs);
-
-                    HeatingModel::HeatingModelOutputs face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
-                    heating_model_manager.evaluate(scratch.face_material_model_inputs,
-                                                   scratch.face_material_model_outputs,
-                                                   face_heating_model_outputs);
-
-                    //set up neighbor values
-                    scratch.neighbor_face_finite_element_values->reinit (neighbor_child, neighbor2);
-
-                    compute_material_model_input_values (current_linearization_point,
-                                                         *scratch.neighbor_face_finite_element_values,
-                                                         neighbor_child,
-                                                         true,
-                                                         scratch.neighbor_face_material_model_inputs);
-                    material_model->evaluate(scratch.neighbor_face_material_model_inputs,
-                                             scratch.neighbor_face_material_model_outputs);
-
-                    HeatingModel::HeatingModelOutputs neighbor_face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
-                    heating_model_manager.evaluate(scratch.neighbor_face_material_model_inputs,
-                                                   scratch.neighbor_face_material_model_outputs,
-                                                   neighbor_face_heating_model_outputs);
-
-                    std::vector<types::global_dof_index> neighbor_dof_indices (scratch.face_finite_element_values->get_fe().dofs_per_cell);
-                    // get all dof indices on the neighbor, then extract those
-                    // that correspond to the solution_field we are interested in
-                    neighbor_child->get_dof_indices (neighbor_dof_indices);
-                    for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
-                      data.neighbor_dof_indices[f * GeometryInfo<dim>::max_children_per_face + subface_no][i] = neighbor_dof_indices[scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, i)];
-                    data.assembled_matrices[f * GeometryInfo<dim>::max_children_per_face + subface_no] = true;
-
-                    for (unsigned int q=0; q<n_q_points; ++q)
-                      {
-                        // precompute the values of shape functions and their gradients.
-                        // We only need to look up values of shape functions if they
-                        // belong to 'our' component. They are zero otherwise anyway.
-                        // Note that we later only look at the values that we do set here.
-                        for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
-                          {
-                            scratch.face_grad_phi_field[k]          = (*scratch.subface_finite_element_values)[solution_field].gradient (scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                            scratch.face_phi_field[k]               = (*scratch.subface_finite_element_values)[solution_field].value (scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                            scratch.neighbor_face_grad_phi_field[k] = (*scratch.neighbor_face_finite_element_values)[solution_field].gradient (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                            scratch.neighbor_face_phi_field[k]      = (*scratch.neighbor_face_finite_element_values)[solution_field].value (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                          }
-
-                        const double density_c_P              =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.face_material_model_outputs.densities[q] *
-                           scratch.face_material_model_outputs.specific_heat[q]
-                           :
-                           1.0);
-
-                        Assert (density_c_P >= 0,
-                                ExcMessage ("The product of density and c_P needs to be a "
-                                            "non-negative quantity."));
-
-                        const double conductivity =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.face_material_model_outputs.thermal_conductivities[q]
-                           :
-                           0.0);
-                        const double latent_heat_LHS =
-                          ((advection_field.is_temperature())
-                           ?
-                           face_heating_model_outputs.lhs_latent_heat_terms[q]
-                           :
-                           0.0);
-                        Assert (density_c_P + latent_heat_LHS >= 0,
-                                ExcMessage ("The sum of density times c_P and the latent heat contribution "
-                                            "to the left hand side needs to be a non-negative quantity."));
-
-                        const double penalty = (advection_field.is_temperature()
-                                                ?
-                                                parameters.discontinuous_penalty
-                                                * parameters.temperature_degree
-                                                * parameters.temperature_degree
-                                                / face->measure()
-                                                * conductivity
-                                                / (density_c_P + latent_heat_LHS)
-                                                :
-                                                0.0);
-
-                        Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
-                        //Subtract off the mesh velocity for ALE corrections if necessary
-                        if (parameters.free_surface_enabled)
-                          current_u -= scratch.face_mesh_velocity_values[q];
-
-                        const double neighbor_density_c_P              =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.neighbor_face_material_model_outputs.densities[q] *
-                           scratch.neighbor_face_material_model_outputs.specific_heat[q]
-                           :
-                           1.0);
-
-                        Assert (neighbor_density_c_P >= 0,
-                                ExcMessage ("The product of density and c_P on the neighbor needs to be a "
-                                            "non-negative quantity."));
-
-                        const double neighbor_conductivity =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.neighbor_face_material_model_outputs.thermal_conductivities[q]
-                           :
-                           0.0);
-                        const double neighbor_latent_heat_LHS =
-                          ((advection_field.is_temperature())
-                           ?
-                           neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
-                           :
-                           0.0);
-                        Assert (neighbor_density_c_P + neighbor_latent_heat_LHS >= 0,
-                                ExcMessage ("The sum of density times c_P and the latent heat contribution "
-                                            "to the left hand side on the neighbor needs to be a non-negative quantity."));
-
-                        const double neighbor_penalty = (advection_field.is_temperature()
-                                                         ?
-                                                         parameters.discontinuous_penalty
-                                                         * parameters.temperature_degree
-                                                         * parameters.temperature_degree
-                                                         / neighbor_child->face(neighbor2)->measure()
-                                                         * neighbor_conductivity
-                                                         / (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                                         :
-                                                         0.0);
-
-                        const double max_penalty = std::max(penalty, neighbor_penalty);
-
-                        const double max_density_c_P_and_latent_heat =
-                          std::max(density_c_P + latent_heat_LHS,
-                                   neighbor_density_c_P + neighbor_latent_heat_LHS);
-
-                        Assert (numbers::is_finite(max_density_c_P_and_latent_heat),
-                                ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a finite quantity."));
-                        Assert (max_density_c_P_and_latent_heat >= 0,
-                                ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a "
-                                            "non-negative quantity."));
-
-                        /**
-                         * The discontinuous Galerkin method uses 2 types of jumps over edges:
-                         * undirected and directed jumps. Undirected jumps are dependent only
-                         * on the order of the numbering of cells. Directed jumps are dependent
-                         * on the direction of the flow. Thus the flow-dependent terms below are
-                         * only calculated if the edge is an inflow edge.
-                         */
-                        const bool inflow = ((current_u * scratch.subface_finite_element_values->normal_vector(q)) < 0.);
-
-                        for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
-                          {
-                            for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
-                              {
-                                data.local_matrix(i,j)
-                                += (- 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[i]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[j]
-
-                                    - 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[j]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[i]
-
-                                    + time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.face_phi_field[i]
-                                    * scratch.face_phi_field[j]
-
-                                    - (inflow
-                                       ?
-                                       (density_c_P + latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.subface_finite_element_values->normal_vector(q))
-                                       * scratch.face_phi_field[i]
-                                       * scratch.face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.subface_finite_element_values->JxW(q);
-
-                                data.local_matrices_int_ext[f * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
-                                += (- 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[j]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[i]
-
-                                    + 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[i]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[j]
-
-                                    - time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.neighbor_face_phi_field[j]
-                                    * scratch.face_phi_field[i]
-
-                                    + (inflow
-                                       ?
-                                       (density_c_P + latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.subface_finite_element_values->normal_vector(q))
-                                       * scratch.face_phi_field[i]
-                                       * scratch.neighbor_face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.subface_finite_element_values->JxW(q);
-
-                                data.local_matrices_ext_int[f * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
-                                += (+ 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[j]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[i]
-
-                                    - 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[i]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[j]
-
-                                    - time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.face_phi_field[j]
-                                    * scratch.neighbor_face_phi_field[i]
-
-                                    - (!inflow
-                                       ?
-                                       (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.subface_finite_element_values->normal_vector(q))
-                                       * scratch.neighbor_face_phi_field[i]
-                                       * scratch.face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.subface_finite_element_values->JxW(q);
-
-                                data.local_matrices_ext_ext[f * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
-                                += (+ 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[i]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[j]
-
-                                    + 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[j]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[i]
-
-                                    + time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.neighbor_face_phi_field[i]
-                                    * scratch.neighbor_face_phi_field[j]
-
-                                    + (!inflow
-                                       ?
-                                       (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.subface_finite_element_values->normal_vector(q))
-                                       * scratch.neighbor_face_phi_field[i]
-                                       * scratch.neighbor_face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.subface_finite_element_values->JxW(q);
-                              }
-                          }
-
-                      }
-                  }
-
-              }
-          }
-      }
-  }
 
   template <int dim>
   void Simulator<dim>::
@@ -2754,14 +2713,6 @@ namespace aspect
     Assert (scratch.grad_phi_field.size() == advection_dofs_per_cell, ExcInternalError());
     Assert (scratch.phi_field.size() == advection_dofs_per_cell, ExcInternalError());
 
-    const unsigned int solution_component
-      = (advection_field.is_temperature()
-         ?
-         introspection.component_indices.temperature
-         :
-         introspection.component_indices.compositional_fields[advection_field.compositional_variable]
-        );
-
     const FEValuesExtractors::Scalar solution_field
       = (advection_field.is_temperature()
          ?
@@ -2769,6 +2720,8 @@ namespace aspect
          :
          introspection.extractors.compositional_fields[advection_field.compositional_variable]
         );
+
+    const unsigned int solution_component = advection_field.component_index(introspection);
 
     scratch.finite_element_values.reinit (cell);
 
@@ -2888,11 +2841,61 @@ namespace aspect
     // all of the assembling
     assemblers->local_assemble_advection_system(cell,advection_field,nu,scratch,data);
 
+    // then also work on possible face terms. if necessary, initialize
+    // the material model data on faces
     if (advection_field.is_discontinuous(introspection))
-      local_assemble_advection_face_terms(advection_field,
-                                          cell,
-                                          scratch,
-                                          data);
+      {
+        // for interior face contributions loop over all possible
+        // subfaces of the cell, and reset their matrices.
+        for (unsigned int f = 0; f < GeometryInfo<dim>::max_children_per_face * GeometryInfo<dim>::faces_per_cell; ++f)
+          {
+            data.local_matrices_ext_int[f] = 0;
+            data.local_matrices_int_ext[f] = 0;
+            data.local_matrices_ext_ext[f] = 0;
+            data.assembled_matrices[f] = false;
+          }
+
+        for (unsigned int face_no=0; face_no<GeometryInfo<dim>::faces_per_cell; ++face_no)
+          {
+            (*scratch.face_finite_element_values).reinit (cell, face_no);
+
+            (*scratch.face_finite_element_values)[introspection.extractors.velocities].get_function_values(current_linearization_point,
+                scratch.face_current_velocity_values);
+
+            //get the mesh velocity, as we need to subtract it off of the advection systems
+            if (parameters.free_surface_enabled)
+              (*scratch.face_finite_element_values)[introspection.extractors.velocities].get_function_values(free_surface->mesh_velocity,
+                  scratch.face_mesh_velocity_values);
+
+            if (assemblers->advection_system_assembler_on_boundary_face_properties.need_face_material_model_data)
+              {
+                compute_material_model_input_values (current_linearization_point,
+                                                     *scratch.face_finite_element_values,
+                                                     cell,
+                                                     true,
+                                                     scratch.face_material_model_inputs);
+                create_additional_material_model_outputs(scratch.face_material_model_outputs);
+
+                material_model->evaluate(scratch.face_material_model_inputs,
+                                         scratch.face_material_model_outputs);
+
+                heating_model_manager.evaluate(scratch.face_material_model_inputs,
+                                               scratch.face_material_model_outputs,
+                                               scratch.face_heating_model_outputs);
+                //TODO: the following doesn't currently compile because the get_quadrature() call returns
+                //  a dim-1 dimensional quadrature
+                // MaterialModel::MaterialAveraging::average (parameters.material_averaging,
+                //                                            cell,
+                //                                            scratch.face_finite_element_values.get_quadrature(),
+                //                                            scratch.face_finite_element_values.get_mapping(),
+                //                                            scratch.face_material_model_outputs);
+              }
+
+            assemblers->local_assemble_advection_system_on_boundary_face(cell, face_no,
+                                                                         advection_field,
+                                                                         scratch, data);
+          }
+      }
   }
 
   template <int dim>
@@ -3064,11 +3067,6 @@ namespace aspect
                                                           const AdvectionField &advection_field) const; \
   template void Simulator<dim>::build_advection_preconditioner (const AdvectionField &, \
                                                                 std_cxx11::shared_ptr<aspect::LinearAlgebra::PreconditionILU> &preconditioner); \
-  template void Simulator<dim>::local_assemble_advection_face_terms ( \
-                                                                      const AdvectionField                        &advection_field, \
-                                                                      const DoFHandler<dim>::active_cell_iterator &cell, \
-                                                                      internal::Assembly::Scratch::AdvectionSystem<dim>  &scratch, \
-                                                                      internal::Assembly::CopyData::AdvectionSystem<dim> &data); \
   template void Simulator<dim>::local_assemble_advection_system ( \
                                                                   const AdvectionField          &advection_field, \
                                                                   const Vector<double>           &viscosity_per_cell, \

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1267,11 +1267,11 @@ namespace aspect
         }
 
         void
-        local_assemble_advection_face_terms(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                                            const unsigned int face_no,
-                                            const typename Simulator<dim>::AdvectionField &advection_field,
-                                            internal::Assembly::Scratch::AdvectionSystem<dim> &scratch,
-                                            internal::Assembly::CopyData::AdvectionSystem<dim> &data) const
+        local_assemble_discontinuous_advection_boundary_face_terms(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                                                                   const unsigned int face_no,
+                                                                   const typename Simulator<dim>::AdvectionField &advection_field,
+                                                                   internal::Assembly::Scratch::AdvectionSystem<dim> &scratch,
+                                                                   internal::Assembly::CopyData::AdvectionSystem<dim> &data) const
         {
           const Parameters<dim> &parameters = this->get_parameters();
           const Introspection<dim> &introspection = this->introspection();
@@ -1279,12 +1279,12 @@ namespace aspect
 
           const double time_step = this->get_timestep();
 
+          if (!advection_field.is_discontinuous(introspection))
+            return;
+
           // also have the number of dofs that correspond just to the element for
           // the system we are currently trying to assemble
           const unsigned int advection_dofs_per_cell = data.local_dof_indices.size();
-
-          Assert (advection_field.is_discontinuous(introspection),
-                  ExcMessage("Face terms only need assembling in the case of discontinuous temperature or compositional discretization."));
 
           Assert (advection_dofs_per_cell < scratch.face_finite_element_values->get_fe().dofs_per_cell, ExcInternalError());
           Assert (scratch.face_grad_phi_field.size() == advection_dofs_per_cell, ExcInternalError());
@@ -1302,36 +1302,265 @@ namespace aspect
 
           typename DoFHandler<dim>::face_iterator face = cell->face (face_no);
 
-          if (face->at_boundary())
+          if (((parameters.fixed_temperature_boundary_indicators.find(
+#if DEAL_II_VERSION_GTE(8,3,0)
+                  face->boundary_id()
+#else
+                  face->boundary_indicator()
+#endif
+                )
+                != parameters.fixed_temperature_boundary_indicators.end())
+               && (advection_field.is_temperature()))
+              ||
+              (( parameters.fixed_composition_boundary_indicators.find(
+#if DEAL_II_VERSION_GTE(8,3,0)
+                   face->boundary_id()
+#else
+                   face->boundary_indicator()
+#endif
+                 )
+                 != parameters.fixed_composition_boundary_indicators.end())
+               && (!advection_field.is_temperature())))
             {
-              if (((parameters.fixed_temperature_boundary_indicators.find(
-#if DEAL_II_VERSION_GTE(8,3,0)
-                      cell->face(face_no)->boundary_id()
-#else
-                      cell->face(face_no)->boundary_indicator()
-#endif
-                    )
-                    != parameters.fixed_temperature_boundary_indicators.end())
-                   && (advection_field.is_temperature()))
-                  ||
-                  (( parameters.fixed_composition_boundary_indicators.find(
-#if DEAL_II_VERSION_GTE(8,3,0)
-                       cell->face(face_no)->boundary_id()
-#else
-                       cell->face(face_no)->boundary_indicator()
-#endif
-                     )
-                     != parameters.fixed_composition_boundary_indicators.end())
-                   && (!advection_field.is_temperature())))
+              /*
+               * We are in the case of a Dirichlet temperature or composition boundary.
+               * In the temperature case, impose the Dirichlet value weakly using a matrix term
+               * and RHS term. In the composition case, Dirichlet conditions can only be imposed
+               * on inflow boundaries, and we only have the flow-dependent terms, so we only
+               * assemble the corresponding flow-dependent and matrix and RHS terms
+               * if we are on an inflow boundary.
+               */
+
+              for (unsigned int q=0; q<n_q_points; ++q)
                 {
-                  /*
-                   * We are in the case of a Dirichlet temperature or composition boundary.
-                   * In the temperature case, impose the Dirichlet value weakly using a matrix term
-                   * and RHS term. In the composition case, Dirichlet conditions can only be imposed
-                   * on inflow boundaries, and we only have the flow-dependent terms, so we only
-                   * assemble the corresponding flow-dependent and matrix and RHS terms
-                   * if we are on an inflow boundary.
+                  // precompute the values of shape functions and their gradients.
+                  // We only need to look up values of shape functions if they
+                  // belong to 'our' component. They are zero otherwise anyway.
+                  // Note that we later only look at the values that we do set here.
+                  for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
+                    {
+                      scratch.face_grad_phi_field[k] = (*scratch.face_finite_element_values)[solution_field].gradient (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                      scratch.face_phi_field[k]      = (*scratch.face_finite_element_values)[solution_field].value (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                    }
+                  const double density_c_P              =
+                    ((advection_field.is_temperature())
+                     ?
+                     scratch.face_material_model_outputs.densities[q] *
+                     scratch.face_material_model_outputs.specific_heat[q]
+                     :
+                     1.0);
+
+                  Assert (density_c_P >= 0,
+                          ExcMessage ("The product of density and c_P needs to be a "
+                                      "non-negative quantity."));
+
+                  const double conductivity =
+                    ((advection_field.is_temperature())
+                     ?
+                     scratch.face_material_model_outputs.thermal_conductivities[q]
+                     :
+                     0.0);
+                  const double latent_heat_LHS =
+                    ((advection_field.is_temperature())
+                     ?
+                     scratch.face_heating_model_outputs.lhs_latent_heat_terms[q]
+                     :
+                     0.0);
+                  Assert (density_c_P + latent_heat_LHS >= 0,
+                          ExcMessage ("The sum of density times c_P and the latent heat contribution "
+                                      "to the left hand side needs to be a non-negative quantity."));
+
+                  const double penalty = (advection_field.is_temperature()
+                                          ?
+                                          parameters.discontinuous_penalty
+                                          * parameters.temperature_degree
+                                          * parameters.temperature_degree
+                                          / face->measure()
+                                          * conductivity
+                                          / (density_c_P + latent_heat_LHS)
+                                          :
+                                          0.0);
+
+                  const double dirichlet_value = (advection_field.is_temperature()
+                                                  ?
+                                                  this->get_boundary_temperature().boundary_temperature(
+#if DEAL_II_VERSION_GTE(8,3,0)
+                                                    cell->face(face_no)->boundary_id(),
+#else
+                                                    cell->face(face_no)->boundary_indicator(),
+#endif
+                                                    scratch.face_finite_element_values->quadrature_point(q))
+                                                  :
+                                                  this->get_boundary_composition().boundary_composition(
+#if DEAL_II_VERSION_GTE(8,3,0)
+                                                    cell->face(face_no)->boundary_id(),
+#else
+                                                    cell->face(face_no)->boundary_indicator(),
+#endif
+                                                    scratch.face_finite_element_values->quadrature_point(q),
+                                                    advection_field.compositional_variable));
+
+                  Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
+                  //Subtract off the mesh velocity for ALE corrections if necessary
+                  if (parameters.free_surface_enabled)
+                    current_u -= scratch.face_mesh_velocity_values[q];
+
+                  /**
+                   * The discontinuous Galerkin method uses 2 types of jumps over edges:
+                   * undirected and directed jumps. Undirected jumps are dependent only
+                   * on the order of the numbering of cells. Directed jumps are dependent
+                   * on the direction of the flow. Thus the flow-dependent terms below are
+                   * only calculated if the edge is an inflow edge.
                    */
+                  const bool inflow = ((current_u * scratch.face_finite_element_values->normal_vector(q)) < 0.);
+
+                  for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+                    {
+                      data.local_rhs(i)
+                      += (- time_step *  conductivity
+                          * scratch.face_grad_phi_field[i]
+                          * scratch.face_finite_element_values->normal_vector(q)
+                          * dirichlet_value
+
+                          + time_step
+                          * (density_c_P + latent_heat_LHS)
+                          * penalty
+                          * scratch.face_phi_field[i]
+                          * dirichlet_value
+
+                          + (inflow
+                             ?
+                             - (density_c_P + latent_heat_LHS)
+                             * time_step
+                             * (current_u
+                                * scratch.face_finite_element_values->normal_vector(q))
+                             * dirichlet_value
+                             * scratch.face_phi_field[i]
+                             :
+                             0.)
+                         )
+                         *
+                         scratch.face_finite_element_values->JxW(q);
+
+                      // local_matrix terms
+                      for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
+                        {
+                          data.local_matrix(i,j)
+                          += (- time_step *  conductivity
+                              * scratch.face_grad_phi_field[i]
+                              * scratch.face_finite_element_values->normal_vector(q)
+                              * scratch.face_phi_field[j]
+
+                              - time_step *  conductivity
+                              * scratch.face_grad_phi_field[j]
+                              * scratch.face_finite_element_values->normal_vector(q)
+                              * scratch.face_phi_field[i]
+
+                              + time_step
+                              * (density_c_P + latent_heat_LHS)
+                              * penalty
+                              * scratch.face_phi_field[i]
+                              * scratch.face_phi_field[j]
+
+                              + (inflow
+                                 ?
+                                 - (density_c_P + latent_heat_LHS)
+                                 * time_step
+                                 * (current_u
+                                    * scratch.face_finite_element_values->normal_vector(q))
+                                 * scratch.face_phi_field[i]
+                                 * scratch.face_phi_field[j]
+                                 :
+                                 0.)
+                             )
+                             * scratch.face_finite_element_values->JxW(q);
+                        }
+                    }
+                }
+            }
+          else
+            {
+              //Neumann temperature term - no non-zero contribution as only homogeneous Neumann boundary conditions are implemented elsewhere for temperature
+            }
+        }
+
+        void
+        local_assemble_discontinuous_advection_interior_face_terms(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                                                                   const unsigned int face_no,
+                                                                   const typename Simulator<dim>::AdvectionField &advection_field,
+                                                                   internal::Assembly::Scratch::AdvectionSystem<dim> &scratch,
+                                                                   internal::Assembly::CopyData::AdvectionSystem<dim> &data) const
+        {
+          const Parameters<dim> &parameters = this->get_parameters();
+          const Introspection<dim> &introspection = this->introspection();
+          const unsigned int n_q_points    = scratch.face_finite_element_values->n_quadrature_points;
+
+          const double time_step = this->get_timestep();
+
+          if (!advection_field.is_discontinuous(introspection))
+            return;
+
+          // also have the number of dofs that correspond just to the element for
+          // the system we are currently trying to assemble
+          const unsigned int advection_dofs_per_cell = data.local_dof_indices.size();
+
+          Assert (advection_dofs_per_cell < scratch.face_finite_element_values->get_fe().dofs_per_cell, ExcInternalError());
+          Assert (scratch.face_grad_phi_field.size() == advection_dofs_per_cell, ExcInternalError());
+          Assert (scratch.face_phi_field.size() == advection_dofs_per_cell, ExcInternalError());
+
+          const unsigned int solution_component = advection_field.component_index(introspection);
+
+          const FEValuesExtractors::Scalar solution_field
+            = (advection_field.is_temperature()
+               ?
+               introspection.extractors.temperature
+               :
+               introspection.extractors.compositional_fields[advection_field.compositional_variable]
+              );
+
+          typename DoFHandler<dim>::face_iterator face = cell->face (face_no);
+
+          //interior face - no contribution on RHS
+          Assert (cell->neighbor(face_no).state() == IteratorState::valid,
+                  ExcInternalError());
+          const typename DoFHandler<dim>::cell_iterator neighbor = cell->neighbor(face_no); //note: NOT active_cell_iterator, so this includes cells that are refined.
+
+          if (!(face->has_children()))
+            {
+              if (!cell->neighbor_is_coarser(face_no) &&
+                  (((neighbor->is_locally_owned()) && (cell->index() < neighbor->index()))
+                   ||
+                   ((!neighbor->is_locally_owned()) && (cell->subdomain_id() < neighbor->subdomain_id()))))
+                {
+                  Assert (cell->is_locally_owned(), ExcInternalError());
+                  //cell and neighbor are equal-sized, and cell has been chosen to assemble this face, so calculate from cell
+
+                  //how does the neighbor talk about this cell?
+                  const unsigned int neighbor2=cell->neighbor_of_neighbor(face_no);
+
+                  //set up neighbor values
+                  scratch.neighbor_face_finite_element_values->reinit (neighbor, neighbor2);
+
+                  this->compute_material_model_input_values (this->get_current_linearization_point(),
+                                                             *scratch.neighbor_face_finite_element_values,
+                                                             neighbor,
+                                                             true,
+                                                             scratch.neighbor_face_material_model_inputs);
+                  this->get_material_model().evaluate(scratch.neighbor_face_material_model_inputs,
+                                                      scratch.neighbor_face_material_model_outputs);
+
+                  HeatingModel::HeatingModelOutputs neighbor_face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
+                  this->get_heating_model_manager().evaluate(scratch.neighbor_face_material_model_inputs,
+                                                             scratch.neighbor_face_material_model_outputs,
+                                                             neighbor_face_heating_model_outputs);
+
+                  std::vector<types::global_dof_index> neighbor_dof_indices (scratch.face_finite_element_values->get_fe().dofs_per_cell);
+                  // get all dof indices on the neighbor, then extract those
+                  // that correspond to the solution_field we are interested in
+                  neighbor->get_dof_indices (neighbor_dof_indices);
+                  for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+                    data.neighbor_dof_indices[face_no * GeometryInfo<dim>::max_children_per_face][i] = neighbor_dof_indices[scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, i)];
+                  data.assembled_matrices[face_no * GeometryInfo<dim>::max_children_per_face] = true;
 
                   for (unsigned int q=0; q<n_q_points; ++q)
                     {
@@ -1341,9 +1570,12 @@ namespace aspect
                       // Note that we later only look at the values that we do set here.
                       for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
                         {
-                          scratch.face_grad_phi_field[k] = (*scratch.face_finite_element_values)[solution_field].gradient (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                          scratch.face_phi_field[k]      = (*scratch.face_finite_element_values)[solution_field].value (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                          scratch.face_grad_phi_field[k]          = (*scratch.face_finite_element_values)[solution_field].gradient (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                          scratch.face_phi_field[k]               = (*scratch.face_finite_element_values)[solution_field].value (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                          scratch.neighbor_face_grad_phi_field[k] = (*scratch.neighbor_face_finite_element_values)[solution_field].gradient (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                          scratch.neighbor_face_phi_field[k]      = (*scratch.neighbor_face_finite_element_values)[solution_field].value (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
                         }
+
                       const double density_c_P              =
                         ((advection_field.is_temperature())
                          ?
@@ -1383,29 +1615,61 @@ namespace aspect
                                               :
                                               0.0);
 
-                      const double dirichlet_value = (advection_field.is_temperature()
-                                                      ?
-                                                      this->get_boundary_temperature().boundary_temperature(
-#if DEAL_II_VERSION_GTE(8,3,0)
-                                                        cell->face(face_no)->boundary_id(),
-#else
-                                                        cell->face(face_no)->boundary_indicator(),
-#endif
-                                                        scratch.face_finite_element_values->quadrature_point(q))
-                                                      :
-                                                      this->get_boundary_composition().boundary_composition(
-#if DEAL_II_VERSION_GTE(8,3,0)
-                                                        cell->face(face_no)->boundary_id(),
-#else
-                                                        cell->face(face_no)->boundary_indicator(),
-#endif
-                                                        scratch.face_finite_element_values->quadrature_point(q),
-                                                        advection_field.compositional_variable));
-
                       Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
                       //Subtract off the mesh velocity for ALE corrections if necessary
                       if (parameters.free_surface_enabled)
                         current_u -= scratch.face_mesh_velocity_values[q];
+
+                      const double neighbor_density_c_P              =
+                        ((advection_field.is_temperature())
+                         ?
+                         scratch.neighbor_face_material_model_outputs.densities[q] *
+                         scratch.neighbor_face_material_model_outputs.specific_heat[q]
+                         :
+                         1.0);
+
+                      Assert (neighbor_density_c_P >= 0,
+                              ExcMessage ("The product of density and c_P on the neighbor needs to be a "
+                                          "non-negative quantity."));
+
+                      const double neighbor_conductivity =
+                        ((advection_field.is_temperature())
+                         ?
+                         scratch.neighbor_face_material_model_outputs.thermal_conductivities[q]
+                         :
+                         0.0);
+                      const double neighbor_latent_heat_LHS =
+                        ((advection_field.is_temperature())
+                         ?
+                         neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
+                         :
+                         0.0);
+                      Assert (neighbor_density_c_P + neighbor_latent_heat_LHS >= 0,
+                              ExcMessage ("The sum of density times c_P and the latent heat contribution "
+                                          "to the left hand side on the neighbor needs to be a non-negative quantity."));
+
+                      const double neighbor_penalty = (advection_field.is_temperature()
+                                                       ?
+                                                       parameters.discontinuous_penalty
+                                                       * parameters.temperature_degree
+                                                       * parameters.temperature_degree
+                                                       / neighbor->face(neighbor2)->measure()
+                                                       * neighbor_conductivity
+                                                       / (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                                       :
+                                                       0.0);
+
+                      const double max_penalty = std::max(penalty, neighbor_penalty);
+
+                      const double max_density_c_P_and_latent_heat =
+                        std::max(density_c_P + latent_heat_LHS,
+                                 neighbor_density_c_P + neighbor_latent_heat_LHS);
+
+                      Assert (numbers::is_finite(max_density_c_P_and_latent_heat),
+                              ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a finite quantity."));
+                      Assert (max_density_c_P_and_latent_heat >= 0,
+                              ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a "
+                                          "non-negative quantity."));
 
                       /**
                        * The discontinuous Galerkin method uses 2 types of jumps over edges:
@@ -1418,60 +1682,123 @@ namespace aspect
 
                       for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
                         {
-                          data.local_rhs(i)
-                          += (- time_step *  conductivity
-                              * scratch.face_grad_phi_field[i]
-                              * scratch.face_finite_element_values->normal_vector(q)
-                              * dirichlet_value
-
-                              + time_step
-                              * (density_c_P + latent_heat_LHS)
-                              * penalty
-                              * scratch.face_phi_field[i]
-                              * dirichlet_value
-
-                              + (inflow
-                                 ?
-                                 - (density_c_P + latent_heat_LHS)
-                                 * time_step
-                                 * (current_u
-                                    * scratch.face_finite_element_values->normal_vector(q))
-                                 * dirichlet_value
-                                 * scratch.face_phi_field[i]
-                                 :
-                                 0.)
-                             )
-                             *
-                             scratch.face_finite_element_values->JxW(q);
-
-                          // local_matrix terms
                           for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
                             {
                               data.local_matrix(i,j)
-                              += (- time_step *  conductivity
+                              += (- 0.5 * time_step * conductivity
                                   * scratch.face_grad_phi_field[i]
                                   * scratch.face_finite_element_values->normal_vector(q)
                                   * scratch.face_phi_field[j]
 
-                                  - time_step *  conductivity
+                                  - 0.5 * time_step * conductivity
                                   * scratch.face_grad_phi_field[j]
                                   * scratch.face_finite_element_values->normal_vector(q)
                                   * scratch.face_phi_field[i]
 
                                   + time_step
-                                  * (density_c_P + latent_heat_LHS)
-                                  * penalty
+                                  * max_density_c_P_and_latent_heat
+                                  * max_penalty
                                   * scratch.face_phi_field[i]
                                   * scratch.face_phi_field[j]
 
-                                  + (inflow
+                                  - (inflow
                                      ?
-                                     - (density_c_P + latent_heat_LHS)
+                                     (density_c_P + latent_heat_LHS)
                                      * time_step
                                      * (current_u
                                         * scratch.face_finite_element_values->normal_vector(q))
                                      * scratch.face_phi_field[i]
                                      * scratch.face_phi_field[j]
+                                     :
+                                     0.)
+                                 )
+                                 * scratch.face_finite_element_values->JxW(q);
+
+                              data.local_matrices_int_ext[face_no * GeometryInfo<dim>::max_children_per_face](i,j)
+                              += (- 0.5 * time_step * neighbor_conductivity
+                                  * scratch.neighbor_face_grad_phi_field[j]
+                                  * scratch.face_finite_element_values->normal_vector(q)
+                                  * scratch.face_phi_field[i]
+
+                                  + 0.5 * time_step * conductivity
+                                  * scratch.face_grad_phi_field[i]
+                                  * scratch.face_finite_element_values->normal_vector(q)
+                                  * scratch.neighbor_face_phi_field[j]
+
+                                  - time_step
+                                  * max_density_c_P_and_latent_heat
+                                  * max_penalty
+                                  * scratch.neighbor_face_phi_field[j]
+                                  * scratch.face_phi_field[i]
+
+                                  + (inflow
+                                     ?
+                                     (density_c_P + latent_heat_LHS)
+                                     * time_step
+                                     * (current_u
+                                        * scratch.face_finite_element_values->normal_vector(q))
+                                     * scratch.face_phi_field[i]
+                                     * scratch.neighbor_face_phi_field[j]
+                                     :
+                                     0.)
+                                 )
+                                 * scratch.face_finite_element_values->JxW(q);
+
+                              data.local_matrices_ext_int[face_no * GeometryInfo<dim>::max_children_per_face](i,j)
+                              += (+ 0.5 * time_step * conductivity
+                                  * scratch.face_grad_phi_field[j]
+                                  * scratch.face_finite_element_values->normal_vector(q)
+                                  * scratch.neighbor_face_phi_field[i]
+
+                                  - 0.5 * time_step * neighbor_conductivity
+                                  * scratch.neighbor_face_grad_phi_field[i]
+                                  * scratch.face_finite_element_values->normal_vector(q)
+                                  * scratch.face_phi_field[j]
+
+                                  - time_step
+                                  * max_density_c_P_and_latent_heat
+                                  * max_penalty
+                                  * scratch.face_phi_field[j]
+                                  * scratch.neighbor_face_phi_field[i]
+
+                                  - (!inflow
+                                     ?
+                                     (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                     * time_step
+                                     * (current_u
+                                        * scratch.face_finite_element_values->normal_vector(q))
+                                     * scratch.neighbor_face_phi_field[i]
+                                     * scratch.face_phi_field[j]
+                                     :
+                                     0.)
+                                 )
+                                 * scratch.face_finite_element_values->JxW(q);
+
+                              data.local_matrices_ext_ext[face_no * GeometryInfo<dim>::max_children_per_face](i,j)
+                              += (+ 0.5 * time_step * neighbor_conductivity
+                                  * scratch.neighbor_face_grad_phi_field[i]
+                                  * scratch.face_finite_element_values->normal_vector(q)
+                                  * scratch.neighbor_face_phi_field[j]
+
+                                  + 0.5 * time_step * neighbor_conductivity
+                                  * scratch.neighbor_face_grad_phi_field[j]
+                                  * scratch.face_finite_element_values->normal_vector(q)
+                                  * scratch.neighbor_face_phi_field[i]
+
+                                  + time_step
+                                  * max_density_c_P_and_latent_heat
+                                  * max_penalty
+                                  * scratch.neighbor_face_phi_field[i]
+                                  * scratch.neighbor_face_phi_field[j]
+
+                                  + (!inflow
+                                     ?
+                                     (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                     * time_step
+                                     * (current_u
+                                        * scratch.face_finite_element_values->normal_vector(q))
+                                     * scratch.neighbor_face_phi_field[i]
+                                     * scratch.neighbor_face_phi_field[j]
                                      :
                                      0.)
                                  )
@@ -1482,620 +1809,323 @@ namespace aspect
                 }
               else
                 {
-                  //Neumann temperature term - no non-zero contribution as only homogeneous Neumann boundary conditions are implemented elsewhere for temperature
+                  /* neighbor is taking responsibility for assembly of this face, because
+                   * either (1) neighbor is coarser, or
+                   *        (2) neighbor is equally-sized and
+                   *           (a) neighbor is on a different subdomain, with lower subdmain_id(), or
+                   *           (b) neighbor is on the same subdomain and has lower index().
+                  */
                 }
             }
-          else
+          else //face->has_children(), so always assemble from here.
             {
-              //interior face - no contribution on RHS
-              Assert (cell->neighbor(face_no).state() == IteratorState::valid,
-                      ExcInternalError());
-              const typename DoFHandler<dim>::cell_iterator neighbor = cell->neighbor(face_no); //note: NOT active_cell_iterator, so this includes cells that are refined.
+              //how does the neighbor talk about this cell?
+              const unsigned int neighbor2 = cell->neighbor_face_no(face_no);
 
-              if (!(face->has_children()))
+              //loop over subfaces
+              for (unsigned int subface_no=0; subface_no<face->number_of_children(); ++subface_no)
                 {
-                  if (!cell->neighbor_is_coarser(face_no) &&
-                      (((neighbor->is_locally_owned()) && (cell->index() < neighbor->index()))
-                       ||
-                       ((!neighbor->is_locally_owned()) && (cell->subdomain_id() < neighbor->subdomain_id()))))
+                  const typename DoFHandler<dim>::active_cell_iterator neighbor_child
+                    = cell->neighbor_child_on_subface (face_no, subface_no);
+
+                  //set up subface values
+                  scratch.subface_finite_element_values->reinit (cell, face_no, subface_no);
+
+                  //subface->face
+                  (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(this->get_current_linearization_point(),
+                      scratch.face_current_velocity_values);
+
+                  //get the mesh velocity, as we need to subtract it off of the advection systems
+                  if (parameters.free_surface_enabled)
+                    (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(this->get_mesh_velocity(),
+                        scratch.face_mesh_velocity_values);
+
+                  //get the mesh velocity, as we need to subtract it off of the advection systems
+                  if (parameters.free_surface_enabled)
+                    (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(this->get_mesh_velocity(),
+                        scratch.face_mesh_velocity_values);
+
+                  this->compute_material_model_input_values (this->get_current_linearization_point(),
+                                                             *scratch.subface_finite_element_values,
+                                                             cell,
+                                                             true,
+                                                             scratch.face_material_model_inputs);
+                  this->get_material_model().evaluate(scratch.face_material_model_inputs,
+                                                      scratch.face_material_model_outputs);
+
+                  HeatingModel::HeatingModelOutputs face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
+                  this->get_heating_model_manager().evaluate(scratch.face_material_model_inputs,
+                                                             scratch.face_material_model_outputs,
+                                                             face_heating_model_outputs);
+
+                  //set up neighbor values
+                  scratch.neighbor_face_finite_element_values->reinit (neighbor_child, neighbor2);
+
+                  this->compute_material_model_input_values (this->get_current_linearization_point(),
+                                                             *scratch.neighbor_face_finite_element_values,
+                                                             neighbor_child,
+                                                             true,
+                                                             scratch.neighbor_face_material_model_inputs);
+                  this->get_material_model().evaluate(scratch.neighbor_face_material_model_inputs,
+                                                      scratch.neighbor_face_material_model_outputs);
+
+                  HeatingModel::HeatingModelOutputs neighbor_face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
+                  this->get_heating_model_manager().evaluate(scratch.neighbor_face_material_model_inputs,
+                                                             scratch.neighbor_face_material_model_outputs,
+                                                             neighbor_face_heating_model_outputs);
+
+                  std::vector<types::global_dof_index> neighbor_dof_indices (scratch.face_finite_element_values->get_fe().dofs_per_cell);
+                  // get all dof indices on the neighbor, then extract those
+                  // that correspond to the solution_field we are interested in
+                  neighbor_child->get_dof_indices (neighbor_dof_indices);
+                  for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+                    data.neighbor_dof_indices[face_no * GeometryInfo<dim>::max_children_per_face + subface_no][i] = neighbor_dof_indices[scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, i)];
+                  data.assembled_matrices[face_no * GeometryInfo<dim>::max_children_per_face + subface_no] = true;
+
+                  for (unsigned int q=0; q<n_q_points; ++q)
                     {
-                      Assert (cell->is_locally_owned(), ExcInternalError());
-                      //cell and neighbor are equal-sized, and cell has been chosen to assemble this face, so calculate from cell
-
-                      //how does the neighbor talk about this cell?
-                      const unsigned int neighbor2=cell->neighbor_of_neighbor(face_no);
-
-                      //set up neighbor values
-                      scratch.neighbor_face_finite_element_values->reinit (neighbor, neighbor2);
-
-                      this->compute_material_model_input_values (this->get_current_linearization_point(),
-                                                                 *scratch.neighbor_face_finite_element_values,
-                                                                 neighbor,
-                                                                 true,
-                                                                 scratch.neighbor_face_material_model_inputs);
-                      this->get_material_model().evaluate(scratch.neighbor_face_material_model_inputs,
-                                                          scratch.neighbor_face_material_model_outputs);
-
-                      HeatingModel::HeatingModelOutputs neighbor_face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
-                      this->get_heating_model_manager().evaluate(scratch.neighbor_face_material_model_inputs,
-                                                                 scratch.neighbor_face_material_model_outputs,
-                                                                 neighbor_face_heating_model_outputs);
-
-                      std::vector<types::global_dof_index> neighbor_dof_indices (scratch.face_finite_element_values->get_fe().dofs_per_cell);
-                      // get all dof indices on the neighbor, then extract those
-                      // that correspond to the solution_field we are interested in
-                      neighbor->get_dof_indices (neighbor_dof_indices);
-                      for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
-                        data.neighbor_dof_indices[face_no * GeometryInfo<dim>::max_children_per_face][i] = neighbor_dof_indices[scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, i)];
-                      data.assembled_matrices[face_no * GeometryInfo<dim>::max_children_per_face] = true;
-
-                      for (unsigned int q=0; q<n_q_points; ++q)
+                      // precompute the values of shape functions and their gradients.
+                      // We only need to look up values of shape functions if they
+                      // belong to 'our' component. They are zero otherwise anyway.
+                      // Note that we later only look at the values that we do set here.
+                      for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
                         {
-                          // precompute the values of shape functions and their gradients.
-                          // We only need to look up values of shape functions if they
-                          // belong to 'our' component. They are zero otherwise anyway.
-                          // Note that we later only look at the values that we do set here.
-                          for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
+                          scratch.face_grad_phi_field[k]          = (*scratch.subface_finite_element_values)[solution_field].gradient (scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                          scratch.face_phi_field[k]               = (*scratch.subface_finite_element_values)[solution_field].value (scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                          scratch.neighbor_face_grad_phi_field[k] = (*scratch.neighbor_face_finite_element_values)[solution_field].gradient (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                          scratch.neighbor_face_phi_field[k]      = (*scratch.neighbor_face_finite_element_values)[solution_field].value (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                        }
+
+                      const double density_c_P              =
+                        ((advection_field.is_temperature())
+                         ?
+                         scratch.face_material_model_outputs.densities[q] *
+                         scratch.face_material_model_outputs.specific_heat[q]
+                         :
+                         1.0);
+
+                      Assert (density_c_P >= 0,
+                              ExcMessage ("The product of density and c_P needs to be a "
+                                          "non-negative quantity."));
+
+                      const double conductivity =
+                        ((advection_field.is_temperature())
+                         ?
+                         scratch.face_material_model_outputs.thermal_conductivities[q]
+                         :
+                         0.0);
+                      const double latent_heat_LHS =
+                        ((advection_field.is_temperature())
+                         ?
+                         face_heating_model_outputs.lhs_latent_heat_terms[q]
+                         :
+                         0.0);
+                      Assert (density_c_P + latent_heat_LHS >= 0,
+                              ExcMessage ("The sum of density times c_P and the latent heat contribution "
+                                          "to the left hand side needs to be a non-negative quantity."));
+
+                      const double penalty = (advection_field.is_temperature()
+                                              ?
+                                              parameters.discontinuous_penalty
+                                              * parameters.temperature_degree
+                                              * parameters.temperature_degree
+                                              / face->measure()
+                                              * conductivity
+                                              / (density_c_P + latent_heat_LHS)
+                                              :
+                                              0.0);
+
+                      Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
+                      //Subtract off the mesh velocity for ALE corrections if necessary
+                      if (parameters.free_surface_enabled)
+                        current_u -= scratch.face_mesh_velocity_values[q];
+
+                      const double neighbor_density_c_P              =
+                        ((advection_field.is_temperature())
+                         ?
+                         scratch.neighbor_face_material_model_outputs.densities[q] *
+                         scratch.neighbor_face_material_model_outputs.specific_heat[q]
+                         :
+                         1.0);
+
+                      Assert (neighbor_density_c_P >= 0,
+                              ExcMessage ("The product of density and c_P on the neighbor needs to be a "
+                                          "non-negative quantity."));
+
+                      const double neighbor_conductivity =
+                        ((advection_field.is_temperature())
+                         ?
+                         scratch.neighbor_face_material_model_outputs.thermal_conductivities[q]
+                         :
+                         0.0);
+                      const double neighbor_latent_heat_LHS =
+                        ((advection_field.is_temperature())
+                         ?
+                         neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
+                         :
+                         0.0);
+                      Assert (neighbor_density_c_P + neighbor_latent_heat_LHS >= 0,
+                              ExcMessage ("The sum of density times c_P and the latent heat contribution "
+                                          "to the left hand side on the neighbor needs to be a non-negative quantity."));
+
+                      const double neighbor_penalty = (advection_field.is_temperature()
+                                                       ?
+                                                       parameters.discontinuous_penalty
+                                                       * parameters.temperature_degree
+                                                       * parameters.temperature_degree
+                                                       / neighbor_child->face(neighbor2)->measure()
+                                                       * neighbor_conductivity
+                                                       / (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                                       :
+                                                       0.0);
+
+                      const double max_penalty = std::max(penalty, neighbor_penalty);
+
+                      const double max_density_c_P_and_latent_heat =
+                        std::max(density_c_P + latent_heat_LHS,
+                                 neighbor_density_c_P + neighbor_latent_heat_LHS);
+
+                      Assert (numbers::is_finite(max_density_c_P_and_latent_heat),
+                              ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a finite quantity."));
+                      Assert (max_density_c_P_and_latent_heat >= 0,
+                              ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a "
+                                          "non-negative quantity."));
+
+                      /**
+                       * The discontinuous Galerkin method uses 2 types of jumps over edges:
+                       * undirected and directed jumps. Undirected jumps are dependent only
+                       * on the order of the numbering of cells. Directed jumps are dependent
+                       * on the direction of the flow. Thus the flow-dependent terms below are
+                       * only calculated if the edge is an inflow edge.
+                       */
+                      const bool inflow = ((current_u * scratch.subface_finite_element_values->normal_vector(q)) < 0.);
+
+                      for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+                        {
+                          for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
                             {
-                              scratch.face_grad_phi_field[k]          = (*scratch.face_finite_element_values)[solution_field].gradient (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                              scratch.face_phi_field[k]               = (*scratch.face_finite_element_values)[solution_field].value (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                              scratch.neighbor_face_grad_phi_field[k] = (*scratch.neighbor_face_finite_element_values)[solution_field].gradient (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                              scratch.neighbor_face_phi_field[k]      = (*scratch.neighbor_face_finite_element_values)[solution_field].value (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                            }
+                              data.local_matrix(i,j)
+                              += (- 0.5 * time_step * conductivity
+                                  * scratch.face_grad_phi_field[i]
+                                  * scratch.subface_finite_element_values->normal_vector(q)
+                                  * scratch.face_phi_field[j]
 
-                          const double density_c_P              =
-                            ((advection_field.is_temperature())
-                             ?
-                             scratch.face_material_model_outputs.densities[q] *
-                             scratch.face_material_model_outputs.specific_heat[q]
-                             :
-                             1.0);
+                                  - 0.5 * time_step * conductivity
+                                  * scratch.face_grad_phi_field[j]
+                                  * scratch.subface_finite_element_values->normal_vector(q)
+                                  * scratch.face_phi_field[i]
 
-                          Assert (density_c_P >= 0,
-                                  ExcMessage ("The product of density and c_P needs to be a "
-                                              "non-negative quantity."));
+                                  + time_step
+                                  * max_density_c_P_and_latent_heat
+                                  * max_penalty
+                                  * scratch.face_phi_field[i]
+                                  * scratch.face_phi_field[j]
 
-                          const double conductivity =
-                            ((advection_field.is_temperature())
-                             ?
-                             scratch.face_material_model_outputs.thermal_conductivities[q]
-                             :
-                             0.0);
-                          const double latent_heat_LHS =
-                            ((advection_field.is_temperature())
-                             ?
-                             scratch.face_heating_model_outputs.lhs_latent_heat_terms[q]
-                             :
-                             0.0);
-                          Assert (density_c_P + latent_heat_LHS >= 0,
-                                  ExcMessage ("The sum of density times c_P and the latent heat contribution "
-                                              "to the left hand side needs to be a non-negative quantity."));
+                                  - (inflow
+                                     ?
+                                     (density_c_P + latent_heat_LHS)
+                                     * time_step
+                                     * (current_u
+                                        * scratch.subface_finite_element_values->normal_vector(q))
+                                     * scratch.face_phi_field[i]
+                                     * scratch.face_phi_field[j]
+                                     :
+                                     0.)
+                                 )
+                                 * scratch.subface_finite_element_values->JxW(q);
 
-                          const double penalty = (advection_field.is_temperature()
-                                                  ?
-                                                  parameters.discontinuous_penalty
-                                                  * parameters.temperature_degree
-                                                  * parameters.temperature_degree
-                                                  / face->measure()
-                                                  * conductivity
-                                                  / (density_c_P + latent_heat_LHS)
-                                                  :
-                                                  0.0);
+                              data.local_matrices_int_ext[face_no * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
+                              += (- 0.5 * time_step * neighbor_conductivity
+                                  * scratch.neighbor_face_grad_phi_field[j]
+                                  * scratch.subface_finite_element_values->normal_vector(q)
+                                  * scratch.face_phi_field[i]
 
-                          Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
-                          //Subtract off the mesh velocity for ALE corrections if necessary
-                          if (parameters.free_surface_enabled)
-                            current_u -= scratch.face_mesh_velocity_values[q];
+                                  + 0.5 * time_step * conductivity
+                                  * scratch.face_grad_phi_field[i]
+                                  * scratch.subface_finite_element_values->normal_vector(q)
+                                  * scratch.neighbor_face_phi_field[j]
 
-                          const double neighbor_density_c_P              =
-                            ((advection_field.is_temperature())
-                             ?
-                             scratch.neighbor_face_material_model_outputs.densities[q] *
-                             scratch.neighbor_face_material_model_outputs.specific_heat[q]
-                             :
-                             1.0);
+                                  - time_step
+                                  * max_density_c_P_and_latent_heat
+                                  * max_penalty
+                                  * scratch.neighbor_face_phi_field[j]
+                                  * scratch.face_phi_field[i]
 
-                          Assert (neighbor_density_c_P >= 0,
-                                  ExcMessage ("The product of density and c_P on the neighbor needs to be a "
-                                              "non-negative quantity."));
+                                  + (inflow
+                                     ?
+                                     (density_c_P + latent_heat_LHS)
+                                     * time_step
+                                     * (current_u
+                                        * scratch.subface_finite_element_values->normal_vector(q))
+                                     * scratch.face_phi_field[i]
+                                     * scratch.neighbor_face_phi_field[j]
+                                     :
+                                     0.)
+                                 )
+                                 * scratch.subface_finite_element_values->JxW(q);
 
-                          const double neighbor_conductivity =
-                            ((advection_field.is_temperature())
-                             ?
-                             scratch.neighbor_face_material_model_outputs.thermal_conductivities[q]
-                             :
-                             0.0);
-                          const double neighbor_latent_heat_LHS =
-                            ((advection_field.is_temperature())
-                             ?
-                             neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
-                             :
-                             0.0);
-                          Assert (neighbor_density_c_P + neighbor_latent_heat_LHS >= 0,
-                                  ExcMessage ("The sum of density times c_P and the latent heat contribution "
-                                              "to the left hand side on the neighbor needs to be a non-negative quantity."));
+                              data.local_matrices_ext_int[face_no * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
+                              += (+ 0.5 * time_step * conductivity
+                                  * scratch.face_grad_phi_field[j]
+                                  * scratch.subface_finite_element_values->normal_vector(q)
+                                  * scratch.neighbor_face_phi_field[i]
 
-                          const double neighbor_penalty = (advection_field.is_temperature()
-                                                           ?
-                                                           parameters.discontinuous_penalty
-                                                           * parameters.temperature_degree
-                                                           * parameters.temperature_degree
-                                                           / neighbor->face(neighbor2)->measure()
-                                                           * neighbor_conductivity
-                                                           / (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                                           :
-                                                           0.0);
+                                  - 0.5 * time_step * neighbor_conductivity
+                                  * scratch.neighbor_face_grad_phi_field[i]
+                                  * scratch.subface_finite_element_values->normal_vector(q)
+                                  * scratch.face_phi_field[j]
 
-                          const double max_penalty = std::max(penalty, neighbor_penalty);
+                                  - time_step
+                                  * max_density_c_P_and_latent_heat
+                                  * max_penalty
+                                  * scratch.face_phi_field[j]
+                                  * scratch.neighbor_face_phi_field[i]
 
-                          const double max_density_c_P_and_latent_heat =
-                            std::max(density_c_P + latent_heat_LHS,
-                                     neighbor_density_c_P + neighbor_latent_heat_LHS);
+                                  - (!inflow
+                                     ?
+                                     (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                     * time_step
+                                     * (current_u
+                                        * scratch.subface_finite_element_values->normal_vector(q))
+                                     * scratch.neighbor_face_phi_field[i]
+                                     * scratch.face_phi_field[j]
+                                     :
+                                     0.)
+                                 )
+                                 * scratch.subface_finite_element_values->JxW(q);
 
-                          Assert (numbers::is_finite(max_density_c_P_and_latent_heat),
-                                  ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a finite quantity."));
-                          Assert (max_density_c_P_and_latent_heat >= 0,
-                                  ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a "
-                                              "non-negative quantity."));
+                              data.local_matrices_ext_ext[face_no * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
+                              += (+ 0.5 * time_step * neighbor_conductivity
+                                  * scratch.neighbor_face_grad_phi_field[i]
+                                  * scratch.subface_finite_element_values->normal_vector(q)
+                                  * scratch.neighbor_face_phi_field[j]
 
-                          /**
-                           * The discontinuous Galerkin method uses 2 types of jumps over edges:
-                           * undirected and directed jumps. Undirected jumps are dependent only
-                           * on the order of the numbering of cells. Directed jumps are dependent
-                           * on the direction of the flow. Thus the flow-dependent terms below are
-                           * only calculated if the edge is an inflow edge.
-                           */
-                          const bool inflow = ((current_u * scratch.face_finite_element_values->normal_vector(q)) < 0.);
+                                  + 0.5 * time_step * neighbor_conductivity
+                                  * scratch.neighbor_face_grad_phi_field[j]
+                                  * scratch.subface_finite_element_values->normal_vector(q)
+                                  * scratch.neighbor_face_phi_field[i]
 
-                          for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
-                            {
-                              for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
-                                {
-                                  data.local_matrix(i,j)
-                                  += (- 0.5 * time_step * conductivity
-                                      * scratch.face_grad_phi_field[i]
-                                      * scratch.face_finite_element_values->normal_vector(q)
-                                      * scratch.face_phi_field[j]
+                                  + time_step
+                                  * max_density_c_P_and_latent_heat
+                                  * max_penalty
+                                  * scratch.neighbor_face_phi_field[i]
+                                  * scratch.neighbor_face_phi_field[j]
 
-                                      - 0.5 * time_step * conductivity
-                                      * scratch.face_grad_phi_field[j]
-                                      * scratch.face_finite_element_values->normal_vector(q)
-                                      * scratch.face_phi_field[i]
-
-                                      + time_step
-                                      * max_density_c_P_and_latent_heat
-                                      * max_penalty
-                                      * scratch.face_phi_field[i]
-                                      * scratch.face_phi_field[j]
-
-                                      - (inflow
-                                         ?
-                                         (density_c_P + latent_heat_LHS)
-                                         * time_step
-                                         * (current_u
-                                            * scratch.face_finite_element_values->normal_vector(q))
-                                         * scratch.face_phi_field[i]
-                                         * scratch.face_phi_field[j]
-                                         :
-                                         0.)
-                                     )
-                                     * scratch.face_finite_element_values->JxW(q);
-
-                                  data.local_matrices_int_ext[face_no * GeometryInfo<dim>::max_children_per_face](i,j)
-                                  += (- 0.5 * time_step * neighbor_conductivity
-                                      * scratch.neighbor_face_grad_phi_field[j]
-                                      * scratch.face_finite_element_values->normal_vector(q)
-                                      * scratch.face_phi_field[i]
-
-                                      + 0.5 * time_step * conductivity
-                                      * scratch.face_grad_phi_field[i]
-                                      * scratch.face_finite_element_values->normal_vector(q)
-                                      * scratch.neighbor_face_phi_field[j]
-
-                                      - time_step
-                                      * max_density_c_P_and_latent_heat
-                                      * max_penalty
-                                      * scratch.neighbor_face_phi_field[j]
-                                      * scratch.face_phi_field[i]
-
-                                      + (inflow
-                                         ?
-                                         (density_c_P + latent_heat_LHS)
-                                         * time_step
-                                         * (current_u
-                                            * scratch.face_finite_element_values->normal_vector(q))
-                                         * scratch.face_phi_field[i]
-                                         * scratch.neighbor_face_phi_field[j]
-                                         :
-                                         0.)
-                                     )
-                                     * scratch.face_finite_element_values->JxW(q);
-
-                                  data.local_matrices_ext_int[face_no * GeometryInfo<dim>::max_children_per_face](i,j)
-                                  += (+ 0.5 * time_step * conductivity
-                                      * scratch.face_grad_phi_field[j]
-                                      * scratch.face_finite_element_values->normal_vector(q)
-                                      * scratch.neighbor_face_phi_field[i]
-
-                                      - 0.5 * time_step * neighbor_conductivity
-                                      * scratch.neighbor_face_grad_phi_field[i]
-                                      * scratch.face_finite_element_values->normal_vector(q)
-                                      * scratch.face_phi_field[j]
-
-                                      - time_step
-                                      * max_density_c_P_and_latent_heat
-                                      * max_penalty
-                                      * scratch.face_phi_field[j]
-                                      * scratch.neighbor_face_phi_field[i]
-
-                                      - (!inflow
-                                         ?
-                                         (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                         * time_step
-                                         * (current_u
-                                            * scratch.face_finite_element_values->normal_vector(q))
-                                         * scratch.neighbor_face_phi_field[i]
-                                         * scratch.face_phi_field[j]
-                                         :
-                                         0.)
-                                     )
-                                     * scratch.face_finite_element_values->JxW(q);
-
-                                  data.local_matrices_ext_ext[face_no * GeometryInfo<dim>::max_children_per_face](i,j)
-                                  += (+ 0.5 * time_step * neighbor_conductivity
-                                      * scratch.neighbor_face_grad_phi_field[i]
-                                      * scratch.face_finite_element_values->normal_vector(q)
-                                      * scratch.neighbor_face_phi_field[j]
-
-                                      + 0.5 * time_step * neighbor_conductivity
-                                      * scratch.neighbor_face_grad_phi_field[j]
-                                      * scratch.face_finite_element_values->normal_vector(q)
-                                      * scratch.neighbor_face_phi_field[i]
-
-                                      + time_step
-                                      * max_density_c_P_and_latent_heat
-                                      * max_penalty
-                                      * scratch.neighbor_face_phi_field[i]
-                                      * scratch.neighbor_face_phi_field[j]
-
-                                      + (!inflow
-                                         ?
-                                         (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                         * time_step
-                                         * (current_u
-                                            * scratch.face_finite_element_values->normal_vector(q))
-                                         * scratch.neighbor_face_phi_field[i]
-                                         * scratch.neighbor_face_phi_field[j]
-                                         :
-                                         0.)
-                                     )
-                                     * scratch.face_finite_element_values->JxW(q);
-                                }
+                                  + (!inflow
+                                     ?
+                                     (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                     * time_step
+                                     * (current_u
+                                        * scratch.subface_finite_element_values->normal_vector(q))
+                                     * scratch.neighbor_face_phi_field[i]
+                                     * scratch.neighbor_face_phi_field[j]
+                                     :
+                                     0.)
+                                 )
+                                 * scratch.subface_finite_element_values->JxW(q);
                             }
                         }
                     }
-                  else
-                    {
-                      /* neighbor is taking responsibility for assembly of this face, because
-                       * either (1) neighbor is coarser, or
-                       *        (2) neighbor is equally-sized and
-                       *           (a) neighbor is on a different subdomain, with lower subdmain_id(), or
-                       *           (b) neighbor is on the same subdomain and has lower index().
-                      */
-                    }
-                }
-              else //face->has_children(), so always assemble from here.
-                {
-                  //how does the neighbor talk about this cell?
-                  const unsigned int neighbor2 = cell->neighbor_face_no(face_no);
-
-                  //loop over subfaces
-                  for (unsigned int subface_no=0; subface_no<face->number_of_children(); ++subface_no)
-                    {
-                      const typename DoFHandler<dim>::active_cell_iterator neighbor_child
-                        = cell->neighbor_child_on_subface (face_no, subface_no);
-
-                      //set up subface values
-                      scratch.subface_finite_element_values->reinit (cell, face_no, subface_no);
-
-                      //subface->face
-                      (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(this->get_current_linearization_point(),
-                          scratch.face_current_velocity_values);
-
-                      //get the mesh velocity, as we need to subtract it off of the advection systems
-                      if (parameters.free_surface_enabled)
-                        (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(this->get_mesh_velocity(),
-                            scratch.face_mesh_velocity_values);
-
-                      //get the mesh velocity, as we need to subtract it off of the advection systems
-                      if (parameters.free_surface_enabled)
-                        (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(this->get_mesh_velocity(),
-                            scratch.face_mesh_velocity_values);
-
-                      this->compute_material_model_input_values (this->get_current_linearization_point(),
-                                                                 *scratch.subface_finite_element_values,
-                                                                 cell,
-                                                                 true,
-                                                                 scratch.face_material_model_inputs);
-                      this->get_material_model().evaluate(scratch.face_material_model_inputs,
-                                                          scratch.face_material_model_outputs);
-
-                      HeatingModel::HeatingModelOutputs face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
-                      this->get_heating_model_manager().evaluate(scratch.face_material_model_inputs,
-                                                                 scratch.face_material_model_outputs,
-                                                                 face_heating_model_outputs);
-
-                      //set up neighbor values
-                      scratch.neighbor_face_finite_element_values->reinit (neighbor_child, neighbor2);
-
-                      this->compute_material_model_input_values (this->get_current_linearization_point(),
-                                                                 *scratch.neighbor_face_finite_element_values,
-                                                                 neighbor_child,
-                                                                 true,
-                                                                 scratch.neighbor_face_material_model_inputs);
-                      this->get_material_model().evaluate(scratch.neighbor_face_material_model_inputs,
-                                                          scratch.neighbor_face_material_model_outputs);
-
-                      HeatingModel::HeatingModelOutputs neighbor_face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
-                      this->get_heating_model_manager().evaluate(scratch.neighbor_face_material_model_inputs,
-                                                                 scratch.neighbor_face_material_model_outputs,
-                                                                 neighbor_face_heating_model_outputs);
-
-                      std::vector<types::global_dof_index> neighbor_dof_indices (scratch.face_finite_element_values->get_fe().dofs_per_cell);
-                      // get all dof indices on the neighbor, then extract those
-                      // that correspond to the solution_field we are interested in
-                      neighbor_child->get_dof_indices (neighbor_dof_indices);
-                      for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
-                        data.neighbor_dof_indices[face_no * GeometryInfo<dim>::max_children_per_face + subface_no][i] = neighbor_dof_indices[scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, i)];
-                      data.assembled_matrices[face_no * GeometryInfo<dim>::max_children_per_face + subface_no] = true;
-
-                      for (unsigned int q=0; q<n_q_points; ++q)
-                        {
-                          // precompute the values of shape functions and their gradients.
-                          // We only need to look up values of shape functions if they
-                          // belong to 'our' component. They are zero otherwise anyway.
-                          // Note that we later only look at the values that we do set here.
-                          for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
-                            {
-                              scratch.face_grad_phi_field[k]          = (*scratch.subface_finite_element_values)[solution_field].gradient (scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                              scratch.face_phi_field[k]               = (*scratch.subface_finite_element_values)[solution_field].value (scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                              scratch.neighbor_face_grad_phi_field[k] = (*scratch.neighbor_face_finite_element_values)[solution_field].gradient (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                              scratch.neighbor_face_phi_field[k]      = (*scratch.neighbor_face_finite_element_values)[solution_field].value (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                            }
-
-                          const double density_c_P              =
-                            ((advection_field.is_temperature())
-                             ?
-                             scratch.face_material_model_outputs.densities[q] *
-                             scratch.face_material_model_outputs.specific_heat[q]
-                             :
-                             1.0);
-
-                          Assert (density_c_P >= 0,
-                                  ExcMessage ("The product of density and c_P needs to be a "
-                                              "non-negative quantity."));
-
-                          const double conductivity =
-                            ((advection_field.is_temperature())
-                             ?
-                             scratch.face_material_model_outputs.thermal_conductivities[q]
-                             :
-                             0.0);
-                          const double latent_heat_LHS =
-                            ((advection_field.is_temperature())
-                             ?
-                             face_heating_model_outputs.lhs_latent_heat_terms[q]
-                             :
-                             0.0);
-                          Assert (density_c_P + latent_heat_LHS >= 0,
-                                  ExcMessage ("The sum of density times c_P and the latent heat contribution "
-                                              "to the left hand side needs to be a non-negative quantity."));
-
-                          const double penalty = (advection_field.is_temperature()
-                                                  ?
-                                                  parameters.discontinuous_penalty
-                                                  * parameters.temperature_degree
-                                                  * parameters.temperature_degree
-                                                  / face->measure()
-                                                  * conductivity
-                                                  / (density_c_P + latent_heat_LHS)
-                                                  :
-                                                  0.0);
-
-                          Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
-                          //Subtract off the mesh velocity for ALE corrections if necessary
-                          if (parameters.free_surface_enabled)
-                            current_u -= scratch.face_mesh_velocity_values[q];
-
-                          const double neighbor_density_c_P              =
-                            ((advection_field.is_temperature())
-                             ?
-                             scratch.neighbor_face_material_model_outputs.densities[q] *
-                             scratch.neighbor_face_material_model_outputs.specific_heat[q]
-                             :
-                             1.0);
-
-                          Assert (neighbor_density_c_P >= 0,
-                                  ExcMessage ("The product of density and c_P on the neighbor needs to be a "
-                                              "non-negative quantity."));
-
-                          const double neighbor_conductivity =
-                            ((advection_field.is_temperature())
-                             ?
-                             scratch.neighbor_face_material_model_outputs.thermal_conductivities[q]
-                             :
-                             0.0);
-                          const double neighbor_latent_heat_LHS =
-                            ((advection_field.is_temperature())
-                             ?
-                             neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
-                             :
-                             0.0);
-                          Assert (neighbor_density_c_P + neighbor_latent_heat_LHS >= 0,
-                                  ExcMessage ("The sum of density times c_P and the latent heat contribution "
-                                              "to the left hand side on the neighbor needs to be a non-negative quantity."));
-
-                          const double neighbor_penalty = (advection_field.is_temperature()
-                                                           ?
-                                                           parameters.discontinuous_penalty
-                                                           * parameters.temperature_degree
-                                                           * parameters.temperature_degree
-                                                           / neighbor_child->face(neighbor2)->measure()
-                                                           * neighbor_conductivity
-                                                           / (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                                           :
-                                                           0.0);
-
-                          const double max_penalty = std::max(penalty, neighbor_penalty);
-
-                          const double max_density_c_P_and_latent_heat =
-                            std::max(density_c_P + latent_heat_LHS,
-                                     neighbor_density_c_P + neighbor_latent_heat_LHS);
-
-                          Assert (numbers::is_finite(max_density_c_P_and_latent_heat),
-                                  ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a finite quantity."));
-                          Assert (max_density_c_P_and_latent_heat >= 0,
-                                  ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a "
-                                              "non-negative quantity."));
-
-                          /**
-                           * The discontinuous Galerkin method uses 2 types of jumps over edges:
-                           * undirected and directed jumps. Undirected jumps are dependent only
-                           * on the order of the numbering of cells. Directed jumps are dependent
-                           * on the direction of the flow. Thus the flow-dependent terms below are
-                           * only calculated if the edge is an inflow edge.
-                           */
-                          const bool inflow = ((current_u * scratch.subface_finite_element_values->normal_vector(q)) < 0.);
-
-                          for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
-                            {
-                              for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
-                                {
-                                  data.local_matrix(i,j)
-                                  += (- 0.5 * time_step * conductivity
-                                      * scratch.face_grad_phi_field[i]
-                                      * scratch.subface_finite_element_values->normal_vector(q)
-                                      * scratch.face_phi_field[j]
-
-                                      - 0.5 * time_step * conductivity
-                                      * scratch.face_grad_phi_field[j]
-                                      * scratch.subface_finite_element_values->normal_vector(q)
-                                      * scratch.face_phi_field[i]
-
-                                      + time_step
-                                      * max_density_c_P_and_latent_heat
-                                      * max_penalty
-                                      * scratch.face_phi_field[i]
-                                      * scratch.face_phi_field[j]
-
-                                      - (inflow
-                                         ?
-                                         (density_c_P + latent_heat_LHS)
-                                         * time_step
-                                         * (current_u
-                                            * scratch.subface_finite_element_values->normal_vector(q))
-                                         * scratch.face_phi_field[i]
-                                         * scratch.face_phi_field[j]
-                                         :
-                                         0.)
-                                     )
-                                     * scratch.subface_finite_element_values->JxW(q);
-
-                                  data.local_matrices_int_ext[face_no * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
-                                  += (- 0.5 * time_step * neighbor_conductivity
-                                      * scratch.neighbor_face_grad_phi_field[j]
-                                      * scratch.subface_finite_element_values->normal_vector(q)
-                                      * scratch.face_phi_field[i]
-
-                                      + 0.5 * time_step * conductivity
-                                      * scratch.face_grad_phi_field[i]
-                                      * scratch.subface_finite_element_values->normal_vector(q)
-                                      * scratch.neighbor_face_phi_field[j]
-
-                                      - time_step
-                                      * max_density_c_P_and_latent_heat
-                                      * max_penalty
-                                      * scratch.neighbor_face_phi_field[j]
-                                      * scratch.face_phi_field[i]
-
-                                      + (inflow
-                                         ?
-                                         (density_c_P + latent_heat_LHS)
-                                         * time_step
-                                         * (current_u
-                                            * scratch.subface_finite_element_values->normal_vector(q))
-                                         * scratch.face_phi_field[i]
-                                         * scratch.neighbor_face_phi_field[j]
-                                         :
-                                         0.)
-                                     )
-                                     * scratch.subface_finite_element_values->JxW(q);
-
-                                  data.local_matrices_ext_int[face_no * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
-                                  += (+ 0.5 * time_step * conductivity
-                                      * scratch.face_grad_phi_field[j]
-                                      * scratch.subface_finite_element_values->normal_vector(q)
-                                      * scratch.neighbor_face_phi_field[i]
-
-                                      - 0.5 * time_step * neighbor_conductivity
-                                      * scratch.neighbor_face_grad_phi_field[i]
-                                      * scratch.subface_finite_element_values->normal_vector(q)
-                                      * scratch.face_phi_field[j]
-
-                                      - time_step
-                                      * max_density_c_P_and_latent_heat
-                                      * max_penalty
-                                      * scratch.face_phi_field[j]
-                                      * scratch.neighbor_face_phi_field[i]
-
-                                      - (!inflow
-                                         ?
-                                         (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                         * time_step
-                                         * (current_u
-                                            * scratch.subface_finite_element_values->normal_vector(q))
-                                         * scratch.neighbor_face_phi_field[i]
-                                         * scratch.face_phi_field[j]
-                                         :
-                                         0.)
-                                     )
-                                     * scratch.subface_finite_element_values->JxW(q);
-
-                                  data.local_matrices_ext_ext[face_no * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
-                                  += (+ 0.5 * time_step * neighbor_conductivity
-                                      * scratch.neighbor_face_grad_phi_field[i]
-                                      * scratch.subface_finite_element_values->normal_vector(q)
-                                      * scratch.neighbor_face_phi_field[j]
-
-                                      + 0.5 * time_step * neighbor_conductivity
-                                      * scratch.neighbor_face_grad_phi_field[j]
-                                      * scratch.subface_finite_element_values->normal_vector(q)
-                                      * scratch.neighbor_face_phi_field[i]
-
-                                      + time_step
-                                      * max_density_c_P_and_latent_heat
-                                      * max_penalty
-                                      * scratch.neighbor_face_phi_field[i]
-                                      * scratch.neighbor_face_phi_field[j]
-
-                                      + (!inflow
-                                         ?
-                                         (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                         * time_step
-                                         * (current_u
-                                            * scratch.subface_finite_element_values->normal_vector(q))
-                                         * scratch.neighbor_face_phi_field[i]
-                                         * scratch.neighbor_face_phi_field[j]
-                                         :
-                                         0.)
-                                     )
-                                     * scratch.subface_finite_element_values->JxW(q);
-                                }
-                            }
-
-                        }
-                    }
-
                 }
             }
         }
@@ -2276,8 +2306,8 @@ namespace aspect
     if (parameters.use_discontinuous_temperature_discretization ||
         parameters.use_discontinuous_composition_discretization)
       {
-        assemblers->local_assemble_advection_system_on_boundary_face
-        .connect(std_cxx11::bind(&aspect::Assemblers::CompleteEquations<dim>::local_assemble_advection_face_terms,
+        assemblers->local_assemble_advection_system_on_interior_face
+        .connect(std_cxx11::bind(&aspect::Assemblers::CompleteEquations<dim>::local_assemble_discontinuous_advection_interior_face_terms,
                                  std_cxx11::cref (*complete_equation_assembler),
                                  std_cxx11::_1,
                                  std_cxx11::_2,
@@ -2285,7 +2315,16 @@ namespace aspect
                                  std_cxx11::_4,
                                  std_cxx11::_5));
 
-        assemblers->advection_system_assembler_on_boundary_face_properties.need_face_material_model_data = true;
+        assemblers->local_assemble_advection_system_on_boundary_face
+        .connect(std_cxx11::bind(&aspect::Assemblers::CompleteEquations<dim>::local_assemble_discontinuous_advection_boundary_face_terms,
+                                 std_cxx11::cref (*complete_equation_assembler),
+                                 std_cxx11::_1,
+                                 std_cxx11::_2,
+                                 std_cxx11::_3,
+                                 std_cxx11::_4,
+                                 std_cxx11::_5));
+
+        assemblers->advection_system_assembler_on_face_properties.need_face_material_model_data = true;
       }
 
     // allow other assemblers to add themselves or modify the existing ones by firing the signal
@@ -2843,7 +2882,10 @@ namespace aspect
 
     // then also work on possible face terms. if necessary, initialize
     // the material model data on faces
-    if (advection_field.is_discontinuous(introspection))
+    const bool has_boundary_face_assemblers = !assemblers->local_assemble_advection_system_on_boundary_face.empty();
+    const bool has_interior_face_assemblers = !assemblers->local_assemble_advection_system_on_interior_face.empty();
+
+    if (has_interior_face_assemblers)
       {
         // for interior face contributions loop over all possible
         // subfaces of the cell, and reset their matrices.
@@ -2854,8 +2896,14 @@ namespace aspect
             data.local_matrices_ext_ext[f] = 0;
             data.assembled_matrices[f] = false;
           }
+      }
 
-        for (unsigned int face_no=0; face_no<GeometryInfo<dim>::faces_per_cell; ++face_no)
+    for (unsigned int face_no=0; face_no<GeometryInfo<dim>::faces_per_cell; ++face_no)
+      {
+        const typename DoFHandler<dim>::face_iterator face = cell->face (face_no);
+
+        if ((has_boundary_face_assemblers && face->at_boundary()) ||
+            (has_interior_face_assemblers && !face->at_boundary()))
           {
             (*scratch.face_finite_element_values).reinit (cell, face_no);
 
@@ -2867,7 +2915,7 @@ namespace aspect
               (*scratch.face_finite_element_values)[introspection.extractors.velocities].get_function_values(free_surface->mesh_velocity,
                   scratch.face_mesh_velocity_values);
 
-            if (assemblers->advection_system_assembler_on_boundary_face_properties.need_face_material_model_data)
+            if (assemblers->advection_system_assembler_on_face_properties.need_face_material_model_data)
               {
                 compute_material_model_input_values (current_linearization_point,
                                                      *scratch.face_finite_element_values,
@@ -2891,9 +2939,14 @@ namespace aspect
                 //                                            scratch.face_material_model_outputs);
               }
 
-            assemblers->local_assemble_advection_system_on_boundary_face(cell, face_no,
-                                                                         advection_field,
-                                                                         scratch, data);
+            if (face->at_boundary())
+              assemblers->local_assemble_advection_system_on_boundary_face(cell, face_no,
+                                                                           advection_field,
+                                                                           scratch, data);
+            else
+              assemblers->local_assemble_advection_system_on_interior_face(cell, face_no,
+                                                                           advection_field,
+                                                                           scratch, data);
           }
       }
   }
@@ -2915,7 +2968,7 @@ namespace aspect
     /* In the following, we copy DG contributions element by element. This
      * is allowed since there are no constraints imposed on discontinuous fields.
      */
-    if (advection_field.is_discontinuous(introspection))
+    if (!assemblers->local_assemble_advection_system_on_interior_face.empty())
       {
         for (unsigned int f=0; f<GeometryInfo<dim>::max_children_per_face
              * GeometryInfo<dim>::faces_per_cell; ++f)
@@ -2952,6 +3005,7 @@ namespace aspect
       computing_timer.enter_section ("   Assemble temperature system");
     else
       computing_timer.enter_section ("   Assemble composition system");
+
     const unsigned int block_idx = advection_field.block_index(introspection);
     system_matrix.block(block_idx, block_idx) = 0;
     system_rhs = 0;
@@ -2963,6 +3017,30 @@ namespace aspect
     Vector<double> viscosity_per_cell;
     viscosity_per_cell.reinit(triangulation.n_active_cells());
     get_artificial_viscosity(viscosity_per_cell, advection_field);
+
+    // We have to assemble the term u.grad phi_i * phi_j, which is
+    // of total polynomial degree
+    //   stokes_deg + 2*temp_deg -1
+    // (or similar for comp_deg). This suggests using a Gauss
+    // quadrature formula of order
+    //   temp_deg + stokes_deg/2
+    // rounded up (note that x/2 rounded up
+    // equals (x+1)/2 using integer division.)
+    //
+    // (Note: All compositional fields have the same base element and therefore
+    // the same composition_degree. Thus, we do not need to find out the degree
+    // of the current field, but use the global instead)
+    const unsigned int advection_quadrature_degree = (advection_field.is_temperature()
+                                                      ?
+                                                      parameters.temperature_degree
+                                                      :
+                                                      parameters.composition_degree)
+                                                     +
+                                                     (parameters.stokes_velocity_degree+1)/2;
+
+    const bool allocate_face_quadrature = !assemblers->local_assemble_advection_system_on_boundary_face.empty() ||
+                                          !assemblers->local_assemble_advection_system_on_interior_face.empty();
+    const bool allocate_neighbor_contributions = !assemblers->local_assemble_advection_system_on_interior_face.empty();
 
     WorkStream::
     run (CellFilter (IteratorFilters::LocallyOwnedCell(),
@@ -2982,50 +3060,21 @@ namespace aspect
                           this,
                           std_cxx11::cref(advection_field),
                           std_cxx11::_1),
-
-         // we have to assemble the term u.grad phi_i * phi_j, which is
-         // of total polynomial degree
-         //   stokes_deg + 2*temp_deg -1
-         // (or similar for comp_deg). this suggests using a Gauss
-         // quadrature formula of order
-         //   temp_deg + stokes_deg/2
-         // rounded up. do so. (note that x/2 rounded up
-         // equals (x+1)/2 using integer division.)
-         //
-         // (note: we need to get at the advection element in
-         // use for the scratch and copy objects below. the
-         // base element for the compositional fields exists
-         // only once, with multiplicity, so only query
-         // introspection.block_indices.compositional_fields[0]
-         // instead of subscripting with the correct compositional
-         // field index.)
          internal::Assembly::Scratch::
          AdvectionSystem<dim> (finite_element,
                                finite_element.base_element(advection_field.base_element(introspection)),
                                mapping,
-                               QGauss<dim>((advection_field.is_temperature()
-                                            ?
-                                            parameters.temperature_degree
-                                            :
-                                            parameters.composition_degree)
-                                           +
-                                           (parameters.stokes_velocity_degree+1)/2),
-                               /* Only generate a valid face quadrature if advection_field is discontinuous.
+                               QGauss<dim>(advection_quadrature_degree),
+                               /* Only generate a valid face quadrature if necessary.
                                 * Otherwise, generate invalid face quadrature rule.
                                 */
-                               (advection_field.is_discontinuous(introspection) ?
-                                QGauss<dim-1>((advection_field.is_temperature()
-                                               ?
-                                               parameters.temperature_degree
-                                               :
-                                               parameters.composition_degree)
-                                              +
-                                              (parameters.stokes_velocity_degree+1)/2) :
+                               (allocate_face_quadrature ?
+                                QGauss<dim-1>(advection_quadrature_degree) :
                                 Quadrature<dim-1> ()),
                                parameters.n_compositional_fields),
          internal::Assembly::CopyData::
          AdvectionSystem<dim> (finite_element.base_element(advection_field.base_element(introspection)),
-                               advection_field.is_discontinuous(introspection)));
+                               allocate_neighbor_contributions));
 
     system_matrix.compress(VectorOperation::add);
     system_rhs.compress(VectorOperation::add);

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -241,6 +241,13 @@ namespace aspect
 
   template <int dim>
   const LinearAlgebra::BlockVector &
+  SimulatorAccess<dim>::get_current_linearization_point () const
+  {
+    return simulator->current_linearization_point;
+  }
+
+  template <int dim>
+  const LinearAlgebra::BlockVector &
   SimulatorAccess<dim>::get_solution () const
   {
     return simulator->solution;
@@ -294,6 +301,22 @@ namespace aspect
 
 
   template <int dim>
+  void
+  SimulatorAccess<dim>::compute_material_model_input_values (const LinearAlgebra::BlockVector                            &input_solution,
+                                                             const FEValuesBase<dim,dim>                                 &input_finite_element_values,
+                                                             const typename DoFHandler<dim>::active_cell_iterator        &cell,
+                                                             const bool                                                   compute_strainrate,
+                                                             MaterialModel::MaterialModelInputs<dim> &material_model_inputs) const
+  {
+    simulator->compute_material_model_input_values(input_solution,
+                                                   input_finite_element_values,
+                                                   cell,
+                                                   compute_strainrate,
+                                                   material_model_inputs);
+  }
+
+
+  template <int dim>
   const MaterialModel::Interface<dim> &
   SimulatorAccess<dim>::get_material_model () const
   {
@@ -325,9 +348,27 @@ namespace aspect
   const BoundaryTemperature::Interface<dim> &
   SimulatorAccess<dim>::get_boundary_temperature () const
   {
-    Assert (simulator->boundary_temperature.get() != 0,
-            ExcMessage("You can not call this function if no such model is actually available."));
+    AssertThrow (simulator->boundary_temperature.get() != 0,
+                 ExcMessage("You can not call this function if no such model is actually available."));
     return *simulator->boundary_temperature.get();
+  }
+
+
+  template <int dim>
+  bool
+  SimulatorAccess<dim>::has_boundary_composition () const
+  {
+    return (simulator->boundary_composition.get() != 0);
+  }
+
+
+  template <int dim>
+  const BoundaryComposition::Interface<dim> &
+  SimulatorAccess<dim>::get_boundary_composition () const
+  {
+    AssertThrow (simulator->boundary_composition.get() != 0,
+                 ExcMessage("You can not call this function if no such model is actually available."));
+    return *simulator->boundary_composition.get();
   }
 
 


### PR DESCRIPTION
This moves the face advection terms of #661 in the same Assembler structure as the cell terms in #769.
All in the intention of #733 to allow extensions of the assembled equations.

This PR is at a pretty early stage (I want to see the test results), and there is a structural problem at the moment that I would like to discuss: 
The FaceQuadrature in the Scratch AdvectionSystem object is currently only initialized in `assemble_advection_system` if the current `advection_field` is discontinuous, because that is the only case we need it so far. However, we currently have only one signal `local_assemble_advection_system_on_boundary_face`, and I would like to use its number of connected slots to determine if the `face_finite_element_values` will be initialized and the signal is called. This leads to conflicts, if only one of the advection systems is discontinuous (the signal is also called for the other).
As far as I can see there are essentially two ways to handle this:

1. Keep one signal, but initialize the FaceQuadrature as soon as it has connected slots (this essentially assumes that the equations between both types of advection fields are more or less similar). This keeps the handling of temperature and composition more similar, but we will unnecessarily allocate a scratch object and initialize face values for some fields (namely the continuous ones, when the other fields are discontinuous).

2. Separate the advection signals (at least the face assembly) into two (temperature vs. composition). This will revert some of our efforts to unify temperature and composition, but it might be faster, and with less complicated logic.

What are your opinions?