### PR TITLE
Fix 'particle density' mesh refinement

### DIFF
--- a/include/aspect/mesh_refinement/particle_density.h
+++ b/include/aspect/mesh_refinement/particle_density.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2015 by the authors of the ASPECT code.
+  Copyright (C) 2015, 2016 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -31,15 +31,19 @@ namespace aspect
   {
 
     /**
-     * A class that implements a mesh refinement criterion based on the
-     * density of particles. The mesh refinement indicator equals the areal
-     * (in 2d) or volumetric (in 3d) particle density in this cell.
-     * This plugin is useful for models with inhomogeneous particle density,
-     * e.g. when tracking an initial interface with a high particle density, or
-     * when the spatial particle density denotes the region of interest.
-     * Additionally, this plugin tends to balance the computational load
-     * between processes in parallel computations, because the particle number
-     * per cell is more similar.
+     * A mesh refinement criterion that computes
+     * refinement indicators based on the density
+     * of particles. In practice this plugin
+     * equilibrates the number of particles per cell,
+     * leading to fine cells in high particle density regions
+     * and coarse cells in low particle density regions.
+     * This plugin is mostly useful for models with inhomogeneous
+     * particle density, e.g. when tracking an initial interface
+     * with a high particle density, or when the spatial particle
+     * density denotes the region of interest. Additionally, this
+     * plugin tends to balance the computational load between
+     * processes in parallel computations, because the particle
+     * and mesh density is more aligned.
      *
      * @ingroup MeshRefinement
      */

--- a/source/mesh_refinement/particle_density.cc
+++ b/source/mesh_refinement/particle_density.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2015 by the authors of the ASPECT code.
+  Copyright (C) 2015, 2016 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -35,7 +35,7 @@ namespace aspect
       const Postprocess::Tracers<dim> *tracer_postprocessor = this->template find_postprocessor<Postprocess::Tracers<dim> >();
 
       AssertThrow(tracer_postprocessor != 0,
-                  ExcMessage("The mesh refinement plugin 'tracer distribution' requires the "
+                  ExcMessage("The mesh refinement plugin 'particle density' requires the "
                              "postprocessor plugin 'tracers' to be selected. Please activate the "
                              "tracers or deactivate this mesh refinement plugin."));
 
@@ -51,10 +51,11 @@ namespace aspect
             const Particle::types::LevelInd cell_index (cell->level(),cell->index());
             const unsigned int n_tracers = particles->count(cell_index);
 
-            // Note that measure() only gives a linear approximation of the cell's volume.
-            // This is unaccurate for curved cells, but the exact measure is likely not
-            // important for this plugin since the cell distortion is usually small.
-            indicators(i) = n_tracers / cell->measure();
+            // Note  that this refinement indicator will level out the number
+            // of particles per cell, therefore creating fine cells in regions
+            // of high particle density and coarse cells in low particle
+            // density regions.
+            indicators(i) = static_cast<float>(n_tracers);
           }
       return;
     }
@@ -69,14 +70,17 @@ namespace aspect
     ASPECT_REGISTER_MESH_REFINEMENT_CRITERION(ParticleDensity,
                                               "particle density",
                                               "A mesh refinement criterion that computes "
-                                              "refinement indicators that equal the areal (in 2d) "
-                                              "or volumetric (in 3d) density of particles in this cell. "
-                                              "This plugin is useful for models with inhomogeneous "
+                                              "refinement indicators based on the density "
+                                              "of particles. In practice this plugin "
+                                              "equilibrates the number of particles per cell, "
+                                              "leading to fine cells in high particle density regions "
+                                              "and coarse cells in low particle density regions. "
+                                              "This plugin is mostly useful for models with inhomogeneous "
                                               "particle density, e.g. when tracking an initial interface "
                                               "with a high particle density, or when the spatial particle "
                                               "density denotes the region of interest. Additionally, this "
                                               "plugin tends to balance the computational load between "
                                               "processes in parallel computations, because the particle "
-                                              "number per cell is more similar.")
+                                              "and mesh density is more aligned.")
   }
 }

--- a/tests/particle_load_balancing_refinement_02.prm
+++ b/tests/particle_load_balancing_refinement_02.prm
@@ -1,0 +1,114 @@
+# A test for the 'tracer distribution' refinement plugin.
+# The cell are refined based on the numbers of particles they
+# contain.
+
+set Dimension                              = 2
+set End time                               = 500
+set Use years in output instead of seconds = false
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent  = 1.0000
+    set Y extent  = 1.0000
+  end
+end
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false
+  set Tangential velocity boundary indicators = left, right
+  set Zero velocity boundary indicators       = bottom, top
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Reference density             = 1010
+    set Viscosity                     = 1e2
+    set Thermal expansion coefficient = 0
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+############### Parameters describing the temperature field
+# Note: The temperature plays no role in this model
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+subsection Initial conditions
+  set Model name = function
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+
+############### Parameters describing the compositional field
+# Note: The compositional field is what drives the flow
+# in this example
+
+subsection Compositional fields
+  set Number of fields = 1
+end
+
+subsection Compositional initial conditions
+  set Model name = function
+  subsection Function
+    set Variable names      = x,z
+    set Function constants  = pi=3.1415926
+    set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
+  end
+end
+
+subsection Material model
+  subsection Simple model
+    set Density differential for compositional field 1 = -10
+  end
+end
+
+
+############### Parameters describing the discretization
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Strategy                           = particle density
+  set Initial global refinement          = 3
+  set Time steps between mesh refinement = 1
+  set Coarsening fraction                = 0.05
+  set Refinement fraction                = 0.3
+end
+
+
+
+############### Parameters describing what to do with the solution
+
+subsection Postprocess
+  set List of postprocessors = tracers
+
+  subsection Tracers
+    set Number of tracers = 10
+    set Time between data output = 100
+    set Load balancing strategy = none
+    set Data output format = ascii
+    set Integration scheme = euler
+    set Particle generator name = probability density function
+
+    subsection Generator
+      subsection Probability density function
+        set Variable names      = x,z
+        set Function expression = x*x*z
+      end
+    end
+  end
+end

--- a/tests/particle_load_balancing_refinement_02/screen-output
+++ b/tests/particle_load_balancing_refinement_02/screen-output
@@ -1,0 +1,83 @@
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 1,237 (578+81+289+289)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 24 iterations.
+
+   Postprocessing:
+     Writing particle output: output-particle_load_balancing_refinement_02/particle-00000
+
+Number of active cells: 25 (on 4 levels)
+Number of degrees of freedom: 554 (258+38+129+129)
+
+*** Timestep 1:  t=100.897 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 24 iterations.
+
+   Postprocessing:
+     Writing particle output: output-particle_load_balancing_refinement_02/particle-00001
+
+Number of active cells: 25 (on 4 levels)
+Number of degrees of freedom: 554 (258+38+129+129)
+
+*** Timestep 2:  t=274.418 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 9 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 24 iterations.
+
+   Postprocessing:
+     Writing particle output: output-particle_load_balancing_refinement_02/particle-00002
+
+Number of active cells: 25 (on 4 levels)
+Number of degrees of freedom: 554 (258+38+129+129)
+
+*** Timestep 3:  t=407.89 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 11 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 24 iterations.
+
+   Postprocessing:
+     Writing particle output: output-particle_load_balancing_refinement_02/particle-00003
+
+Number of active cells: 16 (on 4 levels)
+Number of degrees of freedom: 387 (180+27+90+90)
+
+*** Timestep 4:  t=477.649 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 24 iterations.
+
+   Postprocessing:
+     Number of advected particles: 10
+
+Number of active cells: 10 (on 3 levels)
+Number of degrees of freedom: 246 (114+18+57+57)
+
+*** Timestep 5:  t=500 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 8 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 23 iterations.
+
+   Postprocessing:
+     Writing particle output: output-particle_load_balancing_refinement_02/particle-00004
+
+Number of active cells: 10 (on 3 levels)
+Number of degrees of freedom: 246 (114+18+57+57)
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/particle_load_balancing_refinement_02/statistics
+++ b/tests/particle_load_balancing_refinement_02/statistics
@@ -1,0 +1,20 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Number of degrees of freedom for all compositions
+# 7: Iterations for temperature solver
+# 8: Iterations for composition solver 1
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Time step size (seconds)
+# 13: Number of advected particles
+# 14: Particle file name
+0 0.0000e+00 64 659 289 289 0  0 24 25  24 1.0090e+02 10 output-particle_load_balancing_refinement_02/output-particle_load_balancing_refinement_02/particle-00000 
+1 1.0090e+02 25 296 129 129 0 10 24 25  93 1.7352e+02 10 output-particle_load_balancing_refinement_02/output-particle_load_balancing_refinement_02/particle-00001 
+2 2.7442e+02 25 296 129 129 0  9 24 25  89 1.3347e+02 10 output-particle_load_balancing_refinement_02/output-particle_load_balancing_refinement_02/particle-00002 
+3 4.0789e+02 25 296 129 129 0 11 24 25  91 6.9759e+01 10 output-particle_load_balancing_refinement_02/output-particle_load_balancing_refinement_02/particle-00003 
+4 4.7765e+02 16 207  90  90 0 10 24 25 101 2.2351e+01 10                                                                                                       "" 
+5 5.0000e+02 10 132  57  57 0  8 23 24  95 5.7746e+01 10 output-particle_load_balancing_refinement_02/output-particle_load_balancing_refinement_02/particle-00004 


### PR DESCRIPTION
The refinement criterion 'particle density' did not decrease when the cells were refined, which was not caught by the test, because it only refined once. The correct measure is the number of particles per cell (equivalent to: particle_density * cell_volume). The new test captures this behavior.