### PR TITLE
Make 'Simpler' material model work with compositions

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -5,6 +5,11 @@
  * 1.3. All entries are signed with the names of the author. </p>
  *
  * <ol>
+ * <li> Fixed: The 'Simpler' material model produced floating point exceptions
+ * in models with compositional fields. This is fixed now.
+ * <br>
+ * (Lev Karatun, Rene Gassmoeller, 2016/02/26)
+ *
  * <li> New: The advection systems (for temperature and compositions) can now 
  * be discretized using the symmetric interior penalty discontinuous Galerkin 
  * method. This can be useful to explore solution without adding artificial 

--- a/source/material_model/depth_dependent.cc
+++ b/source/material_model/depth_dependent.cc
@@ -132,7 +132,7 @@ namespace aspect
     DepthDependent<dim>::evaluate(const typename Interface<dim>::MaterialModelInputs &in,
                                   typename Interface<dim>::MaterialModelOutputs &out) const
     {
-      base_model -> evaluate(in,out);
+      base_model->evaluate(in,out);
       if (in.strain_rate.size())
         {
           // Scale the base model viscosity value by the depth dependent prefactor

--- a/source/material_model/simpler.cc
+++ b/source/material_model/simpler.cc
@@ -65,6 +65,9 @@ namespace aspect
           out.specific_heat[i] = reference_specific_heat;
           out.thermal_conductivities[i] = k_value;
           out.compressibilities[i] = 0.0;
+
+          for (unsigned int c=0; c<in.composition[i].size(); ++c)
+            out.reaction_terms[i][c] = 0.0;
         }
 
     }

--- a/tests/simpler_composition.prm
+++ b/tests/simpler_composition.prm
@@ -1,0 +1,59 @@
+# This test ensures that the Simpler material model works 
+# with compositional fields enabled
+
+set Dimension                              = 2
+set End time                               = 0
+
+subsection Boundary temperature model
+  set Model name = initial temperature 
+end
+
+subsection Compositional fields
+  set Number of fields          = 1 
+end
+
+subsection Compositional initial conditions
+  subsection Function
+    set Function expression = 1
+  end
+end
+
+subsection Geometry model
+  set Model name = box 
+  subsection Box
+    set X extent                = 1024e3 
+    set X repetitions           = 2      
+    set Y extent                = 1024e3  
+    set Y repetitions           = 2
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical 
+  subsection Vertical
+    set Magnitude = 9.81 
+  end
+end
+
+subsection Initial conditions
+  set Model name = function 
+  subsection Function
+    set Function expression = 500
+  end
+end
+
+subsection Material model
+  set Model name         = simpler
+  subsection Simpler model
+    set Viscosity = 1e21
+  end
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement              = 0         
+  set Initial global refinement                = 2           
+end
+
+subsection Model settings
+  set Tangential velocity boundary indicators = left, right, top, bottom
+end

--- a/tests/simpler_composition/screen-output
+++ b/tests/simpler_composition/screen-output
@@ -1,0 +1,41 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.4.0-pre
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Number of active cells: 64 (on 3 levels)
+Number of degrees of freedom: 1,237 (578+81+289+289)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 2 iterations.
+
+   Postprocessing:
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |    0.0776s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |    0.0137s |        18% |
+| Assemble composition system     |         1 |   0.00696s |         9% |
+| Assemble temperature system     |         1 |   0.00729s |       9.4% |
+| Build Stokes preconditioner     |         1 |    0.0133s |        17% |
+| Build composition preconditioner|         1 |  0.000367s |      0.47% |
+| Build temperature preconditioner|         1 |  0.000532s |      0.69% |
+| Solve Stokes system             |         1 |   0.00123s |       1.6% |
+| Solve composition system        |         1 |  0.000182s |      0.23% |
+| Solve temperature system        |         1 |  0.000291s |      0.38% |
+| Initialization                  |         2 |    0.0215s |        28% |
+| Postprocessing                  |         1 |   6.6e-05s |     0.085% |
+| Setup dof systems               |         1 |    0.0089s |        11% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/simpler_composition/statistics
+++ b/tests/simpler_composition/statistics
@@ -1,0 +1,13 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Number of degrees of freedom for all compositions
+# 7: Iterations for temperature solver
+# 8: Iterations for composition solver 1
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Time step size (years)
+0 0.0000e+00 64 659 289 289 0 0 2 3 2 3.5636e+18 


### PR DESCRIPTION
The 'Simpler' material model used to throw floating point exceptions, because it did not set the reaction_terms to zero and therefore they were used uninitialized in the assembly. This PR fixes this behaviour.