### PR TITLE
Allow dynamic topography calculation from surface density contrast

### DIFF
--- a/include/aspect/postprocess/dynamic_topography.h
+++ b/include/aspect/postprocess/dynamic_topography.h
@@ -68,6 +68,7 @@ namespace aspect
          * we should subtract the mean topography or not.
          */
         bool subtract_mean_dyn_topography;
+        double density_above;
     };
   }
 }

--- a/include/aspect/postprocess/dynamic_topography.h
+++ b/include/aspect/postprocess/dynamic_topography.h
@@ -68,6 +68,10 @@ namespace aspect
          * we should subtract the mean topography or not.
          */
         bool subtract_mean_dyn_topography;
+
+        /**
+         * A parameter allows users to set the density value outside the surface
+         */
         double density_above;
     };
   }

--- a/include/aspect/postprocess/visualization/dynamic_topography.h
+++ b/include/aspect/postprocess/visualization/dynamic_topography.h
@@ -89,6 +89,11 @@ namespace aspect
            * we should subtract the mean topography or not.
            */
           bool subtract_mean_dyn_topography;
+
+          /**
+           * A parameter allows users to set the density value outside the surface
+           */
+          double density_above;
       };
     }
   }

--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -259,10 +259,12 @@ namespace aspect
                              "the calculated dynamic topography as is. ");
           prm.declare_entry ("Density above","0",
                              Patterns::Double (0),
-                             "Dynamic topography is calculated from the density contrast throughout the surface. "
-                             "This parameter allows users to specify the density value out of the surface boundary, "
-                             "and the surface density contrast at each location is the density difference between "
-                             "the corresponding quadrature point and this outside density value. "
+                             "Dynamic topography is calculated as the excess or lack of mass that is supported by mantle flow. "
+                             "This value depends on the density of material that is moved up or down, i.e. crustal rock, and the "
+                             "density of the material that is displaced (generally water or air). While the density of crustal rock "
+                             "is part of the material model, this parameter 'density_above' allows the user to specify the density "
+                             "value of material that is displaced above the solid surface. By default this material is assumed to "
+                             "be air, with a density of 0. "
                              "Units: $kg/m^3$.");
         }
         prm.leave_subsection();

--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -259,7 +259,11 @@ namespace aspect
                              "the calculated dynamic topography as is. ");
           prm.declare_entry ("Density above","0",
                              Patterns::Double (0),
-                             "The density value out of the surface boundary.");
+                             "Dynamic topography is calculated from the density contrast throughout the surface. "
+                             "This parameter allows users to specify the density value out of the surface boundary, "
+                             "and the surface density contrast at each location is the density difference between "
+                             "the corresponding quadrature point and this outside density value. "
+                             "Units: $kg/m^3$.");
         }
         prm.leave_subsection();
       }

--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -262,7 +262,7 @@ namespace aspect
                              "Dynamic topography is calculated as the excess or lack of mass that is supported by mantle flow. "
                              "This value depends on the density of material that is moved up or down, i.e. crustal rock, and the "
                              "density of the material that is displaced (generally water or air). While the density of crustal rock "
-                             "is part of the material model, this parameter 'density_above' allows the user to specify the density "
+                             "is part of the material model, this parameter 'Density_above' allows the user to specify the density "
                              "value of material that is displaced above the solid surface. By default this material is assumed to "
                              "be air, with a density of 0. "
                              "Units: $kg/m^3$.");

--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -262,7 +262,7 @@ namespace aspect
                              "Dynamic topography is calculated as the excess or lack of mass that is supported by mantle flow. "
                              "This value depends on the density of material that is moved up or down, i.e. crustal rock, and the "
                              "density of the material that is displaced (generally water or air). While the density of crustal rock "
-                             "is part of the material model, this parameter 'Density_above' allows the user to specify the density "
+                             "is part of the material model, this parameter 'Density above' allows the user to specify the density "
                              "value of material that is displaced above the solid surface. By default this material is assumed to "
                              "be air, with a density of 0. "
                              "Units: $kg/m^3$.");

--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -140,7 +140,7 @@ namespace aspect
                   // Subtract the dynamic pressure
                   const double dynamic_pressure   = in.pressure[q] - this->get_adiabatic_conditions().pressure(location);
                   const double sigma_rr           = gravity_direction * (shear_stress * gravity_direction) - dynamic_pressure;
-                  const double dynamic_topography = - sigma_rr / gravity.norm() / density;
+                  const double dynamic_topography = - sigma_rr / gravity.norm() / (density - density_above);
 
                   // JxW provides the volume quadrature weights. This is a general formulation
                   // necessary for when a quadrature formula is used that has more than one point.
@@ -257,7 +257,9 @@ namespace aspect
                              "in the outputted data file (not visualization). "
                              "'true' subtracts the mean, 'false' leaves "
                              "the calculated dynamic topography as is. ");
-
+          prm.declare_entry ("Density above","0",
+                             Patterns::Double (0),
+                             "The density value out of the surface boundary.");
         }
         prm.leave_subsection();
       }
@@ -273,6 +275,7 @@ namespace aspect
         prm.enter_subsection("Dynamic Topography");
         {
           subtract_mean_dyn_topography = prm.get_bool("Subtract mean of dynamic topography");
+          density_above = prm.get_double ("Density above");
         }
         prm.leave_subsection();
       }

--- a/source/postprocess/visualization/dynamic_topography.cc
+++ b/source/postprocess/visualization/dynamic_topography.cc
@@ -212,7 +212,7 @@ namespace aspect
                                  "Dynamic topography is calculated as the excess or lack of mass that is supported by mantle flow. "
                                  "This value depends on the density of material that is moved up or down, i.e. crustal rock, and the "
                                  "density of the material that is displaced (generally water or air). While the density of crustal rock "
-                                 "is part of the material model, this parameter 'density_above' allows the user to specify the density "
+                                 "is part of the material model, this parameter 'Density_above' allows the user to specify the density "
                                  "value of material that is displaced above the solid surface. By default this material is assumed to "
                                  "be air, with a density of 0. "
                                  "Units: $kg/m^3$.");

--- a/source/postprocess/visualization/dynamic_topography.cc
+++ b/source/postprocess/visualization/dynamic_topography.cc
@@ -143,7 +143,7 @@ namespace aspect
                     // Subtract the dynamic pressure
                     const double dynamic_pressure   = in.pressure[q] - this->get_adiabatic_conditions().pressure(location);
                     const double sigma_rr           = gravity_direction * (shear_stress * gravity_direction) - dynamic_pressure;
-                    const double dynamic_topography = - sigma_rr / gravity.norm() / density;
+                    const double dynamic_topography = - sigma_rr / gravity.norm() / (density - density_above);
 
                     // JxW provides the volume quadrature weights. This is a general formulation
                     // necessary for when a quadrature formula is used that has more than one point.
@@ -207,7 +207,9 @@ namespace aspect
                                  "in the outputted data file (not visualization). "
                                  "'true' subtracts the mean, 'false' leaves "
                                  "the calculated dynamic topography as is. ");
-
+              prm.declare_entry ("Density above","0",
+                                 Patterns::Double (0),
+                                 "The density value out of the surface boundary.");
             }
             prm.leave_subsection();
           }
@@ -228,6 +230,7 @@ namespace aspect
             prm.enter_subsection("Dynamic Topography");
             {
               subtract_mean_dyn_topography              = prm.get_bool("Subtract mean of dynamic topography");
+              density_above = prm.get_double ("Density above");
             }
             prm.leave_subsection();
           }

--- a/source/postprocess/visualization/dynamic_topography.cc
+++ b/source/postprocess/visualization/dynamic_topography.cc
@@ -212,7 +212,7 @@ namespace aspect
                                  "Dynamic topography is calculated as the excess or lack of mass that is supported by mantle flow. "
                                  "This value depends on the density of material that is moved up or down, i.e. crustal rock, and the "
                                  "density of the material that is displaced (generally water or air). While the density of crustal rock "
-                                 "is part of the material model, this parameter 'Density_above' allows the user to specify the density "
+                                 "is part of the material model, this parameter 'Density above' allows the user to specify the density "
                                  "value of material that is displaced above the solid surface. By default this material is assumed to "
                                  "be air, with a density of 0. "
                                  "Units: $kg/m^3$.");

--- a/source/postprocess/visualization/dynamic_topography.cc
+++ b/source/postprocess/visualization/dynamic_topography.cc
@@ -209,7 +209,11 @@ namespace aspect
                                  "the calculated dynamic topography as is. ");
               prm.declare_entry ("Density above","0",
                                  Patterns::Double (0),
-                                 "The density value out of the surface boundary.");
+                                 "Dynamic topography is calculated from the density contrast throughout the surface. "
+                                 "This parameter allows users to specify the density value out of the surface boundary, "
+                                 "and the surface density contrast at each location is the density difference between "
+                                 "the corresponding quadrature point and this outside density value. "
+                                 "Units: $kg/m^3$.");
             }
             prm.leave_subsection();
           }

--- a/source/postprocess/visualization/dynamic_topography.cc
+++ b/source/postprocess/visualization/dynamic_topography.cc
@@ -209,10 +209,12 @@ namespace aspect
                                  "the calculated dynamic topography as is. ");
               prm.declare_entry ("Density above","0",
                                  Patterns::Double (0),
-                                 "Dynamic topography is calculated from the density contrast throughout the surface. "
-                                 "This parameter allows users to specify the density value out of the surface boundary, "
-                                 "and the surface density contrast at each location is the density difference between "
-                                 "the corresponding quadrature point and this outside density value. "
+                                 "Dynamic topography is calculated as the excess or lack of mass that is supported by mantle flow. "
+                                 "This value depends on the density of material that is moved up or down, i.e. crustal rock, and the "
+                                 "density of the material that is displaced (generally water or air). While the density of crustal rock "
+                                 "is part of the material model, this parameter 'density_above' allows the user to specify the density "
+                                 "value of material that is displaced above the solid surface. By default this material is assumed to "
+                                 "be air, with a density of 0. "
                                  "Units: $kg/m^3$.");
             }
             prm.leave_subsection();


### PR DESCRIPTION
Sometimes we want to compute dynamic topography underneath ocean or other surface geological body. This needs the density contrast throughout the top boundary instead of only density value of the top cell. I set the default value of outside density to zero.