### PR TITLE
Viscosity limits

### DIFF
--- a/include/aspect/material_model/simple.h
+++ b/include/aspect/material_model/simple.h
@@ -112,6 +112,8 @@ namespace aspect
         double eta;
         double composition_viscosity_prefactor;
         double thermal_viscosity_exponent;
+        double maximum_thermal_prefactor;
+        double minimum_thermal_prefactor;
         double thermal_alpha;
         double reference_specific_heat;
 


### PR DESCRIPTION
Remove hard-coded limits in simple.cc and replace with user-specified viscosity cutoff values. Retain former hard-coded values as default behavior.