### PR TITLE
Update MacOSX install instructions.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2022,9 +2022,17 @@ point for exploring the documentation.
 The here mentioned build was tested on a Cray XC30 cluster, which was set up for default static compiling and linking. On machines that default to dynamic linking additional compiler and/or linker flags may be required (e.g. "-fPIC" / "--static"). In case of questions send an email to the mailing list.
 
 \subsection{Installing and running \aspect{} on Mac OS X}
-OS X has some eccentricities which can complicate installation of \aspect{}. Currently the easiest and most reliable way to run \aspect{} under Mac OS X Mavericks (10.9) and Yosemite (10.10) is to install and run the binary package for \dealii{}. The step-by-step process is described in detail, with screenshots, here: \url{https://wiki.geodynamics.org/_media/software:aspect:aspect_yosemite_20150529.pdf}
+OS X has some eccentricities which can complicate installation of \aspect{}. Currently the easiest and most reliable way to run \aspect{} under Mac OS X Mavericks (10.9), Yosemite (10.10) and El Capitan (10.11) is to install and run the binary package for \dealii{}. The step-by-step process is described in detail, with screenshots, here: \url{https://wiki.geodynamics.org/_media/software:aspect:aspect_yosemite_20150529.pdf}
 
 \begin{enumerate}
+\item Install xcode from the app store. You might need to install the command line tools. Open a terminal and make sure ``clang'' does not report ``command not found''. You might need to run
+
+\begin{verbatim}
+xcode-select --install
+\end{verbatim}
+
+to install the tools.
+
 \item Install Cmake.
 
 CMake is a cross-platform, open-source build system that can be downloaded from \url{http://www.cmake.org}.  After installation of CMake.app, the terminal command for cmake will be
@@ -2045,6 +2053,13 @@ open /Applications/deal.II.app
 \end{verbatim}}
 \dealii{} app opens a terminal window and displays a \dealii{} message.   \dealii{}.app will install all required libraries for \aspect{} (p4est, parMeTiS, and Trilinos) and will include the environment variables needed to use these libraries.
 
+To ensure the correct compilers are picked up when configuring \aspect{}, add the following lines to your .profile or .bash\_profile:
+
+\begin{verbatim}
+export OMPI_CXX=clang++
+export OMPI_CC=clang
+\end{verbatim}
+
 \item Download  the  \aspect{} source from the git repository.
 
 {\footnotesize \begin{verbatim}
@@ -2052,10 +2067,11 @@ cd $HOME/src
 git clone https://github.com/geodynamics/aspect.git
 \end{verbatim}}
 
-
-Note: you {\bf MUST} \underline{build} and \underline{run} \aspect{} in the terminal window started by \dealii{}.
+If you wish to use Xcode as your IDE it is recommended to skip to step 7 below. Otherwise, proceed with steps 5 and 6 below.
 
 \item Build \aspect{}
+
+Note: you {\bf MUST} \underline{build} and \underline{run} \aspect{} in the terminal window started by \dealii{}.
 
 \begin{enumerate}
 \item Go to the  directory where you wish to install \aspect{}  and run the following commands:
@@ -2123,6 +2139,31 @@ To check quickly whether you are running  \aspect{} on the  \dealii{}.app termin
 bash-3.2$ which mpirun
 /Applications/deal.II.app/Contents/Resources/opt/openmpi-1.6.5/bin/mpirun
 \end{verbatim}}
+
+\item Build \aspect{} as an Xcode project.
+
+After completing step 4 above, do the following:
+\begin{enumerate}
+\item Go to the directory where you wish to install \aspect{} and run the following command:
+
+\begin{verbatim}
+cmake -G Xcode .
+\end{verbatim}
+
+Now open the resulting \texttt{aspect.xcodeproj} in Xcode.
+
+\item Open Product\textgreater Scheme\textgreater Manage Schemes, then select ``aspect'' and click ``Edit''. Go to Run\textgreater Arguments, and under "Arguments Passed On Launch" add the filepath to the desired parameter file. Click "Close" then select Product\textgreater Run to run \aspect{} with this parameter file.
+
+\item If you want to run in parallel in Xcode, the easiest way is to create a new scheme. Open Product\textgreater Scheme\textgreater Manage Schemes, select ``aspect'' then select the gear icon, then ``Duplicate scheme''. Rename the new scheme to ``aspect parallel''. Go to Run\textgreater Info, and in Executable choose ``Other...''. Navigate to 
+
+\begin{verbatim}
+/Applications/deal.II.app/Contents/Resources/opt/openmpi-1.10.2/bin
+\end{verbatim}
+and select ``orterun'', then click ``Choose''.
+
+\item Now go to the Arguments tab, and add 3 arguments: first, add \texttt{-np4} (for 4 processors - you may use however many your machine has). Then add a path to your aspect executable - this should be within your aspect folder, or the subfolders Debug or Release. Finally, ensure you have a path to your parameter file as above. Ensure these are in the correct order, or reorder them if necessary. Click ``Close'' then select Product\textgreater Run to run \aspect{} in parallel with this parameter file.
+\end{enumerate}
+
 
 
 \end{enumerate}

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2025,82 +2025,79 @@ The here mentioned build was tested on a Cray XC30 cluster, which was set up for
 OS X has some eccentricities which can complicate installation of \aspect{}. Currently the easiest and most reliable way to run \aspect{} under Mac OS X Mavericks (10.9), Yosemite (10.10) and El Capitan (10.11) is to install and run the binary package for \dealii{}. The step-by-step process is described in detail, with screenshots, here: \url{https://wiki.geodynamics.org/_media/software:aspect:aspect_yosemite_20150529.pdf}
 
 \begin{enumerate}
-\item Install xcode from the app store. You might need to install the command line tools. Open a terminal and make sure ``clang'' does not report ``command not found''. You might need to run
-
+\item Install Xcode from the app store. You might need to install the command line tools. Open a terminal and make sure ``clang'' does not report ``command not found''. You might need to run
 \begin{verbatim}
-xcode-select --install
+  xcode-select --install
 \end{verbatim}
-
 to install the tools.
 
 \item Install Cmake.
 
 CMake is a cross-platform, open-source build system that can be downloaded from \url{http://www.cmake.org}.  After installation of CMake.app, the terminal command for cmake will be
 \begin{verbatim}
-/Applications/CMake.app/Contents/bin/cmake
+  /Applications/CMake.app/Contents/bin/cmake
 \end{verbatim}
 
 \item Download and install the parallel \dealii{}. This is the binary package for Mac OS .dmg file.
-{\footnotesize
 \begin{verbatim}
-open  https://github.com/dealii/dealii/releases/download/v8.4.1/dealii-8.4.1.dmg
+  open  https://github.com/dealii/dealii/releases/download/v8.4.1/dealii-8.4.1.dmg
 \end{verbatim}
-}
+
 Open the downloaded disk image, and drag \dealii{}.app into the Applications folder.
  To start the \dealii{} app, double click the icon in the Applications folder or use the open command:
-{\footnotesize \begin{verbatim}
-open /Applications/deal.II.app
-\end{verbatim}}
+\begin{verbatim}
+  open /Applications/deal.II.app
+\end{verbatim}
 \dealii{} app opens a terminal window and displays a \dealii{} message.   \dealii{}.app will install all required libraries for \aspect{} (p4est, parMeTiS, and Trilinos) and will include the environment variables needed to use these libraries.
 
-To ensure the correct compilers are picked up when configuring \aspect{}, add the following lines to your .profile or .bash\_profile:
+To ensure the correct compilers are picked up when configuring \aspect{}, add the following lines to your \texttt{\textasciitilde/.profile} or \texttt{\textasciitilde/.bash\_profile}:
 
 \begin{verbatim}
-export OMPI_CXX=clang++
-export OMPI_CC=clang
+  export OMPI_CXX=clang++
+  export OMPI_CC=clang
 \end{verbatim}
 
 \item Download  the  \aspect{} source from the git repository.
 
-{\footnotesize \begin{verbatim}
-cd $HOME/src
-git clone https://github.com/geodynamics/aspect.git
-\end{verbatim}}
+\begin{verbatim}
+  cd $HOME/src
+  git clone https://github.com/geodynamics/aspect.git
+\end{verbatim}
 
 If you wish to use Xcode as your IDE it is recommended to skip to step 7 below. Otherwise, proceed with steps 5 and 6 below.
 
 \item Build \aspect{}
 
-Note: you {\bf MUST} \underline{build} and \underline{run} \aspect{} in the terminal window started by \dealii{}.
+Note: if you are not using Xcode (see step 7 below), you {\bf MUST} \underline{build} and \underline{run} \aspect{} in the terminal window started by \dealii{}, rather than in the Terminal app.
 
 \begin{enumerate}
 \item Go to the  directory where you wish to install \aspect{}  and run the following commands:
 
 {\footnotesize
 \begin{verbatim}
-cmake .
+  cmake .
 \end{verbatim}}
 
 This should display something like:
 
 {\footnotesize
 \begin{verbatim}
-Project  aspect  set up with  deal.II-8.4.1  found at /Applications/deal.II.app/Contents/Resources
+  Project aspect set up with  deal.II-8.4.1  found at /Applications/deal.II.app/Contents/Resources
 \end{verbatim}}
 
 \item Run make:
 
 {\footnotesize
 \begin{verbatim}
-bash-3.2$ make
-Scanning dependencies of target aspect
-[  0%] Building CXX object CMakeFiles/aspect.dir/source/adiabatic_conditions/initial_profile.cc.o
-[  0%] Building CXX object CMakeFiles/aspect.dir/source/adiabatic_conditions/interface.cc.o
-...
-Linking CXX executable aspect
-[100%] Built target aspect
-bash-3.2$ ls -l aspect
--rwxr-xr-x  1 <name>  staff  19131292 May  7 15:02 aspect
+  bash-3.2$ make
+  Scanning dependencies of target aspect
+  [  0%] Building CXX object CMakeFiles/aspect.dir/source/adiabatic_conditions/initial_profile.cc.o
+  [  0%] Building CXX object CMakeFiles/aspect.dir/source/adiabatic_conditions/interface.cc.o
+  ...
+  Linking CXX executable aspect
+  [100%] Built target aspect
+  bash-3.2$ ls -l aspect
+  -rwxr-xr-x  1 <name>  staff  19131292 May  7 15:02 aspect
 \end{verbatim}
 }
 There may be  warnings from the compiler, but if the \aspect{} target is created then it was successful.
@@ -2108,14 +2105,14 @@ There may be  warnings from the compiler, but if the \aspect{} target is created
 \item By default,  \aspect{}  compiles the debug version of the code.
 To compile the optimized version:
 {\footnotesize\begin{verbatim}
-make release 
+  make release 
 \end{verbatim}}
 
 \item Run make test
 
 {\footnotesize
 \begin{verbatim}
-make test
+  make test
 \end{verbatim}}
 
 
@@ -2128,17 +2125,15 @@ make test
 A reminder: you {\bf must} run  \aspect{}  on the terminal window which is opened by \dealii{}.app.
 
 To start \aspect{} using MPI for parallelization, from the directory where you installed \aspect{}:
-{\footnotesize
 \begin{verbatim}
-mpirun -np <# of processes> ./aspect <parameter file>
-\end{verbatim}}
+  mpirun -np <# of processes> ./aspect <parameter file>
+\end{verbatim}
 
 To check quickly whether you are running  \aspect{} on the  \dealii{}.app terminal, check the location of the \verb|mpirun| command:
-{\footnotesize
 \begin{verbatim}
-bash-3.2$ which mpirun
-/Applications/deal.II.app/Contents/Resources/opt/openmpi-1.6.5/bin/mpirun
-\end{verbatim}}
+  bash-3.2$ which mpirun
+  /Applications/deal.II.app/Contents/Resources/opt/openmpi-1.6.5/bin/mpirun
+\end{verbatim}
 
 \item Build \aspect{} as an Xcode project.
 
@@ -2147,7 +2142,7 @@ After completing step 4 above, do the following:
 \item Go to the directory where you wish to install \aspect{} and run the following command:
 
 \begin{verbatim}
-cmake -G Xcode .
+  cmake -G Xcode .
 \end{verbatim}
 
 Now open the resulting \texttt{aspect.xcodeproj} in Xcode.
@@ -2155,13 +2150,12 @@ Now open the resulting \texttt{aspect.xcodeproj} in Xcode.
 \item Open Product\textgreater Scheme\textgreater Manage Schemes, then select ``aspect'' and click ``Edit''. Go to Run\textgreater Arguments, and under "Arguments Passed On Launch" add the filepath to the desired parameter file. Click "Close" then select Product\textgreater Run to run \aspect{} with this parameter file.
 
 \item If you want to run in parallel in Xcode, the easiest way is to create a new scheme. Open Product\textgreater Scheme\textgreater Manage Schemes, select ``aspect'' then select the gear icon, then ``Duplicate scheme''. Rename the new scheme to ``aspect parallel''. Go to Run\textgreater Info, and in Executable choose ``Other...''. Navigate to 
-
 \begin{verbatim}
-/Applications/deal.II.app/Contents/Resources/opt/openmpi-1.10.2/bin
+  /Applications/deal.II.app/Contents/Resources/opt/openmpi-1.10.2/bin
 \end{verbatim}
 and select ``orterun'', then click ``Choose''.
 
-\item Now go to the Arguments tab, and add 3 arguments: first, add \texttt{-np4} (for 4 processors - you may use however many your machine has). Then add a path to your aspect executable - this should be within your aspect folder, or the subfolders Debug or Release. Finally, ensure you have a path to your parameter file as above. Ensure these are in the correct order, or reorder them if necessary. Click ``Close'' then select Product\textgreater Run to run \aspect{} in parallel with this parameter file.
+\item Now go to the Arguments tab, and add 3 arguments: first, add \texttt{-np4} (for 4 processors -- you may use however many your machine has). Then add a path to your aspect executable -- this should be within your aspect folder, or the subfolders Debug or Release. Finally, ensure you have a path to your parameter file as above. Ensure these are in the correct order, or reorder them if necessary. Click ``Close'' then select Product\textgreater Run to run \aspect{} in parallel with this parameter file.
 \end{enumerate}
 
 


### PR DESCRIPTION
- Includes instructions to ensure Xcode and command line tools are up-to-date.
- Adds lines to ensure the correct compilers are picked up.
- Includes instructions to generate and run an Aspect project in Xcode in both serial and parallel.

I'd appreciate your thoughts on what I've written.

There is also the matter of the link to Matsui's instructions (URL on line 2025) which are now out-of-date - should I remove the link altogether, or still provide it but caution that it is out-of-date?