### PR TITLE
Split the 'circle' plugin into .h and .cc files.

### DIFF
--- a/include/aspect/prescribed_stokes_solution/circle.h
+++ b/include/aspect/prescribed_stokes_solution/circle.h
@@ -1,0 +1,53 @@
+/*
+  Copyright (C) 2011 - 2016 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef __aspect__prescribed_stokes_solution_circle_h
+#define __aspect__prescribed_stokes_solution_circle_h
+
+#include <aspect/prescribed_stokes_solution/interface.h>
+#include <aspect/simulator_access.h>
+
+
+namespace aspect
+{
+  namespace PrescribedStokesSolution
+  {
+    using namespace dealii;
+
+    /**
+     * A class that implements a circular, divergence-free flow field
+     * around the origin of the coordinate system.
+     *
+     * @ingroup PrescribedStokesSolution
+     */
+    template <int dim>
+    class Circle : public Interface<dim>
+    {
+      public:
+
+        virtual
+        void stokes_solution (const Point<dim> &p, Vector<double> &value) const;
+    };
+  }
+}
+
+
+#endif

--- a/source/prescribed_stokes_solution/circle.cc
+++ b/source/prescribed_stokes_solution/circle.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
+  Copyright (C) 2011 - 2016 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -20,27 +20,21 @@
 
 
 #include <aspect/global.h>
-#include <aspect/prescribed_stokes_solution/interface.h>
+#include <aspect/prescribed_stokes_solution/circle.h>
 
 namespace aspect
 {
   namespace PrescribedStokesSolution
   {
     template <int dim>
-    class Circle: public Interface<dim>
+    void Circle<dim>::stokes_solution (const Point<dim> &p, Vector<double> &value) const
     {
-      public:
-
-        virtual
-        void stokes_solution (const Point<dim> &p, Vector<double> &value) const
-        {
-          value(0) = -p(1);
-          value(1) = p(0);
-          if (dim == 3)
-            value(2) = 0;
-          value(dim) = 0;
-        }
-    };
+      value(0) = -p(1);
+      value(1) = p(0);
+      if (dim == 3)
+        value(2) = 0;
+      value(dim) = 0;
+    }
   }
 }
 


### PR DESCRIPTION
We do this for all other plugins, not because it's necessary, but by convention
and because it makes it possible to show all of these classes via doxygen. Do
this for the 'circle' plugin as well.