### PR TITLE
allow failing tests

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -4,6 +4,11 @@
  * <p> This is the list of changes made after the release of Aspect version
  * 1.4.0. All entries are signed with the names of the author. </p>
  *
+ * <li> New: Tests can now be marked that they are expected to fail by the
+ * EXPECT FAILURE keyword in the .prm.
+ * <br>
+ * (Timo Heister, 2016/06/01)
+ *
  * <li> New: There is a new boundary traction model "ascii data"
  * that prescribes the boundary traction according to pressure values
  * read from an ascii data file.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -217,6 +217,19 @@ FOREACH(_test ${_tests})
         SET(_replacement_script "${CMAKE_CURRENT_SOURCE_DIR}/cmake/default.sh")
     ENDIF()
 
+    # If a .prm contains the keyword "EXPECT FAILURE", make sure aspect fails
+    # with a non-zero return value. Otherwise make sure aspect terminates
+    # without errors. The logic for this is in tests/cmake/run_test.sh,
+    # because we can not do this in ADD_CUSTOM_COMMAND directly.
+    FILE(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/${_test}.prm _input_lines REGEX "EXPECT FAILURE")
+    IF("${_input_lines}" STREQUAL "")
+      SET(EXPECT "0")
+    ELSE()
+      SET(EXPECT "1")
+      IF (NOT "${_mpi_count}" STREQUAL "1")
+        MESSAGE(FATAL_ERROR "Invalid setup in test '${_test}.prm': Tests with 'EXPECT FAILURE' are only supported if they use a single MPI rank.")
+      ENDIF()
+    ENDIF()
     IF("${_mpi_count}" STREQUAL "1")
       ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output
 	COMMAND
@@ -225,8 +238,7 @@ FOREACH(_test ${_tests})
 	      rm -f \$i \;
 	    fi \;
 	  done
-	COMMAND aspect ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm
-		> ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output.tmp
+	COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run_test.sh ${EXPECT} ${CMAKE_BINARY_DIR}/aspect ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output.tmp
 	COMMAND ${_replacement_script} screen-output <${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output.tmp >${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output
 	COMMAND ${PERL_EXECUTABLE} -pi
 		  ${CMAKE_CURRENT_SOURCE_DIR}/normalize.pl
@@ -241,7 +253,7 @@ FOREACH(_test ${_tests})
 	      rm -f \$i \;
 	    fi \;
 	  done
-	COMMAND mpirun -np ${_mpi_count} ${CMAKE_CURRENT_BINARY_DIR}/../aspect ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm
+	COMMAND mpirun -np ${_mpi_count} ${CMAKE_BINARY_DIR}/aspect ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm
 		> ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output.tmp
 	COMMAND ${_replacement_script} screen-output <${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output.tmp >${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output
 	COMMAND ${PERL_EXECUTABLE} -pi

--- a/tests/cmake/default.sh
+++ b/tests/cmake/default.sh
@@ -4,6 +4,8 @@
 # screen output unless you create a <testname>.sh next to your test. The
 # script gets one argument ($1), which is the name of the file (currently this
 # will always be "screen-output") and the input is piped into the script.
-# This implementation here just prints the input unmodified.
 
-cat
+# This implementation here just prints the input unmodified, except that we
+# filter part of exception messages, because the types are compiler dependent:
+
+grep -v "    int main(int, char"

--- a/tests/cmake/run_test.sh
+++ b/tests/cmake/run_test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script is executed to run ASPECT with a given .prm test and process the
+# return value of ASPECT correctly.
+
+# usage: EXPECT ./aspect test.prm output-name
+# where EXPECT is the expected return value
+
+EXPECT="$1"
+BINARY="$2"
+PRM="$3"
+OUTPUT="$4"
+
+$BINARY $PRM >${OUTPUT} 2>&1
+ret=$?
+if [[ "$EXPECT" == "$ret" ]]
+then
+  exit 0
+fi
+
+exit 1

--- a/tests/cmake/run_test.sh
+++ b/tests/cmake/run_test.sh
@@ -3,17 +3,21 @@
 # This script is executed to run ASPECT with a given .prm test and process the
 # return value of ASPECT correctly.
 
-# usage: EXPECT ./aspect test.prm output-name
-# where EXPECT is the expected return value
+# usage: EXPECT_FAIL ./aspect test.prm output-name
+#
+# ASPECT is expected to return a non-zero return code if EXPECT_FAIL=1 and
+# 0 (=success) if EXPECT_FAIL=0
 
-EXPECT="$1"
+EXPECT_FAIL="$1"
 BINARY="$2"
 PRM="$3"
 OUTPUT="$4"
 
 $BINARY $PRM >${OUTPUT} 2>&1
 ret=$?
-if [[ "$EXPECT" == "$ret" ]]
+if [[ ( "$EXPECT_FAIL" == "0" && "$ret" == "0" ) 
+	    ||
+      ( "$EXPECT_FAIL" == "1" && "$ret" != "0" ) ]]
 then
   exit 0
 fi

--- a/tests/fail.prm
+++ b/tests/fail.prm
@@ -1,0 +1,5 @@
+# test that we can have tests where we expect failure triggered by the following line:
+#
+# EXPECT FAILURE
+
+set Dimension = 5

--- a/tests/fail/screen-output
+++ b/tests/fail/screen-output
@@ -8,7 +8,6 @@ Exception on processing:
 
 --------------------------------------------------------
 An error occurred in file <main.cc> in function
-    int main(int, char**)
 The violated condition was: 
     (dim >= 2) && (dim <= 3)
 The name and call sequence of the exception was:

--- a/tests/fail/screen-output
+++ b/tests/fail/screen-output
@@ -1,0 +1,21 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+
+
+----------------------------------------------------
+Exception on processing: 
+
+--------------------------------------------------------
+An error occurred in file <main.cc> in function
+    int main(int, char**)
+The violated condition was: 
+    (dim >= 2) && (dim <= 3)
+The name and call sequence of the exception was:
+    ExcMessage ("ASPECT can only be run in 2d and 3d but a " "different space dimension is given in the parameter file.")
+Additional Information: 
+ASPECT can only be run in 2d and 3d but a different space dimension is given in the parameter file.
+--------------------------------------------------------
+
+Aborting!
+----------------------------------------------------


### PR DESCRIPTION
This pull request allows you to mark tests that you expect to fail by putting the string "EXPECT FAILURE" into the .prm.