### PR TITLE
Remove assembly scratch.explicit_material_model and cleanup

### DIFF
--- a/include/aspect/assembly.h
+++ b/include/aspect/assembly.h
@@ -163,8 +163,8 @@ namespace aspect
           std::vector<double>         old_temperature_values;
           std::vector<double>         old_old_temperature_values;
 
-          std::vector<double>        *old_field_values;
-          std::vector<double>        *old_old_field_values;
+          std::vector<double>         old_field_values;
+          std::vector<double>         old_old_field_values;
           std::vector<Tensor<1,dim> > old_field_grads;
           std::vector<Tensor<1,dim> > old_old_field_grads;
           std::vector<double>         old_field_laplacians;
@@ -196,14 +196,6 @@ namespace aspect
           MaterialModel::MaterialModelOutputs<dim> neighbor_face_material_model_outputs;
 
           /**
-           * Material model inputs and outputs computed at a previous
-           * time step's solution, or an extrapolation from previous
-           * time steps.
-           */
-          MaterialModel::MaterialModelInputs<dim> explicit_material_model_inputs;
-          MaterialModel::MaterialModelOutputs<dim> explicit_material_model_outputs;
-
-          /**
            * Heating model outputs computed at the quadrature points of the
            * current cell at the time of the current linearization point.
            * As explained in the class documentation of
@@ -212,6 +204,7 @@ namespace aspect
            */
           HeatingModel::HeatingModelOutputs heating_model_outputs;
           HeatingModel::HeatingModelOutputs face_heating_model_outputs;
+          HeatingModel::HeatingModelOutputs neighbor_face_heating_model_outputs;
         };
 
 
@@ -346,7 +339,7 @@ namespace aspect
              * get_additional_output() returns an instance before adding a new
              * one to the additional_outputs vector.
              */
-            virtual void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &) {}
+            virtual void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &) const {}
         };
       }
 

--- a/include/aspect/assembly.h
+++ b/include/aspect/assembly.h
@@ -211,6 +211,7 @@ namespace aspect
            * enabled heating mechanism contributions.
            */
           HeatingModel::HeatingModelOutputs heating_model_outputs;
+          HeatingModel::HeatingModelOutputs face_heating_model_outputs;
         };
 
 
@@ -520,6 +521,28 @@ namespace aspect
                                                               ResidualWeightSum<std::vector<double> > > compute_advection_system_residual;
 
         /**
+         * A signal that is called from Simulator::local_assemble_advection_system()
+         * and whose slots are supposed to assemble terms that together form the
+         * boundary contribution of the Advection system matrix and right hand side. This signal is called
+         * once for each boundary face.
+         *
+         * The arguments to the slots are as follows:
+         * - The cell on which we currently assemble.
+         * - The number of the face on which we intend to assemble. This
+         *   face (of the current cell) will be at the boundary of the
+         *   domain.
+         * - The advection field that is currently assembled.
+         * - The scratch object in which temporary data is stored that
+         *   assemblers may need.
+         * - The copy object into which assemblers add up their contributions.
+         */
+        boost::signals2::signal<void (const typename DoFHandler<dim>::active_cell_iterator &,
+                                      const unsigned int,
+                                      const typename Simulator<dim>::AdvectionField &,
+                                      internal::Assembly::Scratch::AdvectionSystem<dim>       &,
+                                      internal::Assembly::CopyData::AdvectionSystem<dim>      &)> local_assemble_advection_system_on_boundary_face;
+
+        /**
          * A structure that describes what information an assembler function
          * (listed as one of the signals/slots above) may need to operate.
          *
@@ -572,6 +595,9 @@ namespace aspect
         Properties stokes_preconditioner_assembler_properties;
         Properties stokes_system_assembler_properties;
         Properties stokes_system_assembler_on_boundary_face_properties;
+        Properties advection_system_assembler_properties;
+        Properties advection_system_assembler_on_boundary_face_properties;
+
       };
 
     }

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -231,7 +231,8 @@ namespace aspect
         is_temperature () const;
 
         /**
-         * Return whether this object refers to a field discretized by discontinuous finite elements.
+         * Return whether this object refers to a field discretized by
+         * discontinuous finite elements.
          */
         bool
         is_discontinuous (const Introspection<dim> &introspection) const;

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -613,7 +613,7 @@ namespace aspect
        * internal::Assemblers::AssemblerBase::create_additional_material_model_outputs()
        * functions from each object in Simulator::assembler_objects.
        */
-      void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &);
+      void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &) const;
 
       /**
        * Determine, based on the run-time parameters of the current simulation,

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -35,6 +35,7 @@
 #include <aspect/geometry_model/interface.h>
 #include <aspect/gravity_model/interface.h>
 #include <aspect/boundary_temperature/interface.h>
+#include <aspect/boundary_composition/interface.h>
 #include <aspect/initial_conditions/interface.h>
 #include <aspect/compositional_initial_conditions/interface.h>
 #include <aspect/velocity_boundary_conditions/interface.h>
@@ -291,6 +292,19 @@ namespace aspect
       /** @name Accessing variables that identify the solution of the problem */
       /** @{ */
 
+      /**
+       * Return a reference to the vector that has the current linearization
+       * point of the entire system, i.e. the velocity and pressure variables
+       * as well as the temperature and compositional fields. This vector is
+       * associated with the DoFHandler object returned by get_dof_handler().
+       * This vector is only different from the one returned by get_solution()
+       * during the solver phase.
+       *
+       * @note In general the vector is a distributed vector; however, it
+       * contains ghost elements for all locally relevant degrees of freedom.
+       */
+      const LinearAlgebra::BlockVector &
+      get_current_linearization_point () const;
 
       /**
        * Return a reference to the vector that has the current solution of the
@@ -368,6 +382,17 @@ namespace aspect
       get_material_model () const;
 
       /**
+       * This function simply calls Simulator<dim>::compute_material_model_input_values()
+       * with the given arguments.
+       */
+      void
+      compute_material_model_input_values (const LinearAlgebra::BlockVector                            &input_solution,
+                                           const FEValuesBase<dim,dim>                                 &input_finite_element_values,
+                                           const typename DoFHandler<dim>::active_cell_iterator        &cell,
+                                           const bool                                                   compute_strainrate,
+                                           MaterialModel::MaterialModelInputs<dim> &material_model_inputs) const;
+
+      /**
        * Return a pointer to the gravity model description.
        */
       const GravityModel::Interface<dim> &
@@ -403,6 +428,23 @@ namespace aspect
        */
       const BoundaryTemperature::Interface<dim> &
       get_boundary_temperature () const;
+
+      /**
+       * Return whether the current model has a boundary composition object
+       * set. This is useful because a simulation does not actually have to
+       * declare any boundary composition model, for example if all
+       * boundaries are insulating. In such cases, there is no
+       * boundary composition model that can provide, for example,
+       * a minimal and maximal temperature on the boundary.
+       */
+      bool has_boundary_composition () const;
+
+      /**
+       * Return a reference to the object that describes the composition
+       * boundary values.
+       */
+      const BoundaryComposition::Interface<dim> &
+      get_boundary_composition () const;
 
       /**
        * Return a reference to the object that describes traction

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -239,7 +239,8 @@ namespace aspect
           neighbor_face_material_model_outputs(face_quadrature.size(), n_compositional_fields),
           explicit_material_model_inputs(quadrature.size(), n_compositional_fields),
           explicit_material_model_outputs(quadrature.size(), n_compositional_fields),
-          heating_model_outputs(quadrature.size(), n_compositional_fields)
+          heating_model_outputs(quadrature.size(), n_compositional_fields),
+          face_heating_model_outputs(quadrature.size(), n_compositional_fields)
         {}
 
 
@@ -294,7 +295,8 @@ namespace aspect
           neighbor_face_material_model_outputs(scratch.neighbor_face_material_model_outputs),
           explicit_material_model_inputs(scratch.explicit_material_model_inputs),
           explicit_material_model_outputs(scratch.explicit_material_model_outputs),
-          heating_model_outputs(scratch.heating_model_outputs)
+          heating_model_outputs(scratch.heating_model_outputs),
+          face_heating_model_outputs(scratch.face_heating_model_outputs)
         {}
 
       }
@@ -1207,7 +1209,7 @@ namespace aspect
         compute_advection_system_residual(const typename Simulator<dim>::AdvectionField     &advection_field,
                                           internal::Assembly::Scratch::AdvectionSystem<dim> &scratch) const
         {
-          const unsigned int n_q_points = scratch.old_field_values->size();
+          const unsigned int n_q_points = scratch.finite_element_values.n_quadrature_points;
           std::vector<double> residuals(n_q_points);
 
           HeatingModel::HeatingModelOutputs heating_model_outputs(n_q_points, this->get_parameters().n_compositional_fields);
@@ -1262,6 +1264,840 @@ namespace aspect
                            - dreaction_term_dt);
             }
           return residuals;
+        }
+
+        void
+        local_assemble_advection_face_terms(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                                            const unsigned int face_no,
+                                            const typename Simulator<dim>::AdvectionField &advection_field,
+                                            internal::Assembly::Scratch::AdvectionSystem<dim> &scratch,
+                                            internal::Assembly::CopyData::AdvectionSystem<dim> &data) const
+        {
+          const Parameters<dim> &parameters = this->get_parameters();
+          const Introspection<dim> &introspection = this->introspection();
+          const unsigned int n_q_points    = scratch.face_finite_element_values->n_quadrature_points;
+
+          const double time_step = this->get_timestep();
+
+          // also have the number of dofs that correspond just to the element for
+          // the system we are currently trying to assemble
+          const unsigned int advection_dofs_per_cell = data.local_dof_indices.size();
+
+          Assert (advection_field.is_discontinuous(introspection),
+                  ExcMessage("Face terms only need assembling in the case of discontinuous temperature or compositional discretization."));
+
+          Assert (advection_dofs_per_cell < scratch.face_finite_element_values->get_fe().dofs_per_cell, ExcInternalError());
+          Assert (scratch.face_grad_phi_field.size() == advection_dofs_per_cell, ExcInternalError());
+          Assert (scratch.face_phi_field.size() == advection_dofs_per_cell, ExcInternalError());
+
+          const unsigned int solution_component = advection_field.component_index(introspection);
+
+          const FEValuesExtractors::Scalar solution_field
+            = (advection_field.is_temperature()
+               ?
+               introspection.extractors.temperature
+               :
+               introspection.extractors.compositional_fields[advection_field.compositional_variable]
+              );
+
+          typename DoFHandler<dim>::face_iterator face = cell->face (face_no);
+
+          if (face->at_boundary())
+            {
+              if (((parameters.fixed_temperature_boundary_indicators.find(
+#if DEAL_II_VERSION_GTE(8,3,0)
+                      cell->face(face_no)->boundary_id()
+#else
+                      cell->face(face_no)->boundary_indicator()
+#endif
+                    )
+                    != parameters.fixed_temperature_boundary_indicators.end())
+                   && (advection_field.is_temperature()))
+                  ||
+                  (( parameters.fixed_composition_boundary_indicators.find(
+#if DEAL_II_VERSION_GTE(8,3,0)
+                       cell->face(face_no)->boundary_id()
+#else
+                       cell->face(face_no)->boundary_indicator()
+#endif
+                     )
+                     != parameters.fixed_composition_boundary_indicators.end())
+                   && (!advection_field.is_temperature())))
+                {
+                  /*
+                   * We are in the case of a Dirichlet temperature or composition boundary.
+                   * In the temperature case, impose the Dirichlet value weakly using a matrix term
+                   * and RHS term. In the composition case, Dirichlet conditions can only be imposed
+                   * on inflow boundaries, and we only have the flow-dependent terms, so we only
+                   * assemble the corresponding flow-dependent and matrix and RHS terms
+                   * if we are on an inflow boundary.
+                   */
+
+                  for (unsigned int q=0; q<n_q_points; ++q)
+                    {
+                      // precompute the values of shape functions and their gradients.
+                      // We only need to look up values of shape functions if they
+                      // belong to 'our' component. They are zero otherwise anyway.
+                      // Note that we later only look at the values that we do set here.
+                      for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
+                        {
+                          scratch.face_grad_phi_field[k] = (*scratch.face_finite_element_values)[solution_field].gradient (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                          scratch.face_phi_field[k]      = (*scratch.face_finite_element_values)[solution_field].value (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                        }
+                      const double density_c_P              =
+                        ((advection_field.is_temperature())
+                         ?
+                         scratch.face_material_model_outputs.densities[q] *
+                         scratch.face_material_model_outputs.specific_heat[q]
+                         :
+                         1.0);
+
+                      Assert (density_c_P >= 0,
+                              ExcMessage ("The product of density and c_P needs to be a "
+                                          "non-negative quantity."));
+
+                      const double conductivity =
+                        ((advection_field.is_temperature())
+                         ?
+                         scratch.face_material_model_outputs.thermal_conductivities[q]
+                         :
+                         0.0);
+                      const double latent_heat_LHS =
+                        ((advection_field.is_temperature())
+                         ?
+                         scratch.face_heating_model_outputs.lhs_latent_heat_terms[q]
+                         :
+                         0.0);
+                      Assert (density_c_P + latent_heat_LHS >= 0,
+                              ExcMessage ("The sum of density times c_P and the latent heat contribution "
+                                          "to the left hand side needs to be a non-negative quantity."));
+
+                      const double penalty = (advection_field.is_temperature()
+                                              ?
+                                              parameters.discontinuous_penalty
+                                              * parameters.temperature_degree
+                                              * parameters.temperature_degree
+                                              / face->measure()
+                                              * conductivity
+                                              / (density_c_P + latent_heat_LHS)
+                                              :
+                                              0.0);
+
+                      const double dirichlet_value = (advection_field.is_temperature()
+                                                      ?
+                                                      this->get_boundary_temperature().boundary_temperature(
+#if DEAL_II_VERSION_GTE(8,3,0)
+                                                        cell->face(face_no)->boundary_id(),
+#else
+                                                        cell->face(face_no)->boundary_indicator(),
+#endif
+                                                        scratch.face_finite_element_values->quadrature_point(q))
+                                                      :
+                                                      this->get_boundary_composition().boundary_composition(
+#if DEAL_II_VERSION_GTE(8,3,0)
+                                                        cell->face(face_no)->boundary_id(),
+#else
+                                                        cell->face(face_no)->boundary_indicator(),
+#endif
+                                                        scratch.face_finite_element_values->quadrature_point(q),
+                                                        advection_field.compositional_variable));
+
+                      Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
+                      //Subtract off the mesh velocity for ALE corrections if necessary
+                      if (parameters.free_surface_enabled)
+                        current_u -= scratch.face_mesh_velocity_values[q];
+
+                      /**
+                       * The discontinuous Galerkin method uses 2 types of jumps over edges:
+                       * undirected and directed jumps. Undirected jumps are dependent only
+                       * on the order of the numbering of cells. Directed jumps are dependent
+                       * on the direction of the flow. Thus the flow-dependent terms below are
+                       * only calculated if the edge is an inflow edge.
+                       */
+                      const bool inflow = ((current_u * scratch.face_finite_element_values->normal_vector(q)) < 0.);
+
+                      for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+                        {
+                          data.local_rhs(i)
+                          += (- time_step *  conductivity
+                              * scratch.face_grad_phi_field[i]
+                              * scratch.face_finite_element_values->normal_vector(q)
+                              * dirichlet_value
+
+                              + time_step
+                              * (density_c_P + latent_heat_LHS)
+                              * penalty
+                              * scratch.face_phi_field[i]
+                              * dirichlet_value
+
+                              + (inflow
+                                 ?
+                                 - (density_c_P + latent_heat_LHS)
+                                 * time_step
+                                 * (current_u
+                                    * scratch.face_finite_element_values->normal_vector(q))
+                                 * dirichlet_value
+                                 * scratch.face_phi_field[i]
+                                 :
+                                 0.)
+                             )
+                             *
+                             scratch.face_finite_element_values->JxW(q);
+
+                          // local_matrix terms
+                          for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
+                            {
+                              data.local_matrix(i,j)
+                              += (- time_step *  conductivity
+                                  * scratch.face_grad_phi_field[i]
+                                  * scratch.face_finite_element_values->normal_vector(q)
+                                  * scratch.face_phi_field[j]
+
+                                  - time_step *  conductivity
+                                  * scratch.face_grad_phi_field[j]
+                                  * scratch.face_finite_element_values->normal_vector(q)
+                                  * scratch.face_phi_field[i]
+
+                                  + time_step
+                                  * (density_c_P + latent_heat_LHS)
+                                  * penalty
+                                  * scratch.face_phi_field[i]
+                                  * scratch.face_phi_field[j]
+
+                                  + (inflow
+                                     ?
+                                     - (density_c_P + latent_heat_LHS)
+                                     * time_step
+                                     * (current_u
+                                        * scratch.face_finite_element_values->normal_vector(q))
+                                     * scratch.face_phi_field[i]
+                                     * scratch.face_phi_field[j]
+                                     :
+                                     0.)
+                                 )
+                                 * scratch.face_finite_element_values->JxW(q);
+                            }
+                        }
+                    }
+                }
+              else
+                {
+                  //Neumann temperature term - no non-zero contribution as only homogeneous Neumann boundary conditions are implemented elsewhere for temperature
+                }
+            }
+          else
+            {
+              //interior face - no contribution on RHS
+              Assert (cell->neighbor(face_no).state() == IteratorState::valid,
+                      ExcInternalError());
+              const typename DoFHandler<dim>::cell_iterator neighbor = cell->neighbor(face_no); //note: NOT active_cell_iterator, so this includes cells that are refined.
+
+              if (!(face->has_children()))
+                {
+                  if (!cell->neighbor_is_coarser(face_no) &&
+                      (((neighbor->is_locally_owned()) && (cell->index() < neighbor->index()))
+                       ||
+                       ((!neighbor->is_locally_owned()) && (cell->subdomain_id() < neighbor->subdomain_id()))))
+                    {
+                      Assert (cell->is_locally_owned(), ExcInternalError());
+                      //cell and neighbor are equal-sized, and cell has been chosen to assemble this face, so calculate from cell
+
+                      //how does the neighbor talk about this cell?
+                      const unsigned int neighbor2=cell->neighbor_of_neighbor(face_no);
+
+                      //set up neighbor values
+                      scratch.neighbor_face_finite_element_values->reinit (neighbor, neighbor2);
+
+                      this->compute_material_model_input_values (this->get_current_linearization_point(),
+                                                                 *scratch.neighbor_face_finite_element_values,
+                                                                 neighbor,
+                                                                 true,
+                                                                 scratch.neighbor_face_material_model_inputs);
+                      this->get_material_model().evaluate(scratch.neighbor_face_material_model_inputs,
+                                                          scratch.neighbor_face_material_model_outputs);
+
+                      HeatingModel::HeatingModelOutputs neighbor_face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
+                      this->get_heating_model_manager().evaluate(scratch.neighbor_face_material_model_inputs,
+                                                                 scratch.neighbor_face_material_model_outputs,
+                                                                 neighbor_face_heating_model_outputs);
+
+                      std::vector<types::global_dof_index> neighbor_dof_indices (scratch.face_finite_element_values->get_fe().dofs_per_cell);
+                      // get all dof indices on the neighbor, then extract those
+                      // that correspond to the solution_field we are interested in
+                      neighbor->get_dof_indices (neighbor_dof_indices);
+                      for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+                        data.neighbor_dof_indices[face_no * GeometryInfo<dim>::max_children_per_face][i] = neighbor_dof_indices[scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, i)];
+                      data.assembled_matrices[face_no * GeometryInfo<dim>::max_children_per_face] = true;
+
+                      for (unsigned int q=0; q<n_q_points; ++q)
+                        {
+                          // precompute the values of shape functions and their gradients.
+                          // We only need to look up values of shape functions if they
+                          // belong to 'our' component. They are zero otherwise anyway.
+                          // Note that we later only look at the values that we do set here.
+                          for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
+                            {
+                              scratch.face_grad_phi_field[k]          = (*scratch.face_finite_element_values)[solution_field].gradient (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                              scratch.face_phi_field[k]               = (*scratch.face_finite_element_values)[solution_field].value (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                              scratch.neighbor_face_grad_phi_field[k] = (*scratch.neighbor_face_finite_element_values)[solution_field].gradient (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                              scratch.neighbor_face_phi_field[k]      = (*scratch.neighbor_face_finite_element_values)[solution_field].value (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                            }
+
+                          const double density_c_P              =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.face_material_model_outputs.densities[q] *
+                             scratch.face_material_model_outputs.specific_heat[q]
+                             :
+                             1.0);
+
+                          Assert (density_c_P >= 0,
+                                  ExcMessage ("The product of density and c_P needs to be a "
+                                              "non-negative quantity."));
+
+                          const double conductivity =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.face_material_model_outputs.thermal_conductivities[q]
+                             :
+                             0.0);
+                          const double latent_heat_LHS =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.face_heating_model_outputs.lhs_latent_heat_terms[q]
+                             :
+                             0.0);
+                          Assert (density_c_P + latent_heat_LHS >= 0,
+                                  ExcMessage ("The sum of density times c_P and the latent heat contribution "
+                                              "to the left hand side needs to be a non-negative quantity."));
+
+                          const double penalty = (advection_field.is_temperature()
+                                                  ?
+                                                  parameters.discontinuous_penalty
+                                                  * parameters.temperature_degree
+                                                  * parameters.temperature_degree
+                                                  / face->measure()
+                                                  * conductivity
+                                                  / (density_c_P + latent_heat_LHS)
+                                                  :
+                                                  0.0);
+
+                          Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
+                          //Subtract off the mesh velocity for ALE corrections if necessary
+                          if (parameters.free_surface_enabled)
+                            current_u -= scratch.face_mesh_velocity_values[q];
+
+                          const double neighbor_density_c_P              =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.neighbor_face_material_model_outputs.densities[q] *
+                             scratch.neighbor_face_material_model_outputs.specific_heat[q]
+                             :
+                             1.0);
+
+                          Assert (neighbor_density_c_P >= 0,
+                                  ExcMessage ("The product of density and c_P on the neighbor needs to be a "
+                                              "non-negative quantity."));
+
+                          const double neighbor_conductivity =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.neighbor_face_material_model_outputs.thermal_conductivities[q]
+                             :
+                             0.0);
+                          const double neighbor_latent_heat_LHS =
+                            ((advection_field.is_temperature())
+                             ?
+                             neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
+                             :
+                             0.0);
+                          Assert (neighbor_density_c_P + neighbor_latent_heat_LHS >= 0,
+                                  ExcMessage ("The sum of density times c_P and the latent heat contribution "
+                                              "to the left hand side on the neighbor needs to be a non-negative quantity."));
+
+                          const double neighbor_penalty = (advection_field.is_temperature()
+                                                           ?
+                                                           parameters.discontinuous_penalty
+                                                           * parameters.temperature_degree
+                                                           * parameters.temperature_degree
+                                                           / neighbor->face(neighbor2)->measure()
+                                                           * neighbor_conductivity
+                                                           / (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                                           :
+                                                           0.0);
+
+                          const double max_penalty = std::max(penalty, neighbor_penalty);
+
+                          const double max_density_c_P_and_latent_heat =
+                            std::max(density_c_P + latent_heat_LHS,
+                                     neighbor_density_c_P + neighbor_latent_heat_LHS);
+
+                          Assert (numbers::is_finite(max_density_c_P_and_latent_heat),
+                                  ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a finite quantity."));
+                          Assert (max_density_c_P_and_latent_heat >= 0,
+                                  ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a "
+                                              "non-negative quantity."));
+
+                          /**
+                           * The discontinuous Galerkin method uses 2 types of jumps over edges:
+                           * undirected and directed jumps. Undirected jumps are dependent only
+                           * on the order of the numbering of cells. Directed jumps are dependent
+                           * on the direction of the flow. Thus the flow-dependent terms below are
+                           * only calculated if the edge is an inflow edge.
+                           */
+                          const bool inflow = ((current_u * scratch.face_finite_element_values->normal_vector(q)) < 0.);
+
+                          for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+                            {
+                              for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
+                                {
+                                  data.local_matrix(i,j)
+                                  += (- 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[i]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[j]
+
+                                      - 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[j]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[i]
+
+                                      + time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.face_phi_field[i]
+                                      * scratch.face_phi_field[j]
+
+                                      - (inflow
+                                         ?
+                                         (density_c_P + latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.face_finite_element_values->normal_vector(q))
+                                         * scratch.face_phi_field[i]
+                                         * scratch.face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.face_finite_element_values->JxW(q);
+
+                                  data.local_matrices_int_ext[face_no * GeometryInfo<dim>::max_children_per_face](i,j)
+                                  += (- 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[j]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[i]
+
+                                      + 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[i]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[j]
+
+                                      - time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.neighbor_face_phi_field[j]
+                                      * scratch.face_phi_field[i]
+
+                                      + (inflow
+                                         ?
+                                         (density_c_P + latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.face_finite_element_values->normal_vector(q))
+                                         * scratch.face_phi_field[i]
+                                         * scratch.neighbor_face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.face_finite_element_values->JxW(q);
+
+                                  data.local_matrices_ext_int[face_no * GeometryInfo<dim>::max_children_per_face](i,j)
+                                  += (+ 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[j]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[i]
+
+                                      - 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[i]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[j]
+
+                                      - time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.face_phi_field[j]
+                                      * scratch.neighbor_face_phi_field[i]
+
+                                      - (!inflow
+                                         ?
+                                         (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.face_finite_element_values->normal_vector(q))
+                                         * scratch.neighbor_face_phi_field[i]
+                                         * scratch.face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.face_finite_element_values->JxW(q);
+
+                                  data.local_matrices_ext_ext[face_no * GeometryInfo<dim>::max_children_per_face](i,j)
+                                  += (+ 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[i]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[j]
+
+                                      + 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[j]
+                                      * scratch.face_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[i]
+
+                                      + time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.neighbor_face_phi_field[i]
+                                      * scratch.neighbor_face_phi_field[j]
+
+                                      + (!inflow
+                                         ?
+                                         (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.face_finite_element_values->normal_vector(q))
+                                         * scratch.neighbor_face_phi_field[i]
+                                         * scratch.neighbor_face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.face_finite_element_values->JxW(q);
+                                }
+                            }
+                        }
+                    }
+                  else
+                    {
+                      /* neighbor is taking responsibility for assembly of this face, because
+                       * either (1) neighbor is coarser, or
+                       *        (2) neighbor is equally-sized and
+                       *           (a) neighbor is on a different subdomain, with lower subdmain_id(), or
+                       *           (b) neighbor is on the same subdomain and has lower index().
+                      */
+                    }
+                }
+              else //face->has_children(), so always assemble from here.
+                {
+                  //how does the neighbor talk about this cell?
+                  const unsigned int neighbor2 = cell->neighbor_face_no(face_no);
+
+                  //loop over subfaces
+                  for (unsigned int subface_no=0; subface_no<face->number_of_children(); ++subface_no)
+                    {
+                      const typename DoFHandler<dim>::active_cell_iterator neighbor_child
+                        = cell->neighbor_child_on_subface (face_no, subface_no);
+
+                      //set up subface values
+                      scratch.subface_finite_element_values->reinit (cell, face_no, subface_no);
+
+                      //subface->face
+                      (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(this->get_current_linearization_point(),
+                          scratch.face_current_velocity_values);
+
+                      //get the mesh velocity, as we need to subtract it off of the advection systems
+                      if (parameters.free_surface_enabled)
+                        (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(this->get_mesh_velocity(),
+                            scratch.face_mesh_velocity_values);
+
+                      //get the mesh velocity, as we need to subtract it off of the advection systems
+                      if (parameters.free_surface_enabled)
+                        (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(this->get_mesh_velocity(),
+                            scratch.face_mesh_velocity_values);
+
+                      this->compute_material_model_input_values (this->get_current_linearization_point(),
+                                                                 *scratch.subface_finite_element_values,
+                                                                 cell,
+                                                                 true,
+                                                                 scratch.face_material_model_inputs);
+                      this->get_material_model().evaluate(scratch.face_material_model_inputs,
+                                                          scratch.face_material_model_outputs);
+
+                      HeatingModel::HeatingModelOutputs face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
+                      this->get_heating_model_manager().evaluate(scratch.face_material_model_inputs,
+                                                                 scratch.face_material_model_outputs,
+                                                                 face_heating_model_outputs);
+
+                      //set up neighbor values
+                      scratch.neighbor_face_finite_element_values->reinit (neighbor_child, neighbor2);
+
+                      this->compute_material_model_input_values (this->get_current_linearization_point(),
+                                                                 *scratch.neighbor_face_finite_element_values,
+                                                                 neighbor_child,
+                                                                 true,
+                                                                 scratch.neighbor_face_material_model_inputs);
+                      this->get_material_model().evaluate(scratch.neighbor_face_material_model_inputs,
+                                                          scratch.neighbor_face_material_model_outputs);
+
+                      HeatingModel::HeatingModelOutputs neighbor_face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
+                      this->get_heating_model_manager().evaluate(scratch.neighbor_face_material_model_inputs,
+                                                                 scratch.neighbor_face_material_model_outputs,
+                                                                 neighbor_face_heating_model_outputs);
+
+                      std::vector<types::global_dof_index> neighbor_dof_indices (scratch.face_finite_element_values->get_fe().dofs_per_cell);
+                      // get all dof indices on the neighbor, then extract those
+                      // that correspond to the solution_field we are interested in
+                      neighbor_child->get_dof_indices (neighbor_dof_indices);
+                      for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+                        data.neighbor_dof_indices[face_no * GeometryInfo<dim>::max_children_per_face + subface_no][i] = neighbor_dof_indices[scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, i)];
+                      data.assembled_matrices[face_no * GeometryInfo<dim>::max_children_per_face + subface_no] = true;
+
+                      for (unsigned int q=0; q<n_q_points; ++q)
+                        {
+                          // precompute the values of shape functions and their gradients.
+                          // We only need to look up values of shape functions if they
+                          // belong to 'our' component. They are zero otherwise anyway.
+                          // Note that we later only look at the values that we do set here.
+                          for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
+                            {
+                              scratch.face_grad_phi_field[k]          = (*scratch.subface_finite_element_values)[solution_field].gradient (scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                              scratch.face_phi_field[k]               = (*scratch.subface_finite_element_values)[solution_field].value (scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                              scratch.neighbor_face_grad_phi_field[k] = (*scratch.neighbor_face_finite_element_values)[solution_field].gradient (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                              scratch.neighbor_face_phi_field[k]      = (*scratch.neighbor_face_finite_element_values)[solution_field].value (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
+                            }
+
+                          const double density_c_P              =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.face_material_model_outputs.densities[q] *
+                             scratch.face_material_model_outputs.specific_heat[q]
+                             :
+                             1.0);
+
+                          Assert (density_c_P >= 0,
+                                  ExcMessage ("The product of density and c_P needs to be a "
+                                              "non-negative quantity."));
+
+                          const double conductivity =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.face_material_model_outputs.thermal_conductivities[q]
+                             :
+                             0.0);
+                          const double latent_heat_LHS =
+                            ((advection_field.is_temperature())
+                             ?
+                             face_heating_model_outputs.lhs_latent_heat_terms[q]
+                             :
+                             0.0);
+                          Assert (density_c_P + latent_heat_LHS >= 0,
+                                  ExcMessage ("The sum of density times c_P and the latent heat contribution "
+                                              "to the left hand side needs to be a non-negative quantity."));
+
+                          const double penalty = (advection_field.is_temperature()
+                                                  ?
+                                                  parameters.discontinuous_penalty
+                                                  * parameters.temperature_degree
+                                                  * parameters.temperature_degree
+                                                  / face->measure()
+                                                  * conductivity
+                                                  / (density_c_P + latent_heat_LHS)
+                                                  :
+                                                  0.0);
+
+                          Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
+                          //Subtract off the mesh velocity for ALE corrections if necessary
+                          if (parameters.free_surface_enabled)
+                            current_u -= scratch.face_mesh_velocity_values[q];
+
+                          const double neighbor_density_c_P              =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.neighbor_face_material_model_outputs.densities[q] *
+                             scratch.neighbor_face_material_model_outputs.specific_heat[q]
+                             :
+                             1.0);
+
+                          Assert (neighbor_density_c_P >= 0,
+                                  ExcMessage ("The product of density and c_P on the neighbor needs to be a "
+                                              "non-negative quantity."));
+
+                          const double neighbor_conductivity =
+                            ((advection_field.is_temperature())
+                             ?
+                             scratch.neighbor_face_material_model_outputs.thermal_conductivities[q]
+                             :
+                             0.0);
+                          const double neighbor_latent_heat_LHS =
+                            ((advection_field.is_temperature())
+                             ?
+                             neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
+                             :
+                             0.0);
+                          Assert (neighbor_density_c_P + neighbor_latent_heat_LHS >= 0,
+                                  ExcMessage ("The sum of density times c_P and the latent heat contribution "
+                                              "to the left hand side on the neighbor needs to be a non-negative quantity."));
+
+                          const double neighbor_penalty = (advection_field.is_temperature()
+                                                           ?
+                                                           parameters.discontinuous_penalty
+                                                           * parameters.temperature_degree
+                                                           * parameters.temperature_degree
+                                                           / neighbor_child->face(neighbor2)->measure()
+                                                           * neighbor_conductivity
+                                                           / (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                                           :
+                                                           0.0);
+
+                          const double max_penalty = std::max(penalty, neighbor_penalty);
+
+                          const double max_density_c_P_and_latent_heat =
+                            std::max(density_c_P + latent_heat_LHS,
+                                     neighbor_density_c_P + neighbor_latent_heat_LHS);
+
+                          Assert (numbers::is_finite(max_density_c_P_and_latent_heat),
+                                  ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a finite quantity."));
+                          Assert (max_density_c_P_and_latent_heat >= 0,
+                                  ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a "
+                                              "non-negative quantity."));
+
+                          /**
+                           * The discontinuous Galerkin method uses 2 types of jumps over edges:
+                           * undirected and directed jumps. Undirected jumps are dependent only
+                           * on the order of the numbering of cells. Directed jumps are dependent
+                           * on the direction of the flow. Thus the flow-dependent terms below are
+                           * only calculated if the edge is an inflow edge.
+                           */
+                          const bool inflow = ((current_u * scratch.subface_finite_element_values->normal_vector(q)) < 0.);
+
+                          for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+                            {
+                              for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
+                                {
+                                  data.local_matrix(i,j)
+                                  += (- 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[i]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[j]
+
+                                      - 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[j]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[i]
+
+                                      + time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.face_phi_field[i]
+                                      * scratch.face_phi_field[j]
+
+                                      - (inflow
+                                         ?
+                                         (density_c_P + latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.subface_finite_element_values->normal_vector(q))
+                                         * scratch.face_phi_field[i]
+                                         * scratch.face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.subface_finite_element_values->JxW(q);
+
+                                  data.local_matrices_int_ext[face_no * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
+                                  += (- 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[j]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[i]
+
+                                      + 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[i]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[j]
+
+                                      - time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.neighbor_face_phi_field[j]
+                                      * scratch.face_phi_field[i]
+
+                                      + (inflow
+                                         ?
+                                         (density_c_P + latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.subface_finite_element_values->normal_vector(q))
+                                         * scratch.face_phi_field[i]
+                                         * scratch.neighbor_face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.subface_finite_element_values->JxW(q);
+
+                                  data.local_matrices_ext_int[face_no * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
+                                  += (+ 0.5 * time_step * conductivity
+                                      * scratch.face_grad_phi_field[j]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[i]
+
+                                      - 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[i]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.face_phi_field[j]
+
+                                      - time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.face_phi_field[j]
+                                      * scratch.neighbor_face_phi_field[i]
+
+                                      - (!inflow
+                                         ?
+                                         (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.subface_finite_element_values->normal_vector(q))
+                                         * scratch.neighbor_face_phi_field[i]
+                                         * scratch.face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.subface_finite_element_values->JxW(q);
+
+                                  data.local_matrices_ext_ext[face_no * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
+                                  += (+ 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[i]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[j]
+
+                                      + 0.5 * time_step * neighbor_conductivity
+                                      * scratch.neighbor_face_grad_phi_field[j]
+                                      * scratch.subface_finite_element_values->normal_vector(q)
+                                      * scratch.neighbor_face_phi_field[i]
+
+                                      + time_step
+                                      * max_density_c_P_and_latent_heat
+                                      * max_penalty
+                                      * scratch.neighbor_face_phi_field[i]
+                                      * scratch.neighbor_face_phi_field[j]
+
+                                      + (!inflow
+                                         ?
+                                         (neighbor_density_c_P + neighbor_latent_heat_LHS)
+                                         * time_step
+                                         * (current_u
+                                            * scratch.subface_finite_element_values->normal_vector(q))
+                                         * scratch.neighbor_face_phi_field[i]
+                                         * scratch.neighbor_face_phi_field[j]
+                                         :
+                                         0.)
+                                     )
+                                     * scratch.subface_finite_element_values->JxW(q);
+                                }
+                            }
+
+                        }
+                    }
+
+                }
+            }
         }
     };
 
@@ -1436,6 +2272,21 @@ namespace aspect
                               // discard cell,
                               std_cxx11::_2,
                               std_cxx11::_3));
+
+    if (parameters.use_discontinuous_temperature_discretization ||
+        parameters.use_discontinuous_composition_discretization)
+      {
+        assemblers->local_assemble_advection_system_on_boundary_face
+        .connect(std_cxx11::bind(&aspect::Assemblers::CompleteEquations<dim>::local_assemble_advection_face_terms,
+                                 std_cxx11::cref (*complete_equation_assembler),
+                                 std_cxx11::_1,
+                                 std_cxx11::_2,
+                                 std_cxx11::_3,
+                                 std_cxx11::_4,
+                                 std_cxx11::_5));
+
+        assemblers->advection_system_assembler_on_boundary_face_properties.need_face_material_model_data = true;
+      }
 
     // allow other assemblers to add themselves or modify the existing ones by firing the signal
     this->signals.set_assemblers(*this, *assemblers, assembler_objects);
@@ -1842,898 +2693,6 @@ namespace aspect
     computing_timer.exit_section();
   }
 
-  template <int dim>
-  void Simulator<dim>::
-  local_assemble_advection_face_terms(const AdvectionField     &advection_field,
-                                      const typename DoFHandler<dim>::active_cell_iterator &cell,
-                                      internal::Assembly::Scratch::AdvectionSystem<dim> &scratch,
-                                      internal::Assembly::CopyData::AdvectionSystem<dim> &data)
-  {
-    const bool use_bdf2_scheme = (timestep_number > 1);
-
-    const unsigned int n_q_points    = scratch.face_finite_element_values->n_quadrature_points;
-
-    // also have the number of dofs that correspond just to the element for
-    // the system we are currently trying to assemble
-    const unsigned int advection_dofs_per_cell = data.local_dof_indices.size();
-
-    Assert (advection_field.is_discontinuous(introspection),
-            ExcMessage("Face terms only need assembling in the case of discontinuous temperature or compositional discretization."));
-
-    Assert (advection_dofs_per_cell < scratch.face_finite_element_values->get_fe().dofs_per_cell, ExcInternalError());
-    Assert (scratch.face_grad_phi_field.size() == advection_dofs_per_cell, ExcInternalError());
-    Assert (scratch.face_phi_field.size() == advection_dofs_per_cell, ExcInternalError());
-
-    const unsigned int solution_component = advection_field.component_index(introspection);
-
-    const FEValuesExtractors::Scalar solution_field
-      = (advection_field.is_temperature()
-         ?
-         introspection.extractors.temperature
-         :
-         introspection.extractors.compositional_fields[advection_field.compositional_variable]
-        );
-
-    //loop over all possible subfaces of the cell, and reset their matrices.
-    for (unsigned int f = 0; f < GeometryInfo<dim>::max_children_per_face * GeometryInfo<dim>::faces_per_cell; ++f)
-      {
-        data.local_matrices_ext_int[f] = 0;
-        data.local_matrices_int_ext[f] = 0;
-        data.local_matrices_ext_ext[f] = 0;
-        data.assembled_matrices[f] = false;
-      }
-
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
-      {
-        typename DoFHandler<dim>::face_iterator face = cell->face (f);
-
-        if (face->at_boundary())
-          {
-            if (((parameters.fixed_temperature_boundary_indicators.find(
-#if DEAL_II_VERSION_GTE(8,3,0)
-                    cell->face(f)->boundary_id()
-#else
-                    cell->face(f)->boundary_indicator()
-#endif
-                  )
-                  != parameters.fixed_temperature_boundary_indicators.end())
-                 && (advection_field.is_temperature()))
-                ||
-                (( parameters.fixed_composition_boundary_indicators.find(
-#if DEAL_II_VERSION_GTE(8,3,0)
-                     cell->face(f)->boundary_id()
-#else
-                     cell->face(f)->boundary_indicator()
-#endif
-                   )
-                   != parameters.fixed_composition_boundary_indicators.end())
-                 && (!advection_field.is_temperature())))
-              {
-                /*
-                 * We are in the case of a Dirichlet temperature or composition boundary.
-                 * In the temperature case, impose the Dirichlet value weakly using a matrix term
-                 * and RHS term. In the composition case, Dirichlet conditions can only be imposed
-                 * on inflow boundaries, and we only have the flow-dependent terms, so we only
-                 * assemble the corresponding flow-dependent and matrix and RHS terms
-                 * if we are on an inflow boundary.
-                 */
-
-                scratch.face_finite_element_values->reinit (cell, f);
-
-                (*scratch.face_finite_element_values)[introspection.extractors.velocities].get_function_values(current_linearization_point,
-                    scratch.face_current_velocity_values);
-
-                //get the mesh velocity, as we need to subtract it off of the advection systems
-                if (parameters.free_surface_enabled)
-                  (*scratch.face_finite_element_values)[introspection.extractors.velocities].get_function_values(free_surface->mesh_velocity,
-                      scratch.face_mesh_velocity_values);
-
-                compute_material_model_input_values (current_linearization_point,
-                                                     *scratch.face_finite_element_values,
-                                                     cell,
-                                                     true,
-                                                     scratch.face_material_model_inputs);
-                material_model->evaluate(scratch.face_material_model_inputs,
-                                         scratch.face_material_model_outputs);
-
-                HeatingModel::HeatingModelOutputs face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
-                heating_model_manager.evaluate(scratch.face_material_model_inputs,
-                                               scratch.face_material_model_outputs,
-                                               face_heating_model_outputs);
-
-                for (unsigned int q=0; q<n_q_points; ++q)
-                  {
-                    // precompute the values of shape functions and their gradients.
-                    // We only need to look up values of shape functions if they
-                    // belong to 'our' component. They are zero otherwise anyway.
-                    // Note that we later only look at the values that we do set here.
-                    for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
-                      {
-                        scratch.face_grad_phi_field[k] = (*scratch.face_finite_element_values)[solution_field].gradient (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                        scratch.face_phi_field[k]      = (*scratch.face_finite_element_values)[solution_field].value (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                      }
-                    const double density_c_P              =
-                      ((advection_field.is_temperature())
-                       ?
-                       scratch.face_material_model_outputs.densities[q] *
-                       scratch.face_material_model_outputs.specific_heat[q]
-                       :
-                       1.0);
-
-                    Assert (density_c_P >= 0,
-                            ExcMessage ("The product of density and c_P needs to be a "
-                                        "non-negative quantity."));
-
-                    const double conductivity =
-                      ((advection_field.is_temperature())
-                       ?
-                       scratch.face_material_model_outputs.thermal_conductivities[q]
-                       :
-                       0.0);
-                    const double latent_heat_LHS =
-                      ((advection_field.is_temperature())
-                       ?
-                       face_heating_model_outputs.lhs_latent_heat_terms[q]
-                       :
-                       0.0);
-                    Assert (density_c_P + latent_heat_LHS >= 0,
-                            ExcMessage ("The sum of density times c_P and the latent heat contribution "
-                                        "to the left hand side needs to be a non-negative quantity."));
-
-                    const double penalty = (advection_field.is_temperature()
-                                            ?
-                                            parameters.discontinuous_penalty
-                                            * parameters.temperature_degree
-                                            * parameters.temperature_degree
-                                            / face->measure()
-                                            * conductivity
-                                            / (density_c_P + latent_heat_LHS)
-                                            :
-                                            0.0);
-
-                    const double dirichlet_value = (advection_field.is_temperature()
-                                                    ?
-                                                    boundary_temperature->temperature(*geometry_model,
-#if DEAL_II_VERSION_GTE(8,3,0)
-                                                                                      cell->face(f)->boundary_id(),
-#else
-                                                                                      cell->face(f)->boundary_indicator(),
-#endif
-                                                                                      scratch.face_finite_element_values->quadrature_point(q))
-                                                    :
-                                                    boundary_composition->composition(*geometry_model,
-#if DEAL_II_VERSION_GTE(8,3,0)
-                                                                                      cell->face(f)->boundary_id(),
-#else
-                                                                                      cell->face(f)->boundary_indicator(),
-#endif
-                                                                                      scratch.face_finite_element_values->quadrature_point(q),
-                                                                                      advection_field.compositional_variable));
-
-                    Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
-                    //Subtract off the mesh velocity for ALE corrections if necessary
-                    if (parameters.free_surface_enabled)
-                      current_u -= scratch.face_mesh_velocity_values[q];
-
-                    /**
-                     * The discontinuous Galerkin method uses 2 types of jumps over edges:
-                     * undirected and directed jumps. Undirected jumps are dependent only
-                     * on the order of the numbering of cells. Directed jumps are dependent
-                     * on the direction of the flow. Thus the flow-dependent terms below are
-                     * only calculated if the edge is an inflow edge.
-                     */
-                    const bool inflow = ((current_u * scratch.face_finite_element_values->normal_vector(q)) < 0.);
-
-                    for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
-                      {
-                        data.local_rhs(i)
-                        += (- time_step *  conductivity
-                            * scratch.face_grad_phi_field[i]
-                            * scratch.face_finite_element_values->normal_vector(q)
-                            * dirichlet_value
-
-                            + time_step
-                            * (density_c_P + latent_heat_LHS)
-                            * penalty
-                            * scratch.face_phi_field[i]
-                            * dirichlet_value
-
-                            + (inflow
-                               ?
-                               - (density_c_P + latent_heat_LHS)
-                               * time_step
-                               * (current_u
-                                  * scratch.face_finite_element_values->normal_vector(q))
-                               * dirichlet_value
-                               * scratch.face_phi_field[i]
-                               :
-                               0.)
-                           )
-                           *
-                           scratch.face_finite_element_values->JxW(q);
-
-                        // local_matrix terms
-                        for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
-                          {
-                            data.local_matrix(i,j)
-                            += (- time_step *  conductivity
-                                * scratch.face_grad_phi_field[i]
-                                * scratch.face_finite_element_values->normal_vector(q)
-                                * scratch.face_phi_field[j]
-
-                                - time_step *  conductivity
-                                * scratch.face_grad_phi_field[j]
-                                * scratch.face_finite_element_values->normal_vector(q)
-                                * scratch.face_phi_field[i]
-
-                                + time_step
-                                * (density_c_P + latent_heat_LHS)
-                                * penalty
-                                * scratch.face_phi_field[i]
-                                * scratch.face_phi_field[j]
-
-                                + (inflow
-                                   ?
-                                   - (density_c_P + latent_heat_LHS)
-                                   * time_step
-                                   * (current_u
-                                      * scratch.face_finite_element_values->normal_vector(q))
-                                   * scratch.face_phi_field[i]
-                                   * scratch.face_phi_field[j]
-                                   :
-                                   0.)
-                               )
-                               * scratch.face_finite_element_values->JxW(q);
-
-                          }
-                      }
-                  }
-              }
-            else
-              {
-                //Neumann temperature term - no non-zero contribution as only homogeneous Neumann boundary conditions are implemented elsewhere for temperature
-              }
-          }
-        else
-          {
-            //interior face - no contribution on RHS
-            Assert (cell->neighbor(f).state() == IteratorState::valid,
-                    ExcInternalError());
-            const typename DoFHandler<dim>::cell_iterator neighbor = cell->neighbor(f); //note: NOT active_cell_iterator, so this includes cells that are refined.
-
-            if (!(face->has_children()))
-              {
-                if (!cell->neighbor_is_coarser(f) &&
-                    (((neighbor->is_locally_owned()) && (cell->index() < neighbor->index()))
-                     ||
-                     ((!neighbor->is_locally_owned()) && (cell->subdomain_id() < neighbor->subdomain_id()))))
-                  {
-                    Assert (cell->is_locally_owned(), ExcInternalError());
-                    //cell and neighbor are equal-sized, and cell has been chosen to assemble this face, so calculate from cell
-
-                    //how does the neighbor talk about this cell?
-                    const unsigned int neighbor2=cell->neighbor_of_neighbor(f);
-
-                    //set up face values
-                    scratch.face_finite_element_values->reinit (cell, f);
-
-                    (*scratch.face_finite_element_values)[introspection.extractors.velocities].get_function_values(current_linearization_point,
-                        scratch.face_current_velocity_values);
-
-                    //get the mesh velocity, as we need to subtract it off of the advection systems
-                    if (parameters.free_surface_enabled)
-                      (*scratch.face_finite_element_values)[introspection.extractors.velocities].get_function_values(free_surface->mesh_velocity,
-                          scratch.face_mesh_velocity_values);
-
-                    compute_material_model_input_values (current_linearization_point,
-                                                         *scratch.face_finite_element_values,
-                                                         cell,
-                                                         true,
-                                                         scratch.face_material_model_inputs);
-                    material_model->evaluate(scratch.face_material_model_inputs,
-                                             scratch.face_material_model_outputs);
-
-                    HeatingModel::HeatingModelOutputs face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
-                    heating_model_manager.evaluate(scratch.face_material_model_inputs,
-                                                   scratch.face_material_model_outputs,
-                                                   face_heating_model_outputs);
-
-
-                    //set up neighbor values
-                    scratch.neighbor_face_finite_element_values->reinit (neighbor, neighbor2);
-
-                    compute_material_model_input_values (current_linearization_point,
-                                                         *scratch.neighbor_face_finite_element_values,
-                                                         neighbor,
-                                                         true,
-                                                         scratch.neighbor_face_material_model_inputs);
-                    material_model->evaluate(scratch.neighbor_face_material_model_inputs,
-                                             scratch.neighbor_face_material_model_outputs);
-
-                    HeatingModel::HeatingModelOutputs neighbor_face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
-                    heating_model_manager.evaluate(scratch.neighbor_face_material_model_inputs,
-                                                   scratch.neighbor_face_material_model_outputs,
-                                                   neighbor_face_heating_model_outputs);
-
-                    std::vector<types::global_dof_index> neighbor_dof_indices (scratch.face_finite_element_values->get_fe().dofs_per_cell);
-                    // get all dof indices on the neighbor, then extract those
-                    // that correspond to the solution_field we are interested in
-                    neighbor->get_dof_indices (neighbor_dof_indices);
-                    for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
-                      data.neighbor_dof_indices[f * GeometryInfo<dim>::max_children_per_face][i] = neighbor_dof_indices[scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, i)];
-                    data.assembled_matrices[f * GeometryInfo<dim>::max_children_per_face] = true;
-
-                    for (unsigned int q=0; q<n_q_points; ++q)
-                      {
-                        // precompute the values of shape functions and their gradients.
-                        // We only need to look up values of shape functions if they
-                        // belong to 'our' component. They are zero otherwise anyway.
-                        // Note that we later only look at the values that we do set here.
-                        for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
-                          {
-                            scratch.face_grad_phi_field[k]          = (*scratch.face_finite_element_values)[solution_field].gradient (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                            scratch.face_phi_field[k]               = (*scratch.face_finite_element_values)[solution_field].value (scratch.face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                            scratch.neighbor_face_grad_phi_field[k] = (*scratch.neighbor_face_finite_element_values)[solution_field].gradient (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                            scratch.neighbor_face_phi_field[k]      = (*scratch.neighbor_face_finite_element_values)[solution_field].value (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                          }
-
-                        const double density_c_P              =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.face_material_model_outputs.densities[q] *
-                           scratch.face_material_model_outputs.specific_heat[q]
-                           :
-                           1.0);
-
-                        Assert (density_c_P >= 0,
-                                ExcMessage ("The product of density and c_P needs to be a "
-                                            "non-negative quantity."));
-
-                        const double conductivity =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.face_material_model_outputs.thermal_conductivities[q]
-                           :
-                           0.0);
-                        const double latent_heat_LHS =
-                          ((advection_field.is_temperature())
-                           ?
-                           face_heating_model_outputs.lhs_latent_heat_terms[q]
-                           :
-                           0.0);
-                        Assert (density_c_P + latent_heat_LHS >= 0,
-                                ExcMessage ("The sum of density times c_P and the latent heat contribution "
-                                            "to the left hand side needs to be a non-negative quantity."));
-
-                        const double penalty = (advection_field.is_temperature()
-                                                ?
-                                                parameters.discontinuous_penalty
-                                                * parameters.temperature_degree
-                                                * parameters.temperature_degree
-                                                / face->measure()
-                                                * conductivity
-                                                / (density_c_P + latent_heat_LHS)
-                                                :
-                                                0.0);
-
-                        Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
-                        //Subtract off the mesh velocity for ALE corrections if necessary
-                        if (parameters.free_surface_enabled)
-                          current_u -= scratch.face_mesh_velocity_values[q];
-
-                        const double neighbor_density_c_P              =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.neighbor_face_material_model_outputs.densities[q] *
-                           scratch.neighbor_face_material_model_outputs.specific_heat[q]
-                           :
-                           1.0);
-
-                        Assert (neighbor_density_c_P >= 0,
-                                ExcMessage ("The product of density and c_P on the neighbor needs to be a "
-                                            "non-negative quantity."));
-
-                        const double neighbor_conductivity =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.neighbor_face_material_model_outputs.thermal_conductivities[q]
-                           :
-                           0.0);
-                        const double neighbor_latent_heat_LHS =
-                          ((advection_field.is_temperature())
-                           ?
-                           neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
-                           :
-                           0.0);
-                        Assert (neighbor_density_c_P + neighbor_latent_heat_LHS >= 0,
-                                ExcMessage ("The sum of density times c_P and the latent heat contribution "
-                                            "to the left hand side on the neighbor needs to be a non-negative quantity."));
-
-                        const double neighbor_penalty = (advection_field.is_temperature()
-                                                         ?
-                                                         parameters.discontinuous_penalty
-                                                         * parameters.temperature_degree
-                                                         * parameters.temperature_degree
-                                                         / neighbor->face(neighbor2)->measure()
-                                                         * neighbor_conductivity
-                                                         / (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                                         :
-                                                         0.0);
-
-                        const double max_penalty = std::max(penalty, neighbor_penalty);
-
-                        const double max_density_c_P_and_latent_heat =
-                          std::max(density_c_P + latent_heat_LHS,
-                                   neighbor_density_c_P + neighbor_latent_heat_LHS);
-
-                        Assert (numbers::is_finite(max_density_c_P_and_latent_heat),
-                                ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a finite quantity."));
-                        Assert (max_density_c_P_and_latent_heat >= 0,
-                                ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a "
-                                            "non-negative quantity."));
-
-                        /**
-                         * The discontinuous Galerkin method uses 2 types of jumps over edges:
-                         * undirected and directed jumps. Undirected jumps are dependent only
-                         * on the order of the numbering of cells. Directed jumps are dependent
-                         * on the direction of the flow. Thus the flow-dependent terms below are
-                         * only calculated if the edge is an inflow edge.
-                         */
-                        const bool inflow = ((current_u * scratch.face_finite_element_values->normal_vector(q)) < 0.);
-
-                        for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
-                          {
-                            for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
-                              {
-                                data.local_matrix(i,j)
-                                += (- 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[i]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[j]
-
-                                    - 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[j]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[i]
-
-                                    + time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.face_phi_field[i]
-                                    * scratch.face_phi_field[j]
-
-                                    - (inflow
-                                       ?
-                                       (density_c_P + latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.face_finite_element_values->normal_vector(q))
-                                       * scratch.face_phi_field[i]
-                                       * scratch.face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.face_finite_element_values->JxW(q);
-
-                                data.local_matrices_int_ext[f * GeometryInfo<dim>::max_children_per_face](i,j)
-                                += (- 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[j]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[i]
-
-                                    + 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[i]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[j]
-
-                                    - time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.neighbor_face_phi_field[j]
-                                    * scratch.face_phi_field[i]
-
-                                    + (inflow
-                                       ?
-                                       (density_c_P + latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.face_finite_element_values->normal_vector(q))
-                                       * scratch.face_phi_field[i]
-                                       * scratch.neighbor_face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.face_finite_element_values->JxW(q);
-
-                                data.local_matrices_ext_int[f * GeometryInfo<dim>::max_children_per_face](i,j)
-                                += (+ 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[j]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[i]
-
-                                    - 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[i]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[j]
-
-                                    - time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.face_phi_field[j]
-                                    * scratch.neighbor_face_phi_field[i]
-
-                                    - (!inflow
-                                       ?
-                                       (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.face_finite_element_values->normal_vector(q))
-                                       * scratch.neighbor_face_phi_field[i]
-                                       * scratch.face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.face_finite_element_values->JxW(q);
-
-                                data.local_matrices_ext_ext[f * GeometryInfo<dim>::max_children_per_face](i,j)
-                                += (+ 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[i]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[j]
-
-                                    + 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[j]
-                                    * scratch.face_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[i]
-
-                                    + time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.neighbor_face_phi_field[i]
-                                    * scratch.neighbor_face_phi_field[j]
-
-                                    + (!inflow
-                                       ?
-                                       (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.face_finite_element_values->normal_vector(q))
-                                       * scratch.neighbor_face_phi_field[i]
-                                       * scratch.neighbor_face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.face_finite_element_values->JxW(q);
-                              }
-                          }
-                      }
-                  }
-                else
-                  {
-                    /* neighbor is taking responsibility for assembly of this face, because
-                     * either (1) neighbor is coarser, or
-                     *        (2) neighbor is equally-sized and
-                     *           (a) neighbor is on a different subdomain, with lower subdmain_id(), or
-                     *           (b) neighbor is on the same subdomain and has lower index().
-                    */
-                  }
-              }
-            else //face->has_children(), so always assemble from here.
-              {
-                //how does the neighbor talk about this cell?
-                const unsigned int neighbor2 = cell->neighbor_face_no(f);
-
-                //loop over subfaces
-                for (unsigned int subface_no=0; subface_no<face->number_of_children(); ++subface_no)
-                  {
-                    const typename DoFHandler<dim>::active_cell_iterator neighbor_child
-                      = cell->neighbor_child_on_subface (f, subface_no);
-
-                    //set up subface values
-                    scratch.subface_finite_element_values->reinit (cell, f, subface_no);
-
-                    //subface->face
-                    (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(current_linearization_point,
-                        scratch.face_current_velocity_values);
-
-                    //get the mesh velocity, as we need to subtract it off of the advection systems
-                    if (parameters.free_surface_enabled)
-                      (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(free_surface->mesh_velocity,
-                          scratch.face_mesh_velocity_values);
-
-                    //get the mesh velocity, as we need to subtract it off of the advection systems
-                    if (parameters.free_surface_enabled)
-                      (*scratch.subface_finite_element_values)[introspection.extractors.velocities].get_function_values(free_surface->mesh_velocity,
-                          scratch.face_mesh_velocity_values);
-
-                    compute_material_model_input_values (current_linearization_point,
-                                                         *scratch.subface_finite_element_values,
-                                                         cell,
-                                                         true,
-                                                         scratch.face_material_model_inputs);
-                    material_model->evaluate(scratch.face_material_model_inputs,
-                                             scratch.face_material_model_outputs);
-
-                    HeatingModel::HeatingModelOutputs face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
-                    heating_model_manager.evaluate(scratch.face_material_model_inputs,
-                                                   scratch.face_material_model_outputs,
-                                                   face_heating_model_outputs);
-
-                    //set up neighbor values
-                    scratch.neighbor_face_finite_element_values->reinit (neighbor_child, neighbor2);
-
-                    compute_material_model_input_values (current_linearization_point,
-                                                         *scratch.neighbor_face_finite_element_values,
-                                                         neighbor_child,
-                                                         true,
-                                                         scratch.neighbor_face_material_model_inputs);
-                    material_model->evaluate(scratch.neighbor_face_material_model_inputs,
-                                             scratch.neighbor_face_material_model_outputs);
-
-                    HeatingModel::HeatingModelOutputs neighbor_face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
-                    heating_model_manager.evaluate(scratch.neighbor_face_material_model_inputs,
-                                                   scratch.neighbor_face_material_model_outputs,
-                                                   neighbor_face_heating_model_outputs);
-
-                    std::vector<types::global_dof_index> neighbor_dof_indices (scratch.face_finite_element_values->get_fe().dofs_per_cell);
-                    // get all dof indices on the neighbor, then extract those
-                    // that correspond to the solution_field we are interested in
-                    neighbor_child->get_dof_indices (neighbor_dof_indices);
-                    for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
-                      data.neighbor_dof_indices[f * GeometryInfo<dim>::max_children_per_face + subface_no][i] = neighbor_dof_indices[scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, i)];
-                    data.assembled_matrices[f * GeometryInfo<dim>::max_children_per_face + subface_no] = true;
-
-                    for (unsigned int q=0; q<n_q_points; ++q)
-                      {
-                        // precompute the values of shape functions and their gradients.
-                        // We only need to look up values of shape functions if they
-                        // belong to 'our' component. They are zero otherwise anyway.
-                        // Note that we later only look at the values that we do set here.
-                        for (unsigned int k=0; k<advection_dofs_per_cell; ++k)
-                          {
-                            scratch.face_grad_phi_field[k]          = (*scratch.subface_finite_element_values)[solution_field].gradient (scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                            scratch.face_phi_field[k]               = (*scratch.subface_finite_element_values)[solution_field].value (scratch.subface_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                            scratch.neighbor_face_grad_phi_field[k] = (*scratch.neighbor_face_finite_element_values)[solution_field].gradient (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                            scratch.neighbor_face_phi_field[k]      = (*scratch.neighbor_face_finite_element_values)[solution_field].value (scratch.neighbor_face_finite_element_values->get_fe().component_to_system_index(solution_component, k), q);
-                          }
-
-                        const double density_c_P              =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.face_material_model_outputs.densities[q] *
-                           scratch.face_material_model_outputs.specific_heat[q]
-                           :
-                           1.0);
-
-                        Assert (density_c_P >= 0,
-                                ExcMessage ("The product of density and c_P needs to be a "
-                                            "non-negative quantity."));
-
-                        const double conductivity =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.face_material_model_outputs.thermal_conductivities[q]
-                           :
-                           0.0);
-                        const double latent_heat_LHS =
-                          ((advection_field.is_temperature())
-                           ?
-                           face_heating_model_outputs.lhs_latent_heat_terms[q]
-                           :
-                           0.0);
-                        Assert (density_c_P + latent_heat_LHS >= 0,
-                                ExcMessage ("The sum of density times c_P and the latent heat contribution "
-                                            "to the left hand side needs to be a non-negative quantity."));
-
-                        const double penalty = (advection_field.is_temperature()
-                                                ?
-                                                parameters.discontinuous_penalty
-                                                * parameters.temperature_degree
-                                                * parameters.temperature_degree
-                                                / face->measure()
-                                                * conductivity
-                                                / (density_c_P + latent_heat_LHS)
-                                                :
-                                                0.0);
-
-                        Tensor<1,dim> current_u = scratch.face_current_velocity_values[q];
-                        //Subtract off the mesh velocity for ALE corrections if necessary
-                        if (parameters.free_surface_enabled)
-                          current_u -= scratch.face_mesh_velocity_values[q];
-
-                        const double neighbor_density_c_P              =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.neighbor_face_material_model_outputs.densities[q] *
-                           scratch.neighbor_face_material_model_outputs.specific_heat[q]
-                           :
-                           1.0);
-
-                        Assert (neighbor_density_c_P >= 0,
-                                ExcMessage ("The product of density and c_P on the neighbor needs to be a "
-                                            "non-negative quantity."));
-
-                        const double neighbor_conductivity =
-                          ((advection_field.is_temperature())
-                           ?
-                           scratch.neighbor_face_material_model_outputs.thermal_conductivities[q]
-                           :
-                           0.0);
-                        const double neighbor_latent_heat_LHS =
-                          ((advection_field.is_temperature())
-                           ?
-                           neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
-                           :
-                           0.0);
-                        Assert (neighbor_density_c_P + neighbor_latent_heat_LHS >= 0,
-                                ExcMessage ("The sum of density times c_P and the latent heat contribution "
-                                            "to the left hand side on the neighbor needs to be a non-negative quantity."));
-
-                        const double neighbor_penalty = (advection_field.is_temperature()
-                                                         ?
-                                                         parameters.discontinuous_penalty
-                                                         * parameters.temperature_degree
-                                                         * parameters.temperature_degree
-                                                         / neighbor_child->face(neighbor2)->measure()
-                                                         * neighbor_conductivity
-                                                         / (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                                         :
-                                                         0.0);
-
-                        const double max_penalty = std::max(penalty, neighbor_penalty);
-
-                        const double max_density_c_P_and_latent_heat =
-                          std::max(density_c_P + latent_heat_LHS,
-                                   neighbor_density_c_P + neighbor_latent_heat_LHS);
-
-                        Assert (numbers::is_finite(max_density_c_P_and_latent_heat),
-                                ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a finite quantity."));
-                        Assert (max_density_c_P_and_latent_heat >= 0,
-                                ExcMessage ("The maximum product of density and c_P plus latent heat LHS on the neighbor needs to be a "
-                                            "non-negative quantity."));
-
-                        /**
-                         * The discontinuous Galerkin method uses 2 types of jumps over edges:
-                         * undirected and directed jumps. Undirected jumps are dependent only
-                         * on the order of the numbering of cells. Directed jumps are dependent
-                         * on the direction of the flow. Thus the flow-dependent terms below are
-                         * only calculated if the edge is an inflow edge.
-                         */
-                        const bool inflow = ((current_u * scratch.subface_finite_element_values->normal_vector(q)) < 0.);
-
-                        for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
-                          {
-                            for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
-                              {
-                                data.local_matrix(i,j)
-                                += (- 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[i]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[j]
-
-                                    - 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[j]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[i]
-
-                                    + time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.face_phi_field[i]
-                                    * scratch.face_phi_field[j]
-
-                                    - (inflow
-                                       ?
-                                       (density_c_P + latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.subface_finite_element_values->normal_vector(q))
-                                       * scratch.face_phi_field[i]
-                                       * scratch.face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.subface_finite_element_values->JxW(q);
-
-                                data.local_matrices_int_ext[f * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
-                                += (- 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[j]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[i]
-
-                                    + 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[i]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[j]
-
-                                    - time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.neighbor_face_phi_field[j]
-                                    * scratch.face_phi_field[i]
-
-                                    + (inflow
-                                       ?
-                                       (density_c_P + latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.subface_finite_element_values->normal_vector(q))
-                                       * scratch.face_phi_field[i]
-                                       * scratch.neighbor_face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.subface_finite_element_values->JxW(q);
-
-                                data.local_matrices_ext_int[f * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
-                                += (+ 0.5 * time_step * conductivity
-                                    * scratch.face_grad_phi_field[j]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[i]
-
-                                    - 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[i]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.face_phi_field[j]
-
-                                    - time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.face_phi_field[j]
-                                    * scratch.neighbor_face_phi_field[i]
-
-                                    - (!inflow
-                                       ?
-                                       (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.subface_finite_element_values->normal_vector(q))
-                                       * scratch.neighbor_face_phi_field[i]
-                                       * scratch.face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.subface_finite_element_values->JxW(q);
-
-                                data.local_matrices_ext_ext[f * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
-                                += (+ 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[i]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[j]
-
-                                    + 0.5 * time_step * neighbor_conductivity
-                                    * scratch.neighbor_face_grad_phi_field[j]
-                                    * scratch.subface_finite_element_values->normal_vector(q)
-                                    * scratch.neighbor_face_phi_field[i]
-
-                                    + time_step
-                                    * max_density_c_P_and_latent_heat
-                                    * max_penalty
-                                    * scratch.neighbor_face_phi_field[i]
-                                    * scratch.neighbor_face_phi_field[j]
-
-                                    + (!inflow
-                                       ?
-                                       (neighbor_density_c_P + neighbor_latent_heat_LHS)
-                                       * time_step
-                                       * (current_u
-                                          * scratch.subface_finite_element_values->normal_vector(q))
-                                       * scratch.neighbor_face_phi_field[i]
-                                       * scratch.neighbor_face_phi_field[j]
-                                       :
-                                       0.)
-                                   )
-                                   * scratch.subface_finite_element_values->JxW(q);
-                              }
-                          }
-
-                      }
-                  }
-
-              }
-          }
-      }
-  }
 
   template <int dim>
   void Simulator<dim>::
@@ -2754,14 +2713,6 @@ namespace aspect
     Assert (scratch.grad_phi_field.size() == advection_dofs_per_cell, ExcInternalError());
     Assert (scratch.phi_field.size() == advection_dofs_per_cell, ExcInternalError());
 
-    const unsigned int solution_component
-      = (advection_field.is_temperature()
-         ?
-         introspection.component_indices.temperature
-         :
-         introspection.component_indices.compositional_fields[advection_field.compositional_variable]
-        );
-
     const FEValuesExtractors::Scalar solution_field
       = (advection_field.is_temperature()
          ?
@@ -2769,6 +2720,8 @@ namespace aspect
          :
          introspection.extractors.compositional_fields[advection_field.compositional_variable]
         );
+
+    const unsigned int solution_component = advection_field.component_index(introspection);
 
     scratch.finite_element_values.reinit (cell);
 
@@ -2888,11 +2841,61 @@ namespace aspect
     // all of the assembling
     assemblers->local_assemble_advection_system(cell,advection_field,nu,scratch,data);
 
+    // then also work on possible face terms. if necessary, initialize
+    // the material model data on faces
     if (advection_field.is_discontinuous(introspection))
-      local_assemble_advection_face_terms(advection_field,
-                                          cell,
-                                          scratch,
-                                          data);
+      {
+        // for interior face contributions loop over all possible
+        // subfaces of the cell, and reset their matrices.
+        for (unsigned int f = 0; f < GeometryInfo<dim>::max_children_per_face * GeometryInfo<dim>::faces_per_cell; ++f)
+          {
+            data.local_matrices_ext_int[f] = 0;
+            data.local_matrices_int_ext[f] = 0;
+            data.local_matrices_ext_ext[f] = 0;
+            data.assembled_matrices[f] = false;
+          }
+
+        for (unsigned int face_no=0; face_no<GeometryInfo<dim>::faces_per_cell; ++face_no)
+          {
+            (*scratch.face_finite_element_values).reinit (cell, face_no);
+
+            (*scratch.face_finite_element_values)[introspection.extractors.velocities].get_function_values(current_linearization_point,
+                scratch.face_current_velocity_values);
+
+            //get the mesh velocity, as we need to subtract it off of the advection systems
+            if (parameters.free_surface_enabled)
+              (*scratch.face_finite_element_values)[introspection.extractors.velocities].get_function_values(free_surface->mesh_velocity,
+                  scratch.face_mesh_velocity_values);
+
+            if (assemblers->advection_system_assembler_on_boundary_face_properties.need_face_material_model_data)
+              {
+                compute_material_model_input_values (current_linearization_point,
+                                                     *scratch.face_finite_element_values,
+                                                     cell,
+                                                     true,
+                                                     scratch.face_material_model_inputs);
+                create_additional_material_model_outputs(scratch.face_material_model_outputs);
+
+                material_model->evaluate(scratch.face_material_model_inputs,
+                                         scratch.face_material_model_outputs);
+
+                heating_model_manager.evaluate(scratch.face_material_model_inputs,
+                                               scratch.face_material_model_outputs,
+                                               scratch.face_heating_model_outputs);
+                //TODO: the following doesn't currently compile because the get_quadrature() call returns
+                //  a dim-1 dimensional quadrature
+                // MaterialModel::MaterialAveraging::average (parameters.material_averaging,
+                //                                            cell,
+                //                                            scratch.face_finite_element_values.get_quadrature(),
+                //                                            scratch.face_finite_element_values.get_mapping(),
+                //                                            scratch.face_material_model_outputs);
+              }
+
+            assemblers->local_assemble_advection_system_on_boundary_face(cell, face_no,
+                                                                         advection_field,
+                                                                         scratch, data);
+          }
+      }
   }
 
   template <int dim>
@@ -3064,11 +3067,6 @@ namespace aspect
                                                           const AdvectionField &advection_field) const; \
   template void Simulator<dim>::build_advection_preconditioner (const AdvectionField &, \
                                                                 std_cxx11::shared_ptr<aspect::LinearAlgebra::PreconditionILU> &preconditioner); \
-  template void Simulator<dim>::local_assemble_advection_face_terms ( \
-                                                                      const AdvectionField                        &advection_field, \
-                                                                      const DoFHandler<dim>::active_cell_iterator &cell, \
-                                                                      internal::Assembly::Scratch::AdvectionSystem<dim>  &scratch, \
-                                                                      internal::Assembly::CopyData::AdvectionSystem<dim> &data); \
   template void Simulator<dim>::local_assemble_advection_system ( \
                                                                   const AdvectionField          &advection_field, \
                                                                   const Vector<double>           &viscosity_per_cell, \

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -215,6 +215,8 @@ namespace aspect
           old_old_strain_rates (quadrature.size(), Utilities::signaling_nan<SymmetricTensor<2,dim> >()),
           old_temperature_values (quadrature.size(), Utilities::signaling_nan<double>()),
           old_old_temperature_values(quadrature.size(), Utilities::signaling_nan<double>()),
+          old_field_values (quadrature.size(), Utilities::signaling_nan<double>()),
+          old_old_field_values(quadrature.size(), Utilities::signaling_nan<double>()),
           old_field_grads(quadrature.size(), Utilities::signaling_nan<Tensor<1,dim> >()),
           old_old_field_grads(quadrature.size(), Utilities::signaling_nan<Tensor<1,dim> >()),
           old_field_laplacians(quadrature.size(), Utilities::signaling_nan<double>()),
@@ -237,10 +239,9 @@ namespace aspect
           face_material_model_outputs(face_quadrature.size(), n_compositional_fields),
           neighbor_face_material_model_inputs(face_quadrature.size(), n_compositional_fields),
           neighbor_face_material_model_outputs(face_quadrature.size(), n_compositional_fields),
-          explicit_material_model_inputs(quadrature.size(), n_compositional_fields),
-          explicit_material_model_outputs(quadrature.size(), n_compositional_fields),
           heating_model_outputs(quadrature.size(), n_compositional_fields),
-          face_heating_model_outputs(quadrature.size(), n_compositional_fields)
+          face_heating_model_outputs(face_quadrature.size(), n_compositional_fields),
+          neighbor_face_heating_model_outputs(face_quadrature.size(), n_compositional_fields)
         {}
 
 
@@ -274,6 +275,8 @@ namespace aspect
           old_old_strain_rates (scratch.old_old_strain_rates),
           old_temperature_values (scratch.old_temperature_values),
           old_old_temperature_values (scratch.old_old_temperature_values),
+          old_field_values (scratch.old_field_values),
+          old_old_field_values(scratch.old_old_field_values),
           old_field_grads (scratch.old_field_grads),
           old_old_field_grads (scratch.old_old_field_grads),
           old_field_laplacians (scratch.old_field_laplacians),
@@ -293,10 +296,9 @@ namespace aspect
           face_material_model_outputs(scratch.face_material_model_outputs),
           neighbor_face_material_model_inputs(scratch.neighbor_face_material_model_inputs),
           neighbor_face_material_model_outputs(scratch.neighbor_face_material_model_outputs),
-          explicit_material_model_inputs(scratch.explicit_material_model_inputs),
-          explicit_material_model_outputs(scratch.explicit_material_model_outputs),
           heating_model_outputs(scratch.heating_model_outputs),
-          face_heating_model_outputs(scratch.face_heating_model_outputs)
+          face_heating_model_outputs(scratch.face_heating_model_outputs),
+          neighbor_face_heating_model_outputs(scratch.neighbor_face_heating_model_outputs)
         {}
 
       }
@@ -544,7 +546,7 @@ namespace aspect
     if (advection_field.is_discontinuous(introspection))
       return 0.;
 
-    std::vector<double> residual = assemblers->compute_advection_system_residual(*scratch.explicit_material_model_inputs.cell,
+    std::vector<double> residual = assemblers->compute_advection_system_residual(*scratch.material_model_inputs.cell,
                                                                                  advection_field,
                                                                                  scratch);
 
@@ -561,7 +563,7 @@ namespace aspect
 
         if (parameters.stabilization_alpha == 2)
           {
-            const double field = ((*scratch.old_field_values)[q] + (*scratch.old_old_field_values)[q]) / 2;
+            const double field = (scratch.old_field_values[q] + scratch.old_old_field_values[q]) / 2;
             residual[q] *= std::abs(field - average_field);
           }
 
@@ -570,9 +572,9 @@ namespace aspect
 
         if (advection_field.is_temperature())
           {
-            max_density = std::max       (scratch.explicit_material_model_outputs.densities[q],              max_density);
-            max_specific_heat = std::max (scratch.explicit_material_model_outputs.specific_heat[q],          max_specific_heat);
-            max_conductivity = std::max  (scratch.explicit_material_model_outputs.thermal_conductivities[q], max_conductivity);
+            max_density = std::max       (scratch.material_model_outputs.densities[q],              max_density);
+            max_specific_heat = std::max (scratch.material_model_outputs.specific_heat[q],          max_specific_heat);
+            max_conductivity = std::max  (scratch.material_model_outputs.thermal_conductivities[q], max_conductivity);
           }
       }
 
@@ -736,14 +738,14 @@ namespace aspect
 
         scratch.old_field_values = (advection_field.is_temperature()
                                     ?
-                                    &scratch.old_temperature_values
+                                    scratch.old_temperature_values
                                     :
-                                    &scratch.old_composition_values[advection_field.compositional_variable]);
+                                    scratch.old_composition_values[advection_field.compositional_variable]);
         scratch.old_old_field_values = (advection_field.is_temperature()
                                         ?
-                                        &scratch.old_old_temperature_values
+                                        scratch.old_old_temperature_values
                                         :
-                                        &scratch.old_old_composition_values[advection_field.compositional_variable]);
+                                        scratch.old_old_composition_values[advection_field.compositional_variable]);
 
         scratch.finite_element_values[solution_field].get_function_gradients (old_solution,
                                                                               scratch.old_field_grads);
@@ -755,26 +757,31 @@ namespace aspect
         scratch.finite_element_values[solution_field].get_function_laplacians (old_old_solution,
                                                                                scratch.old_old_field_laplacians);
 
+        /**
+         * Explicit material model inputs and outputs.
+         */
         for (unsigned int q=0; q<n_q_points; ++q)
           {
-            scratch.explicit_material_model_inputs.temperature[q] = (scratch.old_temperature_values[q] + scratch.old_old_temperature_values[q]) / 2;
-            scratch.explicit_material_model_inputs.position[q] = scratch.finite_element_values.quadrature_point(q);
-            scratch.explicit_material_model_inputs.pressure[q] = (scratch.old_pressure[q] + scratch.old_old_pressure[q]) / 2;
-            scratch.explicit_material_model_inputs.velocity[q] = (scratch.old_velocity_values[q] + scratch.old_old_velocity_values[q]) / 2;
-            scratch.explicit_material_model_inputs.pressure_gradient[q] = (scratch.old_pressure_gradients[q] + scratch.old_old_pressure_gradients[q]) / 2;
+            scratch.material_model_inputs.temperature[q] = (scratch.old_temperature_values[q] + scratch.old_old_temperature_values[q]) / 2;
+            scratch.material_model_inputs.position[q] = scratch.finite_element_values.quadrature_point(q);
+            scratch.material_model_inputs.pressure[q] = (scratch.old_pressure[q] + scratch.old_old_pressure[q]) / 2;
+            scratch.material_model_inputs.velocity[q] = (scratch.old_velocity_values[q] + scratch.old_old_velocity_values[q]) / 2;
+            scratch.material_model_inputs.pressure_gradient[q] = (scratch.old_pressure_gradients[q] + scratch.old_old_pressure_gradients[q]) / 2;
 
             for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
-              scratch.explicit_material_model_inputs.composition[q][c] = (scratch.old_composition_values[c][q] + scratch.old_old_composition_values[c][q]) / 2;
-            scratch.explicit_material_model_inputs.strain_rate[q] = (scratch.old_strain_rates[q] + scratch.old_old_strain_rates[q]) / 2;
+              scratch.material_model_inputs.composition[q][c] = (scratch.old_composition_values[c][q] + scratch.old_old_composition_values[c][q]) / 2;
+            scratch.material_model_inputs.strain_rate[q] = (scratch.old_strain_rates[q] + scratch.old_old_strain_rates[q]) / 2;
           }
-        scratch.explicit_material_model_inputs.cell = &cell;
+        scratch.material_model_inputs.cell = &cell;
 
-        material_model->evaluate(scratch.explicit_material_model_inputs,scratch.explicit_material_model_outputs);
+        create_additional_material_model_outputs(scratch.material_model_outputs);
+
+        material_model->evaluate(scratch.material_model_inputs,scratch.material_model_outputs);
         MaterialModel::MaterialAveraging::average (parameters.material_averaging,
                                                    cell,
                                                    scratch.finite_element_values.get_quadrature(),
                                                    scratch.finite_element_values.get_mapping(),
-                                                   scratch.explicit_material_model_outputs);
+                                                   scratch.material_model_outputs);
 
         viscosity_per_cell[cellidx] = compute_viscosity(scratch,
                                                         global_max_velocity,
@@ -824,7 +831,7 @@ namespace aspect
                                        const FEValuesBase<dim>                                     &input_finite_element_values,
                                        const typename DoFHandler<dim>::active_cell_iterator        &cell,
                                        const bool                                                   compute_strainrate,
-                                       MaterialModel::MaterialModelInputs<dim> &material_model_inputs) const
+                                       MaterialModel::MaterialModelInputs<dim>                     &material_model_inputs) const
   {
     const unsigned int n_q_points = material_model_inputs.temperature.size();
 
@@ -1083,13 +1090,7 @@ namespace aspect
           const double time_step = this->get_timestep();
           const double old_time_step = this->get_old_timestep();
 
-          const unsigned int solution_component
-            = (advection_field.is_temperature()
-               ?
-               introspection.component_indices.temperature
-               :
-               introspection.component_indices.compositional_fields[advection_field.compositional_variable]
-              );
+          const unsigned int solution_component = advection_field.component_index(introspection);
 
           const FEValuesExtractors::Scalar solution_field
             = (advection_field.is_temperature()
@@ -1155,14 +1156,14 @@ namespace aspect
 
               const double field_term_for_rhs
                 = (use_bdf2_scheme ?
-                   ((*scratch.old_field_values)[q] *
+                   (scratch.old_field_values[q] *
                     (1 + time_step/old_time_step)
                     -
-                    (*scratch.old_old_field_values)[q] *
+                    scratch.old_old_field_values[q] *
                     (time_step * time_step) /
                     (old_time_step * (time_step + old_time_step)))
                    :
-                   (*scratch.old_field_values)[q])
+                   scratch.old_field_values[q])
                   *
                   (density_c_P + latent_heat_LHS);
 
@@ -1212,10 +1213,9 @@ namespace aspect
           const unsigned int n_q_points = scratch.finite_element_values.n_quadrature_points;
           std::vector<double> residuals(n_q_points);
 
-          HeatingModel::HeatingModelOutputs heating_model_outputs(n_q_points, this->get_parameters().n_compositional_fields);
-          this->get_heating_model_manager().evaluate(scratch.explicit_material_model_inputs,
-                                                     scratch.explicit_material_model_outputs,
-                                                     heating_model_outputs);
+          this->get_heating_model_manager().evaluate(scratch.material_model_inputs,
+                                                     scratch.material_model_outputs,
+                                                     scratch.heating_model_outputs);
 
           for (unsigned int q=0; q < n_q_points; ++q)
             {
@@ -1224,15 +1224,14 @@ namespace aspect
 
               const double dField_dt = (this->get_old_timestep() == 0.0) ? 0 :
                                        (
-                                         ((*scratch.old_field_values)[q] - (*scratch.old_old_field_values)[q])
+                                         ((scratch.old_field_values)[q] - (scratch.old_old_field_values)[q])
                                          / this->get_old_timestep());
               const double u_grad_field = u * (scratch.old_field_grads[q] +
                                                scratch.old_old_field_grads[q]) / 2;
 
-              const double density              = ((advection_field.is_temperature())
-                                                   ? scratch.explicit_material_model_outputs.densities[q] : 1.0);
-              const double conductivity = ((advection_field.is_temperature()) ? scratch.explicit_material_model_outputs.thermal_conductivities[q] : 0.0);
-              const double c_P                  = ((advection_field.is_temperature()) ? scratch.explicit_material_model_outputs.specific_heat[q] : 1.0);
+              const double density       = ((advection_field.is_temperature()) ? scratch.material_model_outputs.densities[q] : 1.0);
+              const double conductivity  = ((advection_field.is_temperature()) ? scratch.material_model_outputs.thermal_conductivities[q] : 0.0);
+              const double c_P           = ((advection_field.is_temperature()) ? scratch.material_model_outputs.specific_heat[q] : 1.0);
               const double k_Delta_field = conductivity
                                            * (scratch.old_field_laplacians[q] +
                                               scratch.old_old_field_laplacians[q]) / 2;
@@ -1240,14 +1239,14 @@ namespace aspect
               const double gamma =
                 ((advection_field.is_temperature())
                  ?
-                 heating_model_outputs.heating_source_terms[q]
+                 scratch.heating_model_outputs.heating_source_terms[q]
                  :
                  0.0);
 
               const double latent_heat_LHS =
                 ((advection_field.is_temperature())
                  ?
-                 heating_model_outputs.lhs_latent_heat_terms[q]
+                 scratch.heating_model_outputs.lhs_latent_heat_terms[q]
                  :
                  0.0);
 
@@ -1256,7 +1255,7 @@ namespace aspect
                 ?
                 0.0
                 :
-                (scratch.explicit_material_model_outputs.reaction_terms[q][advection_field.compositional_variable]
+                (scratch.material_model_outputs.reaction_terms[q][advection_field.compositional_variable]
                  / this->get_old_timestep());
 
               residuals[q]
@@ -1516,10 +1515,9 @@ namespace aspect
                       this->get_material_model().evaluate(scratch.neighbor_face_material_model_inputs,
                                                           scratch.neighbor_face_material_model_outputs);
 
-                      HeatingModel::HeatingModelOutputs neighbor_face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
                       this->get_heating_model_manager().evaluate(scratch.neighbor_face_material_model_inputs,
                                                                  scratch.neighbor_face_material_model_outputs,
-                                                                 neighbor_face_heating_model_outputs);
+                                                                 scratch.neighbor_face_heating_model_outputs);
 
                       std::vector<types::global_dof_index> neighbor_dof_indices (scratch.face_finite_element_values->get_fe().dofs_per_cell);
                       // get all dof indices on the neighbor, then extract those
@@ -1608,7 +1606,7 @@ namespace aspect
                           const double neighbor_latent_heat_LHS =
                             ((advection_field.is_temperature())
                              ?
-                             neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
+                             scratch.neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
                              :
                              0.0);
                           Assert (neighbor_density_c_P + neighbor_latent_heat_LHS >= 0,
@@ -1820,10 +1818,9 @@ namespace aspect
                       this->get_material_model().evaluate(scratch.face_material_model_inputs,
                                                           scratch.face_material_model_outputs);
 
-                      HeatingModel::HeatingModelOutputs face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
                       this->get_heating_model_manager().evaluate(scratch.face_material_model_inputs,
                                                                  scratch.face_material_model_outputs,
-                                                                 face_heating_model_outputs);
+                                                                 scratch.face_heating_model_outputs);
 
                       //set up neighbor values
                       scratch.neighbor_face_finite_element_values->reinit (neighbor_child, neighbor2);
@@ -1836,10 +1833,9 @@ namespace aspect
                       this->get_material_model().evaluate(scratch.neighbor_face_material_model_inputs,
                                                           scratch.neighbor_face_material_model_outputs);
 
-                      HeatingModel::HeatingModelOutputs neighbor_face_heating_model_outputs(n_q_points, parameters.n_compositional_fields);
                       this->get_heating_model_manager().evaluate(scratch.neighbor_face_material_model_inputs,
                                                                  scratch.neighbor_face_material_model_outputs,
-                                                                 neighbor_face_heating_model_outputs);
+                                                                 scratch.neighbor_face_heating_model_outputs);
 
                       std::vector<types::global_dof_index> neighbor_dof_indices (scratch.face_finite_element_values->get_fe().dofs_per_cell);
                       // get all dof indices on the neighbor, then extract those
@@ -1884,7 +1880,7 @@ namespace aspect
                           const double latent_heat_LHS =
                             ((advection_field.is_temperature())
                              ?
-                             face_heating_model_outputs.lhs_latent_heat_terms[q]
+                             scratch.face_heating_model_outputs.lhs_latent_heat_terms[q]
                              :
                              0.0);
                           Assert (density_c_P + latent_heat_LHS >= 0,
@@ -1928,7 +1924,7 @@ namespace aspect
                           const double neighbor_latent_heat_LHS =
                             ((advection_field.is_temperature())
                              ?
-                             neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
+                             scratch.neighbor_face_heating_model_outputs.lhs_latent_heat_terms[q]
                              :
                              0.0);
                           Assert (neighbor_density_c_P + neighbor_latent_heat_LHS >= 0,
@@ -2181,12 +2177,12 @@ namespace aspect
   template <int dim>
   void
   Simulator<dim>::
-  create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs)
+  create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const
   {
     typedef typename std::vector<std_cxx11::shared_ptr<internal::Assembly::Assemblers::AssemblerBase<dim> > >
     assembler_vector_t;
 
-    for (typename assembler_vector_t::iterator it = assembler_objects.begin();
+    for (typename assembler_vector_t::const_iterator it = assembler_objects.begin();
          it != assembler_objects.end();
          ++it)
       {
@@ -2702,9 +2698,6 @@ namespace aspect
                                    internal::Assembly::Scratch::AdvectionSystem<dim> &scratch,
                                    internal::Assembly::CopyData::AdvectionSystem<dim> &data)
   {
-
-    const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
-
     // also have the number of dofs that correspond just to the element for
     // the system we are currently trying to assemble
     const unsigned int advection_dofs_per_cell = data.local_dof_indices.size();
@@ -2734,64 +2727,25 @@ namespace aspect
     data.local_matrix = 0;
     data.local_rhs = 0;
 
-    scratch.finite_element_values[introspection.extractors.temperature].get_function_values (old_solution,
-        scratch.old_temperature_values);
-    scratch.finite_element_values[introspection.extractors.temperature].get_function_values (old_old_solution,
-        scratch.old_old_temperature_values);
-
-    scratch.finite_element_values[introspection.extractors.velocities].get_function_symmetric_gradients (old_solution,
-        scratch.old_strain_rates);
-    scratch.finite_element_values[introspection.extractors.velocities].get_function_symmetric_gradients (old_old_solution,
-        scratch.old_old_strain_rates);
-    scratch.finite_element_values[introspection.extractors.pressure].get_function_values (old_solution,
-        scratch.old_pressure);
-    scratch.finite_element_values[introspection.extractors.pressure].get_function_values (old_old_solution,
-        scratch.old_old_pressure);
-    for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
-      {
-        scratch.finite_element_values[introspection.extractors.compositional_fields[c]].get_function_values(old_solution,
-            scratch.old_composition_values[c]);
-        scratch.finite_element_values[introspection.extractors.compositional_fields[c]].get_function_values(old_old_solution,
-            scratch.old_old_composition_values[c]);
-      }
-    scratch.finite_element_values[introspection.extractors.pressure].get_function_gradients (old_solution,
-        scratch.old_pressure_gradients);
-    scratch.finite_element_values[introspection.extractors.pressure].get_function_gradients (old_old_solution,
-        scratch.old_old_pressure_gradients);
-
-    scratch.finite_element_values[introspection.extractors.velocities].get_function_values (old_solution,
-        scratch.old_velocity_values);
-    scratch.finite_element_values[introspection.extractors.velocities].get_function_values (old_old_solution,
-        scratch.old_old_velocity_values);
+    scratch.finite_element_values[solution_field].get_function_values (old_solution,
+                                                                       scratch.old_field_values);
+    scratch.finite_element_values[solution_field].get_function_values (old_old_solution,
+                                                                       scratch.old_old_field_values);
     scratch.finite_element_values[introspection.extractors.velocities].get_function_values(current_linearization_point,
         scratch.current_velocity_values);
 
-    //get the mesh velocity, as we need to subtract it off of the advection systems
+    // get the mesh velocity, as we need to subtract it off of the advection systems
     if (parameters.free_surface_enabled)
       scratch.finite_element_values[introspection.extractors.velocities].get_function_values(free_surface->mesh_velocity,
           scratch.mesh_velocity_values);
 
-
-    scratch.old_field_values = ((advection_field.is_temperature()) ? &scratch.old_temperature_values : &scratch.old_composition_values[advection_field.compositional_variable]);
-    scratch.old_old_field_values = ((advection_field.is_temperature()) ? &scratch.old_old_temperature_values : &scratch.old_old_composition_values[advection_field.compositional_variable]);
-
-    scratch.finite_element_values[solution_field].get_function_gradients (old_solution,
-                                                                          scratch.old_field_grads);
-    scratch.finite_element_values[solution_field].get_function_gradients (old_old_solution,
-                                                                          scratch.old_old_field_grads);
-
-    scratch.finite_element_values[solution_field].get_function_laplacians (old_solution,
-                                                                           scratch.old_field_laplacians);
-    scratch.finite_element_values[solution_field].get_function_laplacians (old_old_solution,
-                                                                           scratch.old_old_field_laplacians);
-
+    // compute material properties and heating terms
     compute_material_model_input_values (current_linearization_point,
                                          scratch.finite_element_values,
                                          cell,
                                          true,
                                          scratch.material_model_inputs);
     create_additional_material_model_outputs(scratch.material_model_outputs);
-    create_additional_material_model_outputs(scratch.explicit_material_model_outputs);
 
     material_model->evaluate(scratch.material_model_inputs,
                              scratch.material_model_outputs);
@@ -2804,31 +2758,6 @@ namespace aspect
     heating_model_manager.evaluate(scratch.material_model_inputs,
                                    scratch.material_model_outputs,
                                    scratch.heating_model_outputs);
-
-    // set up scratch.explicit_material_model_*
-    {
-      for (unsigned int q=0; q<n_q_points; ++q)
-        {
-          scratch.explicit_material_model_inputs.temperature[q] = (scratch.old_temperature_values[q] + scratch.old_old_temperature_values[q]) / 2;
-          scratch.explicit_material_model_inputs.position[q] = scratch.finite_element_values.quadrature_point(q);
-          scratch.explicit_material_model_inputs.pressure[q] = (scratch.old_pressure[q] + scratch.old_old_pressure[q]) / 2;
-          scratch.explicit_material_model_inputs.velocity[q] = (scratch.old_velocity_values[q] + scratch.old_old_velocity_values[q]) / 2;
-          scratch.explicit_material_model_inputs.pressure_gradient[q] = (scratch.old_pressure_gradients[q] + scratch.old_old_pressure_gradients[q]) / 2;
-
-          for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
-            scratch.explicit_material_model_inputs.composition[q][c] = (scratch.old_composition_values[c][q] + scratch.old_old_composition_values[c][q]) / 2;
-          scratch.explicit_material_model_inputs.strain_rate[q] = (scratch.old_strain_rates[q] + scratch.old_old_strain_rates[q]) / 2;
-        }
-      scratch.explicit_material_model_inputs.cell = &cell;
-
-      material_model->evaluate(scratch.explicit_material_model_inputs,
-                               scratch.explicit_material_model_outputs);
-      MaterialModel::MaterialAveraging::average (parameters.material_averaging,
-                                                 cell,
-                                                 scratch.finite_element_values.get_quadrature(),
-                                                 scratch.finite_element_values.get_mapping(),
-                                                 scratch.explicit_material_model_outputs);
-    }
 
 
     // TODO: Compute artificial viscosity once per timestep instead of each time

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -241,6 +241,13 @@ namespace aspect
 
   template <int dim>
   const LinearAlgebra::BlockVector &
+  SimulatorAccess<dim>::get_current_linearization_point () const
+  {
+    return simulator->current_linearization_point;
+  }
+
+  template <int dim>
+  const LinearAlgebra::BlockVector &
   SimulatorAccess<dim>::get_solution () const
   {
     return simulator->solution;
@@ -294,6 +301,22 @@ namespace aspect
 
 
   template <int dim>
+  void
+  SimulatorAccess<dim>::compute_material_model_input_values (const LinearAlgebra::BlockVector                            &input_solution,
+                                                             const FEValuesBase<dim,dim>                                 &input_finite_element_values,
+                                                             const typename DoFHandler<dim>::active_cell_iterator        &cell,
+                                                             const bool                                                   compute_strainrate,
+                                                             MaterialModel::MaterialModelInputs<dim> &material_model_inputs) const
+  {
+    simulator->compute_material_model_input_values(input_solution,
+                                                   input_finite_element_values,
+                                                   cell,
+                                                   compute_strainrate,
+                                                   material_model_inputs);
+  }
+
+
+  template <int dim>
   const MaterialModel::Interface<dim> &
   SimulatorAccess<dim>::get_material_model () const
   {
@@ -325,9 +348,27 @@ namespace aspect
   const BoundaryTemperature::Interface<dim> &
   SimulatorAccess<dim>::get_boundary_temperature () const
   {
-    Assert (simulator->boundary_temperature.get() != 0,
-            ExcMessage("You can not call this function if no such model is actually available."));
+    AssertThrow (simulator->boundary_temperature.get() != 0,
+                 ExcMessage("You can not call this function if no such model is actually available."));
     return *simulator->boundary_temperature.get();
+  }
+
+
+  template <int dim>
+  bool
+  SimulatorAccess<dim>::has_boundary_composition () const
+  {
+    return (simulator->boundary_composition.get() != 0);
+  }
+
+
+  template <int dim>
+  const BoundaryComposition::Interface<dim> &
+  SimulatorAccess<dim>::get_boundary_composition () const
+  {
+    AssertThrow (simulator->boundary_composition.get() != 0,
+                 ExcMessage("You can not call this function if no such model is actually available."));
+    return *simulator->boundary_composition.get();
   }
 
 

--- a/tests/additional_outputs_02.cc
+++ b/tests/additional_outputs_02.cc
@@ -72,7 +72,7 @@ namespace aspect
   {
     public:
 
-      virtual void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &out)
+      virtual void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &out) const
       {
         std::cout << "* create_additional_material_model_outputs() called" << std::endl;
 

--- a/tests/additional_outputs_02/screen-output
+++ b/tests/additional_outputs_02/screen-output
@@ -8,27 +8,23 @@ Number of active cells: 4 (on 2 levels)
 Number of degrees of freedom: 84 (50+9+25)
 
 *** Timestep 0:  t=0 seconds
-* evaluate called without additional outputs!
-* evaluate called without additional outputs!
-* evaluate called without additional outputs!
-* evaluate called without additional outputs!
-* create_additional_material_model_outputs() called
-   creating additional output!
 * create_additional_material_model_outputs() called
    creating additional output!
 * evaluate called with additional outputs!
-* evaluate called with additional outputs!
-* create_additional_material_model_outputs() called
 * create_additional_material_model_outputs() called
 * evaluate called with additional outputs!
-* evaluate called with additional outputs!
-* create_additional_material_model_outputs() called
 * create_additional_material_model_outputs() called
 * evaluate called with additional outputs!
-* evaluate called with additional outputs!
-* create_additional_material_model_outputs() called
 * create_additional_material_model_outputs() called
 * evaluate called with additional outputs!
+* create_additional_material_model_outputs() called
+   creating additional output!
+* evaluate called with additional outputs!
+* create_additional_material_model_outputs() called
+* evaluate called with additional outputs!
+* create_additional_material_model_outputs() called
+* evaluate called with additional outputs!
+* create_additional_material_model_outputs() called
 * evaluate called with additional outputs!
    Solving temperature system... 0 iterations.
 * create_additional_material_model_outputs() called
@@ -74,4 +70,4 @@ Termination requested by criterion: end time
 +---------------------------------+-----------+------------+------------+
 +---------------------------------+-----------+------------+------------+
 
-called without: 8 with: 16
+called without: 4 with: 16

--- a/tests/additional_outputs_03.cc
+++ b/tests/additional_outputs_03.cc
@@ -86,7 +86,7 @@ namespace aspect
   {
     public:
 
-      virtual void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &out)
+      virtual void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &out) const
       {
         std::cout << "* create_additional_material_model_outputs() called" << std::endl;
 

--- a/tests/additional_outputs_03/screen-output
+++ b/tests/additional_outputs_03/screen-output
@@ -8,34 +8,30 @@ Number of active cells: 4 (on 2 levels)
 Number of degrees of freedom: 84 (50+9+25)
 
 *** Timestep 0:  t=0 seconds
-* evaluate called without additional outputs!
-* evaluate called without additional outputs!
-* evaluate called without additional outputs!
-* evaluate called without additional outputs!
-* create_additional_material_model_outputs() called
-   creating additional output!
 * create_additional_material_model_outputs() called
    creating additional output!
 * evaluate called with additional outputs!
 averaging!
-* evaluate called with additional outputs!
-averaging!
-* create_additional_material_model_outputs() called
 * create_additional_material_model_outputs() called
 * evaluate called with additional outputs!
 averaging!
-* evaluate called with additional outputs!
-averaging!
-* create_additional_material_model_outputs() called
 * create_additional_material_model_outputs() called
 * evaluate called with additional outputs!
 averaging!
-* evaluate called with additional outputs!
-averaging!
-* create_additional_material_model_outputs() called
 * create_additional_material_model_outputs() called
 * evaluate called with additional outputs!
 averaging!
+* create_additional_material_model_outputs() called
+   creating additional output!
+* evaluate called with additional outputs!
+averaging!
+* create_additional_material_model_outputs() called
+* evaluate called with additional outputs!
+averaging!
+* create_additional_material_model_outputs() called
+* evaluate called with additional outputs!
+averaging!
+* create_additional_material_model_outputs() called
 * evaluate called with additional outputs!
 averaging!
    Solving temperature system... 0 iterations.
@@ -90,4 +86,4 @@ Termination requested by criterion: end time
 +---------------------------------+-----------+------------+------------+
 +---------------------------------+-----------+------------+------------+
 
-called without: 8 with: 16
+called without: 4 with: 16

--- a/tests/cell_reference/screen-output
+++ b/tests/cell_reference/screen-output
@@ -10,12 +10,8 @@ Level: 1 Index: 1
 Level: 1 Index: 2
 Level: 1 Index: 3
 Level: 1 Index: 0
-Level: 1 Index: 0
-Level: 1 Index: 1
 Level: 1 Index: 1
 Level: 1 Index: 2
-Level: 1 Index: 2
-Level: 1 Index: 3
 Level: 1 Index: 3
    Solving temperature system... 0 iterations.
 Level: 1 Index: 0


### PR DESCRIPTION
This PR depends on #775, which in turn depends on #769, so they should be reviewed and merged in order.

While working on #769 and #775 I noticed that we actually do not need to carry around a `scratch.explicit_material_model` any more, because the residual computation and the matrix assembly happens in separate loops over all cells since #425. Therefore we might as well reuse `scratch.material_model`, and just fill it with extrapolated values for the residual and current values for the assembly. At the moment we even fill explicit_material_model in the assembly, although we do not use it afterwards. Also this PR removes another peculiarity around the declaration of the material_model and heating_model_outputs for faces, which should be either completely in scratch (what I propose here), or completely in the advection face assembler function.