### PR TITLE
Remove code duplication in initialization of temperature and composition

### DIFF
--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -51,6 +51,10 @@ namespace aspect
     // we need to track whether we need to normalize the totality of fields
     bool normalize_composition = false;
 
+    // we need the current constraints to be correct for
+    // the current time
+    compute_current_constraints ();
+
 #if DEAL_II_VERSION_GTE(8,5,0)
     initial_solution.reinit(system_rhs, false);
 
@@ -70,9 +74,6 @@ namespace aspect
 
     // then apply constraints and copy the
     // result into vectors with ghost elements. to do so,
-    // we need the current constraints to be correct for
-    // the current time
-    compute_current_constraints ();
     current_constraints.distribute(initial_solution);
 
     // copy temperature/composition block only
@@ -163,9 +164,6 @@ namespace aspect
 
         // then apply constraints and copy the
         // result into vectors with ghost elements. to do so,
-        // we need the current constraints to be correct for
-        // the current time
-        compute_current_constraints ();
         current_constraints.distribute(initial_solution);
 
         // copy temperature/composition block only
@@ -283,9 +281,6 @@ namespace aspect
 
         // then apply constraints and copy the
         // result into vectors with ghost elements. to do so,
-        // we need the current constraints to be correct for
-        // the current time
-        compute_current_constraints ();
         current_constraints.distribute(initial_solution);
 
         // copy temperature/composition block only

--- a/tests/normalize_initial_composition.prm
+++ b/tests/normalize_initial_composition.prm
@@ -1,0 +1,61 @@
+# This test ensures that the Simpler material model works 
+# with compositional fields enabled
+
+set Dimension                              = 2
+set End time                               = 0
+
+subsection Boundary temperature model
+  set Model name = initial temperature 
+end
+
+subsection Compositional fields
+  set Number of fields          = 2
+  set List of normalized fields   =  0,1
+end
+
+subsection Compositional initial conditions
+  subsection Function
+    set Function expression = 1;1
+  end
+end
+
+subsection Geometry model
+  set Model name = box 
+  subsection Box
+    set X extent                = 1
+    set X repetitions           = 2      
+    set Y extent                = 1
+    set Y repetitions           = 2
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical 
+  subsection Vertical
+    set Magnitude = 1
+  end
+end
+
+subsection Initial conditions
+  set Model name = function 
+  subsection Function
+    set Function expression = 1
+  end
+end
+
+subsection Material model
+  set Model name         = simple
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement              = 0         
+  set Initial global refinement                = 0
+end
+
+subsection Model settings
+  set Tangential velocity boundary indicators = left, right, top, bottom
+end
+
+subsection Postprocess
+  set List of postprocessors = composition statistics
+end

--- a/tests/normalize_initial_composition/screen-output
+++ b/tests/normalize_initial_composition/screen-output
@@ -1,0 +1,24 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Number of active cells: 4 (on 1 levels)
+Number of degrees of freedom: 134 (50+9+25+25+25)
+
+Sum of compositional fields is not one, fields will be normalized
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Solving C_2 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 2+0 iterations.
+
+   Postprocessing:
+     Compositions min/max/mass: 0.5/0.5/0.5 // 0.5/0.5/0.5
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+


### PR DESCRIPTION
Addresses issue #1145. 

The unification on the standard of the n_compos+1 loop is due to wanting to reduce logic duplication.

This pull request also adds a test for the composition normalization due to no existing test using said feature.