### PR TITLE
Remove unintended copy of particles

### DIFF
--- a/source/postprocess/visualization/particle_count.cc
+++ b/source/postprocess/visualization/particle_count.cc
@@ -43,7 +43,7 @@ namespace aspect
                                "active postprocessors. You need to select this postprocessor to "
                                "be able to select the <particle count> visualization plugin."));
 
-        const std::multimap<aspect::Particle::types::LevelInd, aspect::Particle::Particle<dim> > particles =
+        const std::multimap<aspect::Particle::types::LevelInd, aspect::Particle::Particle<dim> > &particles =
           tracer_postprocessor->get_particle_world().get_particles();
 
         std::pair<std::string, Vector<float> *>


### PR DESCRIPTION
No, I definitely do not want to copy all particles just to output their numbers, but that is what seems to be happening right here. Who wrote this code? Oh, it was me.