### PR TITLE
Make particle interpolator handle empty cells

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,14 @@
  *
  * <ol>
  *
+ * <li> Changed: The 'cell average' particle interpolator is now more
+ * tolerant against cells without particles by interpolating properties
+ * from neighboring cells. This is necessary, because during refinement
+ * even children of cells with a reasonable number of particles can be
+ * void of particles.
+ * <br>
+ * (Rene Gassmoeller, Jonathan Perry-Houts, 2016/08/31)
+ *
  * <li> Changed: Particle properties should now declare which solution
  * properties they need to update themselves. The particle world then
  * only computes values and gradients of the solution at

--- a/tests/particle_interpolator_empty_cells.prm
+++ b/tests/particle_interpolator_empty_cells.prm
@@ -1,0 +1,87 @@
+# A test that makes sure the 'cell average' particle interpolator 
+# does not crash when single cells do not contain particles.
+
+set Dimension                               = 2
+set End time                                = 7e9
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent    = 1000000.0
+    set Y extent    =  450000.0 
+  end
+end
+
+subsection Model settings
+  set Fixed temperature boundary indicators     = top, bottom
+  set Zero velocity boundary indicators         = left, right, bottom, top
+end
+
+subsection Compositional fields
+  set Number of fields = 1
+  set Names of fields  = c1
+  set Compositional field methods = particles
+end
+
+subsection Material model
+  set Model name = simple
+  set Material averaging = arithmetic average
+end
+
+subsection Compositional initial conditions
+  set Model name = function
+  subsection Function
+    set Variable names = x,z,t
+    set Function expression = if(((450000-z)<=55e3),1,0)
+  end
+end
+
+subsection Initial conditions
+  set Model name = function
+
+  subsection Function
+    set Variable names = x,z,t
+    set Function expression = min(1350/(85e3+15e3*sin(x/100e3))*(450000-z)+293,1350+293)
+  end
+end
+
+subsection Boundary temperature model
+  set Model name = initial temperature
+end
+
+subsection Boundary composition model
+  set Model name = initial composition
+end
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 9.81
+  end
+end
+
+subsection Mesh refinement
+  set Initial global refinement                 = 5
+  set Initial adaptive refinement               = 3
+  set Run postprocessors on initial refinement  = true
+end
+
+subsection Postprocess
+  set List of postprocessors = tracers, particle count statistics
+  subsection Tracers
+    set Number of tracers = 2500
+    set Time between data output = 0
+    set Data output format = none
+    set List of tracer properties = initial composition, initial position
+    set Interpolation scheme = cell average
+    set Particle generator name = random uniform
+    set Minimum tracers per cell = 2
+    set Maximum tracers per cell = 100
+    set Load balancing strategy = remove and add particles
+  end
+end
+
+subsection Termination criteria
+  set Termination criteria = end step
+  set End step = 3
+end

--- a/tests/particle_interpolator_empty_cells/screen-output
+++ b/tests/particle_interpolator_empty_cells/screen-output
@@ -1,0 +1,64 @@
+
+Number of active cells: 1,024 (on 6 levels)
+Number of degrees of freedom: 17,989 (8,450+1,089+4,225+4,225)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+11 iterations.
+
+   Postprocessing:
+     Number of advected particles:        2500
+     Particle count per cell min/avg/max: 0, 2, 9
+
+Number of active cells: 574 (on 7 levels)
+Number of degrees of freedom: 10,643 (4,996+651+2,498+2,498)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+11 iterations.
+
+   Postprocessing:
+     Number of advected particles:        2852
+     Particle count per cell min/avg/max: 2, 4, 20
+
+Number of active cells: 667 (on 7 levels)
+Number of degrees of freedom: 12,463 (5,852+759+2,926+2,926)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+9 iterations.
+
+   Postprocessing:
+     Number of advected particles:        3213
+     Particle count per cell min/avg/max: 2, 4, 51
+
+Number of active cells: 973 (on 8 levels)
+Number of degrees of freedom: 17,743 (8,336+1,071+4,168+4,168)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+9 iterations.
+
+   Postprocessing:
+     Number of advected particles:        3343
+     Particle count per cell min/avg/max: 2, 3, 100
+
+*** Timestep 1:  t=7e+09 years
+   Solving temperature system... 255 iterations.
+   Solving Stokes system... 30+10 iterations.
+
+   Postprocessing:
+     Number of advected particles:        3389
+     Particle count per cell min/avg/max: 2, 3, 100
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/particle_interpolator_empty_cells/statistics
+++ b/tests/particle_interpolator_empty_cells/statistics
@@ -1,0 +1,20 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Number of degrees of freedom for all compositions
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Time step size (years)
+# 12: Number of advected particles
+# 13: Minimal particles per cell: 
+# 14: Average particles per cell: 
+# 15: Maximal particles per cell: 
+0 0.000000000000e+00 1024 9539 4225 4225   0 41 131 12 7.000000000000e+09 2500 0 2   9 
+0 0.000000000000e+00  574 5647 2498 2498   0 41 115 48 7.000000000000e+09 2852 2 4  20 
+0 0.000000000000e+00  667 6611 2926 2926   0 39 102 40 7.000000000000e+09 3213 2 4  51 
+0 0.000000000000e+00  973 9407 4168 4168   0 39 107 41 7.000000000000e+09 3343 2 3 100 
+1 7.000000000000e+09  973 9407 4168 4168 255 40 114 45 5.597748109128e+11 3389 2 3 100 


### PR DESCRIPTION
This makes the particle interpolator handle cells without particles more robustly. Previously it contained an Assertion that prevented such cases, but with a statistical particle distribution it is very easy to refine a cell that contains a reasonable number of particle (10-20 in 2D) and still end up with children that are empty. In these cases it is just reasonable to interpolate from neighboring cells (essentially the same interpolation that is also happening with the solution during refinement).

@jperryhouts: This PR should solve your problem, at least it does for the parameter file you send me. I changed the file a bit and attached it as a test, I hope that is fine with you (since it does not seem to contain any specific things about your model).