### PR TITLE
Add particle timing information. Move parameters to world.

### DIFF
--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -28,9 +28,12 @@
 #include <aspect/particle/integrator/interface.h>
 #include <aspect/particle/interpolator/interface.h>
 #include <aspect/particle/property/interface.h>
+#include <aspect/particle/output/interface.h>
 
 #include <aspect/simulator_access.h>
 #include <aspect/simulator_signals.h>
+
+#include <deal.II/base/timer.h>
 
 namespace aspect
 {
@@ -72,37 +75,9 @@ namespace aspect
         };
 
         /**
-         * Initialize the particle world. Most of the arguments are read by the
-         * Tracer postprocessor and handed to this function, because the
-         * particle world currently does not declare own input parameters.
-         *
-         * @param [in] generator The particle generator for this world.
-         * @param [in] integrator The Integrator scheme for this world.
-         * @param [in] interpolator The Interpolator scheme for this
-         * world. This object defines how particle properties are interpolated
-         * to arbitrary positions within the domain. An example could be to
-         * take the properties of the closest particle, but more complicated
-         * schemes are possible.
-         * @param [in] manager The property manager for this world.
-         * @param [in] load_balancing The strategy used to balance the
-         * computational load for particle advection across processes.
-         * @param [in] max_part_per_cell Threshold for removing
-         * particles from cells.
-         * @param [in] weight The computational load that is associated with
-         * integrating and updating one particle.
-         *
-         * @note World takes ownership of the @p generator, @p integrator, @p
-         * interpolator, and @p manager object in this function.
-         *
+         * Initialize the particle world.
          */
-        void initialize(Generator::Interface<dim> *generator,
-                        Integrator::Interface<dim> *integrator,
-                        Interpolator::Interface<dim> *interpolator,
-                        Property::Manager<dim> *manager,
-                        const ParticleLoadBalancing &load_balancing,
-                        const unsigned int min_part_per_cell,
-                        const unsigned int max_part_per_cell,
-                        const unsigned int weight);
+        void initialize();
 
         /**
          * Get the particle property manager for this particle world.
@@ -216,10 +191,44 @@ namespace aspect
         void update_particles();
 
         /**
+         * Print the selected particle output.
+         */
+        std::string
+        print_output() const;
+
+        /**
          * Serialize the contents of this class.
          */
         template <class Archive>
         void serialize (Archive &ar, const unsigned int version);
+
+        /**
+         * Save the state of the object.
+         */
+        virtual
+        void
+        save (std::ostringstream &os) const;
+
+        /**
+         * Restore the state of the object.
+         */
+        virtual
+        void
+        load (std::istringstream &is);
+
+        /**
+         * Declare the parameters this class takes through input files.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         */
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
 
       private:
         /**
@@ -243,6 +252,11 @@ namespace aspect
          * these properties.
          */
         std_cxx11::unique_ptr<Property::Manager<dim> > property_manager;
+
+        /**
+         * Pointer to an output object
+         */
+        std_cxx11::unique_ptr<Output::Interface<dim> > output;
 
         /**
          * Set of particles currently in the local domain, organized by
@@ -273,6 +287,16 @@ namespace aspect
          * Strategy for tracer load balancing.
          */
         ParticleLoadBalancing particle_load_balancing;
+
+
+        /**
+         * Write a summary of the computing time spent in each part
+         * of the particle algorithm every time particle output is
+         * written. This is mostly useful for benchmarking purposes.
+         * ASPECT's usual output of compute times is unaffected by
+         * this additional output.
+         */
+        bool print_timing_output;
 
         /**
          * Lower limit for particle number per cell. This limit is
@@ -310,6 +334,15 @@ namespace aspect
          * to represent a cost of 1000.
          */
         unsigned int tracer_weight;
+
+        /**
+         * Diagnostic timing output for particles. Because the collection will
+         * not create significant overhead it is always computed. Output
+         * is only written however, when the print_timing_output() function
+         * is called.
+         */
+        std_cxx11::shared_ptr<TimerOutput> particle_timer;
+
 
         /**
          * Calculates the number of particles in the global model domain.

--- a/include/aspect/postprocess/tracers.h
+++ b/include/aspect/postprocess/tracers.h
@@ -23,7 +23,6 @@
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/particle/world.h>
-#include <aspect/particle/output/interface.h>
 
 #include <aspect/simulator_access.h>
 #include <aspect/particle/particle.h>
@@ -155,20 +154,15 @@ namespace aspect
         Particle::World<dim> world;
 
         /**
-         * Pointer to an output object
-         */
-        std_cxx11::shared_ptr<Particle::Output::Interface<dim> > output;
-
-        /**
          * Interval between output (in years if appropriate simulation
          * parameter is set, otherwise seconds)
          */
-        double                          output_interval;
+        double output_interval;
 
         /**
          * Records time for next output to occur
          */
-        double                          last_output_time;
+        double last_output_time;
 
         /**
          * Save the last time output was generated assuming that

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -112,9 +112,6 @@ namespace aspect
                                                                 output_time);
       particle_timer->exit_section();
 
-      if (print_timing_output)
-        particle_timer->print_summary();
-
       return filename;
     }
 
@@ -1079,6 +1076,10 @@ namespace aspect
 
       // Update the number of global particles if some have left the domain
       update_n_global_particles();
+
+      if (print_timing_output &&
+          (this->get_timestep_number() % this->get_parameters().timing_output_frequency == 0))
+        particle_timer->print_summary();
     }
 
     template <int dim>

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -49,25 +49,9 @@ namespace aspect
 
     template <int dim>
     void
-    World<dim>::initialize(Generator::Interface<dim> *particle_generator,
-                           Integrator::Interface<dim> *particle_integrator,
-                           Interpolator::Interface<dim> *property_interpolator,
-                           Property::Manager<dim> *manager,
-                           const ParticleLoadBalancing &load_balancing,
-                           const unsigned int min_part_per_cell,
-                           const unsigned int max_part_per_cell,
-                           const unsigned int weight)
+    World<dim>::initialize()
     {
       connect_to_signals(this->get_signals());
-
-      generator.reset(particle_generator);
-      integrator.reset(particle_integrator);
-      interpolator.reset(property_interpolator);
-      property_manager.reset(manager);
-      particle_load_balancing = load_balancing;
-      min_particles_per_cell = min_part_per_cell;
-      max_particles_per_cell = max_part_per_cell;
-      tracer_weight = weight;
 
 #if DEAL_II_VERSION_GTE(8,4,0)
       if (particle_load_balancing == repartition)
@@ -81,6 +65,11 @@ namespace aspect
                              "which is only available for deal.II 8.4 and newer but the installed version "
                              "seems to be older. Please update your deal.II or choose a different strategy."));
 #endif
+
+      particle_timer.reset(new TimerOutput(this->get_mpi_communicator(),
+                                           const_cast<ConditionalOStream &>(this->get_pcout()),
+                                           TimerOutput::never,
+                                           TimerOutput::wall_times));
     }
 
     template <int dim>
@@ -102,6 +91,31 @@ namespace aspect
     World<dim>::get_particles() const
     {
       return particles;
+    }
+
+    template <int dim>
+    std::string
+    World<dim>::print_output() const
+    {
+      // If we do not write output
+      // return early with the number of particles that were advected
+      if (!output)
+        return "";
+
+      particle_timer->enter_section("Write output");
+      const double output_time = (this->convert_output_to_years() ?
+                                  this->get_time() / year_in_seconds :
+                                  this->get_time());
+
+      const std::string filename = output->output_particle_data(particles,
+                                                                property_manager->get_data_info(),
+                                                                output_time);
+      particle_timer->exit_section();
+
+      if (print_timing_output)
+        particle_timer->print_summary();
+
+      return filename;
     }
 
     template <int dim>
@@ -168,6 +182,8 @@ namespace aspect
     void
     World<dim>::register_store_callback_function(typename parallel::distributed::Triangulation<dim> &triangulation)
     {
+      particle_timer->enter_section("Store particles for refinement");
+
       // Only save and load tracers if there are any, we might get here for
       // example before the tracer generation in timestep 0, or if somebody
       // selected the tracer postprocessor but generated 0 tracers
@@ -191,12 +207,15 @@ namespace aspect
                                                      *  std::pow(2,dim);
           data_offset = triangulation.register_data_attach(transfer_size_per_cell,callback_function);
         }
+      particle_timer->exit_section();
     }
 
     template <int dim>
     void
     World<dim>::register_load_callback_function(typename parallel::distributed::Triangulation<dim> &triangulation)
     {
+      particle_timer->enter_section("Load particles after refinement");
+
       // All particles have been stored, when we reach this point. Empty the
       // map and fill with new particles.
       particles.clear();
@@ -222,6 +241,7 @@ namespace aspect
           data_offset = numbers::invalid_unsigned_int;
           update_n_global_particles();
         }
+      particle_timer->exit_section();
     }
 
     template <int dim>
@@ -508,6 +528,8 @@ namespace aspect
       // because it only knows the subdomain_id of ghost cells, but not
       // of artificial cells.
 
+      particle_timer->enter_section("Sort particles");
+
       // There are three reasons why a particle is not in its old cell:
       // It moved to another cell, to another domain or it left the mesh.
       // Sort the particles accordingly and deal with them
@@ -590,9 +612,15 @@ namespace aspect
       // Reinsert all local particles with their cells
       particles.insert(moved_particles_cell.begin(),moved_particles_cell.end());
 
+      particle_timer->exit_section();
+
       // Swap lost particles between processors if we have more than one process
       if (dealii::Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) > 1)
-        send_recv_particles(moved_particles_domain);
+        {
+          particle_timer->enter_section("Communicate particles");
+          send_recv_particles(moved_particles_domain);
+          particle_timer->exit_section();
+        }
     }
 
     template <int dim>
@@ -927,9 +955,14 @@ namespace aspect
     void
     World<dim>::generate_particles()
     {
+      particle_timer->enter_section("Generate particles");
+
       generator->generate_particles(particles);
       update_n_global_particles();
       update_next_free_particle_index();
+
+      particle_timer->exit_section();
+
     }
 
     template <int dim>
@@ -937,9 +970,10 @@ namespace aspect
     World<dim>::initialize_particles()
     {
       // TODO: Change this loop over all cells to use the WorkStream interface
-
       if (property_manager->get_n_property_components() > 0)
         {
+          particle_timer->enter_section("Initialize particle properties");
+
           // Loop over all cells and initialize the particles cell-wise
           typename DoFHandler<dim>::active_cell_iterator
           cell = this->get_dof_handler().begin_active(),
@@ -958,6 +992,8 @@ namespace aspect
                                              particle_range_in_cell.first,
                                              particle_range_in_cell.second);
               }
+
+          particle_timer->exit_section();
         }
     }
 
@@ -969,6 +1005,8 @@ namespace aspect
 
       if (property_manager->get_n_property_components() > 0)
         {
+          particle_timer->enter_section("Update particle properties");
+
           // Loop over all cells and update the particles cell-wise
           typename DoFHandler<dim>::active_cell_iterator
           cell = this->get_dof_handler().begin_active(),
@@ -987,6 +1025,7 @@ namespace aspect
                                          particle_range_in_cell.first,
                                          particle_range_in_cell.second);
               }
+          particle_timer->exit_section();
         }
     }
 
@@ -995,6 +1034,7 @@ namespace aspect
     World<dim>::advect_particles()
     {
       // TODO: Change this loop over all cells to use the WorkStream interface
+      particle_timer->enter_section("Advect particles");
 
       // Loop over all cells and advect the particles cell-wise
       typename DoFHandler<dim>::active_cell_iterator
@@ -1014,6 +1054,7 @@ namespace aspect
                                      particle_range_in_cell.first,
                                      particle_range_in_cell.second);
           }
+      particle_timer->exit_section();
     }
 
     template <int dim>
@@ -1038,6 +1079,177 @@ namespace aspect
 
       // Update the number of global particles if some have left the domain
       update_n_global_particles();
+    }
+
+    template <int dim>
+    void
+    World<dim>::save (std::ostringstream &os) const
+    {
+      aspect::oarchive oa (os);
+      oa << (*this);
+      output->save(os);
+    }
+
+    template <int dim>
+    void
+    World<dim>::load (std::istringstream &is)
+    {
+      aspect::iarchive ia (is);
+      ia >> (*this);
+      output->load(is);
+    }
+
+    template <int dim>
+    void
+    World<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Postprocess");
+      {
+        prm.enter_subsection("Tracers");
+        {
+          prm.declare_entry ("Load balancing strategy", "none",
+                             Patterns::Selection ("none|remove particles|"
+                                                  "remove and add particles|repartition"),
+                             "Strategy that is used to balance the computational"
+                             "load across processors for adaptive meshes.");
+          prm.declare_entry ("Minimum tracers per cell", "0",
+                             Patterns::Integer (0),
+                             "Lower limit for particle number per cell. This limit is "
+                             "useful for adaptive meshes to prevent fine cells from being empty "
+                             "of particles. It will be checked and enforced after mesh "
+                             "refinement and after particle movement. "
+                             "If there are "
+                             "n_number_of_particles < min_particles_per_cell "
+                             "particles in one cell then "
+                             "min_particles_per_cell - n_number_of_particles "
+                             "particles are generated and randomly placed in "
+                             "this cell. If the particles carry properties the "
+                             "individual property plugins control how the "
+                             "properties of the new particles are initialized.");
+          prm.declare_entry ("Maximum tracers per cell", "100",
+                             Patterns::Integer (0),
+                             "Upper limit for particle number per cell. This limit is "
+                             "useful for adaptive meshes to prevent coarse cells from slowing down "
+                             "the whole model. It will be checked and enforced after mesh "
+                             "refinement, after MPI transfer of particles and after particle "
+                             "movement. If there are "
+                             "n_number_of_particles > max_particles_per_cell "
+                             "particles in one cell then "
+                             "n_number_of_particles - max_particles_per_cell "
+                             "particles in this cell are randomly chosen and destroyed.");
+          prm.declare_entry ("Tracer weight", "10",
+                             Patterns::Integer (0),
+                             "Weight that is associated with the computational load of "
+                             "a single particle. The sum of tracer weights will be added "
+                             "to the sum of cell weights to determine the partitioning of "
+                             "the mesh. Every cell without tracers is associated with a "
+                             "weight of 1000.");
+          prm.declare_entry ("Timing output", "false",
+                             Patterns::Bool (),
+                             "Write a summary of the computing time spent in each part "
+                             "of the particle algorithm every time particle output is "
+                             "written. This is mostly useful for benchmarking purposes. "
+                             "ASPECT's usual output of compute times is unaffected by "
+                             "this additional output.");
+        }
+        prm.leave_subsection ();
+      }
+      prm.leave_subsection ();
+
+      Generator::declare_parameters<dim>(prm);
+      Output::declare_parameters<dim>(prm);
+      Integrator::declare_parameters<dim>(prm);
+      Interpolator::declare_parameters<dim>(prm);
+      Property::Manager<dim>::declare_parameters(prm);
+    }
+
+
+    template <int dim>
+    void
+    World<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      // First do some error checking. The current algorithm does not find
+      // the cells around particles, if the particles moved more than one
+      // cell in one timestep and we are running in parallel, because they
+      // skip the layer of ghost cells around our local domain. Assert this
+      // is not possible.
+      const double CFL_number = prm.get_double ("CFL number");
+      const unsigned int n_processes = Utilities::MPI::n_mpi_processes(this->get_mpi_communicator());
+
+      AssertThrow((n_processes == 1) || (CFL_number <= 1.0),
+                  ExcMessage("The current tracer algorithm does not work in "
+                             "parallel if the CFL number is larger than 1.0, because "
+                             "in this case tracers can move more than one cell's "
+                             "diameter in one time step and therefore skip the layer "
+                             "of ghost cells around the local subdomain."));
+
+      prm.enter_subsection("Postprocess");
+      {
+        prm.enter_subsection("Tracers");
+        {
+          min_particles_per_cell = prm.get_integer("Minimum tracers per cell");
+          max_particles_per_cell = prm.get_integer("Maximum tracers per cell");
+
+          AssertThrow(min_particles_per_cell <= max_particles_per_cell,
+                      ExcMessage("Please select a 'Minimum tracers per cell' parameter "
+                                 "that is smaller than or equal to the 'Maximum tracers per cell' parameter."));
+
+          tracer_weight = prm.get_integer("Tracer weight");
+          print_timing_output = prm.get_bool("Timing output");
+
+          if (prm.get ("Load balancing strategy") == "none")
+            particle_load_balancing = no_balancing;
+          else if (prm.get ("Load balancing strategy") == "remove particles")
+            particle_load_balancing = remove_particles;
+          else if (prm.get ("Load balancing strategy") == "remove and add particles")
+            particle_load_balancing = remove_and_add_particles;
+          else if (prm.get ("Load balancing strategy") == "repartition")
+            particle_load_balancing = repartition;
+          else
+            AssertThrow (false, ExcNotImplemented());
+        }
+        prm.leave_subsection ();
+      }
+      prm.leave_subsection ();
+
+      // Create a generator object depending on what the parameters specify
+      generator.reset(Generator::create_particle_generator<dim> (prm));
+      if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(generator.get()))
+        sim->initialize_simulator (this->get_simulator());
+      generator->parse_parameters(prm);
+
+      // Create an output object depending on what the parameters specify
+      output.reset(Output::create_particle_output<dim>
+                   (prm));
+
+      // We allow to not generate any output plugin, in which case output is
+      // a null pointer. Only initialize output if it was created.
+      if (output)
+        {
+          if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(output.get()))
+            sim->initialize_simulator (this->get_simulator());
+          output->parse_parameters(prm);
+          output->initialize();
+        }
+
+      // Create an integrator object depending on the specified parameter
+      integrator.reset(Integrator::create_particle_integrator<dim> (prm));
+      if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(integrator.get()))
+        sim->initialize_simulator (this->get_simulator());
+      integrator->parse_parameters(prm);
+
+      // Create an interpolator object depending on the specified parameter
+      interpolator.reset(Interpolator::create_particle_interpolator<dim> (prm));
+      if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(interpolator.get()))
+        sim->initialize_simulator (this->get_simulator());
+      interpolator->parse_parameters(prm);
+
+      // Creaty an property_manager object and initialize its properties
+      property_manager.reset(new Property::Manager<dim> ());
+      SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(property_manager.get());
+      sim->initialize_simulator (this->get_simulator());
+      property_manager->parse_parameters(prm);
+      property_manager->initialize();
     }
   }
 }

--- a/tests/particle_timing_information.prm
+++ b/tests/particle_timing_information.prm
@@ -1,0 +1,120 @@
+# This tests the behaviour of the tracers postprocessor, when the
+# 'Run postprocessors on initial refinement option is set. We do not
+# want to advect the tracers in this case, because we are solving the
+# first timestep multiple times.
+
+# MPI: 2
+
+set Dimension                              = 2
+set End time                               = 70
+set Use years in output instead of seconds = false
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent  = 0.9142
+    set Y extent  = 1.0000
+  end
+end
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false
+  set Tangential velocity boundary indicators = left, right
+  set Zero velocity boundary indicators       = bottom, top
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Reference density             = 1010
+    set Viscosity                     = 1e2
+    set Thermal expansion coefficient = 0
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+############### Parameters describing the temperature field
+# Note: The temperature plays no role in this model
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+subsection Initial conditions
+  set Model name = function
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+
+############### Parameters describing the compositional field
+# Note: The compositional field is what drives the flow
+# in this example
+
+subsection Compositional fields
+  set Number of fields = 1
+end
+
+subsection Compositional initial conditions
+  set Model name = function
+  subsection Function
+    set Variable names      = x,z
+    set Function constants  = pi=3.1415926
+    set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
+  end
+end
+
+subsection Material model
+  subsection Simple model
+    set Density differential for compositional field 1 = -10
+  end
+end
+
+
+############### Parameters describing the discretization
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 2
+  set Strategy                           = composition
+  set Initial global refinement          = 2
+  set Run postprocessors on initial refinement = true
+  set Time steps between mesh refinement = 0
+  set Coarsening fraction                = 0.05
+  set Refinement fraction                = 0.3
+end
+
+
+
+############### Parameters describing what to do with the solution
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, composition statistics,tracers
+
+  subsection Tracers
+    set Timing output = true
+    set Number of tracers = 10
+    set Time between data output = 70
+    set Data output format = ascii
+
+    set Particle generator name = uniform box
+
+    subsection Generator
+      subsection Uniform box
+        set Minimum x = 0.3
+        set Maximum x = 0.5
+        set Minimum y = 0.1
+        set Maximum y = 0.3
+      end
+    end
+  end
+end

--- a/tests/particle_timing_information/screen-output
+++ b/tests/particle_timing_information/screen-output
@@ -1,0 +1,72 @@
+
+Number of active cells: 16 (on 3 levels)
+Number of degrees of freedom: 349 (162+25+81+81)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 20 iterations.
+
+   Postprocessing:
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+     RMS, max velocity:         0.000133 m/s, 0.000331 m/s
+     Compositions min/max/mass: 0/1/0.1914
+     Writing particle output:   output-particle_timing_information/particle-00000
+
+Number of active cells: 19 (on 4 levels)
+Number of degrees of freedom: 447 (208+31+104+104)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:            0.000191 m/s, 0.000521 m/s
+     Compositions min/max/mass:    -0.0002044/1.123/0.1846
+     Number of advected particles: 9
+
+Number of active cells: 16 (on 4 levels)
+Number of degrees of freedom: 387 (180+27+90+90)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 24 iterations.
+
+   Postprocessing:
+     RMS, max velocity:            0.000185 m/s, 0.000491 m/s
+     Compositions min/max/mass:    0/1.124/0.1817
+     Number of advected particles: 9
+
+*** Timestep 1:  t=70 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 16 iterations.
+   Solving Stokes system... 22 iterations.
+
+   Postprocessing:
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+     RMS, max velocity:         0.000217 m/s, 0.000582 m/s
+     Compositions min/max/mass: -0.02596/1.114/0.1764
+     Writing particle output:   output-particle_timing_information/particle-00001
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/particle_timing_information/screen-output
+++ b/tests/particle_timing_information/screen-output
@@ -9,12 +9,6 @@ Number of degrees of freedom: 349 (162+25+81+81)
    Solving Stokes system... 20 iterations.
 
    Postprocessing:
-
-
-+---------------------------------------------+------------+------------+
-+---------------------------------+-----------+------------+------------+
-+---------------------------------+-----------+------------+------------+
-
      RMS, max velocity:         0.000133 m/s, 0.000331 m/s
      Compositions min/max/mass: 0/1/0.1914
      Writing particle output:   output-particle_timing_information/particle-00000
@@ -43,6 +37,12 @@ Number of degrees of freedom: 387 (180+27+90+90)
    Solving Stokes system... 24 iterations.
 
    Postprocessing:
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
      RMS, max velocity:            0.000185 m/s, 0.000491 m/s
      Compositions min/max/mass:    0/1.124/0.1817
      Number of advected particles: 9
@@ -53,12 +53,6 @@ Number of degrees of freedom: 387 (180+27+90+90)
    Solving Stokes system... 22 iterations.
 
    Postprocessing:
-
-
-+---------------------------------------------+------------+------------+
-+---------------------------------+-----------+------------+------------+
-+---------------------------------+-----------+------------+------------+
-
      RMS, max velocity:         0.000217 m/s, 0.000582 m/s
      Compositions min/max/mass: -0.02596/1.114/0.1764
      Writing particle output:   output-particle_timing_information/particle-00001


### PR DESCRIPTION
Originally I just intended to add some more granular timing information to the particle code for benchmarking purposes. It turned out I need to shuffle some code from the tracer postprocessor to the particle world in order to also measure the time spent in writing the particle output. On the other hand I should have done this change a while ago already, it was never a good idea to let the postprocessor handle the creation of plugins and then hand over ownership to particle::World. Sorry for mingling these two things in one pull request. 
This patch should not change any functionality. The new `TimerOutput` introduces some MPI_Barriers in the particle code for benchmarking purposes, do you think this is relevant for performance?
Otherwise this is ready for a review.
