### PR TITLE
Introduce AdvectionField::degrees using introspection.degrees.field_name

### DIFF
--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -188,6 +188,24 @@ namespace aspect
        */
       const BaseElements base_elements;
 
+      /**
+       * A structure that contains the polynomial degree of the finite element
+       * that correspond to each of the variables in this problem.
+       *
+       * If there are compositional fields, they are all discretized with the
+       * same polynomial degree and, consequently, we only need a single integer.
+       */
+      struct PolynomialDegree
+      {
+        unsigned int       velocities;
+        unsigned int       temperature;
+        unsigned int       compositional_fields;
+      };
+      /**
+       * A variable that enumerates the polynomial degree of the finite element
+       * that correspond to each of the variables in this problem.
+       */
+      const PolynomialDegree polynomial_degree;
 
       /**
        * A structure that contains component masks for each of the variables

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -271,6 +271,12 @@ namespace aspect
          * <code>source/simulator/helper_functions.cc</code>.
          */
         FEValuesExtractors::Scalar scalar_extractor(const Introspection<dim> &introspection) const;
+
+        /**
+         * Look up the polynomial degree order for this temperature or compositional
+         * field. See Introspection::polynomial_degree for more information.
+         */
+        unsigned int polynomial_degree(const Introspection<dim> &introspection) const;
       };
 
 

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -691,11 +691,7 @@ namespace aspect
     AdvectionSystem<dim> scratch (finite_element,
                                   finite_element.base_element(advection_field.base_element(introspection)),
                                   *mapping,
-                                  QGauss<dim>((advection_field.is_temperature()
-                                               ?
-                                               parameters.temperature_degree
-                                               :
-                                               parameters.composition_degree)
+                                  QGauss<dim>(advection_field.polynomial_degree(introspection)
                                               +
                                               (parameters.stokes_velocity_degree+1)/2),
                                   /* Because we can only get here in the continuous case, which never requires
@@ -3035,11 +3031,7 @@ namespace aspect
     // (Note: All compositional fields have the same base element and therefore
     // the same composition_degree. Thus, we do not need to find out the degree
     // of the current field, but use the global instead)
-    const unsigned int advection_quadrature_degree = (advection_field.is_temperature()
-                                                      ?
-                                                      parameters.temperature_degree
-                                                      :
-                                                      parameters.composition_degree)
+    const unsigned int advection_quadrature_degree = advection_field.polynomial_degree(introspection)
                                                      +
                                                      (parameters.stokes_velocity_degree+1)/2;
 

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -150,6 +150,16 @@ namespace aspect
       return introspection.extractors.compositional_fields[compositional_variable];
   }
 
+  template <int dim>
+  unsigned int
+  Simulator<dim>::AdvectionField::polynomial_degree(const Introspection<dim> &introspection) const
+  {
+    if (this->is_temperature())
+      return introspection.polynomial_degree.temperature;
+    else
+      return introspection.polynomial_degree.compositional_fields;
+  }
+
 
   namespace
   {
@@ -970,12 +980,8 @@ namespace aspect
      * in 2D: the combinations are 21, 12
      * in 3D: the combinations are 211, 121, 112
      */
-    const QGauss<1> quadrature_formula_1 (advection_field.is_temperature() ?
-                                          parameters.temperature_degree+1 :
-                                          parameters.composition_degree+1);
-    const QGaussLobatto<1> quadrature_formula_2 (advection_field.is_temperature() ?
-                                                 parameters.temperature_degree+1 :
-                                                 parameters.composition_degree+1);
+    const QGauss<1> quadrature_formula_1 (advection_field.polynomial_degree(introspection)+1);
+    const QGaussLobatto<1> quadrature_formula_2 (advection_field.polynomial_degree(introspection)+1);
 
     const unsigned int n_q_points_1 = quadrature_formula_1.size();
     const unsigned int n_q_points_2 = quadrature_formula_2.size();
@@ -1070,9 +1076,7 @@ namespace aspect
     Quadrature<dim> quadrature_formula(quadrature_points);
 
     // Quadrature rules only used for the numerical integration for better accuracy
-    const QGauss<dim> quadrature_formula_0 (advection_field.is_temperature() ?
-                                            parameters.temperature_degree+1 :
-                                            parameters.composition_degree+1);
+    const QGauss<dim> quadrature_formula_0 (advection_field.polynomial_degree(introspection)+1);
 
     const unsigned int n_q_points_0 = quadrature_formula_0.size();
 

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -86,6 +86,19 @@ namespace aspect
     }
 
     template <int dim>
+    typename Introspection<dim>::PolynomialDegree
+    setup_polynomial_degree (const Parameters<dim> &parameters)
+    {
+      typename Introspection<dim>::PolynomialDegree polynomial_degree;
+
+      polynomial_degree.velocities = parameters.stokes_velocity_degree;
+      polynomial_degree.temperature = parameters.temperature_degree;
+      polynomial_degree.compositional_fields = parameters.composition_degree;
+
+      return polynomial_degree;
+    }
+
+    template <int dim>
     std_cxx11::shared_ptr<FiniteElement<dim> >
     new_FE_Q_or_DGP(const bool discontinuous,
                     const unsigned int degree)
@@ -167,6 +180,7 @@ namespace aspect
     block_indices (internal::setup_blocks<dim>(*this)),
     extractors (component_indices),
     base_elements (internal::setup_base_elements<dim>(*this)),
+    polynomial_degree (internal::setup_polynomial_degree<dim>(parameters)),
     component_masks (*this),
     system_dofs_per_block (n_blocks),
     composition_names(parameters.names_of_compositional_fields)


### PR DESCRIPTION
Whenever we need to use the degree of polynomial of AdvectionField, we have to verify the advection field name first. This patch is the enhancement of current implementation.