### PR TITLE
Enable time-dependent min/max refinement

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,14 @@
  *
  * <ol>
  *
+ * <li> Improved: Mesh refinement plugins can now update member variables
+ * at the beginning of each time step. This can be used to make things like
+ * time-dependent mesh refinement criteria, or fancy models that depend on
+ * calling an external program. The most immediate added functionality is
+ * the ability to define time-dependent minimum/maximum refinement functions.
+ * <br>
+ * (Jonathan Perry-Houts, 2016/04/13)
+ *
  * <li> Improved: The particle sorting algorithm performance was considerably
  * improved. It now sorts neighbor cells by the distance between the particle
  * and the face center that is between the old cell and the neighbor and then

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -89,6 +89,19 @@ namespace aspect
         virtual void initialize ();
 
         /**
+         * A function that is called once at the beginning of each timestep.
+         * The default implementation of the function does nothing, but
+         * derived classes that need more elaborate setups for a given time
+         * step may overload the function.
+         *
+         * The point of this function is to allow refinement plugins to do an
+         * initialization once during each time step.
+         */
+        virtual
+        void
+        update ();
+
+        /**
          * Execute this mesh refinement criterion. The default implementation
          * sets all the error indicators to zero.
          *
@@ -163,6 +176,16 @@ namespace aspect
          * functions.
          */
         virtual ~Manager ();
+
+        /*
+         * Update all of the mesh refinement objects that have been requested
+         * in the input file. Individual mesh refinement objects may choose to
+         * implement an update function to modify object variables once per
+         * time step.
+         */
+        virtual
+        void
+        update ();
 
         /**
          * Execute all of the mesh refinement objects that have been requested

--- a/include/aspect/mesh_refinement/maximum_refinement_function.h
+++ b/include/aspect/mesh_refinement/maximum_refinement_function.h
@@ -44,6 +44,14 @@ namespace aspect
       public SimulatorAccess<dim>
     {
       public:
+        /*
+         * At the beginning of each time step, update the time for the
+         * ParsedFunction.
+         */
+        virtual
+        void
+        update ();
+
         /**
          * After cells have been marked for coarsening/refinement, apply
          * additional criteria independent of the error estimate.

--- a/include/aspect/mesh_refinement/minimum_refinement_function.h
+++ b/include/aspect/mesh_refinement/minimum_refinement_function.h
@@ -44,6 +44,14 @@ namespace aspect
       public SimulatorAccess<dim>
     {
       public:
+        /*
+         * At the beginning of each time step, update the time for the
+         * ParsedFunction.
+         */
+        virtual
+        void
+        update ();
+
         /**
          * After cells have been marked for coarsening/refinement, apply
          * additional criteria independent of the error estimate.

--- a/source/mesh_refinement/interface.cc
+++ b/source/mesh_refinement/interface.cc
@@ -40,6 +40,13 @@ namespace aspect
     Interface<dim>::initialize ()
     {}
 
+
+    template <int dim>
+    void
+    Interface<dim>::update ()
+    {}
+
+
     template <int dim>
     void
     Interface<dim>::execute (Vector<float> &error_indicators) const
@@ -74,6 +81,71 @@ namespace aspect
     template <int dim>
     Manager<dim>::~Manager()
     {}
+
+
+
+    template <int dim>
+    void
+    Manager<dim>::update ()
+    {
+      Assert (mesh_refinement_objects.size() > 0, ExcInternalError());
+
+      // call the update() functions of all
+      // refinement plugins.
+      unsigned int index = 0;
+      for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
+           p = mesh_refinement_objects.begin();
+           p != mesh_refinement_objects.end(); ++p, ++index)
+        {
+          try
+            {
+              (*p)->update ();
+            }
+
+          // plugins that throw exceptions usually do not result in
+          // anything good because they result in an unwinding of the stack
+          // and, if only one processor triggers an exception, the
+          // destruction of objects often causes a deadlock. thus, if
+          // an exception is generated, catch it, print an error message,
+          // and abort the program
+          catch (std::exception &exc)
+            {
+              std::cerr << std::endl << std::endl
+                        << "----------------------------------------------------"
+                        << std::endl;
+              std::cerr << "Exception on MPI process <"
+                        << Utilities::MPI::this_mpi_process(MPI_COMM_WORLD)
+                        << "> while running mesh refinement plugin <"
+                        << typeid(**p).name()
+                        << ">: " << std::endl
+                        << exc.what() << std::endl
+                        << "Aborting!" << std::endl
+                        << "----------------------------------------------------"
+                        << std::endl;
+
+              // terminate the program!
+              MPI_Abort (MPI_COMM_WORLD, 1);
+            }
+          catch (...)
+            {
+              std::cerr << std::endl << std::endl
+                        << "----------------------------------------------------"
+                        << std::endl;
+              std::cerr << "Exception on MPI process <"
+                        << Utilities::MPI::this_mpi_process(MPI_COMM_WORLD)
+                        << "> while running mesh refinement plugin <"
+                        << typeid(**p).name()
+                        << ">: " << std::endl;
+              std::cerr << "Unknown exception!" << std::endl
+                        << "Aborting!" << std::endl
+                        << "----------------------------------------------------"
+                        << std::endl;
+
+              // terminate the program!
+              MPI_Abort (MPI_COMM_WORLD, 1);
+            }
+        }
+    }
 
 
 

--- a/source/mesh_refinement/maximum_refinement_function.cc
+++ b/source/mesh_refinement/maximum_refinement_function.cc
@@ -33,6 +33,20 @@ namespace aspect
   {
     template <int dim>
     void
+    MaximumRefinementFunction<dim>::update ()
+    {
+      const double time = this->get_time() /
+                          (this->convert_output_to_years()
+                           ?
+                           year_in_seconds
+                           :
+                           1.0);
+
+      max_refinement_level.set_time(time);
+    }
+
+    template <int dim>
+    void
     MaximumRefinementFunction<dim>::tag_additional_cells () const
     {
       for (typename Triangulation<dim>::active_cell_iterator
@@ -200,6 +214,10 @@ namespace aspect
                                               "order of spherical coordinates is r,phi,theta "
                                               "and not r,theta,phi, since this allows for "
                                               "dimension independent expressions. "
+                                              "Each coordinate system also includes a final 't' "
+                                              "variable which represents the model time, evaluated "
+                                              "in years if the 'Use years in output instead of seconds' "
+                                              "parameter is set, otherwise evaluated in seconds. "
                                               "After evaluating the function, its values are "
                                               "rounded to the nearest integer."
                                               "\n\n"

--- a/source/mesh_refinement/minimum_refinement_function.cc
+++ b/source/mesh_refinement/minimum_refinement_function.cc
@@ -33,6 +33,20 @@ namespace aspect
   {
     template <int dim>
     void
+    MinimumRefinementFunction<dim>::update ()
+    {
+      const double time = this->get_time() /
+                          (this->convert_output_to_years()
+                           ?
+                           year_in_seconds
+                           :
+                           1.0);
+
+      min_refinement_level.set_time(time);
+    }
+
+    template <int dim>
+    void
     MinimumRefinementFunction<dim>::tag_additional_cells () const
     {
       for (typename Triangulation<dim>::active_cell_iterator
@@ -200,6 +214,10 @@ namespace aspect
                                               "order of spherical coordinates is r,phi,theta "
                                               "and not r,theta,phi, since this allows for "
                                               "dimension independent expressions. "
+                                              "Each coordinate system also includes a final 't' "
+                                              "variable which represents the model time, evaluated "
+                                              "in years if the 'Use years in output instead of seconds' "
+                                              "parameter is set, otherwise evaluated in seconds. "
                                               "After evaluating the function, its values are "
                                               "rounded to the nearest integer."
                                               "\n\n"

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -785,6 +785,7 @@ namespace aspect
     gravity_model->update();
     heating_model_manager.update();
     adiabatic_conditions->update();
+    mesh_refinement_manager.update();
 
     if (prescribed_stokes_solution.get())
       prescribed_stokes_solution->update();

--- a/tests/minimum_refinement_function_time_dependent.prm
+++ b/tests/minimum_refinement_function_time_dependent.prm
@@ -1,0 +1,223 @@
+# Listing of Parameters
+# ---------------------
+# In order to make the problem in the first time step easier to solve, we need
+# a reasonable guess for the temperature and pressure. To obtain it, we use an
+# adiabatic pressure and temperature field. This parameter describes what the
+# `adiabatic' temperature would be at the surface of the domain (i.e. at depth
+# zero). Note that this value need not coincide with the boundary condition
+# posed at this point. Rather, the boundary condition may differ significantly
+# from the adiabatic value, and then typically induce a thermal boundary
+# layer.
+# For more information, see the section in the manual that discusses the
+# general mathematical model.
+
+# MPI: 2
+
+set Adiabatic surface temperature          = 1623               # default: 0
+set CFL number                             = 1.0
+set Composition solver tolerance           = 1e-12
+
+# The number of space dimensions you want to run this program in.
+set Dimension                              = 2
+
+# The end time of the simulation. Units: years if the 'Use years in output
+# instead of seconds' parameter is set; seconds otherwise.
+set End time                               = 5e9
+
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+set Resume computation                     = false
+set Start time                             = 0
+
+set Use years in output instead of seconds = true
+
+
+subsection Boundary temperature model
+  # Select one of the following models:
+  # 
+  # `Tan Gurnis': A model for the Tan/Gurnis benchmark.
+  # 
+  # `spherical constant': A model in which the temperature is chosen constant
+  # on the inner and outer boundaries of a spherical shell. Parameters are
+  # read from subsection 'Sherical constant'.
+  # 
+  # `box': A model in which the temperature is chosen constant on all the
+  # sides of a box.
+  set Model name = initial temperature
+
+  subsection Initial temperature
+    # Temperature at the inner boundary (core mantle boundary). Units: K.
+    set Maximal temperature = 3773 # default: 6000
+
+    # Temperature at the outer boundary (lithosphere water/air). Units: K.
+    set Minimal temperature = 273  # default: 0
+  end
+
+end
+
+
+subsection Discretization
+  subsection Stabilization parameters
+
+    # The $\beta$ factor in the artificial viscosity stabilization. An
+    # appropriate value for 2d is 0.078 and 0.117 for 3d. Units: None.
+    set beta  = 0.078
+
+    # The $c_R$ factor in the entropy viscosity stabilization. Units: None.
+    set cR    = 0.33
+  end
+
+end
+
+
+subsection Geometry model
+  # Select one of the following models:
+  # 
+  # `spherical shell': A geometry representing a spherical shell or a pice of
+  # it. Inner and outer radii are read from the parameter file in subsection
+  # 'Spherical shell'.
+  # 
+  # `box': A box geometry parallel to the coordinate directions. The extent of
+  # the box in each coordinate direction is set in the parameter file. The box
+  # geometry labels its 2*dim sides as follows: in 2d, boundary indicators 0
+  # through 3 denote the left, right, bottom and top boundaries; in 3d,
+  # boundary indicators 0 through 5 indicate left, right, front, back, bottom
+  # and top boundaries. See also the documentation of the deal.II class
+  # ``GeometryInfo''.
+  set Model name = box # default: 
+
+  subsection Box
+    set X extent  = 500000
+    set Y extent  = 500000
+  end
+
+end
+
+
+subsection Gravity model
+  # Select one of the following models:
+  # 
+  # `vertical': A gravity model in which the gravity direction is vertically
+  # downward and at a constant magnitude by default equal to one.
+  # 
+  # `radial constant': A gravity model in which the gravity direction is
+  # radially inward and at constant magnitude. The magnitude is read from the
+  # parameter file in subsection 'Radial constant'.
+  # 
+  # `radial earth-like': A gravity model in which the gravity direction is
+  # radially inward and with a magnitude that matches that of the earth at the
+  # core-mantle boundary as well as at the surface and in between is
+  # physically correct under the assumption of a constant density.
+  set Model name = vertical # default: 
+
+
+  subsection Vertical
+    # Magnitude of the gravity vector in $m/s^2$. The direction is always
+    # radially outward from the center of the earth.
+    set Magnitude = 10.0 # default: 30
+  end
+
+end
+
+
+subsection Initial conditions
+  set Model name = function # default: 
+  subsection Function
+    set Function constants  = l=250000
+    set Function expression = if(x < l, 1873, 1623)
+    set Variable names      = x,y
+  end
+end
+
+
+subsection Material model
+
+  set Model name = simple # default: 
+
+end
+
+
+subsection Mesh refinement
+
+  set Additional refinement times              = 
+
+  set Coarsening fraction                      = 0.05
+  set Refinement fraction                      = 0.3
+
+  set Initial adaptive refinement              = 3                    # default: 2
+  set Initial global refinement                = 3                    # default: 2
+
+  set Normalize individual refinement criteria = true
+  set Refinement criteria merge operation      = max
+
+  set Run postprocessors on initial refinement = true
+
+  set Strategy                                 = temperature, minimum refinement function
+
+  set Time steps between mesh refinement       = 1
+  subsection Minimum refinement function
+    set Function constants  = 
+
+    # This is in fact the default value
+    set Coordinate system   = depth
+
+    # The following lines are equal to set the line:
+    # set Function expression = 4 + 2*sin(x*pi/250000-t/6e8)
+    # which implies:
+    # set Variable names    = x,y
+    # because that is the default value for Variable names.
+    # To illustrate the possibility to rename function variables
+    # in your favourite naming scheme we use the following:
+    set Variable names      = depth,not_used1,t
+    set Function expression = 4 + 2*sin(depth*pi/250000-t/6e8)
+
+  end
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = 0,3        # default: 
+  set Prescribed velocity boundary indicators =  
+
+  set Tangential velocity boundary indicators = 0,1,2,3
+  set Zero velocity boundary indicators       =           # default: 
+end
+
+
+subsection Postprocess
+
+  set List of postprocessors = basic statistics
+
+  subsection Depth average
+    # The time interval between each generation of graphical output files. A
+    # value of zero indicates that output should be generated in each time
+    # step. Units: years if the 'Use years in output instead of seconds'
+    # parameter is set; seconds otherwise.
+    set Time between graphical output = 0 # default: 1e8
+  end
+
+  subsection Visualization
+
+    set List of output variables      = 
+
+    # VTU file output supports grouping files from several CPUs into one file
+    # using MPI I/O when writing on a parallel filesystem. Select 0 for no
+    # grouping. This will disable parallel file output and instead write one
+    # file per processor in a background thread. A value of 1 will generate
+    # one big file containing the whole solution.
+    set Number of grouped files       = 0
+
+    # The file format to be used for graphical output.
+    set Output format                 = gnuplot
+
+    # The time interval between each generation of graphical output files. A
+    # value of zero indicates that output should be generated in each time
+    # step. Units: years if the 'Use years in output instead of seconds'
+    # parameter is set; seconds otherwise.
+    set Time between graphical output = 0
+  end
+
+end
+
+
+

--- a/tests/minimum_refinement_function_time_dependent/log.txt
+++ b/tests/minimum_refinement_function_time_dependent/log.txt
@@ -1,0 +1,164 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.4.0-pre
+--     . running in OPTIMIZED mode
+--     . running with 2 MPI processes
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 948 (578+81+289)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 18 iterations.
+
+   Postprocessing:
+
+     Reference density (kg/m^3):                    3300
+     Reference gravity (m/s^2):                     10
+     Reference thermal expansion (1/K):             2e-05
+     Temperature contrast across model domain (K):  3500
+     Model domain depth (m):                        500000
+     Reference thermal diffusivity (m^2/s):         1.13939e-06
+     Reference viscosity (Pas):                     5e+24
+     Ra number:                                     50.6848
+     k_value:                                       4.7
+     reference_cp:                                  1250
+     reference_thermal_diffusivity:                 1.13939e-06
+
+
+Number of active cells: 214 (on 5 levels)
+Number of degrees of freedom: 3,113 (1,906+254+953)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 18 iterations.
+
+   Postprocessing:
+
+     Reference density (kg/m^3):                    3300
+     Reference gravity (m/s^2):                     10
+     Reference thermal expansion (1/K):             2e-05
+     Temperature contrast across model domain (K):  3500
+     Model domain depth (m):                        500000
+     Reference thermal diffusivity (m^2/s):         1.13939e-06
+     Reference viscosity (Pas):                     5e+24
+     Ra number:                                     50.6848
+     k_value:                                       4.7
+     reference_cp:                                  1250
+     reference_thermal_diffusivity:                 1.13939e-06
+
+
+Number of active cells: 604 (on 6 levels)
+Number of degrees of freedom: 8,386 (5,146+667+2,573)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+
+     Reference density (kg/m^3):                    3300
+     Reference gravity (m/s^2):                     10
+     Reference thermal expansion (1/K):             2e-05
+     Temperature contrast across model domain (K):  3500
+     Model domain depth (m):                        500000
+     Reference thermal diffusivity (m^2/s):         1.13939e-06
+     Reference viscosity (Pas):                     5e+24
+     Ra number:                                     50.6848
+     k_value:                                       4.7
+     reference_cp:                                  1250
+     reference_thermal_diffusivity:                 1.13939e-06
+
+
+Number of active cells: 1,375 (on 7 levels)
+Number of degrees of freedom: 18,894 (11,610+1,479+5,805)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+
+     Reference density (kg/m^3):                    3300
+     Reference gravity (m/s^2):                     10
+     Reference thermal expansion (1/K):             2e-05
+     Temperature contrast across model domain (K):  3500
+     Model domain depth (m):                        500000
+     Reference thermal diffusivity (m^2/s):         1.13939e-06
+     Reference viscosity (Pas):                     5e+24
+     Ra number:                                     50.6848
+     k_value:                                       4.7
+     reference_cp:                                  1250
+     reference_thermal_diffusivity:                 1.13939e-06
+
+
+Number of active cells: 1,387 (on 7 levels)
+Number of degrees of freedom: 19,089 (11,730+1,494+5,865)
+
+*** Timestep 1:  t=7.45202e+08 years
+   Solving temperature system... 363 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+
+Number of active cells: 1,234 (on 7 levels)
+Number of degrees of freedom: 17,071 (10,492+1,333+5,246)
+
+*** Timestep 2:  t=1.83931e+09 years
+   Solving temperature system... 376 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+
+Number of active cells: 772 (on 7 levels)
+Number of degrees of freedom: 11,026 (6,772+868+3,386)
+
+*** Timestep 3:  t=3.28375e+09 years
+   Solving temperature system... 225 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+
+Number of active cells: 796 (on 6 levels)
+Number of degrees of freedom: 11,282 (6,924+896+3,462)
+
+*** Timestep 4:  t=5e+09 years
+   Solving temperature system... 235 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+
+Number of active cells: 1,108 (on 7 levels)
+Number of degrees of freedom: 15,461 (9,500+1,211+4,750)
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      1.89s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         8 |     0.213s |        11% |
+| Assemble temperature system     |         8 |     0.211s |        11% |
+| Build Stokes preconditioner     |         8 |     0.226s |        12% |
+| Build temperature preconditioner|         8 |    0.0305s |       1.6% |
+| Solve Stokes system             |         8 |     0.414s |        22% |
+| Solve temperature system        |         8 |     0.231s |        12% |
+| Initialization                  |         5 |     0.132s |         7% |
+| Postprocessing                  |         8 |   0.00152s |     0.081% |
+| Refine mesh structure, part 1   |         8 |    0.0981s |       5.2% |
+| Refine mesh structure, part 2   |         8 |    0.0342s |       1.8% |
+| Setup dof systems               |         9 |     0.277s |        15% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/minimum_refinement_function_time_dependent/screen-output
+++ b/tests/minimum_refinement_function_time_dependent/screen-output
@@ -1,0 +1,164 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.4.0-pre
+--     . running in OPTIMIZED mode
+--     . running with 2 MPI processes
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 948 (578+81+289)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 18 iterations.
+
+   Postprocessing:
+
+     Reference density (kg/m^3):                    3300
+     Reference gravity (m/s^2):                     10
+     Reference thermal expansion (1/K):             2e-05
+     Temperature contrast across model domain (K):  3500
+     Model domain depth (m):                        500000
+     Reference thermal diffusivity (m^2/s):         1.13939e-06
+     Reference viscosity (Pas):                     5e+24
+     Ra number:                                     50.6848
+     k_value:                                       4.7
+     reference_cp:                                  1250
+     reference_thermal_diffusivity:                 1.13939e-06
+
+
+Number of active cells: 214 (on 5 levels)
+Number of degrees of freedom: 3,113 (1,906+254+953)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 18 iterations.
+
+   Postprocessing:
+
+     Reference density (kg/m^3):                    3300
+     Reference gravity (m/s^2):                     10
+     Reference thermal expansion (1/K):             2e-05
+     Temperature contrast across model domain (K):  3500
+     Model domain depth (m):                        500000
+     Reference thermal diffusivity (m^2/s):         1.13939e-06
+     Reference viscosity (Pas):                     5e+24
+     Ra number:                                     50.6848
+     k_value:                                       4.7
+     reference_cp:                                  1250
+     reference_thermal_diffusivity:                 1.13939e-06
+
+
+Number of active cells: 604 (on 6 levels)
+Number of degrees of freedom: 8,386 (5,146+667+2,573)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+
+     Reference density (kg/m^3):                    3300
+     Reference gravity (m/s^2):                     10
+     Reference thermal expansion (1/K):             2e-05
+     Temperature contrast across model domain (K):  3500
+     Model domain depth (m):                        500000
+     Reference thermal diffusivity (m^2/s):         1.13939e-06
+     Reference viscosity (Pas):                     5e+24
+     Ra number:                                     50.6848
+     k_value:                                       4.7
+     reference_cp:                                  1250
+     reference_thermal_diffusivity:                 1.13939e-06
+
+
+Number of active cells: 1,375 (on 7 levels)
+Number of degrees of freedom: 18,894 (11,610+1,479+5,805)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+
+     Reference density (kg/m^3):                    3300
+     Reference gravity (m/s^2):                     10
+     Reference thermal expansion (1/K):             2e-05
+     Temperature contrast across model domain (K):  3500
+     Model domain depth (m):                        500000
+     Reference thermal diffusivity (m^2/s):         1.13939e-06
+     Reference viscosity (Pas):                     5e+24
+     Ra number:                                     50.6848
+     k_value:                                       4.7
+     reference_cp:                                  1250
+     reference_thermal_diffusivity:                 1.13939e-06
+
+
+Number of active cells: 1,387 (on 7 levels)
+Number of degrees of freedom: 19,089 (11,730+1,494+5,865)
+
+*** Timestep 1:  t=7.45202e+08 years
+   Solving temperature system... 363 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+
+Number of active cells: 1,234 (on 7 levels)
+Number of degrees of freedom: 17,071 (10,492+1,333+5,246)
+
+*** Timestep 2:  t=1.83931e+09 years
+   Solving temperature system... 376 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+
+Number of active cells: 772 (on 7 levels)
+Number of degrees of freedom: 11,026 (6,772+868+3,386)
+
+*** Timestep 3:  t=3.28375e+09 years
+   Solving temperature system... 225 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+
+Number of active cells: 796 (on 6 levels)
+Number of degrees of freedom: 11,282 (6,924+896+3,462)
+
+*** Timestep 4:  t=5e+09 years
+   Solving temperature system... 235 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+
+Number of active cells: 1,108 (on 7 levels)
+Number of degrees of freedom: 15,461 (9,500+1,211+4,750)
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      1.89s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         8 |     0.213s |        11% |
+| Assemble temperature system     |         8 |     0.211s |        11% |
+| Build Stokes preconditioner     |         8 |     0.226s |        12% |
+| Build temperature preconditioner|         8 |    0.0305s |       1.6% |
+| Solve Stokes system             |         8 |     0.414s |        22% |
+| Solve temperature system        |         8 |     0.231s |        12% |
+| Initialization                  |         5 |     0.132s |         7% |
+| Postprocessing                  |         8 |   0.00152s |     0.081% |
+| Refine mesh structure, part 1   |         8 |    0.0981s |       5.2% |
+| Refine mesh structure, part 2   |         8 |    0.0342s |       1.8% |
+| Setup dof systems               |         9 |     0.277s |        15% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/minimum_refinement_function_time_dependent/statistics
+++ b/tests/minimum_refinement_function_time_dependent/statistics
@@ -1,0 +1,18 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Iterations for temperature solver
+# 7: Iterations for Stokes solver
+# 8: Velocity iterations in Stokes preconditioner
+# 9: Schur complement iterations in Stokes preconditioner
+# 10: Time step size (years)
+0 0.0000e+00   64   659  289   0 18 19  54 5.0000e+09 
+0 0.0000e+00  214  2160  953   0 18 19 141 2.5922e+09 
+0 0.0000e+00  604  5813 2573   0 32 21  25 1.2940e+09 
+0 0.0000e+00 1375 13089 5805   0 32 21  24 7.4520e+08 
+1 7.4520e+08 1387 13224 5865 363 32 21  24 1.0941e+09 
+2 1.8393e+09 1234 11825 5246 376 32 21  26 1.4444e+09 
+3 3.2837e+09  772  7640 3386 225 32 21  24 1.7163e+09 
+4 5.0000e+09  796  7820 3462 235 32 20  25 1.4762e+09 


### PR DESCRIPTION
I'm using a case right now where I'd like the minimum and maximum refinement levels to change with time, which was apparently not previously supported.