### PR TITLE
Avoid a warning about an unused variable.

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1849,8 +1849,6 @@ namespace aspect
                                       internal::Assembly::Scratch::AdvectionSystem<dim> &scratch,
                                       internal::Assembly::CopyData::AdvectionSystem<dim> &data)
   {
-    const bool use_bdf2_scheme = (timestep_number > 1);
-
     const unsigned int n_q_points    = scratch.face_finite_element_values->n_quadrature_points;
 
     // also have the number of dofs that correspond just to the element for


### PR DESCRIPTION
This is in one of the temperature assembly functions, where we now apparently no longer
need to check whether we use the BDF2 formula or a backward Euler for the first
time step. It would actually be interesting to know why we no longer need to check this,
i.e., whether we accidentally lost some functionality in the transition, or whether the
function was just split into two and the variable is only needed in one.