### PR TITLE
Set invalid_manifold_id only on chunk boundaries

### DIFF
--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -314,7 +314,9 @@ namespace aspect
     {
       for (typename Triangulation<dim>::active_cell_iterator cell =
              triangulation.begin_active(); cell != triangulation.end(); ++cell)
-        cell->set_all_manifold_ids (numbers::invalid_manifold_id);
+        for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          if (cell->at_boundary(f))
+            cell->face(f)->set_all_manifold_ids (numbers::invalid_manifold_id);
     }
 
     template <int dim>


### PR DESCRIPTION
This prevents strain rate and velocity anomalies along changes in mesh refinement level for the chunk geometry.

I compared the chunk geometry with the spherical shell geometry in 2D. For otherwise exactly the same setup (the test minimum_refinement_function_spherical.prm) and a similar mesh, velocity and strain rate fields are very different, see first three figures below. 

The chunk manifold sets all manifold ids to `invalid_manifold_id` after refinement, while the shell only does this for boundary faces on the coarse grid and then adds boundary objects. When I change the `clear_manifold_ids` function to clear only boundary manifold ids, the output in the interior of the model improves, but some anomalies are seen along the boundaries (figure 4). These disappear with one extra global level of resolution.

I do not understand the manifolds enough to explain the results. I found we need to clear the boundary manifold ids, otherwise computing the velocity constraints goes wrong, but why do we need to clear all ids? I was surprised by the difference between the solutions for the two geometries and I hope you can help me understand whether this is a problem and whether it can be improved. 

Clearing all chunk manifold ids:
![screen shot 2016-04-14 at 14 02 57](https://cloud.githubusercontent.com/assets/7631624/14556741/f45748a0-02f9-11e6-9c35-ec2149c01f4b.png)
![screen shot 2016-04-14 at 14 03 25](https://cloud.githubusercontent.com/assets/7631624/14556742/f45bb0b6-02f9-11e6-9404-d24e23fd7784.png)
![screen shot 2016-04-14 at 14 05 00](https://cloud.githubusercontent.com/assets/7631624/14556743/f45f40fa-02f9-11e6-8a62-80a4b3666ad0.png)

Clearing only the chunk boundary manifold ids:
![screen shot 2016-04-14 at 17 48 24](https://cloud.githubusercontent.com/assets/7631624/14556878/b11c296a-02fa-11e6-83a7-e7335cc0743e.png)
