### PR TITLE
fix citation info

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -303,14 +303,24 @@ this software:
 Please also cite the User's Manual:
 \begin{lstlisting}[frame=single,language=tex]
 @Manual{aspectmanual,
-  title =        {\textsc{ASPECT}: Advanced Solver for Problems in Earth's
-                  ConvecTion v1.5.0}, 
-  author =       {W. Bangerth and J. Dannberg and 
-                  R. Gassm{\"o}ller and T. Heister and others},
+  title =        {\textsc{ASPECT}: {Advanced Solver for Problems in Earth's
+                  ConvecTion} v1.4.0}, 
+  author =       {W. Bangerth and T. Heister and others},
   organization = {Computational Infrastructure for Geodynamics},
   year =         2016
 }
 \end{lstlisting}
+
+%@Manual{aspectmanual,
+%  title =        {\textsc{ASPECT}: Advanced Solver for Problems in Earth's
+%                  ConvecTion v1.5.0}, 
+%  author =       {W. Bangerth and J. Dannberg and 
+%                  R. Gassm{\"o}ller and T. Heister and others},
+%  organization = {Computational Infrastructure for Geodynamics},
+%  year =         2016
+%}
+
+
 
 Updated citation information can also be found on the \aspect{}
 website at \url{https://aspect.dealii.org/}.


### PR DESCRIPTION
- we can not cite the manual 1.5.0 because it is not released yet and
might never be (if the next one is 2.0.0)
- fix capitalization

note: this is only an intermediate fix