### PR TITLE
Use T1 encoding for latex fonts; also use lmodern package.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -1,5 +1,7 @@
 \documentclass{article}
 \usepackage[pdftex]{graphicx,color}
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
 \usepackage{amsmath}
 \usepackage{amsfonts}
 \usepackage{subfigure}


### PR DESCRIPTION
For a variety of reasons, it is recommended to use the T1 encoding of latex fonts. To
make this work with pdflatex, one then also has to load the appropriate font family,
which today is the Latin Modern (lmodern) family.

For context with the T1 encoding, see 
  http://tex.stackexchange.com/questions/664/why-should-i-use-usepackaget1fontenc
For context with the lmodern package, see
  http://tex.stackexchange.com/questions/172079/t1-encoding-causing-bad-pdf-quality