### PR TITLE
Speed up particle sorting.

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,14 @@
  *
  * <ol>
  *
+ * <li> Improved: The particle sorting algorithm performance was considerably
+ * improved. It now sorts neighbor cells by the distance between the particle
+ * and the face center that is between the old cell and the neighbor and then
+ * checks if the particle is in this list of neighbor cells. Only if it is
+ * not found there, a search over all local cells is performed.
+ * <br>
+ * (Rene Gassmoeller, Wolfgang Bangerth, 2016/04/12)
+ *
  * <li> New: There is now a postprocessor "point values" that allows evaluating
  * the solution at a number of user-defined evaluation points.
  * <br>

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -332,6 +332,23 @@ namespace aspect
         update_next_free_particle_index();
 
         /**
+         * Returns whether a given particle is in the given cell.
+         */
+        bool
+        particle_is_in_cell(const Particle<dim> &particle,
+                            const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const;
+
+        /**
+         * Returns a map of neighbor cells of the current cell. This map is
+         * sorted according to the distance between the particle and the face
+         * of cell that is shared with the neighbor cell. I.e. the first
+         * entries of the map are the most likely ones to find the particle in.
+         */
+        std::multimap<double, typename parallel::distributed::Triangulation<dim>::active_cell_iterator>
+        neighbor_cells_to_search(const Particle<dim> &particle,
+                                 const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const;
+
+        /**
          * Finds the cells containing each particle for all particles. If
          * particles moved out of this subdomain they will be sent
          * to their new process and inserted there. After this function call


### PR DESCRIPTION
These additional lines of code improve the scaling for large number of cells and particles per subdomain, and can save up to 75 % of the total particle computation cost in a few cases. Realistic speed gains are around 10 %.

The sorting into new cells now first considers neighbors in the order of the distance between particle and the center of the face that connects the old cell with the neighbor.