### PR TITLE
[WIP] Synchronize particles and compositional fields

### DIFF
--- a/include/aspect/postprocess/tracers.h
+++ b/include/aspect/postprocess/tracers.h
@@ -79,6 +79,12 @@ namespace aspect
         initialize_particles();
 
         /**
+         * Advect particles.
+         */
+        void
+        advect_particles();
+
+        /**
          * Returns a const reference to the particle world, in case anyone
          * wants to query something about tracers.
          */

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -1012,7 +1012,7 @@ namespace aspect
                               update_values);
 
       fe_value.reinit (cell);
-      fe_value[this->introspection().extractors.velocities].get_function_values (this->get_solution(),
+      fe_value[this->introspection().extractors.velocities].get_function_values (this->get_current_linearization_point(),
                                                                                  result);
       fe_value[this->introspection().extractors.velocities].get_function_values (this->get_old_solution(),
                                                                                  old_result);
@@ -1021,7 +1021,7 @@ namespace aspect
                                        end_particle,
                                        old_result,
                                        result,
-                                       this->get_old_timestep());
+                                       this->get_timestep());
     }
 
     template <int dim>

--- a/source/postprocess/tracers.cc
+++ b/source/postprocess/tracers.cc
@@ -63,6 +63,13 @@ namespace aspect
     }
 
     template <int dim>
+    void
+    Tracers<dim>::advect_particles()
+    {
+      world.advance_timestep();
+    }
+
+    template <int dim>
     const Particle::World<dim> &
     Tracers<dim>::get_particle_world() const
     {
@@ -87,13 +94,6 @@ namespace aspect
         {
           last_output_time = this->get_time() - output_interval;
         }
-
-      // Do not advect the particles in the initial refinement stage
-      const bool in_initial_refinement = (this->get_timestep_number() == 0)
-                                         && (this->get_pre_refinement_step() < this->get_parameters().initial_adaptive_refinement);
-      if (!in_initial_refinement)
-        // Advance the particles in the world to the current time
-        world.advance_timestep();
 
       statistics.add_value("Number of advected particles",world.n_global_particles());
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -23,6 +23,8 @@
 #include <aspect/global.h>
 #include <aspect/assembly.h>
 #include <aspect/utilities.h>
+#include <aspect/postprocess/tracers.h>
+
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/quadrature_lib.h>
@@ -1697,6 +1699,12 @@ namespace aspect
             current_linearization_point.block(introspection.block_indices.compositional_fields[c])
               = solution.block(introspection.block_indices.compositional_fields[c]);
 
+          // If the tracer postprocessor has been selected advect the particles
+          Postprocess::Tracers<dim> *tracer_postprocessor = const_cast<Postprocess::Tracers<dim> *>
+                                                            (postprocess_manager.template find_postprocessor<Postprocess::Tracers<dim> >());
+          if (tracer_postprocessor != 0)
+            tracer_postprocessor->advect_particles();
+
           // the Stokes matrix depends on the viscosity. if the viscosity
           // depends on other solution variables, then after we need to
           // update the Stokes matrix in every time step and so need to set
@@ -1801,6 +1809,12 @@ namespace aspect
                 current_linearization_point.block(introspection.block_indices.compositional_fields[c])
                   = solution.block(introspection.block_indices.compositional_fields[c]);
 
+              // If the tracer postprocessor has been selected advect the particles
+              Postprocess::Tracers<dim> *tracer_postprocessor = const_cast<Postprocess::Tracers<dim> *>
+                                                                (postprocess_manager.template find_postprocessor<Postprocess::Tracers<dim> >());
+              if (tracer_postprocessor != 0)
+                tracer_postprocessor->advect_particles();
+
               // the Stokes matrix depends on the viscosity. if the viscosity
               // depends on other solution variables, then after we need to
               // update the Stokes matrix in every time step and so need to set
@@ -1881,6 +1895,12 @@ namespace aspect
           for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
             current_linearization_point.block(introspection.block_indices.compositional_fields[c])
               = solution.block(introspection.block_indices.compositional_fields[c]);
+
+          // If the tracer postprocessor has been selected advect the particles
+          Postprocess::Tracers<dim> *tracer_postprocessor = const_cast<Postprocess::Tracers<dim> *>
+                                                            (postprocess_manager.template find_postprocessor<Postprocess::Tracers<dim> >());
+          if (tracer_postprocessor != 0)
+            tracer_postprocessor->advect_particles();
 
           // residual vector (only for the velocity)
           LinearAlgebra::Vector residual (introspection.index_sets.system_partitioning[0], mpi_communicator);
@@ -1972,6 +1992,12 @@ namespace aspect
               current_linearization_point.block(introspection.block_indices.compositional_fields[c])
                 = solution.block(introspection.block_indices.compositional_fields[c]);
             }
+
+          // If the tracer postprocessor has been selected advect the particles
+          Postprocess::Tracers<dim> *tracer_postprocessor = const_cast<Postprocess::Tracers<dim> *>
+                                                            (postprocess_manager.template find_postprocessor<Postprocess::Tracers<dim> >());
+          if (tracer_postprocessor != 0)
+            tracer_postprocessor->advect_particles();
 
           break;
         }


### PR DESCRIPTION
This is a draft of what I imagined for closing #829. It needs tests, and we can think about providing the old_old_solution to integrators as well to allow for the advanced time interpolation @bangerth and @egpuckett where suggesting. The tests will change because of this pull request, but I have checked that the convergence order is not affected (only the relative error). 
Of course using the tracer postprocessor inside Simulator is ugly, ultimately I would like to relocate the particle world inside Simulator and leave the tracer postprocessor as a pure postprocessor that is only responsible for outputting the particle positions and nothing else.