### PR TITLE
Avoid deprecated Linear Algebra stuff

### DIFF
--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -275,8 +275,12 @@ namespace aspect
     /**
      * Typedef for the block compressed sparsity pattern type.
      */
-    typedef dealii::BlockCompressedSimpleSparsityPattern BlockCompressedSparsityPattern;
+    typedef dealii::BlockDynamicSparsityPattern BlockDynamicSparsityPattern;
 
+    /**
+     * Typedef for the compressed sparsity pattern type.
+     */
+    typedef dealii::DynamicSparsityPattern DynamicSparsityPattern;
 #else
     /**
      * Typedef for the vector type used.
@@ -327,8 +331,12 @@ namespace aspect
     /**
      * Typedef for the block compressed sparsity pattern type.
      */
-    typedef dealii::TrilinosWrappers::BlockSparsityPattern BlockCompressedSparsityPattern;
+    typedef dealii::TrilinosWrappers::BlockSparsityPattern BlockDynamicSparsityPattern;
 
+    /**
+     * Typedef for the compressed sparsity pattern type.
+     */
+    typedef dealii::TrilinosWrappers::SparsityPattern DynamicSparsityPattern;
 #endif
   }
 }

--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -23,8 +23,8 @@
 #define __aspect__global_h
 
 #ifdef ASPECT_USE_PETSC
-#  include <deal.II/lac/petsc_block_vector.h>
-#  include <deal.II/lac/petsc_block_sparse_matrix.h>
+#  include <deal.II/lac/petsc_parallel_block_vector.h>
+#  include <deal.II/lac/petsc_parallel_block_sparse_matrix.h>
 #  include <deal.II/lac/petsc_precondition.h>
 #else
 #  include <deal.II/lac/trilinos_block_vector.h>

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -985,7 +985,7 @@ namespace aspect
           = DoFTools::always;
     }
 
-    LinearAlgebra::BlockCompressedSparsityPattern sp;
+    LinearAlgebra::BlockDynamicSparsityPattern sp;
 #ifdef ASPECT_USE_PETSC
     sp.reinit (introspection.index_sets.system_relevant_partitioning);
 #else
@@ -1044,7 +1044,7 @@ namespace aspect
         else
           coupling[c][d] = DoFTools::none;
 
-    LinearAlgebra::BlockCompressedSparsityPattern sp;
+    LinearAlgebra::BlockDynamicSparsityPattern sp;
 #ifdef ASPECT_USE_PETSC
     sp.reinit (introspection.index_sets.system_relevant_partitioning);
 #else

--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -331,7 +331,7 @@ namespace aspect
     //set up the matrix
     LinearAlgebra::SparseMatrix mass_matrix;
 #ifdef ASPECT_USE_PETSC
-    CompressedSimpleSparsityPattern sp(mesh_locally_relevant);
+    LinearAlgebra::DynamicSparsityPattern sp(mesh_locally_relevant);
 
 #else
     TrilinosWrappers::SparsityPattern sp (mesh_locally_owned,
@@ -458,7 +458,7 @@ namespace aspect
       coupling[c][c] = DoFTools::always;
 
 #ifdef ASPECT_USE_PETSC
-    CompressedSimpleSparsityPattern sp(mesh_locally_relevant);
+    LinearAlgebra::DynamicSparsityPattern sp(mesh_locally_relevant);
 #else
     TrilinosWrappers::SparsityPattern sp (mesh_locally_owned,
                                           mesh_locally_owned,

--- a/source/simulator/freesurface.cc
+++ b/source/simulator/freesurface.cc
@@ -39,7 +39,9 @@
  * error associated to VectorTools::compute_no_normal_flux_constraints. This is not
  * really understood, but the extra include makes it work for now.
  */
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <deal.II/numerics/vector_tools.templates.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 using namespace dealii;
 

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -324,8 +324,8 @@ namespace aspect
       // apply the top right block
       {
         stokes_matrix.block(0,1).vmult(utmp, dst.block(1)); //B^T
-        utmp*=-1.0;
-        utmp.add(src.block(0));
+        utmp *= -1.0;
+        utmp += src.block(0);
       }
 
       // now either solve with the top left block (if do_solve_A==true)


### PR DESCRIPTION
[Block]CompressedSparsityPattern has been renamed to
[Block]DynamicSparsityPattern in deal.II before 8.4. Use the new name
throughout to avoid deprecation warnings.

Also avoid some other warnings:
- vector.add()
- warnings inside vector_tools.templates.h
- using the wrong petsc header files