### PR TITLE
Thousands separator

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -192,6 +192,21 @@ namespace aspect
                                                       double phi );   //longitude (radians)
 
     /**
+     * A struct to enable numerical output with a comma as thousands separator
+     */
+    struct ThousandSep : std::numpunct<char>
+    {
+      char do_thousands_sep() const
+      {
+        return ',';
+      }
+      std::string do_grouping() const
+      {
+        return "\3";  // groups of 3 digits
+      }
+    };
+
+    /**
      * Checks whether a file named filename exists.
      *
      * @param filename File to check existence

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -196,14 +196,16 @@ namespace aspect
      */
     struct ThousandSep : std::numpunct<char>
     {
-      char do_thousands_sep() const
-      {
-        return ',';
-      }
-      std::string do_grouping() const
-      {
-        return "\3";  // groups of 3 digits
-      }
+      protected:
+        virtual char do_thousands_sep() const
+        {
+          return ',';
+        }
+        virtual std::string do_grouping() const
+        {
+          return "\003";  // groups of 3 digits (this string is in octal format)
+        }
+
     };
 
     /**

--- a/source/postprocess/matrix_statistics.cc
+++ b/source/postprocess/matrix_statistics.cc
@@ -22,6 +22,7 @@
 #include <aspect/postprocess/matrix_statistics.h>
 
 #include <aspect/simulator.h>
+#include <aspect/utilities.h>
 
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
@@ -45,12 +46,13 @@ namespace
            << " MB." << std::endl;
 
     // output number of nonzero elements in matrix. Do so with 1000s separator
-    // since they are frequently large; this is done by using the empty
-    // string locale, but creating std::locale with an empty string causes problems
-    // on some platforms, so catch the exception and ignore
+    // since they are frequently large; this was previously done by using the empty
+    // string locale, but creating std::locale with an empty string caused problems
+    // on some platforms, so the functionaltity yo catch the exception and ignore
+    // is kept here, even though explicitly setting a facet should always work.
     try
       {
-        output.imbue(std::locale(""));
+        output.imbue(std::locale(std::locale(), new aspect::Utilities::ThousandSep));
       }
     catch (std::runtime_error e)
       {

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1256,11 +1256,12 @@ namespace aspect
     // large
     {
       std::locale s = pcout.get_stream().getloc();
-      // Creating std::locale with an empty string causes problems
-      // on some platforms, so catch the exception and ignore
+      // Creating std::locale with an empty string previously caused problems
+      // on some platforms, so the functionality to catch the exception and ignore
+      // is kept here, even though explicitly setting a facet should always work.
       try
         {
-          pcout.get_stream().imbue(std::locale(""));
+          pcout.get_stream().imbue(std::locale(std::locale(), new aspect::Utilities::ThousandSep));
         }
       catch (std::runtime_error e)
         {


### PR DESCRIPTION
Add `struct` in `Utilities` to enable outputting numbers with comma as thousands separator.

See https://github.com/geodynamics/aspect/pull/1138#issuecomment-236851007 for previous discussion. This fixes the issue where `std::locale("")`, dependent on platform, may not give comma-separated thousands.