### PR TITLE
Add post_set_initial_state signal

### DIFF
--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -84,6 +84,14 @@ namespace aspect
     edit_finite_element_variables;
 
     /**
+     * A signal that is called after setting up the initial conditions.
+     *
+     * The functions (slots) that can attach to this signal need to take one
+     * argument: A SimulatorAccess object that descibes the simulator.
+     */
+    boost::signals2::signal<void (const SimulatorAccess<dim> &)>  post_set_initial_state;
+
+    /**
      * A signal that is called at the end of setting up the
      * constraints for the current time step. This allows to add
      * more constraints on degrees of freedom, for example to fix

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -2154,6 +2154,8 @@ namespace aspect
         compute_initial_pressure_field ();
         initialize_tracers ();
 
+        signals.post_set_initial_state (*this);
+
         computing_timer.exit_section();
       }
 


### PR DESCRIPTION
Adds a signal called after setting the initial state.

I am currently looking at moving the initialize_tracers logic into a connection to this signal.