### PR TITLE
Derive two_merged_boxes from box

### DIFF
--- a/include/aspect/geometry_model/box.h
+++ b/include/aspect/geometry_model/box.h
@@ -49,12 +49,14 @@ namespace aspect
          * Return a point that denotes the size of the box in each dimension
          * of the domain.
          */
+        virtual
         Point<dim> get_extents () const;
 
         /**
          * Return a point that denotes the lower left corner of the box
          * domain.
          */
+        virtual
         Point<dim> get_origin () const;
 
         /**

--- a/include/aspect/geometry_model/two_merged_boxes.h
+++ b/include/aspect/geometry_model/two_merged_boxes.h
@@ -22,7 +22,7 @@
 #ifndef __aspect__geometry_model_two_merged_boxes_h
 #define __aspect__geometry_model_two_merged_boxes_h
 
-#include <aspect/geometry_model/interface.h>
+#include <aspect/geometry_model/box.h>
 
 
 namespace aspect
@@ -37,7 +37,7 @@ namespace aspect
      * for the lithospheric part of the vertical boundaries.
      */
     template <int dim>
-    class TwoMergedBoxes : public Interface<dim>
+    class TwoMergedBoxes : public Box<dim>
     {
       public:
 


### PR DESCRIPTION
As suggested to me when discussing #1044. This way we don't need a conditional statement for both Box and TwoMergedBoxes, for example if we want to check whether a plugin can be used for a specific geometry, or when logic is the same for Box and TwoMergedBoxes, we can combine it.