### PR TITLE
Earlier signal creation

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1058,8 +1058,10 @@ namespace aspect
        * @{
        */
       Parameters<dim>                     parameters;
-      Introspection<dim>                  introspection;
       SimulatorSignals<dim>               signals;
+      const IntermediaryConstructorAction post_signal_creation;
+      Introspection<dim>                  introspection;
+
 
       MPI_Comm                            mpi_communicator;
 

--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -201,7 +201,7 @@ namespace aspect
        * with the corresponding signals.
        */
       template <int dim>
-      void call_connector_functions (aspect::SimulatorSignals<dim> &signals_);
+      void call_connector_functions (aspect::SimulatorSignals<dim> &signals);
     }
   }
 

--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -200,8 +200,8 @@ namespace aspect
        * user-provided connector functions to let them register their slots
        * with the corresponding signals.
        */
-      void call_connector_functions (aspect::SimulatorSignals<2> &signals);
-      void call_connector_functions (aspect::SimulatorSignals<3> &signals);
+      template <int dim>
+      void call_connector_functions (aspect::SimulatorSignals<dim> &signals_);
     }
   }
 

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -35,28 +35,12 @@ namespace aspect
 {
   namespace Particle
   {
-    template <>
-    World<2>::World()
+    template <int dim>
+    World<dim>::World()
       :
       global_number_of_particles(0),
       data_offset(numbers::invalid_unsigned_int)
-    {
-
-      aspect::internals::SimulatorSignals::register_connector_function_2d (std_cxx11::bind(&World<2>::connect_to_signals,
-                                                                           std_cxx11::ref(*this),
-                                                                           std_cxx11::_1));
-    }
-
-    template <>
-    World<3>::World()
-      :
-      global_number_of_particles(0),
-      data_offset(numbers::invalid_unsigned_int)
-    {
-      aspect::internals::SimulatorSignals::register_connector_function_3d (std_cxx11::bind(&World<3>::connect_to_signals,
-                                                                           std_cxx11::ref(*this),
-                                                                           std_cxx11::_1));
-    }
+    {}
 
     template <int dim>
     World<dim>::~World()
@@ -72,6 +56,8 @@ namespace aspect
                            const unsigned int max_part_per_cell,
                            const unsigned int weight)
     {
+      World<dim>::connect_to_signals(this->get_signals());
+
       generator.reset(particle_generator);
       integrator.reset(particle_integrator);
       interpolator.reset(property_interpolator);

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -56,7 +56,7 @@ namespace aspect
                            const unsigned int max_part_per_cell,
                            const unsigned int weight)
     {
-      World<dim>::connect_to_signals(this->get_signals());
+      connect_to_signals(this->get_signals());
 
       generator.reset(particle_generator);
       integrator.reset(particle_integrator);

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -101,6 +101,9 @@ namespace aspect
     :
     assemblers (new internal::Assembly::AssemblerLists<dim>()),
     parameters (prm, mpi_communicator_),
+    post_signal_creation(
+      std_cxx11::bind (&internals::SimulatorSignals::call_connector_functions<dim>,
+                       std_cxx11::ref(signals))),
     introspection (parameters),
     mpi_communicator (Utilities::MPI::duplicate_communicator (mpi_communicator_)),
     iostream_tee_device(std::cout, log_file_stream),
@@ -582,10 +585,6 @@ namespace aspect
                                  parameters.output_directory + "parameters.tex>."));
         prm.print_parameters(prm_out, ParameterHandler::LaTeX);
       }
-
-    // let user-provided plugins let their slots
-    // connect to the signals we provide
-    internals::SimulatorSignals::call_connector_functions (signals);
 
     // now that all member variables have been set up, also
     // connect the functions that will actually do the assembly

--- a/source/simulator/simulator_signals.cc
+++ b/source/simulator/simulator_signals.cc
@@ -57,6 +57,7 @@ namespace aspect
 
 
       // call connectors to ensure that plugins get a change to register their slots
+      template <>
       void call_connector_functions (aspect::SimulatorSignals<2> &signals)
       {
         for (std::list<std_cxx11::function<void (aspect::SimulatorSignals<2> &)> >::const_iterator
@@ -66,6 +67,7 @@ namespace aspect
           (*p)(signals);
       }
 
+      template <>
       void call_connector_functions (aspect::SimulatorSignals<3> &signals)
       {
         for (std::list<std_cxx11::function<void (aspect::SimulatorSignals<3> &)> >::const_iterator
@@ -83,7 +85,13 @@ namespace aspect
 namespace aspect
 {
 #define INSTANTIATE(dim) \
-  template struct SimulatorSignals<dim>;
+  template struct SimulatorSignals<dim>; \
+  namespace internals {\
+    namespace SimulatorSignals {\
+      template void call_connector_functions<dim> (aspect::SimulatorSignals<dim> &signals);\
+    }\
+  }\
+   
 
   ASPECT_INSTANTIATE(INSTANTIATE)
 }

--- a/source/simulator/simulator_signals.cc
+++ b/source/simulator/simulator_signals.cc
@@ -43,15 +43,20 @@ namespace aspect
       std::list<std_cxx11::function<void (aspect::SimulatorSignals<2> &)> > connector_functions_2d;
       std::list<std_cxx11::function<void (aspect::SimulatorSignals<3> &)> > connector_functions_3d;
 
+      static bool connector_functions_have_been_called = false;
 
       // add a user-provided connector to the list of connectors we keep
       void register_connector_function_2d (const std_cxx11::function<void (aspect::SimulatorSignals<2> &)> &connector)
       {
+        Assert(!connector_functions_have_been_called,
+               ExcMessage("Registration of signal connector happened after connection has already been called!"));
         connector_functions_2d.push_back (connector);
       }
 
       void register_connector_function_3d (const std_cxx11::function<void (aspect::SimulatorSignals<3> &)> &connector)
       {
+        Assert(!connector_functions_have_been_called,
+               ExcMessage("Registration of signal connector happened after connection has already been called!"));
         connector_functions_3d.push_back (connector);
       }
 
@@ -60,21 +65,30 @@ namespace aspect
       template <>
       void call_connector_functions (aspect::SimulatorSignals<2> &signals)
       {
+        Assert(!connector_functions_have_been_called,
+               ExcInternalError());
+
         for (std::list<std_cxx11::function<void (aspect::SimulatorSignals<2> &)> >::const_iterator
              p = connector_functions_2d.begin();
              p != connector_functions_2d.end();
              ++p)
           (*p)(signals);
+
+        connector_functions_have_been_called = true;
       }
 
       template <>
       void call_connector_functions (aspect::SimulatorSignals<3> &signals)
       {
+        Assert(!connector_functions_have_been_called,
+               ExcInternalError());
+
         for (std::list<std_cxx11::function<void (aspect::SimulatorSignals<3> &)> >::const_iterator
              p = connector_functions_3d.begin();
              p != connector_functions_3d.end();
              ++p)
           (*p)(signals);
+        connector_functions_have_been_called = true;
       }
     }
   }

--- a/tests/additional_outputs_02.cc
+++ b/tests/additional_outputs_02.cc
@@ -108,6 +108,11 @@ namespace aspect
   {
     std::cout << "* set_assemblers()" << std::endl;
 
+    std::cout << "called without: " << counter_without << " with: " << counter_with << std::endl;
+    counter_without = 0;
+    counter_with = 0;
+    quiet = false;
+
     TestAssembler<dim> *test_assembler = new TestAssembler<dim>();
     assembler_objects.push_back(std_cxx11::shared_ptr<internal::Assembly::Assemblers::AssemblerBase<dim> >(test_assembler));
 
@@ -131,11 +136,6 @@ void signal_connector (aspect::SimulatorSignals<dim> &signals)
 {
   std::cout << "* Connecting signals" << std::endl;
   signals.set_assemblers.connect (&aspect::set_assemblers1<dim>);
-
-  std::cout << "called without: " << counter_without << " with: " << counter_with << std::endl;
-  counter_without = 0;
-  counter_with = 0;
-  quiet = false;
 
 }
 

--- a/tests/additional_outputs_02/screen-output
+++ b/tests/additional_outputs_02/screen-output
@@ -2,8 +2,8 @@
 Loading shared library <./libadditional_outputs_02.so>
 
 * Connecting signals
-called without: 999 with: 0
 * set_assemblers()
+called without: 999 with: 0
 Number of active cells: 4 (on 2 levels)
 Number of degrees of freedom: 84 (50+9+25)
 

--- a/tests/additional_outputs_03.cc
+++ b/tests/additional_outputs_03.cc
@@ -122,6 +122,10 @@ namespace aspect
                        std::vector<dealii::std_cxx11::shared_ptr<internal::Assembly::Assemblers::AssemblerBase<dim> > > &assembler_objects)
   {
     std::cout << "* set_assemblers()" << std::endl;
+    std::cout << "called without: " << counter_without << " with: " << counter_with << std::endl;
+    counter_without = 0;
+    counter_with = 0;
+    quiet = false;
 
     TestAssembler<dim> *test_assembler = new TestAssembler<dim>();
     assembler_objects.push_back(std_cxx11::shared_ptr<internal::Assembly::Assemblers::AssemblerBase<dim> >(test_assembler));
@@ -146,11 +150,6 @@ void signal_connector (aspect::SimulatorSignals<dim> &signals)
 {
   std::cout << "* Connecting signals" << std::endl;
   signals.set_assemblers.connect (&aspect::set_assemblers1<dim>);
-
-  std::cout << "called without: " << counter_without << " with: " << counter_with << std::endl;
-  counter_without = 0;
-  counter_with = 0;
-  quiet = false;
 
 }
 

--- a/tests/additional_outputs_03/screen-output
+++ b/tests/additional_outputs_03/screen-output
@@ -2,8 +2,8 @@
 Loading shared library <./libadditional_outputs_03.so>
 
 * Connecting signals
-called without: 999 with: 0
 * set_assemblers()
+called without: 999 with: 0
 Number of active cells: 4 (on 2 levels)
 Number of degrees of freedom: 84 (50+9+25)
 


### PR DESCRIPTION
This patch moves the creation of the ``signals`` object closer to the top of the simulator and call the connector functions as soon as possible (instead of at the end of the initialization). In the future, this will allow us to fire new signals during introspection construction for example. Right now this doesn't do anything exciting.

- connect signals earlier in the program
- catch when you try to register after connector functions have already been called
- update tests