### PR TITLE
fix compiler warning

### DIFF
--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -159,7 +159,7 @@ namespace aspect
         {
           diffusion,
           dislocation,
-          composite,
+          composite
         } viscous_flow_law;
 
 


### PR DESCRIPTION
this fixes
include/aspect/material_model/visco_plastic.h:162:20: warning: comma at end of enumerator list [-pedantic]