### PR TITLE
Component-wise value calculation

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,14 @@
  *
  * <ol>
  *
+ * <li> Changed: Particle properties should now declare which solution
+ * properties they need to update themselves. The particle world then
+ * only computes values and gradients of the solution at
+ * the particle positions if necessary, which can reduce the computational
+ * cost of the particle update for simple particle properties.
+ * <br>
+ * (Rene Gassmoeller, 2016/08/30)
+ *
  * <li> New: .visit output files now also contain information about
  * the model time, as long as ASPECT was build with at least
  * deal.II 8.5.0.pre. Previously, this information was only available

--- a/include/aspect/particle/property/initial_composition.h
+++ b/include/aspect/particle/property/initial_composition.h
@@ -22,7 +22,6 @@
 #define __aspect__particle_property_initial_composition_h
 
 #include <aspect/particle/property/interface.h>
-#include <aspect/simulator_access.h>
 
 namespace aspect
 {
@@ -37,7 +36,7 @@ namespace aspect
        * @ingroup ParticleProperties
        */
       template <int dim>
-      class InitialComposition : public Interface<dim>, public SimulatorAccess<dim>
+      class InitialComposition : public Interface<dim>
       {
         public:
           /**

--- a/include/aspect/particle/property/initial_composition.h
+++ b/include/aspect/particle/property/initial_composition.h
@@ -22,6 +22,7 @@
 #define __aspect__particle_property_initial_composition_h
 
 #include <aspect/particle/property/interface.h>
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {
@@ -36,7 +37,7 @@ namespace aspect
        * @ingroup ParticleProperties
        */
       template <int dim>
-      class InitialComposition : public Interface<dim>
+      class InitialComposition : public Interface<dim>, public SimulatorAccess<dim>
       {
         public:
           /**

--- a/include/aspect/particle/property/integrated_strain.h
+++ b/include/aspect/particle/property/integrated_strain.h
@@ -22,6 +22,7 @@
 #define __aspect__particle_property_integrated_strain_h
 
 #include <aspect/particle/property/interface.h>
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {
@@ -39,7 +40,7 @@ namespace aspect
        * @ingroup ParticleProperties
        */
       template <int dim>
-      class IntegratedStrain : public Interface<dim>
+      class IntegratedStrain : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
       {
         public:
           /**
@@ -95,11 +96,11 @@ namespace aspect
           need_update () const;
 
           /**
-           * Return, which data has to be provided to update the property.
+           * Return which data has to be provided to update the property.
            * The integrated strains needs the gradients of the velocity.
            */
           virtual
-          std::vector<UpdateFlags>
+          UpdateFlags
           get_needed_update_flags () const;
 
           /**

--- a/include/aspect/particle/property/integrated_strain.h
+++ b/include/aspect/particle/property/integrated_strain.h
@@ -22,7 +22,6 @@
 #define __aspect__particle_property_integrated_strain_h
 
 #include <aspect/particle/property/interface.h>
-#include <aspect/simulator_access.h>
 
 namespace aspect
 {
@@ -40,7 +39,7 @@ namespace aspect
        * @ingroup ParticleProperties
        */
       template <int dim>
-      class IntegratedStrain : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
+      class IntegratedStrain : public Interface<dim>
       {
         public:
           /**
@@ -94,6 +93,14 @@ namespace aspect
            */
           UpdateTimeFlags
           need_update () const;
+
+          /**
+           * Return, which data has to be provided to update the property.
+           * The integrated strains needs the gradients of the velocity.
+           */
+          virtual
+          std::vector<UpdateFlags>
+          get_needed_update_flags () const;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -28,6 +28,7 @@
 #include <aspect/plugins.h>
 
 #include <deal.II/base/std_cxx1x/shared_ptr.h>
+#include <deal.II/fe/fe_update_flags.h>
 
 namespace aspect
 {
@@ -94,7 +95,7 @@ namespace aspect
         * @ingroup ParticleProperties
         */
       template <int dim>
-      class Interface: public SimulatorAccess<dim>
+      class Interface
       {
         public:
           /**
@@ -178,16 +179,15 @@ namespace aspect
           need_update () const;
 
           /**
-           * Return, which data has to be provided to update the property.
-           * Note that particle properties can only ask for no data, the
-           * solution values, and the solution gradients and all other update
-           * flags will throw exceptions.
+           * Return which data has to be provided to update all properties.
+           * Note that particle properties can only ask for update_default
+           * (no data), update_values (solution values), and update_gradients
+           * (solution gradients). All other update flags will have no effect.
            *
-           * @return A vector with as many entries as solution components.
-           * Each entry contains the necessary update flags for this component.
+           * @return The necessary update flags for this particle property.
            */
           virtual
-          std::vector<UpdateFlags>
+          UpdateFlags
           get_needed_update_flags () const;
 
           /**
@@ -326,12 +326,12 @@ namespace aspect
           need_update () const;
 
           /**
-           * Return, which data has to be provided to update all properties.
-           * Note that particle properties can only ask for no data, the
-           * solution values, and the solution gradients and all other update
-           * flags will throw exceptions.
+           * Return which data has to be provided to update all properties.
+           * Note that particle properties can only ask for update_default
+           * (no data), update_values (solution values), and update_gradients
+           * (solution gradients). All other update flags will have no effect.
            */
-          std::vector<UpdateFlags>
+          UpdateFlags
           get_needed_update_flags () const;
 
           /**

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -94,7 +94,7 @@ namespace aspect
         * @ingroup ParticleProperties
         */
       template <int dim>
-      class Interface
+      class Interface: public SimulatorAccess<dim>
       {
         public:
           /**
@@ -176,6 +176,19 @@ namespace aspect
           virtual
           UpdateTimeFlags
           need_update () const;
+
+          /**
+           * Return, which data has to be provided to update the property.
+           * Note that particle properties can only ask for no data, the
+           * solution values, and the solution gradients and all other update
+           * flags will throw exceptions.
+           *
+           * @return A vector with as many entries as solution components.
+           * Each entry contains the necessary update flags for this component.
+           */
+          virtual
+          std::vector<UpdateFlags>
+          get_needed_update_flags () const;
 
           /**
            * Returns an enum, which determines how this particle property is
@@ -311,6 +324,15 @@ namespace aspect
            */
           UpdateTimeFlags
           need_update () const;
+
+          /**
+           * Return, which data has to be provided to update all properties.
+           * Note that particle properties can only ask for no data, the
+           * solution values, and the solution gradients and all other update
+           * flags will throw exceptions.
+           */
+          std::vector<UpdateFlags>
+          get_needed_update_flags () const;
 
           /**
            * Get the number of components required to represent this particle's

--- a/include/aspect/particle/property/pT_path.h
+++ b/include/aspect/particle/property/pT_path.h
@@ -22,6 +22,7 @@
 #define __aspect__particle_property_pT_path_h
 
 #include <aspect/particle/property/interface.h>
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {
@@ -39,7 +40,7 @@ namespace aspect
        * @ingroup ParticleProperties
        */
       template <int dim>
-      class PTPath : public Interface<dim>
+      class PTPath : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
       {
         public:
           /**
@@ -95,11 +96,11 @@ namespace aspect
           need_update () const;
 
           /**
-           * Return, which data has to be provided to update the property.
+           * Return which data has to be provided to update the property.
            * The pressure and temperature need the values of their variables.
            */
           virtual
-          std::vector<UpdateFlags>
+          UpdateFlags
           get_needed_update_flags () const;
 
           /**

--- a/include/aspect/particle/property/pT_path.h
+++ b/include/aspect/particle/property/pT_path.h
@@ -22,7 +22,6 @@
 #define __aspect__particle_property_pT_path_h
 
 #include <aspect/particle/property/interface.h>
-#include <aspect/simulator_access.h>
 
 namespace aspect
 {
@@ -40,7 +39,7 @@ namespace aspect
        * @ingroup ParticleProperties
        */
       template <int dim>
-      class PTPath : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
+      class PTPath : public Interface<dim>
       {
         public:
           /**
@@ -94,6 +93,14 @@ namespace aspect
            */
           UpdateTimeFlags
           need_update () const;
+
+          /**
+           * Return, which data has to be provided to update the property.
+           * The pressure and temperature need the values of their variables.
+           */
+          virtual
+          std::vector<UpdateFlags>
+          get_needed_update_flags () const;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/position.h
+++ b/include/aspect/particle/property/position.h
@@ -22,7 +22,6 @@
 #define __aspect__particle_property_position_h
 
 #include <aspect/particle/property/interface.h>
-#include <aspect/simulator_access.h>
 
 namespace aspect
 {
@@ -36,7 +35,7 @@ namespace aspect
        * @ingroup ParticleProperties
        */
       template <int dim>
-      class Position : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
+      class Position : public Interface<dim>
       {
         public:
           /**

--- a/include/aspect/particle/property/velocity.h
+++ b/include/aspect/particle/property/velocity.h
@@ -22,7 +22,6 @@
 #define __aspect__particle_property_velocity_h
 
 #include <aspect/particle/property/interface.h>
-#include <aspect/simulator_access.h>
 
 namespace aspect
 {
@@ -36,7 +35,7 @@ namespace aspect
        * @ingroup ParticleProperties
        */
       template <int dim>
-      class Velocity : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
+      class Velocity : public Interface<dim>
       {
         public:
           /**
@@ -90,6 +89,15 @@ namespace aspect
            */
           UpdateTimeFlags
           need_update () const;
+
+          /**
+           * Return, which data has to be provided to update the property.
+           * The velocity particle property needs the values of the velocity
+           * solution.
+           */
+          virtual
+          std::vector<UpdateFlags>
+          get_needed_update_flags () const;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/velocity.h
+++ b/include/aspect/particle/property/velocity.h
@@ -22,6 +22,7 @@
 #define __aspect__particle_property_velocity_h
 
 #include <aspect/particle/property/interface.h>
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {
@@ -35,7 +36,7 @@ namespace aspect
        * @ingroup ParticleProperties
        */
       template <int dim>
-      class Velocity : public Interface<dim>
+      class Velocity : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
       {
         public:
           /**
@@ -91,12 +92,12 @@ namespace aspect
           need_update () const;
 
           /**
-           * Return, which data has to be provided to update the property.
+           * Return which data has to be provided to update the property.
            * The velocity particle property needs the values of the velocity
            * solution.
            */
           virtual
-          std::vector<UpdateFlags>
+          UpdateFlags
           get_needed_update_flags () const;
 
           /**

--- a/source/particle/property/integrated_strain.cc
+++ b/source/particle/property/integrated_strain.cc
@@ -83,13 +83,10 @@ namespace aspect
       }
 
       template <int dim>
-      std::vector<UpdateFlags>
+      UpdateFlags
       IntegratedStrain<dim>::get_needed_update_flags () const
       {
-        std::vector<UpdateFlags> update(this->introspection().n_components,update_default);
-        for (unsigned int i = 0; i<dim; ++i)
-          update[this->introspection().component_indices.velocities[i]] = update_gradients;
-        return update;
+        return update_gradients;
       }
 
       template <int dim>

--- a/source/particle/property/integrated_strain.cc
+++ b/source/particle/property/integrated_strain.cc
@@ -83,6 +83,16 @@ namespace aspect
       }
 
       template <int dim>
+      std::vector<UpdateFlags>
+      IntegratedStrain<dim>::get_needed_update_flags () const
+      {
+        std::vector<UpdateFlags> update(this->introspection().n_components,update_default);
+        for (unsigned int i = 0; i<dim; ++i)
+          update[this->introspection().component_indices.velocities[i]] = update_gradients;
+        return update;
+      }
+
+      template <int dim>
       std::vector<std::pair<std::string, unsigned int> >
       IntegratedStrain<dim>::get_property_information() const
       {

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -62,6 +62,13 @@ namespace aspect
       }
 
       template <int dim>
+      std::vector<UpdateFlags>
+      Interface<dim>::get_needed_update_flags () const
+      {
+        return std::vector<UpdateFlags> (this->introspection().n_components,update_default);
+      }
+
+      template <int dim>
       InitializationModeForLateParticles
       Interface<dim>::late_initialization_mode () const
       {
@@ -215,6 +222,23 @@ namespace aspect
              p = property_list.begin(); p!=property_list.end(); ++p)
           {
             update = std::max(update,(*p)->need_update());
+          }
+        return update;
+      }
+
+      template <int dim>
+      std::vector<UpdateFlags>
+      Manager<dim>::get_needed_update_flags () const
+      {
+        const unsigned int n_components = this->introspection().n_components;
+        std::vector<UpdateFlags> update (n_components,update_default);
+        for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
+             p = property_list.begin(); p!=property_list.end(); ++p)
+          {
+            const std::vector<UpdateFlags> property_update ((*p)->get_needed_update_flags());
+
+            for (unsigned int i = 0; i<n_components; ++i)
+              update[i] |= property_update[i];
           }
         return update;
       }

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -62,10 +62,10 @@ namespace aspect
       }
 
       template <int dim>
-      std::vector<UpdateFlags>
+      UpdateFlags
       Interface<dim>::get_needed_update_flags () const
       {
-        return std::vector<UpdateFlags> (this->introspection().n_components,update_default);
+        return update_default;
       }
 
       template <int dim>
@@ -227,20 +227,17 @@ namespace aspect
       }
 
       template <int dim>
-      std::vector<UpdateFlags>
+      UpdateFlags
       Manager<dim>::get_needed_update_flags () const
       {
-        const unsigned int n_components = this->introspection().n_components;
-        std::vector<UpdateFlags> update (n_components,update_default);
+        UpdateFlags update = update_default;
         for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
              p = property_list.begin(); p!=property_list.end(); ++p)
           {
-            const std::vector<UpdateFlags> property_update ((*p)->get_needed_update_flags());
-
-            for (unsigned int i = 0; i<n_components; ++i)
-              update[i] |= property_update[i];
+            update |= (*p)->get_needed_update_flags();
           }
-        return update;
+
+        return (update & (update_default | update_values | update_gradients));
       }
 
       template <int dim>

--- a/source/particle/property/pT_path.cc
+++ b/source/particle/property/pT_path.cc
@@ -55,6 +55,16 @@ namespace aspect
       }
 
       template <int dim>
+      std::vector<UpdateFlags>
+      PTPath<dim>::get_needed_update_flags () const
+      {
+        std::vector<UpdateFlags> update(this->introspection().n_components,update_default);
+        update[this->introspection().component_indices.pressure] = update_values;
+        update[this->introspection().component_indices.temperature] = update_values;
+        return update;
+      }
+
+      template <int dim>
       std::vector<std::pair<std::string, unsigned int> >
       PTPath<dim>::get_property_information() const
       {

--- a/source/particle/property/pT_path.cc
+++ b/source/particle/property/pT_path.cc
@@ -55,13 +55,10 @@ namespace aspect
       }
 
       template <int dim>
-      std::vector<UpdateFlags>
+      UpdateFlags
       PTPath<dim>::get_needed_update_flags () const
       {
-        std::vector<UpdateFlags> update(this->introspection().n_components,update_default);
-        update[this->introspection().component_indices.pressure] = update_values;
-        update[this->introspection().component_indices.temperature] = update_values;
-        return update;
+        return update_values;
       }
 
       template <int dim>

--- a/source/particle/property/velocity.cc
+++ b/source/particle/property/velocity.cc
@@ -55,13 +55,10 @@ namespace aspect
       }
 
       template <int dim>
-      std::vector<UpdateFlags>
+      UpdateFlags
       Velocity<dim>::get_needed_update_flags () const
       {
-        std::vector<UpdateFlags> update(this->introspection().n_components,update_default);
-        for (unsigned int i = 0; i<dim; ++i)
-          update[this->introspection().component_indices.velocities[i]] = update_values;
-        return update;
+        return update_values;
       }
 
       template <int dim>

--- a/source/particle/property/velocity.cc
+++ b/source/particle/property/velocity.cc
@@ -55,6 +55,16 @@ namespace aspect
       }
 
       template <int dim>
+      std::vector<UpdateFlags>
+      Velocity<dim>::get_needed_update_flags () const
+      {
+        std::vector<UpdateFlags> update(this->introspection().n_components,update_default);
+        for (unsigned int i = 0; i<dim; ++i)
+          update[this->introspection().component_indices.velocities[i]] = update_values;
+        return update;
+      }
+
+      template <int dim>
       std::vector<std::pair<std::string, unsigned int> >
       Velocity<dim>::get_property_information() const
       {

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -950,77 +950,35 @@ namespace aspect
       const unsigned int particles_in_cell = std::distance(begin_particle,end_particle);
       const unsigned int solution_components = this->introspection().n_components;
 
-      const std::vector<UpdateFlags> update_flags = property_manager->get_needed_update_flags();
-
-      UpdateFlags any_update_flags = update_default;
-
-      for (unsigned int i = 0; i<solution_components; ++i)
-        any_update_flags |= update_flags[i];
-
-      const bool compute_any_values = any_update_flags & update_values;
-      const bool compute_any_gradients = any_update_flags & update_gradients;
-
-      Vector<double> value(solution_components);
+      Vector<double>              value (solution_components);
       std::vector<Tensor<1,dim> > gradient (solution_components,Tensor<1,dim>());
 
-      std::vector<Vector<double> >  values(particles_in_cell,value);
+      std::vector<Vector<double> >              values(particles_in_cell,value);
       std::vector<std::vector<Tensor<1,dim> > > gradients(particles_in_cell,gradient);
-
-      // If we only need to compute solution values and not gradients we can
-      // save quite some time by ignoring the mapping (we already know the
-      // reference coordinates of the particles) and calculate the
-      // values of the solution manually instead of using FEValues
-      if (compute_any_values && !compute_any_gradients)
-        {
-          std::vector<types::global_dof_index> cell_dof_indices (this->get_fe().dofs_per_cell);
-          cell->get_dof_indices (cell_dof_indices);
-
-          for (unsigned int j=0; j<this->get_fe().dofs_per_cell; ++j)
-            {
-              const unsigned int component_index
-                = this->get_fe().system_to_component_index(j).first;
-
-              // The most expensive part of this function is computing the
-              // shape_value below. Only do it if this component is needed
-              // to update the properties.
-              if (update_flags[component_index] & update_values)
-                {
-                  typename std::multimap<types::LevelInd, Particle<dim> >::iterator it = begin_particle;
-                  for (unsigned int particle_index = 0; it!=end_particle; ++it,++particle_index)
-                    {
-                      const double shape_value = this->get_fe().shape_value(j,it->second.get_reference_location());
-                      values[particle_index][component_index] += shape_value * this->get_solution()[cell_dof_indices[j]];
-                    }
-                }
-            }
-        }
-      // If we need to compute gradients of the solution we need the mapping
-      // to transform from the reference cell to the real cell, so there is
-      // not much to save, except that we will not compute solution values if
-      // they are not needed according to any_update_flags.
-      else if (compute_any_gradients)
-        {
-          std::vector<Point<dim> > particle_points(particles_in_cell);
-
-          typename std::multimap<types::LevelInd, Particle<dim> >::iterator it = begin_particle;
-          for (unsigned int i = 0; it!=end_particle; ++it,++i)
-            particle_points[i] = it->second.get_reference_location();
-
-          const Quadrature<dim> quadrature_formula(particle_points);
-          FEValues<dim> fe_value (this->get_mapping(),
-                                  this->get_fe(),
-                                  quadrature_formula,
-                                  any_update_flags);
-
-          fe_value.reinit (cell);
-          if (compute_any_values)
-            fe_value.get_function_values (this->get_solution(),
-                                          values);
-          fe_value.get_function_gradients (this->get_solution(),
-                                           gradients);
-        }
+      std::vector<Point<dim> >                  positions(particles_in_cell);
 
       typename std::multimap<types::LevelInd, Particle<dim> >::iterator it = begin_particle;
+      for (unsigned int i = 0; it!=end_particle; ++it,++i)
+        {
+          positions[i] = it->second.get_reference_location();
+        }
+
+      const Quadrature<dim> quadrature_formula(positions);
+      const UpdateFlags update_flags = property_manager->get_needed_update_flags();
+      FEValues<dim> fe_value (this->get_mapping(),
+                              this->get_fe(),
+                              quadrature_formula,
+                              update_flags);
+
+      fe_value.reinit (cell);
+      if (update_flags & update_values)
+        fe_value.get_function_values (this->get_solution(),
+                                      values);
+      if (update_flags & update_gradients)
+        fe_value.get_function_gradients (this->get_solution(),
+                                         gradients);
+
+      it = begin_particle;
       for (unsigned int i = 0; it!=end_particle; ++it,++i)
         {
           property_manager->update_one_particle(it->second,


### PR DESCRIPTION
This is analogous to #1185 and should speed up particle property update significantly (except for the integrated strain property that needs the gradients of the solution). 
I have one backwards-compatibility issue though: I would like all particle properties by default declare the smallest possible amount of update_flags to prevent wasting time, but that means user-written particle property plugins might suddenly no longer get the solution values / gradients they need. But defining all update_flags by default and letting plugins declare less seems strange too (every user-written plugins will be slow, unless they figure out how to request less updates). Is there anything we can do about that?