### PR TITLE
Shrink Stokes system assembly

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,15 @@
  *
  * <ol>
  *
+ * <li> Improved: The matrix assembly of Stokes and Advection systems has been
+ * optimized, by assembling less (only the relevant) DoFs, and by optimizing
+ * calls to deal.II functions. The overall speedup for box models is between
+ * 20 and 40% of the assembly time, likely somewhat less for curved geometries.
+ * This change will require changes in user written assembler plugins, because
+ * the Stokes system assembly now only loops over Stokes degrees of freedom.
+ * <br>
+ * (Rene Gassmoeller, 2016/10/17)
+ *
  * <li> Improved: Box models without deformed mesh now use a MappingCartesian,
  * which assumes all mesh cells are aligned with cartesian coordinate axes.
  * Matrix assembly and particle transport in such mappings is around 20 % faster

--- a/include/aspect/assembly.h
+++ b/include/aspect/assembly.h
@@ -51,6 +51,7 @@ namespace aspect
                                 const Mapping<dim>       &mapping,
                                 const UpdateFlags         update_flags,
                                 const unsigned int        n_compositional_fields,
+                                const unsigned int        stokes_dofs_per_cell,
                                 const bool                add_compaction_pressure);
           StokesPreconditioner (const StokesPreconditioner &data);
 
@@ -58,6 +59,8 @@ namespace aspect
 
           FEValues<dim>               finite_element_values;
 
+          std::vector<types::global_dof_index> local_dof_indices;
+          std::vector<unsigned int>            dof_component_indices;
           std::vector<SymmetricTensor<2,dim> > grads_phi_u;
           std::vector<double>                  phi_p;
           std::vector<double>                  phi_p_c;
@@ -94,6 +97,7 @@ namespace aspect
                         const UpdateFlags         update_flags,
                         const UpdateFlags         face_update_flags,
                         const unsigned int        n_compositional_fields,
+                        const unsigned int        stokes_dofs_per_cell,
                         const bool                add_compaction_pressure);
 
           StokesSystem (const StokesSystem<dim> &data);
@@ -231,7 +235,7 @@ namespace aspect
         template <int dim>
         struct StokesPreconditioner
         {
-          StokesPreconditioner (const FiniteElement<dim> &finite_element);
+          StokesPreconditioner (const unsigned int stokes_dofs_per_cell);
           StokesPreconditioner (const StokesPreconditioner &data);
 
           virtual ~StokesPreconditioner ();
@@ -245,7 +249,7 @@ namespace aspect
         template <int dim>
         struct StokesSystem : public StokesPreconditioner<dim>
         {
-          StokesSystem (const FiniteElement<dim> &finite_element,
+          StokesSystem (const unsigned int        stokes_dofs_per_cell,
                         const bool                do_pressure_rhs_compatibility_modification);
           StokesSystem (const StokesSystem<dim> &data);
 

--- a/include/aspect/free_surface.h
+++ b/include/aspect/free_surface.h
@@ -67,6 +67,7 @@ namespace aspect
        * assemly of the system matrix.
        */
       void apply_stabilization (const typename DoFHandler<dim>::active_cell_iterator &cell,
+                                internal::Assembly::Scratch::StokesSystem<dim>       &scratch,
                                 internal::Assembly::CopyData::StokesSystem<dim>      &data);
 
       /**

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -84,14 +84,17 @@ namespace aspect
                               const Mapping<dim>       &mapping,
                               const UpdateFlags         update_flags,
                               const unsigned int        n_compositional_fields,
+                              const unsigned int        stokes_dofs_per_cell,
                               const bool                add_compaction_pressure)
           :
           finite_element_values (mapping, finite_element, quadrature,
                                  update_flags),
-          grads_phi_u (finite_element.dofs_per_cell, numbers::signaling_nan<SymmetricTensor<2,dim> >()),
-          phi_p (finite_element.dofs_per_cell, numbers::signaling_nan<double>()),
-          phi_p_c (add_compaction_pressure ? finite_element.dofs_per_cell : 0, numbers::signaling_nan<double>()),
-          grad_phi_p (add_compaction_pressure ? finite_element.dofs_per_cell : 0, numbers::signaling_nan<Tensor<1,dim> >()),
+          local_dof_indices (finite_element.dofs_per_cell),
+          dof_component_indices(stokes_dofs_per_cell),
+          grads_phi_u (stokes_dofs_per_cell, numbers::signaling_nan<SymmetricTensor<2,dim> >()),
+          phi_p (stokes_dofs_per_cell, numbers::signaling_nan<double>()),
+          phi_p_c (add_compaction_pressure ? stokes_dofs_per_cell : 0, numbers::signaling_nan<double>()),
+          grad_phi_p (add_compaction_pressure ? stokes_dofs_per_cell : 0, numbers::signaling_nan<Tensor<1,dim> >()),
           temperature_values (quadrature.size(), numbers::signaling_nan<double>()),
           pressure_values (quadrature.size(), numbers::signaling_nan<double>()),
           strain_rates (quadrature.size(), numbers::signaling_nan<SymmetricTensor<2,dim> >()),
@@ -111,6 +114,8 @@ namespace aspect
                                  scratch.finite_element_values.get_fe(),
                                  scratch.finite_element_values.get_quadrature(),
                                  scratch.finite_element_values.get_update_flags()),
+          local_dof_indices (scratch.local_dof_indices),
+          dof_component_indices( scratch.dof_component_indices),
           grads_phi_u (scratch.grads_phi_u),
           phi_p (scratch.phi_p),
           phi_p_c (scratch.phi_p_c),
@@ -141,12 +146,14 @@ namespace aspect
                       const UpdateFlags         update_flags,
                       const UpdateFlags         face_update_flags,
                       const unsigned int        n_compositional_fields,
+                      const unsigned int        stokes_dofs_per_cell,
                       const bool                add_compaction_pressure)
           :
           StokesPreconditioner<dim> (finite_element, quadrature,
                                      mapping,
                                      update_flags,
                                      n_compositional_fields,
+                                     stokes_dofs_per_cell,
                                      add_compaction_pressure),
 
           face_finite_element_values (mapping,
@@ -154,9 +161,9 @@ namespace aspect
                                       face_quadrature,
                                       face_update_flags),
 
-          phi_u (finite_element.dofs_per_cell, numbers::signaling_nan<Tensor<1,dim> >()),
-          grads_phi_u (finite_element.dofs_per_cell, numbers::signaling_nan<SymmetricTensor<2,dim> >()),
-          div_phi_u (finite_element.dofs_per_cell, numbers::signaling_nan<double>()),
+          phi_u (stokes_dofs_per_cell, numbers::signaling_nan<Tensor<1,dim> >()),
+          grads_phi_u (stokes_dofs_per_cell, numbers::signaling_nan<SymmetricTensor<2,dim> >()),
+          div_phi_u (stokes_dofs_per_cell, numbers::signaling_nan<double>()),
           velocity_values (quadrature.size(), numbers::signaling_nan<Tensor<1,dim> >()),
           face_material_model_inputs(face_quadrature.size(), n_compositional_fields),
           face_material_model_outputs(face_quadrature.size(), n_compositional_fields)
@@ -338,11 +345,11 @@ namespace aspect
 
         template <int dim>
         StokesPreconditioner<dim>::
-        StokesPreconditioner (const FiniteElement<dim> &finite_element)
+        StokesPreconditioner (const unsigned int stokes_dofs_per_cell)
           :
-          local_matrix (finite_element.dofs_per_cell,
-                        finite_element.dofs_per_cell),
-          local_dof_indices (finite_element.dofs_per_cell)
+          local_matrix (stokes_dofs_per_cell,
+                        stokes_dofs_per_cell),
+          local_dof_indices (stokes_dofs_per_cell)
         {}
 
 
@@ -366,13 +373,13 @@ namespace aspect
 
         template <int dim>
         StokesSystem<dim>::
-        StokesSystem (const FiniteElement<dim> &finite_element,
+        StokesSystem (const unsigned int        stokes_dofs_per_cell,
                       const bool                do_pressure_rhs_compatibility_modification)
           :
-          StokesPreconditioner<dim> (finite_element),
-          local_rhs (finite_element.dofs_per_cell),
+          StokesPreconditioner<dim> (stokes_dofs_per_cell),
+          local_rhs (stokes_dofs_per_cell),
           local_pressure_shape_function_integrals (do_pressure_rhs_compatibility_modification ?
-                                                   finite_element.dofs_per_cell
+                                                   stokes_dofs_per_cell
                                                    :
                                                    0)
         {}
@@ -929,42 +936,63 @@ namespace aspect
         {
           const Introspection<dim> &introspection = this->introspection();
           const FiniteElement<dim> &fe = scratch.finite_element_values.get_fe();
-          const unsigned int   dofs_per_cell   = fe.dofs_per_cell;
-          const unsigned int   n_q_points      = scratch.finite_element_values.n_quadrature_points;
+          const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
+          const unsigned int n_q_points           = scratch.finite_element_values.n_quadrature_points;
 
+          // First loop over all dofs and find those that are in the Stokes system
+          // save the component (pressure and dim velocities) each belongs to.
+          for (unsigned int k = 0, i = 0; i < stokes_dofs_per_cell; ++k)
+            {
+              if (introspection.is_stokes_component(fe.system_to_component_index(k).first))
+                {
+                  scratch.dof_component_indices[i] = fe.system_to_component_index(k).first;
+                  ++i;
+                }
+            }
+
+          // Loop over all quadrature points and assemble their contributions to
+          // the preconditioner matrix
           for (unsigned int q = 0; q < n_q_points; ++q)
             {
-              for (unsigned int k = 0; k < dofs_per_cell; ++k)
+              for (unsigned int k = 0, i = 0; i < stokes_dofs_per_cell; ++k)
                 {
-                  scratch.grads_phi_u[k] =
-                    scratch.finite_element_values[introspection.extractors
-                                                  .velocities].symmetric_gradient(k, q);
-                  scratch.phi_p[k] = scratch.finite_element_values[introspection
-                                                                   .extractors.pressure].value(k, q);
+                  if (introspection.is_stokes_component(fe.system_to_component_index(k).first))
+                    {
+                      scratch.grads_phi_u[i] =
+                        scratch.finite_element_values[introspection.extractors
+                                                      .velocities].symmetric_gradient(k, q);
+                      scratch.phi_p[i] = scratch.finite_element_values[introspection
+                                                                       .extractors.pressure].value(k, q);
+                      ++i;
+                    }
                 }
+
               const double eta = scratch.material_model_outputs.viscosities[q];
+              const double one_over_eta = 1. / eta;
+
               const SymmetricTensor<4, dim> &stress_strain_director = scratch
                                                                       .material_model_outputs.stress_strain_directors[q];
               const bool use_tensor = (stress_strain_director
                                        != dealii::identity_tensor<dim>());
-              for (unsigned int i = 0; i < dofs_per_cell; ++i)
-                if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
-                  for (unsigned int j = 0; j < dofs_per_cell; ++j)
-                    if (fe.system_to_component_index(i).first ==
-                        fe.system_to_component_index(j).first)
-                      data.local_matrix(i, j) += ((
-                                                    use_tensor ?
-                                                    eta * (scratch.grads_phi_u[i]
-                                                           * stress_strain_director
-                                                           * scratch.grads_phi_u[j]) :
-                                                    eta * (scratch.grads_phi_u[i]
-                                                           * scratch.grads_phi_u[j]))
-                                                  + (1. / eta) * pressure_scaling
-                                                  * pressure_scaling
-                                                  * (scratch.phi_p[i] * scratch
-                                                     .phi_p[j]))
-                                                 * scratch.finite_element_values.JxW(
-                                                   q);
+
+              const double JxW = scratch.finite_element_values.JxW(q);
+
+              for (unsigned int i = 0; i < stokes_dofs_per_cell; ++i)
+                for (unsigned int j = 0; j < stokes_dofs_per_cell; ++j)
+                  if (scratch.dof_component_indices[i] ==
+                      scratch.dof_component_indices[j])
+                    data.local_matrix(i, j) += ((
+                                                  use_tensor ?
+                                                  eta * (scratch.grads_phi_u[i]
+                                                         * stress_strain_director
+                                                         * scratch.grads_phi_u[j]) :
+                                                  eta * (scratch.grads_phi_u[i]
+                                                         * scratch.grads_phi_u[j]))
+                                                + one_over_eta * pressure_scaling
+                                                * pressure_scaling
+                                                * (scratch.phi_p[i] * scratch
+                                                   .phi_p[j]))
+                                               * JxW;
             }
         }
 
@@ -977,19 +1005,23 @@ namespace aspect
         {
           const Introspection<dim> &introspection = this->introspection();
           const FiniteElement<dim> &fe = scratch.finite_element_values.get_fe();
-          const unsigned int dofs_per_cell = scratch.finite_element_values.get_fe().dofs_per_cell;
+          const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
           const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
 
           for (unsigned int q=0; q<n_q_points; ++q)
             {
-              for (unsigned int k=0; k<dofs_per_cell; ++k)
+              for (unsigned int k=0, i=0; i<stokes_dofs_per_cell; ++k)
                 {
-                  scratch.phi_u[k] = scratch.finite_element_values[introspection.extractors.velocities].value (k,q);
-                  scratch.phi_p[k] = scratch.finite_element_values[introspection.extractors.pressure].value (k, q);
-                  if (rebuild_stokes_matrix)
+                  if (introspection.is_stokes_component(fe.system_to_component_index(k).first))
                     {
-                      scratch.grads_phi_u[k] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(k,q);
-                      scratch.div_phi_u[k]   = scratch.finite_element_values[introspection.extractors.velocities].divergence (k, q);
+                      scratch.phi_u[i] = scratch.finite_element_values[introspection.extractors.velocities].value (k,q);
+                      scratch.phi_p[i] = scratch.finite_element_values[introspection.extractors.pressure].value (k, q);
+                      if (rebuild_stokes_matrix)
+                        {
+                          scratch.grads_phi_u[i] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(k,q);
+                          scratch.div_phi_u[i]   = scratch.finite_element_values[introspection.extractors.velocities].divergence (k, q);
+                        }
+                      ++i;
                     }
                 }
 
@@ -999,6 +1031,11 @@ namespace aspect
                                   scratch.material_model_outputs.viscosities[q]
                                   :
                                   std::numeric_limits<double>::quiet_NaN());
+              const double eta_two_thirds = (rebuild_stokes_matrix
+                                             ?
+                                             scratch.material_model_outputs.viscosities[q] * 2.0 / 3.0
+                                             :
+                                             0.0);
 
               const SymmetricTensor<4,dim> &stress_strain_director =
                 scratch.material_model_outputs.stress_strain_directors[q];
@@ -1011,46 +1048,46 @@ namespace aspect
                 = scratch.material_model_outputs.compressibilities[q];
               const double density = scratch.material_model_outputs.densities[q];
 
-              for (unsigned int i=0; i<dofs_per_cell; ++i)
-                if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
-                  {
-                    data.local_rhs(i) += (
-                                           (density * gravity * scratch.phi_u[i])
-                                           +
-                                           // add the term that results from the compressibility. compared
-                                           // to the manual, this term seems to have the wrong sign, but this
-                                           // is because we negate the entire equation to make sure we get
-                                           // -div(u) as the adjoint operator of grad(p) (see above where
-                                           // we assemble the matrix)
-                                           (pressure_scaling *
-                                            compressibility * density *
-                                            (scratch.velocity_values[q] * gravity) *
-                                            scratch.phi_p[i])
-                                         )
-                                         * scratch.finite_element_values.JxW(q);
+              const double JxW = scratch.finite_element_values.JxW(q);
 
-                    if (rebuild_stokes_matrix)
-                      for (unsigned int j=0; j<dofs_per_cell; ++j)
-                        if (introspection.is_stokes_component(fe.system_to_component_index(j).first))
-                          {
-                            data.local_matrix(i,j) += ( (use_tensor ?
-                                                         eta * 2.0 * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
-                                                         :
-                                                         eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
-                                                        - (use_tensor ?
-                                                           eta * 2.0/3.0 * (scratch.div_phi_u[i] * trace(stress_strain_director * scratch.grads_phi_u[j]))
-                                                           :
-                                                           eta * 2.0/3.0 * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
-                                                          )
-                                                        - (pressure_scaling *
-                                                           scratch.div_phi_u[i] * scratch.phi_p[j])
-                                                        // finally the term -div(u). note the negative sign to make this
-                                                        // operator adjoint to the grad(p) term
-                                                        - (pressure_scaling *
-                                                           scratch.phi_p[i] * scratch.div_phi_u[j]))
-                                                      * scratch.finite_element_values.JxW(q);
-                          }
-                  }
+              for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
+                {
+                  data.local_rhs(i) += (
+                                         (density * gravity * scratch.phi_u[i])
+                                         +
+                                         // add the term that results from the compressibility. compared
+                                         // to the manual, this term seems to have the wrong sign, but this
+                                         // is because we negate the entire equation to make sure we get
+                                         // -div(u) as the adjoint operator of grad(p) (see above where
+                                         // we assemble the matrix)
+                                         (pressure_scaling *
+                                          compressibility * density *
+                                          (scratch.velocity_values[q] * gravity) *
+                                          scratch.phi_p[i])
+                                       )
+                                       * JxW;
+
+                  if (rebuild_stokes_matrix)
+                    for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
+                      {
+                        data.local_matrix(i,j) += ( (use_tensor ?
+                                                     eta * 2.0 * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
+                                                     :
+                                                     eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
+                                                    - (use_tensor ?
+                                                       eta_two_thirds * (scratch.div_phi_u[i] * trace(stress_strain_director * scratch.grads_phi_u[j]))
+                                                       :
+                                                       eta_two_thirds * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
+                                                      )
+                                                    - (pressure_scaling *
+                                                       scratch.div_phi_u[i] * scratch.phi_p[j])
+                                                    // finally the term -div(u). note the negative sign to make this
+                                                    // operator adjoint to the grad(p) term
+                                                    - (pressure_scaling *
+                                                       scratch.phi_p[i] * scratch.div_phi_u[j]))
+                                                  * JxW;
+                      }
+                }
             }
 
         }
@@ -1064,21 +1101,26 @@ namespace aspect
         {
           const Introspection<dim> &introspection = this->introspection();
           const FiniteElement<dim> &fe = scratch.finite_element_values.get_fe();
-          const unsigned int dofs_per_cell = scratch.finite_element_values.get_fe().dofs_per_cell;
+          const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
           const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
 
           for (unsigned int q=0; q<n_q_points; ++q)
             {
-              for (unsigned int k=0; k<dofs_per_cell; ++k)
+              for (unsigned int k=0, i=0; i<stokes_dofs_per_cell; ++k)
                 {
-                  scratch.phi_u[k] = scratch.finite_element_values[introspection.extractors.velocities].value (k,q);
-                  scratch.phi_p[k] = scratch.finite_element_values[introspection.extractors.pressure].value (k, q);
-                  if (rebuild_stokes_matrix)
+                  if (introspection.is_stokes_component(fe.system_to_component_index(k).first))
                     {
-                      scratch.grads_phi_u[k] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(k,q);
-                      scratch.div_phi_u[k]   = scratch.finite_element_values[introspection.extractors.velocities].divergence (k, q);
+                      scratch.phi_u[i] = scratch.finite_element_values[introspection.extractors.velocities].value (k,q);
+                      scratch.phi_p[i] = scratch.finite_element_values[introspection.extractors.pressure].value (k, q);
+                      if (rebuild_stokes_matrix)
+                        {
+                          scratch.grads_phi_u[i] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(k,q);
+                          scratch.div_phi_u[i]   = scratch.finite_element_values[introspection.extractors.velocities].divergence (k, q);
+                        }
+                      ++i;
                     }
                 }
+
 
               // Viscosity scalar
               const double eta = (rebuild_stokes_matrix
@@ -1096,29 +1138,29 @@ namespace aspect
 
               const double density = scratch.material_model_outputs.densities[q];
 
-              for (unsigned int i=0; i<dofs_per_cell; ++i)
-                if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
-                  {
-                    data.local_rhs(i) += (density * gravity * scratch.phi_u[i])
-                                         * scratch.finite_element_values.JxW(q);
+              const double JxW = scratch.finite_element_values.JxW(q);
 
-                    if (rebuild_stokes_matrix)
-                      for (unsigned int j=0; j<dofs_per_cell; ++j)
-                        if (introspection.is_stokes_component(fe.system_to_component_index(j).first))
-                          {
-                            data.local_matrix(i,j) += ( (use_tensor ?
-                                                         eta * 2.0 * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
-                                                         :
-                                                         eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
-                                                        - (pressure_scaling *
-                                                           scratch.div_phi_u[i] * scratch.phi_p[j])
-                                                        // finally the term -div(u). note the negative sign to make this
-                                                        // operator adjoint to the grad(p) term
-                                                        - (pressure_scaling *
-                                                           scratch.phi_p[i] * scratch.div_phi_u[j]))
-                                                      * scratch.finite_element_values.JxW(q);
-                          }
-                  }
+              for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
+                {
+                  data.local_rhs(i) += (density * gravity * scratch.phi_u[i])
+                                       * JxW;
+
+                  if (rebuild_stokes_matrix)
+                    for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
+                      {
+                        data.local_matrix(i,j) += ( (use_tensor ?
+                                                     eta * 2.0 * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
+                                                     :
+                                                     eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
+                                                    - (pressure_scaling *
+                                                       scratch.div_phi_u[i] * scratch.phi_p[j])
+                                                    // finally the term -div(u). note the negative sign to make this
+                                                    // operator adjoint to the grad(p) term
+                                                    - (pressure_scaling *
+                                                       scratch.phi_p[i] * scratch.div_phi_u[j]))
+                                                  * JxW;
+                      }
+                }
             }
         }
 
@@ -2189,16 +2231,19 @@ namespace aspect
                                                internal::Assembly::CopyData::StokesSystem<dim> &data)
       {
         const Introspection<dim> &introspection = simulator_access.introspection();
+        const FiniteElement<dim> &fe = scratch.finite_element_values.get_fe();
 
-        const unsigned int dofs_per_cell = scratch.finite_element_values.get_fe().dofs_per_cell;
+        const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
         const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
 
         for (unsigned int q=0; q<n_q_points; ++q)
-          for (unsigned int i=0; i<dofs_per_cell; ++i)
-            {
-              scratch.phi_p[i] = scratch.finite_element_values[introspection.extractors.pressure].value (i, q);
-              data.local_pressure_shape_function_integrals(i) += scratch.phi_p[i] * scratch.finite_element_values.JxW(q);
-            }
+          for (unsigned int k=0, i=0; i<stokes_dofs_per_cell; ++k)
+            if (introspection.is_stokes_component(fe.system_to_component_index(k).first))
+              {
+                scratch.phi_p[i] = scratch.finite_element_values[introspection.extractors.pressure].value (k, q);
+                data.local_pressure_shape_function_integrals(i) += scratch.phi_p[i] * scratch.finite_element_values.JxW(q);
+                ++i;
+              }
       }
 
 
@@ -2212,11 +2257,12 @@ namespace aspect
                                     internal::Assembly::CopyData::StokesSystem<dim>      &data)
       {
         const Introspection<dim> &introspection = simulator_access.introspection();
-
+        const FiniteElement<dim> &fe = scratch.finite_element_values.get_fe();
 
         // see if any of the faces are traction boundaries for which
         // we need to assemble force terms for the right hand side
-        const unsigned int dofs_per_cell = scratch.finite_element_values.get_fe().dofs_per_cell;
+        const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
+
         if (simulator_access.get_traction_boundary_conditions()
             .find (cell->face(face_no)->boundary_id())
             !=
@@ -2233,10 +2279,14 @@ namespace aspect
                     ->boundary_traction (cell->face(face_no)->boundary_id(),
                                          scratch.face_finite_element_values.quadrature_point(q),
                                          scratch.face_finite_element_values.normal_vector(q));
-                for (unsigned int i=0; i<dofs_per_cell; ++i)
-                  data.local_rhs(i) += scratch.face_finite_element_values[introspection.extractors.velocities].value(i,q) *
-                                       traction *
-                                       scratch.face_finite_element_values.JxW(q);
+                for (unsigned int k=0, i=0; i<stokes_dofs_per_cell; ++k)
+                  if (introspection.is_stokes_component(fe.system_to_component_index(k).first))
+                    {
+                      data.local_rhs(i) += scratch.face_finite_element_values[introspection.extractors.velocities].value(k,q) *
+                                           traction *
+                                           scratch.face_finite_element_values.JxW(q);
+                      ++i;
+                    }
               }
           }
       }
@@ -2454,6 +2504,25 @@ namespace aspect
                                         internal::Assembly::Scratch::StokesPreconditioner<dim> &scratch,
                                         internal::Assembly::CopyData::StokesPreconditioner<dim> &data)
   {
+    // First get all dof indices of the current cell, then extract those
+    // that correspond to the Stokes system we are interested in.
+    // Note that assemblers below can modify this list of dofs, if they in fact
+    // assemble a different system than the standard Stokes system (e.g. in
+    // models with melt transport).
+
+    cell->get_dof_indices (scratch.local_dof_indices);
+
+    const FiniteElement<dim> &fe = scratch.finite_element_values.get_fe();
+    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+
+    for (unsigned int k=0, i=0; k<dofs_per_cell; ++k)
+      if (introspection.is_stokes_component(fe.system_to_component_index(k).first))
+        {
+          data.local_dof_indices[i] = scratch.local_dof_indices[k];
+          ++i;
+        }
+
+    // Prepare the data structures for assembly
     scratch.finite_element_values.reinit (cell);
 
     data.local_matrix = 0;
@@ -2476,8 +2545,6 @@ namespace aspect
     // trigger the invocation of the various functions that actually do
     // all of the assembling
     assemblers->local_assemble_stokes_preconditioner(pressure_scaling, scratch, data);
-
-    cell->get_dof_indices (data.local_dof_indices);
   }
 
 
@@ -2515,6 +2582,12 @@ namespace aspect
          |
          assemblers->stokes_preconditioner_assembler_properties.needed_update_flags);
 
+    unsigned int stokes_dofs_per_cell = dim * finite_element.base_element(introspection.base_elements.velocities).dofs_per_cell
+                                        + finite_element.base_element(introspection.base_elements.pressure).dofs_per_cell;
+
+    if (parameters.include_melt_transport)
+      stokes_dofs_per_cell += finite_element.base_element(introspection.base_elements.pressure).dofs_per_cell;
+
     WorkStream::
     run (CellFilter (IteratorFilters::LocallyOwnedCell(),
                      dof_handler.begin_active()),
@@ -2535,9 +2608,10 @@ namespace aspect
                                     *mapping,
                                     cell_update_flags,
                                     parameters.n_compositional_fields,
+                                    stokes_dofs_per_cell,
                                     parameters.include_melt_transport),
          internal::Assembly::CopyData::
-         StokesPreconditioner<dim> (finite_element));
+         StokesPreconditioner<dim> (stokes_dofs_per_cell));
 
     system_preconditioner_matrix.compress(VectorOperation::add);
   }
@@ -2624,6 +2698,25 @@ namespace aspect
                                 internal::Assembly::Scratch::StokesSystem<dim> &scratch,
                                 internal::Assembly::CopyData::StokesSystem<dim> &data)
   {
+    // First get all dof indices of the current cell, then extract those
+    // that correspond to the Stokes system we are interested in.
+    // Note that assemblers below can modify this list of dofs, if they in fact
+    // assemble a different system than the standard Stokes system (e.g. in
+    // models with melt transport).
+
+    cell->get_dof_indices (scratch.local_dof_indices);
+
+    const FiniteElement<dim> &fe = scratch.finite_element_values.get_fe();
+    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+
+    for (unsigned int k=0, i=0; k<dofs_per_cell; ++k)
+      if (introspection.is_stokes_component(fe.system_to_component_index(k).first))
+        {
+          data.local_dof_indices[i] = scratch.local_dof_indices[k];
+          ++i;
+        }
+
+    // Prepare the data structures for assembly
     scratch.finite_element_values.reinit (cell);
 
     if (rebuild_stokes_matrix)
@@ -2687,8 +2780,6 @@ namespace aspect
                                                                     pressure_scaling, rebuild_stokes_matrix,
                                                                     scratch, data);
         }
-
-    cell->get_dof_indices (data.local_dof_indices);
   }
 
 
@@ -2767,6 +2858,12 @@ namespace aspect
         |
         assemblers->stokes_system_assembler_on_boundary_face_properties.needed_update_flags;
 
+    unsigned int stokes_dofs_per_cell = dim * finite_element.base_element(introspection.base_elements.velocities).dofs_per_cell
+                                        + finite_element.base_element(introspection.base_elements.pressure).dofs_per_cell;
+
+    if (parameters.include_melt_transport)
+      stokes_dofs_per_cell += finite_element.base_element(introspection.base_elements.pressure).dofs_per_cell;
+
     WorkStream::
     run (CellFilter (IteratorFilters::LocallyOwnedCell(),
                      dof_handler.begin_active()),
@@ -2788,9 +2885,10 @@ namespace aspect
                             cell_update_flags,
                             face_update_flags,
                             parameters.n_compositional_fields,
+                            stokes_dofs_per_cell,
                             parameters.include_melt_transport),
          internal::Assembly::CopyData::
-         StokesSystem<dim> (finite_element,
+         StokesSystem<dim> (stokes_dofs_per_cell,
                             do_pressure_rhs_compatibility_modification));
 
     system_matrix.compress(VectorOperation::add);

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -60,6 +60,29 @@ namespace aspect
 
   namespace Assemblers
   {
+    namespace
+    {
+      template<int dim>
+      bool
+      is_stokes_component (const Introspection<dim> &introspection,
+                           const unsigned int p_c_component_index,
+                           const unsigned int p_f_component_index,
+                           const unsigned int component_index)
+      {
+        if (component_index == p_c_component_index)
+          return true;
+
+        if (component_index == p_f_component_index)
+          return true;
+
+        for (unsigned int i=0; i<dim; ++i)
+          if (component_index == introspection.component_indices.velocities[i])
+            return true;
+
+        return false;
+      }
+    }
+
     template <int dim>
     void
     MeltEquations<dim>::create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const
@@ -77,7 +100,7 @@ namespace aspect
     {
       const Introspection<dim> &introspection = this->introspection();
       const FiniteElement<dim> &fe = scratch.finite_element_values.get_fe();
-      const unsigned int   dofs_per_cell   = fe.dofs_per_cell;
+      const unsigned int   stokes_dofs_per_cell = data.local_dof_indices.size();
       const unsigned int   n_q_points      = scratch.finite_element_values.n_quadrature_points;
 
       MaterialModel::MeltOutputs<dim> *melt_outputs = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
@@ -88,14 +111,32 @@ namespace aspect
       const unsigned int p_f_component_index = introspection.variable("fluid pressure").first_component_index;
       const unsigned int p_c_component_index = introspection.variable("compaction pressure").first_component_index;
 
+      for (unsigned int k=0, i=0; i<stokes_dofs_per_cell; ++k)
+        {
+          const unsigned int component_index_k = fe.system_to_component_index(k).first;
+
+          if (is_stokes_component(introspection,p_c_component_index,p_f_component_index,component_index_k))
+            {
+              data.local_dof_indices[i] = scratch.local_dof_indices[k];
+              scratch.dof_component_indices[i] = fe.system_to_component_index(k).first;
+              ++i;
+            }
+        }
+
       for (unsigned int q=0; q<n_q_points; ++q)
         {
-          for (unsigned int k=0; k<dofs_per_cell; ++k)
+          for (unsigned int k=0, i=0; i<stokes_dofs_per_cell; ++k)
             {
-              scratch.grads_phi_u[k] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(k,q);
-              scratch.phi_p[k]       = scratch.finite_element_values[ex_p_f].value (k, q);
-              scratch.phi_p_c[k] = scratch.finite_element_values[ex_p_c].value (k, q);
-              scratch.grad_phi_p[k] = scratch.finite_element_values[ex_p_f].gradient (k, q);
+              const unsigned int component_index_k = fe.system_to_component_index(k).first;
+
+              if (is_stokes_component(introspection,p_c_component_index,p_f_component_index,component_index_k))
+                {
+                  scratch.grads_phi_u[i] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(k,q);
+                  scratch.phi_p[i]       = scratch.finite_element_values[ex_p_f].value (k, q);
+                  scratch.phi_p_c[i] = scratch.finite_element_values[ex_p_c].value (k, q);
+                  scratch.grad_phi_p[i] = scratch.finite_element_values[ex_p_f].gradient (k, q);
+                  ++i;
+                }
             }
 
           const double eta = scratch.material_model_outputs.viscosities[q];
@@ -118,37 +159,33 @@ namespace aspect
             scratch.material_model_outputs.stress_strain_directors[q];
           const bool use_tensor = (stress_strain_director != dealii::identity_tensor<dim> ());
 
-          for (unsigned int i=0; i<dofs_per_cell; ++i)
-            {
-              const unsigned int component_index_i = fe.system_to_component_index(i).first;
-              if (introspection.is_stokes_component(component_index_i) ||
-                  (component_index_i == p_f_component_index)
-                  || (component_index_i == p_c_component_index))
-                for (unsigned int j=0; j<dofs_per_cell; ++j)
-                  if (component_index_i == fe.system_to_component_index(j).first)
-                    data.local_matrix(i,j) += ((use_tensor ?
-                                                eta * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
-                                                :
-                                                eta * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
-                                               +
-                                               (1./eta *
-                                                pressure_scaling *
-                                                pressure_scaling)
-                                               * scratch.phi_p[i] * scratch.phi_p[j]
-                                               +
-                                               (K_D *
-                                                pressure_scaling *
-                                                pressure_scaling) *
-                                               scratch.grad_phi_p[i] *
-                                               scratch.grad_phi_p[j]
-                                               +
-                                               (1./eta + 1./viscosity_c) *
-                                               pressure_scaling *
-                                               pressure_scaling *
-                                               (scratch.phi_p_c[i] * scratch.phi_p_c[j])
-                                              )
-                                              * scratch.finite_element_values.JxW(q);
-            }
+          const double JxW = scratch.finite_element_values.JxW(q);
+
+          for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
+            for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
+              if (scratch.dof_component_indices[i] == scratch.dof_component_indices[j])
+                data.local_matrix(i,j) += ((use_tensor ?
+                                            eta * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
+                                            :
+                                            eta * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
+                                           +
+                                           (1./eta *
+                                            pressure_scaling *
+                                            pressure_scaling)
+                                           * scratch.phi_p[i] * scratch.phi_p[j]
+                                           +
+                                           (K_D *
+                                            pressure_scaling *
+                                            pressure_scaling) *
+                                           scratch.grad_phi_p[i] *
+                                           scratch.grad_phi_p[j]
+                                           +
+                                           (1./eta + 1./viscosity_c) *
+                                           pressure_scaling *
+                                           pressure_scaling *
+                                           (scratch.phi_p_c[i] * scratch.phi_p_c[j])
+                                          )
+                                          * JxW;
         }
     }
 
@@ -165,7 +202,7 @@ namespace aspect
     {
       const Introspection<dim> &introspection = this->introspection();
       const FiniteElement<dim> &fe = scratch.finite_element_values.get_fe();
-      const unsigned int dofs_per_cell = scratch.finite_element_values.get_fe().dofs_per_cell;
+      const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
       const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
 
       const FEValuesExtractors::Scalar extractor_pressure = introspection.variable("fluid pressure").extractor_scalar();
@@ -176,19 +213,36 @@ namespace aspect
 
       MaterialModel::MeltOutputs<dim> *melt_outputs = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
 
+      for (unsigned int k=0, i=0; i<stokes_dofs_per_cell; ++k)
+        {
+          const unsigned int component_index_k = fe.system_to_component_index(k).first;
+
+          if (is_stokes_component(introspection,p_c_component_index,p_f_component_index,component_index_k))
+            {
+              data.local_dof_indices[i] = scratch.local_dof_indices[k];
+              ++i;
+            }
+        }
+
       for (unsigned int q=0; q<n_q_points; ++q)
         {
-          for (unsigned int k=0; k<dofs_per_cell; ++k)
+          for (unsigned int k=0, i=0; i<stokes_dofs_per_cell; ++k)
             {
-              scratch.phi_u[k]   = scratch.finite_element_values[introspection.extractors.velocities].value (k,q);
-              scratch.phi_p[k]   = scratch.finite_element_values[extractor_pressure].value (k, q);
-              scratch.phi_p_c[k] = scratch.finite_element_values[ex_p_c].value (k, q);
-              scratch.grad_phi_p[k] = scratch.finite_element_values[extractor_pressure].gradient (k, q);
+              const unsigned int component_index_k = fe.system_to_component_index(k).first;
 
-              if (rebuild_stokes_matrix)
+              if (is_stokes_component(introspection,p_c_component_index,p_f_component_index,component_index_k))
                 {
-                  scratch.grads_phi_u[k] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(k,q);
-                  scratch.div_phi_u[k]   = scratch.finite_element_values[introspection.extractors.velocities].divergence (k, q);
+                  scratch.phi_u[i]   = scratch.finite_element_values[introspection.extractors.velocities].value (k,q);
+                  scratch.phi_p[i]   = scratch.finite_element_values[extractor_pressure].value (k, q);
+                  scratch.phi_p_c[i] = scratch.finite_element_values[ex_p_c].value (k, q);
+                  scratch.grad_phi_p[i] = scratch.finite_element_values[extractor_pressure].gradient (k, q);
+
+                  if (rebuild_stokes_matrix)
+                    {
+                      scratch.grads_phi_u[i] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(k,q);
+                      scratch.div_phi_u[i]   = scratch.finite_element_values[introspection.extractors.velocities].divergence (k, q);
+                    }
+                  ++i;
                 }
             }
 
@@ -230,81 +284,70 @@ namespace aspect
                                                             q);
           const double bulk_density = (1.0 - porosity) * density_s + porosity * density_f;
 
+          const double JxW = scratch.finite_element_values.JxW(q);
 
-          for (unsigned int i=0; i<dofs_per_cell; ++i)
+          for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
             {
-              const unsigned int component_index_i = fe.system_to_component_index(i).first;
+              data.local_rhs(i) += (
+                                     (bulk_density * gravity * scratch.phi_u[i])
+                                     +
+                                     // add the term that results from the compressibility. compared
+                                     // to the manual, this term seems to have the wrong sign, but this
+                                     // is because we negate the entire equation to make sure we get
+                                     // -div(u) as the adjoint operator of grad(p) (see above where
+                                     // we assemble the matrix)
+                                     (this->get_material_model().is_compressible()
+                                      ?
+                                      (pressure_scaling *
+                                       compressibility * density_s *
+                                       (scratch.velocity_values[q] * gravity) *
+                                       scratch.phi_p[i])
+                                      :
+                                      0)
+                                     + pressure_scaling *
+                                     p_f_RHS * scratch.phi_p[i]
+                                     - pressure_scaling *
+                                     K_D * density_f *
+                                     (scratch.grad_phi_p[i] * gravity)
+                                   )
+                                   * JxW;
 
-              if (introspection.is_stokes_component(component_index_i) ||
-                  (component_index_i == p_f_component_index)
-                  || (component_index_i == p_c_component_index))
-                {
-                  data.local_rhs(i) += (
-                                         (bulk_density * gravity * scratch.phi_u[i])
-                                         +
-                                         // add the term that results from the compressibility. compared
-                                         // to the manual, this term seems to have the wrong sign, but this
-                                         // is because we negate the entire equation to make sure we get
-                                         // -div(u) as the adjoint operator of grad(p) (see above where
-                                         // we assemble the matrix)
-                                         (this->get_material_model().is_compressible()
-                                          ?
-                                          (pressure_scaling *
-                                           compressibility * density_s *
-                                           (scratch.velocity_values[q] * gravity) *
-                                           scratch.phi_p[i])
-                                          :
-                                          0)
-                                         + pressure_scaling *
-                                         p_f_RHS * scratch.phi_p[i]
-                                         - pressure_scaling *
-                                         K_D * density_f *
-                                         (scratch.grad_phi_p[i] * gravity)
-                                       )
-                                       * scratch.finite_element_values.JxW(q);
-
-                  if (rebuild_stokes_matrix)
-                    for (unsigned int j=0; j<dofs_per_cell; ++j)
-                      {
-                        const unsigned int component_index_j = fe.system_to_component_index(j).first;
-
-                        if (introspection.is_stokes_component(component_index_j) ||
-                            (component_index_j == p_f_component_index)
-                            || (component_index_j == p_c_component_index))
-                          data.local_matrix(i,j) += ( (use_tensor ?
-                                                       eta * 2.0 * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
-                                                       :
-                                                       eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
-                                                      - (use_tensor ?
-                                                         eta * 2.0/3.0 * (scratch.div_phi_u[i] * trace(stress_strain_director * scratch.grads_phi_u[j]))
-                                                         :
-                                                         eta * 2.0/3.0 * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
-                                                        )
-                                                      - (pressure_scaling *
-                                                         scratch.div_phi_u[i] * scratch.phi_p[j])
-                                                      // finally the term -div(u). note the negative sign to make this
-                                                      // operator adjoint to the grad(p) term
-                                                      - (pressure_scaling *
-                                                         scratch.phi_p[i] * scratch.div_phi_u[j])
-                                                      +
-                                                      (- pressure_scaling * pressure_scaling / viscosity_c
-                                                       * scratch.phi_p_c[i] * scratch.phi_p_c[j])
-                                                      - pressure_scaling * scratch.div_phi_u[i] * scratch.phi_p_c[j]
-                                                      - pressure_scaling * scratch.phi_p_c[i] * scratch.div_phi_u[j]
-                                                      - K_D * pressure_scaling * pressure_scaling *
-                                                      (scratch.grad_phi_p[i] * scratch.grad_phi_p[j])
-                                                      + (this->get_material_model().is_compressible()
-                                                         ?
-                                                         K_D * pressure_scaling * pressure_scaling / density_f
-                                                         * scratch.phi_p[i] * (scratch.grad_phi_p[j] * density_gradient_f)
-                                                         :
-                                                         0.0))
-                                                    * scratch.finite_element_values.JxW(q);
-                      }
-                }
+              if (rebuild_stokes_matrix)
+                for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
+                  {
+                    data.local_matrix(i,j) += ( (use_tensor ?
+                                                 eta * 2.0 * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
+                                                 :
+                                                 eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
+                                                - (use_tensor ?
+                                                   eta * 2.0/3.0 * (scratch.div_phi_u[i] * trace(stress_strain_director * scratch.grads_phi_u[j]))
+                                                   :
+                                                   eta * 2.0/3.0 * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
+                                                  )
+                                                - (pressure_scaling *
+                                                   scratch.div_phi_u[i] * scratch.phi_p[j])
+                                                // finally the term -div(u). note the negative sign to make this
+                                                // operator adjoint to the grad(p) term
+                                                - (pressure_scaling *
+                                                   scratch.phi_p[i] * scratch.div_phi_u[j])
+                                                +
+                                                (- pressure_scaling * pressure_scaling / viscosity_c
+                                                 * scratch.phi_p_c[i] * scratch.phi_p_c[j])
+                                                - pressure_scaling * scratch.div_phi_u[i] * scratch.phi_p_c[j]
+                                                - pressure_scaling * scratch.phi_p_c[i] * scratch.div_phi_u[j]
+                                                - K_D * pressure_scaling * pressure_scaling *
+                                                (scratch.grad_phi_p[i] * scratch.grad_phi_p[j])
+                                                + (this->get_material_model().is_compressible()
+                                                   ?
+                                                   K_D * pressure_scaling * pressure_scaling / density_f
+                                                   * scratch.phi_p[i] * (scratch.grad_phi_p[j] * density_gradient_f)
+                                                   :
+                                                   0.0))
+                                              * JxW;
+                  }
             }
-
         }
+
     }
 
 
@@ -319,9 +362,13 @@ namespace aspect
                                                 internal::Assembly::CopyData::StokesSystem<dim>      &data) const
     {
       const Introspection<dim> &introspection = this->introspection();
+      const FiniteElement<dim> &fe = scratch.finite_element_values.get_fe();
+
       const unsigned int n_face_q_points = scratch.face_finite_element_values.n_quadrature_points;
-      const unsigned int dofs_per_cell = scratch.finite_element_values.get_fe().dofs_per_cell;
+      const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
       const FEValuesExtractors::Scalar ex_p_f = introspection.variable("fluid pressure").extractor_scalar();
+      const unsigned int p_f_component_index = introspection.variable("fluid pressure").first_component_index;
+      const unsigned int p_c_component_index = introspection.variable("compaction pressure").first_component_index;
 
       MaterialModel::MeltOutputs<dim> *melt_outputs = scratch.face_material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
 
@@ -348,15 +395,21 @@ namespace aspect
                               :
                               0.0);
 
-          for (unsigned int i = 0; i < dofs_per_cell; ++i)
+          for (unsigned int k=0, i=0; i<stokes_dofs_per_cell; ++k)
             {
-              // apply the fluid pressure boundary condition
-              data.local_rhs(i) += (scratch.face_finite_element_values[ex_p_f].value(i, q)
-                                    * pressure_scaling * K_D *
-                                    (density_f
-                                     * (scratch.face_finite_element_values.normal_vector(q) * gravity)
-                                     - grad_p_f[q])
-                                    * scratch.face_finite_element_values.JxW(q));
+              const unsigned int component_index_k = fe.system_to_component_index(k).first;
+
+              if (is_stokes_component(introspection,p_c_component_index,p_f_component_index,component_index_k))
+                {
+                  // apply the fluid pressure boundary condition
+                  data.local_rhs(i) += (scratch.face_finite_element_values[ex_p_f].value(k, q)
+                                        * pressure_scaling * K_D *
+                                        (density_f
+                                         * (scratch.face_finite_element_values.normal_vector(q) * gravity)
+                                         - grad_p_f[q])
+                                        * scratch.face_finite_element_values.JxW(q));
+                  ++i;
+                }
             }
         }
     }
@@ -731,17 +784,27 @@ namespace aspect
                                                     internal::Assembly::CopyData::StokesSystem<dim> &data)
       {
         const Introspection<dim> &introspection = simulator_access.introspection();
+        const FiniteElement<dim> &fe = scratch.finite_element_values.get_fe();
 
-        const unsigned int dofs_per_cell = scratch.finite_element_values.get_fe().dofs_per_cell;
+        const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
+        const unsigned int p_f_component_index = introspection.variable("fluid pressure").first_component_index;
+        const unsigned int p_c_component_index = introspection.variable("compaction pressure").first_component_index;
+
         const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
 
         const FEValuesExtractors::Scalar ex_p_f = introspection.variable("fluid pressure").extractor_scalar();
 
         for (unsigned int q=0; q<n_q_points; ++q)
-          for (unsigned int i=0; i<dofs_per_cell; ++i)
+          for (unsigned int k=0, i=0; i<stokes_dofs_per_cell; ++k)
             {
-              scratch.phi_p[i] = scratch.finite_element_values[ex_p_f].value (i, q);
-              data.local_pressure_shape_function_integrals(i) += scratch.phi_p[i] * scratch.finite_element_values.JxW(q);
+              const unsigned int component_index_k = fe.system_to_component_index(k).first;
+
+              if (is_stokes_component(introspection,p_c_component_index,p_f_component_index,component_index_k))
+                {
+                  scratch.phi_p[i] = scratch.finite_element_values[ex_p_f].value (k, q);
+                  data.local_pressure_shape_function_integrals(i) += scratch.phi_p[i] * scratch.finite_element_values.JxW(q);
+                  ++i;
+                }
             }
       }
     }

--- a/tests/inner_core.cc
+++ b/tests/inner_core.cc
@@ -320,30 +320,44 @@ namespace aspect
                                         internal::Assembly::CopyData::StokesSystem<dim>      &data) const
       {
         const Introspection<dim> &introspection = this->introspection();
+        const FiniteElement<dim> &fe = this->get_fe();
+        const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
+        const unsigned int n_q_points           = scratch.face_finite_element_values.n_quadrature_points;
 
         //assemble force terms for the matrix for all boundary faces
-        const unsigned int dofs_per_cell = scratch.finite_element_values.get_fe().dofs_per_cell;
         if (cell->face(face_no)->at_boundary())
           {
             scratch.face_finite_element_values.reinit (cell, face_no);
 
-            for (unsigned int q=0; q<scratch.face_finite_element_values.n_quadrature_points; ++q)
+            for (unsigned int q=0; q<n_q_points; ++q)
               {
                 const double P = dynamic_cast<const MaterialModel::InnerCore<dim>&>
                                  (this->get_material_model()).resistance_to_phase_change
                                  .value(scratch.material_model_inputs.position[q]);
 
+                for (unsigned int i = 0, i_stokes = 0; i_stokes < stokes_dofs_per_cell; /*increment at end of loop*/)
+                  {
+                    if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
+                      {
+                        scratch.phi_u[i_stokes] = scratch.face_finite_element_values[introspection
+                                                                                     .extractors.velocities].value(i, q);
+                        ++i_stokes;
+                      }
+                    ++i;
+                  }
+
+                const Tensor<1,dim> normal_vector = scratch.face_finite_element_values.normal_vector(q);
+                const double JxW = scratch.face_finite_element_values.JxW(q);
+
                 // boundary term: P*u*n*v*n*JxW(q)
-                for (unsigned int i=0; i<dofs_per_cell; ++i)
-                  for (unsigned int j=0; j<dofs_per_cell; ++j)
+                for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
+                  for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
                     data.local_matrix(i,j) += P *
-                                              scratch.face_finite_element_values
-                                              [introspection.extractors.velocities].value(i,q) *
-                                              scratch.face_finite_element_values.normal_vector(q) *
-                                              scratch.face_finite_element_values
-                                              [introspection.extractors.velocities].value(j,q) *
-                                              scratch.face_finite_element_values.normal_vector(q) *
-                                              scratch.face_finite_element_values.JxW(q);
+                                              scratch.phi_u[i] *
+                                              normal_vector *
+                                              scratch.phi_u[j] *
+                                              normal_vector *
+                                              JxW;
               }
           }
       }


### PR DESCRIPTION
This should address #756. It is quite likely that there will be test failures (I only checked incompressible cases without melt so far), but the speedup I have seen has been very nice (~30% faster Stokes matrix assembly, maybe 10-15% for Stokes preconditioner, for a 3d box test model). Given that for simple models the Stokes assembly takes on the order of 10-30% of the total model time this is a nice 3-10% overall speedup for many of my models. In particular simple benchmark problems will benefit.