### PR TITLE
move expand_ASPECT_SOURCE_DIR() into .cc

### DIFF
--- a/cmake/AspectConfig.cmake.in
+++ b/cmake/AspectConfig.cmake.in
@@ -46,19 +46,21 @@ MACRO(ASPECT_SETUP_PLUGIN _target)
       APPEND PROPERTY COMPILE_DEFINITIONS ASPECT_USE_PETSC="1")
   ENDIF()
 
+  # export ASPECT_SOURCE_DIR as compile definition
+  TARGET_COMPILE_DEFINITIONS( ${_target} PRIVATE ASPECT_SOURCE_DIR="@CMAKE_SOURCE_DIR@")
 
-# workarounds for MAC OS
-IF (APPLE AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  # avoid linker errors about missing functions inside ASPECT:
-  SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -undefined dynamic_lookup")
+  # workarounds for MAC OS
+  IF (APPLE AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    # avoid linker errors about missing functions inside ASPECT:
+    SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -undefined dynamic_lookup")
 
-  # make shared libraries end on .so not .dylib
-  SET_TARGET_PROPERTIES(${_target} PROPERTIES SUFFIX ".so")
-ENDIF()
+    # make shared libraries end on .so not .dylib
+    SET_TARGET_PROPERTIES(${_target} PROPERTIES SUFFIX ".so")
+  ENDIF()
 
 
-# automatically create a symbolic link to aspect in the current directory:
-ADD_CUSTOM_COMMAND(
+  # automatically create a symbolic link to aspect in the current directory:
+  ADD_CUSTOM_COMMAND(
     TARGET ${_target} POST_BUILD
     COMMAND ln -sf ${Aspect_DIR}/aspect .)
 

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -356,18 +356,11 @@ namespace aspect
     }
 
     /**
-     * Add standard call for replacing $ASPECT_SOURCE_DIR
+     * Replace the variable $ASPECT_SOURCE_DIR in @p location by the current
+     * source directory of ASPECT and return the resulting string.
      */
-    inline
     std::string
-    expand_ASPECT_SOURCE_DIR (std::string location)
-    {
-      return Utilities::replace_in_string(location,
-                                          "$ASPECT_SOURCE_DIR",
-                                          ASPECT_SOURCE_DIR);
-    }
-
-
+    expand_ASPECT_SOURCE_DIR (const std::string &location);
 
 
     /**

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -842,6 +842,14 @@ namespace aspect
     } // namespace tk
 
 
+    std::string
+    expand_ASPECT_SOURCE_DIR (const std::string &location)
+    {
+      return Utilities::replace_in_string(location,
+                                          "$ASPECT_SOURCE_DIR",
+                                          ASPECT_SOURCE_DIR);
+    }
+
 
     template <int dim>
     AsciiDataLookup<dim>::AsciiDataLookup(const unsigned int components,

--- a/tests/plugin.cc
+++ b/tests/plugin.cc
@@ -1,5 +1,6 @@
 // make sure we can include deal.II and aspect files
 #include <aspect/simulator.h>
+#include <aspect/utilities.h>
 #include <deal.II/grid/tria.h>
 
 #include <iostream>

--- a/tests/plugin.cc
+++ b/tests/plugin.cc
@@ -10,6 +10,8 @@
 // and that produces some output
 int f()
 {
+  std::cout << aspect::Utilities::expand_ASPECT_SOURCE_DIR("srcdir='$ASPECT_SOURCE_DIR'") << std::endl;
+  
   std::cout << typeid(dealii::Triangulation<2>).name() << " "
             << typeid(aspect::Simulator<2>).name() << std::endl;
   return 42;

--- a/tests/plugin/screen-output
+++ b/tests/plugin/screen-output
@@ -1,5 +1,6 @@
 
 Loading shared library <./libplugin.so>
+srcdir='ASPECT_DIR'
 N6dealii13TriangulationILi2ELi2EEE N6aspect9SimulatorILi2EEE
 
 Number of active cells: 16 (on 3 levels)


### PR DESCRIPTION
Do not inline expand_ASPECT_SOURCE_DIR() so it also works in plugins.
Extend documentation.

Fixes:
```
~/aspect/include/aspect/utilities.h:341:43: error:
use of undeclared identifier 'ASPECT_SOURCE_DIR'
```
when compiling plugins.