### PR TITLE
Bug fix for DG temperature Dirichlet boundary condition

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1419,7 +1419,8 @@ namespace aspect
                    * on the direction of the flow. Thus the flow-dependent terms below are
                    * only calculated if the edge is an inflow edge.
                    */
-                  const bool inflow = ((current_u * scratch.face_finite_element_values->normal_vector(q)) < 0.);
+                  const bool inflow = (advection_field.is_temperature()
+                                       || ((current_u * scratch.face_finite_element_values->normal_vector(q)) < 0.));
 
                   for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
                     {


### PR DESCRIPTION
Just open a new pull request, which originally mentioned from pull request #1171 

For DG approach, the current Dirichlet boundary condition seems only be weakly imposed on inflow boundary condition no matter the filed is temperature field or compositional filed, which needs to be fixed.
