### PR TITLE
move traction boundary conditions to new interface

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -3,6 +3,12 @@
  *
  * <p> This is the list of changes made after the release of Aspect version
  * 1.4.0. All entries are signed with the names of the author. </p>
+ * 
+ * <li> Changed: The traction boundary conditions now use a new interface
+ * that includes the boundary indicator (analogous to the velocity boundary 
+ * conditions).
+ * <br>
+ * (Juliane Dannberg, 2016/05/19)
  *
  * <li> New: There is a new visualization postprocessor "artificial viscosity
  * composition" to visualize the artificial viscosity of a compositional

--- a/include/aspect/traction_boundary_conditions/function.h
+++ b/include/aspect/traction_boundary_conditions/function.h
@@ -55,8 +55,9 @@ namespace aspect
          */
         virtual
         Tensor<1,dim>
-        traction (const Point<dim> &position,
-                  const Tensor<1,dim> &normal_vector) const;
+        boundary_traction (const types::boundary_id boundary_indicator,
+                           const Point<dim> &position,
+                           const Tensor<1,dim> &normal_vector) const;
 
         /**
          * A function that is called at the beginning of each time step to

--- a/include/aspect/traction_boundary_conditions/interface.h
+++ b/include/aspect/traction_boundary_conditions/interface.h
@@ -80,14 +80,26 @@ namespace aspect
         update ();
 
         /**
+         * Return the boundary traction as a function of position.
+         *
+         * @deprecated Use boundary_traction(const types::boundary_id boundary_indicator,
+         * const Point<dim> &position, const Tensor<1,dim> &normal_vector) const instead.
+         */
+        virtual
+        Tensor<1,dim>
+        traction (const Point<dim> &position,
+                  const Tensor<1,dim> &normal_vector) const DEAL_II_DEPRECATED;
+
+        /**
          * Return the boundary traction as a function of position. The
          * (outward) normal vector to the domain is also provided as
          * a second argument.
          */
         virtual
         Tensor<1,dim>
-        traction (const Point<dim> &position,
-                  const Tensor<1,dim> &normal_vector) const = 0;
+        boundary_traction (const types::boundary_id boundary_indicator,
+                           const Point<dim> &position,
+                           const Tensor<1,dim> &normal_vector) const;
 
         /**
          * Declare the parameters this class takes through input files. The

--- a/include/aspect/traction_boundary_conditions/zero_traction.h
+++ b/include/aspect/traction_boundary_conditions/zero_traction.h
@@ -51,8 +51,9 @@ namespace aspect
          */
         virtual
         Tensor<1,dim>
-        traction (const Point<dim> &position,
-                  const Tensor<1,dim> &normal_vector) const;
+        boundary_traction (const types::boundary_id boundary_indicator,
+                           const Point<dim> &position,
+                           const Tensor<1,dim> &normal_vector) const;
     };
   }
 }

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -2191,8 +2191,9 @@ namespace aspect
                       cell->face(face_no)->boundary_indicator()
 #endif
                     )->second
-                    ->traction (scratch.face_finite_element_values.quadrature_point(q),
-                                scratch.face_finite_element_values.normal_vector(q));
+                    ->boundary_traction (cell->face(face_no)->boundary_id(),
+                                         scratch.face_finite_element_values.quadrature_point(q),
+                                         scratch.face_finite_element_values.normal_vector(q));
                 for (unsigned int i=0; i<dofs_per_cell; ++i)
                   data.local_rhs(i) += scratch.face_finite_element_values[introspection.extractors.velocities].value(i,q) *
                                        traction *

--- a/source/traction_boundary_conditions/function.cc
+++ b/source/traction_boundary_conditions/function.cc
@@ -37,8 +37,9 @@ namespace aspect
     template <int dim>
     Tensor<1,dim>
     Function<dim>::
-    traction (const Point<dim> &p,
-              const Tensor<1,dim> &) const
+    boundary_traction (const types::boundary_id,
+                       const Point<dim> &p,
+                       const Tensor<1,dim> &) const
     {
       Tensor<1,dim> traction;
       for (unsigned int d=0; d<dim; ++d)

--- a/source/traction_boundary_conditions/interface.cc
+++ b/source/traction_boundary_conditions/interface.cc
@@ -50,6 +50,39 @@ namespace aspect
     {}
 
 
+    template <int dim>
+    Tensor<1,dim>
+    Interface<dim>::traction (const Point<dim> &,
+                              const Tensor<1,dim> &) const
+    {
+      /**
+       * We can only get here if the new-style boundary_traction function (with
+       * two arguments) calls it. This means that the derived class did not override
+       * the new-style boundary_velocity function, and because we are here, it also
+       * did not override this old-style boundary_velocity function (with one argument).
+       */
+      Assert (false, ExcMessage ("A derived class needs to override either the "
+                                 "boundary_traction(position, normal_vector) "
+                                 "(deprecated) or boundary_traction(types::boundary_id, "
+                                 "position, normal_vector) function."));
+
+      return Tensor<1,dim>();
+    }
+
+
+    DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+    template <int dim>
+    Tensor<1,dim>
+    Interface<dim>::boundary_traction (const types::boundary_id boundary_indicator,
+                                       const Point<dim> &position,
+                                       const Tensor<1,dim> &normal_vector) const
+    {
+      // Call the old-style function without the boundary id to maintain backwards
+      // compatibility. Normally the derived class should override this function.
+      return this->traction(position, normal_vector);
+    }
+    DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
 
     template <int dim>
     void

--- a/source/traction_boundary_conditions/zero_traction.cc
+++ b/source/traction_boundary_conditions/zero_traction.cc
@@ -29,8 +29,9 @@ namespace aspect
     template <int dim>
     Tensor<1,dim>
     ZeroTraction<dim>::
-    traction (const Point<dim> &,
-              const Tensor<1,dim> &) const
+    boundary_traction (const types::boundary_id,
+                       const Point<dim> &,
+                       const Tensor<1,dim> &) const
     {
       // return a zero tensor regardless of position
       return Tensor<1,dim>();

--- a/source/velocity_boundary_conditions/interface.cc
+++ b/source/velocity_boundary_conditions/interface.cc
@@ -76,11 +76,8 @@ namespace aspect
     Interface<dim>::boundary_velocity (const types::boundary_id ,
                                        const Point<dim> &position) const
     {
-      /**
-       * Call the old-style function without the boundary id to maintain backwards
-       * compatibility. Normarly the derived class should override this function.
-       */
-
+      // Call the old-style function without the boundary id to maintain backwards
+      // compatibility. Normally the derived class should override this function.
       return this->boundary_velocity(position);
     }
     DEAL_II_ENABLE_EXTRA_DIAGNOSTICS


### PR DESCRIPTION
Currently, the traction boundary conditions do not get the boundary indicator when they are called (but only the position and the normal). As different boundaries can have different boundary traction plugins, it is useful to also hand over the boundary indicator (just as we do for velocity boundary conditions). 
This pull request updates the interface of the traction boundary conditions. 