### PR TITLE
Prevent a particle from being assigned to two children

### DIFF
--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -491,6 +491,7 @@ namespace aspect
                       if (GeometryInfo<dim>::is_inside_unit_cell(p_unit))
                         {
                           particles.insert(std::make_pair(std::make_pair(child->level(),child->index()),p));
+                          break;
                         }
                     }
                   catch (...)


### PR DESCRIPTION
Tiny bugfix that prevents a few tracers from being duplicated when transferred during adaptive mesh refinement. GeometryInfo<dim>::is_inside_unit_cell apparently returns true for two children, if the position is very close to their boundary. Now the particle is only inserted into one of the children.