### PR TITLE
Silence overloaded-virtual and deprecation warnings

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -509,9 +509,9 @@ namespace aspect
         virtual ~AdditionalMaterialOutputs()
         {}
 
-        virtual void average (const MaterialAveraging::AveragingOperation operation,
-                              const FullMatrix<double>  &projection_matrix,
-                              const FullMatrix<double>  &expansion_matrix)
+        virtual void average (const MaterialAveraging::AveragingOperation /*operation*/,
+                              const FullMatrix<double>  &/*projection_matrix*/,
+                              const FullMatrix<double>  &/*expansion_matrix*/)
         {}
     };
 

--- a/include/aspect/velocity_boundary_conditions/ascii_data.h
+++ b/include/aspect/velocity_boundary_conditions/ascii_data.h
@@ -76,6 +76,9 @@ namespace aspect
         boundary_velocity (const types::boundary_id boundary_indicator,
                            const Point<dim> &position) const;
 
+        // avoid -Woverloaded-virtual warning until the deprecated function
+        // is removed from the interface:
+        using Interface<dim>::boundary_velocity;
 
         /**
          * Declare the parameters this class takes through input files.

--- a/include/aspect/velocity_boundary_conditions/function.h
+++ b/include/aspect/velocity_boundary_conditions/function.h
@@ -58,6 +58,10 @@ namespace aspect
         boundary_velocity (const types::boundary_id boundary_indicator,
                            const Point<dim> &position) const;
 
+        // avoid -Woverloaded-virtual warning until the deprecated function
+        // is removed from the interface:
+        using Interface<dim>::boundary_velocity;
+
         /**
          * A function that is called at the beginning of each time step to
          * indicate what the model time is for which the boundary values will

--- a/include/aspect/velocity_boundary_conditions/gplates.h
+++ b/include/aspect/velocity_boundary_conditions/gplates.h
@@ -190,6 +190,10 @@ namespace aspect
         Tensor<1,dim>
         boundary_velocity (const Point<dim> &position) const;
 
+        // avoid -Woverloaded-virtual warning until the deprecated function
+        // is removed from the interface:
+        using Interface<dim>::boundary_velocity;
+
         /**
          * Initialization function. This function is called once at the
          * beginning of the program. Checks preconditions.

--- a/include/aspect/velocity_boundary_conditions/zero_velocity.h
+++ b/include/aspect/velocity_boundary_conditions/zero_velocity.h
@@ -48,6 +48,10 @@ namespace aspect
         Tensor<1,dim>
         boundary_velocity (const types::boundary_id boundary_indicator,
                            const Point<dim> &position) const;
+
+        // avoid -Woverloaded-virtual warning until the deprecated function
+        // is removed from the interface:
+        using Interface<dim>::boundary_velocity;
     };
   }
 }

--- a/source/velocity_boundary_conditions/interface.cc
+++ b/source/velocity_boundary_conditions/interface.cc
@@ -70,7 +70,8 @@ namespace aspect
     }
 
 
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     template <int dim>
     Tensor<1,dim>
     Interface<dim>::boundary_velocity (const types::boundary_id ,
@@ -83,6 +84,7 @@ namespace aspect
 
       return this->boundary_velocity(position);
     }
+#pragma GCC diagnostic pop
 
 
 


### PR DESCRIPTION
This PR silences a number of warnings (gcc 4.8.4) that have annoyed me in the last time, but I never found the time to actually fix them :smile: