### PR TITLE
Better format matrix nonzero statistics.

### DIFF
--- a/source/postprocess/matrix_statistics.cc
+++ b/source/postprocess/matrix_statistics.cc
@@ -44,7 +44,19 @@ namespace
            << std::fixed << std::setprecision(2) << global_matrix_memory_consumption/mb
            << " MB." << std::endl;
 
-    // output number of nonzero elements in matrix
+    // output number of nonzero elements in matrix. Do so with 1000s separator
+    // since they are frequently large; this is done by using the empty
+    // string locale, but creating std::locale with an empty string causes problems
+    // on some platforms, so catch the exception and ignore
+    try
+      {
+        output.imbue(std::locale(""));
+      }
+    catch (std::runtime_error e)
+      {
+        // If the locale doesn't work, just give up
+      }
+
     const int global_matrix_nnz = matrix.n_nonzero_elements();
     output << "Total " << matrix_name << " nnz: "
            << global_matrix_nnz << std::endl;

--- a/tests/matrix_nonzeros/screen-output
+++ b/tests/matrix_nonzeros/screen-output
@@ -1,9 +1,4 @@
 -----------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.5.0-pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
 -----------------------------------------------------------------------------
 
 Number of active cells: 4 (on 2 levels)
@@ -18,15 +13,15 @@ Number of degrees of freedom: 120 (50+9+36+25)
    Postprocessing:
       
 Total system matrix memory consumption: 0.05 MB.
-Total system matrix nnz: 2901
+Total system matrix nnz: 2,901
 system matrix nnz by block: 
-        1156         242           0           0
+       1,156         242           0           0
          242           0           0           0
            0           0         972           0
            0           0           0         289
 
 Total system preconditioner matrix memory consumption: 0.04 MB.
-Total system preconditioner matrix nnz: 1888
+Total system preconditioner matrix nnz: 1,888
 system preconditioner matrix nnz by block: 
          578           0           0           0
            0          49           0           0
@@ -38,22 +33,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      0.16s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |   0.00769s |       4.8% |
-| Assemble composition system     |         1 |    0.0128s |         8% |
-| Assemble temperature system     |         1 |    0.0148s |       9.3% |
-| Build Stokes preconditioner     |         1 |    0.0121s |       7.5% |
-| Build composition preconditioner|         1 |  0.000135s |     0.084% |
-| Build temperature preconditioner|         1 |   0.00285s |       1.8% |
-| Solve Stokes system             |         1 |   0.00403s |       2.5% |
-| Solve composition system        |         1 |  0.000401s |      0.25% |
-| Solve temperature system        |         1 |  0.000874s |      0.54% |
-| Initialization                  |         1 |    0.0804s |        50% |
-| Postprocessing                  |         1 |  0.000429s |      0.27% |
-| Setup dof systems               |         1 |    0.0154s |       9.6% |
-| Setup initial conditions        |         1 |   0.00291s |       1.8% |
 +---------------------------------+-----------+------------+------------+
 


### PR DESCRIPTION
Specifically, print number of nonzeros (which are often large) with a
separator between thousands, millions, etc.

This is a follow up to @spco's #1105.