### PR TITLE
fix geometric averaging in 3d

### DIFF
--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -449,17 +449,16 @@ namespace aspect
 
             case geometric_average:
             {
-              double prod = 1;
+              double average = 1;
               for (unsigned int i=0; i<N; ++i)
                 {
                   Assert (values_out[i] >= 0,
                           ExcMessage ("Computing the geometric average "
                                       "only makes sense for non-negative "
                                       "quantities."));
-                  prod *= values_out[i];
+                  average *= std::pow (values_out[i], 1./N);
                 }
 
-              const double average = std::pow (prod, 1./N);
               for (unsigned int i=0; i<N; ++i)
                 values_out[i] = average;
               break;

--- a/tests/geometric_average_crash.prm
+++ b/tests/geometric_average_crash.prm
@@ -1,0 +1,58 @@
+# document crash/FPE that happens when doing geometric averaging
+# with viscosities in 3d (due to an overflow)
+
+ set Dimension                               = 3
+
+ subsection Geometry model
+   set Model name = chunk
+   subsection Chunk
+     set Chunk inner radius      = 1
+     set Chunk outer radius      = 2
+     set Chunk minimum latitude  = 37
+     set Chunk maximum latitude  = 49
+     set Chunk minimum longitude = -132
+     set Chunk maximum longitude = -116
+   end
+ end
+
+ subsection Model settings
+   set Fixed temperature boundary indicators     = inner, outer
+   set Tangential velocity boundary indicators   = outer
+   set Zero velocity boundary indicators         = inner
+ end
+
+ subsection Material model
+   set Material averaging    = geometric average
+   set Model name            = simple
+ end
+
+ subsection Initial conditions
+   set Model name = adiabatic
+
+   subsection Adiabatic
+     set Age bottom boundary layer = 1e6
+     set Age top boundary layer = 5e6
+     set Amplitude = 100
+     set Position = center
+     set Radius = 100e3
+     set Subadiabaticity = 0
+   end
+ end
+
+ subsection Boundary temperature model
+   set Model name    = initial temperature
+ end
+
+ subsection Gravity model
+   set Model name    = radial earth-like
+ end
+
+ subsection Mesh refinement
+   set Initial global refinement             = 3
+   set Initial adaptive refinement           = 0
+ end
+
+ subsection Termination criteria
+   set Termination criteria = end step
+   set End step = 0
+ end

--- a/tests/geometric_average_crash/screen-output
+++ b/tests/geometric_average_crash/screen-output
@@ -1,0 +1,25 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.4.0-pre
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Number of active cells: 512 (on 4 levels)
+Number of degrees of freedom: 20,381 (14,739+729+4,913)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+12 iterations.
+
+   Postprocessing:
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+


### PR DESCRIPTION
Computing the geometric average in 3d caused a floating point overflow
when averaging viscosity values.

fixes #871 