### PR TITLE
Silence the comparison warning between int and unsigned int

### DIFF
--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -830,7 +830,7 @@ namespace aspect
       MPI_Waitall(2*n_neighbors,&n_requests[0],MPI_STATUSES_IGNORE);
 
       // Determine how many particles and data we will receive
-      int total_recv_data = 0;
+      unsigned int total_recv_data = 0;
       for (unsigned int neighbor_id=0; neighbor_id<n_neighbors; ++neighbor_id)
         {
           recv_offsets[neighbor_id] = total_recv_data;

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -785,11 +785,11 @@ namespace aspect
 #endif
 
       // Determine the amount of data we will send to other processors
-      std::vector<int> n_send_data(n_neighbors);
-      std::vector<int> n_recv_data(n_neighbors);
+      std::vector<unsigned int> n_send_data(n_neighbors);
+      std::vector<unsigned int> n_recv_data(n_neighbors);
 
-      std::vector<int> send_offsets(n_neighbors);
-      std::vector<int> recv_offsets(n_neighbors);
+      std::vector<unsigned int> send_offsets(n_neighbors);
+      std::vector<unsigned int> recv_offsets(n_neighbors);
 
       // Allocate space for sending and receiving particle data
       std::vector<char> send_data(send_particles.size() * particle_size);


### PR DESCRIPTION
Silence the warning of the comparison between different integer format in the line 866 when compiling ASPECT.