### PR TITLE
wrap boost include with silencing macros

### DIFF
--- a/include/aspect/particle/generator/interface.h
+++ b/include/aspect/particle/generator/interface.h
@@ -28,7 +28,9 @@
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/exceptions.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/random.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 namespace aspect
 {

--- a/include/aspect/particle/generator/probability_density_function.h
+++ b/include/aspect/particle/generator/probability_density_function.h
@@ -25,7 +25,9 @@
 
 #include <deal.II/base/parsed_function.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/random.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 namespace aspect
 {

--- a/include/aspect/particle/generator/random_uniform.h
+++ b/include/aspect/particle/generator/random_uniform.h
@@ -23,7 +23,9 @@
 
 #include <aspect/particle/generator/probability_density_function.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/random.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 namespace aspect
 {

--- a/source/particle/generator/random_uniform.cc
+++ b/source/particle/generator/random_uniform.cc
@@ -20,8 +20,9 @@
 
 #include <aspect/particle/generator/random_uniform.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/random.hpp>
-
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 namespace aspect
 {

--- a/source/particle/generator/uniform_box.cc
+++ b/source/particle/generator/uniform_box.cc
@@ -20,7 +20,10 @@
 
 #include <aspect/particle/generator/uniform_box.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/random.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
 #include <deal.II/base/std_cxx11/array.h>
 
 


### PR DESCRIPTION
suppress warning:
```
In file included from
deal.II/installed-v8.4.1-clang/include/deal.II/bundled/boost/random.hpp:69:
In file included from
deal.II/installed-v8.4.1-clang/include/deal.II/bundled/boost/random/negative_binomial_distribution.hpp:21:
deal.II/installed-v8.4.1-clang/include/deal.II/bundled/boost/random/poisson_distribution.hpp:338:9:
warning: anonymous types declared in an anonymous union are an extension
[-Wnested-anon-types]
```