### PR TITLE
Initial topography plugin prm polygon

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,12 @@
  *
  * <ol>
  *
+ * <li> New: There is now an initial topography plugin which reads 
+ * from the prm file polygon definitions and set the initial topography 
+ * to be constant within those polygons.
+ * <br>
+ * (Menno Fraters, 2016/07/26)
+ * 
  * <li> Changed: Particle initialization no longer routinely computes
  * the solution at the particle positions, since it is usually not needed
  * and complicates the initialization process. Instead it evaluates the 

--- a/include/aspect/geometry_model/initial_topography_model/prm_polygon.h
+++ b/include/aspect/geometry_model/initial_topography_model/prm_polygon.h
@@ -1,0 +1,80 @@
+/*
+  Copyright (C) 2016 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef __aspect__geometry_model__initial_topography_prm_polygon_h
+#define __aspect__geometry_model__initial_topography_prm_polygon_h
+
+#include <aspect/geometry_model/initial_topography_model/interface.h>
+
+
+namespace aspect
+{
+  namespace InitialTopographyModel
+  {
+    using namespace dealii;
+
+    /**
+     * A class that describes an initial topography for the geometry model,
+     * by defining a set of polygons on the surface from the prm file. It
+     * sets the elevation in each polygon to a constant value.
+     */
+    template <int dim>
+    class PrmPolygon : public Interface<dim>
+    {
+      public:
+        /**
+         * Return the value of the topography for a point.
+         */
+        virtual
+        double value (const Point<dim-1> &p) const;
+
+
+        /**
+         * Declare the parameters this class takes through input files.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         */
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
+
+      private:
+        /**
+         * The values of the topography are stored in a vector.
+         */
+        std::vector<double> topography_values;
+
+        /**
+         * The polygons and their points are stored in this vector.
+         */
+        std::vector<std::vector<Point<2> > > point_lists;
+
+    };
+  }
+}
+
+
+#endif

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -132,6 +132,15 @@ namespace aspect
     }
 
     /**
+     * Given a 2d point and a list of points which form a polygon, computes if the point
+     * falls within the polygon.
+     */
+    template <int dim>
+    bool
+    polygon_contains_point(const std::vector<Point<2> > &point_list,
+                           const dealii::Point<2> &point);
+
+    /**
      * Given a vector @p v in @p dim dimensional space, return a set
      * of (dim-1) vectors that are orthogonal to @p v and to each
      * other. The lengths of these vectors equals that of the original

--- a/source/geometry_model/initial_topography_model/prm_polygon.cc
+++ b/source/geometry_model/initial_topography_model/prm_polygon.cc
@@ -1,0 +1,160 @@
+/*
+  Copyright (C) 2016 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/geometry_model/initial_topography_model/prm_polygon.h>
+#include <aspect/utilities.h>
+#include <boost/lexical_cast.hpp>
+
+namespace aspect
+{
+  namespace InitialTopographyModel
+  {
+    template <int dim>
+    double
+    PrmPolygon<dim>::
+    value (const Point<dim-1> &p) const
+    {
+      Point<2> p1 = (dim == 2 ?Point<2>(p[0],0) : Point<2>(p[0],p[1]));
+
+      /**
+       * We go through the loop in the reverse order, because we
+       * want the last entry in the list to prescribe the value.
+       */
+      for (unsigned int i = point_lists.size(); i > 0; i--)
+        {
+          if (aspect::Utilities::polygon_contains_point<dim>(point_lists[i-1],p1))
+            {
+              return topography_values[i-1];
+            }
+        }
+
+      // Point is not in any of the polygons. Return zero.
+      return 0;
+    }
+
+
+
+    template <int dim>
+    void
+    PrmPolygon<dim>::
+    declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry model");
+      {
+        prm.enter_subsection("Initial topography model");
+        {
+          prm.enter_subsection("Prm polygon");
+          {
+            prm.declare_entry("Topography parameters",
+                              "",
+                              Patterns::Anything(),
+                              "Set the topography height and the polygon which should be set to that height. "
+                              "The format is : \"The topography height \textgreater The point list describing "
+                              "a polygon & The next topography height \textgreater the next point list "
+                              "describing a polygon.\" The format for the point list describing the polygon is "
+                              "\"x1,y1;x2,y2\". For example for two triangular areas of 100 and -100 meters high "
+                              "set: '100 \textgreater 0,0;5,5;0,10 & -100 \textgreater 10,10;10,15;20,15'. "
+                              "Units of the height are always in meters. The units of the coordinates are "
+                              "dependent on the geometry model. In the box model they are in meters, in the "
+                              "chunks they are in degrees, etc. Please refer to the manual of the individual "
+                              "geometry model to so see how the topography is implemented.");
+          }
+          prm.leave_subsection();
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+
+
+    template <int dim>
+    void
+    PrmPolygon<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry model");
+      {
+        prm.enter_subsection("Initial topography model");
+        {
+          prm.enter_subsection("Prm polygon");
+          {
+            /**
+             * we need to fill the point lists and topography values. They
+             * are stored in the Topography subsection in the Topography parameter.
+             */
+            const std::string temptopo = prm.get("Topography parameters");
+            const std::vector<std::string> temp_topographies = Utilities::split_string_list(temptopo,'&');
+            const unsigned int temp_topographies_size = temp_topographies.size();
+
+            topography_values.resize(temp_topographies_size,0);
+            point_lists.resize(temp_topographies_size);
+            for (unsigned int i_topo = 0; i_topo < temp_topographies_size; i_topo++)
+              {
+                const std::vector<std::string> temp_topography = Utilities::split_string_list(temp_topographies[i_topo],'>');
+                Assert(temp_topography.size() == 2,ExcMessage ("The given line '" + temp_topographies[i_topo]
+                                                               + "' is not correct. It consists of "
+                                                               + boost::lexical_cast<std::string>(temp_topography.size())
+                                                               + " parts separated by >, but it should only contain "
+                                                               "two parts: the height and the list of point coordinates,"
+                                                               " separated by a >.'"));
+
+                topography_values[i_topo] = Utilities::string_to_double(temp_topography[0]);
+
+                const std::vector<std::string> temp_coordinates = Utilities::split_string_list(temp_topography[1],';');
+                const unsigned int temp_coordinate_size = temp_coordinates.size();
+                point_lists[i_topo].resize(temp_coordinate_size);
+                for (unsigned int i_coord = 0; i_coord < temp_coordinate_size; i_coord++)
+                  {
+                    const std::vector<double> temp_point = Utilities::string_to_double(Utilities::split_string_list(temp_coordinates[i_coord],','));
+                    Assert(temp_point.size() == 2,ExcMessage ("The given coordinate '" + temp_coordinates[i_coord] + "' is not correct. "
+                                                              "It consists of " + boost::lexical_cast<std::string>(temp_topography.size())
+                                                              + " parts separated by :, but it should only contain 2 parts: "
+                                                              "the two coordinates of the polygon points, separated by a ','."));
+
+
+                    point_lists[i_topo][i_coord] = Point<2>(temp_point[0], temp_point[1]);
+                  }
+
+              }
+          }
+          prm.leave_subsection();
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace InitialTopographyModel
+  {
+    ASPECT_REGISTER_INITIAL_TOPOGRAPHY_MODEL(PrmPolygon,
+                                             "prm polygon",
+                                             "An initial topography model that defines the initial topography "
+                                             "as constant inside each of a set of polygonal parts of the "
+                                             "surface. The polygons, and their associated surface elevation, "
+                                             "are defined in the `Geometry model/Initial topography/Prm polygon' "
+                                             "section.")
+  }
+}

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -210,6 +210,62 @@ namespace aspect
     }
 
     template <int dim>
+    bool
+    polygon_contains_point(const std::vector<Point<2> > &point_list,
+                           const dealii::Point<2> &point)
+    {
+      /**
+       * This code has been based on http://geomalgorithms.com/a03-_inclusion.html,
+       * and therefore requires the following copyright notice:
+       *
+       * Copyright 2000 softSurfer, 2012 Dan Sunday
+       * This code may be freely used and modified for any purpose
+       * providing that this copyright notice is included with it.
+       * SoftSurfer makes no warranty for this code, and cannot be held
+       * liable for any real or imagined damage resulting from its use.
+       * Users of this code must verify correctness for their application.
+       *
+       * The main functional difference between the original code and this
+       * code is that all the boundaries are condidered to be inside the
+       * polygon.
+       */
+      int pointNo = point_list.size();
+      int    wn = 0;    // the  winding number counter
+      int   j=pointNo-1;
+
+
+      // loop through all edges of the polygon
+      for (int i=0; i<pointNo; i++)
+        {
+          // edge from V[i] to  V[i+1]
+          if (point_list[j][1] <= point[1])
+            {
+              // start y <= P.y
+              if (point_list[i][1]  >= point[1])      // an upward crossing
+                if (( (point_list[i][0] - point_list[j][0]) * (point[1] - point_list[j][1])
+                      - (point[0] -  point_list[j][0]) * (point_list[i][1] - point_list[j][1]) ) >= 0)
+                  {
+                    // P left of  edge
+                    ++wn;            // have  a valid up intersect
+                  }
+            }
+          else
+            {
+              // start y > P.y (no test needed)
+              if (point_list[i][1]  <= point[1])     // a downward crossing
+                if (( (point_list[i][0] - point_list[j][0]) * (point[1] - point_list[j][1])
+                      - (point[0] -  point_list[j][0]) * (point_list[i][1] - point_list[j][1]) ) <= 0)
+                  {
+                    // P right of  edge
+                    --wn;            // have  a valid down intersect
+                  }
+            }
+          j=i;
+        }
+      return (wn != 0);
+    }
+
+    template <int dim>
     std_cxx11::array<Tensor<1,dim>,dim-1>
     orthogonal_vectors (const Tensor<1,dim> &v)
     {
@@ -1431,8 +1487,13 @@ namespace aspect
     template std_cxx11::array<double,2> Coordinates::cartesian_to_spherical_coordinates<2>(const Point<2> &position);
     template std_cxx11::array<double,3> Coordinates::cartesian_to_spherical_coordinates<3>(const Point<3> &position);
 
+
     template std_cxx11::array<double,2> Coordinates::WGS84_coordinates<2>(const Point<2> &position);
     template std_cxx11::array<double,3> Coordinates::WGS84_coordinates<3>(const Point<3> &position);
+
+    template bool polygon_contains_point<2>(const std::vector<Point<2> > &pointList, const dealii::Point<2> &point);
+    template bool polygon_contains_point<3>(const std::vector<Point<2> > &pointList, const dealii::Point<2> &point);
+
 
     template std_cxx11::array<Tensor<1,2>,1> orthogonal_vectors (const Tensor<1,2> &v);
     template std_cxx11::array<Tensor<1,3>,2> orthogonal_vectors (const Tensor<1,3> &v);

--- a/tests/prm_polygon_in_out.cc
+++ b/tests/prm_polygon_in_out.cc
@@ -1,0 +1,43 @@
+#include <aspect/simulator.h>
+#include <aspect/geometry_model/initial_topography_model/interface.h>
+#include <aspect/geometry_model/initial_topography_model/prm_polygon.h>
+#include <aspect/simulator_access.h>
+
+#include <iostream>
+#include <typeinfo>
+
+int f()
+{
+  using namespace aspect;
+  const int dim=3;
+  std::string parameters = "100 > 0,0;5,0;5,5;0,5 & -100 > 10,10;10,15;15,15";
+  InitialTopographyModel::PrmPolygon<dim> topo;
+  ParameterHandler prm;
+  topo.declare_parameters(prm);
+  prm.enter_subsection("Geometry model");
+  prm.enter_subsection ("Initial topography model");
+  prm.enter_subsection ("Prm polygon");
+  prm.set ("Topography parameters", parameters);
+  prm.leave_subsection();
+  prm.leave_subsection();
+  prm.leave_subsection();
+
+  topo.parse_parameters(prm);
+
+  std::cout << "Testing prm polygon plugin with the following parameters: " << parameters << std::endl;
+  std::cout << "Topo at (-1,-1) = " << topo.value(Point<2>(-1,-1)) << std::endl;
+  std::cout << "Topo at (0,0) = " << topo.value(Point<2>(0,0)) << std::endl;
+  std::cout << "Topo at (0,5) = " << topo.value(Point<2>(0,5)) << std::endl;
+  std::cout << "Topo at (5,0) = " << topo.value(Point<2>(5,0)) << std::endl;
+  std::cout << "Topo at (5,5) = " << topo.value(Point<2>(5,5)) << std::endl;
+  std::cout << "Topo at (5,5.01) = " << topo.value(Point<2>(5,5.01)) << std::endl;
+  std::cout << "Topo at (1,1) = " << topo.value(Point<2>(1,1)) << std::endl;
+  std::cout << "Topo at (12.5,12) = " << topo.value(Point<2>(12.5,12)) << std::endl;
+  std::cout << "Topo at (11.5,12) = " << topo.value(Point<2>(11.5,12)) << std::endl;
+
+  exit(0);
+  return 42;
+}
+// run this function by initializing a global variable by it
+int i = f();
+

--- a/tests/prm_polygon_in_out.prm
+++ b/tests/prm_polygon_in_out.prm
@@ -1,0 +1,1 @@
+set Additional shared libraries = tests/libprm_polygon_in_out.so

--- a/tests/prm_polygon_in_out/screen-output
+++ b/tests/prm_polygon_in_out/screen-output
@@ -1,0 +1,14 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libprm_polygon_in_out.so>
+Testing prm polygon plugin with the following parameters: 100 > 0,0;5,0;5,5;0,5 & -100 > 10,10;10,15;15,15
+Topo at (-1,-1) = 0
+Topo at (0,0) = 100
+Topo at (0,5) = 100
+Topo at (5,0) = 100
+Topo at (5,5) = 100
+Topo at (5,5.01) = 0
+Topo at (1,1) = 100
+Topo at (12.5,12) = 0
+Topo at (11.5,12) = -100


### PR DESCRIPTION
This adds an initial topography plugin which defines the initial topography by defining 2d polygons on the surface and setting it to the desired elevation. After this I will update the ellipsoidal chunk and make a test out of this. Or should I do this within this pull request?