### PR TITLE
Not longer construct FEValues in local_advect_particles

### DIFF
--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -980,36 +980,40 @@ namespace aspect
       std::vector<Tensor<1,dim> >  result(particles_in_cell);
       std::vector<Tensor<1,dim> >  old_result(particles_in_cell);
 
-      std::vector<types::global_dof_index> cell_dof_indices (this->get_fe().dofs_per_cell);
+      // Below we manually evaluate the solution at all support points of the
+      // current cell, and then use the shape functions to interpolate the
+      // solution to the particle points. All of this can be done with less
+      // code using an FEValues object, but since this object initializes a lot
+      // of memory for other purposes and we can not reuse the FEValues object
+      // for other cells, it is much faster to do the work manually. Also this
+      // function is quite performance critical.
 
-      const FiniteElement<dim> &velocity_fe = this->get_fe().base_element(this->introspection().base_elements.velocities);
+      std::vector<types::global_dof_index> cell_dof_indices (this->get_fe().dofs_per_cell);
       cell->get_dof_indices (cell_dof_indices);
 
-      Table<2,double> shape_values (velocity_fe.dofs_per_cell,particles_in_cell);
+      const FiniteElement<dim> &velocity_fe = this->get_fe().base_element(this->introspection().base_elements.velocities);
 
       for (unsigned int j=0; j<velocity_fe.dofs_per_cell; ++j)
         {
+          Tensor<1,dim> solution_at_support_point;
+          Tensor<1,dim> old_solution_at_support_point;
+          for (unsigned int dir=0; dir<dim; ++dir)
+            {
+              const unsigned int support_point_index
+                = this->get_fe().component_to_system_index(/*velocity component=*/ this->introspection().component_indices.velocities[dir],
+                                                                                   /*dof index within component=*/ j);
+              solution_at_support_point[dir] = this->get_solution()[cell_dof_indices[support_point_index]];
+              old_solution_at_support_point[dir] = this->get_old_solution()[cell_dof_indices[support_point_index]];
+            }
+
           typename std::multimap<types::LevelInd, Particle<dim> >::iterator it = begin_particle;
-          for (unsigned int i = 0; it!=end_particle; ++it,++i)
-            shape_values(j,i) = velocity_fe.shape_value(j,it->second.get_reference_location());
+          for (unsigned int particle_index = 0; it!=end_particle; ++it,++particle_index)
+            {
+              const double shape_value = velocity_fe.shape_value(j,it->second.get_reference_location());
+              result[particle_index] += solution_at_support_point * shape_value;
+              old_result[particle_index] += old_solution_at_support_point * shape_value;
+            }
         }
-
-      for (unsigned int j=0; j<velocity_fe.dofs_per_cell; ++j)
-        for (unsigned int dir=0; dir<dim; ++dir)
-          {
-            const unsigned int support_point_index
-            = this->get_fe().component_to_system_index(/*velocity component=*/ this->introspection().component_indices.velocities[dir],
-                /*dof index within component=*/ j);
-            const double solution = this->get_solution()[cell_dof_indices[support_point_index]];
-            const double old_solution = this->get_old_solution()[cell_dof_indices[support_point_index]];
-
-            for (unsigned int particle_index=0; particle_index<particles_in_cell; ++particle_index)
-              {
-                const double shape_value = shape_values(j,particle_index);
-                result[particle_index][dir] += solution * shape_value;
-                old_result[particle_index][dir] += old_solution * shape_value;
-              }
-          }
 
       integrator->local_integrate_step(begin_particle,
                                        end_particle,


### PR DESCRIPTION
More optimizations based on profiling example models with particles. It turns out that creating FEValues objects for every cell with particle positions as quadrature points is expensive (who would have thought :smile:), but since the quadrature is different for every cell we can not use the approach of the matrix assembly and reuse the FEValues object for every cell. Instead we can do the evaluation of the velocity manually, and save between 75% (2D box models) and 25% (3D shell models) of the total particle advection time. In general the cheaper the inversion of the mapping the larger the (relative) saving of advection time.
I am looking for a similar approach for the local_update_particles, but there I not only need the velocity but possibly more variables depending on the particle properties. After this PR is merged in some models the update is actually more expensive than the advection although it is done two times less often, and does not involve finding the unit coordinates of the particles.