### PR TITLE
Spherical harmonics helper

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,11 @@
  *
  * <ol>
  *
+ * <li> New: There is a new function Utilities::real_spherical_harmonic
+ * which calculates the values of a fully normalized real spherical harmonic.
+ * <br>
+ * (Ian Rose, 2016/06/28)
+ *
  * <li> Changed: The files handling the free surface implementation
  * have been renamed to free_surface.h and free_surface.cc for better
  * consistency with the rest of the file names.

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -97,8 +97,8 @@ namespace aspect
      * There are an unfortunate number of normalization conventions in existence
      * for spherical harmonics. Here we use fully normalized spherical harmonics
      * including the Condon-Shortley phase. This corresponds to the definitions
-     * given in equations B.72 and B.99-B.102 in Dahlen and Tromp. The functional
-     * form of the real spherical harmonic is given by
+     * given in equations B.72 and B.99-B.102 in Dahlen and Tromp (1998, ISBN: 9780691001241).
+     * The functional form of the real spherical harmonic is given by
      *
      * \f[
      *    Y_{lm}(\theta, \phi) = \sqrt{2} X_{l \left| m \right| }(\theta) \cos m \phi \qquad \mathrm{if} \qquad -l \le m < 0

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -94,19 +94,33 @@ namespace aspect
      * It also takes the colatitude (theta) and longitude (phi), which are in
      * radians.
      *
-     * This returns a pair of numbers, which correspond to the cosine and sine
-     * parts of the real spherical harmonic (related to the real and imaginary parts
-     * of complex spherical harmonics, respectively). Note that returning the cosine
-     * and sine parts as a pair means that there is no need for negative orders (m>= 0).
-     *
      * There are an unfortunate number of normalization conventions in existence
      * for spherical harmonics. Here we use fully normalized spherical harmonics
      * including the Condon-Shortley phase. This corresponds to the definitions
-     * given in equations B.72 and B.99-B.102 in Dahlen and Tromp.
+     * given in equations B.72 and B.99-B.102 in Dahlen and Tromp. The functional
+     * form of the real spherical harmonic is given by
      *
-     * NOTE: this function uses the Boost spherical harmonics package which is not designed
-     * for very high order (> 100) spherical harmonics computation. If you use harmonic
-     * perturbations of a high order be sure to confirm the accuracy first.
+     * \f[
+     *    Y_{lm}(\theta, \phi) = \sqrt{2} X_{l \left| m \right| }(\theta) \cos m \phi \qquad \mathrm{if} \qquad -l \le m < 0
+     * \f]
+     * \f[
+     *    Y_{lm}(\theta, \phi) = X_{l 0 }(\theta) \qquad \mathrm{if} \qquad m = 0
+     * \f]
+     * \f[
+     *    Y_{lm}(\theta, \phi) = \sqrt{2} X_{lm}(\theta) \sin m \phi \qquad \mathrm{if}  \qquad 0< m \le m
+     * \f]
+     * where \f$X_{lm}( \theta )\f$ is an associated Legendre function.
+     *
+     * In practice it is often convenient to compute the sine (\f$-l \le m < 0\f$) and cosine (\f$0 < m \le l\f$)
+     * variants of the real spherical harmonic at the same time. That is the approach taken
+     * here, where we return a pair of numbers, the first corresponding the cosine part and the
+     * second corresponding to the sine part. Given this, it is no longer necessary to distinguish
+     * between postitive and negative \f$ m \f$, so this function only accepts \f$ m \ge 0 \f$.
+     * For \f$ m = 0 \f$, there is only one part, which is stored in the first entry of the pair.
+     *
+     * @note This function uses the Boost spherical harmonics implementation internally,
+     * which is not designed for very high order (> 100) spherical harmonics computation.
+     * If you use spherical harmonics of a high order be sure to confirm the accuracy first.
      * For more information, see:
      * http://www.boost.org/doc/libs/1_49_0/libs/math/doc/sf_and_dist/html/math_toolkit/special/sf_poly/sph_harm.html
      */

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -94,15 +94,21 @@ namespace aspect
      * It also takes the colatitude (theta) and longitude (phi), which are in
      * radians.
      *
-     * This returns a pair of numbers, which correspond to the sine and cosine
-     * parts of the real spherical harmonic (related to the real and imaginary
-     * parts of complex spherical harmonics). Note that returning the sine and
-     * cosine parts as a pair means that there is no need for negative orders (m>= 0).
+     * This returns a pair of numbers, which correspond to the cosine and sine
+     * parts of the real spherical harmonic (related to the real and imaginary parts
+     * of complex spherical harmonics, respectively). Note that returning the cosine
+     * and sine parts as a pair means that there is no need for negative orders (m>= 0).
      *
      * There are an unfortunate number of normalization conventions in existence
      * for spherical harmonics. Here we use fully normalized spherical harmonics
      * including the Condon-Shortley phase. This corresponds to the definitions
      * given in equations B.72 and B.99-B.102 in Dahlen and Tromp.
+     *
+     * NOTE: this function uses the Boost spherical harmonics package which is not designed
+     * for very high order (> 100) spherical harmonics computation. If you use harmonic
+     * perturbations of a high order be sure to confirm the accuracy first.
+     * For more information, see:
+     * http://www.boost.org/doc/libs/1_49_0/libs/math/doc/sf_and_dist/html/math_toolkit/special/sf_poly/sph_harm.html
      */
     std::pair<double,double> real_spherical_harmonic( unsigned int l, //degree
                                                       unsigned int m, //order

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -89,6 +89,27 @@ namespace aspect
     orthogonal_vectors (const Tensor<1,dim> &v);
 
     /**
+     * A function for evaluating real spherical harmonics. It takes the degree (l)
+     * and the order (m) of the spherical harmonic, where l >= 0 and 0 <= m <=l.
+     * It also takes the colatitude (theta) and longitude (phi), which are in
+     * radians.
+     *
+     * This returns a pair of numbers, which correspond to the sine and cosine
+     * parts of the real spherical harmonic (related to the real and imaginary
+     * parts of complex spherical harmonics). Note that returning the sine and
+     * cosine parts as a pair means that there is no need for negative orders (m>= 0).
+     *
+     * There are an unfortunate number of normalization conventions in existence
+     * for spherical harmonics. Here we use fully normalized spherical harmonics
+     * including the Condon-Shortley phase. This corresponds to the definitions
+     * given in equations B.72 and B.99-B.102 in Dahlen and Tromp.
+     */
+    std::pair<double,double> real_spherical_harmonic( unsigned int l, //degree
+                                                      unsigned int m, //order
+                                                      double theta,   //colatitude (radians)
+                                                      double phi );   //longitude (radians)
+
+    /**
      * Checks whether a file named filename exists.
      *
      * @param filename File to check existence

--- a/source/initial_conditions/SAVANI_perturbation.cc
+++ b/source/initial_conditions/SAVANI_perturbation.cc
@@ -25,7 +25,7 @@
 #include <iostream>
 #include <deal.II/base/std_cxx11/array.h>
 
-#include <boost/math/special_functions/spherical_harmonic.hpp>
+#include <boost/lexical_cast.hpp>
 
 namespace aspect
 {
@@ -163,12 +163,6 @@ namespace aspect
       spline_depths_lookup.reset(new internal::SAVANI::SplineDepthsLookup(datadirectory+spline_depth_file_name,this->get_mpi_communicator()));
     }
 
-    // NOTE: this module uses the Boost spherical harmonics package which is not designed
-    // for very high order (> 100) spherical harmonics computation. If you use harmonic
-    // perturbations of a high order be sure to confirm the accuracy first.
-    // For more information, see:
-    // http://www.boost.org/doc/libs/1_49_0/libs/math/doc/sf_and_dist/html/math_toolkit/special/sf_poly/sph_harm.html
-
     template <>
     double
     SAVANIPerturbation<2>::
@@ -234,8 +228,9 @@ namespace aspect
             {
               for (int order_m = 0; order_m < degree_l+1; order_m++)
                 {
-                  const double cos_component = boost::math::spherical_harmonic_r(degree_l,order_m,scoord[2],scoord[1]); //real / cos part
-                  const double sin_component = boost::math::spherical_harmonic_i(degree_l,order_m,scoord[2],scoord[1]); //imaginary / sine part
+                  const std::pair<double,double> sph_harm_vals = Utilities::real_spherical_harmonic( degree_l, order_m, scoord[2], scoord[1] );
+                  const double cos_component = sph_harm_vals.first;
+                  const double sin_component = sph_harm_vals.second;
 
                   // normalization after Dahlen and Tromp, 1986, Appendix B.6
                   if (degree_l == 0)
@@ -244,10 +239,6 @@ namespace aspect
                                0.
                                :
                                1.);
-                  else if (order_m == 0)
-                    prefact = 1.;
-                  else
-                    prefact = sqrt(2.);
 
                   spline_values[depth_interp] += prefact * (a_lm[ind]*cos_component + b_lm[ind]*sin_component);
 

--- a/source/initial_conditions/SAVANI_perturbation.cc
+++ b/source/initial_conditions/SAVANI_perturbation.cc
@@ -239,6 +239,7 @@ namespace aspect
                                0.
                                :
                                1.);
+                  else prefact = 1.0;
 
                   spline_values[depth_interp] += prefact * (a_lm[ind]*cos_component + b_lm[ind]*sin_component);
 

--- a/source/initial_conditions/harmonic_perturbation.cc
+++ b/source/initial_conditions/harmonic_perturbation.cc
@@ -78,7 +78,9 @@ namespace aspect
                                    "degree >= 0."));
               // use a spherical harmonic function as lateral perturbation
               std::pair<double,double> sph_harm_vals = Utilities::real_spherical_harmonic( lateral_wave_number_1, lateral_wave_number_2, scoord[2], scoord[1] );
-              lateral_perturbation = sph_harm_vals.first;
+              //For historical reasons, this initial conditions module used an unnormalized real spherical harmonic.
+              //Here we denormalize the return value of real_spherical_harmonic to keep the original behavior.
+              lateral_perturbation = sph_harm_vals.first / ( lateral_wave_number_2 == 0 ? 1.0 : std::sqrt(2.) );
             }
         }
       else if (const GeometryModel::Chunk<dim> *

--- a/source/initial_conditions/harmonic_perturbation.cc
+++ b/source/initial_conditions/harmonic_perturbation.cc
@@ -25,18 +25,11 @@
 #include <aspect/geometry_model/chunk.h>
 #include <aspect/utilities.h>
 
-#include <boost/math/special_functions/spherical_harmonic.hpp>
 
 namespace aspect
 {
   namespace InitialConditions
   {
-    // NOTE: this module uses the Boost spherical harmonics package which is not designed
-    // for very high order (> 100) spherical harmonics computation. If you use harmonic
-    // perturbations of a high order be sure to confirm the accuracy first.
-    // For more information, see:
-    // http://www.boost.org/doc/libs/1_49_0/libs/math/doc/sf_and_dist/html/math_toolkit/special/sf_poly/sph_harm.html
-    //
     template <int dim>
     double
     HarmonicPerturbation<dim>::
@@ -84,7 +77,8 @@ namespace aspect
                        ExcMessage ("Spherical harmonics can only be computed for "
                                    "degree >= 0."));
               // use a spherical harmonic function as lateral perturbation
-              lateral_perturbation = boost::math::spherical_harmonic_r(lateral_wave_number_1,lateral_wave_number_2,scoord[2],scoord[1]);
+              std::pair<double,double> sph_harm_vals = Utilities::real_spherical_harmonic( lateral_wave_number_1, lateral_wave_number_2, scoord[2], scoord[1] );
+              lateral_perturbation = sph_harm_vals.first;
             }
         }
       else if (const GeometryModel::Chunk<dim> *

--- a/source/initial_conditions/solidus.cc
+++ b/source/initial_conditions/solidus.cc
@@ -24,7 +24,6 @@
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/boundary_temperature/interface.h>
 
-#include <boost/lexical_cast.hpp>
 #include <cmath>
 
 namespace aspect

--- a/source/initial_conditions/solidus.cc
+++ b/source/initial_conditions/solidus.cc
@@ -24,7 +24,7 @@
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/boundary_temperature/interface.h>
 
-#include <boost/math/special_functions/spherical_harmonic.hpp>
+#include <boost/lexical_cast.hpp>
 #include <cmath>
 
 namespace aspect
@@ -157,7 +157,8 @@ namespace aspect
                    ExcMessage ("Spherical harmonics can only be computed for "
                                "degree >= 0."));
           // use a spherical harmonic function as lateral perturbation
-          lateral_perturbation = boost::math::spherical_harmonic_r(lateral_wave_number_1,lateral_wave_number_2,scoord[2],scoord[1]);
+          std::pair<double,double> sph_harm_vals = Utilities::real_spherical_harmonic( lateral_wave_number_1, lateral_wave_number_2, scoord[2], scoord[1] );
+          lateral_perturbation = sph_harm_vals.first;
         }
       litho_thick_theta=litho_thick-magnitude_lith*lateral_perturbation;
       T_litho=solidus_curve.T(0,spherical_geometry_model->R1-litho_thick_theta)+deltaT;

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -17,6 +17,7 @@
   along with ASPECT; see the file doc/COPYING.  If not see
   <http://www.gnu.org/licenses/>.
 */
+#include <boost/math/special_functions/spherical_harmonic.hpp>
 
 #include <aspect/global.h>
 #include <aspect/utilities.h>
@@ -179,6 +180,23 @@ namespace aspect
       return return_value;
     }
 
+
+    //Evaluate the sine and cosine terms of a real spherical harmonic.
+    //This is a fully normalized harmonic, that is to say, inner products
+    //of these functions should integrate to a kronecker delta over
+    //the surface of a sphere.
+    std::pair<double,double> real_spherical_harmonic( unsigned int l, //degree
+                                                      unsigned int m, //order
+                                                      double theta,   //colatitude (radians)
+                                                      double phi )    //longitude (radians)
+    {
+      const double sqrt_2 = numbers::SQRT2;
+      const std::complex<double> sph_harm_val = boost::math::spherical_harmonic( l, m, theta, phi );
+      if ( m == 0 )
+        return std::make_pair( sph_harm_val.real(), 0.0 );
+      else
+        return std::make_pair( sqrt_2 * sph_harm_val.real(), sqrt_2 * sph_harm_val.imag() );
+    }
 
 
     bool

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -185,10 +185,10 @@ namespace aspect
     //This is a fully normalized harmonic, that is to say, inner products
     //of these functions should integrate to a kronecker delta over
     //the surface of a sphere.
-    std::pair<double,double> real_spherical_harmonic( unsigned int l, //degree
-                                                      unsigned int m, //order
-                                                      double theta,   //colatitude (radians)
-                                                      double phi )    //longitude (radians)
+    std::pair<double,double> real_spherical_harmonic( const unsigned int l, //degree
+                                                      const unsigned int m, //order
+                                                      const double theta,   //colatitude (radians)
+                                                      const double phi )    //longitude (radians)
     {
       const double sqrt_2 = numbers::SQRT2;
       const std::complex<double> sph_harm_val = boost::math::spherical_harmonic( l, m, theta, phi );

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -181,7 +181,7 @@ namespace aspect
     }
 
 
-    //Evaluate the sine and cosine terms of a real spherical harmonic.
+    //Evaluate the cosine and sine terms of a real spherical harmonic.
     //This is a fully normalized harmonic, that is to say, inner products
     //of these functions should integrate to a kronecker delta over
     //the surface of a sphere.


### PR DESCRIPTION
There were several places in the code that call boost's spherical harmonics functions, with duplicated effort and potential for normalization errors. Furthermore, there will soon be more plugins that require spherical harmonics.

This provides a function in the `Utilities` namespace that calculates real spherical harmonics, according the the fully normalized convention (such as that described  in Dahlen and Tromp).

@Shangxin-Liu, @jaustermann  , could you take a glance at this to make sure that I have not broken the fix in #966?