### PR TITLE
use conduction timestep by default

### DIFF
--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -142,7 +142,7 @@ namespace aspect
                        "Units: Years or seconds, depending on the ``Use years "
                        "in output instead of seconds'' parameter.");
 
-    prm.declare_entry ("Use conduction timestep", "false",
+    prm.declare_entry ("Use conduction timestep", "true",
                        Patterns::Bool (),
                        "Mantle convection simulations are often focused on convection "
                        "dominated systems. However, these codes can also be used to "

--- a/tests/depth_average_03.prm
+++ b/tests/depth_average_03.prm
@@ -15,7 +15,7 @@ set Temperature solver tolerance           = 1e-15
 
 set Pressure normalization                 = surface
 set Surface pressure                       = 0
-
+set Use conduction timestep 		   = false
 
 subsection Geometry model
   set Model name = box

--- a/tests/depth_average_04.prm
+++ b/tests/depth_average_04.prm
@@ -12,7 +12,7 @@ set Temperature solver tolerance           = 1e-15
 
 set Pressure normalization                 = surface
 set Surface pressure                       = 0
-
+set Use conduction timestep                = false
 
 subsection Geometry model
   set Model name = box

--- a/tests/diffusion.prm
+++ b/tests/diffusion.prm
@@ -38,6 +38,7 @@ set Dimension = 2
 # particular, one can choose $c>1$) though a CFL number significantly larger
 # than one will yield rather diffusive solutions. Units: None.
 set CFL number                             = 0.01
+set Use conduction timestep                = false
 
 # The end time of the simulation. Units: years if the 'Use years in output
 # instead of seconds' parameter is set; seconds otherwise.

--- a/tests/minimum_refinement_function_time_dependent.prm
+++ b/tests/minimum_refinement_function_time_dependent.prm
@@ -30,7 +30,7 @@ set Resume computation                     = false
 set Start time                             = 0
 
 set Use years in output instead of seconds = true
-
+set Use conduction timestep                = false
 
 subsection Boundary temperature model
   # Select one of the following models:

--- a/tests/point_value_02.prm
+++ b/tests/point_value_02.prm
@@ -10,7 +10,7 @@ set Use years in output instead of seconds = true
 
 set Linear solver tolerance                = 1e-7
 set Pressure normalization                 = volume
-
+set Use conduction timestep		   = false
 
 subsection Geometry model
   set Model name = box

--- a/tests/zero_matrix.prm
+++ b/tests/zero_matrix.prm
@@ -17,6 +17,7 @@ end
 
 set End time                               = 2e5
 set Nonlinear solver scheme                = iterated Stokes
+set Use conduction timestep		   = false
 
 set Pressure normalization                 = surface
 set Surface pressure                       = 0


### PR DESCRIPTION
Per discussion on the aspect-devel mailing list, this pull request enables the conduction timestep by default. This results in improved accuracy for systems that are very close to the critical Rayleigh number.
