### PR TITLE
Parallel benchmarks

### DIFF
--- a/benchmark/burstedde/burstedde.cc
+++ b/benchmark/burstedde/burstedde.cc
@@ -583,10 +583,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      const double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      const double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      const double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      const double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
 

--- a/benchmark/burstedde/burstedde.cc
+++ b/benchmark/burstedde/burstedde.cc
@@ -550,11 +550,6 @@ namespace aspect
       Vector<float> cellwise_errors_ul2 (this->get_triangulation().n_active_cells());
       Vector<float> cellwise_errors_pl2 (this->get_triangulation().n_active_cells());
 
-      double u_l1;
-      double p_l1;
-      double u_l2;
-      double p_l2;
-
       ComponentSelectFunction<dim> comp_u(std::pair<unsigned int, unsigned int>(0,dim),
                                           dim+2);
       ComponentSelectFunction<dim> comp_p(dim, dim+2);
@@ -588,13 +583,12 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),MPI_COMM_WORLD);
-      p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),MPI_COMM_WORLD);
-      u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),MPI_COMM_WORLD));
-      p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),MPI_COMM_WORLD));
+      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
-
 
       os << std::scientific <<  u_l1
          << ", " << p_l1

--- a/benchmark/inclusion/inclusion.cc
+++ b/benchmark/inclusion/inclusion.cc
@@ -515,10 +515,10 @@ namespace aspect
       if (this->introspection().block_indices.velocities != this->introspection().block_indices.pressure)
         n_stokes_dofs  += this->introspection().system_dofs_per_block[this->introspection().block_indices.pressure];
 
-      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os << n_stokes_dofs << "; "

--- a/benchmark/inclusion/inclusion.cc
+++ b/benchmark/inclusion/inclusion.cc
@@ -455,9 +455,6 @@ namespace aspect
     std::pair<std::string,std::string>
     InclusionPostprocessor<dim>::execute (TableHandler &statistics)
     {
-      AssertThrow(Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) == 1,
-                  ExcNotImplemented());
-
       std_cxx1x::shared_ptr<Function<dim> > ref_func;
       if (dynamic_cast<const InclusionMaterial<dim> *>(&this->get_material_model()) != NULL)
         {

--- a/benchmark/inclusion/inclusion.cc
+++ b/benchmark/inclusion/inclusion.cc
@@ -477,11 +477,6 @@ namespace aspect
       Vector<float> cellwise_errors_ul2 (this->get_triangulation().n_active_cells());
       Vector<float> cellwise_errors_pl2 (this->get_triangulation().n_active_cells());
 
-      double u_l1;
-      double p_l1;
-      double u_l2;
-      double p_l2;
-
       ComponentSelectFunction<dim> comp_u(std::pair<unsigned int, unsigned int>(0,dim),
                                           dim+2);
       ComponentSelectFunction<dim> comp_p(dim, dim+2);
@@ -520,10 +515,10 @@ namespace aspect
       if (this->introspection().block_indices.velocities != this->introspection().block_indices.pressure)
         n_stokes_dofs  += this->introspection().system_dofs_per_block[this->introspection().block_indices.pressure];
 
-      u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os << n_stokes_dofs << "; "

--- a/benchmark/inclusion/inclusion.cc
+++ b/benchmark/inclusion/inclusion.cc
@@ -477,6 +477,11 @@ namespace aspect
       Vector<float> cellwise_errors_ul2 (this->get_triangulation().n_active_cells());
       Vector<float> cellwise_errors_pl2 (this->get_triangulation().n_active_cells());
 
+      double u_l1;
+      double p_l1;
+      double u_l2;
+      double p_l2;
+
       ComponentSelectFunction<dim> comp_u(std::pair<unsigned int, unsigned int>(0,dim),
                                           dim+2);
       ComponentSelectFunction<dim> comp_p(dim, dim+2);
@@ -510,17 +515,22 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      unsigned int n = this->get_solution().block(this->introspection().block_indices.velocities).size();
-
+      // Compute stokes unknowns, do not include temperature
+      unsigned int n_stokes_dofs = this->introspection().system_dofs_per_block[this->introspection().block_indices.velocities];
       if (this->introspection().block_indices.velocities != this->introspection().block_indices.pressure)
-        n += this->get_solution().block(this->introspection().block_indices.pressure).size();
+        n_stokes_dofs  += this->introspection().system_dofs_per_block[this->introspection().block_indices.pressure];
+
+      u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
-      os << n << "; "
-         << std::scientific  << cellwise_errors_u.l1_norm()
-         << ", " << cellwise_errors_p.l1_norm()
-         << ", " << cellwise_errors_ul2.l2_norm()
-         << ", " << cellwise_errors_pl2.l2_norm();
+      os << n_stokes_dofs << "; "
+         << std::scientific << u_l1
+         << ", " << p_l1
+         << ", " << u_l2
+         << ", " << p_l2;
 
       return std::make_pair("DoFs; Errors u_L1, p_L1, u_L2, p_L2:", os.str());
     }

--- a/benchmark/inclusion/inclusion.cc
+++ b/benchmark/inclusion/inclusion.cc
@@ -515,10 +515,10 @@ namespace aspect
       if (this->introspection().block_indices.velocities != this->introspection().block_indices.pressure)
         n_stokes_dofs  += this->introspection().system_dofs_per_block[this->introspection().block_indices.pressure];
 
-      double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      const double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      const double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      const double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      const double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os << n_stokes_dofs << "; "

--- a/benchmark/inclusion/run.sh
+++ b/benchmark/inclusion/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+NP=1
+
 # averaging scheme:
 for avg in "none" "arithmetic average" "geometric average"
 do
@@ -19,7 +21,7 @@ do
     echo "subsection Mesh refinement" >> temp.prm
     echo "set Initial global refinement = $r" >> temp.prm
     echo "end" >> temp.prm
-    ./aspect temp.prm | grep DoFs
+    mpirun -n $NP ./aspect temp.prm | grep DoFs
     rm -f temp.prm
   done
 
@@ -31,6 +33,6 @@ do
   echo "subsection Material model" >> temp.prm
   echo "set Material averaging = $avg" >> temp.prm
   echo "end" >> temp.prm
-  ./aspect temp.prm | grep DoFs
+  mpirun -n $NP ./aspect temp.prm | grep DoFs
   rm -f temp.prm
 done

--- a/benchmark/inclusion/run.sh
+++ b/benchmark/inclusion/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Number of processors to run on
 NP=1
 
 # averaging scheme:

--- a/benchmark/solcx/solcx.cc
+++ b/benchmark/solcx/solcx.cc
@@ -2803,10 +2803,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      const double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      const double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      const double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      const double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os << std::scientific << u_l1

--- a/benchmark/solcx/solcx.cc
+++ b/benchmark/solcx/solcx.cc
@@ -2770,6 +2770,11 @@ namespace aspect
       Vector<float> cellwise_errors_ul2 (this->get_triangulation().n_active_cells());
       Vector<float> cellwise_errors_pl2 (this->get_triangulation().n_active_cells());
 
+      double u_l1;
+      double p_l1;
+      double u_l2;
+      double p_l2;
+
       ComponentSelectFunction<dim> comp_u(std::pair<unsigned int, unsigned int>(0,dim),
                                           dim+2);
       ComponentSelectFunction<dim> comp_p(dim, dim+2);
@@ -2803,11 +2808,16 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
+      u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+
       std::ostringstream os;
-      os << std::scientific << cellwise_errors_u.l1_norm()
-         << ", " << cellwise_errors_p.l1_norm()
-         << ", " << cellwise_errors_ul2.l2_norm()
-         << ", " << cellwise_errors_pl2.l2_norm();
+      os << std::scientific << u_l1
+         << ", " << p_l1
+         << ", " << u_l2
+         << ", " << p_l2;
 
       return std::make_pair("Errors u_L1, p_L1, u_L2, p_L2:", os.str());
     }

--- a/benchmark/solcx/solcx.cc
+++ b/benchmark/solcx/solcx.cc
@@ -2803,10 +2803,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os << std::scientific << u_l1

--- a/benchmark/solcx/solcx.cc
+++ b/benchmark/solcx/solcx.cc
@@ -2770,11 +2770,6 @@ namespace aspect
       Vector<float> cellwise_errors_ul2 (this->get_triangulation().n_active_cells());
       Vector<float> cellwise_errors_pl2 (this->get_triangulation().n_active_cells());
 
-      double u_l1;
-      double p_l1;
-      double u_l2;
-      double p_l2;
-
       ComponentSelectFunction<dim> comp_u(std::pair<unsigned int, unsigned int>(0,dim),
                                           dim+2);
       ComponentSelectFunction<dim> comp_p(dim, dim+2);
@@ -2808,10 +2803,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os << std::scientific << u_l1

--- a/benchmark/solcx/solcx.cc
+++ b/benchmark/solcx/solcx.cc
@@ -2747,9 +2747,6 @@ namespace aspect
     std::pair<std::string,std::string>
     SolCxPostprocessor<dim>::execute (TableHandler &statistics)
     {
-      AssertThrow(Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) == 1,
-                  ExcNotImplemented());
-
       std_cxx1x::shared_ptr<Function<dim> > ref_func;
       if (dynamic_cast<const SolCxMaterial<dim> *>(&this->get_material_model()) != NULL)
         {

--- a/benchmark/solkz/solkz.cc
+++ b/benchmark/solkz/solkz.cc
@@ -873,10 +873,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      const double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      const double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      const double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      const double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os << std::scientific << u_l1

--- a/benchmark/solkz/solkz.cc
+++ b/benchmark/solkz/solkz.cc
@@ -873,10 +873,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os << std::scientific << u_l1

--- a/benchmark/solkz/solkz.cc
+++ b/benchmark/solkz/solkz.cc
@@ -840,6 +840,11 @@ namespace aspect
       Vector<float> cellwise_errors_ul2 (this->get_triangulation().n_active_cells());
       Vector<float> cellwise_errors_pl2 (this->get_triangulation().n_active_cells());
 
+      double u_l1;
+      double p_l1;
+      double u_l2;
+      double p_l2;
+
       ComponentSelectFunction<dim> comp_u(std::pair<unsigned int, unsigned int>(0,dim),
                                           dim+2);
       ComponentSelectFunction<dim> comp_p(dim, dim+2);
@@ -873,11 +878,16 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
+      u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+
       std::ostringstream os;
-      os << std::scientific << cellwise_errors_u.l1_norm()
-         << ", " << cellwise_errors_p.l1_norm()
-         << ", " << cellwise_errors_ul2.l2_norm()
-         << ", " << cellwise_errors_pl2.l2_norm();
+      os << std::scientific << u_l1
+         << ", " << p_l1
+         << ", " << u_l2
+         << ", " << p_l2;
 
       return std::make_pair("Errors u_L1, p_L1, u_L2, p_L2:", os.str());
     }

--- a/benchmark/solkz/solkz.cc
+++ b/benchmark/solkz/solkz.cc
@@ -818,9 +818,6 @@ namespace aspect
     std::pair<std::string,std::string>
     SolKzPostprocessor<dim>::execute (TableHandler &statistics)
     {
-      AssertThrow(Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) == 1,
-                  ExcNotImplemented());
-
       std_cxx1x::shared_ptr<Function<dim> > ref_func;
       if (dynamic_cast<const SolKzMaterial<dim> *>(&this->get_material_model()) != NULL)
         {

--- a/benchmark/solkz/solkz.cc
+++ b/benchmark/solkz/solkz.cc
@@ -840,11 +840,6 @@ namespace aspect
       Vector<float> cellwise_errors_ul2 (this->get_triangulation().n_active_cells());
       Vector<float> cellwise_errors_pl2 (this->get_triangulation().n_active_cells());
 
-      double u_l1;
-      double p_l1;
-      double u_l2;
-      double p_l2;
-
       ComponentSelectFunction<dim> comp_u(std::pair<unsigned int, unsigned int>(0,dim),
                                           dim+2);
       ComponentSelectFunction<dim> comp_p(dim, dim+2);
@@ -878,10 +873,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os << std::scientific << u_l1

--- a/tests/burstedde.cc
+++ b/tests/burstedde.cc
@@ -550,11 +550,6 @@ namespace aspect
       Vector<float> cellwise_errors_ul2 (this->get_triangulation().n_active_cells());
       Vector<float> cellwise_errors_pl2 (this->get_triangulation().n_active_cells());
 
-      double u_l1;
-      double p_l1;
-      double u_l2;
-      double p_l2;
-
       ComponentSelectFunction<dim> comp_u(std::pair<unsigned int, unsigned int>(0,dim),
                                           dim+2);
       ComponentSelectFunction<dim> comp_p(dim, dim+2);
@@ -588,10 +583,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),MPI_COMM_WORLD);
-      p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),MPI_COMM_WORLD);
-      u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),MPI_COMM_WORLD));
-      p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),MPI_COMM_WORLD));
+      const double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),MPI_COMM_WORLD);
+      const double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),MPI_COMM_WORLD);
+      const double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),MPI_COMM_WORLD));
+      const double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),MPI_COMM_WORLD));
 
       std::ostringstream os;
 

--- a/tests/burstedde.cc
+++ b/tests/burstedde.cc
@@ -588,10 +588,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),MPI_COMM_WORLD);
-      p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),MPI_COMM_WORLD);
-      u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),MPI_COMM_WORLD));
-      p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),MPI_COMM_WORLD));
+      u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),MPI_COMM_WORLD);
+      p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),MPI_COMM_WORLD);
+      u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),MPI_COMM_WORLD));
+      p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),MPI_COMM_WORLD));
 
       std::ostringstream os;
 

--- a/tests/inclusion_2.cc
+++ b/tests/inclusion_2.cc
@@ -461,9 +461,6 @@ namespace aspect
     std::pair<std::string,std::string>
     InclusionPostprocessor<dim>::execute (TableHandler &statistics)
     {
-      AssertThrow(Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) == 1,
-                  ExcNotImplemented());
-
       std_cxx1x::shared_ptr<Function<dim> > ref_func;
       if (dynamic_cast<const InclusionMaterial<dim> *>(&this->get_material_model()) != NULL)
         {
@@ -519,11 +516,16 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
+      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+
       std::ostringstream os;
-      os << std::scientific << cellwise_errors_u.l1_norm()
-         << ", " << cellwise_errors_p.l1_norm()
-         << ", " << cellwise_errors_ul2.l2_norm()
-         << ", " << cellwise_errors_pl2.l2_norm();
+      os<< std::scientific << u_l1
+        << ", " << p_l1
+        << ", " << u_l2
+        << ", " << p_l2;
 
       return std::make_pair("Errors u_L1, p_L1, u_L2, p_L2:", os.str());
     }

--- a/tests/inclusion_2.cc
+++ b/tests/inclusion_2.cc
@@ -516,10 +516,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      const double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      const double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      const double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      const double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os<< std::scientific << u_l1

--- a/tests/inclusion_2.cc
+++ b/tests/inclusion_2.cc
@@ -516,10 +516,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os<< std::scientific << u_l1

--- a/tests/melt_compressible_advection.cc
+++ b/tests/melt_compressible_advection.cc
@@ -134,7 +134,7 @@ namespace aspect
                                        VectorTools::L2_norm,
                                        &comp_porosity);
 
-    double poro_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
+    const double poro_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
 
     std::ostringstream os;
     os << std::scientific << poro_l2;

--- a/tests/melt_compressible_advection.cc
+++ b/tests/melt_compressible_advection.cc
@@ -134,10 +134,10 @@ namespace aspect
                                        VectorTools::L2_norm,
                                        &comp_porosity);
 
-    double pore_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
+    double poro_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
 
     std::ostringstream os;
-    os << std::scientific << pore_l2;
+    os << std::scientific << poro_l2;
     return std::make_pair("Error porosity_L2:", os.str());
   }
 

--- a/tests/melt_compressible_advection.cc
+++ b/tests/melt_compressible_advection.cc
@@ -119,9 +119,6 @@ namespace aspect
   std::pair<std::string,std::string>
   CompressibleMeltPostprocessor<dim>::execute (TableHandler &statistics)
   {
-    AssertThrow(Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) == 1,
-                ExcNotImplemented());
-
     RefFunction<dim> ref_func;
     const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.velocities).degree+2);
 
@@ -137,8 +134,10 @@ namespace aspect
                                        VectorTools::L2_norm,
                                        &comp_porosity);
 
+    double pore_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
+
     std::ostringstream os;
-    os << std::scientific << cellwise_errors_porosity.l2_norm();
+    os << std::scientific << pore_l2;
     return std::make_pair("Error porosity_L2:", os.str());
   }
 

--- a/tests/melt_material_4.cc
+++ b/tests/melt_material_4.cc
@@ -159,14 +159,14 @@ namespace aspect
                                        VectorTools::L2_norm,
                                        &comp_porosity);
 
-    double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),this->get_mpi_communicator()));
-    double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),this->get_mpi_communicator()));
-    double pore_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
+    double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),this->get_mpi_communicator()));
+    double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),this->get_mpi_communicator()));
+    double poro_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
 
     std::ostringstream os;
     os << std::scientific << u_l2
        << ", " << p_l2
-       << ", " << pore_l2;
+       << ", " << poro_l2;
 
     return std::make_pair("Errors u_L2, p_f_L2, porosity_L2:", os.str());
 

--- a/tests/melt_material_4.cc
+++ b/tests/melt_material_4.cc
@@ -159,9 +159,9 @@ namespace aspect
                                        VectorTools::L2_norm,
                                        &comp_porosity);
 
-    double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),this->get_mpi_communicator()));
-    double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),this->get_mpi_communicator()));
-    double poro_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
+    const double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),this->get_mpi_communicator()));
+    const double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),this->get_mpi_communicator()));
+    const double poro_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
 
     std::ostringstream os;
     os << std::scientific << u_l2

--- a/tests/melt_material_4.cc
+++ b/tests/melt_material_4.cc
@@ -120,9 +120,6 @@ namespace aspect
   std::pair<std::string,std::string>
   MMPostprocessor<dim>::execute (TableHandler &statistics)
   {
-    AssertThrow(Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) == 1,
-                ExcNotImplemented());
-
     RefFunction<dim> ref_func;
     const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.velocities).degree+2);
 
@@ -161,10 +158,15 @@ namespace aspect
                                        quadrature_formula,
                                        VectorTools::L2_norm,
                                        &comp_porosity);
+
+    double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),this->get_mpi_communicator()));
+    double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),this->get_mpi_communicator()));
+    double pore_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
+
     std::ostringstream os;
-    os << std::scientific << cellwise_errors_u.l2_norm()
-       << ", " << cellwise_errors_p.l2_norm()
-       << ", " << cellwise_errors_porosity.l2_norm();
+    os << std::scientific << u_l2
+       << ", " << p_l2
+       << ", " << pore_l2;
 
     return std::make_pair("Errors u_L2, p_f_L2, porosity_L2:", os.str());
 

--- a/tests/melt_transport_convergence_simple.cc
+++ b/tests/melt_transport_convergence_simple.cc
@@ -129,9 +129,6 @@ namespace aspect
   std::pair<std::string,std::string>
   ConvergenceMeltPostprocessor<dim>::execute (TableHandler &statistics)
   {
-    AssertThrow(Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) == 1,
-                ExcNotImplemented());
-
     RefFunction<dim> ref_func;
     const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.velocities).degree+2);
 
@@ -196,13 +193,20 @@ namespace aspect
                                        VectorTools::L2_norm,
                                        &comp_u_f);
 
+    double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),this->get_mpi_communicator()));
+    double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),this->get_mpi_communicator()));
+    double p_f_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_p_f.norm_sqr(),this->get_mpi_communicator()));
+    double p_c_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_p_c.norm_sqr(),this->get_mpi_communicator()));
+    double pore_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
+    double u_f_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_u_f.norm_sqr(),this->get_mpi_communicator()));
+
     std::ostringstream os;
-    os << std::scientific << cellwise_errors_u.l2_norm()
-       << ", " << cellwise_errors_p.l2_norm()
-       << ", " << cellwise_errors_p_f.l2_norm()
-       << ", " << cellwise_errors_p_c.l2_norm()
-       << ", " << cellwise_errors_porosity.l2_norm()
-       << ", " << cellwise_errors_u_f.l2_norm();
+    os << std::scientific << u_l2
+       << ", " << p_l2
+       << ", " << p_f_l2
+       << ", " << p_c_l2
+       << ", " << pore_l2
+       << ", " << u_f_l2;
 
     return std::make_pair("Errors u_L2, p_L2, p_f_L2, p_c_L2, porosity_L2, u_f_L2:", os.str());
   }

--- a/tests/melt_transport_convergence_simple.cc
+++ b/tests/melt_transport_convergence_simple.cc
@@ -193,19 +193,19 @@ namespace aspect
                                        VectorTools::L2_norm,
                                        &comp_u_f);
 
-    double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),this->get_mpi_communicator()));
-    double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),this->get_mpi_communicator()));
-    double p_f_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_p_f.norm_sqr(),this->get_mpi_communicator()));
-    double p_c_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_p_c.norm_sqr(),this->get_mpi_communicator()));
-    double pore_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
-    double u_f_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_u_f.norm_sqr(),this->get_mpi_communicator()));
+    double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),this->get_mpi_communicator()));
+    double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),this->get_mpi_communicator()));
+    double p_f_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p_f.norm_sqr(),this->get_mpi_communicator()));
+    double p_c_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p_c.norm_sqr(),this->get_mpi_communicator()));
+    double poro_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
+    double u_f_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_u_f.norm_sqr(),this->get_mpi_communicator()));
 
     std::ostringstream os;
     os << std::scientific << u_l2
        << ", " << p_l2
        << ", " << p_f_l2
        << ", " << p_c_l2
-       << ", " << pore_l2
+       << ", " << poro_l2
        << ", " << u_f_l2;
 
     return std::make_pair("Errors u_L2, p_L2, p_f_L2, p_c_L2, porosity_L2, u_f_L2:", os.str());

--- a/tests/melt_transport_convergence_simple.cc
+++ b/tests/melt_transport_convergence_simple.cc
@@ -193,12 +193,12 @@ namespace aspect
                                        VectorTools::L2_norm,
                                        &comp_u_f);
 
-    double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),this->get_mpi_communicator()));
-    double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),this->get_mpi_communicator()));
-    double p_f_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p_f.norm_sqr(),this->get_mpi_communicator()));
-    double p_c_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p_c.norm_sqr(),this->get_mpi_communicator()));
-    double poro_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
-    double u_f_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_u_f.norm_sqr(),this->get_mpi_communicator()));
+    const double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),this->get_mpi_communicator()));
+    const double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),this->get_mpi_communicator()));
+    const double p_f_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p_f.norm_sqr(),this->get_mpi_communicator()));
+    const double p_c_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p_c.norm_sqr(),this->get_mpi_communicator()));
+    const double poro_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
+    const double u_f_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_u_f.norm_sqr(),this->get_mpi_communicator()));
 
     std::ostringstream os;
     os << std::scientific << u_l2

--- a/tests/melt_transport_convergence_test.cc
+++ b/tests/melt_transport_convergence_test.cc
@@ -130,9 +130,6 @@ namespace aspect
   std::pair<std::string,std::string>
   ConvergenceMeltPostprocessor<dim>::execute (TableHandler &statistics)
   {
-    AssertThrow(Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) == 1,
-                ExcNotImplemented());
-
     RefFunction<dim> ref_func;
     const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.velocities).degree+2);
     const unsigned int n_total_comp = this->introspection().n_components;
@@ -197,13 +194,21 @@ namespace aspect
                                        VectorTools::L2_norm,
                                        &comp_u_f);
 
+    double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),this->get_mpi_communicator()));
+    double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),this->get_mpi_communicator()));
+    double p_f_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_p_f.norm_sqr(),this->get_mpi_communicator()));
+    double p_c_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_p_c.norm_sqr(),this->get_mpi_communicator()));
+    double pore_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
+    double u_f_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_u_f.norm_sqr(),this->get_mpi_communicator()));
+
+
     std::ostringstream os;
-    os << std::scientific << cellwise_errors_u.l2_norm()
-       << ", " << cellwise_errors_p.l2_norm()
-       << ", " << cellwise_errors_p_f.l2_norm()
-       << ", " << cellwise_errors_p_c.l2_norm()
-       << ", " << cellwise_errors_porosity.l2_norm()
-       << ", " << cellwise_errors_u_f.l2_norm();
+    os << std::scientific << u_l2
+       << ", " << p_l2
+       << ", " << p_f_l2
+       << ", " << p_c_l2
+       << ", " << pore_l2
+       << ", " << u_f_l2;
 
     return std::make_pair("Errors u_L2, p_L2, p_f_L2, p_c_L2, porosity_L2, u_f_L2:", os.str());
   }

--- a/tests/melt_transport_convergence_test.cc
+++ b/tests/melt_transport_convergence_test.cc
@@ -194,12 +194,12 @@ namespace aspect
                                        VectorTools::L2_norm,
                                        &comp_u_f);
 
-    double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),this->get_mpi_communicator()));
-    double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),this->get_mpi_communicator()));
-    double p_f_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_p_f.norm_sqr(),this->get_mpi_communicator()));
-    double p_c_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_p_c.norm_sqr(),this->get_mpi_communicator()));
-    double pore_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
-    double u_f_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_u_f.norm_sqr(),this->get_mpi_communicator()));
+    double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),this->get_mpi_communicator()));
+    double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),this->get_mpi_communicator()));
+    double p_f_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p_f.norm_sqr(),this->get_mpi_communicator()));
+    double p_c_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p_c.norm_sqr(),this->get_mpi_communicator()));
+    double poro_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
+    double u_f_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_u_f.norm_sqr(),this->get_mpi_communicator()));
 
 
     std::ostringstream os;
@@ -207,7 +207,7 @@ namespace aspect
        << ", " << p_l2
        << ", " << p_f_l2
        << ", " << p_c_l2
-       << ", " << pore_l2
+       << ", " << poro_l2
        << ", " << u_f_l2;
 
     return std::make_pair("Errors u_L2, p_L2, p_f_L2, p_c_L2, porosity_L2, u_f_L2:", os.str());

--- a/tests/melt_transport_convergence_test.cc
+++ b/tests/melt_transport_convergence_test.cc
@@ -194,12 +194,12 @@ namespace aspect
                                        VectorTools::L2_norm,
                                        &comp_u_f);
 
-    double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),this->get_mpi_communicator()));
-    double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),this->get_mpi_communicator()));
-    double p_f_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p_f.norm_sqr(),this->get_mpi_communicator()));
-    double p_c_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p_c.norm_sqr(),this->get_mpi_communicator()));
-    double poro_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
-    double u_f_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_u_f.norm_sqr(),this->get_mpi_communicator()));
+    const double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),this->get_mpi_communicator()));
+    const double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),this->get_mpi_communicator()));
+    const double p_f_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p_f.norm_sqr(),this->get_mpi_communicator()));
+    const double p_c_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_p_c.norm_sqr(),this->get_mpi_communicator()));
+    const double poro_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),this->get_mpi_communicator()));
+    const double u_f_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_u_f.norm_sqr(),this->get_mpi_communicator()));
 
 
     std::ostringstream os;

--- a/tests/prescribed_velocity_boundary.cc
+++ b/tests/prescribed_velocity_boundary.cc
@@ -520,10 +520,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      const double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      const double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      const double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      const double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os << std::scientific << u_l1

--- a/tests/prescribed_velocity_boundary.cc
+++ b/tests/prescribed_velocity_boundary.cc
@@ -465,9 +465,6 @@ namespace aspect
     std::pair<std::string,std::string>
     InclusionPostprocessor<dim>::execute (TableHandler &statistics)
     {
-      AssertThrow(Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) == 1,
-                  ExcNotImplemented());
-
       std_cxx1x::shared_ptr<Function<dim> > ref_func;
       if (dynamic_cast<const InclusionMaterial<dim> *>(&this->get_material_model()) != NULL)
         {
@@ -523,11 +520,16 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
+      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+
       std::ostringstream os;
-      os << std::scientific << cellwise_errors_u.l1_norm()
-         << ", " << cellwise_errors_p.l1_norm()
-         << ", " << cellwise_errors_ul2.l2_norm()
-         << ", " << cellwise_errors_pl2.l2_norm();
+      os << std::scientific << u_l1
+         << ", " << p_l1
+         << ", " << u_l2
+         << ", " << p_l2;
 
       return std::make_pair("Errors u_L1, p_L1, u_L2, p_L2:", os.str());
     }

--- a/tests/prescribed_velocity_boundary.cc
+++ b/tests/prescribed_velocity_boundary.cc
@@ -520,10 +520,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os << std::scientific << u_l1

--- a/tests/sol_cx_mpi_2.cc
+++ b/tests/sol_cx_mpi_2.cc
@@ -1,0 +1,2 @@
+#include "solcx.cc"
+

--- a/tests/sol_cx_mpi_2.prm
+++ b/tests/sol_cx_mpi_2.prm
@@ -1,3 +1,4 @@
+# Like sol_cx_2.prm, but with 2 processors
 
 # MPI: 2
 

--- a/tests/sol_cx_mpi_2.prm
+++ b/tests/sol_cx_mpi_2.prm
@@ -1,0 +1,119 @@
+
+# MPI: 2
+
+set Additional shared libraries            = ./libsolcx.so
+
+
+set Dimension = 2
+
+
+set CFL number                             = 1.0
+
+set End time                               = 0
+
+
+set Resume computation                     = false
+
+set Start time                             = 0
+
+set Adiabatic surface temperature          = 0
+
+set Surface pressure                       = 0
+
+set Use years in output instead of seconds = false  # default: true
+
+set Nonlinear solver scheme                = Stokes only
+
+subsection Boundary temperature model
+  set Model name = box
+
+end
+
+
+subsection Discretization
+  set Stokes velocity polynomial degree       = 2
+
+  set Temperature polynomial degree           = 2
+
+  set Use locally conservative discretization = false
+
+  subsection Stabilization parameters
+    set alpha = 2
+
+    set beta  = 0.078
+
+    set cR    = 0.5   # default: 0.11
+  end
+
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+
+    set Y extent = 1
+
+    set Z extent = 1
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+end
+
+
+subsection Initial conditions
+  set Model name = perturbed box
+
+end
+
+
+subsection Material model
+  set Model name = SolCxMaterial
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0                       # default: 2
+  set Initial global refinement          = 2                       # default: 2
+
+  set Strategy                           = density, temperature
+end
+
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false # default: true
+
+
+  set Fixed temperature boundary indicators   = 0, 1
+
+  set Prescribed velocity boundary indicators =
+
+  set Tangential velocity boundary indicators = 0,1,2,3
+
+  set Zero velocity boundary indicators       =
+end
+
+
+subsection Postprocess
+  set List of postprocessors = SolCxPostprocessor
+
+  subsection Depth average
+    set Time between graphical output = 1e8
+  end
+
+  subsection Visualization
+    set Number of grouped files       = 0
+
+    set Output format                 = gnuplot
+
+    set Time between graphical output = 0   # default: 1e8
+  end
+end
+

--- a/tests/sol_cx_mpi_2/screen-output
+++ b/tests/sol_cx_mpi_2/screen-output
@@ -1,5 +1,5 @@
 
-Loading shared library <./libsol_cx_2.so>
+Loading shared library <./libsol_cx_mpi_2.so>
 
 Number of active cells: 16 (on 3 levels)
 Number of degrees of freedom: 268 (162+25+81)

--- a/tests/sol_cx_mpi_2/screen-output
+++ b/tests/sol_cx_mpi_2/screen-output
@@ -1,0 +1,23 @@
+
+Loading shared library <./libsol_cx_2.so>
+
+Number of active cells: 16 (on 3 levels)
+Number of degrees of freedom: 268 (162+25+81)
+
+*** Timestep 0:  t=0 seconds
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 17+0 iterations.
+      Nonlinear Stokes residual: 0.0667217
+   Solving Stokes system... 0+0 iterations.
+      Nonlinear Stokes residual: 4.40627e-09
+
+   Postprocessing:
+     Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174943e-01, 1.069688e-04, 1.192654e-01
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/sol_cx_mpi_2/statistics
+++ b/tests/sol_cx_mpi_2/statistics
@@ -1,0 +1,11 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Iterations for Stokes solver
+# 7: Velocity iterations in Stokes preconditioner
+# 8: Schur complement iterations in Stokes preconditioner
+# 9: Time step size (seconds)
+0 0.000000000000e+00 16 187 81 17 18 17 0.000000000000e+00 
+0 0.000000000000e+00  0   0  0  0  0  0 3.428701026554e+01 

--- a/tests/sol_cx_mpi_2/statistics
+++ b/tests/sol_cx_mpi_2/statistics
@@ -7,5 +7,5 @@
 # 7: Velocity iterations in Stokes preconditioner
 # 8: Schur complement iterations in Stokes preconditioner
 # 9: Time step size (seconds)
-0 0.000000000000e+00 16 187 81 17 18 17 0.000000000000e+00 
+0 0.000000000000e+00 16 187 81 17 18 51 0.000000000000e+00 
 0 0.000000000000e+00  0   0  0  0  0  0 3.428701026554e+01 

--- a/tests/solcx.cc
+++ b/tests/solcx.cc
@@ -2803,10 +2803,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      const double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      const double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      const double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      const double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os << std::scientific << u_l1

--- a/tests/solcx.cc
+++ b/tests/solcx.cc
@@ -2747,9 +2747,6 @@ namespace aspect
     std::pair<std::string,std::string>
     SolCxPostprocessor<dim>::execute (TableHandler &statistics)
     {
-      AssertThrow(Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) == 1,
-                  ExcNotImplemented());
-
       std_cxx1x::shared_ptr<Function<dim> > ref_func;
       if (dynamic_cast<const SolCxMaterial<dim> *>(&this->get_material_model()) != NULL)
         {
@@ -2806,11 +2803,16 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
+      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+
       std::ostringstream os;
-      os << std::scientific << cellwise_errors_u.l1_norm()
-         << ", " << cellwise_errors_p.l1_norm()
-         << ", " << cellwise_errors_ul2.l2_norm()
-         << ", " << cellwise_errors_pl2.l2_norm();
+      os << std::scientific << u_l1
+         << ", " << p_l1
+         << ", " << u_l2
+         << ", " << p_l2;
 
       return std::make_pair("Errors u_L1, p_L1, u_L2, p_L2:", os.str());
     }

--- a/tests/solcx.cc
+++ b/tests/solcx.cc
@@ -2803,10 +2803,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os << std::scientific << u_l1

--- a/tests/solkz.cc
+++ b/tests/solkz.cc
@@ -816,9 +816,6 @@ namespace aspect
     std::pair<std::string,std::string>
     SolKzPostprocessor<dim>::execute (TableHandler &statistics)
     {
-      AssertThrow(Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) == 1,
-                  ExcNotImplemented());
-
       std_cxx1x::shared_ptr<Function<dim> > ref_func;
       if (dynamic_cast<const SolKzMaterial<dim> *>(&this->get_material_model()) != NULL)
         {
@@ -874,11 +871,16 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
+      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+
       std::ostringstream os;
-      os << std::scientific << cellwise_errors_u.l1_norm()
-         << ", " << cellwise_errors_p.l1_norm()
-         << ", " << cellwise_errors_ul2.l2_norm()
-         << ", " << cellwise_errors_pl2.l2_norm();
+      os << std::scientific << u_l1
+         << ", " << p_l1
+         << ", " << u_l2
+         << ", " << p_l2;
 
       return std::make_pair("Errors u_L1, p_L1, u_L2, p_L2:", os.str());
     }

--- a/tests/solkz.cc
+++ b/tests/solkz.cc
@@ -871,10 +871,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      const double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      const double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      const double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      const double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os << std::scientific << u_l1

--- a/tests/solkz.cc
+++ b/tests/solkz.cc
@@ -871,10 +871,10 @@ namespace aspect
                                          VectorTools::L2_norm,
                                          &comp_p);
 
-      double u_l1 =  Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
-      double p_l1 =  Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
-      double u_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
-      double p_l2 =  std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
+      double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),this->get_mpi_communicator());
+      double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),this->get_mpi_communicator());
+      double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),this->get_mpi_communicator()));
+      double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),this->get_mpi_communicator()));
 
       std::ostringstream os;
       os << std::scientific << u_l1


### PR DESCRIPTION
Fix issue #958.

Testing completed.
For solcx and solkx logs match for single processor, for MPI change in computed error is within epsilon.
For inclusion, script output matches for single processor, and to within a reasonable epsilon for MPI.