### PR TITLE
Always pass vtk flags time into the output

### DIFF
--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -489,6 +489,13 @@ namespace aspect
                                        + Utilities::int_to_string (my_file_id, 4)
                                        + ".vtu";
 
+          // pass time step number and time as metadata into the output file
+          DataOutBase::VtkFlags vtk_flags;
+          vtk_flags.cycle = this->get_timestep_number();
+          vtk_flags.time = time_in_years_or_seconds;
+
+          data_out.set_flags (vtk_flags);
+
           // Write as many files as processes. For this case we support writing in a
           // background thread and to a temporary location, so we first write everything
           // into a string that is written to disk in a writer function
@@ -499,13 +506,6 @@ namespace aspect
               const std::string *file_contents;
               {
                 std::ostringstream tmp;
-
-                // pass time step number and time as metadata into the output file
-                DataOutBase::VtkFlags vtk_flags;
-                vtk_flags.cycle = this->get_timestep_number();
-                vtk_flags.time = time_in_years_or_seconds;
-
-                data_out.set_flags (vtk_flags);
 
                 data_out.write (tmp, DataOutBase::parse_output_format(output_format));
                 file_contents = new std::string (tmp.str());

--- a/tests/parallel_output_group_1/solution/solution-00000.0000.vtu
+++ b/tests/parallel_output_group_1/solution/solution-00000.0000.vtu
@@ -2,9 +2,11 @@
 <!-- 
 # vtk DataFile Version 3.0
 #This file was generated 
--->
 <VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
 <UnstructuredGrid>
+<FieldData>
+<DataArray type="Float32" Name="TIME" NumberOfTuples="1" format="ascii">0</DataArray>
+</FieldData>
 <Piece NumberOfPoints="32" NumberOfCells="8" >
   <Points>
     <DataArray type="Float64" NumberOfComponents="3" format="binary">
@@ -32,6 +34,9 @@ AQAAAAABAAAAAQAAdwAAAA==eNpjYGBweMi96iADA4NCm9hKMP3/vrATkG7gfAymYeIOp10WH0QSf+D2
 AQAAAAABAAAAAQAASQAAAA==eNpjYACCjD4HBmRaYg6IXsBSNhdVHEIjxNnnYVdftwREJ0SkL8WmHibOwHBiKTbzYeoI2w+xF1M9xFxM+yHqEfYD3QkAh7ou+w==    </DataArray>
   </PointData>
  </Piece>
+<FieldData>
+<DataArray type="Float32" Name="TIME" NumberOfTuples="1" format="ascii">0</DataArray>
+</FieldData>
 <Piece NumberOfPoints="40" NumberOfCells="10" >
   <Points>
     <DataArray type="Float64" NumberOfComponents="3" format="binary">
@@ -59,6 +64,9 @@ AQAAAEABAABAAQAAhQAAAA==eNpjYGB4kByv7MTAwKDQFgqmD+x9YwSiEza+M0IWZ+itUkYWXzDvPUTd
 AQAAAEABAABAAQAAUwAAAA==eNpjYACCuiUOIIrhxFIIvXEDKg0Th6lDl8/oQ6Vh6kwWY5eHicPUoatHNx9dPSH7JeaA6AUsZXOxySPE2edhVw+xJyEifSk29TBxcLgAAAYpOWA=    </DataArray>
   </PointData>
  </Piece>
+<FieldData>
+<DataArray type="Float32" Name="TIME" NumberOfTuples="1" format="ascii">0</DataArray>
+</FieldData>
 <Piece NumberOfPoints="24" NumberOfCells="6" >
   <Points>
     <DataArray type="Float64" NumberOfComponents="3" format="binary">

--- a/tests/parallel_output_group_1/solution/solution-00001.0000.vtu
+++ b/tests/parallel_output_group_1/solution/solution-00001.0000.vtu
@@ -2,9 +2,12 @@
 <!-- 
 # vtk DataFile Version 3.0
 #This file was generated 
--->
 <VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
 <UnstructuredGrid>
+<FieldData>
+<DataArray type="Float32" Name="CYCLE" NumberOfTuples="1" format="ascii">1</DataArray>
+<DataArray type="Float32" Name="TIME" NumberOfTuples="1" format="ascii">1</DataArray>
+</FieldData>
 <Piece NumberOfPoints="32" NumberOfCells="8" >
   <Points>
     <DataArray type="Float64" NumberOfComponents="3" format="binary">
@@ -32,6 +35,10 @@ AQAAAAABAAAAAQAAdwAAAA==eNpjYGBgeMi96iCQOtAqthJEK/y/L+wEpBs4H4NpmLjDaZfFB5HEH7i9
 AQAAAAABAAAAAQAASwAAAA==eNpjYACCjD4HBmRaYg6IXsBSNhdVHELDxBUY2OdhV1+3BEQnRKQvxaYeJq7AcGIpNvNh6gjZD7MXXT3MXHT7YeoR9gPdCQDfGi/b    </DataArray>
   </PointData>
  </Piece>
+<FieldData>
+<DataArray type="Float32" Name="CYCLE" NumberOfTuples="1" format="ascii">1</DataArray>
+<DataArray type="Float32" Name="TIME" NumberOfTuples="1" format="ascii">1</DataArray>
+</FieldData>
 <Piece NumberOfPoints="40" NumberOfCells="10" >
   <Points>
     <DataArray type="Float64" NumberOfComponents="3" format="binary">
@@ -59,6 +66,10 @@ AQAAAEABAABAAQAAhAAAAA==eNpjYGB4kByv7MTAwKDQFgqmD+x9YwSiEza+M0IWZ+itUkYWXzDvPUTd
 AQAAAEABAABAAQAAXgAAAA==eNpjYACCuiUOQFKB4cRSEM3AsHEDMg0TV4CqQ5dnYMjoQ6YR6kwWY5OHiSvA7UVXj24+qnpC9jMwSMwB0QtYyuZik4eJKzCwz8OmHmZPQkT6UmzqYeLgcAEA5Qk6wA==    </DataArray>
   </PointData>
  </Piece>
+<FieldData>
+<DataArray type="Float32" Name="CYCLE" NumberOfTuples="1" format="ascii">1</DataArray>
+<DataArray type="Float32" Name="TIME" NumberOfTuples="1" format="ascii">1</DataArray>
+</FieldData>
 <Piece NumberOfPoints="24" NumberOfCells="6" >
   <Points>
     <DataArray type="Float64" NumberOfComponents="3" format="binary">

--- a/tests/parallel_output_group_2/solution/solution-00000.0000.vtu
+++ b/tests/parallel_output_group_2/solution/solution-00000.0000.vtu
@@ -2,9 +2,11 @@
 <!-- 
 # vtk DataFile Version 3.0
 #This file was generated 
--->
 <VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
 <UnstructuredGrid>
+<FieldData>
+<DataArray type="Float32" Name="TIME" NumberOfTuples="1" format="ascii">0</DataArray>
+</FieldData>
 <Piece NumberOfPoints="32" NumberOfCells="8" >
   <Points>
     <DataArray type="Float64" NumberOfComponents="3" format="binary">
@@ -32,6 +34,9 @@ AQAAAAABAAAAAQAAdwAAAA==eNpjYGBweMi96iADA4NCm9hKMP3/vrATkG7gfAymYeIOp10WH0QSf+D2
 AQAAAAABAAAAAQAASQAAAA==eNpjYACCjD4HBmRaYg6IXsBSNhdVHEIjxNnnYVdftwREJ0SkL8WmHibOwHBiKTbzYeoI2w+xF1M9xFxM+yHqEfYD3QkAh7ou+w==    </DataArray>
   </PointData>
  </Piece>
+<FieldData>
+<DataArray type="Float32" Name="TIME" NumberOfTuples="1" format="ascii">0</DataArray>
+</FieldData>
 <Piece NumberOfPoints="24" NumberOfCells="6" >
   <Points>
     <DataArray type="Float64" NumberOfComponents="3" format="binary">

--- a/tests/parallel_output_group_2/solution/solution-00000.0001.vtu
+++ b/tests/parallel_output_group_2/solution/solution-00000.0001.vtu
@@ -2,9 +2,11 @@
 <!-- 
 # vtk DataFile Version 3.0
 #This file was generated 
--->
 <VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
 <UnstructuredGrid>
+<FieldData>
+<DataArray type="Float32" Name="TIME" NumberOfTuples="1" format="ascii">0</DataArray>
+</FieldData>
 <Piece NumberOfPoints="40" NumberOfCells="10" >
   <Points>
     <DataArray type="Float64" NumberOfComponents="3" format="binary">

--- a/tests/parallel_output_group_2/solution/solution-00001.0000.vtu
+++ b/tests/parallel_output_group_2/solution/solution-00001.0000.vtu
@@ -2,9 +2,12 @@
 <!-- 
 # vtk DataFile Version 3.0
 #This file was generated 
--->
 <VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
 <UnstructuredGrid>
+<FieldData>
+<DataArray type="Float32" Name="CYCLE" NumberOfTuples="1" format="ascii">1</DataArray>
+<DataArray type="Float32" Name="TIME" NumberOfTuples="1" format="ascii">1</DataArray>
+</FieldData>
 <Piece NumberOfPoints="32" NumberOfCells="8" >
   <Points>
     <DataArray type="Float64" NumberOfComponents="3" format="binary">
@@ -32,6 +35,10 @@ AQAAAAABAAAAAQAAdwAAAA==eNpjYGBgeMi96iCQOtAqthJEK/y/L+wEpBs4H4NpmLjDaZfFB5HEH7i9
 AQAAAAABAAAAAQAASwAAAA==eNpjYACCjD4HBmRaYg6IXsBSNhdVHELDxBUY2OdhV1+3BEQnRKQvxaYeJq7AcGIpNvNh6gjZD7MXXT3MXHT7YeoR9gPdCQDfGi/b    </DataArray>
   </PointData>
  </Piece>
+<FieldData>
+<DataArray type="Float32" Name="CYCLE" NumberOfTuples="1" format="ascii">1</DataArray>
+<DataArray type="Float32" Name="TIME" NumberOfTuples="1" format="ascii">1</DataArray>
+</FieldData>
 <Piece NumberOfPoints="24" NumberOfCells="6" >
   <Points>
     <DataArray type="Float64" NumberOfComponents="3" format="binary">

--- a/tests/parallel_output_group_2/solution/solution-00001.0001.vtu
+++ b/tests/parallel_output_group_2/solution/solution-00001.0001.vtu
@@ -2,9 +2,12 @@
 <!-- 
 # vtk DataFile Version 3.0
 #This file was generated 
--->
 <VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
 <UnstructuredGrid>
+<FieldData>
+<DataArray type="Float32" Name="CYCLE" NumberOfTuples="1" format="ascii">1</DataArray>
+<DataArray type="Float32" Name="TIME" NumberOfTuples="1" format="ascii">1</DataArray>
+</FieldData>
 <Piece NumberOfPoints="40" NumberOfCells="10" >
   <Points>
     <DataArray type="Float64" NumberOfComponents="3" format="binary">


### PR DESCRIPTION
This achieves what #1186 was supposed to do without relying on new deal.II features. Currently we only write the vtkflags 'time' and 'cycle' into the .vtk files if 'Number of grouped files' is set to 0, although we should do it in every case.