### PR TITLE
Remove deprecated 'temperature' and 'composition'

### DIFF
--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -82,36 +82,6 @@ namespace aspect
          * Return the composition that is to hold at a particular position on
          * the boundary of the domain.
          *
-         * @param geometry_model The geometry model that describes the domain.
-         * This may be used to determine whether the boundary composition
-         * model is implemented for this geometry.
-         * @param boundary_indicator The boundary indicator of the part of the
-         * boundary of the domain on which the point is located at which we
-         * are requesting the composition.
-         * @param position The position of the point at which we ask for the
-         * composition.
-         * @param compositional_field The index of the compositional field
-         * between 0 and @p parameters.n_compositional_fields.
-         * @return Boundary value of the compositional field @p
-         * compositional_field at the position @p position.
-         *
-         * @deprecated Use <code>boundary_composition(const types::boundary_id
-         * boundary_indicator,const Point<dim> &position, const unsigned
-         * int compositional_field) const</code> instead. The reference to
-         * the geometry model can be reached by deriving plugins from
-         * aspect::SimulatorAccess<dim>.
-         */
-        virtual
-        double
-        composition (const GeometryModel::Interface<dim> &geometry_model,
-                     const types::boundary_id             boundary_indicator,
-                     const Point<dim>                    &position,
-                     const unsigned int                   compositional_field) const DEAL_II_DEPRECATED;
-
-        /**
-         * Return the composition that is to hold at a particular position on
-         * the boundary of the domain.
-         *
          * @param boundary_indicator The boundary indicator of the part of the
          * boundary of the domain on which the point is located at which we
          * are requesting the composition.

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -67,30 +67,6 @@ namespace aspect
          * Return the temperature that is to hold at a particular position on
          * the boundary of the domain.
          *
-         * @param geometry_model The geometry model that describes the domain.
-         * This may be used to determine whether the boundary temperature
-         * model is implemented for this geometry.
-         * @param boundary_indicator The boundary indicator of the part of the
-         * boundary of the domain on which the point is located at which we
-         * are requesting the temperature.
-         * @param position The position of the point at which we ask for the
-         * temperature.
-         * @return Boundary temperature at position @p position.
-         *
-         * @deprecated Use <code>boundary_temperature(const types::boundary_id
-         * boundary_indicator,const Point<dim> &position) const</code> instead.
-         * The reference to the geometry model can be reached by deriving
-         * plugins from aspect::SimulatorAccess<dim>.
-         */
-        virtual
-        double temperature (const GeometryModel::Interface<dim> &geometry_model,
-                            const types::boundary_id             boundary_indicator,
-                            const Point<dim>                    &position) const DEAL_II_DEPRECATED;
-
-        /**
-         * Return the temperature that is to hold at a particular position on
-         * the boundary of the domain.
-         *
          * @param boundary_indicator The boundary indicator of the part of the
          * boundary of the domain on which the point is located at which we
          * are requesting the temperature.

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -51,22 +51,6 @@ namespace aspect
 
     template <int dim>
     double
-    Interface<dim>::composition (const GeometryModel::Interface<dim> &/*geometry_model*/,
-                                 const types::boundary_id             boundary_indicator,
-                                 const Point<dim>                    &position,
-                                 const unsigned int                   compositional_field) const
-    {
-      /**
-       * Call the new-style function without the geometry model
-       * to maintain backwards compatibility. After removal of this deprecated
-       * function the new function will be called directly by Simulator.
-       */
-
-      return boundary_composition(boundary_indicator,position,compositional_field);
-    }
-
-    template <int dim>
-    double
     Interface<dim>::boundary_composition (const types::boundary_id /*boundary_indicator*/,
                                           const Point<dim>        &/*position*/,
                                           const unsigned int       /*compositional_field*/) const

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -52,21 +52,6 @@ namespace aspect
 
     template <int dim>
     double
-    Interface<dim>::temperature (const GeometryModel::Interface<dim> &/*geometry_model*/,
-                                 const types::boundary_id             boundary_indicator,
-                                 const Point<dim>                    &position) const
-    {
-      /**
-       * Call the new-style function without the geometry model
-       * to maintain backwards compatibility. After removal of this deprecated
-       * function the new function will be called directly by Simulator.
-       */
-
-      return this->boundary_temperature(boundary_indicator,position);
-    }
-
-    template <int dim>
-    double
     Interface<dim>::boundary_temperature (const types::boundary_id /*boundary_indicator*/,
                                           const Point<dim>        &/*position*/) const
     {

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -909,9 +909,8 @@ namespace aspect
                     ExcInternalError());
             VectorTools::interpolate_boundary_values (dof_handler,
                                                       *p,
-                                                      VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (&BoundaryTemperature::Interface<dim>::temperature,
+                                                      VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (&BoundaryTemperature::Interface<dim>::boundary_temperature,
                                                           std_cxx11::cref(*boundary_temperature),
-                                                          std_cxx11::cref(*geometry_model),
                                                           *p,
                                                           std_cxx11::_1),
                                                           introspection.component_masks.temperature.first_selected_component(),
@@ -941,9 +940,8 @@ namespace aspect
                       ExcInternalError());
               VectorTools::interpolate_boundary_values (dof_handler,
                                                         *p,
-                                                        VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (&BoundaryComposition::Interface<dim>::composition,
+                                                        VectorFunctionFromScalarFunctionObject<dim>(std_cxx11::bind (&BoundaryComposition::Interface<dim>::boundary_composition,
                                                             std_cxx11::cref(*boundary_composition),
-                                                            std_cxx11::cref(*geometry_model),
                                                             *p,
                                                             std_cxx11::_1,
                                                             c),


### PR DESCRIPTION
Replaces them with `boundary_temperature` and `boundary_composition`, as brought in with #689 . Contributes towards #943