### PR TITLE
Avoid warning about potentially unused variable.

### DIFF
--- a/source/postprocess/point_values.cc
+++ b/source/postprocess/point_values.cc
@@ -60,12 +60,12 @@ namespace aspect
             }
 
           // ensure that exactly one processor found things
-          Assert (Utilities::MPI::sum (point_found ? 1 : 0, this->get_mpi_communicator()) == 1,
-                  ExcMessage ("While trying to evaluate the values of the solution at "
-                              "evaluation point " + Utilities::int_to_string(p) +
-                              ", no (or more than one) processor reported that that point lies inside the "
-                              "set of cells it owns. Are you trying to evaluate the "
-                              "solution at a point that lies outside the domain?"));
+          AssertThrow (Utilities::MPI::sum (point_found ? 1 : 0, this->get_mpi_communicator()) == 1,
+                       ExcMessage ("While trying to evaluate the values of the solution at "
+                                   "evaluation point " + Utilities::int_to_string(p) +
+                                   ", no (or more than one) processor reported that that point lies inside the "
+                                   "set of cells it owns. Are you trying to evaluate the "
+                                   "solution at a point that lies outside the domain?"));
 
           // now exchange things. because we have exactly one processor that found
           // the point, we can just add up that value plus all of the zero


### PR DESCRIPTION
In optimized mode, we did not check that a point at which we want to evaluate
the solution was actually found. This led to a warning about an unused
variable 'point_found'. This could be addressed by doing a 'void' cast
of said variable, but the better solution appears to be to actually
perform the check also in optimized mode -- after all, the list of points
at which we want to evaluate the solution is read at run-time from the
input field.