### PR TITLE
Particle init signal

### DIFF
--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -88,6 +88,11 @@ namespace aspect
         get_property_manager() const;
 
         /**
+         * Do initial logic for handling pre-refinement steps
+         */
+        void setup_initial_state ();
+
+        /**
          * Initialize the particle properties.
          */
         void generate_particles();

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -154,6 +154,8 @@ namespace aspect
     void
     World<dim>::connect_to_signals(aspect::SimulatorSignals<dim> &signals)
     {
+      signals.post_set_initial_state.connect(std_cxx11::bind(&World<dim>::setup_initial_state,
+                                                             std_cxx11::ref(*this)));
       signals.pre_refinement_store_user_data.connect(std_cxx11::bind(&World<dim>::register_store_callback_function,
                                                                      std_cxx11::ref(*this),
                                                                      std_cxx11::_1));
@@ -1009,6 +1011,19 @@ namespace aspect
                                        old_result,
                                        result,
                                        this->get_old_timestep());
+    }
+
+    template <int dim>
+    void
+    World<dim>::setup_initial_state ()
+    {
+      // If we are in the first adaptive refinement cycle generate particles
+      if (this->get_pre_refinement_step() == 0)
+        generate_particles();
+
+      // And initialize the tracer properties according to the initial
+      // conditions on the current mesh
+      initialize_particles();
     }
 
     template <int dim>

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -2152,7 +2152,6 @@ namespace aspect
 
         set_initial_temperature_and_compositional_fields ();
         compute_initial_pressure_field ();
-        initialize_tracers ();
 
         signals.post_set_initial_state (*this);
 

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -174,27 +174,6 @@ namespace aspect
 
 
   template <int dim>
-  void Simulator<dim>::initialize_tracers ()
-  {
-    Postprocess::Tracers<dim> *tracer_postprocessor = const_cast<Postprocess::Tracers<dim> *>
-                                                      (postprocess_manager.template find_postprocessor<Postprocess::Tracers<dim> >());
-
-    // If the tracer postprocessor has been selected
-    if (tracer_postprocessor != 0)
-      {
-        // If we are in the first adaptive refinement cycle generate particles
-        if (pre_refinement_step == 0)
-          tracer_postprocessor->generate_particles();
-
-        // And initialize the tracer properties according to the initial
-        // conditions on the current mesh
-        tracer_postprocessor->initialize_particles();
-      }
-
-  }
-
-
-  template <int dim>
   void Simulator<dim>::compute_initial_pressure_field ()
   {
     // Note that this code will overwrite the velocity solution with 0 if
@@ -349,8 +328,7 @@ namespace aspect
 {
 #define INSTANTIATE(dim) \
   template void Simulator<dim>::set_initial_temperature_and_compositional_fields(); \
-  template void Simulator<dim>::compute_initial_pressure_field(); \
-  template void Simulator<dim>::initialize_tracers();
+  template void Simulator<dim>::compute_initial_pressure_field();
 
   ASPECT_INSTANTIATE(INSTANTIATE)
 }


### PR DESCRIPTION
Depends on pull request #1079.

Removes postprocessors scanning logic from initial conditions to instead use post_set_initial_state signal