### PR TITLE
fix documentation spelling mistake

### DIFF
--- a/source/initial_conditions/S40RTS_perturbation.cc
+++ b/source/initial_conditions/S40RTS_perturbation.cc
@@ -403,7 +403,7 @@ namespace aspect
                                        "splitting function measurements, Geophys. J. Int. 184, 1223-1236. "
                                        "The scaling between the shear wave perturbation and the "
                                        "temperature perturbation can be set by the user with the "
-                                       "'vs to density scaling' parameter and the 'Thermal "
+                                       "'Vs to density scaling' parameter and the 'Thermal "
                                        "expansion coefficient in initial temperature scaling' "
                                        "parameter. The scaling is as follows: $\\delta ln \\rho "
                                        "(r,\\theta,\\phi) = \\xi \\cdot \\delta ln v_s(r,\\theta, "

--- a/source/initial_conditions/SAVANI_perturbation.cc
+++ b/source/initial_conditions/SAVANI_perturbation.cc
@@ -398,7 +398,7 @@ namespace aspect
                                        "Research: Solid Earth 119.4 (2014): 3006-3034. "
                                        "The scaling between the shear wave perturbation and the "
                                        "temperature perturbation can be set by the user with the "
-                                       "'vs to density scaling' parameter and the 'Thermal "
+                                       "'Vs to density scaling' parameter and the 'Thermal "
                                        "expansion coefficient in initial temperature scaling' "
                                        "parameter. The scaling is as follows: $\\delta ln \\rho "
                                        "(r,\\theta,\\phi) = \\xi \\cdot \\delta ln v_s(r,\\theta, "


### PR DESCRIPTION
- change 'vs' to "Vs" in S40RTS and SAVANI perturbation implementations
- see issue #976