### PR TITLE
add harmonic averaging to inclusion benchmark

### DIFF
--- a/benchmark/inclusion/run.sh
+++ b/benchmark/inclusion/run.sh
@@ -4,7 +4,7 @@
 NP=1
 
 # averaging scheme:
-for avg in "none" "arithmetic average" "geometric average"
+for avg in "none" "arithmetic average" "geometric average" "harmonic average"
 do
   echo "----Averaging scheme: $avg----"
 


### PR DESCRIPTION
- add harmonic averaging to the current list of averaging schemes (none, arithmetic, geometric) in the inclusion benchmark
- compared to other averaging schemes, harmonic averaging seems to reduce both velocity and pressure L2 errors
- https://docs.google.com/spreadsheets/d/1GYPWl4UOe-Jc5AkVqDX6PDQmL73YU-0S9rwBi7S-Ce0/edit?usp=sharing