### PR TITLE
fix the initialization of traction boundary conditions

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -541,11 +541,11 @@ namespace aspect
         TractionBoundaryConditions::Interface<dim> *bv
           = TractionBoundaryConditions::create_traction_boundary_conditions<dim>
             (p->second.second);
+        traction_boundary_conditions[p->first].reset (bv);
         if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(bv))
           sim->initialize_simulator(*this);
         bv->parse_parameters (prm);
         bv->initialize ();
-        traction_boundary_conditions[p->first].reset (bv);
       }
 
     // determine how to treat the pressure. we have to scale it for the solver


### PR DESCRIPTION
Right now, the traction boundary conditions are initialized before we fill the map that contains the information which plugin is used for which boundary indicator. This means that during their initialization, traction boundary plugins do not know if they are used for a given model boundary. 
This pull request should fix this, and the implementation is now the same as for the velocity boundary conditions. 