### PR TITLE
fix title layout of manual

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -131,19 +131,20 @@ COMPUTATIONAL INFRASTRUCTURE FOR GEODYNAMICS (CIG)
 \raggedleft \huge \fontfamily{\sfdefault}\selectfont Version
 % keep the following line as is so that we can replace this using a script:
 1.5.0-pre %VERSION-INFO%
-\\\large(generated \today)\\}
+\\\large(generated \today)\\
+{\Large Wolfgang Bangerth\\Juliane Dannberg\\Rene Gassm{\"o}ller\\Timo Heister\\}
+}
 
 %AUTHOR(S) & WEBSITE%
 \null
-\vspace{22em}
+\vspace{18em}
 \color{dark_grey}
-\Large \hfill {\raggedleft \fontfamily{\sfdefault}\selectfont
+{\fontfamily{\sfdefault}\selectfont
 % FILL: author list
 % e.g. Author One\\Author Two\\Author Three\\
 % be sure to have a newline (\\) after the final author
-Wolfgang Bangerth\\Juliane Dannberg\\Rene Gassm{\"o}ller\\Timo Heister\\
 \large
-    with contributions by:
+\noindent with contributions by: \\
     Jacqueline Austermann,
     Markus B{\"u}rg,
     Samuel Cox,
@@ -164,7 +165,7 @@ Wolfgang Bangerth\\Juliane Dannberg\\Rene Gassm{\"o}ller\\Timo Heister\\
     Cedric Thieulot,
     Iris van Zelst,
     Siqi Zhang \\
-
+\vspace{1em}
 }
 
 {\fontfamily{\sfdefault}\selectfont \href{https://geodynamics.org}{geodynamics.org}}


### PR DESCRIPTION
- make fit on one page again
- move maintainers up to save space
- arrange contributors at left boundary