### PR TITLE
Update on the DG bound preserving limiter for 3D

### DIFF
--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -986,10 +986,10 @@ namespace aspect
   void Simulator<dim>::apply_limiter_to_dg_solutions (const AdvectionField &advection_field)
   {
     /*
-     * first setup the quadrature points which are used to find the maximum and minimum solution values at those points.
-     * To construct those special quadrature points:
-     * use combination of 1) one dimentional Gauss points; 2) one dimentional Gauss-Lobatto points;
-     * we require that the Guass-Lobatto points (2) appear  in only one direction.
+     * First setup the quadrature points which are used to find the maximum and minimum solution values at those points.
+     * A quadrature formula that combines all quadrature points constructed as all tensor products of
+     * 1) one dimentional Gauss points; 2) one dimentional Gauss-Lobatto points.
+     * We require that the Gauss-Lobatto points (2) appear in only one direction.
      * Therefore, possible combination
      * in 2D: the combinations are 21, 12
      * in 3D: the combinations are 211, 121, 112
@@ -1005,33 +1005,31 @@ namespace aspect
     const unsigned int n_q_points_2 = quadrature_formula_2.size();
     const unsigned int n_q_points   = dim * n_q_points_2 *std::pow(n_q_points_1, dim-1) ;
 
-    std::vector< Point <dim> > points_values (n_q_points);
+    std::vector< Point <dim> > quadrature_points (n_q_points);
 
     switch (dim)
       {
         case 2:
         {
-          //make quadrature points combination 12
+          //append quadrature points combination 12
           for ( unsigned int i=0; i < n_q_points_1 ; i++)
             {
-              const Point <1>  x = quadrature_formula_1.point(i);
+              const double  x = quadrature_formula_1.point(i)(0);
               for ( unsigned int j=0; j < n_q_points_2 ; j++)
                 {
-                  const Point <1>  y = quadrature_formula_2.point(j);
-                  points_values[i * n_q_points_2+j](0) = x(0);
-                  points_values[i * n_q_points_2+j](1) = y(0);
+                  const double  y = quadrature_formula_2.point(j)(0);
+                  quadrature_points[i * n_q_points_2+j] = Point<dim>(x,y);
                 }
             }
           const unsigned int n_q_points_12 = n_q_points_1 * n_q_points_2;
-          //make quadrature points combination 21
+          //append quadrature points combination 21
           for ( unsigned int i=0; i < n_q_points_2 ; i++)
             {
-              const Point <1>  x = quadrature_formula_2.point(i);
+              const double  x = quadrature_formula_2.point(i)(0);
               for ( unsigned int j=0; j < n_q_points_1 ; j++)
                 {
-                  const Point <1>  y = quadrature_formula_1.point(j);
-                  points_values[n_q_points_12 + i * n_q_points_1+j ](0) = x(0);
-                  points_values[n_q_points_12 + i * n_q_points_1+j ](1) = y(0);
+                  const double  y = quadrature_formula_1.point(j)(0);
+                  quadrature_points[n_q_points_12 + i * n_q_points_1+j ] = Point<dim>(x,y);
                 }
             }
           break;
@@ -1039,57 +1037,51 @@ namespace aspect
 
         case 3:
         {
-          //make quadrature points combination 121
+          //append quadrature points combination 121
           for ( unsigned int i=0; i < n_q_points_1 ; i++)
             {
-              const Point <1>  x = quadrature_formula_1.point(i);
+              const double  x = quadrature_formula_1.point(i)(0);
               for ( unsigned int j=0; j < n_q_points_2 ; j++)
                 {
-                  const Point <1>  y = quadrature_formula_2.point(j);
+                  const double  y = quadrature_formula_2.point(j)(0);
                   for ( unsigned int k=0; k < n_q_points_1 ; k++)
                     {
                       const unsigned int k_index = i * n_q_points_2 * n_q_points_1 + j * n_q_points_2 + k;
-                      const Point <1>  z = quadrature_formula_1.point(k);
-                      points_values[k_index](0) = x(0);
-                      points_values[k_index](1) = y(0);
-                      points_values[k_index](2) = z(0);
+                      const double  z = quadrature_formula_1.point(k)(0);
+                      quadrature_points[k_index] = Point<dim>(x,y,z);
                     }
                 }
             }
           const unsigned int n_q_points_121 = n_q_points_1 * n_q_points_2 * n_q_points_1;
-          //make quadrature points combination 112
+          //append quadrature points combination 112
           for ( unsigned int i=0; i < n_q_points_1 ; i++)
             {
-              const Point <1>  x = quadrature_formula_1.point(i);
+              const double  x = quadrature_formula_1.point(i)(0);
               for ( unsigned int j=0; j < n_q_points_1 ; j++)
                 {
-                  const Point <1>  y = quadrature_formula_1.point(j);
+                  const double y = quadrature_formula_1.point(j)(0);
                   for ( unsigned int k=0; k < n_q_points_2 ; k++)
                     {
                       const unsigned int k_index =
                         n_q_points_121 + i * n_q_points_1 * n_q_points_2 + j * n_q_points_2 + k;
-                      const Point <1>  z = quadrature_formula_2.point(k);
-                      points_values[k_index](0) = x(0);
-                      points_values[k_index](1) = y(0);
-                      points_values[k_index](2) = z(0);
+                      const double  z = quadrature_formula_2.point(k)(0);
+                      quadrature_points[k_index] = Point<dim>(x,y,z);
                     }
                 }
             }
-          //make quadrature points combination 211
+          //append quadrature points combination 211
           for ( unsigned int i=0; i < n_q_points_2 ; i++)
             {
-              const Point <1>  x = quadrature_formula_2.point(i);
+              const double  x = quadrature_formula_2.point(i)(0);
               for ( unsigned int j=0; j < n_q_points_1 ; j++)
                 {
-                  const Point <1>  y = quadrature_formula_1.point(j);
+                  const double  y = quadrature_formula_1.point(j)(0);
                   for ( unsigned int k=0; k < n_q_points_1 ; k++)
                     {
                       const unsigned int k_index =
                         2 * n_q_points_121 + i * n_q_points_2 * n_q_points_1 + j * n_q_points_1 + k;
-                      const Point <1>  z = quadrature_formula_1.point(k);
-                      points_values  [k_index](0) = x(0);
-                      points_values  [k_index](1) = y(0);
-                      points_values  [k_index](2) = z(0);
+                      const double  z = quadrature_formula_1.point(k)(0);
+                      quadrature_points[k_index] = Point<dim>(x,y,z);
                     }
                 }
             }
@@ -1099,7 +1091,7 @@ namespace aspect
         default:
           Assert (false, ExcNotImplemented());
       }
-    Quadrature<dim> quadrature_formula(points_values);
+    Quadrature<dim> quadrature_formula(quadrature_points);
 
     // Quadrature rules only used for the numerical integration for better accuracy
     const QGauss<dim> quadrature_formula_0 (advection_field.is_temperature() ?
@@ -1115,7 +1107,8 @@ namespace aspect
                              update_values   |
                              update_quadrature_points);
     std::vector<double> values (n_q_points);
-    // fe values for numerical integration, which points is 1/dim of the total points above
+    // fe values for numerical integration, with a number of quadrature points
+    // that is equal to 1/dim times the number of total points above
     FEValues<dim> fe_values_0 (mapping,
                                finite_element,
                                quadrature_formula_0,

--- a/tests/discontinuous_composition_bound_preserving_limiter_3d.prm
+++ b/tests/discontinuous_composition_bound_preserving_limiter_3d.prm
@@ -1,0 +1,111 @@
+# this test is specifically designed for the bound-preserving limiter
+# A description of the falling box benchmark see the reference:
+# Gerya, T. V., Yuen, D. A., 2003a. Characteristics-based marker-in-cell method
+# with conservative finite-differences schemes for modeling geological flows with
+# strongly variable transport properties
+# This test uses two falling boxes in order to use two different compositional fields
+
+set Dimension                              = 3
+set Start time                             = 0
+set End time                               = 5e5
+set Use years in output instead of seconds = true
+set CFL number                             = .5
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent  = 500e3
+    set Y extent  = 500e3
+    set Z extent  = 500e3
+  end
+end
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false
+  set Tangential velocity boundary indicators = left, right, front, back, bottom, top
+end
+
+# Thermal expansion coeff = 0 --> no temperature depedence
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Reference density             = 3200
+    set Viscosity                     = 1e21
+    set Thermal expansion coefficient = 0
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 9.81
+  end
+end
+
+
+############### Parameters describing the temperature field
+# Note: The temperature plays no role in this model
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+subsection Initial conditions
+  set Model name = function
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+
+############### Parameters describing the compositional field
+# Note: The compositional field is what drives the flow
+# in this example
+
+subsection Compositional fields
+  set Number of fields = 1
+end
+
+subsection Compositional initial conditions
+  set Model name = function
+  subsection Function
+    set Variable names      = x,y,z
+    set Function expression = if(((x>125e3)&&(x<375e3)&&(y>125e3)&&(y<375e3)&&(z>125e3)&&(z<375e3)), 1, 0)
+ end
+end
+
+subsection Material model
+  subsection Simple model
+    set Density differential for compositional field 1 = 100  # 3300 kg/m^3
+    set Composition viscosity prefactor = 1  # ONLY PARAMETER THAT CHANGES IN THESE TESTS
+  end
+end
+
+
+############### Parameters describing the discretization
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 1
+  set Strategy                           = composition
+  set Initial global refinement          = 2
+  set Time steps between mesh refinement = 2
+end
+
+
+
+############### Parameters describing what to do with the solution
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, composition statistics
+end
+
+subsection Discretization
+  set Use discontinuous composition discretization = true
+  subsection Stabilization parameters
+      set Use limiter for discontinuous composition solution = true # apply the limiter to the DG solutions
+      set Global composition maximum = 1.0
+      set Global composition minimum = 0.0
+  end
+end
+

--- a/tests/discontinuous_composition_bound_preserving_limiter_3d/screen-output
+++ b/tests/discontinuous_composition_bound_preserving_limiter_3d/screen-output
@@ -1,0 +1,61 @@
+
+Number of active cells: 64 (on 3 levels)
+Number of degrees of freedom: 4,769 (2,187+125+729+1,728)
+
+*** Timestep 0:  t=0 years
+   Skipping temperature solve because RHS is zero.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 27+0 iterations.
+
+Number of active cells: 120 (on 4 levels)
+Number of degrees of freedom: 9,083 (4,215+223+1,405+3,240)
+
+*** Timestep 0:  t=0 years
+   Skipping temperature solve because RHS is zero.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 28+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:         0.0288 m/year, 0.0899 m/year
+     Compositions min/max/mass: 0/1/1.52e+16
+
+*** Timestep 1:  t=175148 years
+   Skipping temperature solve because RHS is zero.
+   Solving C_1 system ... 4 iterations.
+   Solving Stokes system... 24+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:         0.0285 m/year, 0.0891 m/year
+     Compositions min/max/mass: -0.005362/1.035/1.519e+16
+
+*** Timestep 2:  t=352467 years
+   Skipping temperature solve because RHS is zero.
+   Solving C_1 system ... 4 iterations.
+   Solving Stokes system... 22+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:         0.0281 m/year, 0.0878 m/year
+     Compositions min/max/mass: -0.04655/1.038/1.519e+16
+
+Number of active cells: 204 (on 4 levels)
+Number of degrees of freedom: 14,954 (6,825+346+2,275+5,508)
+
+*** Timestep 3:  t=500000 years
+   Skipping temperature solve because RHS is zero.
+   Solving C_1 system ... 4 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 25+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:         0.0278 m/year, 0.0868 m/year
+     Compositions min/max/mass: -0.0508/1.029/1.519e+16
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/discontinuous_composition_bound_preserving_limiter_3d/statistics
+++ b/tests/discontinuous_composition_bound_preserving_limiter_3d/statistics
@@ -1,0 +1,22 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Number of degrees of freedom for all compositions
+# 7: Iterations for temperature solver
+# 8: Iterations for composition solver 1
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Time step size (years)
+# 13: RMS velocity (m/year)
+# 14: Max. velocity (m/year)
+# 15: Minimal value for composition C_1
+# 16: Maximal value for composition C_1
+# 17: Global mass for composition C_1
+0 0.000000000000e+00  64 2312  729 1728 0 0 27 28  27 3.800841576155e+05 0.00000000e+00 0.00000000e+00  0.00000000e+00 0.00000000e+00 0.00000000e+00 
+0 0.000000000000e+00 120 4438 1405 3240 0 0 28 29  91 1.751481142857e+05 2.87758913e-02 8.99249024e-02  0.00000000e+00 1.00000000e+00 1.52011447e+16 
+1 1.751481142857e+05 120 4438 1405 3240 0 4 24 25  86 1.773185211173e+05 2.85004632e-02 8.91260531e-02 -5.36164370e-03 1.03536664e+00 1.51947669e+16 
+2 3.524666354030e+05 120 4438 1405 3240 0 4 22 23  77 1.475333645970e+05 2.81216032e-02 8.78274453e-02 -4.65459700e-02 1.03816376e+00 1.51912631e+16 
+3 5.000000000000e+05 204 7171 2275 5508 0 4 25 26 104 1.816662201915e+05 2.77700216e-02 8.68063742e-02 -5.08010153e-02 1.02943219e+00 1.51898371e+16 


### PR DESCRIPTION
The DG bound preserving limiter now can be applied to both 2d and 3D cases, and the new version has the same 2D outputs of the test case used in the early version. For 3D case, only run a simple short time run test example, and it works.