### PR TITLE
Fix indentation of test file.

### DIFF
--- a/tests/resume_free_surface.cc
+++ b/tests/resume_free_surface.cc
@@ -7,64 +7,64 @@
 int f()
 {
   std::cout << "* starting from beginning:" << std::endl;
-  
+
   // call ASPECT with "--" and pipe an existing input file into it.
   int ret;
-  
+
   ret = system ("cd output-resume_free_surface ; "
-	  "(cat " ASPECT_SOURCE_DIR "/tests/resume_free_surface.prm "
-	  " ; "
-	  " echo 'set Output directory = output1.tmp' "
-	  " ; "
-	  " rm -rf output1.tmp ; mkdir output1.tmp "
-	  ") "
-	  "| ../../aspect -- >/dev/null ");
+                "(cat " ASPECT_SOURCE_DIR "/tests/resume_free_surface.prm "
+                " ; "
+                " echo 'set Output directory = output1.tmp' "
+                " ; "
+                " rm -rf output1.tmp ; mkdir output1.tmp "
+                ") "
+                "| ../../aspect -- >/dev/null ");
 
   if (ret!=0)
     std::cout << "system() returned error " << ret << std::endl;
 
   ret = system ("cd output-resume_free_surface ; "
-	  " rm -rf output2.tmp ; cp -r output1.tmp output2.tmp ;"
-		" rm -f output1.tmp/log.txt; "
-	  " cp output1.tmp/restart.mesh.old output1.tmp/restart.mesh;"
-	  " cp output1.tmp/restart.mesh.info.old output1.tmp/restart.mesh.info;"
-	  " cp output1.tmp/restart.resume.z.old output1.tmp/restart.resume.z;");
+                " rm -rf output2.tmp ; cp -r output1.tmp output2.tmp ;"
+                " rm -f output1.tmp/log.txt; "
+                " cp output1.tmp/restart.mesh.old output1.tmp/restart.mesh;"
+                " cp output1.tmp/restart.mesh.info.old output1.tmp/restart.mesh.info;"
+                " cp output1.tmp/restart.resume.z.old output1.tmp/restart.resume.z;");
   if (ret!=0)
     std::cout << "system() returned error " << ret << std::endl;
-  
-  
+
+
   std::cout << "* now resuming:" << std::endl;
   ret = system ("cd output-resume_free_surface ; "
-	  "(cat " ASPECT_SOURCE_DIR "/tests/resume_free_surface.prm "
-	  " ; "
-	  " echo 'set Output directory = output1.tmp' "
-	  " ; "
-	  " echo 'set Resume computation = true' "
-	  ") "
-	  "| ../../aspect -- >/dev/null");
+                "(cat " ASPECT_SOURCE_DIR "/tests/resume_free_surface.prm "
+                " ; "
+                " echo 'set Output directory = output1.tmp' "
+                " ; "
+                " echo 'set Resume computation = true' "
+                ") "
+                "| ../../aspect -- >/dev/null");
   if (ret!=0)
     std::cout << "system() returned error " << ret << std::endl;
 
   std::cout << "* now comparing:" << std::endl;
 
   ret = system ("cd output-resume_free_surface ; "
-	  "cp output1.tmp/solution-00009.0000.gnuplot solution-00009.0000.gnuplot1;"
-	  "cp output2.tmp/solution-00009.0000.gnuplot solution-00009.0000.gnuplot2;"
-	  "cp output1.tmp/log.txt log.txt1;"
-	  "cp output2.tmp/log.txt log.txt2;"
-	  "cp output1.tmp/statistics statistics1;"
-	  "cp output2.tmp/statistics statistics2;"
-	  "");
+                "cp output1.tmp/solution-00009.0000.gnuplot solution-00009.0000.gnuplot1;"
+                "cp output2.tmp/solution-00009.0000.gnuplot solution-00009.0000.gnuplot2;"
+                "cp output1.tmp/log.txt log.txt1;"
+                "cp output2.tmp/log.txt log.txt2;"
+                "cp output1.tmp/statistics statistics1;"
+                "cp output2.tmp/statistics statistics2;"
+                "");
   if (ret!=0)
     std::cout << "system() returned error " << ret << std::endl;
 
   ret = system ("cd output-resume_free_surface ; "
-	  "diff -c output?.tmp/restart.resume.z;"
-	  "diff -c output?.tmp/restart.mesh;"
-	  "");
+                "diff -c output?.tmp/restart.resume.z;"
+                "diff -c output?.tmp/restart.mesh;"
+                "");
   if (ret!=0)
     std::cout << "system() returned error " << ret << std::endl;
-  
+
   // abort current process:
   exit (0);
   return 42;


### PR DESCRIPTION
#1110 accidentally merged a file that is not properly indented. Fix this here.
This fixes #1117.

I think that something must have been wrong with the tester when we merged #1110
because it both missed the fact that the indentation is wrong, as well as the
fact that the test seems to fail since then on the tester. Nothing we can do about
this right now other than address one issue at a time.