### PR TITLE
Move apply_limiter_to_dg_solutions to solver.cc

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1781,10 +1781,6 @@ namespace aspect
           assemble_advection_system (AdvectionField::temperature());
           solve_advection(AdvectionField::temperature());
 
-          if (parameters.use_discontinuous_temperature_discretization
-              && parameters.use_limiter_for_discontinuous_temperature_solution)
-            apply_limiter_to_dg_solutions(AdvectionField::temperature());
-
           current_linearization_point.block(introspection.block_indices.temperature)
             = solution.block(introspection.block_indices.temperature);
 
@@ -1792,9 +1788,6 @@ namespace aspect
             {
               assemble_advection_system (AdvectionField::composition(c));
               solve_advection(AdvectionField::composition(c));
-              if (parameters.use_discontinuous_composition_discretization
-                  && parameters.use_limiter_for_discontinuous_composition_solution)
-                apply_limiter_to_dg_solutions(AdvectionField::composition(c));
             }
 
           for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1013,12 +1013,6 @@ namespace aspect
           = prm.get_bool("Use limiter for discontinuous temperature solution");
         use_limiter_for_discontinuous_composition_solution
           = prm.get_bool("Use limiter for discontinuous composition solution");
-        if (use_limiter_for_discontinuous_temperature_solution
-            || use_limiter_for_discontinuous_composition_solution)
-          AssertThrow (nonlinear_solver == NonlinearSolver::IMPES,
-                       ExcMessage ("The bound preserving limiter currently is "
-                                   "only implemented for the scheme using IMPES nonlinear solver. "
-                                   "Please deactivate the limiter or change the solver scheme."));
         global_temperature_max_preset       = prm.get_double ("Global temperature maximum");
         global_temperature_min_preset       = prm.get_double ("Global temperature minimum");
         global_composition_max_preset       = Utilities::string_to_double

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -497,6 +497,15 @@ namespace aspect
                            Utilities::int_to_string(advection_field.compositional_variable+1),
                            solver_control.last_step());
 
+    if ((advection_field.is_temperature()
+         && parameters.use_discontinuous_temperature_discretization
+         && parameters.use_limiter_for_discontinuous_temperature_solution)
+        ||
+        (!advection_field.is_temperature()
+         && parameters.use_discontinuous_composition_discretization
+         && parameters.use_limiter_for_discontinuous_composition_solution))
+      apply_limiter_to_dg_solutions(advection_field);
+
     computing_timer.exit_section();
 
     return initial_residual;


### PR DESCRIPTION
Currently  the function " apply_limiter_to_dg_solutions "  is implemented inside the core.cc, and only for the nonlinear solver IMPES. In order to be applied to other nonlinear solver, it's better to move it inside the solver.cc  