### PR TITLE
Keep ghost particles around

### DIFF
--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -122,6 +122,14 @@ namespace aspect
         get_particles() const;
 
         /**
+         * Const access to ghost particles in this world.
+         * Ghost particles are all particles that are owned by another process
+         * and live in one of the ghost cells of the local subdomain.
+         */
+        const std::multimap<types::LevelInd, Particle<dim> > &
+        get_ghost_particles() const;
+
+        /**
          * Advance particles by the old timestep using the current
          * integration scheme. This accounts for the fact that the tracers
          * are actually still at their old positions and the current timestep
@@ -286,7 +294,7 @@ namespace aspect
          * organized by the level/index of the cell they are in. These
          * particles are marked read-only.
          */
-        std::multimap<types::LevelInd, const Particle<dim> > ghost_particles;
+        std::multimap<types::LevelInd, Particle<dim> > ghost_particles;
 
         /**
          * This variable stores how many particles are stored globally. It is

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -386,23 +386,9 @@ namespace aspect
         update_next_free_particle_index();
 
         /**
-         * Find all subdomain_ids from neighboring cells that are not of the
-         * local subdomain_id (i.e. find all ghost neighbors of this cell).
-         */
-        void
-        find_ghost_neighbor_subdomains(const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell,
-                                       std::vector<unsigned int> &cell_neighbor_domains);
-
-        /**
-         * Removes all particles from the local domain that live in ghost
-         * cells.
-         */
-        void
-        remove_ghost_particles();
-
-        /**
-         * Removes all particles from the local domain that live in ghost
-         * cells.
+         * Exchanges all particles that live in cells adjacent to ghost cells
+         * (i.e. cells that are ghosts to other processes) with the neighboring
+         * domains. Clears and re-populates the ghost_neighbors member variable.
          */
         void
         exchange_ghost_particles();

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -282,6 +282,13 @@ namespace aspect
         std::multimap<types::LevelInd, Particle<dim> > particles;
 
         /**
+         * Set of particles currently in the ghost cells of the local domain,
+         * organized by the level/index of the cell they are in. These
+         * particles are marked read-only.
+         */
+        std::multimap<types::LevelInd, const Particle<dim> > ghost_particles;
+
+        /**
          * This variable stores how many particles are stored globally. It is
          * calculated by update_n_global_particles().
          */
@@ -377,6 +384,28 @@ namespace aspect
          */
         void
         update_next_free_particle_index();
+
+        /**
+         * Find all subdomain_ids from neighboring cells that are not of the
+         * local subdomain_id (i.e. find all ghost neighbors of this cell).
+         */
+        void
+        find_ghost_neighbor_subdomains(const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell,
+                                       std::vector<unsigned int> &cell_neighbor_domains);
+
+        /**
+         * Removes all particles from the local domain that live in ghost
+         * cells.
+         */
+        void
+        remove_ghost_particles();
+
+        /**
+         * Removes all particles from the local domain that live in ghost
+         * cells.
+         */
+        void
+        exchange_ghost_particles();
 
         /**
          * Returns a map of neighbor cells of the current cell. This map is

--- a/source/particle/interpolator/cell_average.cc
+++ b/source/particle/interpolator/cell_average.cc
@@ -19,6 +19,8 @@
  */
 
 #include <aspect/particle/interpolator/cell_average.h>
+#include <aspect/postprocess/tracers.h>
+#include <aspect/simulator.h>
 
 #include <deal.II/grid/grid_tools.h>
 
@@ -34,6 +36,11 @@ namespace aspect
                                              const std::vector<Point<dim> > &positions,
                                              const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
       {
+        const Postprocess::Tracers<dim> *tracer_postprocessor = this->template find_postprocessor<Postprocess::Tracers<dim> >();
+
+        const std::multimap<aspect::Particle::types::LevelInd, aspect::Particle::Particle<dim> > &ghost_particles =
+          tracer_postprocessor->get_particle_world().get_ghost_particles();
+
         typename parallel::distributed::Triangulation<dim>::active_cell_iterator found_cell;
 
         if (cell == typename parallel::distributed::Triangulation<dim>::active_cell_iterator())
@@ -57,8 +64,18 @@ namespace aspect
           found_cell = cell;
 
         const types::LevelInd cell_index = std::make_pair(found_cell->level(),found_cell->index());
-        const std::pair<typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator,
-              typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator> particle_range = particles.equal_range(cell_index);
+
+        std::pair<typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator,
+              typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator> particle_range;
+
+        if (cell->is_locally_owned())
+          {
+            particle_range = particles.equal_range(cell_index);
+          }
+        else
+          {
+            particle_range = ghost_particles.equal_range(cell_index);
+          }
 
         const unsigned int n_particles = std::distance(particle_range.first,particle_range.second);
         const unsigned int n_properties = particles.begin()->second.get_properties().size();
@@ -90,7 +107,11 @@ namespace aspect
               {
                 // Only recursively call this function if the neighbor cell contains
                 // particles (else we end up in an endless recursion)
-                if (particles.count(std::make_pair(neighbors[i]->level(),neighbors[i]->index())) == 0)
+                if ((neighbors[i]->is_locally_owned())
+                    && (particles.count(std::make_pair(neighbors[i]->level(),neighbors[i]->index())) == 0))
+                  continue;
+                else if ((!neighbors[i]->is_locally_owned())
+                  && (ghost_particles.count(std::make_pair(neighbors[i]->level(),neighbors[i]->index())) == 0))
                   continue;
 
                 std::vector<double> neighbor_properties = properties_at_points(particles,

--- a/source/particle/interpolator/cell_average.cc
+++ b/source/particle/interpolator/cell_average.cc
@@ -65,17 +65,13 @@ namespace aspect
 
         const types::LevelInd cell_index = std::make_pair(found_cell->level(),found_cell->index());
 
-        std::pair<typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator,
-              typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator> particle_range;
-
-        if (cell->is_locally_owned())
-          {
-            particle_range = particles.equal_range(cell_index);
-          }
-        else
-          {
-            particle_range = ghost_particles.equal_range(cell_index);
-          }
+        const std::pair<typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator,
+              typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator> particle_range =
+                (cell->is_locally_owned())
+                ?
+                particles.equal_range(cell_index)
+                :
+                ghost_particles.equal_range(cell_index);
 
         const unsigned int n_particles = std::distance(particle_range.first,particle_range.second);
         const unsigned int n_properties = particles.begin()->second.get_properties().size();
@@ -111,7 +107,7 @@ namespace aspect
                     && (particles.count(std::make_pair(neighbors[i]->level(),neighbors[i]->index())) == 0))
                   continue;
                 else if ((!neighbors[i]->is_locally_owned())
-                  && (ghost_particles.count(std::make_pair(neighbors[i]->level(),neighbors[i]->index())) == 0))
+                         && (ghost_particles.count(std::make_pair(neighbors[i]->level(),neighbors[i]->index())) == 0))
                   continue;
 
                 std::vector<double> neighbor_properties = properties_at_points(particles,

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -583,7 +583,7 @@ namespace aspect
                         particle_range_in_cell = particles.equal_range(std::make_pair(cell->level(),cell->index()));
 
                   for (std::set<unsigned int>::iterator domain=cell_to_neighbor_subdomain.begin();
-                       domain!= cell_to_neighbor_subdomain.end(); ++domain)
+                       domain != cell_to_neighbor_subdomain.end(); ++domain)
                     {
                       for (typename std::multimap<types::LevelInd,Particle <dim> >::iterator particle = particle_range_in_cell.first;
                            particle != particle_range_in_cell.second;

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -89,6 +89,13 @@ namespace aspect
     }
 
     template <int dim>
+    const std::multimap<types::LevelInd, Particle<dim> > &
+    World<dim>::get_ghost_particles() const
+    {
+      return ghost_particles;
+    }
+
+    template <int dim>
     std::string
     World<dim>::generate_output() const
     {
@@ -550,16 +557,15 @@ namespace aspect
       typename DoFHandler<dim>::active_cell_iterator
       cell = this->get_dof_handler().begin_active(),
       endc = this->get_dof_handler().end();
-      for (typename Triangulation<dim>::active_cell_iterator cell=
-             this->get_triangulation().begin_active(); cell != this->get_triangulation().end(); ++cell)
+      for (; cell != endc; ++cell)
         {
           if (cell->is_ghost())
             for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_cell; ++v)
               vertex_to_neighbor_subdomain[cell->vertex_index(v)].insert(cell->subdomain_id());
         }
 
-      for (typename Triangulation<dim>::active_cell_iterator cell=
-             this->get_triangulation().begin_active(); cell != this->get_triangulation().end(); ++cell)
+      cell = this->get_triangulation().begin_active();
+      for (; cell != endc; ++cell)
         {
           if (!cell->is_ghost())
             {
@@ -1189,6 +1195,7 @@ namespace aspect
                   local_initialize_particles(particle_range_in_cell.first,
                                              particle_range_in_cell.second);
               }
+          exchange_ghost_particles();
         }
     }
 

--- a/tests/particle_interpolator_from_ghost_cells.prm
+++ b/tests/particle_interpolator_from_ghost_cells.prm
@@ -1,0 +1,89 @@
+# A test that makes sure the 'cell average' particle interpolator 
+# also uses data from ghost particles to compute the averaged
+# properties in a cell without particles.
+
+# MPI: 2
+
+set Dimension                               = 2
+set End time                                = 0
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent    = 1000000.0
+    set Y extent    =  450000.0 
+  end
+end
+
+subsection Model settings
+  set Fixed temperature boundary indicators     = top, bottom
+  set Zero velocity boundary indicators         = left, right, bottom, top
+end
+
+subsection Compositional fields
+  set Number of fields = 1
+  set Compositional field methods = particles
+end
+
+subsection Material model
+  set Model name = simple
+  set Material averaging = arithmetic average
+end
+
+subsection Compositional initial conditions
+  set Model name = function
+  subsection Function
+    set Variable names = x,z,t
+    set Function expression = if(((450000-z)<=225000),1,0)
+  end
+end
+
+subsection Initial conditions
+  set Model name = function
+
+  subsection Function
+    set Variable names = x,z,t
+    set Function expression = 1613
+  end
+end
+
+subsection Boundary temperature model
+  set Model name = initial temperature
+end
+
+subsection Boundary composition model
+  set Model name = initial composition
+end
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 9.81
+  end
+end
+
+subsection Mesh refinement
+  set Initial global refinement                 = 4
+  set Initial adaptive refinement               = 0
+  set Time steps between mesh refinement         = 0
+end
+
+subsection Postprocess
+  set List of postprocessors = tracers, particle count statistics
+
+  subsection Visualization
+    set Time between graphical output = 0
+    set List of output variables = particle count, partition
+  end
+
+  subsection Tracers
+    set Number of tracers = 400
+    set Time between data output = 0
+    set Data output format = none
+    set List of tracer properties = initial composition
+    set Particle generator name = random uniform
+    set Minimum tracers per cell = 2
+    set Maximum tracers per cell = 100
+    set Load balancing strategy = none
+  end
+end

--- a/tests/particle_interpolator_from_ghost_cells/screen-output
+++ b/tests/particle_interpolator_from_ghost_cells/screen-output
@@ -1,0 +1,20 @@
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+10 iterations.
+
+   Postprocessing:
+     Number of advected particles:        400
+     Particle count per cell min/avg/max: 0, 1, 6
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/particle_interpolator_from_ghost_cells/statistics
+++ b/tests/particle_interpolator_from_ghost_cells/statistics
@@ -1,0 +1,16 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Number of mesh cells
+# 4: Number of Stokes degrees of freedom
+# 5: Number of temperature degrees of freedom
+# 6: Number of degrees of freedom for all compositions
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Time step size (years)
+# 12: Number of advected particles
+# 13: Minimal particles per cell: 
+# 14: Average particles per cell: 
+# 15: Maximal particles per cell: 
+0 0.000000000000e+00 256 2467 1089 1089 0 40 105 33 3.231679664777e+16 400 0 1 6 


### PR DESCRIPTION
A first stab at the problem raised by @egpuckett that many algorithms projecting particle properties onto the mesh want to use particles from neighboring cells, but they might not be available in our code, because they might be owned by a different processor. 
After discussion with @bangerth I tried to keep the ghost particles as separated from the normal particles as possible to avoid the problem of one process changing particle properties that it does not own. Still the access to ghost particles in the interpolator feels somewhat clumsy at the moment (having to ask for the postprocessor once per cell just does not feel right), but other options would involve changing the interface, which would be incompatible, or handing over a merged version of `particles` and `ghost_particles`, which would be slow. I am happy about suggestions for improvements.