### PR TITLE
Add time information to .visit files

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,13 @@
  *
  * <ol>
  *
+ * <li> New: .visit output files now also contain information about
+ * the model time, as long as ASPECT was build with at least
+ * deal.II 8.5.0.pre. Previously, this information was only available
+ * in the Paraview .pvd files.
+ * <br>
+ * (Rene Gassmoeller, Juliane Dannberg, 2016/08/24)
+ *
  * <li> New: There is now an initial topography plugin that returns
  * initial topography values based on an ascii data file.
  * <br>

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -283,7 +283,16 @@ namespace aspect
 
       std::ofstream global_visit_master ((this->get_output_directory() +
                                           "solution.visit").c_str());
+
+#if DEAL_II_VERSION_GTE(8,5,0)
+      std::vector<std::pair<double, std::vector<std::string> > > times_and_output_file_names;
+      for (unsigned int timestep=0; timestep<times_and_pvtu_names.size(); ++timestep)
+        times_and_output_file_names.push_back(std::make_pair(times_and_pvtu_names[timestep].first,
+                                                             output_file_names_by_timestep[timestep]));
+      data_out.write_visit_record (global_visit_master, times_and_output_file_names);
+#else
       data_out.write_visit_record (global_visit_master, output_file_names_by_timestep);
+#endif
     }
 
     template <int dim>


### PR DESCRIPTION
See dealii/dealii#3012 for a discussion of the issue (this PR should only be merged after that one). This adds time information to the .visit files.