### PR TITLE
Do not solve advection system if RHS is zero

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1678,8 +1678,6 @@ namespace aspect
             free_surface->execute ();
 
           assemble_advection_system (AdvectionField::temperature());
-          build_advection_preconditioner(AdvectionField::temperature(),
-                                         T_preconditioner);
           solve_advection(AdvectionField::temperature());
 
           current_linearization_point.block(introspection.block_indices.temperature)
@@ -1688,8 +1686,6 @@ namespace aspect
           for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
             {
               assemble_advection_system (AdvectionField::composition(c));
-              build_advection_preconditioner(AdvectionField::composition(c),
-                                             C_preconditioner);
               solve_advection(AdvectionField::composition(c));
             }
 
@@ -1769,8 +1765,6 @@ namespace aspect
           do
             {
               assemble_advection_system(AdvectionField::temperature());
-              build_advection_preconditioner(AdvectionField::temperature(),
-                                             T_preconditioner);
 
               if (iteration == 0)
                 initial_temperature_residual = system_rhs.block(introspection.block_indices.temperature).l2_norm();
@@ -1785,8 +1779,6 @@ namespace aspect
               for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
                 {
                   assemble_advection_system (AdvectionField::composition(c));
-                  build_advection_preconditioner(AdvectionField::composition(c),
-                                                 C_preconditioner);
 
                   if (iteration == 0)
                     initial_composition_residual[c] = system_rhs.block(introspection.block_indices.compositional_fields[c]).l2_norm();
@@ -1862,10 +1854,8 @@ namespace aspect
           if (parameters.free_surface_enabled)
             free_surface->execute ();
 
-          // solve the temperature system once...
+          // solve the temperature and composition systems once...
           assemble_advection_system (AdvectionField::temperature());
-          build_advection_preconditioner (AdvectionField::temperature (),
-                                          T_preconditioner);
           solve_advection(AdvectionField::temperature());
           current_linearization_point.block(introspection.block_indices.temperature)
             = solution.block(introspection.block_indices.temperature);
@@ -1873,8 +1863,6 @@ namespace aspect
           for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
             {
               assemble_advection_system (AdvectionField::composition(c));
-              build_advection_preconditioner (AdvectionField::composition (c),
-                                              C_preconditioner);
               solve_advection(AdvectionField::composition(c));
             }
 
@@ -1956,8 +1944,6 @@ namespace aspect
           solution.block(block_p) = distributed_stokes_solution.block(block_p);
 
           assemble_advection_system (AdvectionField::temperature());
-          build_advection_preconditioner(AdvectionField::temperature(),
-                                         T_preconditioner);
           solve_advection(AdvectionField::temperature());
 
           current_linearization_point.block(introspection.block_indices.temperature)
@@ -1966,8 +1952,6 @@ namespace aspect
           for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
             {
               assemble_advection_system (AdvectionField::composition(c));
-              build_advection_preconditioner(AdvectionField::composition(c),
-                                             C_preconditioner);
               solve_advection(AdvectionField::composition(c));
               current_linearization_point.block(introspection.block_indices.compositional_fields[c])
                 = solution.block(introspection.block_indices.compositional_fields[c]);

--- a/tests/advect_mesh_vertically/screen-output
+++ b/tests/advect_mesh_vertically/screen-output
@@ -5,7 +5,7 @@ Number of degrees of freedom: 2,977 (1,394+189+697+697)
 Number of free surface degrees of freedom: 378
 *** Timestep 0:  t=0 years
    Solving mesh velocity system... 0 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
@@ -16,7 +16,7 @@ Number of degrees of freedom: 1,962 (918+126+459+459)
 Number of free surface degrees of freedom: 252
 *** Timestep 0:  t=0 years
    Solving mesh velocity system... 0 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
@@ -27,7 +27,7 @@ Number of degrees of freedom: 2,567 (1,202+163+601+601)
 Number of free surface degrees of freedom: 326
 *** Timestep 0:  t=0 years
    Solving mesh velocity system... 0 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
@@ -39,7 +39,7 @@ Number of free surface degrees of freedom: 326
 
 *** Timestep 1:  t=316.49 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
@@ -50,7 +50,7 @@ Number of free surface degrees of freedom: 326
 
 *** Timestep 2:  t=658.949 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
@@ -61,7 +61,7 @@ Number of free surface degrees of freedom: 326
 
 *** Timestep 3:  t=1012.67 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
@@ -72,7 +72,7 @@ Number of free surface degrees of freedom: 326
 
 *** Timestep 4:  t=1382.88 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
@@ -83,7 +83,7 @@ Number of free surface degrees of freedom: 326
 
 *** Timestep 5:  t=1772.03 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
@@ -98,7 +98,7 @@ Number of degrees of freedom: 3,587 (1,682+223+841+841)
 Number of free surface degrees of freedom: 446
 *** Timestep 6:  t=2178.46 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
@@ -109,7 +109,7 @@ Number of free surface degrees of freedom: 446
 
 *** Timestep 7:  t=2595.91 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
@@ -120,7 +120,7 @@ Number of free surface degrees of freedom: 446
 
 *** Timestep 8:  t=3036.53 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
@@ -131,7 +131,7 @@ Number of free surface degrees of freedom: 446
 
 *** Timestep 9:  t=3501.64 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
@@ -142,7 +142,7 @@ Number of free surface degrees of freedom: 446
 
 *** Timestep 10:  t=3992.46 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
@@ -157,7 +157,7 @@ Number of degrees of freedom: 4,420 (2,074+272+1,037+1,037)
 Number of free surface degrees of freedom: 544
 *** Timestep 11:  t=4504.34 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+16 iterations.
@@ -168,7 +168,7 @@ Number of free surface degrees of freedom: 544
 
 *** Timestep 12:  t=5040.64 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+21 iterations.
@@ -179,7 +179,7 @@ Number of free surface degrees of freedom: 544
 
 *** Timestep 13:  t=5602.42 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+11 iterations.
@@ -190,7 +190,7 @@ Number of free surface degrees of freedom: 544
 
 *** Timestep 14:  t=6189.59 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+13 iterations.
@@ -201,7 +201,7 @@ Number of free surface degrees of freedom: 544
 
 *** Timestep 15:  t=6801.98 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+9 iterations.
@@ -216,7 +216,7 @@ Number of degrees of freedom: 4,556 (2,138+280+1,069+1,069)
 Number of free surface degrees of freedom: 560
 *** Timestep 16:  t=7439.04 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+27 iterations.
@@ -227,7 +227,7 @@ Number of free surface degrees of freedom: 560
 
 *** Timestep 17:  t=8099.89 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+17 iterations.
@@ -238,7 +238,7 @@ Number of free surface degrees of freedom: 560
 
 *** Timestep 18:  t=8782.96 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+11 iterations.
@@ -249,7 +249,7 @@ Number of free surface degrees of freedom: 560
 
 *** Timestep 19:  t=9487.36 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+8 iterations.
@@ -260,7 +260,7 @@ Number of free surface degrees of freedom: 560
 
 *** Timestep 20:  t=10212.1 years
    Solving mesh velocity system... 1 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+14 iterations.

--- a/tests/artificial_postprocess/screen-output
+++ b/tests/artificial_postprocess/screen-output
@@ -6,7 +6,7 @@ Number of degrees of freedom: 430 (162+25+81+81+81)
 
 *** Timestep 0:  t=0 years
    Solving temperature system... 0 iterations.
-   Solving comp1 system ... 0 iterations.
+   Skipping comp1 composition solve because RHS is zero.
    Solving comp2 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
@@ -23,7 +23,7 @@ EV composition 1:
 
 *** Timestep 1:  t=2.13881e+10 years
    Solving temperature system... 18 iterations.
-   Solving comp1 system ... 0 iterations.
+   Skipping comp1 composition solve because RHS is zero.
    Solving comp2 system ... 13 iterations.
    Solving Stokes system... 20+0 iterations.
 
@@ -39,7 +39,7 @@ EV composition 1:
 
 *** Timestep 2:  t=6.66473e+10 years
    Solving temperature system... 19 iterations.
-   Solving comp1 system ... 0 iterations.
+   Skipping comp1 composition solve because RHS is zero.
    Solving comp2 system ... 12 iterations.
    Solving Stokes system... 20+0 iterations.
 
@@ -55,7 +55,7 @@ EV composition 1:
 
 *** Timestep 3:  t=1e+11 years
    Solving temperature system... 16 iterations.
-   Solving comp1 system ... 0 iterations.
+   Skipping comp1 composition solve because RHS is zero.
    Solving comp2 system ... 8 iterations.
    Solving Stokes system... 16+0 iterations.
 

--- a/tests/ascii_data_boundary_temperature_2d_box_time/screen-output
+++ b/tests/ascii_data_boundary_temperature_2d_box_time/screen-output
@@ -9,7 +9,7 @@ Number of active cells: 80 (on 3 levels)
 Number of degrees of freedom: 1,212 (738+105+369)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+4 iterations.
 
@@ -19,7 +19,7 @@ Number of degrees of freedom: 1,212 (738+105+369)
      Heat fluxes through boundary parts: 0 W, 0 W, 0 W, 0 W
 
 *** Timestep 1:  t=82500 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
 

--- a/tests/average_arithmetic/screen-output
+++ b/tests/average_arithmetic/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.3.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+13 iterations.

--- a/tests/average_geometric/screen-output
+++ b/tests/average_geometric/screen-output
@@ -1,22 +1,15 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.3.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+12 iterations.
 
    Postprocessing:
-     Pressure min/avg/max: -1.561 Pa, 8.326e-14 Pa, 1.561 Pa
+     Pressure min/avg/max: -1.561 Pa, 8.323e-14 Pa, 1.561 Pa
 
 Termination requested by criterion: end time
 

--- a/tests/average_harmonic/screen-output
+++ b/tests/average_harmonic/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.3.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+10 iterations.

--- a/tests/average_log/screen-output
+++ b/tests/average_log/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in OPTIMIZED mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+12 iterations.
@@ -22,21 +15,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.408s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0348s |       8.5% |
-| Assemble composition system     |         1 |    0.0197s |       4.8% |
-| Assemble temperature system     |         1 |    0.0228s |       5.6% |
-| Build Stokes preconditioner     |         1 |    0.0369s |       9.1% |
-| Build composition preconditioner|         1 |   0.00335s |      0.82% |
-| Build temperature preconditioner|         1 |   0.00502s |       1.2% |
-| Solve Stokes system             |         1 |     0.131s |        32% |
-| Solve composition system        |         1 |  0.000632s |      0.16% |
-| Solve temperature system        |         1 |   0.00124s |       0.3% |
-| Initialization                  |         2 |    0.0646s |        16% |
-| Postprocessing                  |         1 |  0.000853s |      0.21% |
-| Setup dof systems               |         1 |    0.0749s |        18% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/average_none/screen-output
+++ b/tests/average_none/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.3.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+67 iterations.

--- a/tests/average_nwd_arithmetic/screen-output
+++ b/tests/average_nwd_arithmetic/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in OPTIMIZED mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+33 iterations.
@@ -22,21 +15,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      1.23s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0185s |       1.5% |
-| Assemble composition system     |         1 |    0.0132s |       1.1% |
-| Assemble temperature system     |         1 |    0.0285s |       2.3% |
-| Build Stokes preconditioner     |         1 |     0.229s |        19% |
-| Build composition preconditioner|         1 |   0.00127s |       0.1% |
-| Build temperature preconditioner|         1 |     0.043s |       3.5% |
-| Solve Stokes system             |         1 |     0.136s |        11% |
-| Solve composition system        |         1 |  0.000259s |     0.021% |
-| Solve temperature system        |         1 |    0.0364s |         3% |
-| Initialization                  |         2 |     0.228s |        18% |
-| Postprocessing                  |         1 |  0.000343s |     0.028% |
-| Setup dof systems               |         1 |     0.326s |        26% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/average_nwd_geometric/screen-output
+++ b/tests/average_nwd_geometric/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in OPTIMIZED mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+25 iterations.
@@ -22,21 +15,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |       0.3s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |      0.02s |       6.6% |
-| Assemble composition system     |         1 |    0.0153s |       5.1% |
-| Assemble temperature system     |         1 |    0.0156s |       5.2% |
-| Build Stokes preconditioner     |         1 |    0.0169s |       5.6% |
-| Build composition preconditioner|         1 |   0.00129s |      0.43% |
-| Build temperature preconditioner|         1 |   0.00144s |      0.48% |
-| Solve Stokes system             |         1 |     0.197s |        65% |
-| Solve composition system        |         1 |  0.000267s |     0.089% |
-| Solve temperature system        |         1 |   0.00036s |      0.12% |
-| Initialization                  |         2 |    0.0188s |       6.3% |
-| Postprocessing                  |         1 |  0.000334s |      0.11% |
-| Setup dof systems               |         1 |    0.0113s |       3.8% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/average_nwd_harmonic/screen-output
+++ b/tests/average_nwd_harmonic/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in OPTIMIZED mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+15 iterations.
@@ -22,21 +15,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.169s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0171s |        10% |
-| Assemble composition system     |         1 |      0.01s |         6% |
-| Assemble temperature system     |         1 |   0.00999s |       5.9% |
-| Build Stokes preconditioner     |         1 |     0.015s |       8.9% |
-| Build composition preconditioner|         1 |   0.00151s |      0.89% |
-| Build temperature preconditioner|         1 |   0.00141s |      0.84% |
-| Solve Stokes system             |         1 |    0.0801s |        47% |
-| Solve composition system        |         1 |  0.000381s |      0.23% |
-| Solve temperature system        |         1 |  0.000329s |      0.19% |
-| Initialization                  |         2 |     0.019s |        11% |
-| Postprocessing                  |         1 |  0.000329s |      0.19% |
-| Setup dof systems               |         1 |    0.0114s |       6.7% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/average_pick_largest/screen-output
+++ b/tests/average_pick_largest/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.3.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+13 iterations.

--- a/tests/average_project_to_q1/screen-output
+++ b/tests/average_project_to_q1/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.3.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+15 iterations.

--- a/tests/composition_names/screen-output
+++ b/tests/composition_names/screen-output
@@ -4,8 +4,8 @@ Number of degrees of freedom: 49 (18+4+9+9+9)
 
 *** Timestep 0:  t=0 years
    Solving temperature system... 0 iterations.
-   Solving peridotite system ... 0 iterations.
-   Solving eclogite system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Skipping eclogite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
 

--- a/tests/composition_reaction_iterated_IMPES/screen-output
+++ b/tests/composition_reaction_iterated_IMPES/screen-output
@@ -6,9 +6,9 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
 
 *** Timestep 0:  t=0 seconds
    Solving temperature system... 0 iterations.
-   Solving C_1 system ... 0 iterations.
+   Skipping C_1 composition solve because RHS is zero.
    Solving C_2 system ... 11 iterations.
-   Solving C_3 system ... 0 iterations.
+   Skipping C_3 composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+5 iterations.
       Nonlinear residuals: 1.37468e-11, 0, 0.0346137, 0, 22.3625
@@ -54,7 +54,7 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_2 system ... 0 iterations.
    Solving C_3 system ... 11 iterations.
    Solving Stokes system... 30+2 iterations.
-      Nonlinear residuals: 0.0161267, 0.0346137, 6.51932e-14, 0.0346137, 0.172797
+      Nonlinear residuals: 0.0161273, 0.0346137, 6.51932e-14, 0.0346137, 0.172797
       Total relative nonlinear residual: 0.5
 
 
@@ -63,8 +63,8 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_2 system ... 0 iterations.
    Solving C_3 system ... 0 iterations.
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 0.0118361, 6.52004e-14, 6.51931e-14, 6.52004e-14, 2.06654e-06
-      Total relative nonlinear residual: 1.4051e-07
+      Nonlinear residuals: 0.0118359, 6.52004e-14, 6.51929e-14, 6.52004e-14, 2.03819e-06
+      Total relative nonlinear residual: 1.40508e-07
 
 
 

--- a/tests/compositional_vectors/screen-output
+++ b/tests/compositional_vectors/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 10,090 (2,178+289+1,089+1,089+1,089+1,089+1,089+1,089+1,089)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving unrelated1 system ... 0 iterations.
    Solving vec1x system ... 0 iterations.
    Solving vec1y system ... 0 iterations.

--- a/tests/compositional_vectors_3d/screen-output
+++ b/tests/compositional_vectors_3d/screen-output
@@ -3,12 +3,12 @@ Number of active cells: 64 (on 3 levels)
 Number of degrees of freedom: 6,686 (2,187+125+729+729+729+729+729+729)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving unrelated1 system ... 0 iterations.
    Solving vec_x system ... 0 iterations.
    Solving vec_y system ... 0 iterations.
    Solving vec_z system ... 0 iterations.
-   Solving unrelated2 system ... 0 iterations.
+   Skipping unrelated2 composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
 

--- a/tests/drucker_prager_compression/screen-output
+++ b/tests/drucker_prager_compression/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 4 levels)
 Number of degrees of freedom: 2,804 (2,210+297+297)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+14 iterations.
    Residual after nonlinear iteration 1: 1
@@ -33,7 +26,7 @@ Number of degrees of freedom: 2,804 (2,210+297+297)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+10 iterations.
-   Residual after nonlinear iteration 6: 0.000797159
+   Residual after nonlinear iteration 6: 0.000797158
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
@@ -41,15 +34,15 @@ Number of degrees of freedom: 2,804 (2,210+297+297)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
-   Residual after nonlinear iteration 8: 0.000677242
+   Residual after nonlinear iteration 8: 0.000677241
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
-   Residual after nonlinear iteration 9: 0.000633528
+   Residual after nonlinear iteration 9: 0.000633529
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
-   Residual after nonlinear iteration 10: 0.000597176
+   Residual after nonlinear iteration 10: 0.000597175
 
 
    Postprocessing:
@@ -60,18 +53,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      4.28s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |        10 |      1.83s |        43% |
-| Assemble temperature system     |         1 |    0.0499s |       1.2% |
-| Build Stokes preconditioner     |        10 |      1.47s |        34% |
-| Build temperature preconditioner|         1 |  0.000808s |     0.019% |
-| Solve Stokes system             |        10 |     0.666s |        16% |
-| Solve temperature system        |         1 |   0.00101s |     0.024% |
-| Initialization                  |         2 |     0.115s |       2.7% |
-| Postprocessing                  |         1 |    0.0114s |      0.27% |
-| Setup dof systems               |         1 |    0.0818s |       1.9% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/drucker_prager_extension/screen-output
+++ b/tests/drucker_prager_extension/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 4 levels)
 Number of degrees of freedom: 2,804 (2,210+297+297)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+14 iterations.
    Residual after nonlinear iteration 1: 1
@@ -29,27 +22,27 @@ Number of degrees of freedom: 2,804 (2,210+297+297)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Residual after nonlinear iteration 5: 0.001193
+   Residual after nonlinear iteration 5: 0.00119301
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+12 iterations.
-   Residual after nonlinear iteration 6: 0.00153361
+   Residual after nonlinear iteration 6: 0.0015339
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Residual after nonlinear iteration 7: 0.00116626
+   Residual after nonlinear iteration 7: 0.00116625
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Residual after nonlinear iteration 8: 0.00101506
+   Residual after nonlinear iteration 8: 0.00101504
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Residual after nonlinear iteration 9: 0.000933725
+   Residual after nonlinear iteration 9: 0.000933714
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Residual after nonlinear iteration 10: 0.00085987
+   Residual after nonlinear iteration 10: 0.000859832
 
 
    Postprocessing:
@@ -60,18 +53,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      5.72s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |        10 |      1.79s |        31% |
-| Assemble temperature system     |         1 |    0.0567s |      0.99% |
-| Build Stokes preconditioner     |        10 |      1.48s |        26% |
-| Build temperature preconditioner|         1 |  0.000747s |     0.013% |
-| Solve Stokes system             |        10 |      2.14s |        37% |
-| Solve temperature system        |         1 |  0.000999s |     0.017% |
-| Initialization                  |         2 |     0.114s |         2% |
-| Postprocessing                  |         1 |    0.0107s |      0.19% |
-| Setup dof systems               |         1 |    0.0756s |       1.3% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/free_surface_relaxation/screen-output
+++ b/tests/free_surface_relaxation/screen-output
@@ -7,7 +7,7 @@ Number of degrees of freedom: 13,494 (8,282+1,071+4,141)
 Number of free surface degrees of freedom: 2142
 *** Timestep 0:  t=0 years
    Solving mesh velocity system... 0 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
 
@@ -30,7 +30,7 @@ Number of free surface degrees of freedom: 2142
 
 *** Timestep 1:  t=245.098 years
    Solving mesh velocity system... 7 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
 
@@ -40,7 +40,7 @@ Number of free surface degrees of freedom: 2142
 
 *** Timestep 2:  t=491.632 years
    Solving mesh velocity system... 7 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
 
@@ -50,7 +50,7 @@ Number of free surface degrees of freedom: 2142
 
 *** Timestep 3:  t=739.215 years
    Solving mesh velocity system... 7 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
 
@@ -60,7 +60,7 @@ Number of free surface degrees of freedom: 2142
 
 *** Timestep 4:  t=987.856 years
    Solving mesh velocity system... 7 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
 
@@ -70,7 +70,7 @@ Number of free surface degrees of freedom: 2142
 
 *** Timestep 5:  t=1237.56 years
    Solving mesh velocity system... 7 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
 
@@ -86,7 +86,7 @@ Number of free surface degrees of freedom: 2142
 
 *** Timestep 6:  t=1488.34 years
    Solving mesh velocity system... 7 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
 
@@ -96,7 +96,7 @@ Number of free surface degrees of freedom: 2142
 
 *** Timestep 7:  t=1740.21 years
    Solving mesh velocity system... 7 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
 
@@ -106,7 +106,7 @@ Number of free surface degrees of freedom: 2142
 
 *** Timestep 8:  t=1993.17 years
    Solving mesh velocity system... 7 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
 
@@ -116,7 +116,7 @@ Number of free surface degrees of freedom: 2142
 
 *** Timestep 9:  t=2247.23 years
    Solving mesh velocity system... 7 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
 
@@ -126,7 +126,7 @@ Number of free surface degrees of freedom: 2142
 
 *** Timestep 10:  t=2502.4 years
    Solving mesh velocity system... 7 iterations.
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
 

--- a/tests/iterated_IMPES_residual/screen-output
+++ b/tests/iterated_IMPES_residual/screen-output
@@ -4,7 +4,7 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 
 *** Timestep 0:  t=0 years
    Solving temperature system... 0 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+6 iterations.
       Nonlinear residuals: 1.00594e-09, 0, 8.98822e+07
@@ -12,7 +12,7 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 
 
    Solving temperature system... 0 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 1.00594e-09, 0, 8.8648e-06
       Total relative nonlinear residual: 9.86269e-14
@@ -23,56 +23,56 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 
 *** Timestep 1:  t=13251 years
    Solving temperature system... 10 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+5 iterations.
       Nonlinear residuals: 1.30257e+07, 0, 7.76212e+07
       Total relative nonlinear residual: 0.821377
 
 
    Solving temperature system... 10 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+4 iterations.
       Nonlinear residuals: 1.54989e+06, 0, 1.16379e+07
       Total relative nonlinear residual: 0.113623
 
 
    Solving temperature system... 9 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+4 iterations.
       Nonlinear residuals: 267787, 0, 2.1001e+06
       Total relative nonlinear residual: 0.0205037
 
 
    Solving temperature system... 9 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+3 iterations.
       Nonlinear residuals: 50859, 0, 402412
       Total relative nonlinear residual: 0.00392882
 
 
    Solving temperature system... 8 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 10042.3, 0, 79675.5
       Total relative nonlinear residual: 0.000777886
 
 
    Solving temperature system... 8 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 2028.44, 0, 16133
       Total relative nonlinear residual: 0.000157509
 
 
    Solving temperature system... 7 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 416.177, 0, 3319.9
       Total relative nonlinear residual: 3.24128e-05
 
 
    Solving temperature system... 6 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
       Nonlinear residuals: 86.3598, 0, 691.174
       Total relative nonlinear residual: 6.74805e-06
@@ -83,56 +83,56 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 
 *** Timestep 2:  t=25357.2 years
    Solving temperature system... 11 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+5 iterations.
       Nonlinear residuals: 8.74328e+06, 0, 2.77541e+07
       Total relative nonlinear residual: 0.455259
 
 
    Solving temperature system... 10 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+4 iterations.
       Nonlinear residuals: 534360, 0, 3.36554e+06
       Total relative nonlinear residual: 0.055206
 
 
    Solving temperature system... 9 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+4 iterations.
       Nonlinear residuals: 73992, 0, 562190
       Total relative nonlinear residual: 0.00922176
 
 
    Solving temperature system... 8 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 13458.8, 0, 102450
       Total relative nonlinear residual: 0.00168053
 
 
    Solving temperature system... 7 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 2554.88, 0, 19327.3
       Total relative nonlinear residual: 0.000317032
 
 
    Solving temperature system... 6 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 494.904, 0, 3733.66
       Total relative nonlinear residual: 6.12444e-05
 
 
    Solving temperature system... 6 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
       Nonlinear residuals: 97.4349, 0, 734.428
       Total relative nonlinear residual: 1.2047e-05
 
 
    Solving temperature system... 5 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
       Nonlinear residuals: 19.4318, 0, 146.478
       Total relative nonlinear residual: 2.40272e-06
@@ -143,42 +143,42 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 
 *** Timestep 3:  t=36192.1 years
    Solving temperature system... 11 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+5 iterations.
       Nonlinear residuals: 8.78636e+06, 0, 3.96054e+07
       Total relative nonlinear residual: 0.647102
 
 
    Solving temperature system... 9 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+4 iterations.
       Nonlinear residuals: 298794, 0, 1.66045e+06
       Total relative nonlinear residual: 0.0271297
 
 
    Solving temperature system... 8 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 13880.1, 0, 90098
       Total relative nonlinear residual: 0.00147209
 
 
    Solving temperature system... 7 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 1194.47, 0, 8793.38
       Total relative nonlinear residual: 0.000143673
 
 
    Solving temperature system... 6 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+1 iterations.
       Nonlinear residuals: 150.623, 0, 1120.11
       Total relative nonlinear residual: 1.83012e-05
 
 
    Solving temperature system... 5 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
       Nonlinear residuals: 20.2838, 0, 150.152
       Total relative nonlinear residual: 2.45329e-06
@@ -189,42 +189,42 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 
 *** Timestep 4:  t=46125 years
    Solving temperature system... 11 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+5 iterations.
       Nonlinear residuals: 3.47276e+06, 0, 3.10297e+07
       Total relative nonlinear residual: 0.594093
 
 
    Solving temperature system... 9 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+4 iterations.
       Nonlinear residuals: 121429, 0, 787205
       Total relative nonlinear residual: 0.0150718
 
 
    Solving temperature system... 8 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 7066.23, 0, 54337
       Total relative nonlinear residual: 0.00104033
 
 
    Solving temperature system... 7 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 662.283, 0, 5212.76
       Total relative nonlinear residual: 9.98032e-05
 
 
    Solving temperature system... 6 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+1 iterations.
       Nonlinear residuals: 68.9605, 0, 551.256
       Total relative nonlinear residual: 1.05543e-05
 
 
    Solving temperature system... 5 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
       Nonlinear residuals: 7.34032, 0, 58.7242
       Total relative nonlinear residual: 1.12433e-06
@@ -235,35 +235,35 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 
 *** Timestep 5:  t=55855.4 years
    Solving temperature system... 11 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+5 iterations.
       Nonlinear residuals: 2.20444e+06, 0, 1.81351e+07
       Total relative nonlinear residual: 0.383226
 
 
    Solving temperature system... 9 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+4 iterations.
       Nonlinear residuals: 71532.3, 0, 568086
       Total relative nonlinear residual: 0.0120047
 
 
    Solving temperature system... 8 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 5106.63, 0, 43981.5
       Total relative nonlinear residual: 0.000929408
 
 
    Solving temperature system... 7 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 482.134, 0, 4266.08
       Total relative nonlinear residual: 9.01498e-05
 
 
    Solving temperature system... 6 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
       Nonlinear residuals: 47.948, 0, 427.409
       Total relative nonlinear residual: 9.03192e-06
@@ -274,35 +274,35 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 
 *** Timestep 6:  t=65167.2 years
    Solving temperature system... 11 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+5 iterations.
       Nonlinear residuals: 1.47905e+06, 0, 1.27436e+07
       Total relative nonlinear residual: 0.258279
 
 
    Solving temperature system... 9 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+4 iterations.
       Nonlinear residuals: 45392.6, 0, 397634
       Total relative nonlinear residual: 0.00805902
 
 
    Solving temperature system... 8 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 3292.31, 0, 31095.5
       Total relative nonlinear residual: 0.000630225
 
 
    Solving temperature system... 7 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 305.892, 0, 2975.96
       Total relative nonlinear residual: 6.03151e-05
 
 
    Solving temperature system... 6 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
       Nonlinear residuals: 29.6602, 0, 293.926
       Total relative nonlinear residual: 5.95712e-06
@@ -313,35 +313,35 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 
 *** Timestep 7:  t=73771.7 years
    Solving temperature system... 11 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+4 iterations.
       Nonlinear residuals: 940943, 0, 8.43616e+06
       Total relative nonlinear residual: 0.159808
 
 
    Solving temperature system... 10 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+3 iterations.
       Nonlinear residuals: 29828.2, 0, 290743
       Total relative nonlinear residual: 0.00550759
 
 
    Solving temperature system... 9 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 2227.05, 0, 23200.1
       Total relative nonlinear residual: 0.000439483
 
 
    Solving temperature system... 8 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 202.163, 0, 2177.95
       Total relative nonlinear residual: 4.12574e-05
 
 
    Solving temperature system... 7 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
       Nonlinear residuals: 19.0298, 0, 209.279
       Total relative nonlinear residual: 3.96441e-06
@@ -352,35 +352,35 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 
 *** Timestep 8:  t=81630.4 years
    Solving temperature system... 12 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+4 iterations.
       Nonlinear residuals: 595028, 0, 5.46878e+06
       Total relative nonlinear residual: 0.0961601
 
 
    Solving temperature system... 11 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+3 iterations.
       Nonlinear residuals: 21593.2, 0, 227820
       Total relative nonlinear residual: 0.00400586
 
 
    Solving temperature system... 9 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 1686.01, 0, 18497.6
       Total relative nonlinear residual: 0.000325253
 
 
    Solving temperature system... 8 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 148.22, 0, 1669.59
       Total relative nonlinear residual: 2.93572e-05
 
 
    Solving temperature system... 7 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
       Nonlinear residuals: 13.3331, 0, 152.216
       Total relative nonlinear residual: 2.67649e-06
@@ -391,35 +391,35 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 
 *** Timestep 9:  t=88740.3 years
    Solving temperature system... 12 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+4 iterations.
       Nonlinear residuals: 391929, 0, 3.62238e+06
       Total relative nonlinear residual: 0.0590716
 
 
    Solving temperature system... 11 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+3 iterations.
       Nonlinear residuals: 16341.4, 0, 180512
       Total relative nonlinear residual: 0.00294368
 
 
    Solving temperature system... 9 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 1276.77, 0, 14484.8
       Total relative nonlinear residual: 0.000236209
 
 
    Solving temperature system... 8 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 106.113, 0, 1230.69
       Total relative nonlinear residual: 2.00694e-05
 
 
    Solving temperature system... 7 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
       Nonlinear residuals: 8.96327, 0, 104.715
       Total relative nonlinear residual: 1.70762e-06
@@ -430,35 +430,35 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 
 *** Timestep 10:  t=95202.3 years
    Solving temperature system... 12 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+4 iterations.
       Nonlinear residuals: 292800, 0, 2.74823e+06
       Total relative nonlinear residual: 0.0416316
 
 
    Solving temperature system... 11 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+3 iterations.
       Nonlinear residuals: 13530.5, 0, 148179
       Total relative nonlinear residual: 0.00224469
 
 
    Solving temperature system... 9 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 984.765, 0, 11239.9
       Total relative nonlinear residual: 0.000170268
 
 
    Solving temperature system... 8 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+1 iterations.
       Nonlinear residuals: 75.5848, 0, 878.747
       Total relative nonlinear residual: 1.33117e-05
 
 
    Solving temperature system... 7 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
       Nonlinear residuals: 5.89606, 0, 68.8876
       Total relative nonlinear residual: 1.04354e-06
@@ -469,28 +469,28 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 
 *** Timestep 11:  t=100000 years
    Solving temperature system... 11 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+4 iterations.
       Nonlinear residuals: 180228, 0, 1.78002e+06
       Total relative nonlinear residual: 0.0254169
 
 
    Solving temperature system... 10 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 6885.83, 0, 78122
       Total relative nonlinear residual: 0.00111551
 
 
    Solving temperature system... 8 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+2 iterations.
       Nonlinear residuals: 382.885, 0, 4559.4
       Total relative nonlinear residual: 6.51037e-05
 
 
    Solving temperature system... 7 iterations.
-   Solving porosity system ... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
       Nonlinear residuals: 22.6766, 0, 274.304
       Total relative nonlinear residual: 3.9168e-06

--- a/tests/lithosphere_boundary_indicator/screen-output
+++ b/tests/lithosphere_boundary_indicator/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 2,048 (on 6 levels)
 Number of degrees of freedom: 35,685 (16,770+2,145+8,385+8,385)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+9 iterations.
@@ -24,21 +17,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      12.9s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |       2.9s |        23% |
-| Assemble composition system     |         1 |     0.751s |       5.8% |
-| Assemble temperature system     |         1 |      0.73s |       5.7% |
-| Build Stokes preconditioner     |         1 |      2.01s |        16% |
-| Build composition preconditioner|         1 |    0.0186s |      0.14% |
-| Build temperature preconditioner|         1 |    0.0197s |      0.15% |
-| Solve Stokes system             |         1 |      1.76s |        14% |
-| Solve composition system        |         1 |   0.00478s |     0.037% |
-| Solve temperature system        |         1 |    0.0047s |     0.036% |
-| Initialization                  |         2 |      2.09s |        16% |
-| Postprocessing                  |         1 |     0.184s |       1.4% |
-| Setup dof systems               |         1 |      1.25s |       9.7% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/lithosphere_boundary_indicator_3d/screen-output
+++ b/tests/lithosphere_boundary_indicator_3d/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 128 (on 3 levels)
 Number of degrees of freedom: 7,110 (4,131+225+1,377+1,377)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+8 iterations.
@@ -24,21 +17,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      15.9s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |      7.54s |        47% |
-| Assemble composition system     |         1 |     0.513s |       3.2% |
-| Assemble temperature system     |         1 |     0.494s |       3.1% |
-| Build Stokes preconditioner     |         1 |      4.05s |        25% |
-| Build composition preconditioner|         1 |    0.0134s |     0.084% |
-| Build temperature preconditioner|         1 |    0.0112s |     0.071% |
-| Solve Stokes system             |         1 |     0.346s |       2.2% |
-| Solve composition system        |         1 |   0.00227s |     0.014% |
-| Solve temperature system        |         1 |   0.00245s |     0.015% |
-| Initialization                  |         2 |       1.5s |       9.4% |
-| Postprocessing                  |         1 |    0.0528s |      0.33% |
-| Setup dof systems               |         1 |     0.686s |       4.3% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/no_adiabatic_heating_03/screen-output
+++ b/tests/no_adiabatic_heating_03/screen-output
@@ -5,7 +5,7 @@ Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
    Residual after nonlinear iteration 1: 1
@@ -24,7 +24,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Residual after nonlinear iteration 5: 2.11507e-06
+   Residual after nonlinear iteration 5: 2.11502e-06
 
    Postprocessing:
 
@@ -48,7 +48,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 17 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Residual after nonlinear iteration 1: 2.20615e-07
+   Residual after nonlinear iteration 1: 2.20604e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0.003202 K, 0.003462 K
@@ -58,7 +58,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Residual after nonlinear iteration 1: 2.09917e-07
+   Residual after nonlinear iteration 1: 2.09902e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0.006333 K, 0.006918 K
@@ -68,7 +68,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Residual after nonlinear iteration 1: 2.12537e-07
+   Residual after nonlinear iteration 1: 2.12359e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0.009376 K, 0.01037 K
@@ -78,7 +78,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 13 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Residual after nonlinear iteration 1: 1.12544e-07
+   Residual after nonlinear iteration 1: 1.12424e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0.01093 K, 0.01215 K

--- a/tests/particle_generator_ascii/screen-output
+++ b/tests/particle_generator_ascii/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 4 MPI processes
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+2 iterations.
@@ -21,7 +14,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing particle output:   output-particle_generator_ascii/particles-00000
 
 *** Timestep 1:  t=70 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 18 iterations.
    Solving Stokes system... 30+2 iterations.
 
@@ -34,21 +27,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      5.86s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |      0.26s |       4.4% |
-| Assemble composition system     |         2 |     0.106s |       1.8% |
-| Assemble temperature system     |         2 |    0.0862s |       1.5% |
-| Build Stokes preconditioner     |         1 |      2.94s |        50% |
-| Build composition preconditioner|         2 |   0.00212s |     0.036% |
-| Build temperature preconditioner|         2 |    0.0219s |      0.37% |
-| Solve Stokes system             |         2 |      1.83s |        31% |
-| Solve composition system        |         2 |     0.121s |       2.1% |
-| Solve temperature system        |         2 |     0.146s |       2.5% |
-| Initialization                  |         2 |     0.144s |       2.5% |
-| Postprocessing                  |         2 |      0.02s |      0.34% |
-| Setup dof systems               |         1 |    0.0665s |       1.1% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/particle_generator_box/screen-output
+++ b/tests/particle_generator_box/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
@@ -21,7 +14,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing particle output:   output-particle_generator_box/particles-00000
 
 *** Timestep 1:  t=70 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Solving Stokes system... 30+3 iterations.
 
@@ -34,21 +27,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.833s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |     0.205s |        25% |
-| Assemble composition system     |         2 |    0.0829s |        10% |
-| Assemble temperature system     |         2 |     0.128s |        15% |
-| Build Stokes preconditioner     |         1 |     0.134s |        16% |
-| Build composition preconditioner|         2 |   0.00514s |      0.62% |
-| Build temperature preconditioner|         2 |   0.00447s |      0.54% |
-| Solve Stokes system             |         2 |     0.151s |        18% |
-| Solve composition system        |         2 |   0.00398s |      0.48% |
-| Solve temperature system        |         2 |   0.00127s |      0.15% |
-| Initialization                  |         2 |    0.0499s |         6% |
-| Postprocessing                  |         2 |    0.0162s |       1.9% |
-| Setup dof systems               |         1 |    0.0369s |       4.4% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/particle_generator_box_3d/screen-output
+++ b/tests/particle_generator_box_3d/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 64 (on 3 levels)
 Number of degrees of freedom: 3,770 (2,187+125+729+729)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+2 iterations.
@@ -14,7 +14,7 @@ Number of degrees of freedom: 3,770 (2,187+125+729+729)
      Writing particle output:   output-particle_generator_box_3d/particle-00000
 
 *** Timestep 1:  t=10 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 11 iterations.
    Solving Stokes system... 26+0 iterations.
 

--- a/tests/particle_generator_radial/screen-output
+++ b/tests/particle_generator_radial/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
@@ -21,7 +14,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing particle output:   output-particle_generator_radial/particles-00000
 
 *** Timestep 1:  t=70 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Solving Stokes system... 30+3 iterations.
 
@@ -34,21 +27,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.864s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |     0.242s |        28% |
-| Assemble composition system     |         2 |    0.0979s |        11% |
-| Assemble temperature system     |         2 |    0.0951s |        11% |
-| Build Stokes preconditioner     |         1 |     0.101s |        12% |
-| Build composition preconditioner|         2 |   0.00375s |      0.43% |
-| Build temperature preconditioner|         2 |    0.0294s |       3.4% |
-| Solve Stokes system             |         2 |    0.0967s |        11% |
-| Solve composition system        |         2 |   0.00271s |      0.31% |
-| Solve temperature system        |         2 |   0.00156s |      0.18% |
-| Initialization                  |         2 |    0.0746s |       8.6% |
-| Postprocessing                  |         2 |   0.00822s |      0.95% |
-| Setup dof systems               |         1 |    0.0951s |        11% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/particle_initial_adaptive_output/screen-output
+++ b/tests/particle_initial_adaptive_output/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 16 (on 3 levels)
 Number of degrees of freedom: 349 (162+25+81+81)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
@@ -17,7 +17,7 @@ Number of active cells: 22 (on 4 levels)
 Number of degrees of freedom: 490 (228+34+114+114)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
@@ -31,7 +31,7 @@ Number of active cells: 31 (on 4 levels)
 Number of degrees of freedom: 673 (314+45+157+157)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
@@ -42,7 +42,7 @@ Number of degrees of freedom: 673 (314+45+157+157)
      Number of advected particles: 9
 
 *** Timestep 1:  t=70 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 10 iterations.
    Solving Stokes system... 24+0 iterations.
 

--- a/tests/particle_initial_adaptive_refinement/screen-output
+++ b/tests/particle_initial_adaptive_refinement/screen-output
@@ -3,25 +3,25 @@ Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
 
    Postprocessing:
-     RMS, max velocity:           0.000181 m/s, 0.000404 m/s
-     Compositions min/max/mass:   0/1/0.1825
-     Number of advected particles 9
+     RMS, max velocity:            0.000181 m/s, 0.000404 m/s
+     Compositions min/max/mass:    0/1/0.1825
+     Number of advected particles: 9
 
 *** Timestep 1:  t=70 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Solving Stokes system... 30+3 iterations.
 
    Postprocessing:
-     RMS, max velocity:           0.000327 m/s, 0.000728 m/s
-     Compositions min/max/mass:   -0.002207/1.002/0.1825
-     Number of advected particles 9
+     RMS, max velocity:            0.000327 m/s, 0.000728 m/s
+     Compositions min/max/mass:    -0.002207/1.002/0.1825
+     Number of advected particles: 9
 
 Termination requested by criterion: end time
 

--- a/tests/particle_integrator_euler/screen-output
+++ b/tests/particle_integrator_euler/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
@@ -21,7 +14,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing particle output:   output-particle_integrator_euler/particles-00000
 
 *** Timestep 1:  t=70 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Solving Stokes system... 30+3 iterations.
 
@@ -34,21 +27,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.803s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |     0.247s |        31% |
-| Assemble composition system     |         2 |    0.0644s |         8% |
-| Assemble temperature system     |         2 |    0.0997s |        12% |
-| Build Stokes preconditioner     |         1 |      0.13s |        16% |
-| Build composition preconditioner|         2 |   0.00326s |      0.41% |
-| Build temperature preconditioner|         2 |   0.00455s |      0.57% |
-| Solve Stokes system             |         2 |    0.0609s |       7.6% |
-| Solve composition system        |         2 |   0.00276s |      0.34% |
-| Solve temperature system        |         2 |   0.00137s |      0.17% |
-| Initialization                  |         2 |    0.0746s |       9.3% |
-| Postprocessing                  |         2 |    0.0106s |       1.3% |
-| Setup dof systems               |         1 |    0.0842s |        10% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/particle_integrator_rk4/screen-output
+++ b/tests/particle_integrator_rk4/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
@@ -21,7 +14,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing particle output:   output-particle_integrator_rk4/particles-00000
 
 *** Timestep 1:  t=70 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Solving Stokes system... 30+3 iterations.
 
@@ -34,21 +27,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.719s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |      0.16s |        22% |
-| Assemble composition system     |         2 |       0.1s |        14% |
-| Assemble temperature system     |         2 |     0.116s |        16% |
-| Build Stokes preconditioner     |         1 |    0.0691s |       9.6% |
-| Build composition preconditioner|         2 |   0.00379s |      0.53% |
-| Build temperature preconditioner|         2 |   0.00434s |       0.6% |
-| Solve Stokes system             |         2 |    0.0586s |       8.1% |
-| Solve composition system        |         2 |   0.00242s |      0.34% |
-| Solve temperature system        |         2 |   0.00129s |      0.18% |
-| Initialization                  |         2 |    0.0567s |       7.9% |
-| Postprocessing                  |         2 |   0.00968s |       1.3% |
-| Setup dof systems               |         1 |    0.0921s |        13% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/particle_linear_accelerated_flow_rk2/screen-output
+++ b/tests/particle_linear_accelerated_flow_rk2/screen-output
@@ -1,41 +1,25 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 1 (on 1 levels)
 Number of degrees of freedom: 31 (18+4+9)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
 
    Postprocessing:
-     RMS, max velocity:        0.1 m/s, 0.1 m/s
-     Writing particle output:  output-particle_linear_accelerated_flow_rk2/particle-00000
+     RMS, max velocity:       0.1 m/s, 0.1 m/s
+     Writing particle output: output-particle_linear_accelerated_flow_rk2/particle-00000
 
 *** Timestep 1:  t=1 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
 
    Postprocessing:
-     RMS, max velocity:        1.1 m/s, 1.1 m/s
-     Writing particle output:  output-particle_linear_accelerated_flow_rk2/particle-00001
+     RMS, max velocity:       1.1 m/s, 1.1 m/s
+     Writing particle output: output-particle_linear_accelerated_flow_rk2/particle-00001
 
 Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |    0.0735s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble temperature system     |         2 |    0.0028s |       3.8% |
-| Build temperature preconditioner|         2 |  0.000417s |      0.57% |
-| Solve temperature system        |         2 |  0.000529s |      0.72% |
-| Initialization                  |         2 |    0.0637s |        87% |
-| Postprocessing                  |         2 |   0.00101s |       1.4% |
-| Setup dof systems               |         1 |   0.00265s |       3.6% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/particle_load_balancing_refinement/screen-output
+++ b/tests/particle_load_balancing_refinement/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 64 (on 4 levels)
 Number of degrees of freedom: 1,237 (578+81+289+289)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
@@ -15,7 +15,7 @@ Number of active cells: 25 (on 4 levels)
 Number of degrees of freedom: 554 (258+38+129+129)
 
 *** Timestep 1:  t=100 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.

--- a/tests/particle_load_balancing_refinement_02/screen-output
+++ b/tests/particle_load_balancing_refinement_02/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 64 (on 4 levels)
 Number of degrees of freedom: 1,237 (578+81+289+289)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
@@ -15,7 +15,7 @@ Number of active cells: 25 (on 4 levels)
 Number of degrees of freedom: 554 (258+38+129+129)
 
 *** Timestep 1:  t=100.897 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
@@ -27,7 +27,7 @@ Number of active cells: 25 (on 4 levels)
 Number of degrees of freedom: 554 (258+38+129+129)
 
 *** Timestep 2:  t=274.418 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
@@ -39,7 +39,7 @@ Number of active cells: 25 (on 4 levels)
 Number of degrees of freedom: 554 (258+38+129+129)
 
 *** Timestep 3:  t=407.89 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
@@ -51,7 +51,7 @@ Number of active cells: 16 (on 4 levels)
 Number of degrees of freedom: 387 (180+27+90+90)
 
 *** Timestep 4:  t=477.649 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
@@ -63,7 +63,7 @@ Number of active cells: 10 (on 3 levels)
 Number of degrees of freedom: 246 (114+18+57+57)
 
 *** Timestep 5:  t=500 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.

--- a/tests/particle_load_balancing_removal/screen-output
+++ b/tests/particle_load_balancing_removal/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 16 (on 3 levels)
 Number of degrees of freedom: 349 (162+25+81+81)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
@@ -15,7 +15,7 @@ Number of active cells: 10 (on 3 levels)
 Number of degrees of freedom: 246 (114+18+57+57)
 
 *** Timestep 1:  t=100 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.

--- a/tests/particle_load_balancing_removal_addition/screen-output
+++ b/tests/particle_load_balancing_removal_addition/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 16 (on 3 levels)
 Number of degrees of freedom: 349 (162+25+81+81)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
@@ -15,7 +15,7 @@ Number of active cells: 10 (on 3 levels)
 Number of degrees of freedom: 246 (114+18+57+57)
 
 *** Timestep 1:  t=100 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.

--- a/tests/particle_load_balancing_removal_addition_properties/screen-output
+++ b/tests/particle_load_balancing_removal_addition_properties/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 16 (on 3 levels)
 Number of degrees of freedom: 349 (162+25+81+81)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
@@ -15,7 +15,7 @@ Number of active cells: 10 (on 3 levels)
 Number of degrees of freedom: 246 (114+18+57+57)
 
 *** Timestep 1:  t=248.486 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
@@ -27,7 +27,7 @@ Number of active cells: 10 (on 3 levels)
 Number of degrees of freedom: 246 (114+18+57+57)
 
 *** Timestep 2:  t=446.771 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
@@ -39,7 +39,7 @@ Number of active cells: 10 (on 3 levels)
 Number of degrees of freedom: 246 (114+18+57+57)
 
 *** Timestep 3:  t=500 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.

--- a/tests/particle_output_hdf5/screen-output
+++ b/tests/particle_output_hdf5/screen-output
@@ -1,50 +1,28 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 2 MPI processes
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+2 iterations.
 
    Postprocessing:
-     Writing particle output:  output-particle_output_hdf5/particle-00000
+     Writing particle output: output-particle_output_hdf5/particle-00000
 
 *** Timestep 1:  t=70 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 16 iterations.
    Solving Stokes system... 30+2 iterations.
 
    Postprocessing:
-     Writing particle output:  output-particle_output_hdf5/particle-00001
+     Writing particle output: output-particle_output_hdf5/particle-00001
 
 Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.513s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |     0.118s |        23% |
-| Assemble composition system     |         2 |    0.0621s |        12% |
-| Assemble temperature system     |         2 |    0.0307s |         6% |
-| Build Stokes preconditioner     |         1 |    0.0421s |       8.2% |
-| Build composition preconditioner|         2 |   0.00281s |      0.55% |
-| Build temperature preconditioner|         2 |   0.00244s |      0.48% |
-| Solve Stokes system             |         2 |     0.055s |        11% |
-| Solve composition system        |         2 |   0.00411s |       0.8% |
-| Solve temperature system        |         2 |   0.00179s |      0.35% |
-| Initialization                  |         2 |    0.0775s |        15% |
-| Postprocessing                  |         2 |    0.0599s |        12% |
-| Setup dof systems               |         1 |    0.0401s |       7.8% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/particle_output_none/screen-output
+++ b/tests/particle_output_none/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 16 (on 3 levels)
 Number of degrees of freedom: 349 (162+25+81+81)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
@@ -14,7 +14,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Number of advected particles: 30
 
 *** Timestep 1:  t=10 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Solving Stokes system... 10+0 iterations.
 

--- a/tests/particle_periodic_boundaries/screen-output
+++ b/tests/particle_periodic_boundaries/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 2 MPI processes
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
@@ -21,7 +14,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing particle output:   output-particle_periodic_boundaries/particles-00000
 
 *** Timestep 1:  t=70 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Solving Stokes system... 30+3 iterations.
 
@@ -34,21 +27,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.577s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |     0.124s |        21% |
-| Assemble composition system     |         2 |    0.0647s |        11% |
-| Assemble temperature system     |         2 |    0.0674s |        12% |
-| Build Stokes preconditioner     |         1 |    0.0528s |       9.2% |
-| Build composition preconditioner|         2 |   0.00286s |       0.5% |
-| Build temperature preconditioner|         2 |   0.00257s |      0.45% |
-| Solve Stokes system             |         2 |    0.0883s |        15% |
-| Solve composition system        |         2 |   0.00364s |      0.63% |
-| Solve temperature system        |         2 |   0.00195s |      0.34% |
-| Initialization                  |         2 |    0.0697s |        12% |
-| Postprocessing                  |         2 |   0.00688s |       1.2% |
-| Setup dof systems               |         1 |    0.0799s |        14% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/particle_property_function/screen-output
+++ b/tests/particle_property_function/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 2 MPI processes
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+2 iterations.
@@ -21,7 +14,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing particle output:   output-particle_property_function/particles-00000
 
 *** Timestep 1:  t=70 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 16 iterations.
    Solving Stokes system... 30+2 iterations.
 
@@ -34,21 +27,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.575s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |    0.0673s |        12% |
-| Assemble composition system     |         2 |    0.0814s |        14% |
-| Assemble temperature system     |         2 |    0.0557s |       9.7% |
-| Build Stokes preconditioner     |         1 |    0.0899s |        16% |
-| Build composition preconditioner|         2 |   0.00215s |      0.37% |
-| Build temperature preconditioner|         2 |   0.00254s |      0.44% |
-| Solve Stokes system             |         2 |     0.138s |        24% |
-| Solve composition system        |         2 |    0.0029s |       0.5% |
-| Solve temperature system        |         2 |   0.00193s |      0.34% |
-| Initialization                  |         2 |    0.0611s |        11% |
-| Postprocessing                  |         2 |   0.00988s |       1.7% |
-| Setup dof systems               |         1 |    0.0443s |       7.7% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/particle_timing_information/screen-output
+++ b/tests/particle_timing_information/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 16 (on 3 levels)
 Number of degrees of freedom: 349 (162+25+81+81)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
@@ -17,7 +17,7 @@ Number of active cells: 19 (on 4 levels)
 Number of degrees of freedom: 447 (208+31+104+104)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
@@ -31,7 +31,7 @@ Number of active cells: 16 (on 4 levels)
 Number of degrees of freedom: 387 (180+27+90+90)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
@@ -42,7 +42,7 @@ Number of degrees of freedom: 387 (180+27+90+90)
      Number of advected particles: 9
 
 *** Timestep 1:  t=70 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 16 iterations.
    Solving Stokes system... 22+0 iterations.
 

--- a/tests/particle_visualization_particle_count/screen-output
+++ b/tests/particle_visualization_particle_count/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 16 (on 3 levels)
 Number of degrees of freedom: 349 (162+25+81+81)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
@@ -13,7 +13,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing graphical output:     output-particle_visualization_particle_count/solution-00000
 
 *** Timestep 1:  t=70 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 9 iterations.
    Solving Stokes system... 20+0 iterations.
 

--- a/tests/passive_comp/screen-output
+++ b/tests/passive_comp/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 768 (on 4 levels)
 Number of degrees of freedom: 13,920 (6,528+864+3,264+3,264)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+12 iterations.

--- a/tests/petsc_composition_names/screen-output
+++ b/tests/petsc_composition_names/screen-output
@@ -1,18 +1,11 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.1.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using PETSc
------------------------------------------------------------------------------
 
 Number of active cells: 1 (on 1 levels)
 Number of degrees of freedom: 49 (18+4+9+9+9)
 
 *** Timestep 0:  t=0 years
    Solving temperature system... 0 iterations.
-   Solving peridotite system ... 0 iterations.
-   Solving eclogite system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Skipping eclogite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
 
@@ -24,21 +17,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.194s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |   0.00551s |       2.8% |
-| Assemble composition system     |         2 |    0.0328s |        17% |
-| Assemble temperature system     |         1 |    0.0199s |        10% |
-| Build Stokes preconditioner     |         1 |    0.0134s |       6.9% |
-| Build composition preconditioner|         2 |  0.000357s |      0.18% |
-| Build temperature preconditioner|         1 |   0.00038s |       0.2% |
-| Solve Stokes system             |         1 |    0.0477s |        25% |
-| Solve composition system        |         2 |   0.00298s |       1.5% |
-| Solve temperature system        |         1 |   0.00209s |       1.1% |
-| Initialization                  |         2 |    0.0328s |        17% |
-| Postprocessing                  |         1 |   0.00423s |       2.2% |
-| Setup dof systems               |         1 |    0.0257s |        13% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/petsc_refinement/screen-output
+++ b/tests/petsc_refinement/screen-output
@@ -1,17 +1,10 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.2.pre
---     . running in DEBUG mode
---     . running with 3 MPI processes
---     . using PETSc
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 seconds
    Solving temperature system... 0 iterations.
-   Solving C_1 system ... 0 iterations.
+   Skipping C_1 composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
 
@@ -20,7 +13,7 @@ Number of degrees of freedom: 8,170 (3,832+506+1,916+1,916)
 
 *** Timestep 0:  t=0 seconds
    Solving temperature system... 0 iterations.
-   Solving C_1 system ... 0 iterations.
+   Skipping C_1 composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
 
@@ -32,8 +25,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/petsc_use_petsc/screen-output
+++ b/tests/petsc_use_petsc/screen-output
@@ -1,10 +1,3 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.2.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using PETSc
------------------------------------------------------------------------------
 
 Loading shared library <./libpetsc_use_petsc.so>
 hey petsc!
@@ -14,8 +7,8 @@ Number of degrees of freedom: 49 (18+4+9+9+9)
 
 *** Timestep 0:  t=0 years
    Solving temperature system... 0 iterations.
-   Solving peridotite system ... 0 iterations.
-   Solving eclogite system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Skipping eclogite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
 
@@ -27,21 +20,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.367s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0127s |       3.5% |
-| Assemble composition system     |         2 |     0.062s |        17% |
-| Assemble temperature system     |         1 |    0.0462s |        13% |
-| Build Stokes preconditioner     |         1 |    0.0223s |       6.1% |
-| Build composition preconditioner|         2 |   0.00114s |      0.31% |
-| Build temperature preconditioner|         1 |  0.000874s |      0.24% |
-| Solve Stokes system             |         1 |    0.0732s |        20% |
-| Solve composition system        |         2 |    0.0121s |       3.3% |
-| Solve temperature system        |         1 |   0.00637s |       1.7% |
-| Initialization                  |         2 |    0.0546s |        15% |
-| Postprocessing                  |         1 |   0.00776s |       2.1% |
-| Setup dof systems               |         1 |    0.0612s |        17% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/point_value_01/screen-output
+++ b/tests/point_value_01/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.0-pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+10 iterations.
@@ -20,7 +13,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_01/point_values.txt
 
 *** Timestep 1:  t=0.1 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+5 iterations.
@@ -33,21 +26,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.545s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |     0.116s |        21% |
-| Assemble composition system     |         2 |    0.0558s |        10% |
-| Assemble temperature system     |         2 |    0.0539s |       9.9% |
-| Build Stokes preconditioner     |         2 |     0.102s |        19% |
-| Build composition preconditioner|         2 |   0.00267s |      0.49% |
-| Build temperature preconditioner|         2 |   0.00308s |      0.57% |
-| Solve Stokes system             |         2 |     0.106s |        19% |
-| Solve composition system        |         2 |   0.00184s |      0.34% |
-| Solve temperature system        |         2 |  0.000896s |      0.16% |
-| Initialization                  |         2 |    0.0269s |       4.9% |
-| Postprocessing                  |         2 |     0.032s |       5.9% |
-| Setup dof systems               |         1 |     0.032s |       5.9% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/point_value_02/screen-output
+++ b/tests/point_value_02/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+10 iterations.
@@ -13,7 +13,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 1:  t=3.85098e-08 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+9 iterations.
@@ -23,7 +23,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 2:  t=8.43635e-08 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+12 iterations.
@@ -33,7 +33,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 3:  t=1.33523e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+11 iterations.
@@ -43,7 +43,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 4:  t=1.85895e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+11 iterations.
@@ -53,7 +53,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 5:  t=2.4208e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+8 iterations.
@@ -63,7 +63,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 6:  t=3.02674e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+9 iterations.
@@ -73,7 +73,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 7:  t=3.68562e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+10 iterations.
@@ -83,7 +83,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 8:  t=4.4072e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+12 iterations.
@@ -93,7 +93,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 9:  t=5.21042e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+13 iterations.
@@ -103,7 +103,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 10:  t=6.12069e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+15 iterations.
@@ -116,7 +116,7 @@ Number of active cells: 64 (on 4 levels)
 Number of degrees of freedom: 1,237 (578+81+289+289)
 
 *** Timestep 11:  t=7.15292e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+10 iterations.
@@ -126,7 +126,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 12:  t=9.44845e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+10 iterations.
@@ -136,7 +136,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 13:  t=1.29715e-06 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+10 iterations.
@@ -146,7 +146,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 14:  t=2.0387e-06 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+9 iterations.
@@ -156,7 +156,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 15:  t=3.24612e-06 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+8 iterations.
@@ -166,7 +166,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 16:  t=4.5336e-06 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+6 iterations.
@@ -176,7 +176,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 17:  t=5.94223e-06 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+5 iterations.
@@ -186,7 +186,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 18:  t=7.55685e-06 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+4 iterations.
@@ -196,7 +196,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 19:  t=9.38709e-06 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+4 iterations.
@@ -206,7 +206,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 20:  t=1.14364e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+4 iterations.
@@ -219,7 +219,7 @@ Number of active cells: 16 (on 3 levels)
 Number of degrees of freedom: 349 (162+25+81+81)
 
 *** Timestep 21:  t=1.3728e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
@@ -229,7 +229,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 22:  t=1.74579e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
@@ -239,7 +239,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 23:  t=3.42235e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 98 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
@@ -249,7 +249,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 24:  t=3.91963e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 13 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+1 iterations.
@@ -259,7 +259,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 25:  t=4.63181e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
@@ -269,7 +269,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 26:  t=5.71431e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
@@ -279,7 +279,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 27:  t=7.54304e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+1 iterations.
@@ -289,7 +289,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 28:  t=0.000105193 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
@@ -299,7 +299,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 29:  t=0.000163954 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
@@ -309,7 +309,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 30:  t=0.00018897 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
@@ -322,7 +322,7 @@ Number of active cells: 4 (on 2 levels)
 Number of degrees of freedom: 109 (50+9+25+25)
 
 *** Timestep 31:  t=0.000243809 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
@@ -332,7 +332,7 @@ Number of degrees of freedom: 109 (50+9+25+25)
      Writing point values:     output-point_value_02/point_values.txt
 
 *** Timestep 32:  t=0.1 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 49 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.

--- a/tests/point_value_02_mpi/screen-output
+++ b/tests/point_value_02_mpi/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+11 iterations.
@@ -13,7 +13,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 1:  t=3.85098e-08 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 21 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+10 iterations.
@@ -23,7 +23,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 2:  t=8.43635e-08 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 17 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+12 iterations.
@@ -33,7 +33,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 3:  t=1.33523e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 18 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+11 iterations.
@@ -43,7 +43,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 4:  t=1.85895e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 17 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+10 iterations.
@@ -53,7 +53,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 5:  t=2.4208e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 17 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+9 iterations.
@@ -63,7 +63,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 6:  t=3.02674e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 17 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+10 iterations.
@@ -73,7 +73,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 7:  t=3.68562e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 17 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+10 iterations.
@@ -83,7 +83,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 8:  t=4.4072e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+11 iterations.
@@ -93,7 +93,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 9:  t=5.21042e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+13 iterations.
@@ -103,7 +103,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 10:  t=6.12069e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+13 iterations.
@@ -116,7 +116,7 @@ Number of active cells: 64 (on 4 levels)
 Number of degrees of freedom: 1,237 (578+81+289+289)
 
 *** Timestep 11:  t=7.15292e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+10 iterations.
@@ -126,7 +126,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 12:  t=9.44845e-07 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+9 iterations.
@@ -136,7 +136,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 13:  t=1.29715e-06 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+10 iterations.
@@ -146,7 +146,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 14:  t=2.0387e-06 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+9 iterations.
@@ -156,7 +156,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 15:  t=3.24612e-06 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 13 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+8 iterations.
@@ -166,7 +166,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 16:  t=4.5336e-06 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+6 iterations.
@@ -176,7 +176,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 17:  t=5.94223e-06 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+5 iterations.
@@ -186,7 +186,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 18:  t=7.55685e-06 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+4 iterations.
@@ -196,7 +196,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 19:  t=9.38709e-06 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+4 iterations.
@@ -206,7 +206,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 20:  t=1.14364e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+5 iterations.
@@ -219,7 +219,7 @@ Number of active cells: 22 (on 4 levels)
 Number of degrees of freedom: 519 (242+35+121+121)
 
 *** Timestep 21:  t=1.3728e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+10 iterations.
@@ -229,7 +229,7 @@ Number of degrees of freedom: 519 (242+35+121+121)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 22:  t=1.61126e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 17 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+9 iterations.
@@ -239,7 +239,7 @@ Number of degrees of freedom: 519 (242+35+121+121)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 23:  t=1.96229e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+7 iterations.
@@ -249,7 +249,7 @@ Number of degrees of freedom: 519 (242+35+121+121)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 24:  t=2.56358e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+6 iterations.
@@ -259,7 +259,7 @@ Number of degrees of freedom: 519 (242+35+121+121)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 25:  t=3.23498e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+6 iterations.
@@ -269,7 +269,7 @@ Number of degrees of freedom: 519 (242+35+121+121)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 26:  t=4.0912e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+5 iterations.
@@ -279,7 +279,7 @@ Number of degrees of freedom: 519 (242+35+121+121)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 27:  t=5.05323e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+4 iterations.
@@ -289,7 +289,7 @@ Number of degrees of freedom: 519 (242+35+121+121)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 28:  t=6.01849e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
@@ -299,7 +299,7 @@ Number of degrees of freedom: 519 (242+35+121+121)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 29:  t=7.43393e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
@@ -309,7 +309,7 @@ Number of degrees of freedom: 519 (242+35+121+121)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 30:  t=8.29617e-05 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+2 iterations.
@@ -322,7 +322,7 @@ Number of active cells: 16 (on 3 levels)
 Number of degrees of freedom: 349 (162+25+81+81)
 
 *** Timestep 31:  t=0.000102991 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 18 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
@@ -332,7 +332,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 32:  t=0.000113755 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 18 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+4 iterations.
@@ -342,7 +342,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 33:  t=0.000138619 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 43 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+4 iterations.
@@ -352,7 +352,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 34:  t=0.000145174 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 18 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
@@ -362,7 +362,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 35:  t=0.000158994 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
@@ -372,7 +372,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 36:  t=0.000173478 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+2 iterations.
@@ -382,7 +382,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 37:  t=0.000236253 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 50 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+2 iterations.
@@ -392,7 +392,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 38:  t=0.000243622 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 17 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
@@ -402,7 +402,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 39:  t=0.000255041 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
@@ -412,7 +412,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 40:  t=0.000273333 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+2 iterations.
@@ -425,7 +425,7 @@ Number of active cells: 16 (on 3 levels)
 Number of degrees of freedom: 349 (162+25+81+81)
 
 *** Timestep 41:  t=0.00030419 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+2 iterations.
@@ -435,7 +435,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 42:  t=0.000347767 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+1 iterations.
@@ -445,7 +445,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 43:  t=0.000554282 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 83 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+1 iterations.
@@ -455,7 +455,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 44:  t=0.00056464 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
@@ -465,7 +465,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 45:  t=0.00058051 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
@@ -475,7 +475,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 46:  t=0.000605205 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
@@ -485,7 +485,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 47:  t=0.000648354 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
@@ -495,7 +495,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 48:  t=0.000711217 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+1 iterations.
@@ -505,7 +505,7 @@ Number of degrees of freedom: 349 (162+25+81+81)
      Writing point values:     output-point_value_02_mpi/point_values.txt
 
 *** Timestep 49:  t=0.001 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 63 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.

--- a/tests/poiseuille_2d_horizontal_pressure_bc/screen-output
+++ b/tests/poiseuille_2d_horizontal_pressure_bc/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+7 iterations.
 
@@ -23,18 +16,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      1.49s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |     0.373s |        25% |
-| Assemble temperature system     |         1 |     0.112s |       7.5% |
-| Build Stokes preconditioner     |         1 |     0.251s |        17% |
-| Build temperature preconditioner|         1 |   0.00321s |      0.22% |
-| Solve Stokes system             |         1 |      0.12s |         8% |
-| Solve temperature system        |         1 |   0.00139s |     0.094% |
-| Initialization                  |         2 |     0.224s |        15% |
-| Postprocessing                  |         1 |    0.0187s |       1.3% |
-| Setup dof systems               |         1 |     0.202s |        14% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/poiseuille_2d_pressure_bc/screen-output
+++ b/tests/poiseuille_2d_pressure_bc/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+8 iterations.
 
@@ -23,18 +16,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      1.38s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |     0.376s |        27% |
-| Assemble temperature system     |         1 |     0.112s |       8.1% |
-| Build Stokes preconditioner     |         1 |     0.256s |        19% |
-| Build temperature preconditioner|         1 |   0.00331s |      0.24% |
-| Solve Stokes system             |         1 |     0.128s |       9.3% |
-| Solve temperature system        |         1 |   0.00136s |     0.099% |
-| Initialization                  |         2 |     0.159s |        12% |
-| Postprocessing                  |         1 |    0.0188s |       1.4% |
-| Setup dof systems               |         1 |     0.202s |        15% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/poiseuille_3d_x_horizontal_pressure_bc/screen-output
+++ b/tests/poiseuille_3d_x_horizontal_pressure_bc/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 64 (on 3 levels)
 Number of degrees of freedom: 3,041 (2,187+125+729)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+9 iterations.
 
@@ -23,18 +16,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      8.73s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |      4.85s |        56% |
-| Assemble temperature system     |         1 |     0.327s |       3.7% |
-| Build Stokes preconditioner     |         1 |      2.13s |        24% |
-| Build temperature preconditioner|         1 |   0.00775s |     0.089% |
-| Solve Stokes system             |         1 |     0.177s |         2% |
-| Solve temperature system        |         1 |   0.00204s |     0.023% |
-| Initialization                  |         2 |     0.353s |         4% |
-| Postprocessing                  |         1 |    0.0658s |      0.75% |
-| Setup dof systems               |         1 |     0.545s |       6.2% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/prescribed_velocity/screen-output
+++ b/tests/prescribed_velocity/screen-output
@@ -1,10 +1,3 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Loading shared library <./libprescribed_velocity.so>
 
@@ -12,7 +5,7 @@ Number of active cells: 64 (on 4 levels)
 Number of degrees of freedom: 948 (578+81+289)
 
 *** Timestep 0:  t=0 years
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+6 iterations.
 
@@ -23,18 +16,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.184s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0127s |       6.9% |
-| Assemble temperature system     |         1 |   0.00636s |       3.5% |
-| Build Stokes preconditioner     |         1 |     0.019s |        10% |
-| Build temperature preconditioner|         1 |  0.000688s |      0.37% |
-| Solve Stokes system             |         1 |    0.0138s |       7.5% |
-| Solve temperature system        |         1 |  0.000394s |      0.21% |
-| Initialization                  |         2 |     0.115s |        63% |
-| Postprocessing                  |         1 |  0.000523s |      0.28% |
-| Setup dof systems               |         1 |   0.00967s |       5.3% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/signal_fem/screen-output
+++ b/tests/signal_fem/screen-output
@@ -14,8 +14,8 @@ Number of degrees of freedom: 334 (50+9+25+200+25+25)
 
 *** Timestep 0:  t=0 seconds
    Solving temperature system... 0 iterations.
-   Solving A system ... 0 iterations.
-   Solving B system ... 0 iterations.
+   Skipping A composition solve because RHS is zero.
+   Skipping B composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
 

--- a/tests/stokes/screen-output
+++ b/tests/stokes/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 64 (on 3 levels)
 Number of degrees of freedom: 3,770 (2,187+125+729+729)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
@@ -12,7 +12,7 @@ Number of active cells: 120 (on 4 levels)
 Number of degrees of freedom: 7,248 (4,215+223+1,405+1,405)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
@@ -21,7 +21,7 @@ Number of active cells: 155 (on 5 levels)
 Number of degrees of freedom: 9,767 (5,682+297+1,894+1,894)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+2 iterations.

--- a/tests/time_dependent_temperature_bc/screen-output
+++ b/tests/time_dependent_temperature_bc/screen-output
@@ -5,7 +5,7 @@ Number of active cells: 16 (on 3 levels)
 Number of degrees of freedom: 268 (162+25+81)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
 

--- a/tests/time_dependent_temperature_bc_2/screen-output
+++ b/tests/time_dependent_temperature_bc_2/screen-output
@@ -5,7 +5,7 @@ Number of active cells: 16 (on 3 levels)
 Number of degrees of freedom: 268 (162+25+81)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
 

--- a/tests/van_keken_smooth_tracer/screen-output
+++ b/tests/van_keken_smooth_tracer/screen-output
@@ -1,16 +1,9 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+3 iterations.
@@ -21,7 +14,7 @@ Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
      Writing particle output:   output-van_keken_smooth_tracer/particles-00000
 
 *** Timestep 1:  t=70 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 14 iterations.
    Solving Stokes system... 30+3 iterations.
 
@@ -34,21 +27,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      1.93s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |     0.328s |        17% |
-| Assemble composition system     |         2 |     0.409s |        21% |
-| Assemble temperature system     |         2 |     0.441s |        23% |
-| Build Stokes preconditioner     |         1 |     0.285s |        15% |
-| Build composition preconditioner|         2 |   0.00506s |      0.26% |
-| Build temperature preconditioner|         2 |   0.00521s |      0.27% |
-| Solve Stokes system             |         2 |     0.187s |       9.7% |
-| Solve composition system        |         2 |   0.00369s |      0.19% |
-| Solve temperature system        |         2 |    0.0015s |     0.078% |
-| Initialization                  |         2 |    0.0659s |       3.4% |
-| Postprocessing                  |         2 |    0.0132s |      0.68% |
-| Setup dof systems               |         1 |       0.1s |       5.2% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/viscous_dissipation_statistics/screen-output
+++ b/tests/viscous_dissipation_statistics/screen-output
@@ -3,7 +3,7 @@ Number of active cells: 64 (on 3 levels)
 Number of degrees of freedom: 3,770 (2,187+125+729+729)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
@@ -12,7 +12,7 @@ Number of active cells: 120 (on 4 levels)
 Number of degrees of freedom: 7,248 (4,215+223+1,405+1,405)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
@@ -21,7 +21,7 @@ Number of active cells: 155 (on 5 levels)
 Number of degrees of freedom: 9,767 (5,682+297+1,894+1,894)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+2 iterations.

--- a/tests/zero_RHS.prm
+++ b/tests/zero_RHS.prm
@@ -1,0 +1,122 @@
+# This is a test for models where the right-hand side of
+# the temperature or composition system is zero (i.e., the field
+# is zero, and there are no boundary conditions/additional RHS
+# terms).
+# In this case, the solver scheme should skip solving this 
+# field. 
+
+set Dimension = 2
+
+set End time                               = 2e5
+set Nonlinear solver scheme                = iterated Stokes
+
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+set Use years in output instead of seconds = true
+
+subsection Compositional fields
+  set Number of fields = 2
+end
+
+subsection Boundary temperature model
+  set Model name = constant
+  subsection Constant
+    set Boundary indicator to temperature mappings = left:0, right:0, bottom:0, top:0
+  end
+end
+
+
+subsection Discretization
+  set Use locally conservative discretization = false
+  subsection Stabilization parameters
+    set alpha = 2
+    set beta  = 0.078
+    set cR    = 0.5  
+  end
+end
+
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent = 100.e2 
+    set Y extent = 1000.e2
+    set X repetitions = 10
+    set Y repetitions = 100
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+subsection Initial conditions
+  set Model name = function
+  subsection Function 
+    set Variable names      = x,y
+    set Function expression = 0.0 
+  end
+end
+
+subsection Compositional initial conditions
+  set Model name = function
+  subsection Function
+    set Function expression = 0.0; if(y>500e2,1,0)
+    set Variable names      = x,y
+  end
+end
+
+subsection Material model
+  set Model name = simple compressible
+  subsection Simple compressible model
+    set Reference density             = 3300
+    set Reference specific heat       = 0.0
+    set Thermal conductivity          = 0.0
+    set Thermal expansion coefficient = 0.0
+    set Viscosity                     = 1.e20
+    set Reference compressibility     = 1e-11
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0              
+  set Initial global refinement          = 0    
+  set Time steps between mesh refinement = 0             
+end
+
+subsection Boundary velocity model
+  subsection Function 
+    set Variable names      = x,y
+    set Function expression = 0.0;-0.01
+  end
+end
+
+# Here we specify that the model has fixed temperature
+# boundary conditions, as well as free slip boundary
+# conditions for the sides and bottom. 
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false
+  set Fixed temperature boundary indicators   = left, right, bottom, top
+  set Prescribed velocity boundary indicators = bottom:function
+  set Tangential velocity boundary indicators = left, right 
+  set Zero velocity boundary indicators       = 
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization,velocity statistics,
+  subsection Visualization
+    set Time between graphical output = 1
+    set List of output variables      = material properties, nonadiabatic temperature, nonadiabatic pressure, strain rate
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity, reaction terms
+    end
+  end
+end

--- a/tests/zero_RHS/screen-output
+++ b/tests/zero_RHS/screen-output
@@ -1,0 +1,115 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.5.0-pre
+--     . running in OPTIMIZED mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Number of active cells: 1,000 (on 1 levels)
+Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
+
+*** Timestep 0:  t=0 years
+   Skipping temperature solve because RHS is zero.
+   Skipping C_1 composition solve because RHS is zero.
+   Solving C_2 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 25+0 iterations.
+   Residual after nonlinear iteration 1: 1
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 16+0 iterations.
+   Residual after nonlinear iteration 2: 0.00375062
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 9+0 iterations.
+   Residual after nonlinear iteration 3: 7.22702e-05
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 4+0 iterations.
+   Residual after nonlinear iteration 4: 9.38664e-07
+
+   Postprocessing:
+     Writing graphical output: output-zero_RHS/solution-00000
+     RMS, max velocity:        0.0102 m/year, 0.0103 m/year
+
+*** Timestep 1:  t=48350 years
+   Skipping temperature solve because RHS is zero.
+   Skipping C_1 composition solve because RHS is zero.
+   Solving C_2 system ... 18 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Residual after nonlinear iteration 1: 9.47243e-08
+
+   Postprocessing:
+     Writing graphical output: output-zero_RHS/solution-00001
+     RMS, max velocity:        0.0102 m/year, 0.0103 m/year
+
+*** Timestep 2:  t=96700 years
+   Skipping temperature solve because RHS is zero.
+   Skipping C_1 composition solve because RHS is zero.
+   Solving C_2 system ... 20 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Residual after nonlinear iteration 1: 9.47243e-08
+
+   Postprocessing:
+     Writing graphical output: output-zero_RHS/solution-00002
+     RMS, max velocity:        0.0102 m/year, 0.0103 m/year
+
+*** Timestep 3:  t=145050 years
+   Skipping temperature solve because RHS is zero.
+   Skipping C_1 composition solve because RHS is zero.
+   Solving C_2 system ... 19 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Residual after nonlinear iteration 1: 9.47243e-08
+
+   Postprocessing:
+     Writing graphical output: output-zero_RHS/solution-00003
+     RMS, max velocity:        0.0102 m/year, 0.0103 m/year
+
+*** Timestep 4:  t=193400 years
+   Skipping temperature solve because RHS is zero.
+   Skipping C_1 composition solve because RHS is zero.
+   Solving C_2 system ... 18 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Residual after nonlinear iteration 1: 9.47243e-08
+
+   Postprocessing:
+     Writing graphical output: output-zero_RHS/solution-00004
+     RMS, max velocity:        0.0102 m/year, 0.0103 m/year
+
+*** Timestep 5:  t=200000 years
+   Skipping temperature solve because RHS is zero.
+   Skipping C_1 composition solve because RHS is zero.
+   Solving C_2 system ... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Residual after nonlinear iteration 1: 9.47243e-08
+
+   Postprocessing:
+     Writing graphical output: output-zero_RHS/solution-00005
+     RMS, max velocity:        0.0102 m/year, 0.0103 m/year
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      2.96s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         9 |      1.06s |        36% |
+| Assemble composition system     |        12 |     0.478s |        16% |
+| Assemble temperature system     |         6 |     0.227s |       7.7% |
+| Build Stokes preconditioner     |         9 |     0.525s |        18% |
+| Build composition preconditioner|         6 |    0.0291s |      0.98% |
+| Solve Stokes system             |         9 |     0.111s |       3.8% |
+| Solve composition system        |         6 |    0.0253s |      0.86% |
+| Initialization                  |         2 |    0.0358s |       1.2% |
+| Postprocessing                  |         6 |     0.382s |        13% |
+| Setup dof systems               |         1 |    0.0577s |         2% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/zero_RHS/statistics
+++ b/tests/zero_RHS/statistics
@@ -1,0 +1,25 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Number of degrees of freedom for all compositions
+# 7: Iterations for temperature solver
+# 8: Iterations for composition solver 1
+# 9: Iterations for composition solver 2
+# 10: Iterations for Stokes solver
+# 11: Velocity iterations in Stokes preconditioner
+# 12: Schur complement iterations in Stokes preconditioner
+# 13: Time step size (years)
+# 14: Visualization file name
+# 15: RMS velocity (m/year)
+# 16: Max. velocity (m/year)
+0 0.000000000000e+00 1000 9553 4221 8442 0 0  0 25 26 26 0.000000000000e+00                             "" 0.00000000e+00 0.00000000e+00 
+0 0.000000000000e+00    0    0    0    0 0 0  0 16 17 17 0.000000000000e+00                             "" 0.00000000e+00 0.00000000e+00 
+0 0.000000000000e+00    0    0    0    0 0 0  0  9 10 10 0.000000000000e+00                             "" 0.00000000e+00 0.00000000e+00 
+1 4.834999236935e+04 1000 9553 4221 8442 0 0 18  4  5  5 4.834999236935e+04 output-zero_RHS/solution-00000 1.01711095e-02 1.03408787e-02 
+2 9.669998473869e+04 1000 9553 4221 8442 0 0 20  0  0  0 4.834999236935e+04 output-zero_RHS/solution-00001 1.01711095e-02 1.03408787e-02 
+3 1.450499771080e+05 1000 9553 4221 8442 0 0 19  0  0  0 4.834999236935e+04 output-zero_RHS/solution-00002 1.01711095e-02 1.03408787e-02 
+4 1.933999694774e+05 1000 9553 4221 8442 0 0 18  0  0  0 4.834999236935e+04 output-zero_RHS/solution-00003 1.01711095e-02 1.03408787e-02 
+5 2.000000000000e+05 1000 9553 4221 8442 0 0 10  0  0  0 6.600030522617e+03 output-zero_RHS/solution-00004 1.01711095e-02 1.03408787e-02 
+0 0.000000000000e+00    0    0    0    0 0 0  0  0  0  0 4.834999236935e+04 output-zero_RHS/solution-00005 1.01711095e-02 1.03408787e-02 

--- a/tests/zero_matrix.prm
+++ b/tests/zero_matrix.prm
@@ -1,0 +1,130 @@
+# This is a test for models where matrix of
+# the temperature or composition system is zero (i.e., the field
+# is zero, but there are non-zero RHS terms).
+# In this case, the solver should throw an exception. 
+#
+# EXPECT FAILURE
+
+set Dimension = 2
+
+subsection Heating model
+  set Model name = constant heating
+
+  subsection Constant heating
+    set Radiogenic heating rate = 1
+  end
+end
+
+set End time                               = 2e5
+set Nonlinear solver scheme                = iterated Stokes
+
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+set Use years in output instead of seconds = true
+
+subsection Compositional fields
+  set Number of fields = 2
+end
+
+subsection Boundary temperature model
+  set Model name = constant
+  subsection Constant
+    set Boundary indicator to temperature mappings = left:0, right:0, bottom:0, top:0
+  end
+end
+
+
+subsection Discretization
+  set Use locally conservative discretization = false
+  subsection Stabilization parameters
+    set alpha = 2
+    set beta  = 0.078
+    set cR    = 0.5  
+  end
+end
+
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent = 100.e2 
+    set Y extent = 1000.e2
+    set X repetitions = 10
+    set Y repetitions = 100
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+subsection Initial conditions
+  set Model name = function
+  subsection Function 
+    set Variable names      = x,y
+    set Function expression = 0.0 
+  end
+end
+
+subsection Compositional initial conditions
+  set Model name = function
+  subsection Function
+    set Function expression = 0.0; if(y>500e2,1,0)
+    set Variable names      = x,y
+  end
+end
+
+subsection Material model
+  set Model name = simple compressible
+  subsection Simple compressible model
+    set Reference density             = 3300
+    set Reference specific heat       = 0.0
+    set Thermal conductivity          = 0.0
+    set Thermal expansion coefficient = 0.0
+    set Viscosity                     = 1.e20
+    set Reference compressibility     = 1e-11
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0              
+  set Initial global refinement          = 0    
+  set Time steps between mesh refinement = 0             
+end
+
+subsection Boundary velocity model
+  subsection Function 
+    set Variable names      = x,y
+    set Function expression = 0.0;-0.01
+  end
+end
+
+# Here we specify that the model has fixed temperature
+# boundary conditions, as well as free slip boundary
+# conditions for the sides and bottom. 
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false
+  set Fixed temperature boundary indicators   = left, right, bottom, top
+  set Prescribed velocity boundary indicators = bottom:function
+  set Tangential velocity boundary indicators = left, right 
+  set Zero velocity boundary indicators       = 
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization,velocity statistics,
+  subsection Visualization
+    set Time between graphical output = 1
+    set List of output variables      = material properties, nonadiabatic temperature, nonadiabatic pressure, strain rate
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity, reaction terms
+    end
+  end
+end

--- a/tests/zero_matrix/screen-output
+++ b/tests/zero_matrix/screen-output
@@ -1,0 +1,54 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.5.0-pre
+--     . running in OPTIMIZED mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Number of active cells: 1,000 (on 1 levels)
+Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
+
+*** Timestep 0:  t=0 years
+   Skipping temperature solve because RHS is zero.
+   Skipping C_1 composition solve because RHS is zero.
+   Solving C_2 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 25+0 iterations.
+   Residual after nonlinear iteration 1: 1
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 16+0 iterations.
+   Residual after nonlinear iteration 2: 0.00375062
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 9+0 iterations.
+   Residual after nonlinear iteration 3: 7.22702e-05
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 4+0 iterations.
+   Residual after nonlinear iteration 4: 9.38664e-07
+
+   Postprocessing:
+     Writing graphical output: output-zero_matrix/solution-00000
+     RMS, max velocity:        0.0102 m/year, 0.0103 m/year
+
+*** Timestep 1:  t=48350 years
+
+
+----------------------------------------------------
+Exception on processing: 
+
+--------------------------------------------------------
+An error occurred in file <solver.cc> in function
+    double aspect::Simulator<dim>::solve_advection(const aspect::Simulator<dim>::AdvectionField&) [with int dim = 2]
+The violated condition was: 
+    system_matrix.block(block_idx, block_idx).linfty_norm() > std::numeric_limits<double>::min()
+The name and call sequence of the exception was:
+    ExcMessage ("The " + field_name + " equation can not be solved, because the matrix is zero, " "but the right-hand side is nonzero.")
+Additional Information: 
+The temperature equation can not be solved, because the matrix is zero, but the right-hand side is nonzero.
+--------------------------------------------------------
+
+Aborting!
+----------------------------------------------------

--- a/tests/zero_matrix/statistics
+++ b/tests/zero_matrix/statistics
@@ -1,0 +1,20 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Number of degrees of freedom for all compositions
+# 7: Iterations for temperature solver
+# 8: Iterations for composition solver 1
+# 9: Iterations for composition solver 2
+# 10: Iterations for Stokes solver
+# 11: Velocity iterations in Stokes preconditioner
+# 12: Schur complement iterations in Stokes preconditioner
+# 13: Time step size (years)
+# 14: Visualization file name
+# 15: RMS velocity (m/year)
+# 16: Max. velocity (m/year)
+0 0.000000000000e+00 1000 9553 4221 8442 0 0 0 25 26 26 0.000000000000e+00                                "" 0.00000000e+00 0.00000000e+00 
+0 0.000000000000e+00    0    0    0    0 0 0 0 16 17 17 0.000000000000e+00                                "" 0.00000000e+00 0.00000000e+00 
+0 0.000000000000e+00    0    0    0    0 0 0 0  9 10 10 0.000000000000e+00                                "" 0.00000000e+00 0.00000000e+00 
+0 0.000000000000e+00    0    0    0    0 0 0 0  4  5  5 4.834999233676e+04 output-zero_matrix/solution-00000 1.01711095e-02 1.03408787e-02 

--- a/tests/zero_temperature/screen-output
+++ b/tests/zero_temperature/screen-output
@@ -1,9 +1,16 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.5.0-pre
+--     . running in OPTIMIZED mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
 
 Number of active cells: 1,024 (on 6 levels)
 Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
 
 *** Timestep 0:  t=0 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+7 iterations.
 
@@ -11,7 +18,7 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
      Temperature min/avg/max: 0 K, 0 K, 0 K
 
 *** Timestep 1:  t=1 seconds
-   Solving temperature system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
 
    Postprocessing:
@@ -21,6 +28,16 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.498s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |    0.0493s |       9.9% |
+| Assemble temperature system     |         2 |    0.0616s |        12% |
+| Build Stokes preconditioner     |         1 |    0.0401s |       8.1% |
+| Solve Stokes system             |         2 |     0.233s |        47% |
+| Initialization                  |         2 |    0.0241s |       4.8% |
+| Postprocessing                  |         2 |   0.00201s |       0.4% |
+| Setup dof systems               |         1 |    0.0344s |       6.9% |
 +---------------------------------+-----------+------------+------------+
 


### PR DESCRIPTION
Right now if the matrix and the right-hand side are zero (for example for the temperature advection), we get a floating point exception in the advection preconditioner that is not really helpful to figure out what the problem is. In addition, if there is a problem that does not need the temperature, but needs compositional fields, or it has a non-zero temperature/composition only from a given time step on, then we do not really want to solve the advection system in the time steps before. 
This pull request changes the solver schemes, so that in case of a zero RHS we do not solve for the advection field, but just set it to zero everywhere. 