### PR TITLE
Fix typo in FPE check cmake path

### DIFF
--- a/cmake/fpe_check.cmake
+++ b/cmake/fpe_check.cmake
@@ -8,7 +8,7 @@
 INCLUDE (CheckCXXSourceRuns)
 
 SET(_backup_libs ${CMAKE_REQUIRED_LIBRARIES})
-SET(_backup_includes ${CMAKE_REQUIRED_LIBRARIES})
+SET(_backup_includes ${CMAKE_REQUIRED_INCLUDES})
 SET(_build "RELEASE")
 STRING(TOLOWER "${CMAKE_BUILD_TYPE}" _cmake_build_type)
 IF("${_cmake_build_type}" MATCHES "debug")


### PR DESCRIPTION
We accidentally save/restore a wrong value for include dirs in the FPE check. Both vars are empty on my machines, but I expect this could break the build or disable the FPE check if they are not.