### PR TITLE
Remove duplicative #include statements.

### DIFF
--- a/source/mesh_refinement/interface.cc
+++ b/source/mesh_refinement/interface.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/mesh_refinement/interface.h>
-#include <aspect/simulator_access.h>
 
 #include <typeinfo>
 

--- a/source/postprocess/basic_statistics.cc
+++ b/source/postprocess/basic_statistics.cc
@@ -21,7 +21,6 @@
 
 #include <aspect/postprocess/basic_statistics.h>
 #include <aspect/material_model/simple.h>
-#include <aspect/simulator_access.h>
 #include <aspect/global.h>
 
 #include <deal.II/base/quadrature_lib.h>

--- a/source/postprocess/boundary_densities.cc
+++ b/source/postprocess/boundary_densities.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/boundary_densities.h>
-#include <aspect/simulator_access.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/boundary_pressures.cc
+++ b/source/postprocess/boundary_pressures.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/boundary_pressures.h>
-#include <aspect/simulator_access.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/composition_statistics.cc
+++ b/source/postprocess/composition_statistics.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/composition_statistics.h>
-#include <aspect/simulator_access.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/depth_average.cc
+++ b/source/postprocess/depth_average.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/depth_average.h>
-#include <aspect/simulator_access.h>
 #include <aspect/lateral_averaging.h>
 #include <aspect/global.h>
 

--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/dynamic_topography.h>
-#include <aspect/simulator_access.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/heat_flux_statistics.cc
+++ b/source/postprocess/heat_flux_statistics.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/heat_flux_statistics.h>
-#include <aspect/simulator_access.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/heating_statistics.cc
+++ b/source/postprocess/heating_statistics.cc
@@ -21,7 +21,6 @@
 
 
 #include <aspect/postprocess/heating_statistics.h>
-#include <aspect/simulator_access.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/interface.cc
+++ b/source/postprocess/interface.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/interface.h>
-#include <aspect/simulator_access.h>
 
 #include <typeinfo>
 

--- a/source/postprocess/mass_flux_statistics.cc
+++ b/source/postprocess/mass_flux_statistics.cc
@@ -19,7 +19,6 @@
 */
 
 
-#include <aspect/simulator_access.h>
 #include <aspect/postprocess/mass_flux_statistics.h>
 
 #include <deal.II/base/quadrature_lib.h>

--- a/source/postprocess/point_values.cc
+++ b/source/postprocess/point_values.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/point_values.h>
-#include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <deal.II/numerics/vector_tools.h>
 

--- a/source/postprocess/pressure_statistics.cc
+++ b/source/postprocess/pressure_statistics.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/pressure_statistics.h>
-#include <aspect/simulator_access.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/spherical_velocity_statistics.cc
+++ b/source/postprocess/spherical_velocity_statistics.cc
@@ -23,7 +23,6 @@
 #include <aspect/postprocess/spherical_velocity_statistics.h>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/sphere.h>
-#include <aspect/simulator_access.h>
 #include <aspect/global.h>
 
 #include <deal.II/base/quadrature_lib.h>

--- a/source/postprocess/stokes_residual.cc
+++ b/source/postprocess/stokes_residual.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/stokes_residual.h>
-#include <aspect/simulator_access.h>
 #include <aspect/simulator.h>
 #include <aspect/global.h>
 

--- a/source/postprocess/temperature_statistics.cc
+++ b/source/postprocess/temperature_statistics.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/temperature_statistics.h>
-#include <aspect/simulator_access.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/tracers.cc
+++ b/source/postprocess/tracers.cc
@@ -20,7 +20,6 @@
 
 #include <aspect/global.h>
 #include <aspect/postprocess/tracers.h>
-#include <aspect/simulator_access.h>
 
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>

--- a/source/postprocess/velocity_boundary_statistics.cc
+++ b/source/postprocess/velocity_boundary_statistics.cc
@@ -21,7 +21,6 @@
 
 
 #include <aspect/postprocess/velocity_boundary_statistics.h>
-#include <aspect/simulator_access.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/velocity_statistics.cc
+++ b/source/postprocess/velocity_statistics.cc
@@ -21,7 +21,6 @@
 
 #include <aspect/postprocess/velocity_statistics.h>
 #include <aspect/material_model/simple.h>
-#include <aspect/simulator_access.h>
 #include <aspect/global.h>
 
 #include <deal.II/base/quadrature_lib.h>

--- a/source/postprocess/viscous_dissipation_statistics.cc
+++ b/source/postprocess/viscous_dissipation_statistics.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/viscous_dissipation_statistics.h>
-#include <aspect/simulator_access.h>
 #include <aspect/global.h>
 
 #include <deal.II/base/quadrature_lib.h>

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization.h>
-#include <aspect/simulator_access.h>
 #include <aspect/global.h>
 
 #include <deal.II/dofs/dof_tools.h>

--- a/source/postprocess/visualization/artificial_viscosity.cc
+++ b/source/postprocess/visualization/artificial_viscosity.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/artificial_viscosity.h>
-#include <aspect/simulator_access.h>
 
 
 namespace aspect

--- a/source/postprocess/visualization/artificial_viscosity_composition.cc
+++ b/source/postprocess/visualization/artificial_viscosity_composition.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/artificial_viscosity_composition.h>
-#include <aspect/simulator_access.h>
 
 
 namespace aspect

--- a/source/postprocess/visualization/boundary_indicator.cc
+++ b/source/postprocess/visualization/boundary_indicator.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/boundary_indicator.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/compositional_vector.cc
+++ b/source/postprocess/visualization/compositional_vector.cc
@@ -19,7 +19,6 @@
 */
 
 #include <aspect/postprocess/visualization/compositional_vector.h>
-#include <aspect/simulator_access.h>
 
 namespace aspect
 {

--- a/source/postprocess/visualization/density.cc
+++ b/source/postprocess/visualization/density.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/density.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/depth.cc
+++ b/source/postprocess/visualization/depth.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/depth.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/dynamic_topography.cc
+++ b/source/postprocess/visualization/dynamic_topography.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/dynamic_topography.h>
-#include <aspect/simulator_access.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/visualization/error_indicator.cc
+++ b/source/postprocess/visualization/error_indicator.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/error_indicator.h>
-#include <aspect/simulator_access.h>
 
 
 namespace aspect

--- a/source/postprocess/visualization/friction_heating.cc
+++ b/source/postprocess/visualization/friction_heating.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/friction_heating.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/gravity.cc
+++ b/source/postprocess/visualization/gravity.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/gravity.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/heating.cc
+++ b/source/postprocess/visualization/heating.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/heating.h>
-#include <aspect/simulator_access.h>
 #include <deal.II/base/utilities.h>
 
 #include <algorithm>

--- a/source/postprocess/visualization/material_properties.cc
+++ b/source/postprocess/visualization/material_properties.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/material_properties.h>
-#include <aspect/simulator_access.h>
 
 #include <algorithm>
 

--- a/source/postprocess/visualization/melt_fraction.cc
+++ b/source/postprocess/visualization/melt_fraction.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/melt_fraction.h>
-#include <aspect/simulator_access.h>
 
 #include <deal.II/base/parameter_handler.h>
 

--- a/source/postprocess/visualization/nonadiabatic_pressure.cc
+++ b/source/postprocess/visualization/nonadiabatic_pressure.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/nonadiabatic_pressure.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/nonadiabatic_temperature.cc
+++ b/source/postprocess/visualization/nonadiabatic_temperature.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/nonadiabatic_temperature.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/partition.cc
+++ b/source/postprocess/visualization/partition.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/partition.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/seismic_anomalies.cc
+++ b/source/postprocess/visualization/seismic_anomalies.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/seismic_anomalies.h>
-#include <aspect/simulator_access.h>
 #include <aspect/lateral_averaging.h>
 #include <aspect/utilities.h>
 

--- a/source/postprocess/visualization/seismic_vp.cc
+++ b/source/postprocess/visualization/seismic_vp.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/seismic_vp.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/seismic_vs.cc
+++ b/source/postprocess/visualization/seismic_vs.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/seismic_vs.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/shear_stress.cc
+++ b/source/postprocess/visualization/shear_stress.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/shear_stress.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/specific_heat.cc
+++ b/source/postprocess/visualization/specific_heat.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/specific_heat.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/strain_rate.cc
+++ b/source/postprocess/visualization/strain_rate.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/strain_rate.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/stress.cc
+++ b/source/postprocess/visualization/stress.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/stress.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/thermal_expansivity.cc
+++ b/source/postprocess/visualization/thermal_expansivity.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/thermal_expansivity.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/thermodynamic_phase.cc
+++ b/source/postprocess/visualization/thermodynamic_phase.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/thermodynamic_phase.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/vertical_heat_flux.cc
+++ b/source/postprocess/visualization/vertical_heat_flux.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/vertical_heat_flux.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/viscosity.cc
+++ b/source/postprocess/visualization/viscosity.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/viscosity.h>
-#include <aspect/simulator_access.h>
 
 
 

--- a/source/postprocess/visualization/viscosity_ratio.cc
+++ b/source/postprocess/visualization/viscosity_ratio.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/postprocess/visualization/viscosity_ratio.h>
-#include <aspect/simulator_access.h>
 
 
 


### PR DESCRIPTION
In postprocessors, if a .cc file references SimulatorAccess, then that can
only happen if the class is derived from SimulatorAccess. But in that case, the
corresponding #include file must already have appeared in the header file. Thus,
it is duplicative and can be removed.