### PR TITLE
Improve particle serialization scalability

### DIFF
--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -168,24 +168,21 @@ namespace aspect
 
         /**
          * Callback function that is called from Simulator before every
-         * refinement. Allows registering store_tracers() in the triangulation.
+         * refinement and when writing checkpoints.
+         * Allows registering store_tracers() in the triangulation.
          */
         void
-        register_store_callback_function(typename parallel::distributed::Triangulation<dim> &triangulation);
+        register_store_callback_function(const bool serialization,
+                                         typename parallel::distributed::Triangulation<dim> &triangulation);
 
         /**
          * Callback function that is called from Simulator after every
-         * refinement. Allows registering load_tracers() in the triangulation.
+         * refinement and after resuming from a checkpoint.
+         * Allows registering load_tracers() in the triangulation.
          */
         void
-        register_load_callback_function(typename parallel::distributed::Triangulation<dim> &triangulation);
-
-        /**
-         * Callback function that is called from Simulator after resuming from
-         * a checkpoint. Allows registering load_tracers() in the triangulation.
-         */
-        void
-        register_serialization_load_callback_function(typename parallel::distributed::Triangulation<dim> &triangulation);
+        register_load_callback_function(const bool serialization,
+                                        typename parallel::distributed::Triangulation<dim> &triangulation);
 
         /**
          * Called by listener functions from Triangulation for every cell

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -122,16 +122,6 @@ namespace aspect
         get_particles() const;
 
         /**
-         * Calculates and stores the number of particles in the cell that
-         * contains the most tracers in the global model. This variable is a
-         * state variable, because it is needed to serialize and deserialize
-         * the particle data correctly in parallel (it determines the size of
-         * the data chunks per cell that are stored and read).
-         */
-        void
-        update_global_max_particles_per_cell();
-
-        /**
          * Advance particles by the old timestep using the current
          * integration scheme. This accounts for the fact that the tracers
          * are actually still at their old positions and the current timestep
@@ -300,7 +290,10 @@ namespace aspect
         /**
          * The maximum number of particles per cell in the global domain. This
          * variable is important to store and load particle data during
-         * repartition and serialization of the solution.
+         * repartition and serialization of the solution. Note that the
+         * variable is only updated when it is needed, e.g. before or after
+         * serialization (before/after mesh refinement, before creating a
+         * checkpoint and after resuming from a checkpoint).
          */
         unsigned int global_max_particles_per_cell;
 
@@ -364,6 +357,19 @@ namespace aspect
          */
         void
         update_n_global_particles();
+
+        /**
+         * Calculates and stores the number of particles in the cell that
+         * contains the most tracers in the global model (stored in the
+         * member variable global_max_particles_per_cell). This variable is a
+         * state variable, because it is needed to serialize and deserialize
+         * the particle data correctly in parallel (it determines the size of
+         * the data chunks per cell that are stored and read). Before accessing
+         * the variable this function has to be called, unless the state was
+         * read from another source (e.g. after resuming from a checkpoint).
+         */
+        void
+        update_global_max_particles_per_cell();
 
         /**
          * Calculates the next free particle index in the global model domain.

--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -155,7 +155,7 @@ namespace aspect
     * argument. This argument will point to the triangulation used by
     * the Simulator class.
     */
-    boost::signals2::signal<void (typename parallel::distributed::Triangulation<dim> &)>  pre_serialization_store_user_data;
+    boost::signals2::signal<void (typename parallel::distributed::Triangulation<dim> &)>  pre_checkpoint_store_user_data;
 
     /**
     * A signal that is called after resuming from a checkpoint.
@@ -170,7 +170,7 @@ namespace aspect
     * argument. This argument will point to the triangulation used by
     * the Simulator class.
     */
-    boost::signals2::signal<void (typename parallel::distributed::Triangulation<dim> &)>  post_serialization_load_user_data;
+    boost::signals2::signal<void (typename parallel::distributed::Triangulation<dim> &)>  post_resume_load_user_data;
 
     /**
      * A signal that is called at the beginning of the program. It

--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -125,12 +125,10 @@ namespace aspect
     * that is related to mesh cells and needs to be transferred with the cells
     * during the repartitioning.
 
-    * The functions that connect to this signal must take a list of pairs of
-    * a size and a callback function that has the signature of the
-    * parallel::distributed::Triangulation::register_attach_data function.
-    * The intention of the function should be to add another pair, describing
-    * the amount of space per cell that needs to be send and a function
-    * that is called for every cell by the Triangulation.
+    * The functions that connect to this signal must take a reference
+    * to a parallel::distributed::Triangulation object as
+    * argument. This argument will point to the triangulation used by
+    * the Simulator class.
     */
     boost::signals2::signal<void (typename parallel::distributed::Triangulation<dim> &)>  pre_refinement_store_user_data;
 
@@ -146,6 +144,33 @@ namespace aspect
     * the Simulator class.
     */
     boost::signals2::signal<void (typename parallel::distributed::Triangulation<dim> &)>  post_refinement_load_user_data;
+
+    /**
+    * A signal that is called before the creation of every checkpoint.
+    * This signal allows for registering functions that store data
+    * related to mesh cells.
+    *
+    * The functions that connect to this signal must take a reference
+    * to a parallel::distributed::Triangulation object as
+    * argument. This argument will point to the triangulation used by
+    * the Simulator class.
+    */
+    boost::signals2::signal<void (typename parallel::distributed::Triangulation<dim> &)>  pre_serialization_store_user_data;
+
+    /**
+    * A signal that is called after resuming from a checkpoint.
+    * This signal allows for registering functions that load data
+    * related to mesh cells that was previously stored in the checkpoint.
+    * Note that before calling Triangulation::notify_ready_to_unpack() the
+    * function needs to call register_attach_data() with the appropriate arguments
+    * to restore the state of the triangulation.
+    *
+    * The functions that connect to this signal must take a reference
+    * to a parallel::distributed::Triangulation object as
+    * argument. This argument will point to the triangulation used by
+    * the Simulator class.
+    */
+    boost::signals2::signal<void (typename parallel::distributed::Triangulation<dim> &)>  post_serialization_load_user_data;
 
     /**
      * A signal that is called at the beginning of the program. It

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -211,9 +211,9 @@ namespace aspect
           const std::size_t transfer_size_per_cell = sizeof (unsigned int) +
                                                      (property_manager->get_particle_size() * max_particles_per_cell) *
                                                      (serialization ?
-                                                         1
-                                                     :
-                                                         std::pow(2,dim));
+                                                      1
+                                                      :
+                                                      std::pow(2,dim));
 
           data_offset = triangulation.register_data_attach(transfer_size_per_cell,callback_function);
         }

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -193,7 +193,7 @@ namespace aspect
       // selected the tracer postprocessor but generated 0 tracers
       update_global_max_particles_per_cell();
 
-      if (max_particles_per_cell > 0)
+      if (global_max_particles_per_cell > 0)
         {
           const std_cxx11::function<void(const typename parallel::distributed::Triangulation<dim>::cell_iterator &,
                                          const typename parallel::distributed::Triangulation<dim>::CellStatus, void *) > callback_function
@@ -209,7 +209,7 @@ namespace aspect
           // space for the data in case a cell is coarsened and all tracers
           // of the children have to be stored in the parent cell.
           const std::size_t transfer_size_per_cell = sizeof (unsigned int) +
-                                                     (property_manager->get_particle_size() * max_particles_per_cell) *
+                                                     (property_manager->get_particle_size() * global_max_particles_per_cell) *
                                                      (serialization ?
                                                       1
                                                       :
@@ -234,7 +234,7 @@ namespace aspect
       // store function again, to set the triangulation in the same state as
       // before the serialization. Only by this it knows how to deserialize the
       // data correctly. Only do this if something was actually stored.
-      if (serialization && (max_particles_per_cell > 0))
+      if (serialization && (global_max_particles_per_cell > 0))
         {
           const std_cxx11::function<void(const typename parallel::distributed::Triangulation<dim>::cell_iterator &,
                                          const typename parallel::distributed::Triangulation<dim>::CellStatus, void *) > callback_function
@@ -248,7 +248,7 @@ namespace aspect
           // the tracer data itself and we need to provide 2^dim times the
           // space for the data in case a cell is coarsened
           const std::size_t transfer_size_per_cell = sizeof (unsigned int) +
-                                                     (property_manager->get_particle_size() * max_particles_per_cell);
+                                                     (property_manager->get_particle_size() * global_max_particles_per_cell);
           data_offset = triangulation.register_data_attach(transfer_size_per_cell,callback_function);
         }
 

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -149,7 +149,7 @@ namespace aspect
             const types::LevelInd found_cell = std::make_pair<int, int> (cell->level(),cell->index());
             const unsigned int particles_in_cell = particles.count(found_cell);
             local_max_particles_per_cell = std::max(local_max_particles_per_cell,
-                                                 particles_in_cell);
+                                                    particles_in_cell);
           }
 
       global_max_particles_per_cell = dealii::Utilities::MPI::max(local_max_particles_per_cell,this->get_mpi_communicator());
@@ -161,23 +161,30 @@ namespace aspect
     {
       signals.post_set_initial_state.connect(std_cxx11::bind(&World<dim>::setup_initial_state,
                                                              std_cxx11::ref(*this)));
+
       signals.pre_refinement_store_user_data.connect(std_cxx11::bind(&World<dim>::register_store_callback_function,
                                                                      std_cxx11::ref(*this),
+                                                                     false,
                                                                      std_cxx11::_1));
       signals.pre_serialization_store_user_data.connect(std_cxx11::bind(&World<dim>::register_store_callback_function,
-                                                                     std_cxx11::ref(*this),
-                                                                     std_cxx11::_1));
+                                                                        std_cxx11::ref(*this),
+                                                                        true,
+                                                                        std_cxx11::_1));
+
       signals.post_refinement_load_user_data.connect(std_cxx11::bind(&World<dim>::register_load_callback_function,
                                                                      std_cxx11::ref(*this),
+                                                                     false,
                                                                      std_cxx11::_1));
-      signals.post_serialization_load_user_data.connect(std_cxx11::bind(&World<dim>::register_serialization_load_callback_function,
-                                                                     std_cxx11::ref(*this),
-                                                                     std_cxx11::_1));
+      signals.post_serialization_load_user_data.connect(std_cxx11::bind(&World<dim>::register_load_callback_function,
+                                                                        std_cxx11::ref(*this),
+                                                                        true,
+                                                                        std_cxx11::_1));
     }
 
     template <int dim>
     void
-    World<dim>::register_store_callback_function(typename parallel::distributed::Triangulation<dim> &triangulation)
+    World<dim>::register_store_callback_function(const bool serialization,
+                                                 typename parallel::distributed::Triangulation<dim> &triangulation)
     {
       TimerOutput::Scope timer_section(this->get_computing_timer(), "Particles: Refine mesh, store");
 
@@ -197,24 +204,53 @@ namespace aspect
                               std_cxx11::_3);
 
           // We need to transfer the number of tracers for this cell and
-          // the tracer data itself and we need to provide 2^dim times the
-          // space for the data in case a cell is coarsened
+          // the tracer data itself. If we are in the process of refinement
+          // (i.e. not in serialization) we need to provide 2^dim times the
+          // space for the data in case a cell is coarsened and all tracers
+          // of the children have to be stored in the parent cell.
           const std::size_t transfer_size_per_cell = sizeof (unsigned int) +
-                                                     (property_manager->get_particle_size() * max_particles_per_cell)
-                                                     *  std::pow(2,dim);
+                                                     (property_manager->get_particle_size() * max_particles_per_cell) *
+                                                     (serialization ?
+                                                         1
+                                                     :
+                                                         std::pow(2,dim));
+
           data_offset = triangulation.register_data_attach(transfer_size_per_cell,callback_function);
         }
     }
 
     template <int dim>
     void
-    World<dim>::register_load_callback_function(typename parallel::distributed::Triangulation<dim> &triangulation)
+    World<dim>::register_load_callback_function(const bool serialization,
+                                                typename parallel::distributed::Triangulation<dim> &triangulation)
     {
       TimerOutput::Scope timer_section(this->get_computing_timer(), "Particles: Refine mesh, load");
 
       // All particles have been stored, when we reach this point. Empty the
       // map and fill with new particles.
       particles.clear();
+
+      // If we are resuming from a checkpoint, we first have to register the
+      // store function again, to set the triangulation in the same state as
+      // before the serialization. Only by this it knows how to deserialize the
+      // data correctly. Only do this if something was actually stored.
+      if (serialization && (max_particles_per_cell > 0))
+        {
+          const std_cxx11::function<void(const typename parallel::distributed::Triangulation<dim>::cell_iterator &,
+                                         const typename parallel::distributed::Triangulation<dim>::CellStatus, void *) > callback_function
+            = std_cxx11::bind(&aspect::Particle::World<dim>::store_tracers,
+                              std_cxx11::ref(*this),
+                              std_cxx11::_1,
+                              std_cxx11::_2,
+                              std_cxx11::_3);
+
+          // We need to transfer the number of tracers for this cell and
+          // the tracer data itself and we need to provide 2^dim times the
+          // space for the data in case a cell is coarsened
+          const std::size_t transfer_size_per_cell = sizeof (unsigned int) +
+                                                     (property_manager->get_particle_size() * max_particles_per_cell);
+          data_offset = triangulation.register_data_attach(transfer_size_per_cell,callback_function);
+        }
 
       // Check if something was stored and load it
       if (data_offset != numbers::invalid_unsigned_int)
@@ -237,33 +273,6 @@ namespace aspect
           data_offset = numbers::invalid_unsigned_int;
           update_n_global_particles();
         }
-    }
-
-    template <int dim>
-    void
-    World<dim>::register_serialization_load_callback_function(typename parallel::distributed::Triangulation<dim> &triangulation)
-    {
-      TimerOutput::Scope timer_section(this->get_computing_timer(), "Particles: Refine mesh, store");
-
-      if (max_particles_per_cell > 0)
-        {
-          const std_cxx11::function<void(const typename parallel::distributed::Triangulation<dim>::cell_iterator &,
-                                         const typename parallel::distributed::Triangulation<dim>::CellStatus, void *) > callback_function
-            = std_cxx11::bind(&aspect::Particle::World<dim>::store_tracers,
-                              std_cxx11::ref(*this),
-                              std_cxx11::_1,
-                              std_cxx11::_2,
-                              std_cxx11::_3);
-
-          // We need to transfer the number of tracers for this cell and
-          // the tracer data itself and we need to provide 2^dim times the
-          // space for the data in case a cell is coarsened
-          const std::size_t transfer_size_per_cell = sizeof (unsigned int) +
-                                                     (property_manager->get_particle_size() * max_particles_per_cell);
-          data_offset = triangulation.register_data_attach(transfer_size_per_cell,callback_function);
-        }
-
-      register_load_callback_function(triangulation);
     }
 
     template <int dim>

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -166,19 +166,19 @@ namespace aspect
                                                                      std_cxx11::ref(*this),
                                                                      false,
                                                                      std_cxx11::_1));
-      signals.pre_serialization_store_user_data.connect(std_cxx11::bind(&World<dim>::register_store_callback_function,
-                                                                        std_cxx11::ref(*this),
-                                                                        true,
-                                                                        std_cxx11::_1));
+      signals.pre_checkpoint_store_user_data.connect(std_cxx11::bind(&World<dim>::register_store_callback_function,
+                                                                     std_cxx11::ref(*this),
+                                                                     true,
+                                                                     std_cxx11::_1));
 
       signals.post_refinement_load_user_data.connect(std_cxx11::bind(&World<dim>::register_load_callback_function,
                                                                      std_cxx11::ref(*this),
                                                                      false,
                                                                      std_cxx11::_1));
-      signals.post_serialization_load_user_data.connect(std_cxx11::bind(&World<dim>::register_load_callback_function,
-                                                                        std_cxx11::ref(*this),
-                                                                        true,
-                                                                        std_cxx11::_1));
+      signals.post_resume_load_user_data.connect(std_cxx11::bind(&World<dim>::register_load_callback_function,
+                                                                 std_cxx11::ref(*this),
+                                                                 true,
+                                                                 std_cxx11::_1));
     }
 
     template <int dim>

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -304,8 +304,7 @@ namespace aspect
                                  "option to support checkpoint/restart, but deal.II "
                                  "did not detect its presence when you called 'cmake'."));
 #endif
-        signals.pre_refinement_store_user_data(triangulation);
-        signals.post_refinement_load_user_data(triangulation);
+        signals.post_serialization_load_user_data(triangulation);
       }
     catch (std::exception &e)
       {

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -126,6 +126,8 @@ namespace aspect
           freesurface_trans->prepare_serialization(x_fs_system);
         }
 
+      signals.pre_serialization_store_user_data(triangulation);
+
       triangulation.save ((parameters.output_directory + "restart.mesh").c_str());
     }
 
@@ -173,6 +175,7 @@ namespace aspect
 #endif
 
     }
+
     pcout << "*** Snapshot created!" << std::endl << std::endl;
     computing_timer.exit_section();
   }
@@ -301,6 +304,8 @@ namespace aspect
                                  "option to support checkpoint/restart, but deal.II "
                                  "did not detect its presence when you called 'cmake'."));
 #endif
+        signals.pre_refinement_store_user_data(triangulation);
+        signals.post_refinement_load_user_data(triangulation);
       }
     catch (std::exception &e)
       {

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -126,7 +126,7 @@ namespace aspect
           freesurface_trans->prepare_serialization(x_fs_system);
         }
 
-      signals.pre_serialization_store_user_data(triangulation);
+      signals.pre_checkpoint_store_user_data(triangulation);
 
       triangulation.save ((parameters.output_directory + "restart.mesh").c_str());
     }
@@ -304,7 +304,7 @@ namespace aspect
                                  "option to support checkpoint/restart, but deal.II "
                                  "did not detect its presence when you called 'cmake'."));
 #endif
-        signals.post_serialization_load_user_data(triangulation);
+        signals.post_resume_load_user_data(triangulation);
       }
     catch (std::exception &e)
       {


### PR DESCRIPTION
Previously the particle serialization was not very scalable, because the data was serialized in the usual way for postprocessors. Every process had to send its data to process 0, which then wrote the data  into an output stream,  which was saved to disk. This is impractical or even impossible for large application models. The new implementation utilizes the same functionality that we use for remeshing, i.e. the particle data is attached to the cells of the triangulation and stored together with the mesh. In essence this is similar to a SolutionTransfer object for particle data. The drawback is that every cell has to store the same amount of data (p4est limitation), therefore we now need significantly more disk space. An example application with around 20 million particles now need 4 GB instead of 600 MB disk space for serialization. I still think the new approach is better, the old one simply did crash for large models.
Additionally the new approach was implemented by adding signals before and after serialization. This also allows other plugins to serialize data more efficiently. E.g. the code that handles the free surface serialization could now be moved outside of the checkpoint_restart file and into the free_surface file (I will open an issue for that).