### PR TITLE
Hand over cell iterator to initialize late particle

### DIFF
--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -300,7 +300,8 @@ namespace aspect
           void
           initialize_late_particle (Particle<dim> &particle,
                                     const std::multimap<types::LevelInd, Particle<dim> > &particles,
-                                    const Interpolator::Interface<dim> &interpolator) const;
+                                    const Interpolator::Interface<dim> &interpolator,
+                                    const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell = typename parallel::distributed::Triangulation<dim>::active_cell_iterator()) const;
 
           /**
            * Update function for particle properties. This function is

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -350,7 +350,8 @@ namespace aspect
                         std::pair<aspect::Particle::types::LevelInd,Particle<dim> > new_particle = generator->generate_particle(cell,local_next_particle_index);
                         property_manager->initialize_late_particle(new_particle.second,
                                                                    particles,
-                                                                   *interpolator);
+                                                                   *interpolator,
+                                                                   cell);
 
                         particles.insert(new_particle);
                       }


### PR DESCRIPTION
Since we know the cell in which to generate a particle it is unnecessary to search for it again in the late_initialization function.This saves some time in models that set a minimum bound on the number of particles per cell and see a lot of refinement happening.