### PR TITLE
Update 'box' descriptions

### DIFF
--- a/source/boundary_composition/box.cc
+++ b/source/boundary_composition/box.cc
@@ -174,6 +174,7 @@ namespace aspect
     ASPECT_REGISTER_BOUNDARY_COMPOSITION_MODEL(Box,
                                                "box",
                                                "A model in which the composition is chosen constant on "
-                                               "all the sides of a box.")
+                                               "the sides of a box which are selected by the parameters "
+                                               "Left/Right/Top/Bottom/Front/Back composition")
   }
 }

--- a/source/boundary_temperature/box.cc
+++ b/source/boundary_temperature/box.cc
@@ -174,6 +174,7 @@ namespace aspect
     ASPECT_REGISTER_BOUNDARY_TEMPERATURE_MODEL(Box,
                                                "box",
                                                "A model in which the temperature is chosen constant on "
-                                               "all the sides of a box.")
+                                               "the sides of a box which are selected by the parameters "
+                                               "Left/Right/Top/Bottom/Front/Back temperature")
   }
 }


### PR DESCRIPTION
Update 'box' descriptions to clarify that unselected sides default to zero flux, not zero Dirichlet.

Addresses #1033 