### PR TITLE
Avoid using the user_index when we can use active_cell_index instead.

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -666,15 +666,14 @@ namespace aspect
                                   parameters.n_compositional_fields);
 
     typename DoFHandler<dim>::active_cell_iterator cell = dof_handler.begin_active();
-    for (unsigned int cellidx=0; cellidx<triangulation.n_active_cells(); ++cellidx, ++cell)
+    for (; cell<dof_handler.end(); ++cell)
       {
         if (!cell->is_locally_owned()
             || (parameters.use_artificial_viscosity_smoothing  == true  &&  cell->is_artificial()))
           {
-            viscosity_per_cell[cellidx]=-1;
+            viscosity_per_cell[cell->active_cell_index()]=-1;
             continue;
           }
-        cell->set_user_index(cellidx);
 
         const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
 
@@ -783,13 +782,13 @@ namespace aspect
                                                    scratch.finite_element_values.get_mapping(),
                                                    scratch.material_model_outputs);
 
-        viscosity_per_cell[cellidx] = compute_viscosity(scratch,
-                                                        global_max_velocity,
-                                                        global_field_range.second - global_field_range.first,
-                                                        0.5 * (global_field_range.second + global_field_range.first),
-                                                        global_entropy_variation,
-                                                        cell->diameter(),
-                                                        advection_field);
+        viscosity_per_cell[cell->active_cell_index()] = compute_viscosity(scratch,
+                                                                          global_max_velocity,
+                                                                          global_field_range.second - global_field_range.first,
+                                                                          0.5 * (global_field_range.second + global_field_range.first),
+                                                                          global_entropy_variation,
+                                                                          cell->diameter(),
+                                                                          advection_field);
       }
 
     // if set to true, the maximum of the artificial viscosity in the cell as well
@@ -810,13 +809,13 @@ namespace aspect
                 if (cell->at_boundary(face_no) == false)
                   {
                     if (cell->neighbor(face_no)->active())
-                      viscosity_per_cell[cell->user_index()] = std::max(viscosity_per_cell[cell->user_index()],
-                                                                        viscosity_per_cell_temp[cell->neighbor(face_no)->user_index()]);
+                      viscosity_per_cell[cell->active_cell_index()] = std::max(viscosity_per_cell[cell->active_cell_index()],
+                                                                               viscosity_per_cell_temp[cell->neighbor(face_no)->active_cell_index()]);
                     else
                       for (unsigned int l=0; l<cell->neighbor(face_no)->n_children(); l++)
                         if (cell->neighbor(face_no)->child(l)->active())
-                          viscosity_per_cell[cell->user_index()] = std::max(viscosity_per_cell[cell->user_index()],
-                                                                            viscosity_per_cell_temp[cell->neighbor(face_no)->child(l)->user_index()]);
+                          viscosity_per_cell[cell->active_cell_index()] = std::max(viscosity_per_cell[cell->active_cell_index()],
+                                                                                   viscosity_per_cell_temp[cell->neighbor(face_no)->child(l)->active_cell_index()]);
                   }
           }
       }
@@ -2802,7 +2801,7 @@ namespace aspect
     // TODO: Compute artificial viscosity once per timestep instead of each time
     // temperature system is assembled (as this might happen more than once per
     // timestep for iterative solvers)
-    const double nu = viscosity_per_cell[cell->user_index()];
+    const double nu = viscosity_per_cell[cell->active_cell_index()];
     Assert (nu >= 0, ExcMessage ("The artificial viscosity needs to be a non-negative quantity."));
 
     // trigger the invocation of the various functions that actually do


### PR DESCRIPTION
This is a hostile takeover of #717 as discussed there and fixes #711.

This avoids stepping on indices that may be used elsewhere.