### PR TITLE
replace $ASPECT_SOURCE_DIR in central location

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,11 @@
  *
  * <ol>
  *
+ * <li> New: The variable $ASPECT_SOURCE_DIR can now be used inside
+ * .prm files in various locations (including "include" statements).
+ * <br>
+ * (Timo Heister, 2016/05/02)
+ *
  * <li> Improved: Mesh refinement plugins can now update member variables
  * at the beginning of each time step. This can be used to make things like
  * time-dependent mesh refinement criteria, or fancy models that depend on

--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -219,6 +219,36 @@ dealii::Tensor<1,dim> cross_product_2d(const dealii::Tensor<1,dim> &a)
 }
 #endif
 
+/*
+ * Utilities::replace_in_string() got introduced in 8.3.0
+ */
+#if !DEAL_II_VERSION_GTE(8,3,0)
+namespace dealii
+{
+  namespace Utilities
+  {
+    inline
+    std::string
+    replace_in_string(const std::string &input,
+                      const std::string &from,
+                      const std::string &to)
+    {
+      if (from.empty())
+        return input;
+
+      std::string out = input;
+      std::string::size_type pos = out.find(from);
+
+      while (pos != std::string::npos)
+        {
+          out.replace(pos, from.size(), to);
+          pos = out.find(from, pos + to.size());
+        }
+      return out;
+    }
+  }
+}
+#endif
 
 /*
  * MPI::min() functions

--- a/source/initial_conditions/S40RTS_perturbation.cc
+++ b/source/initial_conditions/S40RTS_perturbation.cc
@@ -363,15 +363,9 @@ namespace aspect
       {
         prm.enter_subsection("S40RTS perturbation");
         {
-          datadirectory           = prm.get ("Data directory");
-          {
-            const std::string      subst_text = "$ASPECT_SOURCE_DIR";
-            std::string::size_type position;
-            while (position = datadirectory.find (subst_text),  position!=std::string::npos)
-              datadirectory.replace (datadirectory.begin()+position,
-                                     datadirectory.begin()+position+subst_text.size(),
-                                     ASPECT_SOURCE_DIR);
-          }
+          datadirectory = Utilities::replace_in_string(prm.get ("Data directory"),
+                                                       "$ASPECT_SOURCE_DIR",
+                                                       ASPECT_SOURCE_DIR);
           harmonics_coeffs_file_name = prm.get ("Initial condition file name");
           spline_depth_file_name  = prm.get ("Spline knots depth file name");
           vs_to_density           = prm.get_double ("Vs to density scaling");

--- a/source/initial_conditions/SAVANI_perturbation.cc
+++ b/source/initial_conditions/SAVANI_perturbation.cc
@@ -358,15 +358,9 @@ namespace aspect
       {
         prm.enter_subsection("SAVANI perturbation");
         {
-          datadirectory           = prm.get ("Data directory");
-          {
-            const std::string      subst_text = "$ASPECT_SOURCE_DIR";
-            std::string::size_type position;
-            while (position = datadirectory.find (subst_text),  position!=std::string::npos)
-              datadirectory.replace (datadirectory.begin()+position,
-                                     datadirectory.begin()+position+subst_text.size(),
-                                     ASPECT_SOURCE_DIR);
-          }
+          datadirectory = Utilities::replace_in_string(prm.get ("Data directory"),
+                                                       "$ASPECT_SOURCE_DIR",
+                                                       ASPECT_SOURCE_DIR);
           harmonics_coeffs_file_name = prm.get ("Initial condition file name");
           spline_depth_file_name  = prm.get ("Spline knots depth file name");
           vs_to_density           = prm.get_double ("Vs to density scaling");

--- a/source/initial_conditions/solidus.cc
+++ b/source/initial_conditions/solidus.cc
@@ -280,23 +280,10 @@ namespace aspect
           }
           prm.leave_subsection();
           prm.enter_subsection("Data");
-          {
-            // Get the path to the data files. If it contains a reference
-            // to $ASPECT_SOURCE_DIR, replace it by what CMake has given us
-            // as a #define
-            solidus_filename = prm.get ("Solidus filename");
-            {
-              const std::string      subst_text = "$ASPECT_SOURCE_DIR";
-              std::string::size_type position;
-              while (position = solidus_filename.find (subst_text),  position!=std::string::npos)
-                solidus_filename.replace (solidus_filename.begin()+position,
-                                          solidus_filename.begin()+position+subst_text.size(),
-                                          ASPECT_SOURCE_DIR);
-            }
-
-            // then actually read the file
-            solidus_curve.read(solidus_filename,this->get_mpi_communicator());
-          }
+          solidus_filename = Utilities::replace_in_string(prm.get ("Solidus filename"),
+                                                          "$ASPECT_SOURCE_DIR",
+                                                          ASPECT_SOURCE_DIR);
+          solidus_curve.read(solidus_filename,this->get_mpi_communicator());
           prm.leave_subsection();
         }
         prm.leave_subsection();

--- a/source/main.cc
+++ b/source/main.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/simulator.h>
+#include <aspect/utilities.h>
 
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/mpi.h>
@@ -474,6 +475,12 @@ int main (int argc, char *argv[])
               delete[] p;
             }
         }
+
+      // Replace $ASPECT_SOURCE_DIR in the input so that include statements
+      // like "include $ASPECT_SOURCE_DIR/tests/bla.prm" work.
+      input_as_string = Utilities::replace_in_string(input_as_string,
+                                                     "$ASPECT_SOURCE_DIR",
+                                                     ASPECT_SOURCE_DIR);
 
 
       // try to determine the dimension we want to work in. the default

--- a/source/material_model/depth_dependent.cc
+++ b/source/material_model/depth_dependent.cc
@@ -251,15 +251,12 @@ namespace aspect
 
           if (viscosity_source == File)
             {
-              std::string datadirectory                = prm.get ("Data directory");
+              std::string datadirectory = Utilities::replace_in_string(prm.get ("Data directory"),
+                                                                       "$ASPECT_SOURCE_DIR",
+                                                                       ASPECT_SOURCE_DIR);
+
               const std::string radial_viscosity_file_name   = prm.get ("Viscosity depth file");
 
-              const std::string      subst_text = "$ASPECT_SOURCE_DIR";
-              std::string::size_type position;
-              while (position = datadirectory.find (subst_text),  position!=std::string::npos)
-                datadirectory.replace (datadirectory.begin()+position,
-                                       datadirectory.begin()+position+subst_text.size(),
-                                       ASPECT_SOURCE_DIR);
               /* If using the File method for depth-dependence, initialize the lookup table */
               read_viscosity_file(datadirectory+radial_viscosity_file_name,this->get_mpi_communicator());
             }

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -903,15 +903,9 @@ namespace aspect
       {
         prm.enter_subsection("Steinberger model");
         {
-          datadirectory        = prm.get ("Data directory");
-          {
-            const std::string      subst_text = "$ASPECT_SOURCE_DIR";
-            std::string::size_type position;
-            while (position = datadirectory.find (subst_text),  position!=std::string::npos)
-              datadirectory.replace (datadirectory.begin()+position,
-                                     datadirectory.begin()+position+subst_text.size(),
-                                     ASPECT_SOURCE_DIR);
-          }
+          datadirectory = Utilities::replace_in_string(prm.get ("Data directory"),
+                                                       "$ASPECT_SOURCE_DIR",
+                                                       ASPECT_SOURCE_DIR);
           material_file_names  = Utilities::split_string_list
                                  (prm.get ("Material file names"));
           radial_viscosity_file_name   = prm.get ("Radial viscosity file name");

--- a/source/particle/generator/ascii_file.cc
+++ b/source/particle/generator/ascii_file.cc
@@ -110,19 +110,9 @@ namespace aspect
             {
               prm.enter_subsection("Ascii file");
               {
-                // Get the path to the data files. If it contains a reference
-                // to $ASPECT_SOURCE_DIR, replace it by what CMake has given us
-                // as a #define
-                data_directory        = prm.get ("Data directory");
-                {
-                  const std::string      subst_text = "$ASPECT_SOURCE_DIR";
-                  std::string::size_type position;
-                  while (position = data_directory.find (subst_text),  position!=std::string::npos)
-                    data_directory.replace (data_directory.begin()+position,
-                                            data_directory.begin()+position+subst_text.size(),
-                                            ASPECT_SOURCE_DIR);
-                }
-
+                data_directory = Utilities::replace_in_string(prm.get ("Data directory"),
+                                                              "$ASPECT_SOURCE_DIR",
+                                                              ASPECT_SOURCE_DIR);
                 data_filename    = prm.get ("Data file name");
               }
               prm.leave_subsection();

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -801,16 +801,9 @@ namespace aspect
         // Get the path to the data files. If it contains a reference
         // to $ASPECT_SOURCE_DIR, replace it by what CMake has given us
         // as a #define
-        data_directory    = prm.get ("Data directory");
-        {
-          const std::string      subst_text = "$ASPECT_SOURCE_DIR";
-          std::string::size_type position;
-          while (position = data_directory.find (subst_text),  position!=std::string::npos)
-            data_directory.replace (data_directory.begin()+position,
-                                    data_directory.begin()+position+subst_text.size(),
-                                    ASPECT_SOURCE_DIR);
-        }
-
+        data_directory = Utilities::replace_in_string(prm.get ("Data directory"),
+                                                      "$ASPECT_SOURCE_DIR",
+                                                      ASPECT_SOURCE_DIR);
         data_file_name    = prm.get ("Data file name");
         scale_factor      = prm.get_double ("Scale factor");
       }

--- a/source/velocity_boundary_conditions/gplates.cc
+++ b/source/velocity_boundary_conditions/gplates.cc
@@ -852,18 +852,9 @@ namespace aspect
       {
         prm.enter_subsection("GPlates model");
         {
-          // Get the path to the data files. If it contains a reference
-          // to $ASPECT_SOURCE_DIR, replace it by what CMake has given us
-          // as a #define
-          data_directory        = prm.get ("Data directory");
-          {
-            const std::string      subst_text = "$ASPECT_SOURCE_DIR";
-            std::string::size_type position;
-            while (position = data_directory.find (subst_text),  position!=std::string::npos)
-              data_directory.replace (data_directory.begin()+position,
-                                      data_directory.begin()+position+subst_text.size(),
-                                      ASPECT_SOURCE_DIR);
-          }
+          data_directory = Utilities::replace_in_string(prm.get ("Data directory"),
+                                                        "$ASPECT_SOURCE_DIR",
+                                                        ASPECT_SOURCE_DIR);
 
           velocity_file_name              = prm.get ("Velocity file name");
           data_file_time_step             = prm.get_double ("Data file time step");


### PR DESCRIPTION
We had many places where we replace ``$ASPECT_SOURCE_DIR`` in input
variables by the current source dir. Do this once at the beginning
instead. This patch allows us to use this variable in include statements inside tests.

Note that this patch will break the usage of ``$ASPECT_SOURCE_DIR`` within ``include``'d files, see #852.