### PR TITLE
Fix hdf5 output

### DIFF
--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -446,30 +446,30 @@ namespace aspect
       if (output_format=="hdf5")
         {
           XDMFEntry new_xdmf_entry;
-          std::string     h5_solution_file_name = this->get_output_directory() + "solution/" + solution_file_prefix + ".h5";
-          std::string     xdmf_filename = this->get_output_directory() + "solution.xdmf";
+          const std::string h5_solution_file_name = "solution/" + solution_file_prefix + ".h5";
+          const std::string xdmf_filename = "solution.xdmf";
 
           // Filter redundant values
-          DataOutBase::DataOutFilter   data_filter(DataOutBase::DataOutFilterFlags(true, true));
+          DataOutBase::DataOutFilter data_filter(DataOutBase::DataOutFilterFlags(true, true));
 
           // If the mesh changed since the last output, make a new mesh file
-          std::string mesh_file_prefix = "mesh-" + Utilities::int_to_string (output_file_number, 5);
+          const std::string mesh_file_prefix = "mesh-" + Utilities::int_to_string (output_file_number, 5);
           if (mesh_changed)
-            last_mesh_file_name = mesh_file_prefix + ".h5";
+            last_mesh_file_name = "solution/" + mesh_file_prefix + ".h5";
 
           data_out.write_filtered_data(data_filter);
           data_out.write_hdf5_parallel(data_filter,
                                        mesh_changed,
-                                       this->get_output_directory()+"solution/"+last_mesh_file_name,
-                                       this->get_output_directory()+"solution/"+h5_solution_file_name,
+                                       this->get_output_directory()+last_mesh_file_name,
+                                       this->get_output_directory()+h5_solution_file_name,
                                        this->get_mpi_communicator());
           new_xdmf_entry = data_out.create_xdmf_entry(data_filter,
-                                                      "solution/"+last_mesh_file_name,
-                                                      "solution/"+h5_solution_file_name,
+                                                      last_mesh_file_name,
+                                                      h5_solution_file_name,
                                                       time_in_years_or_seconds,
                                                       this->get_mpi_communicator());
           xdmf_entries.push_back(new_xdmf_entry);
-          data_out.write_xdmf_file(xdmf_entries, xdmf_filename.c_str(),
+          data_out.write_xdmf_file(xdmf_entries, this->get_output_directory() + xdmf_filename,
                                    this->get_mpi_communicator());
           mesh_changed = false;
         }

--- a/tests/graphical_output_hdf5.cc
+++ b/tests/graphical_output_hdf5.cc
@@ -1,0 +1,2 @@
+#include "solcx.cc"
+

--- a/tests/graphical_output_hdf5.prm
+++ b/tests/graphical_output_hdf5.prm
@@ -1,0 +1,120 @@
+# A copy of the graphical_output test designed to test the 
+# hdf5 visualization output format.
+
+
+set Dimension = 2
+
+
+set CFL number                             = 1.0
+
+set End time                               = 0
+
+
+set Resume computation                     = false
+
+set Start time                             = 0
+
+set Adiabatic surface temperature          = 0
+
+set Surface pressure                       = 0
+
+set Use years in output instead of seconds = false  # default: true
+
+set Nonlinear solver scheme                = Stokes only
+
+
+subsection Boundary temperature model
+  set Model name = box
+
+end
+
+
+subsection Discretization
+  set Stokes velocity polynomial degree       = 2
+
+  set Temperature polynomial degree           = 2
+
+  set Use locally conservative discretization = false
+
+  subsection Stabilization parameters
+    set alpha = 2
+
+    set beta  = 0.078
+
+    set cR    = 0.5   # default: 0.11
+  end
+
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+
+    set Y extent = 1
+
+    set Z extent = 1
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+end
+
+
+subsection Initial conditions
+  set Model name = perturbed box
+
+end
+
+
+subsection Material model
+  set Model name = SolCxMaterial
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0                       # default: 2
+  set Initial global refinement          = 2                       # default: 2
+
+  set Strategy                           = density, temperature
+end
+
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false # default: true
+
+
+  set Fixed temperature boundary indicators   = 0, 1
+
+  set Prescribed velocity boundary indicators =
+
+  set Tangential velocity boundary indicators = 0,1,2,3
+
+  set Zero velocity boundary indicators       =
+end
+
+
+subsection Postprocess
+  set List of postprocessors = SolCxPostprocessor, visualization
+
+  subsection Depth average
+    set Time between graphical output = 0
+  end
+
+  subsection Visualization
+    set Number of grouped files       = 0
+
+    set Output format                 = hdf5
+
+    set Time between graphical output = 0   # default: 1e8
+
+    set List of output variables = viscosity, nonadiabatic pressure
+  end
+end
+

--- a/tests/graphical_output_hdf5/screen-output
+++ b/tests/graphical_output_hdf5/screen-output
@@ -1,0 +1,26 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libgraphical_output_hdf5.so>
+
+Number of active cells: 16 (on 3 levels)
+Number of degrees of freedom: 268 (162+25+81)
+
+*** Timestep 0:  t=0 seconds
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 17+0 iterations.
+      Nonlinear Stokes residual: 0.0667217
+   Solving Stokes system... 0+0 iterations.
+      Nonlinear Stokes residual: 4.40627e-09
+
+   Postprocessing:
+     Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174943e-01, 1.069688e-04, 1.192654e-01
+     Writing graphical output:      output-graphical_output_hdf5/solution/solution-00000
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/graphical_output_hdf5/solution.xdmf
+++ b/tests/graphical_output_hdf5/solution.xdmf
@@ -1,0 +1,46 @@
+<?xml version="1.0" ?>
+<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>
+<Xdmf Version="2.0">
+  <Domain>
+    <Grid Name="CellTime" GridType="Collection" CollectionType="Temporal">
+      <Grid Name="mesh" GridType="Uniform">
+        <Time Value="0"/>
+        <Geometry GeometryType="XY">
+          <DataItem Dimensions="25 2" NumberType="Float" Precision="8" Format="HDF">
+            solution/mesh-00000.h5:/nodes
+          </DataItem>
+        </Geometry>
+        <Topology TopologyType="Quadrilateral" NumberOfElements="16">
+          <DataItem Dimensions="16 4" NumberType="UInt" Format="HDF">
+            solution/mesh-00000.h5:/cells
+          </DataItem>
+        </Topology>
+        <Attribute Name="T" AttributeType="Scalar" Center="Node">
+          <DataItem Dimensions="25 1" NumberType="Float" Precision="8" Format="HDF">
+            solution/solution-00000.h5:/T
+          </DataItem>
+        </Attribute>
+        <Attribute Name="nonadiabatic_pressure" AttributeType="Scalar" Center="Node">
+          <DataItem Dimensions="25 1" NumberType="Float" Precision="8" Format="HDF">
+            solution/solution-00000.h5:/nonadiabatic_pressure
+          </DataItem>
+        </Attribute>
+        <Attribute Name="p" AttributeType="Scalar" Center="Node">
+          <DataItem Dimensions="25 1" NumberType="Float" Precision="8" Format="HDF">
+            solution/solution-00000.h5:/p
+          </DataItem>
+        </Attribute>
+        <Attribute Name="velocity" AttributeType="Vector" Center="Node">
+          <DataItem Dimensions="25 3" NumberType="Float" Precision="8" Format="HDF">
+            solution/solution-00000.h5:/velocity
+          </DataItem>
+        </Attribute>
+        <Attribute Name="viscosity" AttributeType="Scalar" Center="Node">
+          <DataItem Dimensions="25 1" NumberType="Float" Precision="8" Format="HDF">
+            solution/solution-00000.h5:/viscosity
+          </DataItem>
+        </Attribute>
+      </Grid>
+    </Grid>
+  </Domain>
+</Xdmf>

--- a/tests/graphical_output_hdf5/statistics
+++ b/tests/graphical_output_hdf5/statistics
@@ -1,0 +1,12 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for Stokes solver
+# 8: Velocity iterations in Stokes preconditioner
+# 9: Schur complement iterations in Stokes preconditioner
+# 10: Visualization file name
+0 0.000000000000e+00 0.000000000000e+00 16 187 81 17 18 17                                                   "" 
+0 0.000000000000e+00 0.000000000000e+00  0   0  0  0  0  0 output-graphical_output_hdf5/solution/solution-00000 


### PR DESCRIPTION
It looks like our HDF5 output was broken since the conversion to solution/ subdirectories, because the paths in the .xdmf file were added twice ("solution/output_directory/solution/filename.h5") and nobody noticed. Does not seem to be our usual output format :smile:. Anyway, this fixes the paths, and adds a test for the output format (sadly another binary output test, but it is small). I might also remove the .h5 files if we prefer to keep the binary files out of the repository.