### PR TITLE
Fix adaptive mesh particle bug

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,12 @@
  *
  * <ol>
  *
+ * <li> Fixed: Combining particles with initial adaptive refinement steps
+ * used to create a multiple of the selected number of particles.
+ * This is fixed now.
+ * <br>
+ * (Rene Gassmoeller, 2016/03/18)
+ *
  * <li> Improved: The Introspection class has now a new base class
  * FEVariableCollection that allows flexible modification of the finite
  * element variables involved in a computation, even inside a plugin.

--- a/include/aspect/postprocess/tracers.h
+++ b/include/aspect/postprocess/tracers.h
@@ -62,13 +62,22 @@ namespace aspect
         initialize();
 
         /**
-         * Generate and initialize particles. This can not be done in another
-         * place, because we want to generate and initialize the particles
+         * Generate the particles. This can not be done in another
+         * place, because we want to generate the particles
          * before the first timestep, but after the initial conditions have
          * been set.
          */
         void
-        generate_and_initialize_particles();
+        generate_particles();
+
+        /**
+         * Initialize particle properties. This can not be done in another
+         * place, because we want to initialize the particle properties
+         * before the first timestep, but after the initial conditions have
+         * been set.
+         */
+        void
+        initialize_particles();
 
         /**
          * Returns a const reference to the particle world, in case anyone

--- a/source/postprocess/tracers.cc
+++ b/source/postprocess/tracers.cc
@@ -55,9 +55,15 @@ namespace aspect
 
     template <int dim>
     void
-    Tracers<dim>::generate_and_initialize_particles()
+    Tracers<dim>::generate_particles()
     {
       world.generate_particles();
+    }
+
+    template <int dim>
+    void
+    Tracers<dim>::initialize_particles()
+    {
       world.initialize_particles();
     }
 

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -181,7 +181,16 @@ namespace aspect
 
     // If the tracer postprocessor has been selected
     if (tracer_postprocessor != 0)
-      tracer_postprocessor->generate_and_initialize_particles();
+      {
+        // If we are in the first adaptive refinement cycle generate particles
+        if (pre_refinement_step == 0)
+          tracer_postprocessor->generate_particles();
+
+        // And initialize the tracer properties according to the initial
+        // conditions on the current mesh
+        tracer_postprocessor->initialize_particles();
+      }
+
   }
 
 

--- a/tests/particle_initial_adaptive_refinement.prm
+++ b/tests/particle_initial_adaptive_refinement.prm
@@ -1,0 +1,117 @@
+# A description of the van Keken et al. benchmark using smooth initial
+# conditions instead of the discontinuous ones in
+# van-keken-discontinuous.prm. See the manual for more information.
+# This test adds tracers to the cookbook parameter file, and therefore
+# tests the behaviour of the tracers.
+
+set Dimension                              = 2
+set End time                               = 70
+set Use years in output instead of seconds = false
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent  = 0.9142
+    set Y extent  = 1.0000
+  end
+end
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false
+  set Tangential velocity boundary indicators = left, right
+  set Zero velocity boundary indicators       = bottom, top
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Reference density             = 1010
+    set Viscosity                     = 1e2
+    set Thermal expansion coefficient = 0
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+############### Parameters describing the temperature field
+# Note: The temperature plays no role in this model
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+subsection Initial conditions
+  set Model name = function
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+
+############### Parameters describing the compositional field
+# Note: The compositional field is what drives the flow
+# in this example
+
+subsection Compositional fields
+  set Number of fields = 1
+end
+
+subsection Compositional initial conditions
+  set Model name = function
+  subsection Function
+    set Variable names      = x,z
+    set Function constants  = pi=3.1415926
+    set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
+  end
+end
+
+subsection Material model
+  subsection Simple model
+    set Density differential for compositional field 1 = -10
+  end
+end
+
+
+############### Parameters describing the discretization
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Strategy                           = composition
+  set Initial global refinement          = 4
+  set Time steps between mesh refinement = 0
+  set Coarsening fraction                = 0.05
+  set Refinement fraction                = 0.3
+end
+
+
+
+############### Parameters describing what to do with the solution
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, composition statistics,tracers
+
+  subsection Tracers
+    set Number of tracers = 10
+    set Time between data output = 70
+    set Data output format = none
+
+    set Particle generator name = uniform box
+
+    subsection Generator
+      subsection Uniform box
+        set Minimum x = 0.3
+        set Maximum x = 0.5
+        set Minimum y = 0.1
+        set Maximum y = 0.3
+      end
+    end
+  end
+end

--- a/tests/particle_initial_adaptive_refinement/screen-output
+++ b/tests/particle_initial_adaptive_refinement/screen-output
@@ -1,0 +1,32 @@
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+3 iterations.
+
+   Postprocessing:
+     RMS, max velocity:           0.000181 m/s, 0.000404 m/s
+     Compositions min/max/mass:   0/1/0.1825
+     Number of advected particles 9
+
+*** Timestep 1:  t=70 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 14 iterations.
+   Solving Stokes system... 30+3 iterations.
+
+   Postprocessing:
+     RMS, max velocity:           0.000327 m/s, 0.000728 m/s
+     Compositions min/max/mass:   -0.002207/1.002/0.1825
+     Number of advected particles 9
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/particle_initial_adaptive_refinement/statistics
+++ b/tests/particle_initial_adaptive_refinement/statistics
@@ -1,0 +1,20 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Number of degrees of freedom for all compositions
+# 7: Iterations for temperature solver
+# 8: Iterations for composition solver 1
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Time step size (seconds)
+# 13: RMS velocity (m/s)
+# 14: Max. velocity (m/s)
+# 15: Minimal value for composition C_1
+# 16: Maximal value for composition C_1
+# 17: Global mass for composition C_1
+# 18: Number of advected particles
+0 0.0000e+00 256 2467 1089 1089 0  0 33 24 4 7.0000e+01 1.81487741e-04 4.04466709e-04  0.00000000e+00 1.00000000e+00 1.82454287e-01 9 
+1 7.0000e+01 256 2467 1089 1089 0 14 33 24 4 3.9382e+01 3.27312910e-04 7.27581702e-04 -2.20654268e-03 1.00187358e+00 1.82473299e-01 9 


### PR DESCRIPTION
The particle creation contained a bug with initial adaptive refinements that was never found because none of my testcases used the 'Initial adaptive refinement' setting. Later adaptive refinements did not produce this error. The bug is now fixed by only generating the particles in the first initial refinement cycle and only reinitializing the particle properties in following cycles (identical to what we do with the initial condition).