### PR TITLE
Move parameter section to the end of the manual

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -3213,10 +3213,8 @@ improvements in run-time.
 \index[prmindexfull]{Material model!Material averaging}
 
 
-\section{Run-time input parameters}
-\label{sec:parameters}
 
-\subsection{Overview}
+\subsection{Input parameter files}
 \label{sec:parameters-overview}
 
 What \aspect{} computes is driven by two things:
@@ -3237,7 +3235,7 @@ What \aspect{} computes is driven by two things:
 \end{itemize}
 In this section, let us give an overview of what can be selected in the
 parameter file. Specific parameters, their default values, and allowed values
-for these parameters are documented in the following subsections. An index
+for these parameters are documented in the Section~\ref{sec:parameters}. An index
 with page numbers for all run-time parameters can be found on
 page~\pageref{sec:runtime-parameter-index}.
 
@@ -3367,9 +3365,6 @@ an if-statement that has the general form
 the syntax understood, reference the documentation of the muparser library
 linked to above.
 
-
-% now include a file that describes all currently available run-time parameters
-\input{parameters}
 
 
 \section{Cookbooks}
@@ -9967,6 +9962,13 @@ resources:
     Heister: \url{heister@clemson.edu}.
   \end{itemize}
 \end{itemize}
+
+
+\section{Run-time input parameters}
+\label{sec:parameters}
+
+% now include a file that describes all currently available run-time parameters
+\input{parameters}
 
 
 \pagebreak


### PR DESCRIPTION
I moved the parameter section to the end of the manual but kept the overview subsection in the main text. I moved that into section 4 - Running ASPECT. This addresses issue #940.