### PR TITLE
Minor bugfixes

### DIFF
--- a/benchmark/davies_et_al/case-2.3-plugin/VoT.cc
+++ b/benchmark/davies_et_al/case-2.3-plugin/VoT.cc
@@ -125,6 +125,10 @@ namespace aspect
           out.specific_heat[i] = reference_specific_heat;
           out.thermal_conductivities[i] = k_value;
           out.compressibilities[i] = 0.0;
+          out.entropy_derivative_pressure[i] = 0.0;
+          out.entropy_derivative_temperature[i] = 0.0;
+          for (unsigned int c=0; c<in.composition[i].size(); ++c)
+            out.reaction_terms[i][c] = 0.0;
         }
     }
 

--- a/cookbooks/free-surface-with-crust/plugin/simpler-with-crust.cc
+++ b/cookbooks/free-surface-with-crust/plugin/simpler-with-crust.cc
@@ -130,6 +130,10 @@ namespace aspect
           out.specific_heat[i] = reference_specific_heat;
           out.thermal_conductivities[i] = k_value;
           out.compressibilities[i] = 0.0;
+          out.entropy_derivative_pressure[i] = 0.0;
+          out.entropy_derivative_temperature[i] = 0.0;
+          for (unsigned int c=0; c<in.composition[i].size(); ++c)
+            out.reaction_terms[i][c] = 0.0;
         }
     }
 


### PR DESCRIPTION
This should close #777. I went through all the benchmarks and cookbooks, and they mostly use the `InterfaceCompatibility` base class, which does prevent this problem by setting the reaction terms to 0 in the default implementation.