### PR TITLE
Send CellId during particle mpi transfer

### DIFF
--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -419,9 +419,9 @@ namespace aspect
          * that can not be found are discarded.
          */
         void
-        move_particles_back_into_mesh(const std::vector<std::pair<types::LevelInd, Particle<dim> > > &lost_particles,
-                                      std::vector<std::pair<types::LevelInd, Particle<dim> > >       &moved_particles_cell,
-                                      std::multimap<types::subdomain_id, Particle<dim> >             &moved_particles_domain);
+        move_particles_back_into_mesh(const std::vector<std::pair<types::LevelInd, Particle<dim> > >                  &lost_particles,
+                                      std::vector<std::pair<types::LevelInd, Particle<dim> > >                        &moved_particles_cell,
+                                      std::multimap<types::subdomain_id, std::pair<types::LevelInd, Particle<dim> > > &moved_particles_domain);
 
         /**
          * Transfer particles that have crossed subdomain boundaries to other
@@ -437,14 +437,14 @@ namespace aspect
          * @param [in] sent_particles All particles that should be sent and
          * their new subdomain_ids are in this map.
          *
-         * @param [in,out] received_particles List that stores all received
+         * @param [in,out] received_particles Vector that stores all received
          * particles. Note that it is not required nor checked that the list
          * is empty, received particles are simply attached to the end of
          * the vector.
          */
         void
-        send_recv_particles(const std::multimap<types::subdomain_id,Particle <dim> > &sent_particles,
-                            std::vector<std::pair<types::LevelInd, Particle<dim> > > &received_particles);
+        send_recv_particles(const std::multimap<types::subdomain_id, std::pair<types::LevelInd,Particle <dim> > > &sent_particles,
+                            std::vector<std::pair<types::LevelInd, Particle<dim> > >                              &received_particles);
 
         /**
          * Advect the particle positions by one integration step. Needs to be


### PR DESCRIPTION
This makes use of dealii/dealii#2981 and ships the cellid and reference location of a particle with it when sending it to a different process. This makes the code cleaner (when we can remove the old code path for deal.II 8.4) and saves a bit of time (only a few percent of the overall particle time, depending on how many particles are sent around). I have tested the code both for deal.II 8.4 and 8.5.0.pre. 
The only thing I am not quite happy with is the frequent casting of pointers and comparing them to integers in the `send_recv_particles` function, but since the length of a CellId is not constant there is no way around it (except padding each data package with zeroes, which I would not like).