### PR TITLE
Speed up Stokes assembly by only assembling Stokes degrees of freedom

### DIFF
--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -353,6 +353,16 @@ namespace aspect
       bool
       compositional_name_exists (const std::string &name) const;
 
+      /**
+       * A function that gets a component index as an input
+       * parameter and returns if the component is one of the stokes system
+       * (i.e. if it is the pressure or one of the velocity components).
+       *
+       * @param component_index The component index to check.
+       */
+      bool
+      is_stokes_component (const unsigned int component_index) const;
+
     private:
       /**
        * A vector that stores the names of the compositional fields that will

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -273,6 +273,20 @@ namespace aspect
             false);
   }
 
+  template <int dim>
+  bool
+  Introspection<dim>::is_stokes_component (const unsigned int component_index) const
+  {
+    if (component_index == component_indices.pressure)
+      return true;
+
+    for (unsigned int i=0; i<dim; ++i)
+      if (component_index == component_indices.velocities[i])
+        return true;
+
+    return false;
+  }
+
 
 }
 


### PR DESCRIPTION
Currently we assemble every degree of freedom in the Stokes assembly, although many of them are zero because they belong to temperature or compositional fields. This PR fixes this by skipping all non Stokes dofs, which speeds up the assembly of an example model of mine by 20% (3D, box, incompressible, 1 compositional field). I think we could save even more, if we would figure out a way to make the scratch matrices and objects only large enough to hold the Stokes dofs, and only loop over them (as we do for the advection system). This would make the call to `is_stokes_component` unnecessary. It is a bit more tricky for Stokes though, because we would need a way from an index (0,stokes_dofs), which can be either a pressure or a velocity dof, to the correct dof of the global system. Something for a follow-up PR.