### PR TITLE
dG face measure for nonplanar faces

### DIFF
--- a/tests/discontinuous_temperature_spherical_shell_3d.prm
+++ b/tests/discontinuous_temperature_spherical_shell_3d.prm
@@ -1,0 +1,93 @@
+# This is to ensure that face->measure() is not being 
+# called in the dG method - that breaks in 3d, in the 
+# case of non-planar faces.
+
+# Define the number of space dimensions we would like to 
+# work in:
+set Dimension                              = 3 
+
+# Specify the time you want to let the model run for in 
+# years and the output directory. Here we only calculate
+# the instantaneous solution.
+set End time                               = 0
+
+# Here we specify the geometry of the domain, which is 
+# a spherical shell with inner radius of 3481km and 
+# outer radius of 6371km
+subsection Geometry model
+  set Model name = spherical shell
+  subsection Spherical shell
+    set Inner radius  = 3481000
+    set Outer radius  = 6371000
+  end
+end
+
+# This section specifies the temperature at the boundary of 
+# the domain. Here we set the temperature to be constant.
+# Alternatively it could be set to the initial condition.
+subsection Boundary temperature model
+  set Model name = spherical constant
+  subsection Spherical constant
+    set Inner temperature = 1600
+    set Outer temperature = 1600
+  end
+end
+
+# This section describes the gravity field, which is pointing
+# towards the Earth's center with the same magnitude of 10 m/s^2
+# everywhere
+subsection Gravity model
+  set Model name = radial constant
+  subsection Radial constant
+    set Magnitude = 10
+  end
+end
+
+# This section prescribes the initial condition in the temperature
+# field, which is chosen as a scaled version of the S20RTS shear
+# wave velocity model (Ritsema et al., 2000). S20RTS is defined
+# by spherical harmonics up to degree 20 that are radially interpolated
+# with a cubic spline. 
+subsection Initial conditions
+  set Model name = function
+
+  subsection Function
+    set Function expression = 1
+  end
+end
+
+# The material model is based on the simple material model, which assumes
+# a constant density, and other parameters as stated below.
+subsection Material model
+  set Model name = simple
+    subsection Simple model
+    set Reference density                 = 3300
+    set Viscosity                         = 1e21
+    set Thermal expansion coefficient     = 3e-5
+    set Reference temperature             = 1600
+    set Thermal conductivity              = 4.125 
+    set Reference specific heat           = 1250
+  end
+end
+
+# For this calculation we only do 2 global refinement steps. This resolution
+# is too low to fully resolve the mantle flow, however it does capture
+# the main features.
+subsection Mesh refinement
+  set Initial global refinement          = 0
+  set Initial adaptive refinement        = 0
+end
+
+# We assume fixed temperatures and free slip at the inner and outer boundary
+subsection Model settings
+  set Fixed temperature boundary indicators   = 0,1
+
+  set Include adiabatic heating               = false 
+  set Include shear heating                   = false
+
+  set Tangential velocity boundary indicators = 0,1
+end
+
+subsection Discretization
+  set Use discontinuous temperature discretization = true
+end

--- a/tests/discontinuous_temperature_spherical_shell_3d/screen-output
+++ b/tests/discontinuous_temperature_spherical_shell_3d/screen-output
@@ -1,0 +1,18 @@
+
+Number of active cells: 96 (on 1 levels)
+Number of degrees of freedom: 5,652 (2,910+150+2,592)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+13 iterations.
+
+   Postprocessing:
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+


### PR DESCRIPTION
Replace face->measure() in dG face assembly functions with a new function dg_approximaion_to_face_measure(face), which has 2d and 3d implementations. This fudges an issue where, in 3d, faces can be non-planar, and deal.II doesn't implement a measure for such non-planar faces. Since the only important feature of the measure here is that it scales correctly, this may be sufficient.

For reference, these come from 
https://www.dealii.org/developer/doxygen/deal.II/tria__accessor_8cc_source.html#l00900 (2d) and https://www.dealii.org/developer/doxygen/deal.II/tria__accessor_8cc_source.html#l00974 (3d) (only using the part for planar faces)

What do you guys think?
- is this a sufficient calculation, given we only want the scaling to be right? We don't make any use of the Jacobian, for example, so we are not exact by any means.
- is this the best way to implement this function, or would it be better situated elsewhere? On one hand it is only ever used in the assembly, so sits quite nicely where it is, but on the other hand it has more a feel of a helper function. I'm not precious about this.