### PR TITLE
Allow use of multiple particle load balancing techniques

### DIFF
--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -66,14 +66,6 @@ namespace aspect
          */
         ~World();
 
-        enum ParticleLoadBalancing
-        {
-          no_balancing,
-          remove_particles,
-          remove_and_add_particles,
-          repartition
-        };
-
         /**
          * Initialize the particle world.
          */
@@ -256,6 +248,18 @@ namespace aspect
         parse_parameters (ParameterHandler &prm);
 
       private:
+        struct ParticleLoadBalancing
+        {
+          enum Kind
+          {
+            no_balancing = 0x0,
+            remove_particles = 0x1,
+            add_particles = 0x2,
+            repartition = 0x4,
+            remove_and_add_particles = remove_particles | add_particles
+          };
+        };
+
         /**
          * Generation scheme for creating particles in this world
          */
@@ -328,7 +332,7 @@ namespace aspect
         /**
          * Strategy for tracer load balancing.
          */
-        ParticleLoadBalancing particle_load_balancing;
+        typename ParticleLoadBalancing::Kind particle_load_balancing;
 
         /**
          * Lower limit for particle number per cell. This limit is
@@ -360,7 +364,7 @@ namespace aspect
         /**
          * The computational cost of a single particle. This is an input
          * parameter that is set during initialization and is only used if the
-         * particle_load_balancing strategy 'repartition' is used. This value
+         * particle load balancing strategy 'repartition' is used. This value
          * determines how costly the computation of a single tracer is compared
          * to the computation of a whole cell, which is arbitrarily defined
          * to represent a cost of 1000.

--- a/tests/particle_timing_information/screen-output
+++ b/tests/particle_timing_information/screen-output
@@ -27,28 +27,28 @@ Number of degrees of freedom: 447 (208+31+104+104)
      Compositions min/max/mass:    -0.0002044/1.123/0.1846
      Number of advected particles: 9
 
-Number of active cells: 16 (on 4 levels)
-Number of degrees of freedom: 387 (180+27+90+90)
+Number of active cells: 31 (on 4 levels)
+Number of degrees of freedom: 673 (314+45+157+157)
 
 *** Timestep 0:  t=0 seconds
    Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 24+0 iterations.
+   Solving Stokes system... 25+0 iterations.
 
    Postprocessing:
-     RMS, max velocity:            0.000185 m/s, 0.000491 m/s
-     Compositions min/max/mass:    0/1.124/0.1817
+     RMS, max velocity:            0.000201 m/s, 0.000505 m/s
+     Compositions min/max/mass:    -0.003371/1.122/0.1836
      Number of advected particles: 9
 
 *** Timestep 1:  t=70 seconds
    Skipping temperature solve because RHS is zero.
-   Solving C_1 system ... 16 iterations.
-   Solving Stokes system... 22+0 iterations.
+   Solving C_1 system ... 15 iterations.
+   Solving Stokes system... 24+0 iterations.
 
    Postprocessing:
-     RMS, max velocity:         0.000217 m/s, 0.000582 m/s
-     Compositions min/max/mass: -0.02596/1.114/0.1764
+     RMS, max velocity:         0.000294 m/s, 0.000754 m/s
+     Compositions min/max/mass: -0.03271/1.126/0.1805
      Writing particle output:   output-particle_timing_information/particles/particle-00001
 
 Termination requested by criterion: end time


### PR DESCRIPTION
In hindsight it was wrong to assume that a user would only want to use one particle load balancing strategy. If for example one has a wide spectrum of allowed number of particles per cell, one might still want to repartition the mesh according to the combined weights of cells and particles (this is what I want to do right now in a model).  This PR allows to combine the existing strategies. It also allows to only add particles in poorly populated areas, which was previously only possible if the remove particles strategy was selected as well. Finally, I would like to change the default balancing strategy to 'repartition', since it does not harm a model (it is a small slowdown of the repartition, but it can lead to significant improvements in runtime), and it speeds up models for users with parallel models who want to 'just switch on the particles' without thinking about the details.

One thing I noticed in the tests is that apparently the partition influences the mesh refinement, e.g. I get different meshes when they are partitioned differently. Is that something to worry about, or is it expected? And should I therefore leave the change of the default value for another PR?