### PR TITLE
Change to ParameterHandler::parse_*

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -312,7 +312,21 @@ parse_parameters (const std::string &input_as_string,
   // try reading on processor 0
   bool success = true;
   if (dealii::Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
+#if DEAL_II_VERSION_GTE(8,5,0)
+    try
+      {
+        prm.parse_input_from_string(input_as_string.c_str());
+      }
+    catch (const dealii::ExceptionBase &e)
+      {
+        success = false;
+        e.print_info(std::cerr);
+        std::cerr << std::endl;
+      }
+#else
     success = prm.read_input_from_string(input_as_string.c_str());
+#endif
+
 
   // broadcast the result. we'd like to do this with a bool
   // data type but MPI_C_BOOL is not part of old MPI standards.
@@ -339,8 +353,12 @@ parse_parameters (const std::string &input_as_string,
   // other processors will be ok as well
   if (dealii::Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) != 0)
     {
+#if DEAL_II_VERSION_GTE(8,5,0)
+      prm.parse_input_from_string(input_as_string.c_str());
+#else
       success = prm.read_input_from_string(input_as_string.c_str());
       AssertThrow(success, dealii::ExcMessage ("Invalid input parameter file."));
+#endif
     }
 }
 


### PR DESCRIPTION
Handle #1239.

When ending due to bad prm file also include reason if provided through exception.

Tester failure expected due to current test output being based on deal.II 8.5.