### PR TITLE
Prevent crash when chunk domain crosses 180 hemisphere

### DIFF
--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -237,6 +237,8 @@ namespace aspect
         class ChunkGeometry : public ChartManifold<dim,dim>
         {
           public:
+            ChunkGeometry();
+
             virtual
             Point<dim>
             pull_back(const Point<dim> &space_point) const;
@@ -244,6 +246,14 @@ namespace aspect
             virtual
             Point<dim>
             push_forward(const Point<dim> &chart_point) const;
+
+            virtual
+            void
+            set_min_longitude(const double p1_lon);
+
+          private:
+            // The minimum longitude of the domain
+            double point1_lon;
         };
 
         Point<dim> pull_back(const Point<dim>) const;

--- a/tests/chunk_cross_hemisphere.prm
+++ b/tests/chunk_cross_hemisphere.prm
@@ -1,0 +1,81 @@
+# An input script to test the chunk geometry model
+# where the domain crosses both hemispheres.
+
+set Dimension = 2
+set CFL number                             = 1.0
+set End time                               = 0
+set Start time                             = 0
+set Adiabatic surface temperature          = 1613.0
+set Surface pressure                       = 0
+set Use years in output instead of seconds = true
+set Nonlinear solver scheme                = IMPES
+
+
+subsection Gravity model
+  set Model name = radial constant
+
+  subsection Radial constant
+    set Magnitude = 10
+  end
+end
+
+
+subsection Geometry model
+  set Model name = chunk
+
+  subsection Chunk
+    set Chunk minimum longitude = -10
+    set Chunk maximum longitude = 220
+    set Longitude repetitions = 2
+    set Chunk inner radius = 3000000
+    set Chunk outer radius = 6000000
+    set Radius repetitions = 1
+  end
+end
+
+
+subsection Initial conditions
+  set Model name = function
+  subsection Function
+    set Function expression = 1613.0
+  end
+end
+
+
+subsection Boundary temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 1613.0
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Reference density = 3340
+    set Reference specific heat = 1200
+    set Thermal expansion coefficient = 3e-5
+    set Viscosity = 1e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 3
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = inner, outer
+  set Prescribed velocity boundary indicators =
+  set Tangential velocity boundary indicators = outer, east, west
+  set Zero velocity boundary indicators       = inner
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, basic statistics,  temperature statistics
+end
+

--- a/tests/chunk_cross_hemisphere/screen-output
+++ b/tests/chunk_cross_hemisphere/screen-output
@@ -1,0 +1,53 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.5.0-pre
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Number of active cells: 128 (on 4 levels)
+Number of degrees of freedom: 1,836 (1,122+153+561)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+5 iterations.
+
+   Postprocessing:
+
+     Reference density (kg/m^3):                    3340
+     Reference gravity (m/s^2):                     10
+     Reference thermal expansion (1/K):             3e-05
+     Temperature contrast across model domain (K):  3500
+     Model domain depth (m):                        3e+06
+     Reference thermal diffusivity (m^2/s):         1.17265e-06
+     Reference viscosity (Pas):                     1e+21
+     Ra number:                                     8.07476e+07
+     k_value:                                       4.7
+     reference_cp:                                  1200
+     reference_thermal_diffusivity:                 1.17265e-06
+
+     RMS, max velocity:       0.192 m/year, 0.284 m/year
+     Temperature min/avg/max: 1613 K, 1613 K, 1613 K
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.902s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |     0.158s |        18% |
+| Assemble temperature system     |         1 |     0.252s |        28% |
+| Build Stokes preconditioner     |         1 |     0.118s |        13% |
+| Build temperature preconditioner|         1 |   0.00438s |      0.49% |
+| Solve Stokes system             |         1 |    0.0305s |       3.4% |
+| Solve temperature system        |         1 |   0.00103s |      0.11% |
+| Initialization                  |         1 |     0.152s |        17% |
+| Postprocessing                  |         1 |    0.0268s |         3% |
+| Setup dof systems               |         1 |    0.0631s |         7% |
+| Setup initial conditions        |         1 |    0.0291s |       3.2% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/chunk_cross_hemisphere/statistics
+++ b/tests/chunk_cross_hemisphere/statistics
@@ -1,0 +1,17 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Iterations for temperature solver
+# 7: Iterations for Stokes solver
+# 8: Velocity iterations in Stokes preconditioner
+# 9: Schur complement iterations in Stokes preconditioner
+# 10: Time step size (years)
+# 11: RMS velocity (m/year)
+# 12: Max. velocity (m/year)
+# 13: Minimal temperature (K)
+# 14: Average temperature (K)
+# 15: Maximal temperature (K)
+# 16: Average nondimensional temperature (K)
+0 0.000000000000e+00 128 1275 561 0 35 24 6 3.294471812263e+05 1.92417085e-01 2.83934603e-01 1.61300000e+03 1.61300000e+03 1.61300000e+03 -3.31315927e-15 


### PR DESCRIPTION
When the longitude of the chunk geometry crosses 180 degrees, 
the model will crash because of the negative longitudes returned in the
pull_back function for all points between 180 and 360 degrees.

It is not sufficient to add 360 degrees to all negative longitudes,
because this will still cause a crash when the geometry runs from, 
for example, -10 to 220 degrees longitude. Returned points will
then run from 350 to 220 degrees, while angles should be strictly
increasing.