### PR TITLE
Include line diff in numdiff output

### DIFF
--- a/tests/cmake/diff_test.sh
+++ b/tests/cmake/diff_test.sh
@@ -59,7 +59,7 @@ rm -f ${DIFF_OUTPUT}.failed ${DIFF_OUTPUT}
 
 case ${DIFF_EXE} in
     *numdiff)
-	${DIFF_EXE} -a 1e-6 -r 1e-8 -s ' \t\n:<>=,;' \
+	${DIFF_EXE} -V -a 1e-6 -r 1e-8 -s ' \t\n:<>=,;' \
 	    ${REF_FILE} ${GEN_FILE} > ${DIFF_OUTPUT}.tmp
 	;;
     *)


### PR DESCRIPTION
When running tests, if Numdiff is used only the differing values and their position in the lines in question are shown in the generated diff files. This results in having to either visually do the comparison, use another diff tool or redoing the diff using "numdiff -V" in order to obtain the context of the variations between the two. The change made is to use "numdiff -V" when generating the DIFF_OUTPUT intended to become *.diff or *.diff.failed in order to also include the originating lines when printing the diff.

Is not making use of this flag an intended design decision, a compatibility limitation, or was the capability overlooked?