### PR TITLE
Speedup particle sorting

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,17 @@
  *
  * <ol>
  *
+ * <li> Changed: Particles now also store their location in the
+ * coordinate system of their current cell. This decreases the
+ * number of times this location has to be computed by inverting
+ * the mapping for the current cell, which is expensive.
+ * On average this change will save 40-50% of the overall
+ * particle computing time, while increasing the particle
+ * memory footprint (which is usually small compared to the
+ * system matrix).
+ * <br>
+ * (Rene Gassmoeller, 2016/08/12)
+ *
  * <li> Changed: Chunk geometry pull back function now returns
  * a corrected longitude value when 180 hemisphere is crossed.
  * <br>

--- a/include/aspect/particle/particle.h
+++ b/include/aspect/particle/particle.h
@@ -114,11 +114,14 @@ namespace aspect
          * does not check for duplicate particle IDs so the generator must
          * make sure the IDs are unique over all processes.
          *
-         * @param[in] new_loc Initial location of particle.
+         * @param[in] new_location Initial location of particle.
+         * @param[in] new_reference_location Initial location of the particle
+         * in the coordinate system of the reference cell.
          * @param[in] new_id Globally unique ID number of particle.
          */
-        Particle (const Point<dim> &new_loc,
-                  const types::particle_index &new_id);
+        Particle (const Point<dim> &new_location,
+                  const Point<dim> &new_reference_location,
+                  const types::particle_index new_id);
 
         /**
          * Constructor for Particle, creates a particle from a data vector.
@@ -190,6 +193,23 @@ namespace aspect
         get_location () const;
 
         /**
+         * Set the reference location of this particle. Note that this does not
+         * check whether this is a valid location in the simulation domain.
+         *
+         * @param [in] new_loc The new reference location for this particle.
+         */
+        void
+        set_reference_location (const Point<dim> &new_loc);
+
+        /**
+         * Get the reference location of this particle in its current cell.
+         *
+         * @return The reference location of this particle.
+         */
+        const Point<dim> &
+        get_reference_location () const;
+
+        /**
          * Get the ID number of this particle.
          *
          * @return The id of this particle.
@@ -232,6 +252,13 @@ namespace aspect
          * Current particle location
          */
         Point<dim>             location;
+
+        /**
+         * Current particle location in the reference cell.
+         * Storing this reduces the number of times we need to compute this
+         * location, which takes a significant amount of computing time.
+         */
+        Point<dim>             reference_location;
 
         /**
          * Globally unique ID of particle

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -376,7 +376,7 @@ namespace aspect
          * process and in its current cell, or deleted (if it could not find
          * its new process or cell).
          *
-         * @param [in,out] particles_to_sort Vector containing all pairs of
+         * @param [in] particles_to_sort Vector containing all pairs of
          * particles and their old cells that will be sorted into the
          * 'particles' member variable in this function.
          */
@@ -399,9 +399,9 @@ namespace aspect
          * that can not be found are discarded.
          */
         void
-        move_particles_back_into_mesh(std::vector<std::pair<types::LevelInd, Particle<dim> > > &lost_particles,
-                                      std::vector<std::pair<types::LevelInd, Particle<dim> > > &moved_particles_cell,
-                                      std::multimap<types::subdomain_id, Particle<dim> >       &moved_particles_domain);
+        move_particles_back_into_mesh(const std::vector<std::pair<types::LevelInd, Particle<dim> > > &lost_particles,
+                                      std::vector<std::pair<types::LevelInd, Particle<dim> > >       &moved_particles_cell,
+                                      std::multimap<types::subdomain_id, Particle<dim> >             &moved_particles_domain);
 
         /**
          * Transfer particles that have crossed subdomain boundaries to other
@@ -420,7 +420,7 @@ namespace aspect
          * @param [in,out] received_particles List that stores all received
          * particles. Note that it is not required nor checked that the list
          * is empty, received particles are simply attached to the end of
-         * the list.
+         * the vector.
          */
         void
         send_recv_particles(const std::multimap<types::subdomain_id,Particle <dim> > &sent_particles,

--- a/source/particle/particle.cc
+++ b/source/particle/particle.cc
@@ -25,21 +25,25 @@ namespace aspect
   namespace Particle
   {
     template <int dim>
-    Particle<dim>::Particle (const Point<dim> &new_loc,
-                             const types::particle_index &new_id)
-      :
-      location (new_loc),
-      id (new_id),
-      properties ()
-    {
-    }
-
-    template <int dim>
     Particle<dim>::Particle ()
       :
       location (),
+      reference_location(),
       id (0),
       properties()
+    {
+    }
+
+
+    template <int dim>
+    Particle<dim>::Particle (const Point<dim> &new_location,
+                             const Point<dim> &new_reference_location,
+                             const types::particle_index new_id)
+      :
+      location (new_location),
+      reference_location (new_reference_location),
+      id (new_id),
+      properties ()
     {
     }
 
@@ -48,11 +52,12 @@ namespace aspect
     Particle<dim>::Particle (const void *&data,
                              const unsigned int data_size)
     {
-      // The data_size includes the space for position and id, so the number
+      // The data_size includes the space for position, reference_position and
+      // id, so the number
       // of properties is the total size minus the space for position and id
       // divided by the size of one double (currently we only allow doubles as
       // tracer properties).
-      const unsigned int property_size = data_size - dim * sizeof(double) - sizeof(types::particle_index);
+      const unsigned int property_size = data_size - 2 * dim * sizeof(double) - sizeof(types::particle_index);
       properties.resize(property_size / sizeof(double));
 
       const types::particle_index *id_data = static_cast<const types::particle_index *> (data);
@@ -61,6 +66,9 @@ namespace aspect
 
       for (unsigned int i = 0; i < dim; ++i)
         location(i) = *pdata++;
+
+      for (unsigned int i = 0; i < dim; ++i)
+        reference_location(i) = *pdata++;
 
       for (unsigned int i = 0; i < properties.size(); ++i)
         properties [i] = *pdata++;
@@ -74,13 +82,6 @@ namespace aspect
     {
     }
 
-
-    template <int dim>
-    void
-    Particle<dim>::set_location (const Point<dim> &new_loc)
-    {
-      location = new_loc;
-    }
 
     template <int dim>
     void
@@ -100,7 +101,11 @@ namespace aspect
 
       // Write location data
       for (unsigned int i = 0; i < dim; ++i,++pdata)
-        *pdata =location(i);
+        *pdata = location(i);
+
+      // Write reference location data
+      for (unsigned int i = 0; i < dim; ++i,++pdata)
+        *pdata = reference_location(i);
 
       // Write property data
       for (unsigned int i = 0; i < properties.size(); ++i,++pdata)
@@ -109,12 +114,32 @@ namespace aspect
       data = static_cast<void *> (pdata);
     }
 
+    template <int dim>
+    void
+    Particle<dim>::set_location (const Point<dim> &new_loc)
+    {
+      location = new_loc;
+    }
 
     template <int dim>
     const Point<dim> &
     Particle<dim>::get_location () const
     {
       return location;
+    }
+
+    template <int dim>
+    void
+    Particle<dim>::set_reference_location (const Point<dim> &new_loc)
+    {
+      reference_location = new_loc;
+    }
+
+    template <int dim>
+    const Point<dim> &
+    Particle<dim>::get_reference_location () const
+    {
+      return reference_location;
     }
 
     template <int dim>

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -230,7 +230,7 @@ namespace aspect
       std::size_t
       Manager<dim>::get_particle_size () const
       {
-        return (n_property_components+dim) * sizeof(double) + sizeof(types::particle_index);
+        return (n_property_components+2*dim) * sizeof(double) + sizeof(types::particle_index);
       }
 
       template <int dim>


### PR DESCRIPTION
Particles now also store their location in the
coordinate system of their current cell. This decreases the
number of times this location has to be computed by inverting
the mapping for the current cell, which is expensive.
On average this change will save 40-50% of the overall
particle computing time, while increasing the particle
memory footprint (which is usually small compared to the
system matrix).

The new algorithm relies on the fact that the reference location is set before the particles are advected. All implemented particle generators do that, but it is possible to use the old constructor to construct a particle without setting this location (e.g. in a user-written generator). What should I do about the old constructor? Remove? Deprecate? Add a sentence to the documentation that if using this constructor the user has to set the reference_location manually?