### PR TITLE
Add strain weakening option to the visco_plastic material model

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,15 @@
  *
  * <ol>
  *
+ * <li> New: The visco plastic material model now includes an option for
+ * strain-weakening of cohesion and the internal angle of friction. 
+ * Strain-weakeing of these properties is commonly used to help localize 
+ * deformation in regions undergoing plastic failure. Note that using this
+ * option requires tracking the finite strain tensor through particles or
+ * compositional fields.    
+ * <br>
+ * (John Naliboff, 2016/11/10) 
+ *
  * <li> New: Two particle generators were added. One, generates particles
  * at the quadrature points for each active cell in the triangulation.
  * Two, generates a uniform distribution of particles in the unit cell

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -180,10 +180,17 @@ namespace aspect
         calculate_isostrain_viscosities ( const std::vector<double> &volume_fractions,
                                           const double &pressure,
                                           const double &temperature,
+                                          const std::vector<double> &composition,
                                           const SymmetricTensor<2,dim> &strain_rate,
                                           const ViscosityScheme &viscous_type,
                                           const YieldScheme &yield_type) const;
 
+        bool use_strain_weakening;
+        std::vector<double> start_strain_weakening_intervals;
+        std::vector<double> end_strain_weakening_intervals;
+        std::vector<double> viscous_strain_weakening_factors;
+        std::vector<double> cohesion_strain_weakening_factors;
+        std::vector<double> friction_strain_weakening_factors;
 
         std::vector<double> prefactors_diffusion;
         std::vector<double> stress_exponents_diffusion;

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -207,7 +207,7 @@ namespace aspect
               // Assign strain values for compositional field to a symmetric tensor
               SymmetricTensor<2,dim> strain;
               for (unsigned int i = 0; i < SymmetricTensor<2,dim>::n_independent_components ; ++i)
-               strain[SymmetricTensor<2,dim>::unrolled_to_component_indices(i)] = composition[i];
+                strain[SymmetricTensor<2,dim>::unrolled_to_component_indices(i)] = composition[i];
 
               // Calculate second strain invariant
               const double strain_ii = std::fabs(second_invariant(strain));
@@ -424,7 +424,7 @@ namespace aspect
                              "If only one value is given, then all use the same value.  Units: $1 / K$");
 
           // Strain weakening parameters
-          prm.declare_entry ("Use strain weakening", "true",
+          prm.declare_entry ("Use strain weakening", "false",
                              Patterns::Bool (),
                              "Apply strain weakening to viscosity, cohesion and internal angle "
                              "of friction based on accumulated finite strain.  Units: None");
@@ -755,7 +755,7 @@ namespace aspect
                                    "The user has the option to linearly reduce the cohesion and "
                                    "internal friction angle as a function of accumulated finite strain. "
                                    "Finite strain may be calculated through tracers (implemented by Rene Gassmoeller) "
-                                   "or the compositional field finite strain plugin (implemented Juliane Dannberg). "
+                                   "or the compositional field finite strain plugin (implemented by Juliane Dannberg). "
                                    "In either case, the user specifies compositional fields for each of "
                                    "the symmetric strain tensor components, which must be listed before "
                                    "any additional compositional fields and will reflect the following order "

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -39,6 +39,11 @@ namespace aspect
       for ( unsigned int i=0; i < x_comp.size(); ++i)
         x_comp[i] = std::min(std::max(x_comp[i], 0.0), 1.0);
 
+      // assign compositional fields associated with strain a value of 0
+      if (use_strain_weakening == true)
+        for ( unsigned int i=0; i < SymmetricTensor<2,dim>::n_independent_components; ++i)
+          x_comp[i] = 0.0;
+
       //sum the compositional fields for normalization purposes
       double sum_composition = 0.0;
       for ( unsigned int i=0; i < x_comp.size(); ++i)
@@ -115,6 +120,7 @@ namespace aspect
     calculate_isostrain_viscosities ( const std::vector<double> &volume_fractions,
                                       const double &pressure,
                                       const double &temperature,
+                                      const std::vector<double> &composition,
                                       const SymmetricTensor<2,dim> &strain_rate,
                                       const ViscosityScheme &viscous_type,
                                       const YieldScheme &yield_type) const
@@ -191,15 +197,34 @@ namespace aspect
           // Convert friction angle from degrees to radians
           double phi = angles_internal_friction[j] * numbers::PI/180.0;
 
+          // Assing cohesions to a new variable
+          double coh = cohesions[j];
+
+          // Strain weakening
+          double strain_ii = 0;
+          if (use_strain_weakening == true)
+
+            // Calculate second strain invariant
+            strain_ii = ( (dim==3)
+                          ?
+                          ( composition[0]*composition[1] + composition[1]*composition[2] + composition[2]*composition[0] -
+                            composition[3]*composition[3] - composition[4]*composition[4] - composition[5]*composition[5]   )
+                          :
+                          ( composition[0]*composition[1] - composition[2]*composition[2] ) );
+
+          // Linear strain weakening of cohesion and internal friction angle between specified strain values
+          double strain_fraction = ( strain_ii - start_strain_weakening_intervals[j] ) /
+                                   ( start_strain_weakening_intervals[j] - end_strain_weakening_intervals[j] );
+          coh = coh + ( coh - coh * cohesion_strain_weakening_factors[j] ) * strain_fraction;
+          phi = phi + ( phi - phi * friction_strain_weakening_factors[j] ) * strain_fraction;
+
           // Calculate drucker prager yield strength (i.e. yield stress)
           double yield_strength = ( (dim==3)
                                     ?
-                                    ( 6.0 * cohesions[j] * std::cos(phi) + 2.0 * std::max(pressure,0.0) * std::sin(phi) )
+                                    ( 6.0 * coh * std::cos(phi) + 2.0 * std::max(pressure,0.0) * std::sin(phi) )
                                     / ( std::sqrt(3.0) * (3.0 + std::sin(phi) ) )
                                     :
-                                    cohesions[j] * std::cos(phi) + std::max(pressure,0.0) * std::sin(phi) );
-
-
+                                    coh * std::cos(phi) + std::max(pressure,0.0) * std::sin(phi) );
 
           // If the viscous stress is greater than the yield strength, rescale the viscosity back to yield surface
           double viscosity_drucker_prager;
@@ -296,7 +321,7 @@ namespace aspect
               // TODO: This is only consistent with viscosity averaging if the arithmetic averaging
               // scheme is chosen. It would be useful to have a function to calculate isostress viscosities.
               const std::vector<double> composition_viscosities =
-                calculate_isostrain_viscosities(volume_fractions, pressure, temperature, in.strain_rate[i],viscous_flow_law,yield_mechanism);
+                calculate_isostrain_viscosities(volume_fractions, pressure, temperature, composition, in.strain_rate[i],viscous_flow_law,yield_mechanism);
 
               // The isostrain condition implies that the viscosity averaging should be arithmetic (see above).
               // We have given the user freedom to apply alternative bounds, because in diffusion-dominated
@@ -395,6 +420,42 @@ namespace aspect
                              "List of thermal expansivities for background material and compositional fields, "
                              "for a total of N+1 values, where N is the number of compositional fields. "
                              "If only one values is given, then all use the same value.  Units: $1 / K$");
+
+          // Strain weakening parameters
+          prm.declare_entry ("Use strain weakening", "true",
+                             Patterns::Bool (),
+                             "Apply strain weakening to viscosity, cohesion and internal angle "
+                             "of friction based on accumulated finite strain.  Units: None");
+          prm.declare_entry ("Start strain weakening intervals", "0.",
+                             Patterns::List(Patterns::Double(0)),
+                             "List of strain weakening interval initial strains "
+                             "for background material and compositional fields, "
+                             "for a total of N+1 values, where N is the number of compositional fields. "
+                             "If only one values is given, then all use the same value.  Units: None");
+          prm.declare_entry ("End strain weakening intervals", "1.",
+                             Patterns::List(Patterns::Double(0)),
+                             "List of strain weakening interval final strains "
+                             "for background material and compositional fields, "
+                             "for a total of N+1 values, where N is the number of compositional fields. "
+                             "If only one values is given, then all use the same value.  Units: None");
+          prm.declare_entry ("Viscous strain weakening factors", "1.",
+                             Patterns::List(Patterns::Double(0)),
+                             "List of viscous strain weakening factors "
+                             "for background material and compositional fields, "
+                             "for a total of N+1 values, where N is the number of compositional fields. "
+                             "If only one values is given, then all use the same value.  Units: None");
+          prm.declare_entry ("Cohesion strain weakening factors", "1.",
+                             Patterns::List(Patterns::Double(0)),
+                             "List of cohesion strain weakening factors "
+                             "for background material and compositional fields, "
+                             "for a total of N+1 values, where N is the number of compositional fields. "
+                             "If only one values is given, then all use the same value.  Units: None");
+          prm.declare_entry ("Friction strain weakening factors", "1.",
+                             Patterns::List(Patterns::Double(0)),
+                             "List of friction strain weakening factors "
+                             "for background material and compositional fields, "
+                             "for a total of N+1 values, where N is the number of compositional fields. "
+                             "If only one values is given, then all use the same value.  Units: None");
 
           // Rheological parameters
           prm.declare_entry ("Grain size", "1e-3", Patterns::Double(0), "Units: $m$");
@@ -534,6 +595,24 @@ namespace aspect
                                                                           n_fields,
                                                                           "Thermal expansivities");
 
+          // Strain weakening parameters
+          use_strain_weakening             = prm.get_bool ("Use strain weakening");
+          start_strain_weakening_intervals = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Start strain weakening intervals"))),
+                                                                                     n_fields,
+                                                                                     "Start strain weakening intervals");
+          end_strain_weakening_intervals = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("End strain weakening intervals"))),
+                                                                                   n_fields,
+                                                                                   "End strain weakening intervals");
+          viscous_strain_weakening_factors = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Viscous strain weakening factors"))),
+                                                                                     n_fields,
+                                                                                     "Viscous strain weakening factors");
+          cohesion_strain_weakening_factors = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Cohesion strain weakening factors"))),
+                                                                                      n_fields,
+                                                                                      "Cohesion strain weakening factors");
+          friction_strain_weakening_factors = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Friction strain weakening factors"))),
+                                                                                      n_fields,
+                                                                                      "Friction strain weakening factors");
+
           // Rheological parameters
           if (prm.get ("Viscosity averaging scheme") == "harmonic")
             viscosity_averaging = harmonic;
@@ -670,6 +749,21 @@ namespace aspect
                                    "surface: $v_{y}=\\sigma_{y}/(2{\\varepsilon}_{ii})$. "
                                    "This form of plasticity is commonly used in geodynamic models "
                                    "See, for example, Thieulot, C. (2011), PEPI 188, pp. 47-68. "
+                                   "\n"
+                                   "The user now has the option to linearly reduce the cohesion and "
+                                   "internal friction angle as a function of accumulated finite strain. "
+                                   "Finite strain may be calculated through tracers (Rene Gassmoeller) "
+                                   "or the compositional field finite strain plugin (Juliane Dannberg). "
+                                   "In either case, the user specifies compositional fields for each of "
+                                   "the symmetric strain tensor components, which must be listed before "
+                                   "any additional compositional fields and will reflect the following order "
+                                   "2D: fs[0][0], fs[1][1], fs[0][1] "
+                                   "3D: fs[0][0], fs[1][1], fs[2][2], fs[0][1], fs[0][2], fs[1][2] "
+                                   "Above, fs refers to the 'finite strain' tensor and the numbers "
+                                   "represent tensor indices.  While the user may define any names "
+                                   "for each of the finite strain components, the above ordering is "
+                                   "assumed in the strain weakening section. "
+                                   ""
                                    "\n\n"
                                    "Viscous stress may also be limited by a non-linear stress limiter "
                                    "that has a form similar to the Peierls creep mechanism. "

--- a/tests/visco_plastic/screen-output
+++ b/tests/visco_plastic/screen-output
@@ -13,7 +13,7 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
    Solving temperature system... 0 iterations.
    Solving crust system ... 0 iterations.
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+6 iterations.
+   Solving Stokes system... 0+11 iterations.
    Residual after nonlinear iteration 1: 1
 
 

--- a/tests/visco_plastic/screen-output
+++ b/tests/visco_plastic/screen-output
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------------------
 -- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.0-pre
+--     . version 1.5.0-pre
 --     . running in DEBUG mode
 --     . running with 1 MPI process
 --     . using Trilinos
@@ -13,7 +13,7 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
    Solving temperature system... 0 iterations.
    Solving crust system ... 0 iterations.
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+11 iterations.
+   Solving Stokes system... 0+6 iterations.
    Residual after nonlinear iteration 1: 1
 
 
@@ -24,43 +24,45 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      0.12s |            |
+| Total wallclock time elapsed since start    |     0.109s |            |
 |                                             |            |            |
 | Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0218s |        18% |
-| Assemble composition system     |         1 |    0.0108s |         9% |
-| Assemble temperature system     |         1 |    0.0118s |       9.8% |
-| Build Stokes preconditioner     |         1 |    0.0169s |        14% |
-| Build composition preconditioner|         1 |  0.000551s |      0.46% |
-| Build temperature preconditioner|         1 |  0.000703s |      0.59% |
-| Solve Stokes system             |         1 |   0.00331s |       2.8% |
-| Solve composition system        |         1 |   0.00025s |      0.21% |
-| Solve temperature system        |         1 |  0.000318s |      0.27% |
-| Initialization                  |         2 |    0.0326s |        27% |
-| Postprocessing                  |         1 |   0.00132s |       1.1% |
-| Setup dof systems               |         1 |    0.0156s |        13% |
+| Assemble Stokes system          |         1 |    0.0207s |        19% |
+| Assemble composition system     |         1 |   0.00955s |       8.8% |
+| Assemble temperature system     |         1 |      0.01s |       9.2% |
+| Build Stokes preconditioner     |         1 |    0.0161s |        15% |
+| Build composition preconditioner|         1 |   0.00047s |      0.43% |
+| Build temperature preconditioner|         1 |  0.000592s |      0.54% |
+| Solve Stokes system             |         1 |   0.00761s |         7% |
+| Solve composition system        |         1 |  0.000224s |      0.21% |
+| Solve temperature system        |         1 |  0.000298s |      0.27% |
+| Initialization                  |         1 |    0.0215s |        20% |
+| Postprocessing                  |         1 |   0.00143s |       1.3% |
+| Setup dof systems               |         1 |    0.0125s |        12% |
+| Setup initial conditions        |         1 |   0.00451s |       4.1% |
 +---------------------------------+-----------+------------+------------+
 
 Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      0.12s |            |
+| Total wallclock time elapsed since start    |     0.109s |            |
 |                                             |            |            |
 | Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0218s |        18% |
-| Assemble composition system     |         1 |    0.0108s |         9% |
-| Assemble temperature system     |         1 |    0.0118s |       9.8% |
-| Build Stokes preconditioner     |         1 |    0.0169s |        14% |
-| Build composition preconditioner|         1 |  0.000551s |      0.46% |
-| Build temperature preconditioner|         1 |  0.000703s |      0.59% |
-| Solve Stokes system             |         1 |   0.00331s |       2.8% |
-| Solve composition system        |         1 |   0.00025s |      0.21% |
-| Solve temperature system        |         1 |  0.000318s |      0.27% |
-| Initialization                  |         2 |    0.0326s |        27% |
-| Postprocessing                  |         1 |   0.00132s |       1.1% |
-| Setup dof systems               |         1 |    0.0156s |        13% |
+| Assemble Stokes system          |         1 |    0.0207s |        19% |
+| Assemble composition system     |         1 |   0.00955s |       8.8% |
+| Assemble temperature system     |         1 |      0.01s |       9.2% |
+| Build Stokes preconditioner     |         1 |    0.0161s |        15% |
+| Build composition preconditioner|         1 |   0.00047s |      0.43% |
+| Build temperature preconditioner|         1 |  0.000592s |      0.54% |
+| Solve Stokes system             |         1 |   0.00761s |         7% |
+| Solve composition system        |         1 |  0.000224s |      0.21% |
+| Solve temperature system        |         1 |  0.000298s |      0.27% |
+| Initialization                  |         1 |    0.0215s |        20% |
+| Postprocessing                  |         1 |   0.00143s |       1.3% |
+| Setup dof systems               |         1 |    0.0125s |        12% |
+| Setup initial conditions        |         1 |   0.00451s |       4.1% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/visco_plastic/screen-output
+++ b/tests/visco_plastic/screen-output
@@ -1,10 +1,3 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.5.0-pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 100 (on 1 levels)
 Number of degrees of freedom: 1,885 (882+121+441+441)
@@ -24,45 +17,13 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.109s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0207s |        19% |
-| Assemble composition system     |         1 |   0.00955s |       8.8% |
-| Assemble temperature system     |         1 |      0.01s |       9.2% |
-| Build Stokes preconditioner     |         1 |    0.0161s |        15% |
-| Build composition preconditioner|         1 |   0.00047s |      0.43% |
-| Build temperature preconditioner|         1 |  0.000592s |      0.54% |
-| Solve Stokes system             |         1 |   0.00761s |         7% |
-| Solve composition system        |         1 |  0.000224s |      0.21% |
-| Solve temperature system        |         1 |  0.000298s |      0.27% |
-| Initialization                  |         1 |    0.0215s |        20% |
-| Postprocessing                  |         1 |   0.00143s |       1.3% |
-| Setup dof systems               |         1 |    0.0125s |        12% |
-| Setup initial conditions        |         1 |   0.00451s |       4.1% |
 +---------------------------------+-----------+------------+------------+
 
 Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.109s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0207s |        19% |
-| Assemble composition system     |         1 |   0.00955s |       8.8% |
-| Assemble temperature system     |         1 |      0.01s |       9.2% |
-| Build Stokes preconditioner     |         1 |    0.0161s |        15% |
-| Build composition preconditioner|         1 |   0.00047s |      0.43% |
-| Build temperature preconditioner|         1 |  0.000592s |      0.54% |
-| Solve Stokes system             |         1 |   0.00761s |         7% |
-| Solve composition system        |         1 |  0.000224s |      0.21% |
-| Solve temperature system        |         1 |  0.000298s |      0.27% |
-| Initialization                  |         1 |    0.0215s |        20% |
-| Postprocessing                  |         1 |   0.00143s |       1.3% |
-| Setup dof systems               |         1 |    0.0125s |        12% |
-| Setup initial conditions        |         1 |   0.00451s |       4.1% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/visco_plastic_yield/screen-output
+++ b/tests/visco_plastic_yield/screen-output
@@ -1,10 +1,3 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.5.0-pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 100 (on 1 levels)
 Number of degrees of freedom: 1,885 (882+121+441+441)
@@ -24,45 +17,13 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.197s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0104s |       5.3% |
-| Assemble composition system     |         1 |   0.00994s |         5% |
-| Assemble temperature system     |         1 |    0.0157s |         8% |
-| Build Stokes preconditioner     |         1 |    0.0285s |        14% |
-| Build composition preconditioner|         1 |  0.000624s |      0.32% |
-| Build temperature preconditioner|         1 |   0.00232s |       1.2% |
-| Solve Stokes system             |         1 |   0.00884s |       4.5% |
-| Solve composition system        |         1 |   0.00029s |      0.15% |
-| Solve temperature system        |         1 |   0.00196s |         1% |
-| Initialization                  |         1 |    0.0475s |        24% |
-| Postprocessing                  |         1 |   0.00359s |       1.8% |
-| Setup dof systems               |         1 |    0.0406s |        21% |
-| Setup initial conditions        |         1 |    0.0154s |       7.8% |
 +---------------------------------+-----------+------------+------------+
 
 Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.197s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0104s |       5.3% |
-| Assemble composition system     |         1 |   0.00994s |         5% |
-| Assemble temperature system     |         1 |    0.0157s |         8% |
-| Build Stokes preconditioner     |         1 |    0.0285s |        14% |
-| Build composition preconditioner|         1 |  0.000624s |      0.32% |
-| Build temperature preconditioner|         1 |   0.00232s |       1.2% |
-| Solve Stokes system             |         1 |   0.00884s |       4.5% |
-| Solve composition system        |         1 |   0.00029s |      0.15% |
-| Solve temperature system        |         1 |   0.00196s |         1% |
-| Initialization                  |         1 |    0.0475s |        24% |
-| Postprocessing                  |         1 |   0.00359s |       1.8% |
-| Setup dof systems               |         1 |    0.0406s |        21% |
-| Setup initial conditions        |         1 |    0.0154s |       7.8% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/visco_plastic_yield/screen-output
+++ b/tests/visco_plastic_yield/screen-output
@@ -13,7 +13,7 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
    Solving temperature system... 0 iterations.
    Solving crust system ... 0 iterations.
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+6 iterations.
+   Solving Stokes system... 0+11 iterations.
    Residual after nonlinear iteration 1: 1
 
 

--- a/tests/visco_plastic_yield/screen-output
+++ b/tests/visco_plastic_yield/screen-output
@@ -13,7 +13,7 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
    Solving temperature system... 0 iterations.
    Solving crust system ... 0 iterations.
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+11 iterations.
+   Solving Stokes system... 0+6 iterations.
    Residual after nonlinear iteration 1: 1
 
 
@@ -24,43 +24,45 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.115s |            |
+| Total wallclock time elapsed since start    |     0.197s |            |
 |                                             |            |            |
 | Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0213s |        18% |
-| Assemble composition system     |         1 |   0.00964s |       8.4% |
-| Assemble temperature system     |         1 |    0.0102s |       8.9% |
-| Build Stokes preconditioner     |         1 |    0.0185s |        16% |
-| Build composition preconditioner|         1 |  0.000505s |      0.44% |
-| Build temperature preconditioner|         1 |  0.000775s |      0.67% |
-| Solve Stokes system             |         1 |   0.00463s |         4% |
-| Solve composition system        |         1 |  0.000292s |      0.25% |
-| Solve temperature system        |         1 |  0.000388s |      0.34% |
-| Initialization                  |         2 |    0.0284s |        25% |
-| Postprocessing                  |         1 |   0.00357s |       3.1% |
-| Setup dof systems               |         1 |    0.0129s |        11% |
+| Assemble Stokes system          |         1 |    0.0104s |       5.3% |
+| Assemble composition system     |         1 |   0.00994s |         5% |
+| Assemble temperature system     |         1 |    0.0157s |         8% |
+| Build Stokes preconditioner     |         1 |    0.0285s |        14% |
+| Build composition preconditioner|         1 |  0.000624s |      0.32% |
+| Build temperature preconditioner|         1 |   0.00232s |       1.2% |
+| Solve Stokes system             |         1 |   0.00884s |       4.5% |
+| Solve composition system        |         1 |   0.00029s |      0.15% |
+| Solve temperature system        |         1 |   0.00196s |         1% |
+| Initialization                  |         1 |    0.0475s |        24% |
+| Postprocessing                  |         1 |   0.00359s |       1.8% |
+| Setup dof systems               |         1 |    0.0406s |        21% |
+| Setup initial conditions        |         1 |    0.0154s |       7.8% |
 +---------------------------------+-----------+------------+------------+
 
 Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.116s |            |
+| Total wallclock time elapsed since start    |     0.197s |            |
 |                                             |            |            |
 | Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0213s |        18% |
-| Assemble composition system     |         1 |   0.00964s |       8.3% |
-| Assemble temperature system     |         1 |    0.0102s |       8.8% |
-| Build Stokes preconditioner     |         1 |    0.0185s |        16% |
-| Build composition preconditioner|         1 |  0.000505s |      0.44% |
-| Build temperature preconditioner|         1 |  0.000775s |      0.67% |
-| Solve Stokes system             |         1 |   0.00463s |         4% |
-| Solve composition system        |         1 |  0.000292s |      0.25% |
-| Solve temperature system        |         1 |  0.000388s |      0.34% |
-| Initialization                  |         2 |    0.0284s |        25% |
-| Postprocessing                  |         1 |   0.00357s |       3.1% |
-| Setup dof systems               |         1 |    0.0129s |        11% |
+| Assemble Stokes system          |         1 |    0.0104s |       5.3% |
+| Assemble composition system     |         1 |   0.00994s |         5% |
+| Assemble temperature system     |         1 |    0.0157s |         8% |
+| Build Stokes preconditioner     |         1 |    0.0285s |        14% |
+| Build composition preconditioner|         1 |  0.000624s |      0.32% |
+| Build temperature preconditioner|         1 |   0.00232s |       1.2% |
+| Solve Stokes system             |         1 |   0.00884s |       4.5% |
+| Solve composition system        |         1 |   0.00029s |      0.15% |
+| Solve temperature system        |         1 |   0.00196s |         1% |
+| Initialization                  |         1 |    0.0475s |        24% |
+| Postprocessing                  |         1 |   0.00359s |       1.8% |
+| Setup dof systems               |         1 |    0.0406s |        21% |
+| Setup initial conditions        |         1 |    0.0154s |       7.8% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/visco_plastic_yield_strain_weakening.prm
+++ b/tests/visco_plastic_yield_strain_weakening.prm
@@ -1,0 +1,239 @@
+# A simple model to test if the visco_plastic material
+# model returns the correct viscosity for the specified
+# viscous flaws, brittle parameters and geotherm. The 
+# model (100x100 km) contains two distinct materials
+# (crust & mantle), with the crust (upper 30 km) specified
+# by a compositional field. The specified geotherm is typical
+# of the continental lithosphere. The top and bottom boundaries  
+# have fixed temepratures (sides are insulating), while all the
+# boundaries are free-slip (tangential velocity b.c.). The strain-rate 
+# used in the viscous flow laws is specified in the material model
+# As we only want to check the viscosity profile, no need to do more
+# than 1 nonlinear iteration. See additional comments below for more details.
+
+# Global parameters
+set Dimension                              = 2
+set Start time                             = 0
+set End time                               = 0
+set Use years in output instead of seconds = true
+set Linear solver tolerance                = 1e-7
+set Nonlinear solver scheme                = iterated Stokes
+set Nonlinear solver tolerance             = 1e-8
+set Max nonlinear iterations               = 1
+set Number of cheap Stokes solver steps    = 0
+set CFL number                             = 0.5
+set Output directory                       = visco_plastic_yield_strain_weakening
+set Timing output frequency                = 1
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+
+# Model geometry (100x100 km, 10 km spacing)
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X repetitions = 10
+    set Y repetitions = 10
+    set X extent      = 100e3
+    set Y extent      = 100e3
+  end
+end
+
+# Mesh refinement specifications (no global or adaptive refinement)
+subsection Mesh refinement
+  set Initial global refinement                 = 0
+  set Initial adaptive refinement               = 0
+end
+
+# Boundary classifications (free-slip, fixed T at top & bottom, insulating side) 
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false
+  set Fixed temperature boundary indicators   = bottom, top
+  set Tangential velocity boundary indicators = bottom, top, left, right
+end
+
+# Number and name of compositional fields.
+# Below, we specify four compositional fields.  The first three fields are
+# for each component of the 2D symmetric finite strain tensor and the fourth
+# is for the crust.  The name of each field associated with finite strain 
+# refers to the index of the strain tensor (i.e. s11 = index [1,1]).  As 
+# opposed to using advect compositional fields, we will track the integrated
+# strain and crust via particles that carry information (see Traceris subsection
+# under Postprocesses subsection).  In addition to specifying that we are 
+# particles to track properties, we also must specify what particle properties
+# are "mapped" at each time step to a separate compositional field accessed
+# by the material model.  Here, we are specifying a specific component of
+# integrated strain is mapped to s11/s22/s12 and the field "crust" tracks
+# initial composition. 
+subsection Compositional fields
+  set Number of fields = 4
+  set Names of fields = s11, s22, s12, crust
+  set Compositional field methods = particles, particles, particles, particles
+  set Mapped particle properties = s11:integrated strain [1], s22:integrated strain [2], s12:integrated strain [3], crust:initial crust
+end
+
+# Spatial domain of different compositional fields (crust is present in upper 30 km)
+# The integrated finite strain composition fields initially have a value of 0 
+# throughout the entire domain.
+subsection Compositional initial conditions
+  set Model name = function
+  subsection Function
+    set Variable names      = x,y
+    set Function expression = 0; 0; 0; if(y>=70.e3, 1, 0);
+  end
+end
+
+# Boundary composition specification
+subsection Boundary composition model
+  set Model name = initial composition
+end
+
+
+# Temperature boundary conditions (fixed: top = 273 K, bottom = 1573 K)
+subsection Boundary temperature model
+  set Model name = box
+  subsection Box
+    set Bottom temperature = 1573
+    set Left temperature   =  273
+    set Right temperature  =  273
+    set Top temperature    =  273
+  end
+end
+
+# Initial temperature field
+# Typical continental geotherm based equations 4-6 from Chapman 1986 (Geol. Soc. Lon.)
+# The initial constraints are:
+#   surface temperature (ts) = 273 K; basal temperature (tb) = 1573 K; Moho
+#   temperature (tm) = 873 K; crust heat production (A) = 9.e-7 W/m^3; crust
+#   thermal conductivity (kc) = 2.5 (W/(m K)); 
+# To satisfy these constraints, the following values are required:
+#   surface heat flow (qs) = 0.0635 W/m^2; basal heat flow = 0.365 W/m^2;
+#   mantle thermal conducitivty (km) = 3.65 (W/(m K)); 
+subsection Initial conditions
+  set Model name = function
+  subsection Function
+    set Variable names = x,y
+    set Function constants = h=100e3,ts=273,tm=873.,qs=0.0635,qb=0.0365,kc=2.5,km=3.65,A=9.e-7
+    set Function expression = if( (h-y)<=30.e3, \
+                                  ts + (qs/kc)*(h-y) - (A*(h-y)*(h-y))/(2.0*kc), \
+                                  tm + (qb/km)*(h-y-30.e3))                             
+  end
+end
+
+# Internal heating (only internal heating for crust)
+# Assuming a very large decay time, the heat production (W/m^3) is effectively:
+#   radioactive_heating_rate (W/kg) * density (kg/m^3)
+# For a reference crustal density of 2800 kg/m^3 and 9.e-7 W/m^3 heating production,
+# the heating rate (assuming a single element) is 9.e-7/2800. = 3.214287e-10.
+subsection Heating model
+  set Model name = radioactive decay
+  subsection Radioactive decay
+    set Number of elements    = 1
+    set Heating rates                 = 3.2142857e-10
+    set Half decay times              = 1.e20
+    set Initial concentrations mantle = 0.0
+    set Initial concentrations crust  = 1.0 
+    set Crust defined by composition  = true
+    set Crust composition number      = 0
+  end
+end
+
+
+# Material model (values for background material & compositional fields)
+# Note that since we now are tracking finite strain compositional fields,
+# (3 components in 2D), properties must be specified for each of these
+# fields.  However, the material model does not use these values in 
+# determining the element properties given the finite strain compositional
+# fields are listed first.  
+subsection Material model
+  set Model name = visco plastic
+
+  subsection Visco Plastic
+
+    set Reference temperature = 293
+
+    # As the boundaries are all free-slip, so use the reference strain-rate
+    # (used on first nonlinear iteration) to specify the strain-rate used
+    # in the viscous flow law.  Set the minimum strain-rate to the same value.
+    set Minimum strain rate = 1.e-20
+    set Reference strain rate = 1.e-20
+
+    # Minimum, maximum and reference viscosity 
+    set Minimum viscosity = 1e18
+    set Maximum viscosity = 1e28
+    set Reference viscosity = 1e22
+
+    # Thermal diffusivity is adjusted to match thermal conductivities
+    # assumed in the assigning the initial geotherm
+    set Thermal diffusivities = 1.474747e-6,1.190476e-6,1.190476e-6,1.190476e-6,1.190476e-6
+    set Heat capacities = 750.,750.,750.,750.,750.
+    set Densities = 3300,2800,2800,2800,2800
+    set Thermal expansivities = 0.,0.,0.,0.,0.
+
+    # Harmonic viscosity averaging
+    set Viscosity averaging scheme = harmonic
+    
+    # Choose to have the viscosity (pre-yield) follow a dislocation
+    # diffusion or composite flow law.  Here, dislocation is selected
+    # so no need to specify diffusion creep parameters below, which are
+    # only used if "diffusion" or "composite" option is selected.
+    set Viscous flow law = dislocation
+
+    # Dislocation creep parameters for background material (dry olivine;
+    # Hirth & Kohlstedt, 2004) and crust compositional field (wet quarzite;
+    # (Rutter & Brodie, 2004).
+    set Prefactors for dislocation creep = 6.52e-16,8.57e-28,8.57e-28,8.57e-28,8.57e-28,
+    set Stress exponents for dislocation creep = 3.5,4.0,4.0,4.0,4.0
+    set Activation energies for dislocation creep = 530.e3,223.e3,223.e3,223.e3,223.e3
+    set Activation volumes for dislocation creep = 18.e-6,0.,0.,0.,0.
+
+    # Specify that we will use Drucker Prager yield criterion rather than
+    # stress limiter criterion.
+    set Yield mechanism = drucker
+
+    # Parameters for Drucker Prager yield criterion.  To avoid any convergence
+    # issues with pressure-dependent yielding, we set the friction angle to
+    # zero.  The Drucker Prager yield criterion thus becomes a fixed value equal
+    # to the cohesion (i.e. Von Mises yield criterion).  Note that in the test
+    # visco_plastic.prm the cohesion was set to sufficiently high values so
+    # that yielding never occured.
+    set Angles of internal friction = 0.,0.,0.,0.,0.
+    set Cohesions = 250.e6,250.e6,250.e6,250.e6,250.e6
+
+    # Parameters for strain weakening
+    set Use strain weakening = true
+    set Start strain weakening intervals = 0.,0.,0.,0.,0.
+    set End strain weakening intervals = 1.0,1.0,1.0,1.0,1.0
+    set Cohesion strain weakening factors = 0.5,0.5,0.5,0.5,0.5
+    set Friction strain weakening factors = 0.5,0.5,0.5,0.5,0.5
+
+  end
+end
+
+# Gravity model
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 9.81
+  end
+end
+
+# Post processing (use output data to compare to predicted viscosities)
+# We also specify tracer properties in this section.  In this case, the
+# tracers will track the initial composition and integrated strain.  
+# On average, each element will contain roouhgly 10 tracers. See the 
+# particle & tracer section of manual for additional information.
+subsection Postprocess
+  set List of postprocessors = velocity statistics, mass flux statistics, tracers
+  subsection Tracers
+    set Number of tracers = 1000
+    set Time between data output = 1e9 
+    set Data output format = none 
+    set List of tracer properties = initial composition, integrated strain
+    set Interpolation scheme = cell average
+    set Particle generator name = random uniform
+    set Minimum tracers per cell = 9
+    set Maximum tracers per cell = 11
+  end 
+end

--- a/tests/visco_plastic_yield_strain_weakening.prm
+++ b/tests/visco_plastic_yield_strain_weakening.prm
@@ -232,6 +232,7 @@ subsection Postprocess
     set Data output format = none 
     set List of tracer properties = initial composition, integrated strain
     set Interpolation scheme = cell average
+    set Update ghost particles = true
     set Particle generator name = random uniform
     set Minimum tracers per cell = 9
     set Maximum tracers per cell = 11

--- a/tests/visco_plastic_yield_strain_weakening/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening/screen-output
@@ -1,0 +1,74 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.5.0-pre
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Number of active cells: 100 (on 1 levels)
+Number of degrees of freedom: 3,208 (882+121+441+441+441+441+441)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+6 iterations.
+   Residual after nonlinear iteration 1: 1
+
+
+   Postprocessing:
+     RMS, max velocity:                  1.39e-10 m/year, 5.01e-10 m/year
+     Mass fluxes through boundary parts: 0 kg/yr, 0 kg/yr, 0 kg/yr, 0 kg/yr
+     Number of advected particles:       1000
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.246s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |    0.0504s |        20% |
+| Assemble temperature system     |         1 |    0.0145s |       5.9% |
+| Build Stokes preconditioner     |         1 |    0.0321s |        13% |
+| Build temperature preconditioner|         1 |  0.000568s |      0.23% |
+| Solve Stokes system             |         1 |   0.00343s |       1.4% |
+| Solve temperature system        |         1 |  0.000336s |      0.14% |
+| Initialization                  |         1 |    0.0291s |        12% |
+| Particles: Advect               |         2 |    0.0446s |        18% |
+| Particles: Generate             |         1 |  0.000535s |      0.22% |
+| Particles: Initialization       |         1 |  0.000159s |     0.065% |
+| Particles: Initialize properties|         1 |  0.000499s |       0.2% |
+| Particles: Sort                 |         2 |  4.05e-06s |    0.0016% |
+| Particles: Update properties    |         1 |    0.0303s |        12% |
+| Postprocessing                  |         1 |    0.0773s |        31% |
+| Setup dof systems               |         1 |    0.0204s |       8.3% |
+| Setup initial conditions        |         1 |    0.0098s |         4% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.246s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |    0.0504s |        20% |
+| Assemble temperature system     |         1 |    0.0145s |       5.9% |
+| Build Stokes preconditioner     |         1 |    0.0321s |        13% |
+| Build temperature preconditioner|         1 |  0.000568s |      0.23% |
+| Solve Stokes system             |         1 |   0.00343s |       1.4% |
+| Solve temperature system        |         1 |  0.000336s |      0.14% |
+| Initialization                  |         1 |    0.0291s |        12% |
+| Particles: Advect               |         2 |    0.0446s |        18% |
+| Particles: Generate             |         1 |  0.000535s |      0.22% |
+| Particles: Initialization       |         1 |  0.000159s |     0.065% |
+| Particles: Initialize properties|         1 |  0.000499s |       0.2% |
+| Particles: Sort                 |         2 |  4.05e-06s |    0.0016% |
+| Particles: Update properties    |         1 |    0.0303s |        12% |
+| Postprocessing                  |         1 |    0.0773s |        31% |
+| Setup dof systems               |         1 |    0.0204s |       8.3% |
+| Setup initial conditions        |         1 |    0.0098s |         4% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/visco_plastic_yield_strain_weakening/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening/screen-output
@@ -24,51 +24,53 @@ Number of degrees of freedom: 3,208 (882+121+441+441+441+441+441)
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.246s |            |
+| Total wallclock time elapsed since start    |     0.132s |            |
 |                                             |            |            |
 | Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0504s |        20% |
-| Assemble temperature system     |         1 |    0.0145s |       5.9% |
-| Build Stokes preconditioner     |         1 |    0.0321s |        13% |
-| Build temperature preconditioner|         1 |  0.000568s |      0.23% |
-| Solve Stokes system             |         1 |   0.00343s |       1.4% |
-| Solve temperature system        |         1 |  0.000336s |      0.14% |
-| Initialization                  |         1 |    0.0291s |        12% |
-| Particles: Advect               |         2 |    0.0446s |        18% |
-| Particles: Generate             |         1 |  0.000535s |      0.22% |
-| Particles: Initialization       |         1 |  0.000159s |     0.065% |
-| Particles: Initialize properties|         1 |  0.000499s |       0.2% |
-| Particles: Sort                 |         2 |  4.05e-06s |    0.0016% |
-| Particles: Update properties    |         1 |    0.0303s |        12% |
-| Postprocessing                  |         1 |    0.0773s |        31% |
-| Setup dof systems               |         1 |    0.0204s |       8.3% |
-| Setup initial conditions        |         1 |    0.0098s |         4% |
+| Assemble Stokes system          |         1 |    0.0114s |       8.6% |
+| Assemble temperature system     |         1 |    0.0149s |        11% |
+| Build Stokes preconditioner     |         1 |    0.0116s |       8.8% |
+| Build temperature preconditioner|         1 |  0.000588s |      0.44% |
+| Solve Stokes system             |         1 |   0.00355s |       2.7% |
+| Solve temperature system        |         1 |  0.000366s |      0.28% |
+| Initialization                  |         1 |    0.0219s |        17% |
+| Particles: Advect               |         2 |   0.00182s |       1.4% |
+| Particles: Exchange ghosts      |         2 |  7.87e-05s |     0.059% |
+| Particles: Generate             |         1 |  0.000441s |      0.33% |
+| Particles: Initialization       |         1 |  8.39e-05s |     0.063% |
+| Particles: Initialize properties|         1 |  0.000716s |      0.54% |
+| Particles: Sort                 |         2 |  0.000409s |      0.31% |
+| Particles: Update properties    |         1 |    0.0246s |        19% |
+| Postprocessing                  |         1 |    0.0291s |        22% |
+| Setup dof systems               |         1 |    0.0195s |        15% |
+| Setup initial conditions        |         1 |    0.0116s |       8.7% |
 +---------------------------------+-----------+------------+------------+
 
 Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.246s |            |
+| Total wallclock time elapsed since start    |     0.132s |            |
 |                                             |            |            |
 | Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0504s |        20% |
-| Assemble temperature system     |         1 |    0.0145s |       5.9% |
-| Build Stokes preconditioner     |         1 |    0.0321s |        13% |
-| Build temperature preconditioner|         1 |  0.000568s |      0.23% |
-| Solve Stokes system             |         1 |   0.00343s |       1.4% |
-| Solve temperature system        |         1 |  0.000336s |      0.14% |
-| Initialization                  |         1 |    0.0291s |        12% |
-| Particles: Advect               |         2 |    0.0446s |        18% |
-| Particles: Generate             |         1 |  0.000535s |      0.22% |
-| Particles: Initialization       |         1 |  0.000159s |     0.065% |
-| Particles: Initialize properties|         1 |  0.000499s |       0.2% |
-| Particles: Sort                 |         2 |  4.05e-06s |    0.0016% |
-| Particles: Update properties    |         1 |    0.0303s |        12% |
-| Postprocessing                  |         1 |    0.0773s |        31% |
-| Setup dof systems               |         1 |    0.0204s |       8.3% |
-| Setup initial conditions        |         1 |    0.0098s |         4% |
+| Assemble Stokes system          |         1 |    0.0114s |       8.6% |
+| Assemble temperature system     |         1 |    0.0149s |        11% |
+| Build Stokes preconditioner     |         1 |    0.0116s |       8.8% |
+| Build temperature preconditioner|         1 |  0.000588s |      0.44% |
+| Solve Stokes system             |         1 |   0.00355s |       2.7% |
+| Solve temperature system        |         1 |  0.000366s |      0.28% |
+| Initialization                  |         1 |    0.0219s |        17% |
+| Particles: Advect               |         2 |   0.00182s |       1.4% |
+| Particles: Exchange ghosts      |         2 |  7.87e-05s |     0.059% |
+| Particles: Generate             |         1 |  0.000441s |      0.33% |
+| Particles: Initialization       |         1 |  8.39e-05s |     0.063% |
+| Particles: Initialize properties|         1 |  0.000716s |      0.54% |
+| Particles: Sort                 |         2 |  0.000409s |      0.31% |
+| Particles: Update properties    |         1 |    0.0246s |        19% |
+| Postprocessing                  |         1 |    0.0291s |        22% |
+| Setup dof systems               |         1 |    0.0195s |        15% |
+| Setup initial conditions        |         1 |    0.0116s |       8.7% |
 +---------------------------------+-----------+------------+------------+
 


### PR DESCRIPTION
Implementation of a strain weakening option to the visco_plastic material model.  Strain weakening is calculated via finite strain, which may be calculated through particles or compositional fields through the finite_strain plugin.  

For either of these options, the material model assumes (and states in the documentation) that the fields tracking each finite strain component must be listed prior to any additional fields.  This allows removing the contribution of the finite strain fields from the volume fraction of each element.  Is there a better way to do this?  I can think of a few other methods, but am interested to hear new ideas on this point.
