### PR TITLE
Allow using AsciiDataBoundary as member variable

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -459,32 +459,14 @@ namespace aspect
          */
         AsciiDataBoundary();
 
-      protected:
-
         /**
-         * Initialization function. This function is called once at the
-         * beginning of the program. Checks preconditions.
-         */
+          * Initialization function. This function is called once at the
+          * beginning of the program. Checks preconditions.
+          */
         virtual
         void
         initialize (const std::set<types::boundary_id> &boundary_ids,
                     const unsigned int components);
-
-        /**
-         * Determines which of the dimensions of the position is used to find
-         * the data point in the data grid. E.g. the left boundary of a box
-         * model extents in the y and z direction (position[1] and
-         * position[2]), therefore the function would return [1,2] for dim==3
-         * or [1] for dim==2. We are lucky that these indices are identical
-         * for the box and the spherical shell (if we use spherical
-         * coordinates for the spherical shell), therefore we do not need to
-         * distinguish between them. For the initial condition this function
-         * is trivial, because the position in the data grid is the same as
-         * the actual position (the function returns [0,1,2] or [0,1]), but
-         * for the boundary conditions it matters.
-         */
-        std_cxx11::array<unsigned int,dim-1>
-        get_boundary_dimensions (const types::boundary_id boundary_id) const;
 
         /**
          * A function that is called at the beginning of each time step. For
@@ -502,6 +484,39 @@ namespace aspect
         get_data_component (const types::boundary_id             boundary_indicator,
                             const Point<dim>                    &position,
                             const unsigned int                   component) const;
+
+        /**
+         * Declare the parameters all derived classes take from input files.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler  &prm,
+                            const std::string &default_directory,
+                            const std::string &default_filename);
+
+        /**
+         * Read the parameters from the parameter file.
+         */
+        void
+        parse_parameters (ParameterHandler &prm);
+
+      protected:
+
+        /**
+         * Determines which of the dimensions of the position is used to find
+         * the data point in the data grid. E.g. the left boundary of a box
+         * model extents in the y and z direction (position[1] and
+         * position[2]), therefore the function would return [1,2] for dim==3
+         * or [1] for dim==2. We are lucky that these indices are identical
+         * for the box and the spherical shell (if we use spherical
+         * coordinates for the spherical shell), therefore we do not need to
+         * distinguish between them. For the initial condition this function
+         * is trivial, because the position in the data grid is the same as
+         * the actual position (the function returns [0,1,2] or [0,1]), but
+         * for the boundary conditions it matters.
+         */
+        std_cxx11::array<unsigned int,dim-1>
+        get_boundary_dimensions (const types::boundary_id boundary_id) const;
 
         /**
          * A variable that stores the currently used data file of a series. It
@@ -584,22 +599,6 @@ namespace aspect
         std::string
         create_filename (const int timestep,
                          const types::boundary_id boundary_id) const;
-
-
-        /**
-         * Declare the parameters all derived classes take from input files.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler  &prm,
-                            const std::string &default_directory,
-                            const std::string &default_filename);
-
-        /**
-         * Read the parameters from the parameter file.
-         */
-        void
-        parse_parameters (ParameterHandler &prm);
     };
 
     /**

--- a/tests/ascii_boundary_member.cc
+++ b/tests/ascii_boundary_member.cc
@@ -1,0 +1,192 @@
+#include <aspect/velocity_boundary_conditions/interface.h>
+#include <aspect/utilities.h>
+#include <aspect/global.h>
+
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/function_lib.h>
+#include <deal.II/numerics/error_estimator.h>
+#include <deal.II/numerics/vector_tools.h>
+
+
+
+namespace aspect
+{
+  using namespace dealii;
+  /**
+   * A boundary velocity plugin that uses an AsciiDataBoundary object as member
+   */
+  template <int dim>
+  class AsciiBoundaryMember : public VelocityBoundaryConditions::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+  {
+    public:
+      /**
+       * Empty Constructor.
+       */
+      AsciiBoundaryMember ();
+
+      /**
+       * Initialization function. This function is called once at the
+       * beginning of the program. Checks preconditions.
+       */
+      void
+      initialize ();
+
+      /**
+       * A function that is called at the beginning of each time step. For
+       * the current plugin, this function loads the next data files if
+       * necessary and outputs a warning if the end of the set of data files
+       * is reached.
+       */
+      void
+      update ();
+
+      /**
+       * Return the boundary velocity as a function of position. For the
+       * current class, this function returns value from the text files.
+       */
+      Tensor<1,dim>
+      boundary_velocity (const types::boundary_id boundary_indicator,
+                         const Point<dim> &position) const;
+
+      /**
+       * Declare the parameters this class takes through input files.
+       */
+      static
+      void
+      declare_parameters (ParameterHandler &prm);
+
+      /**
+       * Read the parameters this class declares from the parameter file.
+       */
+      void
+      parse_parameters (ParameterHandler &prm);
+
+      std_cxx11::shared_ptr<Utilities::AsciiDataBoundary<dim> > member;
+
+      std::set<types::boundary_id> boundary_ids;
+  };
+
+  template <int dim>
+  AsciiBoundaryMember<dim>::AsciiBoundaryMember ()
+  {}
+
+
+  template <int dim>
+  void
+  AsciiBoundaryMember<dim>::initialize ()
+  {
+    const std::map<types::boundary_id,std_cxx11::shared_ptr<VelocityBoundaryConditions::Interface<dim> > >
+    bvs = this->get_prescribed_velocity_boundary_conditions();
+    for (typename std::map<types::boundary_id,std_cxx11::shared_ptr<VelocityBoundaryConditions::Interface<dim> > >::const_iterator
+         p = bvs.begin();
+         p != bvs.end(); ++p)
+      {
+        if (p->second.get() == this)
+          boundary_ids.insert(p->first);
+      }
+    AssertThrow(*(boundary_ids.begin()) != numbers::invalid_boundary_id,
+                ExcMessage("Did not find the boundary indicator for the prescribed data plugin."));
+
+    member->initialize(boundary_ids,
+                       dim);
+  }
+
+  template <int dim>
+  void
+  AsciiBoundaryMember<dim>::update ()
+  {
+    member->update();
+  }
+
+
+  template <int dim>
+  Tensor<1,dim>
+  AsciiBoundaryMember<dim>::
+  boundary_velocity (const types::boundary_id ,
+                     const Point<dim> &position) const
+  {
+    Tensor<1,dim> velocity;
+    for (unsigned int i = 0; i < dim; i++)
+      velocity[i] = member->get_data_component(*(boundary_ids.begin()),
+                                               position,
+                                               i);
+    return velocity;
+  }
+
+
+  template <int dim>
+  void
+  AsciiBoundaryMember<dim>::declare_parameters (ParameterHandler &prm)
+  {
+    prm.enter_subsection("Boundary velocity model");
+    {
+      Utilities::AsciiDataBoundary<dim>::declare_parameters(prm,
+                                                            "$ASPECT_SOURCE_DIR/data/velocity-boundary-conditions/ascii-data/test/",
+                                                            "box_2d_%s.%d.txt");
+    }
+    prm.leave_subsection();
+  }
+
+
+  template <int dim>
+  void
+  AsciiBoundaryMember<dim>::parse_parameters (ParameterHandler &prm)
+  {
+    prm.enter_subsection("Boundary velocity model");
+    {
+      member.reset(new Utilities::AsciiDataBoundary<dim>);
+      member->initialize_simulator(this->get_simulator());
+
+      member->parse_parameters(prm);
+
+      if (this->convert_output_to_years() == true)
+        {
+          member->scale_factor               /= year_in_seconds;
+        }
+
+    }
+    prm.leave_subsection();
+  }
+
+}
+
+
+
+// explicit instantiations
+namespace aspect
+{
+  ASPECT_REGISTER_VELOCITY_BOUNDARY_CONDITIONS(AsciiBoundaryMember,
+                                               "ascii boundary member",
+                                               "Implementation of a model in which the boundary "
+                                               "velocity is derived from files containing data "
+                                               "in ascii format. Note the required format of the "
+                                               "input data: The first lines may contain any number of comments "
+                                               "if they begin with '#', but one of these lines needs to "
+                                               "contain the number of grid points in each dimension as "
+                                               "for example '# POINTS: 3 3'. "
+                                               "The order of the data columns "
+                                               "has to be 'x', 'velocity_x', 'velocity_y' in a 2d model "
+                                               "or 'x', 'y', 'velocity_x', 'velocity_y', "
+                                               "'velocity_z' in a 3d model. "
+                                               "Note that the data in the input "
+                                               "files need to be sorted in a specific order: "
+                                               "the first coordinate needs to ascend first, "
+                                               "followed by the second in order to "
+                                               "assign the correct data to the prescribed coordinates."
+                                               "If you use a spherical model, "
+                                               "then the velocities will still be handled as Cartesian, "
+                                               "however the assumed grid changes. 'x' will be replaced by "
+                                               "the radial distance of the point to the bottom of the model, "
+                                               "'y' by the azimuth angle and 'z' by the polar angle measured "
+                                               "positive from the north pole. The grid will be assumed to be "
+                                               "a latitude-longitude grid. Note that the order "
+                                               "of spherical coordinates is 'r', 'phi', 'theta' "
+                                               "and not 'r', 'theta', 'phi', since this allows "
+                                               "for dimension independent expressions. "
+                                               "No matter which geometry model is chosen, "
+                                               "the unit of the velocities is assumed to be "
+                                               "m/s or m/yr depending on the 'Use years in output "
+                                               "instead of seconds' flag.")
+}

--- a/tests/ascii_boundary_member.prm
+++ b/tests/ascii_boundary_member.prm
@@ -1,0 +1,85 @@
+##### simple test for ascii data
+
+set Dimension                              = 2
+
+set Use years in output instead of seconds = true
+set End time                               = 1e6
+
+set Adiabatic surface temperature          = 1613.0
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 3300000
+    set Y extent = 660000
+    set X repetitions = 5
+  end
+end
+
+subsection Initial conditions
+  set Model name = adiabatic
+  subsection Adiabatic
+    set Amplitude = 300
+    set Radius    = 250000
+  end
+end
+
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = top,bottom
+
+  set Zero velocity boundary indicators       =
+  set Prescribed velocity boundary indicators = bottom:ascii boundary member,left: ascii boundary member,right: ascii boundary member,top: ascii boundary member
+
+  set Tangential velocity boundary indicators = 
+
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false
+end
+
+
+subsection Boundary velocity model
+  subsection Ascii data model
+    set Data file name       = box_2d_%s.0.txt
+    
+    set Data directory = $ASPECT_SOURCE_DIR/data/velocity-boundary-conditions/ascii-data/test/
+    set Scale factor = 0.01
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Viscosity = 1e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 2
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+  set Strategy                                 = temperature
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics
+end
+

--- a/tests/ascii_boundary_member/screen-output
+++ b/tests/ascii_boundary_member/screen-output
@@ -1,0 +1,61 @@
+
+Loading shared library <./libascii_boundary_member.so>
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/velocity-boundary-conditions/ascii-data/test/box_2d_left.0.txt.
+
+
+   Loading new data file did not succeed.
+   Assuming constant boundary conditions for rest of model run.
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/velocity-boundary-conditions/ascii-data/test/box_2d_right.0.txt.
+
+
+   Loading new data file did not succeed.
+   Assuming constant boundary conditions for rest of model run.
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/velocity-boundary-conditions/ascii-data/test/box_2d_bottom.0.txt.
+
+
+   Loading new data file did not succeed.
+   Assuming constant boundary conditions for rest of model run.
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/velocity-boundary-conditions/ascii-data/test/box_2d_top.0.txt.
+
+
+   Loading new data file did not succeed.
+   Assuming constant boundary conditions for rest of model run.
+
+Number of active cells: 80 (on 3 levels)
+Number of degrees of freedom: 1,212 (738+105+369)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+11 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.00616 m/year, 0.0156 m/year
+     Temperature min/avg/max:            0 K, 1488 K, 1913 K
+     Heat fluxes through boundary parts: 1.046e-11 W, -7.474e-13 W, 4.647e+05 W, 4.549e+05 W
+
+*** Timestep 1:  t=1e+06 years
+   Solving temperature system... 9 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+6 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.00627 m/year, 0.0157 m/year
+     Temperature min/avg/max:            0 K, 1478 K, 1977 K
+     Heat fluxes through boundary parts: 2.239 W, 3.621 W, 4.518e+05 W, 4.358e+05 W
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/ascii_boundary_member/statistics
+++ b/tests/ascii_boundary_member/statistics
@@ -1,0 +1,21 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Iterations for temperature solver
+# 7: Iterations for Stokes solver
+# 8: Velocity iterations in Stokes preconditioner
+# 9: Schur complement iterations in Stokes preconditioner
+# 10: Time step size (years)
+# 11: RMS velocity (m/year)
+# 12: Max. velocity (m/year)
+# 13: Minimal temperature (K)
+# 14: Average temperature (K)
+# 15: Maximal temperature (K)
+# 16: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 17: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 18: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 19: Outward heat flux through boundary with indicator 3 ("top") (W)
+0 0.000000000000e+00 80 843 369 0 41 36 12 1.000000000000e+06 6.16429348e-03 1.56267177e-02 0.00000000e+00 1.48816667e+03 1.91300000e+03 1.12106505e-11 0.00000000e+00 4.64736000e+05 4.54866000e+05 
+1 1.000000000000e+06 80 843 369 9 36 21  7 5.255443634611e+06 6.26605998e-03 1.57218695e-02 0.00000000e+00 1.47834072e+03 1.97657259e+03 2.23856596e+00 3.62092262e+00 4.51848663e+05 4.35816356e+05 


### PR DESCRIPTION
This PR closes #857 and is useful for user plugins that want to keep around an object of type AsciiDataBoundary for lookup purposes.