### PR TITLE
several changes using introspection advection field,  degree and component index

### DIFF
--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -433,19 +433,11 @@ namespace aspect
   get_extrapolated_advection_field_range (const AdvectionField &advection_field) const
   {
     const QIterated<dim> quadrature_formula (QTrapez<1>(),
-                                             (advection_field.is_temperature() ?
-                                              parameters.temperature_degree :
-                                              parameters.composition_degree));
+                                             advection_field.polynomial_degree(introspection));
 
     const unsigned int n_q_points = quadrature_formula.size();
 
-    const FEValuesExtractors::Scalar field
-      = (advection_field.is_temperature()
-         ?
-         introspection.extractors.temperature
-         :
-         introspection.extractors.compositional_fields[advection_field.compositional_variable]
-        );
+    const FEValuesExtractors::Scalar field = advection_field.scalar_extractor(introspection);
 
     FEValues<dim> fe_values (*mapping, finite_element, quadrature_formula,
                              update_values);

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -350,13 +350,7 @@ namespace aspect
       const double time_step = this->get_timestep();
       const double old_time_step = this->get_old_timestep();
 
-      const unsigned int solution_component
-        = (advection_field.is_temperature()
-           ?
-           introspection.component_indices.temperature
-           :
-           introspection.component_indices.compositional_fields[advection_field.compositional_variable]
-          );
+      const unsigned int solution_component = advection_field.component_index(introspection);
 
       const FEValuesExtractors::Scalar solution_field = advection_field.scalar_extractor(introspection);
 


### PR DESCRIPTION
When go though the advection solver part,  I found several places can be improved by using current introspection properties for advection field.

Besides above, I also made one change on assembly.cc . For DG approach, the current Dirichlet boundary condition seems only be weakly imposed on inflow boundary condition no matter the filed is temperature field or compositional filed, but I think we don't have to check this for the temperature filed. So I'll just wait for other opinions. 
