### PR TITLE
Make ghost particle exchange optional

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,15 @@
  *
  * <ol>
  *
+ * <li> Changed: The exchange of ghost particles that was introduced lately
+ * can be quite expensive for models with many particles,
+ * and is often unnecessary if the particles are used as passive tracers.
+ * Therefore, a new input parameter 'Update ghost particles' controls this
+ * exchange, and its default is set to 'false'. Model parameter files using
+ * active particles will need to be changed accordingly.
+ * <br>
+ * (Rene Gassmoeller, 2016/10/18)
+ *
  * <li> Improved: The matrix assembly of Stokes and Advection systems has been
  * optimized, by assembling less (only the relevant) DoFs, and by optimizing
  * calls to deal.II functions. The overall speedup for box models is between

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -372,6 +372,15 @@ namespace aspect
         unsigned int tracer_weight;
 
         /**
+         * Some particle interpolation algorithms require knowledge
+         * about particles in neighboring cells. To allow this,
+         * particles in ghost cells need to be exchanged between the
+         * processes neighboring this cell. This parameter determines
+         * whether this transport is happening.
+         */
+        bool update_ghost_particles;
+
+        /**
          * Calculates the number of particles in the global model domain.
          */
         void

--- a/tests/matrix_nonzeros_2.prm
+++ b/tests/matrix_nonzeros_2.prm
@@ -98,6 +98,7 @@ subsection Postprocess
     set Data output format = none
     set List of tracer properties = initial composition
     set Interpolation scheme = cell average
+    set Update ghost particles = true
   end
 end
 

--- a/tests/matrix_nonzeros_3.prm
+++ b/tests/matrix_nonzeros_3.prm
@@ -105,6 +105,7 @@ subsection Postprocess
     set Data output format = none
     set List of tracer properties = initial composition
     set Interpolation scheme = cell average
+    set Update ghost particles = true
   end
 end
 

--- a/tests/particle_interpolator_cell_average.prm
+++ b/tests/particle_interpolator_cell_average.prm
@@ -115,6 +115,7 @@ subsection Postprocess
     set Data output format = none
     set List of tracer properties = velocity, function, initial composition
     set Interpolation scheme = cell average
+    set Update ghost particles = true
 
     subsection Function
       set Variable names      = x,z

--- a/tests/particle_interpolator_cell_average_2.prm
+++ b/tests/particle_interpolator_cell_average_2.prm
@@ -98,6 +98,7 @@ subsection Postprocess
     set Time between data output = 0.03
     set Data output format       = none
     set List of tracer properties = initial composition
+    set Update ghost particles   = true
   end
 end
 

--- a/tests/particle_interpolator_empty_cells.prm
+++ b/tests/particle_interpolator_empty_cells.prm
@@ -74,6 +74,7 @@ subsection Postprocess
     set Data output format = none
     set List of tracer properties = initial composition, initial position
     set Interpolation scheme = cell average
+    set Update ghost particles = true
     set Particle generator name = random uniform
     set Minimum tracers per cell = 2
     set Maximum tracers per cell = 100

--- a/tests/particle_interpolator_from_ghost_cells.prm
+++ b/tests/particle_interpolator_from_ghost_cells.prm
@@ -85,5 +85,6 @@ subsection Postprocess
     set Minimum tracers per cell = 2
     set Maximum tracers per cell = 100
     set Load balancing strategy = none
+    set Update ghost particles = true
   end
 end

--- a/tests/particle_load_balancing_removal_addition_properties.prm
+++ b/tests/particle_load_balancing_removal_addition_properties.prm
@@ -106,5 +106,6 @@ subsection Postprocess
     set Minimum tracers per cell = 5
     set Data output format = ascii
     set Integration scheme = euler
+    set Update ghost particles = true
   end
 end

--- a/tests/particle_property_multiple_functions_with_interpolation.prm
+++ b/tests/particle_property_multiple_functions_with_interpolation.prm
@@ -108,6 +108,7 @@ subsection Postprocess
     set Time between data output = 70
     set Data output format = none
     set List of tracer properties = velocity, function, initial composition
+    set Update ghost particles = true
 
     subsection Function
       set Number of components = 2


### PR DESCRIPTION
I have observed that in some models with many particles the exchange of ghost particles is quite expensive. It might be possible that there is a bottleneck in the code that I do not quite understand, but so far I have not observed  this behaviour in applications (only in tests). Therefore I would like to disable the exchange by default for now, until we figure out what is going on. @naliboff, @egpuckett, @hlokavarapu: This will likely require you do add the parameter 'Update ghost particles = true' to your models with active particles, sorry for that inconvenience. Did you ever had a model in which the exchange of ghost particles took longer than all of the rest of the particle algorithm combined?