### PR TITLE
rename initialization compute-time section

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -2036,7 +2036,7 @@ namespace aspect
 
     if (parameters.resume_computation == false)
       {
-        computing_timer.enter_section ("Initialization");
+        computing_timer.enter_section ("Setup initial conditions");
 
         time                      = parameters.start_time;
         timestep_number           = 0;


### PR DESCRIPTION
- remove ambiguity from two 'Initialization' sections
- rename 'Initialization' that computes the initial temperature, compositional, and pressure fields to 'Setup initial conditions'

EDIT: 'Initial Conditions' -> 'Setup initial conditions'