### PR TITLE
Moving this include to avoid MPICH error.

### DIFF
--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -17,8 +17,6 @@
   along with ASPECT; see the file doc/COPYING.  If not see
   <http://www.gnu.org/licenses/>.
 */
-#include <boost/math/special_functions/spherical_harmonic.hpp>
-
 #include <aspect/global.h>
 #include <aspect/utilities.h>
 
@@ -39,6 +37,8 @@
 #include <string>
 #include <sys/stat.h>
 #include <errno.h>
+
+#include <boost/math/special_functions/spherical_harmonic.hpp>
 
 namespace aspect
 {


### PR DESCRIPTION
John Rudge reported to me that compiling with icc and mpich2 causes a SEEK_SET issue (I have seen similar issues with Trilinos, but not with ASPECT previously). The bug is documented here:

https://wiki.mpich.org/mpich/index.php/Frequently_Asked_Questions#Q:_I_get_compile_errors_saying_.22SEEK_SET_is_.23defined_but_must_not_be_for_the_C.2B.2B_binding_of_MPI.22.

I have not reproduced this myself, but apparently moving the `boost` include further down fixes the issue.