### PR TITLE
Add base model functions to initial conditions

### DIFF
--- a/include/aspect/initial_conditions/interface.h
+++ b/include/aspect/initial_conditions/interface.h
@@ -117,6 +117,7 @@ namespace aspect
                                        void (*declare_parameters_function) (ParameterHandler &),
                                        Interface<dim> *(*factory_function) ());
 
+
     /**
      * A function that given the name of a model returns a pointer to an
      * object that describes it. Ownership of the pointer is transferred to
@@ -130,6 +131,32 @@ namespace aspect
     template <int dim>
     Interface<dim> *
     create_initial_conditions (ParameterHandler &prm);
+
+
+    /**
+     * A function that given the name of a model returns a pointer to an
+     * object that describes it. Ownership of the pointer is transferred to
+     * the caller.
+     *
+     * The initial conditions object returned is not yet initialized and has not
+     * read its runtime parameters yet.
+     *
+     * @ingroup InitialConditionsModels
+     */
+    template <int dim>
+    Interface<dim> *
+    create_initial_conditions (const std::string &model_name);
+
+
+    /**
+     * Return a string that consists of the names of initial conditions that can
+     * be selected. These names are separated by a vertical line '|' so
+     * that the string can be an input to the deal.II classes
+     * Patterns::Selection or Patterns::MultipleSelection.
+     */
+    template <int dim>
+    std::string
+    get_valid_model_names_pattern ();
 
 
     /**

--- a/source/initial_conditions/interface.cc
+++ b/source/initial_conditions/interface.cc
@@ -105,9 +105,25 @@ namespace aspect
                   ExcMessage("You need to select initial conditions for the temperature "
                              "('set Model name' in 'subsection Initial conditions')."));
 
+      return create_initial_conditions<dim> (model_name);
+    }
+
+
+    template <int dim>
+    Interface<dim> *
+    create_initial_conditions(const std::string &model_name)
+    {
       Interface<dim> *plugin = std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
                                                                                       "Initial conditions::Model name");
       return plugin;
+    }
+
+
+    template <int dim>
+    std::string
+    get_valid_model_names_pattern ()
+    {
+      return std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
     }
 
 
@@ -120,7 +136,7 @@ namespace aspect
       prm.enter_subsection ("Initial conditions");
       {
         const std::string pattern_of_names
-          = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
+          = get_valid_model_names_pattern<dim> ();
         prm.declare_entry ("Model name", "unspecified",
                            Patterns::Selection (pattern_of_names+"|unspecified"),
                            "Select one of the following models:\n\n"
@@ -168,7 +184,15 @@ namespace aspect
   \
   template \
   Interface<dim> * \
-  create_initial_conditions<dim> (ParameterHandler &prm);
+  create_initial_conditions<dim> (ParameterHandler &prm); \
+  \
+  template \
+  Interface<dim> * \
+  create_initial_conditions(const std::string &model_name); \
+  \
+  template \
+  std::string \
+  get_valid_model_names_pattern<dim> ();
 
     ASPECT_INSTANTIATE(INSTANTIATE)
   }


### PR DESCRIPTION
When for example reading in temperature perturbations from tomography (e.g. with the `ascii_data` plugin), the perturbations have to be added to a reference profile (e.g. from the `adiabatic` plugin). With the base model functions we can easily do this without copying code.