### PR TITLE
Make message uniform

### DIFF
--- a/source/postprocess/depth_average.cc
+++ b/source/postprocess/depth_average.cc
@@ -257,7 +257,7 @@ namespace aspect
 
       // return what should be printed to the screen. note that we had
       // just incremented the number, so use the previous value
-      return std::make_pair (std::string ("Writing depth average"),
+      return std::make_pair (std::string ("Writing depth average:"),
                              filename);
     }
 

--- a/tests/adiabatic_conditions/screen-output
+++ b/tests/adiabatic_conditions/screen-output
@@ -32,7 +32,7 @@ Number of degrees of freedom: 40,836 (25,090+3,201+12,545)
      RMS, max velocity:                  9e+07 m/s, 2.21e+08 m/s
      Temperature min/avg/max:            1613 K, 1613 K, 1613 K
      Heat fluxes through boundary parts: 6.751e-18 W, 2.123e-17 W, 3.273e-18 W, 6.354e-18 W
-     Writing depth average               output-adiabatic_conditions/depth_average.gnuplot
+     Writing depth average:              output-adiabatic_conditions/depth_average.gnuplot
 
 Termination requested by criterion: end time
 

--- a/tests/adiabatic_initial_conditions/screen-output
+++ b/tests/adiabatic_initial_conditions/screen-output
@@ -16,7 +16,7 @@ Number of degrees of freedom: 40,836 (25,090+3,201+12,545)
 
    Postprocessing:
      Writing graphical output: output-adiabatic_initial_conditions/solution-00000
-     Writing depth average     output-adiabatic_initial_conditions/depth_average.gnuplot
+     Writing depth average:    output-adiabatic_initial_conditions/depth_average.gnuplot
 
 Termination requested by criterion: end time
 

--- a/tests/adiabatic_initial_conditions_chunk/screen-output
+++ b/tests/adiabatic_initial_conditions_chunk/screen-output
@@ -39,7 +39,7 @@ Number of degrees of freedom: 5,173 (3,174+412+1,587)
    Solving Stokes system... 30+17 iterations.
 
    Postprocessing:
-     Writing depth average output-adiabatic_initial_conditions_chunk/depth_average.gnuplot
+     Writing depth average:output-adiabatic_initial_conditions_chunk/depth_average.gnuplot
 
 Termination requested by criterion: end time
 

--- a/tests/adiabatic_initial_conditions_chunk_3d/screen-output
+++ b/tests/adiabatic_initial_conditions_chunk_3d/screen-output
@@ -23,7 +23,7 @@ Number of degrees of freedom: 13,612 (9,837+496+3,279)
    Solving Stokes system... 30+21 iterations.
 
    Postprocessing:
-     Writing depth average output-adiabatic_initial_conditions_chunk_3d/depth_average.gnuplot
+     Writing depth average:output-adiabatic_initial_conditions_chunk_3d/depth_average.gnuplot
 
 Termination requested by criterion: end time
 

--- a/tests/adiabatic_initial_conditions_constant/screen-output
+++ b/tests/adiabatic_initial_conditions_constant/screen-output
@@ -16,7 +16,7 @@ Number of degrees of freedom: 40,836 (25,090+3,201+12,545)
 
    Postprocessing:
      Writing graphical output: output-adiabatic_initial_conditions_constant/solution-00000
-     Writing depth average     output-adiabatic_initial_conditions_constant/depth_average.gnuplot
+     Writing depth average:    output-adiabatic_initial_conditions_constant/depth_average.gnuplot
 
 Termination requested by criterion: end time
 

--- a/tests/adiabatic_initial_conditions_subadiabaticity/screen-output
+++ b/tests/adiabatic_initial_conditions_subadiabaticity/screen-output
@@ -16,7 +16,7 @@ Number of degrees of freedom: 40,836 (25,090+3,201+12,545)
 
    Postprocessing:
      Writing graphical output: output-adiabatic_initial_conditions_subadiabaticity/solution-00000
-     Writing depth average     output-adiabatic_initial_conditions_subadiabaticity/depth_average.gnuplot
+     Writing depth average:    output-adiabatic_initial_conditions_subadiabaticity/depth_average.gnuplot
 
 Termination requested by criterion: end time
 

--- a/tests/depth_dependent_box_none_simple/screen-output
+++ b/tests/depth_dependent_box_none_simple/screen-output
@@ -11,7 +11,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
      RMS, max velocity:                  5.73e-12 m/year, 9.5e-12 m/year
      Temperature min/avg/max:            273 K, 1523 K, 2773 K
      Heat fluxes through boundary parts: -0.01859 W, 0.01859 W, -1e+04 W, 1e+04 W
-     Writing depth average               output-depth_dependent_box_none_simple/depth_average.gnuplot
+     Writing depth average:              output-depth_dependent_box_none_simple/depth_average.gnuplot
 
 *** Timestep 1:  t=1e+08 years
    Solving temperature system... 5 iterations.
@@ -21,7 +21,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
      RMS, max velocity:                  5.69e-12 m/year, 9.4e-12 m/year
      Temperature min/avg/max:            273 K, 1523 K, 2773 K
      Heat fluxes through boundary parts: -0.0192 W, 0.0192 W, -1e+04 W, 1e+04 W
-     Writing depth average               output-depth_dependent_box_none_simple/depth_average.gnuplot
+     Writing depth average:              output-depth_dependent_box_none_simple/depth_average.gnuplot
 
 Termination requested by criterion: end time
 

--- a/tests/diffusion/screen-output
+++ b/tests/diffusion/screen-output
@@ -17,7 +17,7 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
    Postprocessing:
      Temperature min/avg/max:            -6.784e-17 K, 0.005208 K, 1 K
      Heat fluxes through boundary parts: -4.762e-20 W, -8.314e-20 W, -4.288e-45 W, -9.6e-05 W
-     Writing depth average               output-diffusion/depth_average.gnuplot
+     Writing depth average:              output-diffusion/depth_average.gnuplot
 
 *** Timestep 1:  t=2.38851e+06 seconds
    Solving temperature system... 48 iterations.
@@ -26,7 +26,7 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
    Postprocessing:
      Temperature min/avg/max:            0 K, 0.04382 K, 1 K
      Heat fluxes through boundary parts: -7.3e-19 W, -1.375e-19 W, 5.093e-15 W, -2.137e-05 W
-     Writing depth average               output-diffusion/depth_average.gnuplot
+     Writing depth average:              output-diffusion/depth_average.gnuplot
 
 *** Timestep 2:  t=9.99233e+06 seconds
    Solving temperature system... 63 iterations.
@@ -35,7 +35,7 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
    Postprocessing:
      Temperature min/avg/max:            0 K, 0.103 K, 1 K
      Heat fluxes through boundary parts: -1.672e-16 W, 7.787e-16 W, 5.329e-12 W, -1.202e-06 W
-     Writing depth average               output-diffusion/depth_average.gnuplot
+     Writing depth average:              output-diffusion/depth_average.gnuplot
 
 *** Timestep 3:  t=2.75733e+07 seconds
    Solving temperature system... 93 iterations.
@@ -44,7 +44,7 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
    Postprocessing:
      Temperature min/avg/max:            0 K, 0.1734 K, 1 K
      Heat fluxes through boundary parts: -1.505e-16 W, -7.036e-16 W, 1.646e-09 W, -1.595e-06 W
-     Writing depth average               output-diffusion/depth_average.gnuplot
+     Writing depth average:              output-diffusion/depth_average.gnuplot
 
 *** Timestep 4:  t=4e+07 seconds
    Solving temperature system... 78 iterations.
@@ -53,7 +53,7 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
    Postprocessing:
      Temperature min/avg/max:            0 K, 0.2056 K, 1 K
      Heat fluxes through boundary parts: 7.09e-17 W, -3.934e-16 W, 6.823e-09 W, -2.496e-06 W
-     Writing depth average               output-diffusion/depth_average.gnuplot
+     Writing depth average:              output-diffusion/depth_average.gnuplot
 
 Termination requested by criterion: end time
 

--- a/tests/diffusion_dislocation_fixed_strain_rate/screen-output
+++ b/tests/diffusion_dislocation_fixed_strain_rate/screen-output
@@ -17,7 +17,7 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
    Postprocessing:
      RMS, max velocity:       0.577 m/year, 0.993 m/year
      Temperature min/avg/max: 1600 K, 1600 K, 1600 K
-     Writing depth average    output-diffusion_dislocation_fixed_strain_rate/depth_average.gnuplot
+     Writing depth average:   output-diffusion_dislocation_fixed_strain_rate/depth_average.gnuplot
 
 Termination requested by criterion: end step
 

--- a/tests/maximum_refinement_function/screen-output
+++ b/tests/maximum_refinement_function/screen-output
@@ -32,7 +32,7 @@ Number of degrees of freedom: 948 (578+81+289)
      RMS, max velocity:                  3.8e-06 m/year, 5.98e-06 m/year
      Temperature min/avg/max:            1623 K, 1743 K, 1873 K
      Heat fluxes through boundary parts: 2.378e-11 W, 7.927e-12 W, 2.14e-11 W, -4.601e-12 W
-     Writing depth average               output-maximum_refinement_function/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function/depth_average.gnuplot
 
 Number of active cells: 88 (on 5 levels)
 Number of degrees of freedom: 1,388 (850+113+425)
@@ -60,7 +60,7 @@ Number of degrees of freedom: 1,388 (850+113+425)
      RMS, max velocity:                  3.8e-06 m/year, 6.03e-06 m/year
      Temperature min/avg/max:            1623 K, 1745 K, 1873 K
      Heat fluxes through boundary parts: 9.059e-12 W, 6.794e-12 W, 4.45e-11 W, 1.13e-11 W
-     Writing depth average               output-maximum_refinement_function/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function/depth_average.gnuplot
 
 Number of active cells: 160 (on 6 levels)
 Number of degrees of freedom: 2,546 (1,562+203+781)
@@ -88,7 +88,7 @@ Number of degrees of freedom: 2,546 (1,562+203+781)
      RMS, max velocity:                  3.8e-06 m/year, 6.04e-06 m/year
      Temperature min/avg/max:            1623 K, 1746 K, 1904 K
      Heat fluxes through boundary parts: 9.059e-12 W, 6.794e-12 W, 1.687e-11 W, -3.686e-11 W
-     Writing depth average               output-maximum_refinement_function/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function/depth_average.gnuplot
 
 Number of active cells: 256 (on 7 levels)
 Number of degrees of freedom: 4,048 (2,486+319+1,243)
@@ -116,7 +116,7 @@ Number of degrees of freedom: 4,048 (2,486+319+1,243)
      RMS, max velocity:                  3.8e-06 m/year, 6.04e-06 m/year
      Temperature min/avg/max:            1623 K, 1747 K, 1904 K
      Heat fluxes through boundary parts: 9.059e-12 W, 6.794e-12 W, 1.687e-11 W, -1.028e-10 W
-     Writing depth average               output-maximum_refinement_function/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function/depth_average.gnuplot
 
 Number of active cells: 400 (on 8 levels)
 Number of degrees of freedom: 6,284 (3,862+491+1,931)
@@ -144,7 +144,7 @@ Number of degrees of freedom: 6,284 (3,862+491+1,931)
      RMS, max velocity:                  3.8e-06 m/year, 6.04e-06 m/year
      Temperature min/avg/max:            1623 K, 1747 K, 1904 K
      Heat fluxes through boundary parts: 9.059e-12 W, 6.794e-12 W, 1.687e-11 W, -1.028e-10 W
-     Writing depth average               output-maximum_refinement_function/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function/depth_average.gnuplot
 
 Number of active cells: 568 (on 9 levels)
 Number of degrees of freedom: 8,884 (5,462+691+2,731)
@@ -172,7 +172,7 @@ Number of degrees of freedom: 8,884 (5,462+691+2,731)
      RMS, max velocity:                  3.8e-06 m/year, 6.04e-06 m/year
      Temperature min/avg/max:            1623 K, 1747 K, 1904 K
      Heat fluxes through boundary parts: 9.059e-12 W, 6.794e-12 W, 1.687e-11 W, -1.028e-10 W
-     Writing depth average               output-maximum_refinement_function/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function/depth_average.gnuplot
 
 Number of active cells: 400 (on 8 levels)
 Number of degrees of freedom: 6,284 (3,862+491+1,931)

--- a/tests/maximum_refinement_function_cartesian/screen-output
+++ b/tests/maximum_refinement_function_cartesian/screen-output
@@ -32,7 +32,7 @@ Number of degrees of freedom: 948 (578+81+289)
      RMS, max velocity:                  3.8e-06 m/year, 5.98e-06 m/year
      Temperature min/avg/max:            1623 K, 1743 K, 1873 K
      Heat fluxes through boundary parts: 2.378e-11 W, 7.927e-12 W, 2.14e-11 W, -4.601e-12 W
-     Writing depth average               output-maximum_refinement_function_cartesian/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function_cartesian/depth_average.gnuplot
 
 Number of active cells: 88 (on 5 levels)
 Number of degrees of freedom: 1,388 (850+113+425)
@@ -60,7 +60,7 @@ Number of degrees of freedom: 1,388 (850+113+425)
      RMS, max velocity:                  3.8e-06 m/year, 6.03e-06 m/year
      Temperature min/avg/max:            1623 K, 1745 K, 1873 K
      Heat fluxes through boundary parts: 9.059e-12 W, 6.794e-12 W, 4.45e-11 W, 1.13e-11 W
-     Writing depth average               output-maximum_refinement_function_cartesian/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function_cartesian/depth_average.gnuplot
 
 Number of active cells: 184 (on 6 levels)
 Number of degrees of freedom: 2,858 (1,754+227+877)
@@ -88,7 +88,7 @@ Number of degrees of freedom: 2,858 (1,754+227+877)
      RMS, max velocity:                  3.8e-06 m/year, 6.04e-06 m/year
      Temperature min/avg/max:            1623 K, 1747 K, 1873 K
      Heat fluxes through boundary parts: 9.059e-12 W, 6.794e-12 W, 1.687e-11 W, -3.686e-11 W
-     Writing depth average               output-maximum_refinement_function_cartesian/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function_cartesian/depth_average.gnuplot
 
 Number of active cells: 304 (on 7 levels)
 Number of degrees of freedom: 4,900 (3,010+385+1,505)
@@ -116,7 +116,7 @@ Number of degrees of freedom: 4,900 (3,010+385+1,505)
      RMS, max velocity:                  3.8e-06 m/year, 6.04e-06 m/year
      Temperature min/avg/max:            1623 K, 1747 K, 1904 K
      Heat fluxes through boundary parts: 9.059e-12 W, 6.794e-12 W, 5.866e-11 W, -1.028e-10 W
-     Writing depth average               output-maximum_refinement_function_cartesian/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function_cartesian/depth_average.gnuplot
 
 Number of active cells: 232 (on 7 levels)
 Number of degrees of freedom: 3,704 (2,274+293+1,137)
@@ -144,7 +144,7 @@ Number of degrees of freedom: 3,704 (2,274+293+1,137)
      RMS, max velocity:                  3.8e-06 m/year, 6.04e-06 m/year
      Temperature min/avg/max:            1623 K, 1747 K, 1904 K
      Heat fluxes through boundary parts: 9.059e-12 W, 6.794e-12 W, 5.866e-11 W, -1.028e-10 W
-     Writing depth average               output-maximum_refinement_function_cartesian/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function_cartesian/depth_average.gnuplot
 
 Number of active cells: 256 (on 7 levels)
 Number of degrees of freedom: 4,158 (2,554+327+1,277)
@@ -172,7 +172,7 @@ Number of degrees of freedom: 4,158 (2,554+327+1,277)
      RMS, max velocity:                  3.8e-06 m/year, 6.04e-06 m/year
      Temperature min/avg/max:            1623 K, 1747 K, 1904 K
      Heat fluxes through boundary parts: 9.059e-12 W, 6.794e-12 W, 1.687e-11 W, -3.686e-11 W
-     Writing depth average               output-maximum_refinement_function_cartesian/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function_cartesian/depth_average.gnuplot
 
 Number of active cells: 184 (on 6 levels)
 Number of degrees of freedom: 2,858 (1,754+227+877)

--- a/tests/maximum_refinement_function_spherical/screen-output
+++ b/tests/maximum_refinement_function_spherical/screen-output
@@ -32,7 +32,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  8.28e-07 m/year, 1.47e-06 m/year
      Temperature min/avg/max:            1400 K, 1627 K, 1800 K
      Heat fluxes through boundary parts: 998.6 W, 1953 W, 2479 W, 2479 W
-     Writing depth average               output-maximum_refinement_function_spherical/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function_spherical/depth_average.gnuplot
 
 Number of active cells: 414 (on 5 levels)
 Number of degrees of freedom: 6,181 (3,790+496+1,895)
@@ -60,7 +60,7 @@ Number of degrees of freedom: 6,181 (3,790+496+1,895)
      RMS, max velocity:                  8.28e-07 m/year, 1.47e-06 m/year
      Temperature min/avg/max:            1400 K, 1627 K, 1800 K
      Heat fluxes through boundary parts: 1002 W, 1955 W, 2463 W, 2463 W
-     Writing depth average               output-maximum_refinement_function_spherical/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function_spherical/depth_average.gnuplot
 
 Number of active cells: 894 (on 6 levels)
 Number of degrees of freedom: 12,734 (7,814+1,013+3,907)
@@ -88,7 +88,7 @@ Number of degrees of freedom: 12,734 (7,814+1,013+3,907)
      RMS, max velocity:                  8.17e-07 m/year, 1.45e-06 m/year
      Temperature min/avg/max:            1400 K, 1627 K, 1800 K
      Heat fluxes through boundary parts: 984.1 W, 1956 W, 2452 W, 2452 W
-     Writing depth average               output-maximum_refinement_function_spherical/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function_spherical/depth_average.gnuplot
 
 Number of active cells: 1,557 (on 6 levels)
 Number of degrees of freedom: 22,397 (13,758+1,760+6,879)
@@ -116,7 +116,7 @@ Number of degrees of freedom: 22,397 (13,758+1,760+6,879)
      RMS, max velocity:                  8.26e-07 m/year, 1.47e-06 m/year
      Temperature min/avg/max:            1400 K, 1627 K, 1800 K
      Heat fluxes through boundary parts: 986.3 W, 1958 W, 2453 W, 2453 W
-     Writing depth average               output-maximum_refinement_function_spherical/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function_spherical/depth_average.gnuplot
 
 Number of active cells: 2,682 (on 7 levels)
 Number of degrees of freedom: 37,687 (23,154+2,956+11,577)
@@ -144,7 +144,7 @@ Number of degrees of freedom: 37,687 (23,154+2,956+11,577)
      RMS, max velocity:                  8.28e-07 m/year, 1.47e-06 m/year
      Temperature min/avg/max:            1400 K, 1627 K, 1800 K
      Heat fluxes through boundary parts: 987.8 W, 1961 W, 2449 W, 2449 W
-     Writing depth average               output-maximum_refinement_function_spherical/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function_spherical/depth_average.gnuplot
 
 Number of active cells: 4,098 (on 7 levels)
 Number of degrees of freedom: 57,495 (35,338+4,488+17,669)
@@ -172,7 +172,7 @@ Number of degrees of freedom: 57,495 (35,338+4,488+17,669)
      RMS, max velocity:                  8.28e-07 m/year, 1.47e-06 m/year
      Temperature min/avg/max:            1400 K, 1627 K, 1800 K
      Heat fluxes through boundary parts: 986.4 W, 1962 W, 2448 W, 2448 W
-     Writing depth average               output-maximum_refinement_function_spherical/depth_average.gnuplot
+     Writing depth average:              output-maximum_refinement_function_spherical/depth_average.gnuplot
 
 Number of active cells: 5,277 (on 7 levels)
 Number of degrees of freedom: 74,477 (45,778+5,810+22,889)

--- a/tests/minimum_refinement_function/screen-output
+++ b/tests/minimum_refinement_function/screen-output
@@ -32,7 +32,7 @@ Number of degrees of freedom: 948 (578+81+289)
      RMS, max velocity:                  3.8e-06 m/year, 5.98e-06 m/year
      Temperature min/avg/max:            1623 K, 1743 K, 1873 K
      Heat fluxes through boundary parts: 2.378e-11 W, 7.927e-12 W, 2.14e-11 W, -4.601e-12 W
-     Writing depth average               output-minimum_refinement_function/depth_average.gnuplot
+     Writing depth average:              output-minimum_refinement_function/depth_average.gnuplot
 
 Number of active cells: 214 (on 5 levels)
 Number of degrees of freedom: 3,113 (1,906+254+953)
@@ -60,7 +60,7 @@ Number of degrees of freedom: 3,113 (1,906+254+953)
      RMS, max velocity:                  3.8e-06 m/year, 6.03e-06 m/year
      Temperature min/avg/max:            1623 K, 1745 K, 1873 K
      Heat fluxes through boundary parts: 2.661e-11 W, 2.038e-12 W, 6.228e-11 W, 1.073e-11 W
-     Writing depth average               output-minimum_refinement_function/depth_average.gnuplot
+     Writing depth average:              output-minimum_refinement_function/depth_average.gnuplot
 
 Number of active cells: 604 (on 6 levels)
 Number of degrees of freedom: 8,386 (5,146+667+2,573)
@@ -88,7 +88,7 @@ Number of degrees of freedom: 8,386 (5,146+667+2,573)
      RMS, max velocity:                  3.8e-06 m/year, 6.04e-06 m/year
      Temperature min/avg/max:            1623 K, 1746 K, 1904 K
      Heat fluxes through boundary parts: 4.246e-11 W, 1.914e-11 W, 6.228e-11 W, -1.818e-11 W
-     Writing depth average               output-minimum_refinement_function/depth_average.gnuplot
+     Writing depth average:              output-minimum_refinement_function/depth_average.gnuplot
 
 Number of active cells: 1,375 (on 7 levels)
 Number of degrees of freedom: 18,894 (11,610+1,479+5,805)
@@ -116,7 +116,7 @@ Number of degrees of freedom: 18,894 (11,610+1,479+5,805)
      RMS, max velocity:                  3.8e-06 m/year, 6.04e-06 m/year
      Temperature min/avg/max:            1623 K, 1746 K, 1904 K
      Heat fluxes through boundary parts: 6.228e-11 W, 3.057e-12 W, 6.228e-11 W, -1.818e-11 W
-     Writing depth average               output-minimum_refinement_function/depth_average.gnuplot
+     Writing depth average:              output-minimum_refinement_function/depth_average.gnuplot
 
 Number of active cells: 1,387 (on 7 levels)
 Number of degrees of freedom: 19,089 (11,730+1,494+5,865)

--- a/tests/minimum_refinement_function_cartesian/screen-output
+++ b/tests/minimum_refinement_function_cartesian/screen-output
@@ -32,7 +32,7 @@ Number of degrees of freedom: 948 (578+81+289)
      RMS, max velocity:                  3.8e-06 m/year, 5.98e-06 m/year
      Temperature min/avg/max:            1623 K, 1743 K, 1873 K
      Heat fluxes through boundary parts: 2.378e-11 W, 7.927e-12 W, 2.14e-11 W, -4.601e-12 W
-     Writing depth average               output-minimum_refinement_function_cartesian/depth_average.gnuplot
+     Writing depth average:              output-minimum_refinement_function_cartesian/depth_average.gnuplot
 
 Number of active cells: 232 (on 5 levels)
 Number of degrees of freedom: 3,348 (2,050+273+1,025)
@@ -60,7 +60,7 @@ Number of degrees of freedom: 3,348 (2,050+273+1,025)
      RMS, max velocity:                  3.8e-06 m/year, 6.03e-06 m/year
      Temperature min/avg/max:            1623 K, 1745 K, 1873 K
      Heat fluxes through boundary parts: 3.68e-11 W, -2.265e-13 W, 6.228e-11 W, 1.073e-11 W
-     Writing depth average               output-minimum_refinement_function_cartesian/depth_average.gnuplot
+     Writing depth average:              output-minimum_refinement_function_cartesian/depth_average.gnuplot
 
 Number of active cells: 640 (on 6 levels)
 Number of degrees of freedom: 8,969 (5,504+713+2,752)
@@ -88,7 +88,7 @@ Number of degrees of freedom: 8,969 (5,504+713+2,752)
      RMS, max velocity:                  3.8e-06 m/year, 6.04e-06 m/year
      Temperature min/avg/max:            1623 K, 1747 K, 1873 K
      Heat fluxes through boundary parts: 4.983e-11 W, 1.687e-11 W, 5.209e-11 W, -2.837e-11 W
-     Writing depth average               output-minimum_refinement_function_cartesian/depth_average.gnuplot
+     Writing depth average:              output-minimum_refinement_function_cartesian/depth_average.gnuplot
 
 Number of active cells: 1,018 (on 7 levels)
 Number of degrees of freedom: 14,302 (8,786+1,123+4,393)
@@ -116,7 +116,7 @@ Number of degrees of freedom: 14,302 (8,786+1,123+4,393)
      RMS, max velocity:                  3.8e-06 m/year, 6.04e-06 m/year
      Temperature min/avg/max:            1623 K, 1747 K, 1873 K
      Heat fluxes through boundary parts: 5.209e-11 W, 1.982e-11 W, 5.039e-11 W, -2.837e-11 W
-     Writing depth average               output-minimum_refinement_function_cartesian/depth_average.gnuplot
+     Writing depth average:              output-minimum_refinement_function_cartesian/depth_average.gnuplot
 
 Number of active cells: 1,024 (on 7 levels)
 Number of degrees of freedom: 14,374 (8,830+1,129+4,415)

--- a/tests/minimum_refinement_function_spherical/screen-output
+++ b/tests/minimum_refinement_function_spherical/screen-output
@@ -32,7 +32,7 @@ Number of degrees of freedom: 740 (450+65+225)
      RMS, max velocity:                  8.27e-07 m/year, 1.47e-06 m/year
      Temperature min/avg/max:            1400 K, 1627 K, 1800 K
      Heat fluxes through boundary parts: 1037 W, 1978 W, 2572 W, 2572 W
-     Writing depth average               output-minimum_refinement_function_spherical/depth_average.gnuplot
+     Writing depth average:              output-minimum_refinement_function_spherical/depth_average.gnuplot
 
 Number of active cells: 144 (on 4 levels)
 Number of degrees of freedom: 2,124 (1,298+177+649)
@@ -60,7 +60,7 @@ Number of degrees of freedom: 2,124 (1,298+177+649)
      RMS, max velocity:                  6.23e-07 m/year, 1.16e-06 m/year
      Temperature min/avg/max:            1400 K, 1627 K, 1800 K
      Heat fluxes through boundary parts: 960.2 W, 1927 W, 2479 W, 2479 W
-     Writing depth average               output-minimum_refinement_function_spherical/depth_average.gnuplot
+     Writing depth average:              output-minimum_refinement_function_spherical/depth_average.gnuplot
 
 Number of active cells: 357 (on 5 levels)
 Number of degrees of freedom: 5,205 (3,194+414+1,597)
@@ -88,7 +88,7 @@ Number of degrees of freedom: 5,205 (3,194+414+1,597)
      RMS, max velocity:                  6.23e-07 m/year, 1.16e-06 m/year
      Temperature min/avg/max:            1400 K, 1627 K, 1800 K
      Heat fluxes through boundary parts: 960.2 W, 1927 W, 2479 W, 2479 W
-     Writing depth average               output-minimum_refinement_function_spherical/depth_average.gnuplot
+     Writing depth average:              output-minimum_refinement_function_spherical/depth_average.gnuplot
 
 Number of active cells: 573 (on 6 levels)
 Number of degrees of freedom: 8,325 (5,114+654+2,557)
@@ -116,7 +116,7 @@ Number of degrees of freedom: 8,325 (5,114+654+2,557)
      RMS, max velocity:                  6.23e-07 m/year, 1.16e-06 m/year
      Temperature min/avg/max:            1400 K, 1627 K, 1800 K
      Heat fluxes through boundary parts: 960.2 W, 1927 W, 2479 W, 2479 W
-     Writing depth average               output-minimum_refinement_function_spherical/depth_average.gnuplot
+     Writing depth average:              output-minimum_refinement_function_spherical/depth_average.gnuplot
 
 Number of active cells: 573 (on 6 levels)
 Number of degrees of freedom: 8,325 (5,114+654+2,557)

--- a/tests/morency_doin/screen-output
+++ b/tests/morency_doin/screen-output
@@ -17,7 +17,7 @@ Number of degrees of freedom: 22,214 (8,450+1,089+4,225+4,225+4,225)
    Solving Stokes system... 30+23 iterations.
 
    Postprocessing:
-     Writing depth average output-morency_doin/depth_average.gnuplot
+     Writing depth average:output-morency_doin/depth_average.gnuplot
 
 Termination requested by criterion: end step
 

--- a/tests/no_adiabatic_heating_03/screen-output
+++ b/tests/no_adiabatic_heating_03/screen-output
@@ -49,7 +49,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
      Temperature min/avg/max: 0 K, 0 K, 0 K
      RMS, max velocity:       1.05 m/s, 1.1 m/s
-     Writing depth average    output-no_adiabatic_heating_03/depth_average.gnuplot
+     Writing depth average:   output-no_adiabatic_heating_03/depth_average.gnuplot
 
 *** Timestep 1:  t=0.0284091 seconds
    Solving temperature system... 17 iterations.

--- a/tests/passive_comp/screen-output
+++ b/tests/passive_comp/screen-output
@@ -33,7 +33,7 @@ Number of degrees of freedom: 13,920 (6,528+864+3,264+3,264)
      RMS, max velocity:                  5.11e-08 m/s, 6.29e-08 m/s
      Temperature min/avg/max:            0 K, 0 K, 0 K
      Heat fluxes through boundary parts: 0 W, 0 W
-     Writing depth average               output-passive_comp/depth_average.gnuplot
+     Writing depth average:              output-passive_comp/depth_average.gnuplot
 
 *** Timestep 1:  t=2.81625e+12 seconds
    Solving temperature system... 18 iterations.
@@ -46,7 +46,7 @@ Number of degrees of freedom: 13,920 (6,528+864+3,264+3,264)
      RMS, max velocity:                  5.11e-08 m/s, 6.29e-08 m/s
      Temperature min/avg/max:            0 K, 0.0003907 K, 0.002625 K
      Heat fluxes through boundary parts: -0.2152 W, 0.07768 W
-     Writing depth average               output-passive_comp/depth_average.gnuplot
+     Writing depth average:              output-passive_comp/depth_average.gnuplot
 
 *** Timestep 2:  t=5.6325e+12 seconds
    Solving temperature system... 12 iterations.
@@ -59,7 +59,7 @@ Number of degrees of freedom: 13,920 (6,528+864+3,264+3,264)
      RMS, max velocity:                  5.11e-08 m/s, 6.29e-08 m/s
      Temperature min/avg/max:            0 K, 0.0007814 K, 0.004368 K
      Heat fluxes through boundary parts: 0.08938 W, 0.2083 W
-     Writing depth average               output-passive_comp/depth_average.gnuplot
+     Writing depth average:              output-passive_comp/depth_average.gnuplot
 
 *** Timestep 3:  t=8e+12 seconds
    Solving temperature system... 11 iterations.
@@ -72,7 +72,7 @@ Number of degrees of freedom: 13,920 (6,528+864+3,264+3,264)
      RMS, max velocity:                  5.11e-08 m/s, 6.29e-08 m/s
      Temperature min/avg/max:            0 K, 0.001107 K, 0.005515 K
      Heat fluxes through boundary parts: 0.5138 W, 0.3178 W
-     Writing depth average               output-passive_comp/depth_average.gnuplot
+     Writing depth average:              output-passive_comp/depth_average.gnuplot
 
 Termination requested by criterion: end time
 

--- a/tests/petsc_refinement/screen-output
+++ b/tests/petsc_refinement/screen-output
@@ -25,7 +25,7 @@ Number of degrees of freedom: 8,170 (3,832+506+1,916+1,916)
    Solving Stokes system... 18 iterations.
 
    Postprocessing:
-     Writing depth average     output-petsc_refinement/depth_average.gnuplot
+     Writing depth average:    output-petsc_refinement/depth_average.gnuplot
      Writing graphical output: output-petsc_refinement/solution-00000
 
 Termination requested by criterion: end time

--- a/tests/refine_vel/screen-output
+++ b/tests/refine_vel/screen-output
@@ -32,7 +32,7 @@ Number of degrees of freedom: 10,436 (6,402+833+3,201)
      RMS, max velocity:                  1.2e-09 m/s, 3.64e-09 m/s
      Temperature min/avg/max:            0 K, 100.4 K, 1613 K
      Heat fluxes through boundary parts: -0.1197 W, -0.2657 W, -1.004e-07 W, -1.004e-07 W
-     Writing depth average               output-refine_vel/depth_average.gnuplot
+     Writing depth average:              output-refine_vel/depth_average.gnuplot
 
 Number of active cells: 822 (on 6 levels)
 Number of degrees of freedom: 11,412 (7,002+909+3,501)
@@ -50,7 +50,7 @@ Number of degrees of freedom: 12,427 (7,624+991+3,812)
      RMS, max velocity:                  1.26e-09 m/s, 3.74e-09 m/s
      Temperature min/avg/max:            -200.3 K, 101.8 K, 1613 K
      Heat fluxes through boundary parts: -0.117 W, -0.2643 W, -1.326e-06 W, -8.533e-06 W
-     Writing depth average               output-refine_vel/depth_average.gnuplot
+     Writing depth average:              output-refine_vel/depth_average.gnuplot
 
 *** Timestep 2:  t=2.33241e+13 seconds
    Solving temperature system... 12 iterations.
@@ -61,7 +61,7 @@ Number of degrees of freedom: 12,427 (7,624+991+3,812)
      RMS, max velocity:                  1.29e-09 m/s, 3.79e-09 m/s
      Temperature min/avg/max:            -199 K, 102.8 K, 1613 K
      Heat fluxes through boundary parts: -0.1147 W, -0.2627 W, -2.308e-06 W, -1.453e-05 W
-     Writing depth average               output-refine_vel/depth_average.gnuplot
+     Writing depth average:              output-refine_vel/depth_average.gnuplot
 
 Number of active cells: 951 (on 6 levels)
 Number of degrees of freedom: 13,447 (8,250+1,072+4,125)
@@ -76,7 +76,7 @@ Number of degrees of freedom: 13,447 (8,250+1,072+4,125)
      RMS, max velocity:                  1.32e-09 m/s, 3.83e-09 m/s
      Temperature min/avg/max:            -197.8 K, 103.7 K, 1613 K
      Heat fluxes through boundary parts: -0.1126 W, -0.2615 W, -3.359e-06 W, -1.902e-05 W
-     Writing depth average               output-refine_vel/depth_average.gnuplot
+     Writing depth average:              output-refine_vel/depth_average.gnuplot
 
 *** Timestep 4:  t=3.8364e+13 seconds
    Solving temperature system... 12 iterations.
@@ -87,7 +87,7 @@ Number of degrees of freedom: 13,447 (8,250+1,072+4,125)
      RMS, max velocity:                  1.35e-09 m/s, 3.87e-09 m/s
      Temperature min/avg/max:            -197 K, 104.7 K, 1613 K
      Heat fluxes through boundary parts: -0.1105 W, -0.26 W, -4.416e-06 W, -2.285e-05 W
-     Writing depth average               output-refine_vel/depth_average.gnuplot
+     Writing depth average:              output-refine_vel/depth_average.gnuplot
 
 Number of active cells: 1,029 (on 6 levels)
 Number of degrees of freedom: 14,588 (8,950+1,163+4,475)
@@ -102,7 +102,7 @@ Number of degrees of freedom: 14,588 (8,950+1,163+4,475)
      RMS, max velocity:                  1.38e-09 m/s, 3.92e-09 m/s
      Temperature min/avg/max:            -197.5 K, 105.6 K, 1613 K
      Heat fluxes through boundary parts: -0.1086 W, -0.259 W, -5.462e-06 W, -3.318e-05 W
-     Writing depth average               output-refine_vel/depth_average.gnuplot
+     Writing depth average:              output-refine_vel/depth_average.gnuplot
 
 *** Timestep 6:  t=5.32369e+13 seconds
    Solving temperature system... 12 iterations.
@@ -113,7 +113,7 @@ Number of degrees of freedom: 14,588 (8,950+1,163+4,475)
      RMS, max velocity:                  1.41e-09 m/s, 3.95e-09 m/s
      Temperature min/avg/max:            -197 K, 106.5 K, 1613 K
      Heat fluxes through boundary parts: -0.1069 W, -0.2578 W, -6.491e-06 W, -3.627e-05 W
-     Writing depth average               output-refine_vel/depth_average.gnuplot
+     Writing depth average:              output-refine_vel/depth_average.gnuplot
 
 Number of active cells: 1,107 (on 6 levels)
 Number of degrees of freedom: 15,677 (9,618+1,250+4,809)
@@ -128,7 +128,7 @@ Number of degrees of freedom: 15,677 (9,618+1,250+4,809)
      RMS, max velocity:                  1.44e-09 m/s, 3.99e-09 m/s
      Temperature min/avg/max:            -201.8 K, 107.3 K, 1613 K
      Heat fluxes through boundary parts: -0.1054 W, -0.2569 W, -1.387e-05 W, -3.892e-05 W
-     Writing depth average               output-refine_vel/depth_average.gnuplot
+     Writing depth average:              output-refine_vel/depth_average.gnuplot
 
 *** Timestep 8:  t=6.7723e+13 seconds
    Solving temperature system... 12 iterations.
@@ -139,7 +139,7 @@ Number of degrees of freedom: 15,677 (9,618+1,250+4,809)
      RMS, max velocity:                  1.46e-09 m/s, 4.02e-09 m/s
      Temperature min/avg/max:            -201.6 K, 108.1 K, 1613 K
      Heat fluxes through boundary parts: -0.1041 W, -0.2558 W, -1.467e-05 W, -4.111e-05 W
-     Writing depth average               output-refine_vel/depth_average.gnuplot
+     Writing depth average:              output-refine_vel/depth_average.gnuplot
 
 Number of active cells: 1,206 (on 6 levels)
 Number of degrees of freedom: 17,133 (10,512+1,365+5,256)
@@ -154,7 +154,7 @@ Number of degrees of freedom: 17,133 (10,512+1,365+5,256)
      RMS, max velocity:                  1.49e-09 m/s, 4.06e-09 m/s
      Temperature min/avg/max:            -201.5 K, 108.7 K, 1613 K
      Heat fluxes through boundary parts: -0.1032 W, -0.2549 W, -1.546e-05 W, -4.292e-05 W
-     Writing depth average               output-refine_vel/depth_average.gnuplot
+     Writing depth average:              output-refine_vel/depth_average.gnuplot
 
 *** Timestep 10:  t=8.1819e+13 seconds
    Solving temperature system... 13 iterations.
@@ -165,7 +165,7 @@ Number of degrees of freedom: 17,133 (10,512+1,365+5,256)
      RMS, max velocity:                  1.52e-09 m/s, 4.09e-09 m/s
      Temperature min/avg/max:            -201.4 K, 109.3 K, 1613 K
      Heat fluxes through boundary parts: -0.1027 W, -0.254 W, -1.623e-05 W, -4.449e-05 W
-     Writing depth average               output-refine_vel/depth_average.gnuplot
+     Writing depth average:              output-refine_vel/depth_average.gnuplot
 
 Number of active cells: 1,320 (on 6 levels)
 Number of degrees of freedom: 18,709 (11,480+1,489+5,740)

--- a/tests/simple_compressible/screen-output
+++ b/tests/simple_compressible/screen-output
@@ -12,7 +12,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  0.582 m/year, 1.12 m/year
      Temperature min/avg/max:            273 K, 2253 K, 4250 K
      Heat fluxes through boundary parts: -2.351e+05 W, 5.296e+05 W, 1969 W, 1969 W
-     Writing depth average               output-simple_compressible/depth_average.gnuplot
+     Writing depth average:              output-simple_compressible/depth_average.gnuplot
 
 *** Timestep 1:  t=100000 years
    Solving temperature system... 12 iterations.
@@ -23,7 +23,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  0.575 m/year, 1.11 m/year
      Temperature min/avg/max:            273 K, 2251 K, 4250 K
      Heat fluxes through boundary parts: -2.228e+05 W, 5.057e+05 W, 1749 W, 1749 W
-     Writing depth average               output-simple_compressible/depth_average.gnuplot
+     Writing depth average:              output-simple_compressible/depth_average.gnuplot
 
 Termination requested by criterion: end time
 

--- a/tests/simple_incompressible/screen-output
+++ b/tests/simple_incompressible/screen-output
@@ -25,7 +25,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  0.507 m/year, 0.971 m/year
      Temperature min/avg/max:            273 K, 1629 K, 4250 K
      Heat fluxes through boundary parts: -5.703e+05 W, 5.112e+05 W, 1868 W, 1868 W
-     Writing depth average               output-simple_incompressible/depth_average.gnuplot
+     Writing depth average:              output-simple_incompressible/depth_average.gnuplot
 
 *** Timestep 1:  t=100000 years
    Solving temperature system... 11 iterations.
@@ -36,7 +36,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  0.506 m/year, 0.973 m/year
      Temperature min/avg/max:            273 K, 1631 K, 4250 K
      Heat fluxes through boundary parts: -5.395e+05 W, 4.901e+05 W, 1620 W, 1620 W
-     Writing depth average               output-simple_incompressible/depth_average.gnuplot
+     Writing depth average:              output-simple_incompressible/depth_average.gnuplot
 
 Termination requested by criterion: end time
 

--- a/tests/solidus_initial_conditions/screen-output
+++ b/tests/solidus_initial_conditions/screen-output
@@ -9,7 +9,7 @@ Number of degrees of freedom: 10,656 (6,528+864+3,264)
 
    Postprocessing:
      Temperature min/avg/max: 250 K, 1589 K, 2255 K
-     Writing depth average    output-solidus_initial_conditions/depth_average.gnuplot
+     Writing depth average:   output-solidus_initial_conditions/depth_average.gnuplot
 
 *** Timestep 1:  t=1.5e-09 years
    Solving temperature system... 0 iterations.

--- a/tests/spherical_velocity_statistics/screen-output
+++ b/tests/spherical_velocity_statistics/screen-output
@@ -32,7 +32,7 @@ Number of degrees of freedom: 10,436 (6,402+833+3,201)
      RMS, max velocity:                              1.2e-09 m/s, 3.64e-09 m/s
      Temperature min/avg/max:                        0 K, 100.4 K, 1613 K
      Heat fluxes through boundary parts:             -0.1197 W, -0.2657 W, -1.004e-07 W, -1.004e-07 W
-     Writing depth average                           output-spherical_velocity_statistics/depth_average.gnuplot
+     Writing depth average:                          output-spherical_velocity_statistics/depth_average.gnuplot
      Radial RMS, tangential RMS, total RMS velocity: 8.06e-10 m/s, 8.91e-10 m/s, 1.2e-09 m/s
 
 Number of active cells: 822 (on 6 levels)
@@ -51,7 +51,7 @@ Number of degrees of freedom: 12,427 (7,624+991+3,812)
      RMS, max velocity:                              1.26e-09 m/s, 3.74e-09 m/s
      Temperature min/avg/max:                        -200.3 K, 101.8 K, 1613 K
      Heat fluxes through boundary parts:             -0.117 W, -0.2643 W, -1.326e-06 W, -8.533e-06 W
-     Writing depth average                           output-spherical_velocity_statistics/depth_average.gnuplot
+     Writing depth average:                          output-spherical_velocity_statistics/depth_average.gnuplot
      Radial RMS, tangential RMS, total RMS velocity: 8.5e-10 m/s, 9.28e-10 m/s, 1.26e-09 m/s
 
 *** Timestep 2:  t=2.33241e+13 seconds
@@ -63,7 +63,7 @@ Number of degrees of freedom: 12,427 (7,624+991+3,812)
      RMS, max velocity:                              1.29e-09 m/s, 3.79e-09 m/s
      Temperature min/avg/max:                        -199 K, 102.8 K, 1613 K
      Heat fluxes through boundary parts:             -0.1147 W, -0.2627 W, -2.308e-06 W, -1.453e-05 W
-     Writing depth average                           output-spherical_velocity_statistics/depth_average.gnuplot
+     Writing depth average:                          output-spherical_velocity_statistics/depth_average.gnuplot
      Radial RMS, tangential RMS, total RMS velocity: 8.73e-10 m/s, 9.47e-10 m/s, 1.29e-09 m/s
 
 Number of active cells: 951 (on 6 levels)
@@ -79,7 +79,7 @@ Number of degrees of freedom: 13,447 (8,250+1,072+4,125)
      RMS, max velocity:                              1.32e-09 m/s, 3.83e-09 m/s
      Temperature min/avg/max:                        -197.8 K, 103.7 K, 1613 K
      Heat fluxes through boundary parts:             -0.1126 W, -0.2615 W, -3.359e-06 W, -1.902e-05 W
-     Writing depth average                           output-spherical_velocity_statistics/depth_average.gnuplot
+     Writing depth average:                          output-spherical_velocity_statistics/depth_average.gnuplot
      Radial RMS, tangential RMS, total RMS velocity: 8.96e-10 m/s, 9.66e-10 m/s, 1.32e-09 m/s
 
 *** Timestep 4:  t=3.8364e+13 seconds
@@ -91,7 +91,7 @@ Number of degrees of freedom: 13,447 (8,250+1,072+4,125)
      RMS, max velocity:                              1.35e-09 m/s, 3.87e-09 m/s
      Temperature min/avg/max:                        -197 K, 104.7 K, 1613 K
      Heat fluxes through boundary parts:             -0.1105 W, -0.26 W, -4.416e-06 W, -2.285e-05 W
-     Writing depth average                           output-spherical_velocity_statistics/depth_average.gnuplot
+     Writing depth average:                          output-spherical_velocity_statistics/depth_average.gnuplot
      Radial RMS, tangential RMS, total RMS velocity: 9.19e-10 m/s, 9.84e-10 m/s, 1.35e-09 m/s
 
 Number of active cells: 1,029 (on 6 levels)
@@ -107,7 +107,7 @@ Number of degrees of freedom: 14,588 (8,950+1,163+4,475)
      RMS, max velocity:                              1.38e-09 m/s, 3.92e-09 m/s
      Temperature min/avg/max:                        -197.5 K, 105.6 K, 1613 K
      Heat fluxes through boundary parts:             -0.1086 W, -0.259 W, -5.462e-06 W, -3.318e-05 W
-     Writing depth average                           output-spherical_velocity_statistics/depth_average.gnuplot
+     Writing depth average:                          output-spherical_velocity_statistics/depth_average.gnuplot
      Radial RMS, tangential RMS, total RMS velocity: 9.42e-10 m/s, 1e-09 m/s, 1.38e-09 m/s
 
 *** Timestep 6:  t=5.32369e+13 seconds
@@ -119,7 +119,7 @@ Number of degrees of freedom: 14,588 (8,950+1,163+4,475)
      RMS, max velocity:                              1.41e-09 m/s, 3.95e-09 m/s
      Temperature min/avg/max:                        -197 K, 106.5 K, 1613 K
      Heat fluxes through boundary parts:             -0.1069 W, -0.2578 W, -6.491e-06 W, -3.627e-05 W
-     Writing depth average                           output-spherical_velocity_statistics/depth_average.gnuplot
+     Writing depth average:                          output-spherical_velocity_statistics/depth_average.gnuplot
      Radial RMS, tangential RMS, total RMS velocity: 9.66e-10 m/s, 1.02e-09 m/s, 1.41e-09 m/s
 
 Number of active cells: 1,107 (on 6 levels)
@@ -135,7 +135,7 @@ Number of degrees of freedom: 15,677 (9,618+1,250+4,809)
      RMS, max velocity:                              1.44e-09 m/s, 3.99e-09 m/s
      Temperature min/avg/max:                        -201.8 K, 107.3 K, 1613 K
      Heat fluxes through boundary parts:             -0.1054 W, -0.2569 W, -1.387e-05 W, -3.892e-05 W
-     Writing depth average                           output-spherical_velocity_statistics/depth_average.gnuplot
+     Writing depth average:                          output-spherical_velocity_statistics/depth_average.gnuplot
      Radial RMS, tangential RMS, total RMS velocity: 9.89e-10 m/s, 1.04e-09 m/s, 1.44e-09 m/s
 
 *** Timestep 8:  t=6.7723e+13 seconds
@@ -147,7 +147,7 @@ Number of degrees of freedom: 15,677 (9,618+1,250+4,809)
      RMS, max velocity:                              1.46e-09 m/s, 4.02e-09 m/s
      Temperature min/avg/max:                        -201.6 K, 108.1 K, 1613 K
      Heat fluxes through boundary parts:             -0.1041 W, -0.2558 W, -1.467e-05 W, -4.111e-05 W
-     Writing depth average                           output-spherical_velocity_statistics/depth_average.gnuplot
+     Writing depth average:                          output-spherical_velocity_statistics/depth_average.gnuplot
      Radial RMS, tangential RMS, total RMS velocity: 1.01e-09 m/s, 1.06e-09 m/s, 1.46e-09 m/s
 
 Number of active cells: 1,206 (on 6 levels)
@@ -163,7 +163,7 @@ Number of degrees of freedom: 17,133 (10,512+1,365+5,256)
      RMS, max velocity:                              1.49e-09 m/s, 4.06e-09 m/s
      Temperature min/avg/max:                        -201.5 K, 108.7 K, 1613 K
      Heat fluxes through boundary parts:             -0.1032 W, -0.2549 W, -1.546e-05 W, -4.292e-05 W
-     Writing depth average                           output-spherical_velocity_statistics/depth_average.gnuplot
+     Writing depth average:                          output-spherical_velocity_statistics/depth_average.gnuplot
      Radial RMS, tangential RMS, total RMS velocity: 1.04e-09 m/s, 1.08e-09 m/s, 1.49e-09 m/s
 
 *** Timestep 10:  t=8.1819e+13 seconds
@@ -175,7 +175,7 @@ Number of degrees of freedom: 17,133 (10,512+1,365+5,256)
      RMS, max velocity:                              1.52e-09 m/s, 4.09e-09 m/s
      Temperature min/avg/max:                        -201.4 K, 109.3 K, 1613 K
      Heat fluxes through boundary parts:             -0.1027 W, -0.254 W, -1.623e-05 W, -4.449e-05 W
-     Writing depth average                           output-spherical_velocity_statistics/depth_average.gnuplot
+     Writing depth average:                          output-spherical_velocity_statistics/depth_average.gnuplot
      Radial RMS, tangential RMS, total RMS velocity: 1.06e-09 m/s, 1.09e-09 m/s, 1.52e-09 m/s
 
 Number of active cells: 1,320 (on 6 levels)

--- a/tests/steinberger_compressible/screen-output
+++ b/tests/steinberger_compressible/screen-output
@@ -12,7 +12,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  0.582 m/year, 1.12 m/year
      Temperature min/avg/max:            273 K, 2253 K, 4250 K
      Heat fluxes through boundary parts: -2.351e+05 W, 5.296e+05 W, 1969 W, 1969 W
-     Writing depth average               output-steinberger_compressible/depth_average.gnuplot
+     Writing depth average:              output-steinberger_compressible/depth_average.gnuplot
 
 *** Timestep 1:  t=100000 years
    Solving temperature system... 12 iterations.
@@ -24,7 +24,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  0.575 m/year, 1.11 m/year
      Temperature min/avg/max:            273 K, 2251 K, 4250 K
      Heat fluxes through boundary parts: -2.228e+05 W, 5.057e+05 W, 1750 W, 1750 W
-     Writing depth average               output-steinberger_compressible/depth_average.gnuplot
+     Writing depth average:              output-steinberger_compressible/depth_average.gnuplot
 
 Termination requested by criterion: end time
 

--- a/tests/steinberger_incompressible/screen-output
+++ b/tests/steinberger_incompressible/screen-output
@@ -12,7 +12,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  0.507 m/year, 0.97 m/year
      Temperature min/avg/max:            273 K, 1629 K, 4250 K
      Heat fluxes through boundary parts: -5.703e+05 W, 5.112e+05 W, 1868 W, 1868 W
-     Writing depth average               output-steinberger_incompressible/depth_average.gnuplot
+     Writing depth average:              output-steinberger_incompressible/depth_average.gnuplot
 
 *** Timestep 1:  t=100000 years
    Solving temperature system... 11 iterations.
@@ -24,7 +24,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  0.505 m/year, 0.972 m/year
      Temperature min/avg/max:            273 K, 1631 K, 4250 K
      Heat fluxes through boundary parts: -5.403e+05 W, 4.901e+05 W, 1613 W, 1613 W
-     Writing depth average               output-steinberger_incompressible/depth_average.gnuplot
+     Writing depth average:              output-steinberger_incompressible/depth_average.gnuplot
 
 Termination requested by criterion: end time
 

--- a/tests/steinberger_viscosity/screen-output
+++ b/tests/steinberger_viscosity/screen-output
@@ -12,7 +12,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5 m/year, 17 m/year
      Temperature min/avg/max:            273 K, 2253 K, 4250 K
      Heat fluxes through boundary parts: -2.351e+05 W, 5.296e+05 W, 1969 W, 1969 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 1:  t=5721.16 years
    Solving temperature system... 9 iterations.
@@ -24,7 +24,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.24 m/year, 16.9 m/year
      Temperature min/avg/max:            273 K, 2251 K, 4250 K
      Heat fluxes through boundary parts: -2.241e+05 W, 5.061e+05 W, 1773 W, 1773 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 2:  t=11444.9 years
    Solving temperature system... 10 iterations.
@@ -36,7 +36,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.21 m/year, 16.9 m/year
      Temperature min/avg/max:            273 K, 2248 K, 4250 K
      Heat fluxes through boundary parts: -2.146e+05 W, 4.804e+05 W, 1681 W, 1681 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 3:  t=17182.9 years
    Solving temperature system... 10 iterations.
@@ -48,7 +48,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.23 m/year, 17.1 m/year
      Temperature min/avg/max:            273 K, 2245 K, 4250 K
      Heat fluxes through boundary parts: -2.066e+05 W, 4.546e+05 W, 1641 W, 1641 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 4:  t=22839.3 years
    Solving temperature system... 10 iterations.
@@ -60,7 +60,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.24 m/year, 17.2 m/year
      Temperature min/avg/max:            273 K, 2242 K, 4250 K
      Heat fluxes through boundary parts: -2e+05 W, 4.308e+05 W, 1626 W, 1626 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 5:  t=28448.7 years
    Solving temperature system... 10 iterations.
@@ -72,7 +72,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.24 m/year, 17.3 m/year
      Temperature min/avg/max:            273 K, 2238 K, 4250 K
      Heat fluxes through boundary parts: -1.943e+05 W, 4.098e+05 W, 1624 W, 1624 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 6:  t=34023.3 years
    Solving temperature system... 10 iterations.
@@ -84,7 +84,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.24 m/year, 17.4 m/year
      Temperature min/avg/max:            273 K, 2235 K, 4250 K
      Heat fluxes through boundary parts: -1.893e+05 W, 3.918e+05 W, 1628 W, 1628 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 7:  t=39565.1 years
    Solving temperature system... 10 iterations.
@@ -96,7 +96,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.24 m/year, 17.5 m/year
      Temperature min/avg/max:            273 K, 2233 K, 4250 K
      Heat fluxes through boundary parts: -1.85e+05 W, 3.767e+05 W, 1636 W, 1636 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 8:  t=45077.9 years
    Solving temperature system... 10 iterations.
@@ -108,7 +108,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.24 m/year, 17.6 m/year
      Temperature min/avg/max:            273 K, 2231 K, 4250 K
      Heat fluxes through boundary parts: -1.811e+05 W, 3.64e+05 W, 1646 W, 1646 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 9:  t=50562.3 years
    Solving temperature system... 10 iterations.
@@ -120,7 +120,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.24 m/year, 17.7 m/year
      Temperature min/avg/max:            273 K, 2229 K, 4250 K
      Heat fluxes through boundary parts: -1.777e+05 W, 3.533e+05 W, 1656 W, 1656 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 10:  t=56016.7 years
    Solving temperature system... 10 iterations.
@@ -132,7 +132,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.24 m/year, 17.8 m/year
      Temperature min/avg/max:            273 K, 2228 K, 4250 K
      Heat fluxes through boundary parts: -1.748e+05 W, 3.441e+05 W, 1663 W, 1663 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 11:  t=61439.2 years
    Solving temperature system... 10 iterations.
@@ -144,7 +144,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.24 m/year, 17.9 m/year
      Temperature min/avg/max:            273 K, 2227 K, 4250 K
      Heat fluxes through boundary parts: -1.723e+05 W, 3.361e+05 W, 1664 W, 1664 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 12:  t=66828 years
    Solving temperature system... 9 iterations.
@@ -156,7 +156,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.24 m/year, 18 m/year
      Temperature min/avg/max:            273 K, 2227 K, 4250 K
      Heat fluxes through boundary parts: -1.703e+05 W, 3.288e+05 W, 1660 W, 1660 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 13:  t=72181.9 years
    Solving temperature system... 9 iterations.
@@ -168,7 +168,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.23 m/year, 18.1 m/year
      Temperature min/avg/max:            273 K, 2226 K, 4250 K
      Heat fluxes through boundary parts: -1.686e+05 W, 3.221e+05 W, 1653 W, 1653 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 14:  t=77500.6 years
    Solving temperature system... 9 iterations.
@@ -180,7 +180,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.23 m/year, 18.2 m/year
      Temperature min/avg/max:            273 K, 2226 K, 4250 K
      Heat fluxes through boundary parts: -1.673e+05 W, 3.158e+05 W, 1645 W, 1645 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 15:  t=82784.4 years
    Solving temperature system... 9 iterations.
@@ -192,7 +192,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.23 m/year, 18.3 m/year
      Temperature min/avg/max:            273 K, 2226 K, 4250 K
      Heat fluxes through boundary parts: -1.663e+05 W, 3.097e+05 W, 1636 W, 1636 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 16:  t=88034.6 years
    Solving temperature system... 9 iterations.
@@ -204,7 +204,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.23 m/year, 18.5 m/year
      Temperature min/avg/max:            273 K, 2226 K, 4250 K
      Heat fluxes through boundary parts: -1.655e+05 W, 3.039e+05 W, 1629 W, 1629 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 17:  t=93248.4 years
    Solving temperature system... 9 iterations.
@@ -216,7 +216,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.22 m/year, 18.6 m/year
      Temperature min/avg/max:            273 K, 2226 K, 4250 K
      Heat fluxes through boundary parts: -1.65e+05 W, 2.982e+05 W, 1623 W, 1623 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 18:  t=98426.9 years
    Solving temperature system... 9 iterations.
@@ -228,7 +228,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.22 m/year, 18.7 m/year
      Temperature min/avg/max:            273 K, 2226 K, 4250 K
      Heat fluxes through boundary parts: -1.647e+05 W, 2.926e+05 W, 1617 W, 1617 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 *** Timestep 19:  t=100000 years
    Solving temperature system... 8 iterations.
@@ -240,7 +240,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  5.21 m/year, 18.7 m/year
      Temperature min/avg/max:            273 K, 2226 K, 4250 K
      Heat fluxes through boundary parts: -1.647e+05 W, 2.91e+05 W, 1615 W, 1615 W
-     Writing depth average               output-steinberger_viscosity/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity/depth_average.gnuplot
 
 Termination requested by criterion: end time
 

--- a/tests/steinberger_viscosity_adiabatic/screen-output
+++ b/tests/steinberger_viscosity_adiabatic/screen-output
@@ -12,7 +12,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  0.0791 m/year, 0.283 m/year
      Temperature min/avg/max:            273 K, 2253 K, 4250 K
      Heat fluxes through boundary parts: -2.351e+05 W, 5.296e+05 W, 1969 W, 1969 W
-     Writing depth average               output-steinberger_viscosity_adiabatic/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity_adiabatic/depth_average.gnuplot
 
 *** Timestep 1:  t=100000 years
    Solving temperature system... 9 iterations.
@@ -24,7 +24,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
      RMS, max velocity:                  0.0844 m/year, 0.288 m/year
      Temperature min/avg/max:            273 K, 2253 K, 4250 K
      Heat fluxes through boundary parts: -2.316e+05 W, 5.211e+05 W, 1911 W, 1911 W
-     Writing depth average               output-steinberger_viscosity_adiabatic/depth_average.gnuplot
+     Writing depth average:              output-steinberger_viscosity_adiabatic/depth_average.gnuplot
 
 Termination requested by criterion: end time
 

--- a/tests/velocity_boundary_statistics/screen-output
+++ b/tests/velocity_boundary_statistics/screen-output
@@ -32,7 +32,7 @@ Number of degrees of freedom: 10,436 (6,402+833+3,201)
      RMS, max velocity:                         1.2e-09 m/s, 3.64e-09 m/s
      Temperature min/avg/max:                   0 K, 100.4 K, 1613 K
      Heat fluxes through boundary parts:        -0.1197 W, -0.2657 W, -1.004e-07 W, -1.004e-07 W
-     Writing depth average                      output-velocity_boundary_statistics/depth_average.gnuplot
+     Writing depth average:                     output-velocity_boundary_statistics/depth_average.gnuplot
      Max and min velocity along boundary parts: 3.628e-09 m/s, 4.251e-12 m/s, 0 m/s, 0 m/s, 1.745e-10 m/s, 1.821e-12 m/s, 1.422e-09 m/s, 1.635e-12 m/s
 
 Number of active cells: 822 (on 6 levels)
@@ -51,7 +51,7 @@ Number of degrees of freedom: 12,427 (7,624+991+3,812)
      RMS, max velocity:                         1.26e-09 m/s, 3.74e-09 m/s
      Temperature min/avg/max:                   -200.3 K, 101.8 K, 1613 K
      Heat fluxes through boundary parts:        -0.117 W, -0.2643 W, -1.326e-06 W, -8.533e-06 W
-     Writing depth average                      output-velocity_boundary_statistics/depth_average.gnuplot
+     Writing depth average:                     output-velocity_boundary_statistics/depth_average.gnuplot
      Max and min velocity along boundary parts: 3.719e-09 m/s, 4.363e-12 m/s, 0 m/s, 0 m/s, 1.776e-10 m/s, 1.818e-12 m/s, 1.453e-09 m/s, 1.836e-12 m/s
 
 *** Timestep 2:  t=2.33241e+13 seconds
@@ -63,7 +63,7 @@ Number of degrees of freedom: 12,427 (7,624+991+3,812)
      RMS, max velocity:                         1.29e-09 m/s, 3.79e-09 m/s
      Temperature min/avg/max:                   -199 K, 102.8 K, 1613 K
      Heat fluxes through boundary parts:        -0.1147 W, -0.2627 W, -2.308e-06 W, -1.453e-05 W
-     Writing depth average                      output-velocity_boundary_statistics/depth_average.gnuplot
+     Writing depth average:                     output-velocity_boundary_statistics/depth_average.gnuplot
      Max and min velocity along boundary parts: 3.773e-09 m/s, 4.447e-12 m/s, 0 m/s, 0 m/s, 1.797e-10 m/s, 1.815e-12 m/s, 1.469e-09 m/s, 1.852e-12 m/s
 
 Number of active cells: 951 (on 6 levels)
@@ -79,7 +79,7 @@ Number of degrees of freedom: 13,447 (8,250+1,072+4,125)
      RMS, max velocity:                         1.32e-09 m/s, 3.83e-09 m/s
      Temperature min/avg/max:                   -197.8 K, 103.7 K, 1613 K
      Heat fluxes through boundary parts:        -0.1126 W, -0.2615 W, -3.359e-06 W, -1.902e-05 W
-     Writing depth average                      output-velocity_boundary_statistics/depth_average.gnuplot
+     Writing depth average:                     output-velocity_boundary_statistics/depth_average.gnuplot
      Max and min velocity along boundary parts: 3.821e-09 m/s, 4.536e-12 m/s, 0 m/s, 0 m/s, 1.818e-10 m/s, 1.812e-12 m/s, 1.484e-09 m/s, 9.687e-13 m/s
 
 *** Timestep 4:  t=3.8364e+13 seconds
@@ -91,7 +91,7 @@ Number of degrees of freedom: 13,447 (8,250+1,072+4,125)
      RMS, max velocity:                         1.35e-09 m/s, 3.87e-09 m/s
      Temperature min/avg/max:                   -197 K, 104.7 K, 1613 K
      Heat fluxes through boundary parts:        -0.1105 W, -0.26 W, -4.416e-06 W, -2.285e-05 W
-     Writing depth average                      output-velocity_boundary_statistics/depth_average.gnuplot
+     Writing depth average:                     output-velocity_boundary_statistics/depth_average.gnuplot
      Max and min velocity along boundary parts: 3.859e-09 m/s, 4.627e-12 m/s, 0 m/s, 0 m/s, 1.841e-10 m/s, 1.809e-12 m/s, 1.499e-09 m/s, 9.787e-13 m/s
 
 Number of active cells: 1,029 (on 6 levels)
@@ -107,7 +107,7 @@ Number of degrees of freedom: 14,588 (8,950+1,163+4,475)
      RMS, max velocity:                         1.38e-09 m/s, 3.92e-09 m/s
      Temperature min/avg/max:                   -197.5 K, 105.6 K, 1613 K
      Heat fluxes through boundary parts:        -0.1086 W, -0.259 W, -5.462e-06 W, -3.318e-05 W
-     Writing depth average                      output-velocity_boundary_statistics/depth_average.gnuplot
+     Writing depth average:                     output-velocity_boundary_statistics/depth_average.gnuplot
      Max and min velocity along boundary parts: 3.902e-09 m/s, 4.719e-12 m/s, 0 m/s, 0 m/s, 1.863e-10 m/s, 1.81e-12 m/s, 1.515e-09 m/s, 4.565e-13 m/s
 
 *** Timestep 6:  t=5.32369e+13 seconds
@@ -119,7 +119,7 @@ Number of degrees of freedom: 14,588 (8,950+1,163+4,475)
      RMS, max velocity:                         1.41e-09 m/s, 3.95e-09 m/s
      Temperature min/avg/max:                   -197 K, 106.5 K, 1613 K
      Heat fluxes through boundary parts:        -0.1069 W, -0.2578 W, -6.491e-06 W, -3.627e-05 W
-     Writing depth average                      output-velocity_boundary_statistics/depth_average.gnuplot
+     Writing depth average:                     output-velocity_boundary_statistics/depth_average.gnuplot
      Max and min velocity along boundary parts: 3.937e-09 m/s, 4.811e-12 m/s, 0 m/s, 0 m/s, 1.886e-10 m/s, 1.806e-12 m/s, 1.53e-09 m/s, 4.526e-13 m/s
 
 Number of active cells: 1,107 (on 6 levels)
@@ -135,7 +135,7 @@ Number of degrees of freedom: 15,677 (9,618+1,250+4,809)
      RMS, max velocity:                         1.44e-09 m/s, 3.99e-09 m/s
      Temperature min/avg/max:                   -201.8 K, 107.3 K, 1613 K
      Heat fluxes through boundary parts:        -0.1054 W, -0.2569 W, -1.387e-05 W, -3.892e-05 W
-     Writing depth average                      output-velocity_boundary_statistics/depth_average.gnuplot
+     Writing depth average:                     output-velocity_boundary_statistics/depth_average.gnuplot
      Max and min velocity along boundary parts: 3.966e-09 m/s, 4.9e-12 m/s, 0 m/s, 0 m/s, 1.907e-10 m/s, 7.075e-13 m/s, 1.546e-09 m/s, 4.488e-13 m/s
 
 *** Timestep 8:  t=6.7723e+13 seconds
@@ -147,7 +147,7 @@ Number of degrees of freedom: 15,677 (9,618+1,250+4,809)
      RMS, max velocity:                         1.46e-09 m/s, 4.02e-09 m/s
      Temperature min/avg/max:                   -201.6 K, 108.1 K, 1613 K
      Heat fluxes through boundary parts:        -0.1041 W, -0.2558 W, -1.467e-05 W, -4.111e-05 W
-     Writing depth average                      output-velocity_boundary_statistics/depth_average.gnuplot
+     Writing depth average:                     output-velocity_boundary_statistics/depth_average.gnuplot
      Max and min velocity along boundary parts: 3.996e-09 m/s, 4.985e-12 m/s, 0 m/s, 0 m/s, 1.928e-10 m/s, 7.068e-13 m/s, 1.56e-09 m/s, 4.452e-13 m/s
 
 Number of active cells: 1,206 (on 6 levels)
@@ -163,7 +163,7 @@ Number of degrees of freedom: 17,133 (10,512+1,365+5,256)
      RMS, max velocity:                         1.49e-09 m/s, 4.06e-09 m/s
      Temperature min/avg/max:                   -201.5 K, 108.7 K, 1613 K
      Heat fluxes through boundary parts:        -0.1032 W, -0.2549 W, -1.546e-05 W, -4.292e-05 W
-     Writing depth average                      output-velocity_boundary_statistics/depth_average.gnuplot
+     Writing depth average:                     output-velocity_boundary_statistics/depth_average.gnuplot
      Max and min velocity along boundary parts: 4.031e-09 m/s, 5.056e-12 m/s, 0 m/s, 0 m/s, 1.945e-10 m/s, 7.062e-13 m/s, 1.575e-09 m/s, 4.416e-13 m/s
 
 *** Timestep 10:  t=8.1819e+13 seconds
@@ -175,7 +175,7 @@ Number of degrees of freedom: 17,133 (10,512+1,365+5,256)
      RMS, max velocity:                         1.52e-09 m/s, 4.09e-09 m/s
      Temperature min/avg/max:                   -201.4 K, 109.3 K, 1613 K
      Heat fluxes through boundary parts:        -0.1027 W, -0.254 W, -1.623e-05 W, -4.449e-05 W
-     Writing depth average                      output-velocity_boundary_statistics/depth_average.gnuplot
+     Writing depth average:                     output-velocity_boundary_statistics/depth_average.gnuplot
      Max and min velocity along boundary parts: 4.056e-09 m/s, 5.121e-12 m/s, 0 m/s, 0 m/s, 1.958e-10 m/s, 7.055e-13 m/s, 1.589e-09 m/s, 4.38e-13 m/s
 
 Number of active cells: 1,320 (on 6 levels)


### PR DESCRIPTION
Like #794: Almost all postprocessors write a colon at the end of the first part of their screen message. Depth average did not. Fix this.