### PR TITLE
Only compute hessians in assembly if necessary

### DIFF
--- a/include/aspect/assembly.h
+++ b/include/aspect/assembly.h
@@ -127,6 +127,8 @@ namespace aspect
                            const Mapping<dim>       &mapping,
                            const Quadrature<dim>    &quadrature,
                            const Quadrature<dim-1>  &face_quadrature,
+                           const UpdateFlags         update_flags,
+                           const UpdateFlags         face_update_flags,
                            const unsigned int        n_compositional_fields);
           AdvectionSystem (const AdvectionSystem &data);
 


### PR DESCRIPTION
Something I realized when reviewing #1210. There is really only one case when we need the hessians in the advection system assembly: When calculating the advection system residual for the artificial viscosity of the temperature equation. In all other cases we either treat the diffusion implicitly (matrix assembly for temperature equation), or there is no diffusion at all (compositional fields). This change can save significant time in the assembly for curved geometries (up to 50% for the composition system for 3D spherical shells).

As a side effect this PR makes the constructor of `Scratch::AdvectionSystem` more similar to `Scratch::StokesSystem`.