### PR TITLE
Update gplates plugin to use new interface

### DIFF
--- a/include/aspect/velocity_boundary_conditions/gplates.h
+++ b/include/aspect/velocity_boundary_conditions/gplates.h
@@ -188,7 +188,8 @@ namespace aspect
          * current class, this function returns value from gplates.
          */
         Tensor<1,dim>
-        boundary_velocity (const Point<dim> &position) const;
+        boundary_velocity (const types::boundary_id boundary_indicator,
+                           const Point<dim> &position) const;
 
         // avoid -Woverloaded-virtual warning until the deprecated function
         // is removed from the interface:

--- a/source/velocity_boundary_conditions/gplates.cc
+++ b/source/velocity_boundary_conditions/gplates.cc
@@ -745,7 +745,8 @@ namespace aspect
     template <int dim>
     Tensor<1,dim>
     GPlates<dim>::
-    boundary_velocity (const Point<dim> &position) const
+    boundary_velocity (const types::boundary_id /*boundary_indicator*/,
+                       const Point<dim> &position) const
     {
       // We compare the depth of the current point to the lithosphere thickness.
       // The depth is calculated using squares, sums, square-roots and differences


### PR DESCRIPTION
While cleaning my local repository I found this branch that I thought merged long ago. Anyway, this will remove deprecation warnings for some compilers for the gplates plugin. It now uses the new boundary_velocity interface (all other plugins were updated long ago already).