### PR TITLE
Adjust names in the document.

### DIFF
--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013 by the authors of the ASPECT code.
+  Copyright (C) 2013, 2016 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -95,7 +95,7 @@ namespace aspect
          * @return Boundary value of the compositional field @p
          * compositional_field at the position @p position.
          *
-         * @deprecated Use <code>composition(const types::boundary_id
+         * @deprecated Use <code>boundary_composition(const types::boundary_id
          * boundary_indicator,const Point<dim> &position, const unsigned
          * int compositional_field) const</code> instead. The reference to
          * the geometry model can be reached by deriving plugins from

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011, 2012 by the authors of the ASPECT code.
+  Copyright (C) 2011, 2012, 2016 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -77,7 +77,7 @@ namespace aspect
          * temperature.
          * @return Boundary temperature at position @p position.
          *
-         * @deprecated Use <code>temperature(const types::boundary_id
+         * @deprecated Use <code>boundary_temperature(const types::boundary_id
          * boundary_indicator,const Point<dim> &position) const</code> instead.
          * The reference to the geometry model can be reached by deriving
          * plugins from aspect::SimulatorAccess<dim>.


### PR DESCRIPTION
The docs of these two deprecated functions point to the new names, but misspelled them.