### PR TITLE
Use SymmetricTensor for finite strain

### DIFF
--- a/cookbooks/finite_strain/finite_strain.cc
+++ b/cookbooks/finite_strain/finite_strain.cc
@@ -68,18 +68,18 @@ namespace aspect
               const Tensor<2,dim> rotation = (velocity_gradients[q] - symmetrize(velocity_gradients[q])) * this->get_timestep()
                                              + unit_symmetric_tensor<dim>();
 
-              Tensor<2,dim> accumulated_strain;
-              for (unsigned int i=0; i<Tensor<2,dim>::n_independent_components; ++i)
-                accumulated_strain[Tensor<2,dim>::unrolled_to_component_indices(i)] = in.composition[q][i];
+              SymmetricTensor<2,dim> accumulated_strain;
+              for (unsigned int i=0; i<SymmetricTensor<2,dim>::n_independent_components; ++i)
+                accumulated_strain[SymmetricTensor<2,dim>::unrolled_to_component_indices(i)] = in.composition[q][i];
 
               // the new strain is the rotated old strain plus the
               // strain of the current time step
-              const Tensor<2,dim> rotated_strain = rotation * accumulated_strain * transpose(rotation) + in.strain_rate[q] * this->get_timestep();
+              const SymmetricTensor<2,dim> rotated_strain = symmetrize(rotation * Tensor<2,dim>(accumulated_strain) * transpose(rotation)) + in.strain_rate[q] * this->get_timestep();
 
-              for (unsigned int c=0; c<Tensor<2,dim>::n_independent_components; ++c)
+              for (unsigned int c=0; c<SymmetricTensor<2,dim>::n_independent_components; ++c)
                 {
                   out.reaction_terms[q][c] = - in.composition[q][c]
-                                             + rotated_strain[Tensor<2,dim>::unrolled_to_component_indices(c)];
+                                             + rotated_strain[SymmetricTensor<2,dim>::unrolled_to_component_indices(c)];
                 }
             }
         }
@@ -93,7 +93,7 @@ namespace aspect
     {
       Simple<dim>::parse_parameters (prm);
 
-      AssertThrow(this->n_compositional_fields() >= (Tensor<2,dim>::n_independent_components),
+      AssertThrow(this->n_compositional_fields() >= (SymmetricTensor<2,dim>::n_independent_components),
                   ExcMessage("There must be at least as many compositional fields as independent components in the full "
                              "strain rate tensor."));
     }

--- a/cookbooks/finite_strain/finite_strain.prm
+++ b/cookbooks/finite_strain/finite_strain.prm
@@ -37,8 +37,8 @@ subsection Boundary temperature model
 end
 
 subsection Compositional fields
-  set Number of fields = 4
-  set Names of fields = strain1, strain2, strain3, strain4
+  set Number of fields = 3
+  set Names of fields = strain_xx, strain_yy, strain_xy
 end
 
 subsection Boundary composition model
@@ -84,7 +84,7 @@ subsection Initial conditions
     set Radius                    = 350000
 
     subsection Function
-      set Function expression       = 0;0;0;0
+      set Function expression       = 0;0;0
     end
   end
 
@@ -97,7 +97,7 @@ subsection Compositional initial conditions
   set Model name = function
   subsection Function
     set Function constants  = pi=3.1415926,a = 0.0, b = 2500000, c = 100000, d=1450000
-    set Function expression = 0;0;0;0
+    set Function expression = 0;0;0
     set Variable names      = x,y
   end
 end

--- a/doc/manual/cookbooks/finite_strain/finite_strain.cc
+++ b/doc/manual/cookbooks/finite_strain/finite_strain.cc
@@ -8,18 +8,18 @@ for (unsigned int q=0; q < in.position.size(); ++q)
                                    * this->get_timestep()
                                    + unit_symmetric_tensor<dim>();
 
-    Tensor<2,dim> accumulated_strain;
-    for (unsigned int i=0; i<Tensor<2,dim>::n_independent_components; ++i)
-      accumulated_strain[Tensor<2,dim>::unrolled_to_component_indices(i)] = in.composition[q][i];
+    SymmetricTensor<2,dim> accumulated_strain;
+    for (unsigned int i=0; i<SymmetricTensor<2,dim>::n_independent_components; ++i)
+      accumulated_strain[SymmetricTensor<2,dim>::unrolled_to_component_indices(i)] = in.composition[q][i];
 
     // the new strain is the rotated old strain plus the strain of the
     // current time step
-    const Tensor<2,dim> rotated_strain = rotation * accumulated_strain * transpose(rotation)
-                                         + in.strain_rate[q] * this->get_timestep();
+    const SymmetricTensor<2,dim> rotated_strain = symmetrize(rotation * Tensor<2,dim>(accumulated_strain) * transpose(rotation))
+                                                  + in.strain_rate[q] * this->get_timestep();
 
-    for (unsigned int c=0; c<Tensor<2,dim>::n_independent_components; ++c)
+    for (unsigned int c=0; c<SymmetricTensor<2,dim>::n_independent_components; ++c)
       {
         out.reaction_terms[q][c] = - in.composition[q][c]
-                                   + rotated_strain[Tensor<2,dim>::unrolled_to_component_indices(c)];
+                                   + rotated_strain[SymmetricTensor<2,dim>::unrolled_to_component_indices(c)];
       }
   }


### PR DESCRIPTION
This PR is analogous to the changes in #856 in that it changes the storage type for the finite strain from `Tensor<2,dim>` to `SymmetricTensor<2,dim>`. This requires 1 less compositional field in 2D and 3 less in 3D.