### PR TITLE
Simplify particle property initialization

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,19 @@
  *
  * <ol>
  *
+ * <li> Changed: Particle initialization no longer routinely computes
+ * the solution at the particle positions, since it is usually not needed
+ * and complicates the initialization process. Instead it evaluates the 
+ * initial conditions at the particle positions. It is still possible to
+ * access the solution by evaluating it manually inside of particle
+ * property plugins. Additionally the 'initial composition' property
+ * now utilizes the user-provided names of the compositional fields
+ * to identify its particle properties (they are now named
+ * 'initial <field_name>', where <field_name> is replaced by the user
+ * provided name).
+ * <br>
+ * (Rene Gassmoeller, 2016/07/18)
+ *
  * <li> Changed: It is now possible to set the gravity to a negative
  * value in order to calculate backward advection.
  * <br>

--- a/include/aspect/particle/property/function.h
+++ b/include/aspect/particle/property/function.h
@@ -49,13 +49,6 @@ namespace aspect
            * value.
            *
            * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
            * @param [in,out] particle_properties The properties of the particle
            * that is initialized within the call of this function. The purpose
            * of this function should be to extend this vector by a number of
@@ -64,21 +57,7 @@ namespace aspect
           virtual
           void
           initialize_one_particle_property (const Point<dim> &position,
-                                            const Vector<double> &solution,
-                                            const std::vector<Tensor<1,dim> > &gradients,
                                             std::vector<double> &particle_properties) const;
-
-          /**
-           * Returns an enum, which determines how this particle property is
-           * initialized for particles that are created later than the initial
-           * particle generation, e.g. to balance the particle load or prevent
-           * empty cells. The implementation of this function in the current
-           * class returns interpolate, which signals that particle properties
-           * should be interpolated from other particles in this cell.
-           */
-          virtual
-          InitializationModeForLateParticles
-          late_initialization_mode () const;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/initial_composition.h
+++ b/include/aspect/particle/property/initial_composition.h
@@ -46,13 +46,6 @@ namespace aspect
            * value.
            *
            * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
            * @param [in,out] particle_properties The properties of the particle
            * that is initialized within the call of this function. The purpose
            * of this function should be to extend this vector by a number of
@@ -61,21 +54,7 @@ namespace aspect
           virtual
           void
           initialize_one_particle_property (const Point<dim> &position,
-                                            const Vector<double> &solution,
-                                            const std::vector<Tensor<1,dim> > &gradients,
                                             std::vector<double> &particle_properties) const;
-
-          /**
-           * Returns an enum, which determines how this particle property is
-           * initialized for particles that are created later than the initial
-           * particle generation, e.g. to balance the particle load or prevent
-           * empty cells. The implementation of this function in the current
-           * class returns interpolate, which signals that particle properties
-           * should be interpolated from other particles in this cell.
-           */
-          virtual
-          InitializationModeForLateParticles
-          late_initialization_mode () const;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/initial_position.h
+++ b/include/aspect/particle/property/initial_position.h
@@ -45,13 +45,6 @@ namespace aspect
            * value.
            *
            * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
            * @param [in,out] particle_properties The properties of the particle
            * that is initialized within the call of this function. The purpose
            * of this function should be to extend this vector by a number of
@@ -60,21 +53,7 @@ namespace aspect
           virtual
           void
           initialize_one_particle_property (const Point<dim> &position,
-                                            const Vector<double> &solution,
-                                            const std::vector<Tensor<1,dim> > &gradients,
                                             std::vector<double> &particle_properties) const;
-
-          /**
-           * Returns an enum, which determines how this particle property is
-           * initialized for particles that are created later than the initial
-           * particle generation, e.g. to balance the particle load or prevent
-           * empty cells. The implementation of this function in the current
-           * class returns interpolate, which signals that particle properties
-           * should be interpolated from other particles in this cell.
-           */
-          virtual
-          InitializationModeForLateParticles
-          late_initialization_mode () const;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/integrated_strain.h
+++ b/include/aspect/particle/property/integrated_strain.h
@@ -49,13 +49,6 @@ namespace aspect
            * value.
            *
            * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
            * @param [in,out] particle_properties The properties of the particle
            * that is initialized within the call of this function. The purpose
            * of this function should be to extend this vector by a number of
@@ -64,8 +57,6 @@ namespace aspect
           virtual
           void
           initialize_one_particle_property (const Point<dim> &position,
-                                            const Vector<double> &solution,
-                                            const std::vector<Tensor<1,dim> > &gradients,
                                             std::vector<double> &particle_properties) const;
 
           /**

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -117,13 +117,6 @@ namespace aspect
            * value.
            *
            * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
            * @param [in,out] particle_properties The properties of the particle
            * that is initialized within the call of this function. The purpose
            * of this function should be to extend this vector by a number of
@@ -132,8 +125,6 @@ namespace aspect
           virtual
           void
           initialize_one_particle_property (const Point<dim> &position,
-                                            const Vector<double> &solution,
-                                            const std::vector<Tensor<1,dim> > &gradients,
                                             std::vector<double> &particle_properties) const;
 
           /**
@@ -285,9 +276,7 @@ namespace aspect
            * collection after it was created.
            */
           void
-          initialize_one_particle (Particle<dim> &particle,
-                                   const Vector<double> &solution,
-                                   const std::vector<Tensor<1,dim> > &gradients) const;
+          initialize_one_particle (Particle<dim> &particle) const;
 
           /**
            * Initialization function for particle properties. This function is
@@ -298,9 +287,7 @@ namespace aspect
           void
           initialize_late_particle (Particle<dim> &particle,
                                     const std::multimap<types::LevelInd, Particle<dim> > &particles,
-                                    const Interpolator::Interface<dim> &interpolator,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim> > &gradients) const;
+                                    const Interpolator::Interface<dim> &interpolator) const;
 
           /**
            * Update function for particle properties. This function is

--- a/include/aspect/particle/property/pT_path.h
+++ b/include/aspect/particle/property/pT_path.h
@@ -49,13 +49,6 @@ namespace aspect
            * value.
            *
            * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
            * @param [in,out] particle_properties The properties of the particle
            * that is initialized within the call of this function. The purpose
            * of this function should be to extend this vector by a number of
@@ -64,8 +57,6 @@ namespace aspect
           virtual
           void
           initialize_one_particle_property (const Point<dim> &position,
-                                            const Vector<double> &solution,
-                                            const std::vector<Tensor<1,dim> > &gradients,
                                             std::vector<double> &particle_properties) const;
 
           /**

--- a/include/aspect/particle/property/position.h
+++ b/include/aspect/particle/property/position.h
@@ -45,13 +45,6 @@ namespace aspect
            * value.
            *
            * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
            * @param [in,out] particle_properties The properties of the particle
            * that is initialized within the call of this function. The purpose
            * of this function should be to extend this vector by a number of
@@ -60,8 +53,6 @@ namespace aspect
           virtual
           void
           initialize_one_particle_property (const Point<dim> &position,
-                                            const Vector<double> &solution,
-                                            const std::vector<Tensor<1,dim> > &gradients,
                                             std::vector<double> &particle_properties) const;
 
           /**

--- a/include/aspect/particle/property/velocity.h
+++ b/include/aspect/particle/property/velocity.h
@@ -45,13 +45,6 @@ namespace aspect
            * value.
            *
            * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
            * @param [in,out] particle_properties The properties of the particle
            * that is initialized within the call of this function. The purpose
            * of this function should be to extend this vector by a number of
@@ -60,8 +53,6 @@ namespace aspect
           virtual
           void
           initialize_one_particle_property (const Point<dim> &position,
-                                            const Vector<double> &solution,
-                                            const std::vector<Tensor<1,dim> > &gradients,
                                             std::vector<double> &particle_properties) const;
 
           /**

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -424,8 +424,7 @@ namespace aspect
          * Initialize the particle properties of one cell.
          */
         void
-        local_initialize_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                                   const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &begin_particle,
+        local_initialize_particles(const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &begin_particle,
                                    const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &end_particle);
 
         /**

--- a/source/particle/property/function.cc
+++ b/source/particle/property/function.cc
@@ -28,26 +28,16 @@ namespace aspect
     {
       template <int dim>
       Function<dim>::Function()
-        :
-        function (1)
       {}
 
       template <int dim>
       void
       Function<dim>::initialize_one_particle_property(const Point<dim> &position,
-                                                      const Vector<double> &,
-                                                      const std::vector<Tensor<1,dim> > &,
                                                       std::vector<double> &data) const
       {
         data.push_back(function.value(position));
       }
 
-      template <int dim>
-      InitializationModeForLateParticles
-      Function<dim>::late_initialization_mode () const
-      {
-        return interpolate;
-      }
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int> >

--- a/source/particle/property/initial_composition.cc
+++ b/source/particle/property/initial_composition.cc
@@ -44,7 +44,7 @@ namespace aspect
         for (unsigned int i = 0; i < this->n_compositional_fields(); i++)
           {
             std::ostringstream field_name;
-            field_name << "initial composition_" << i;
+            field_name << "initial " << this->introspection().name_for_compositional_index(i);
             property_information.push_back(std::make_pair(field_name.str(),1));
           }
 

--- a/source/particle/property/initial_composition.cc
+++ b/source/particle/property/initial_composition.cc
@@ -29,19 +29,10 @@ namespace aspect
       template <int dim>
       void
       InitialComposition<dim>::initialize_one_particle_property(const Point<dim> &position,
-                                                                const Vector<double> &,
-                                                                const std::vector<Tensor<1,dim> > &,
                                                                 std::vector<double> &data) const
       {
         for (unsigned int i = 0; i < this->n_compositional_fields(); i++)
           data.push_back(this->get_compositional_initial_conditions().initial_composition(position,i));
-      }
-
-      template <int dim>
-      InitializationModeForLateParticles
-      InitialComposition<dim>::late_initialization_mode () const
-      {
-        return interpolate;
       }
 
       template <int dim>
@@ -53,7 +44,7 @@ namespace aspect
         for (unsigned int i = 0; i < this->n_compositional_fields(); i++)
           {
             std::ostringstream field_name;
-            field_name << "initial C_" << i;
+            field_name << "initial composition_" << i;
             property_information.push_back(std::make_pair(field_name.str(),1));
           }
 

--- a/source/particle/property/initial_position.cc
+++ b/source/particle/property/initial_position.cc
@@ -30,19 +30,10 @@ namespace aspect
       template <int dim>
       void
       InitialPosition<dim>::initialize_one_particle_property(const Point<dim> &position,
-                                                             const Vector<double> &,
-                                                             const std::vector<Tensor<1,dim> > &,
                                                              std::vector<double> &data) const
       {
         for (unsigned int i = 0; i < dim; i++)
           data.push_back(position[i]);
-      }
-
-      template <int dim>
-      InitializationModeForLateParticles
-      InitialPosition<dim>::late_initialization_mode () const
-      {
-        return interpolate;
       }
 
       template <int dim>

--- a/source/particle/property/integrated_strain.cc
+++ b/source/particle/property/integrated_strain.cc
@@ -29,8 +29,6 @@ namespace aspect
       template <int dim>
       void
       IntegratedStrain<dim>::initialize_one_particle_property(const Point<dim> &,
-                                                              const Vector<double> &,
-                                                              const std::vector<Tensor<1,dim> > &,
                                                               std::vector<double> &data) const
       {
         for (unsigned int i = 0; i < SymmetricTensor<2,dim>::n_independent_components ; ++i)

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -42,8 +42,6 @@ namespace aspect
       template <int dim>
       void
       Interface<dim>::initialize_one_particle_property (const Point<dim> &,
-                                                        const Vector<double> &,
-                                                        const std::vector<Tensor<1,dim> > &,
                                                         std::vector<double> &) const
       {}
 
@@ -67,7 +65,7 @@ namespace aspect
       InitializationModeForLateParticles
       Interface<dim>::late_initialization_mode () const
       {
-        return initialize_to_zero;
+        return interpolate;
       }
 
       template <int dim>
@@ -121,9 +119,7 @@ namespace aspect
 
       template <int dim>
       void
-      Manager<dim>::initialize_one_particle (Particle<dim> &particle,
-                                             const Vector<double> &solution,
-                                             const std::vector<Tensor<1,dim> > &gradients) const
+      Manager<dim>::initialize_one_particle (Particle<dim> &particle) const
       {
         std::vector<double> particle_properties (0);
         particle.set_n_property_components(n_property_components);
@@ -131,8 +127,6 @@ namespace aspect
              p = property_list.begin(); p!=property_list.end(); ++p)
           {
             (*p)->initialize_one_particle_property(particle.get_location(),
-                                                   solution,
-                                                   gradients,
                                                    particle_properties);
           }
 
@@ -149,9 +143,7 @@ namespace aspect
       void
       Manager<dim>::initialize_late_particle (Particle<dim> &particle,
                                               const std::multimap<types::LevelInd, Particle<dim> > &particles,
-                                              const Interpolator::Interface<dim> &interpolator,
-                                              const Vector<double> &solution,
-                                              const std::vector<Tensor<1,dim> > &gradients) const
+                                              const Interpolator::Interface<dim> &interpolator) const
       {
         std::vector<double> particle_properties (0);
 
@@ -171,8 +163,6 @@ namespace aspect
                 case aspect::Particle::Property::initialize:
                 {
                   (*p)->initialize_one_particle_property(particle.get_location(),
-                                                         solution,
-                                                         gradients,
                                                          particle_properties);
                   break;
                 }

--- a/source/particle/property/pT_path.cc
+++ b/source/particle/property/pT_path.cc
@@ -28,13 +28,11 @@ namespace aspect
     {
       template <int dim>
       void
-      PTPath<dim>::initialize_one_particle_property(const Point<dim> &,
-                                                    const Vector<double> &solution,
-                                                    const std::vector<Tensor<1,dim> > &,
+      PTPath<dim>::initialize_one_particle_property(const Point<dim> &position,
                                                     std::vector<double> &data) const
       {
-        data.push_back(solution[this->introspection().component_indices.pressure]);
-        data.push_back(solution[this->introspection().component_indices.temperature]);
+        data.push_back(this->get_adiabatic_conditions().pressure(position));
+        data.push_back(this->get_initial_conditions().initial_temperature(position));
       }
 
       template <int dim>

--- a/source/particle/property/position.cc
+++ b/source/particle/property/position.cc
@@ -29,8 +29,6 @@ namespace aspect
       template <int dim>
       void
       Position<dim>::initialize_one_particle_property(const Point<dim> &position,
-                                                      const Vector<double> &,
-                                                      const std::vector<Tensor<1,dim> > &,
                                                       std::vector<double> &data) const
       {
         for (unsigned int i = 0; i < dim; ++i)

--- a/source/particle/property/velocity.cc
+++ b/source/particle/property/velocity.cc
@@ -29,12 +29,10 @@ namespace aspect
       template <int dim>
       void
       Velocity<dim>::initialize_one_particle_property(const Point<dim> &,
-                                                      const Vector<double> &solution,
-                                                      const std::vector<Tensor<1,dim> > &,
                                                       std::vector<double> &data) const
       {
         for (unsigned int i = 0; i < dim; ++i)
-          data.push_back(solution[this->introspection().component_indices.velocities[i]]);
+          data.push_back(0.0);
       }
 
       template <int dim>

--- a/tests/particle_generator_ascii/particles/particles-00000.0000.vtu
+++ b/tests/particle_generator_ascii/particles/particles-00000.0000.vtu
@@ -19,7 +19,7 @@
         </DataArray>
         <DataArray type="Float64" Name="function" NumberOfComponents="1" Format="ascii">
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
         </DataArray>
         <DataArray type="Float64" Name="initial position" NumberOfComponents="3" Format="ascii">
         </DataArray>

--- a/tests/particle_generator_ascii/particles/particles-00000.0001.vtu
+++ b/tests/particle_generator_ascii/particles/particles-00000.0001.vtu
@@ -23,13 +23,13 @@
           0
         </DataArray>
         <DataArray type="Float64" Name="function" NumberOfComponents="1" Format="ascii">
-          0 
+          0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
-          6.97344e-14 
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
+          6.97775e-14
         </DataArray>
         <DataArray type="Float64" Name="initial position" NumberOfComponents="3" Format="ascii">
-          0.5 0.5 0 
+          0.5 0.5 0
         </DataArray>
       </PointData>
     </Piece>

--- a/tests/particle_generator_ascii/particles/particles-00000.0002.vtu
+++ b/tests/particle_generator_ascii/particles/particles-00000.0002.vtu
@@ -23,13 +23,13 @@
           1
         </DataArray>
         <DataArray type="Float64" Name="function" NumberOfComponents="1" Format="ascii">
-          0 
+          0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
-          0 
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
+          0
         </DataArray>
         <DataArray type="Float64" Name="initial position" NumberOfComponents="3" Format="ascii">
-          0.2 0.7 0 
+          0.2 0.7 0
         </DataArray>
       </PointData>
     </Piece>

--- a/tests/particle_generator_ascii/particles/particles-00000.0003.vtu
+++ b/tests/particle_generator_ascii/particles/particles-00000.0003.vtu
@@ -19,7 +19,7 @@
         </DataArray>
         <DataArray type="Float64" Name="function" NumberOfComponents="1" Format="ascii">
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
         </DataArray>
         <DataArray type="Float64" Name="initial position" NumberOfComponents="3" Format="ascii">
         </DataArray>

--- a/tests/particle_generator_ascii/particles/particles-00001.0000.vtu
+++ b/tests/particle_generator_ascii/particles/particles-00001.0000.vtu
@@ -19,7 +19,7 @@
         </DataArray>
         <DataArray type="Float64" Name="function" NumberOfComponents="1" Format="ascii">
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
         </DataArray>
         <DataArray type="Float64" Name="initial position" NumberOfComponents="3" Format="ascii">
         </DataArray>

--- a/tests/particle_generator_ascii/particles/particles-00001.0002.vtu
+++ b/tests/particle_generator_ascii/particles/particles-00001.0002.vtu
@@ -23,13 +23,13 @@
           1
         </DataArray>
         <DataArray type="Float64" Name="function" NumberOfComponents="1" Format="ascii">
-          0 
+          0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
-          0 
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
+          0
         </DataArray>
         <DataArray type="Float64" Name="initial position" NumberOfComponents="3" Format="ascii">
-          0.2 0.7 0 
+          0.2 0.7 0
         </DataArray>
       </PointData>
     </Piece>

--- a/tests/particle_generator_ascii/particles/particles-00001.0003.vtu
+++ b/tests/particle_generator_ascii/particles/particles-00001.0003.vtu
@@ -19,7 +19,7 @@
         </DataArray>
         <DataArray type="Float64" Name="function" NumberOfComponents="1" Format="ascii">
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
         </DataArray>
         <DataArray type="Float64" Name="initial position" NumberOfComponents="3" Format="ascii">
         </DataArray>

--- a/tests/particle_generator_box/particles/particles-00000.0000.vtu
+++ b/tests/particle_generator_box/particles/particles-00000.0000.vtu
@@ -84,7 +84,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           0.999984
           0.999969
           0.736536

--- a/tests/particle_generator_box/particles/particles-00001.0000.vtu
+++ b/tests/particle_generator_box/particles/particles-00001.0000.vtu
@@ -84,7 +84,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           0.999984
           0.999969
           0.736536

--- a/tests/particle_generator_box_3d/particles/particle-00000.0000.txt
+++ b/tests/particle_generator_box_3d/particles/particle-00000.0000.txt
@@ -1,4 +1,4 @@
-# position[0] position[1] position[2] id function initial C_0 initial position[0] initial position[1] initial position[2] 
+# position[0] position[1] position[2] id function initial C_1 initial position[0] initial position[1] initial position[2] 
 0.3 0.2 0.1 0 1 0.999984 0.3 0.2 0.1
 0.3 0.2 0.175 1 1 0.971475 0.3 0.2 0.175
 0.3 0.2 0.25 2 0 0.0184882 0.3 0.2 0.25

--- a/tests/particle_generator_box_3d/particles/particle-00001.0000.txt
+++ b/tests/particle_generator_box_3d/particles/particle-00001.0000.txt
@@ -1,4 +1,4 @@
-# position[0] position[1] position[2] id function initial C_0 initial position[0] initial position[1] initial position[2] 
+# position[0] position[1] position[2] id function initial C_1 initial position[0] initial position[1] initial position[2] 
 0.299541 0.2 0.101498 0 1 0.999984 0.3 0.2 0.1
 0.299482 0.2 0.174683 1 1 0.971475 0.3 0.2 0.175
 0.299668 0.2 0.245347 2 0 0.0184882 0.3 0.2 0.25

--- a/tests/particle_generator_radial/particles/particles-00000.0000.vtu
+++ b/tests/particle_generator_radial/particles/particles-00000.0000.vtu
@@ -85,7 +85,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           0.999997
           1
           0.990285

--- a/tests/particle_generator_radial/particles/particles-00001.0000.vtu
+++ b/tests/particle_generator_radial/particles/particles-00001.0000.vtu
@@ -85,7 +85,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           0.990285
           0.999997
           1

--- a/tests/particle_integrator_euler/particles/particles-00000.0000.vtu
+++ b/tests/particle_integrator_euler/particles/particles-00000.0000.vtu
@@ -79,7 +79,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           9.38694e-14
           1.26738e-09
           2.22036e-09

--- a/tests/particle_integrator_euler/particles/particles-00001.0000.vtu
+++ b/tests/particle_integrator_euler/particles/particles-00001.0000.vtu
@@ -79,7 +79,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           9.38694e-14
           1.26738e-09
           2.22036e-09

--- a/tests/particle_integrator_rk4/particles/particles-00000.0000.vtu
+++ b/tests/particle_integrator_rk4/particles/particles-00000.0000.vtu
@@ -79,7 +79,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           9.38694e-14
           1.26738e-09
           2.22036e-09

--- a/tests/particle_integrator_rk4/particles/particles-00001.0000.vtu
+++ b/tests/particle_integrator_rk4/particles/particles-00001.0000.vtu
@@ -79,7 +79,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           9.38694e-14
           2.22036e-09
           1.26738e-09

--- a/tests/particle_output_hdf5/particle.xdmf
+++ b/tests/particle_output_hdf5/particle.xdmf
@@ -22,9 +22,9 @@
             particles/particle-00000.h5:/id
           </DataItem>
         </Attribute>
-        <Attribute Name="initial C_0" AttributeType="Scalar" Center="Node">
+        <Attribute Name="initial C_1" AttributeType="Scalar" Center="Node">
           <DataItem Dimensions="10 1" NumberType="Float" Precision="8" Format="HDF">
-            particles/particle-00000.h5:/initial C_0
+            particles/particle-00000.h5:/initial C_1
           </DataItem>
         </Attribute>
         <Attribute Name="initial position" AttributeType="Vector" Center="Node">
@@ -52,9 +52,9 @@
             particles/particle-00001.h5:/id
           </DataItem>
         </Attribute>
-        <Attribute Name="initial C_0" AttributeType="Scalar" Center="Node">
+        <Attribute Name="initial C_1" AttributeType="Scalar" Center="Node">
           <DataItem Dimensions="10 1" NumberType="Float" Precision="8" Format="HDF">
-            particles/particle-00001.h5:/initial C_0
+            particles/particle-00001.h5:/initial C_1
           </DataItem>
         </Attribute>
         <Attribute Name="initial position" AttributeType="Vector" Center="Node">

--- a/tests/particle_periodic_boundaries/particles/particles-00000.0000.vtu
+++ b/tests/particle_periodic_boundaries/particles/particles-00000.0000.vtu
@@ -49,7 +49,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           1.70119e-07
           3.73385e-12
           1

--- a/tests/particle_periodic_boundaries/particles/particles-00000.0001.vtu
+++ b/tests/particle_periodic_boundaries/particles/particles-00000.0001.vtu
@@ -49,7 +49,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           0
           0
           2.5091e-14

--- a/tests/particle_periodic_boundaries/particles/particles-00001.0000.vtu
+++ b/tests/particle_periodic_boundaries/particles/particles-00001.0000.vtu
@@ -49,7 +49,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           1.70119e-07
           3.73385e-12
           1

--- a/tests/particle_periodic_boundaries/particles/particles-00001.0001.vtu
+++ b/tests/particle_periodic_boundaries/particles/particles-00001.0001.vtu
@@ -49,7 +49,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           0
           0
           2.5091e-14

--- a/tests/particle_property_function/particles/particles-00000.0000.vtu
+++ b/tests/particle_property_function/particles/particles-00000.0000.vtu
@@ -42,7 +42,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           5.20428e-11
           2.92932e-13
           4.63574e-13

--- a/tests/particle_property_function/particles/particles-00000.0001.vtu
+++ b/tests/particle_property_function/particles/particles-00000.0001.vtu
@@ -70,7 +70,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           0
           0
           0

--- a/tests/particle_property_function/particles/particles-00001.0000.vtu
+++ b/tests/particle_property_function/particles/particles-00001.0000.vtu
@@ -42,7 +42,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           5.20428e-11
           2.92932e-13
           4.63574e-13

--- a/tests/particle_property_function/particles/particles-00001.0001.vtu
+++ b/tests/particle_property_function/particles/particles-00001.0001.vtu
@@ -70,7 +70,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           0
           0
           0

--- a/tests/particle_property_initial_composition.prm
+++ b/tests/particle_property_initial_composition.prm
@@ -1,0 +1,110 @@
+# A description of the van Keken et al. benchmark using smooth initial
+# conditions instead of the discontinuous ones in
+# van-keken-discontinuous.prm. See the manual for more information.
+# This test adds tracers to the cookbook parameter file, and specifically tests
+# the particle property initial composition and its naming scheme
+
+# MPI: 2
+
+set Dimension                              = 2
+set End time                               = 70
+set Use years in output instead of seconds = false
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent  = 0.9142
+    set Y extent  = 1.0000
+  end
+end
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false
+  set Tangential velocity boundary indicators = left, right
+  set Zero velocity boundary indicators       = bottom, top
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Reference density             = 1010
+    set Viscosity                     = 1e2
+    set Thermal expansion coefficient = 0
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+############### Parameters describing the temperature field
+# Note: The temperature plays no role in this model
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+subsection Initial conditions
+  set Model name = function
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+
+############### Parameters describing the compositional field
+# Note: The compositional field is what drives the flow
+# in this example
+
+subsection Compositional fields
+  set Number of fields = 1
+  set Names of fields  = anomaly
+end
+
+subsection Compositional initial conditions
+  set Model name = function
+  subsection Function
+    set Variable names      = x,z
+    set Function constants  = pi=3.1415926
+    set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
+  end
+end
+
+subsection Material model
+  subsection Simple model
+    set Density differential for compositional field 1 = -10
+  end
+end
+
+
+############### Parameters describing the discretization
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Strategy                           = composition
+  set Initial global refinement          = 4
+  set Time steps between mesh refinement = 0
+  set Coarsening fraction                = 0.05
+  set Refinement fraction                = 0.3
+end
+
+
+
+############### Parameters describing what to do with the solution
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, composition statistics,tracers
+
+  subsection Tracers
+    set Number of tracers = 10
+    set Time between data output = 70
+    set Data output format = vtu
+    set List of tracer properties = initial composition
+  end
+end

--- a/tests/particle_property_initial_composition/particles.pvd
+++ b/tests/particle_property_initial_composition/particles.pvd
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--
+#This file was generated 
+-->
+<VTKFile type="Collection" version="0.1" ByteOrder="LittleEndian">
+  <Collection>
+    <DataSet timestep="0" group="" part="0" file="particles/particles-00000.pvtu"/>
+    <DataSet timestep="70" group="" part="0" file="particles/particles-00001.pvtu"/>
+  </Collection>
+</VTKFile>

--- a/tests/particle_property_initial_composition/particles/particles-00000.0000.vtu
+++ b/tests/particle_property_initial_composition/particles/particles-00000.0000.vtu
@@ -1,35 +1,53 @@
 <?xml version="1.0"?>
 <VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <UnstructuredGrid>
-    <Piece NumberOfPoints="1" NumberOfCells="1">
+    <Piece NumberOfPoints="5" NumberOfCells="5">
       <Points>
         <DataArray name="Position" type="Float64" NumberOfComponents="3" Format="ascii">
-          0.512935 0.493386 0.0
+          0.442382 0.356879 0.0
+          0.388042 0.467838 0.0
+          0.4865 0.0111377 0.0
+          0.617799 0.36825 0.0
+          0.695098 0.4761 0.0
         </DataArray>
       </Points>
       <Cells>
         <DataArray type="Int32" Name="connectivity" Format="ascii">
           0
+          1
+          2
+          3
+          4
         </DataArray>
         <DataArray type="Int32" Name="offsets" Format="ascii">
           1
+          2
+          3
+          4
+          5
         </DataArray>
         <DataArray type="UInt8" Name="types" Format="ascii">
+          1
+          1
+          1
+          1
           1
         </DataArray>
       </Cells>
       <PointData Scalars="scalars">
         <DataArray type="UInt64" Name="id" NumberOfComponents="1" Format="ascii">
           0
+          1
+          2
+          3
+          4
         </DataArray>
-        <DataArray type="Float64" Name="function" NumberOfComponents="1" Format="ascii">
-          0
-        </DataArray>
-        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
-          6.97775e-14
-        </DataArray>
-        <DataArray type="Float64" Name="initial position" NumberOfComponents="3" Format="ascii">
-          0.5 0.5 0
+        <DataArray type="Float64" Name="initial anomaly" NumberOfComponents="1" Format="ascii">
+          1.70119e-07
+          3.73385e-12
+          1
+          1.72729e-08
+          2.3731e-13
         </DataArray>
       </PointData>
     </Piece>

--- a/tests/particle_property_initial_composition/particles/particles-00000.0001.vtu
+++ b/tests/particle_property_initial_composition/particles/particles-00000.0001.vtu
@@ -1,35 +1,53 @@
 <?xml version="1.0"?>
 <VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <UnstructuredGrid>
-    <Piece NumberOfPoints="1" NumberOfCells="1">
+    <Piece NumberOfPoints="5" NumberOfCells="5">
       <Points>
         <DataArray name="Position" type="Float64" NumberOfComponents="3" Format="ascii">
-          0.512935 0.493386 0.0
+          0.442382 0.856879 0.0
+          0.388042 0.967838 0.0
+          0.4865 0.511138 0.0
+          0.617799 0.86825 0.0
+          0.695098 0.9761 0.0
         </DataArray>
       </Points>
       <Cells>
         <DataArray type="Int32" Name="connectivity" Format="ascii">
           0
+          1
+          2
+          3
+          4
         </DataArray>
         <DataArray type="Int32" Name="offsets" Format="ascii">
           1
+          2
+          3
+          4
+          5
         </DataArray>
         <DataArray type="UInt8" Name="types" Format="ascii">
+          1
+          1
+          1
+          1
           1
         </DataArray>
       </Cells>
       <PointData Scalars="scalars">
         <DataArray type="UInt64" Name="id" NumberOfComponents="1" Format="ascii">
+          5
+          6
+          7
+          8
+          9
+        </DataArray>
+        <DataArray type="Float64" Name="initial anomaly" NumberOfComponents="1" Format="ascii">
           0
-        </DataArray>
-        <DataArray type="Float64" Name="function" NumberOfComponents="1" Format="ascii">
           0
-        </DataArray>
-        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
-          6.97775e-14
-        </DataArray>
-        <DataArray type="Float64" Name="initial position" NumberOfComponents="3" Format="ascii">
-          0.5 0.5 0
+          2.5091e-14
+          0
+          0
         </DataArray>
       </PointData>
     </Piece>

--- a/tests/particle_property_initial_composition/particles/particles-00000.pvtu
+++ b/tests/particle_property_initial_composition/particles/particles-00000.pvtu
@@ -6,10 +6,7 @@
     </PPoints>
     <PPointData Scalars="scalars">
       <PDataArray type="UInt64" Name="id" NumberOfComponents="1" Format="ascii"/>
-      <PDataArray type="Float64" Name="velocity" NumberOfComponents="3" format="ascii"/>
-      <PDataArray type="Float64" Name="function" NumberOfComponents="1" format="ascii"/>
-      <PDataArray type="Float64" Name="initial C_1" NumberOfComponents="1" format="ascii"/>
-      <PDataArray type="Float64" Name="initial position" NumberOfComponents="3" format="ascii"/>
+      <PDataArray type="Float64" Name="initial anomaly" NumberOfComponents="1" format="ascii"/>
     </PPointData>
     <Piece Source="particles-00000.0000.vtu"/>
     <Piece Source="particles-00000.0001.vtu"/>

--- a/tests/particle_property_initial_composition/particles/particles-00001.0000.vtu
+++ b/tests/particle_property_initial_composition/particles/particles-00001.0000.vtu
@@ -1,35 +1,53 @@
 <?xml version="1.0"?>
 <VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <UnstructuredGrid>
-    <Piece NumberOfPoints="1" NumberOfCells="1">
+    <Piece NumberOfPoints="5" NumberOfCells="5">
       <Points>
         <DataArray name="Position" type="Float64" NumberOfComponents="3" Format="ascii">
-          0.512935 0.493386 0.0
+          0.444282 0.35251 0.0
+          0.400923 0.469248 0.0
+          0.480312 0.0111003 0.0
+          0.618859 0.35277 0.0
+          0.701754 0.459391 0.0
         </DataArray>
       </Points>
       <Cells>
         <DataArray type="Int32" Name="connectivity" Format="ascii">
           0
+          1
+          2
+          3
+          4
         </DataArray>
         <DataArray type="Int32" Name="offsets" Format="ascii">
           1
+          2
+          3
+          4
+          5
         </DataArray>
         <DataArray type="UInt8" Name="types" Format="ascii">
+          1
+          1
+          1
+          1
           1
         </DataArray>
       </Cells>
       <PointData Scalars="scalars">
         <DataArray type="UInt64" Name="id" NumberOfComponents="1" Format="ascii">
           0
+          1
+          2
+          3
+          4
         </DataArray>
-        <DataArray type="Float64" Name="function" NumberOfComponents="1" Format="ascii">
-          0
-        </DataArray>
-        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
-          6.97775e-14
-        </DataArray>
-        <DataArray type="Float64" Name="initial position" NumberOfComponents="3" Format="ascii">
-          0.5 0.5 0
+        <DataArray type="Float64" Name="initial anomaly" NumberOfComponents="1" Format="ascii">
+          1.70119e-07
+          3.73385e-12
+          1
+          1.72729e-08
+          2.3731e-13
         </DataArray>
       </PointData>
     </Piece>

--- a/tests/particle_property_initial_composition/particles/particles-00001.0001.vtu
+++ b/tests/particle_property_initial_composition/particles/particles-00001.0001.vtu
@@ -1,35 +1,53 @@
 <?xml version="1.0"?>
 <VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <UnstructuredGrid>
-    <Piece NumberOfPoints="1" NumberOfCells="1">
+    <Piece NumberOfPoints="5" NumberOfCells="5">
       <Points>
         <DataArray name="Position" type="Float64" NumberOfComponents="3" Format="ascii">
-          0.512935 0.493386 0.0
+          0.453815 0.856681 0.0
+          0.391371 0.967863 0.0
+          0.500202 0.505601 0.0
+          0.626477 0.866684 0.0
+          0.696704 0.976022 0.0
         </DataArray>
       </Points>
       <Cells>
         <DataArray type="Int32" Name="connectivity" Format="ascii">
           0
+          1
+          2
+          3
+          4
         </DataArray>
         <DataArray type="Int32" Name="offsets" Format="ascii">
           1
+          2
+          3
+          4
+          5
         </DataArray>
         <DataArray type="UInt8" Name="types" Format="ascii">
+          1
+          1
+          1
+          1
           1
         </DataArray>
       </Cells>
       <PointData Scalars="scalars">
         <DataArray type="UInt64" Name="id" NumberOfComponents="1" Format="ascii">
+          5
+          6
+          7
+          8
+          9
+        </DataArray>
+        <DataArray type="Float64" Name="initial anomaly" NumberOfComponents="1" Format="ascii">
           0
-        </DataArray>
-        <DataArray type="Float64" Name="function" NumberOfComponents="1" Format="ascii">
           0
-        </DataArray>
-        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
-          6.97775e-14
-        </DataArray>
-        <DataArray type="Float64" Name="initial position" NumberOfComponents="3" Format="ascii">
-          0.5 0.5 0
+          2.5091e-14
+          0
+          0
         </DataArray>
       </PointData>
     </Piece>

--- a/tests/particle_property_initial_composition/particles/particles-00001.pvtu
+++ b/tests/particle_property_initial_composition/particles/particles-00001.pvtu
@@ -6,10 +6,7 @@
     </PPoints>
     <PPointData Scalars="scalars">
       <PDataArray type="UInt64" Name="id" NumberOfComponents="1" Format="ascii"/>
-      <PDataArray type="Float64" Name="velocity" NumberOfComponents="3" format="ascii"/>
-      <PDataArray type="Float64" Name="function" NumberOfComponents="1" format="ascii"/>
-      <PDataArray type="Float64" Name="initial C_1" NumberOfComponents="1" format="ascii"/>
-      <PDataArray type="Float64" Name="initial position" NumberOfComponents="3" format="ascii"/>
+      <PDataArray type="Float64" Name="initial anomaly" NumberOfComponents="1" format="ascii"/>
     </PPointData>
     <Piece Source="particles-00001.0000.vtu"/>
     <Piece Source="particles-00001.0001.vtu"/>

--- a/tests/particle_property_initial_composition/screen-output
+++ b/tests/particle_property_initial_composition/screen-output
@@ -1,0 +1,34 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
+
+*** Timestep 0:  t=0 seconds
+   Skipping temperature solve because RHS is zero.
+   Solving anomaly system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+     RMS, max velocity:         0.000181 m/s, 0.000404 m/s
+     Compositions min/max/mass: 0/1/0.1825
+     Writing particle output:   output-particle_property_initial_composition/particles/particles-00000
+
+*** Timestep 1:  t=70 seconds
+   Skipping temperature solve because RHS is zero.
+   Solving anomaly system ... 16 iterations.
+   Solving Stokes system... 30+2 iterations.
+
+   Postprocessing:
+     RMS, max velocity:         0.000327 m/s, 0.000728 m/s
+     Compositions min/max/mass: -0.002207/1.002/0.1825
+     Writing particle output:   output-particle_property_initial_composition/particles/particles-00001
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/particle_property_initial_composition/statistics
+++ b/tests/particle_property_initial_composition/statistics
@@ -1,0 +1,21 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Number of degrees of freedom for all compositions
+# 7: Iterations for temperature solver
+# 8: Iterations for composition solver 1
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Time step size (seconds)
+# 13: RMS velocity (m/s)
+# 14: Max. velocity (m/s)
+# 15: Minimal value for composition anomaly
+# 16: Maximal value for composition anomaly
+# 17: Global mass for composition anomaly
+# 18: Number of advected particles
+# 19: Particle file name
+0 0.000000000000e+00 256 2467 1089 1089 0  0 32 18 9 7.000000000000e+01 1.81487742e-04 4.04466706e-04  0.00000000e+00 1.00000000e+00 1.82454287e-01 10 output-particle_property_initial_composition/output-particle_property_initial_composition/particles/particles-00000 
+1 7.000000000000e+01 256 2467 1089 1089 0 16 32 18 9 3.938220675571e+01 3.27312914e-04 7.27581707e-04 -2.20654270e-03 1.00187358e+00 1.82473299e-01 10 output-particle_property_initial_composition/output-particle_property_initial_composition/particles/particles-00001 

--- a/tests/van_keken_smooth_tracer/particles/particles-00000.0000.vtu
+++ b/tests/van_keken_smooth_tracer/particles/particles-00000.0000.vtu
@@ -79,7 +79,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           9.38694e-14
           1.26738e-09
           2.22036e-09

--- a/tests/van_keken_smooth_tracer/particles/particles-00001.0000.vtu
+++ b/tests/van_keken_smooth_tracer/particles/particles-00001.0000.vtu
@@ -79,7 +79,7 @@
           0
           0
         </DataArray>
-        <DataArray type="Float64" Name="initial C_0" NumberOfComponents="1" Format="ascii">
+        <DataArray type="Float64" Name="initial C_1" NumberOfComponents="1" Format="ascii">
           9.38694e-14
           2.22036e-09
           1.26738e-09


### PR DESCRIPTION
by treating particle properties as initial conditions. In particular by considering that the solution and the gradients of the solution at the time of the particle initialization only contain the initial condition anyway, and so it is much more sensible to call the initial conditions directly. This make the plugins easier to understand, and removes a lot of code. Contributes to #1069 