### PR TITLE
A fix to postprocessers which crash with deal.ii 8.5.0-pre.

### DIFF
--- a/source/postprocess/heat_flux_statistics.cc
+++ b/source/postprocess/heat_flux_statistics.cc
@@ -153,7 +153,7 @@ namespace aspect
           local_values.push_back (local_boundary_fluxes[*p]);
 
         // then collect contributions from all processors
-        std::vector<double> global_values;
+        std::vector<double> global_values (local_values.size());
         Utilities::MPI::sum (local_values, this->get_mpi_communicator(), global_values);
 
         // and now take them apart into the global map again

--- a/source/postprocess/mass_flux_statistics.cc
+++ b/source/postprocess/mass_flux_statistics.cc
@@ -158,7 +158,7 @@ namespace aspect
           local_values.push_back (local_boundary_fluxes[*p]);
 
         // then collect contributions from all processors
-        std::vector<double> global_values;
+        std::vector<double> global_values (local_values.size());
         Utilities::MPI::sum (local_values, this->get_mpi_communicator(), global_values);
 
         // and now take them apart into the global map again

--- a/source/postprocess/velocity_boundary_statistics.cc
+++ b/source/postprocess/velocity_boundary_statistics.cc
@@ -129,9 +129,9 @@ namespace aspect
             local_min_values.push_back (local_min_vel[*p]);
           }
         // then collect contributions from all processors
-        std::vector<double> global_max_values;
+        std::vector<double> global_max_values (local_max_values.size());
         Utilities::MPI::max (local_max_values, this->get_mpi_communicator(), global_max_values);
-        std::vector<double> global_min_values;
+        std::vector<double> global_min_values (local_min_values.size());
         Utilities::MPI::min (local_min_values, this->get_mpi_communicator(), global_min_values);
 
         // and now take them apart into the global map again


### PR DESCRIPTION
Initializing the vectors used for MPI function to the correct size to prevent crashes as described in #909. 

I checked most post-processors (basic statistics, boundary densities, boundary pressures, composition statistics, depth average, dynamic topography, heat flux statistics,  heating statistics, mass flux statistics, point values, pressure statistics, Stokes residual, temperature statistics, velocity boundary statistics, velocity statistics, viscous dissipation statistics,visualization) by running them. I but I didn't run command, spherical velocity statistics and topography (only checked out the code), because they where incompatible with the model I was testing it with and I assumed that spherical velocity statistics, topography are in the testing package anyway because they are fairly new and command doesn't seem to use a MPI all_reduce (sum, min, max).