### PR TITLE
Remove references to the IMPES algorithm used earlier.

### DIFF
--- a/doc/manual/manual.bib
+++ b/doc/manual/manual.bib
@@ -10646,13 +10646,6 @@ lower mantle structures},
 }
 
 
-@Article{GHB12,
-  author =       {T. Geenen and T. Heister and M. Kronbichler and W. Bangerth},
-  title =        {3D high resolution phase distribution and seismic velocity structure
-evolution of the transition zone: modeled in a full spherical-shell
-compressible mantle convection context},
-  journal =      {in preparation},
-  year =         2011}
 
 @Article{KRH90,
   author =       {S. D. King and A. Raefsky and B. H. Hager},

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -1511,7 +1511,8 @@ temperature equation. These kind of time stepping schemes are often referred
 to as \textit{operator splitting} methods. A particular operator
 splitting method, used in
 earlier \aspect{} versions, solves first the Stokes equations and then
-uses an explicit time stepping method for the temperature equation;
+uses a semi-explicit time stepping method for the temperature equation
+where diffusion is handled implicitly and advection explicitly;
 this algorithm is often called \textit{IMPES} (it originated in the
 porous media flow 
 community, where the acronym stands for \textit{Im}plicit \textit{P}ressure,

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -1508,9 +1508,17 @@ set of equations at once, iterating out nonlinearities as necessary, but
 instead in each time step solves first the Stokes system with the previous
 time step's temperature, and then uses the so-computed velocity to solve the
 temperature equation. These kind of time stepping schemes are often referred
-to as \textit{IMPES} methods (they originate in the porous media flow
+to as \textit{operator splitting} methods. A particular operator
+splitting method, used in
+earlier \aspect{} versions, solves first the Stokes equations and then
+uses an explicit time stepping method for the temperature equation;
+this algorithm is often called \textit{IMPES} (it originated in the
+porous media flow 
 community, where the acronym stands for \textit{Im}plicit \textit{P}ressure,
-\textit{E}xplicit \textit{S}aturation). For details see \cite{KHB12}.
+\textit{E}xplicit \textit{S}aturation) and is explained in more detail
+in \cite{KHB12}. However, since then the algorithm in \aspect{} has
+been rewritten to use an implicit time stepping algorithm also for the
+temperature equation because this allows to use larger time steps.
 
 
 


### PR DESCRIPTION
Instead mention it in a historical context.

Fixes #925.