### PR TITLE
No longer necessary to detach manifolds since we use MappingQ1Eulerian.

### DIFF
--- a/include/aspect/free_surface.h
+++ b/include/aspect/free_surface.h
@@ -70,21 +70,6 @@ namespace aspect
                                 internal::Assembly::CopyData::StokesSystem<dim>      &data);
 
       /**
-       * If a geometry model uses manifolds for the refinement behavior
-       * it can produce nonsensical meshes on refinement when using a
-       * free surface, since the free surface may deform the mesh to the
-       * point where the manifold is no longer a good description of the
-       * domain.  However, it can still be useful to have the manifold
-       * description for producing a nice starting mesh with the initial
-       * refinements (that is to say, before timestepping).  This detaches
-       * manifolds from cells, and is called after the initial refinements
-       * redistribution of the system.
-       * redistribution of the system.
-       * of the domain.
-       */
-      void detach_manifolds();
-
-      /**
        * Declare parameters for the free surface handling.
        */
       static

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -263,8 +263,6 @@ namespace aspect
 
         freesurface_trans.deserialize (fs_system);
         free_surface->mesh_displacements = distributed_mesh_displacements;
-
-        free_surface->detach_manifolds();
       }
 
     // read zlib compressed resume.z

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -2203,12 +2203,6 @@ namespace aspect
         if ( timestep_number == 0 )
           pre_refinement_step = std::numeric_limits<unsigned int>::max();
 
-        // as soon as the mesh starts deforming with a free surface, a manifold
-        // description and boundary shape are no longer guaranteed to be any good.
-        // Here we detach those manifolds and boundaries.
-        if ( timestep_number == 0 && parameters.free_surface_enabled == true )
-          free_surface->detach_manifolds();
-
         postprocess ();
 
         // see if this is a time step where additional refinement is requested

--- a/source/simulator/free_surface.cc
+++ b/source/simulator/free_surface.cc
@@ -729,22 +729,6 @@ namespace aspect
           }
 
   }
-
-  template <int dim>
-  void
-  FreeSurfaceHandler<dim>::detach_manifolds()
-  {
-    //remove manifold ids for all cells
-    for (typename Triangulation<dim>::active_cell_iterator
-         cell = sim.triangulation.begin_active();
-         cell != sim.triangulation.end(); ++cell)
-      cell->set_all_manifold_ids (numbers::invalid_manifold_id);
-
-    //also remove boundary description for the free surface indicators
-    std::set<types::boundary_id>::iterator id = sim.parameters.free_surface_boundary_indicators.begin();
-    for (; id != sim.parameters.free_surface_boundary_indicators.end(); ++id)
-      sim.triangulation.set_boundary( *id );
-  }
 }
 
 


### PR DESCRIPTION
This, along with #965, addresses #369 and #1006.