### PR TITLE
fix bugs when MPI proc has no DoFs

### DIFF
--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -292,7 +292,7 @@ namespace aspect
   const FiniteElement<dim> &
   SimulatorAccess<dim>::get_fe () const
   {
-    Assert (simulator->dof_handler.n_locally_owned_dofs() != 0,
+    Assert (simulator->dof_handler.n_dofs() > 0,
             ExcMessage("You are trying to access the FiniteElement before the DOFs have been "
                        "initialized. This may happen when accessing the Simulator from a plugin "
                        "that gets executed early in some cases (like material models) or from "


### PR DESCRIPTION
When an MPI rank has no cells and as such no DoFs, we are triggering two
problems:

- Assert in SimulatorAccess::get_fe()
- handling of nullspace constraints

There are still issues with deal 8.2.1, but this fixes parallel
computations with 8.3 or newer.