### PR TITLE
[post-1.4] Silence warnings for other compilers

### DIFF
--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -52,8 +52,7 @@ namespace aspect
 
 
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
     template <int dim>
     void
     Interface<dim>::evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
@@ -72,7 +71,7 @@ namespace aspect
           heating_model_outputs.lhs_latent_heat_terms[q] = 0.0;
         }
     }
-#pragma GCC diagnostic pop
+    DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 
     template <int dim>

--- a/source/velocity_boundary_conditions/interface.cc
+++ b/source/velocity_boundary_conditions/interface.cc
@@ -70,8 +70,7 @@ namespace aspect
     }
 
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
     template <int dim>
     Tensor<1,dim>
     Interface<dim>::boundary_velocity (const types::boundary_id ,
@@ -84,8 +83,7 @@ namespace aspect
 
       return this->boundary_velocity(position);
     }
-#pragma GCC diagnostic pop
-
+    DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 
     template <int dim>


### PR DESCRIPTION
This was suggested in #785 and indeed removes some warnings for Intel compilers, thanks @tjhei.
The only remaining warning I get is: "icpc: command line warning #10006: ignoring unknown option '-fuse-ld=gold'". That is related to the deal.II build system I guess? I can open an issue there.