### PR TITLE
Aspect alpha1

### DIFF
--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -641,7 +641,8 @@ namespace aspect
                            "Heister and Bangerth that describes ASPECT, see \\cite{KHB12}. "
                            "Rather, the paper always uses 2 as the exponent in the definition "
                            "of the entropy, following equation (15) of the paper. The full "
-                           "approach is discussed in \\cite{GPP11}.) "
+                           "approach is discussed in \\cite{GPP11}.) Note that this is not the "
+                           "thermal expansion coefficient, also commonly referred to as $\\alpha$."
                            "Units: None.");
         prm.declare_entry ("cR", "0.33",
                            Patterns::Double (0),
@@ -1436,7 +1437,6 @@ namespace aspect
     MaterialModel::declare_parameters<dim> (prm);
     HeatingModel::Manager<dim>::declare_parameters (prm);
     GeometryModel::declare_parameters <dim>(prm);
-    InitialTopographyModel::declare_parameters <dim>(prm);
     GravityModel::declare_parameters<dim> (prm);
     InitialConditions::declare_parameters<dim> (prm);
     CompositionalInitialConditions::declare_parameters<dim> (prm);


### PR DESCRIPTION
#989 Clarify that alpha is used for two different quantities. Disambiguation in parameter.cc ; add text clarifying that alpha (entropy viscosity stabilization) is not alpha (thermal expansion coefficient)
