### PR TITLE
Fix test output.

### DIFF
--- a/tests/particle_interpolator_from_ghost_cells/statistics
+++ b/tests/particle_interpolator_from_ghost_cells/statistics
@@ -1,16 +1,16 @@
 # 1: Time step number
 # 2: Time (years)
-# 3: Number of mesh cells
-# 4: Number of Stokes degrees of freedom
-# 5: Number of temperature degrees of freedom
-# 6: Number of degrees of freedom for all compositions
-# 7: Iterations for temperature solver
-# 8: Iterations for Stokes solver
-# 9: Velocity iterations in Stokes preconditioner
-# 10: Schur complement iterations in Stokes preconditioner
-# 11: Time step size (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
 # 12: Number of advected particles
 # 13: Minimal particles per cell: 
 # 14: Average particles per cell: 
 # 15: Maximal particles per cell: 
-0 0.000000000000e+00 256 2467 1089 1089 0 40 105 33 3.231679664777e+16 400 0 1 6 
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 1089 0 40 105 33 400 0 1 6 


### PR DESCRIPTION
The test was created on a branch that branched off another patch that changed the
output in the 'statistics' file, and so the continuous integration machine did not
catch the issue. This fixes the statistics output to conform to the current standard.