### PR TITLE
Reduce particle creations in load_tracers

### DIFF
--- a/include/aspect/particle/particle.h
+++ b/include/aspect/particle/particle.h
@@ -153,6 +153,16 @@ namespace aspect
          * one.
          */
         Particle (Particle<dim> &&particle);
+
+        /**
+         * Copy assignment operator.
+         */
+        Particle<dim> &operator=(const Particle<dim> &particle);
+
+        /**
+         * Move assignment operator.
+         */
+        Particle<dim> &operator=(Particle<dim> &&particle);
 #endif
 
         /**

--- a/include/aspect/particle/particle.h
+++ b/include/aspect/particle/particle.h
@@ -141,11 +141,19 @@ namespace aspect
         Particle (const void *&begin_data,
                   const unsigned int data_size);
 
+#ifdef DEAL_II_WITH_CXX11
         /**
-         * Destructor for Particle
+         * Copy constructor for Particle, creates a particle from an existing
+         * one.
          */
-        virtual
-        ~Particle ();
+        Particle (const Particle<dim> &particle);
+
+        /**
+         * Move constructor for Particle, creates a particle from an existing
+         * one.
+         */
+        Particle (Particle<dim> &&particle);
+#endif
 
         /**
           * Resize the properties member variable to hold the number of doubles

--- a/source/particle/particle.cc
+++ b/source/particle/particle.cc
@@ -76,11 +76,25 @@ namespace aspect
       data = static_cast<const void *> (pdata);
     }
 
+#ifdef DEAL_II_WITH_CXX11
+    template <int dim>
+    Particle<dim>::Particle (const Particle<dim> &particle)
+      :
+      location (particle.location),
+      reference_location(particle.reference_location),
+      id (particle.id),
+      properties(particle.properties)
+    {}
 
     template <int dim>
-    Particle<dim>::~Particle ()
-    {
-    }
+    Particle<dim>::Particle (Particle<dim> &&particle)
+      :
+      location (particle.location),
+      reference_location(particle.reference_location),
+      id (particle.id),
+      properties(std::move(particle.properties))
+    {}
+#endif
 
 
     template <int dim>

--- a/source/particle/particle.cc
+++ b/source/particle/particle.cc
@@ -94,6 +94,34 @@ namespace aspect
       id (particle.id),
       properties(std::move(particle.properties))
     {}
+
+    template <int dim>
+    Particle<dim> &
+    Particle<dim>::operator=(const Particle<dim> &particle)
+    {
+      if (this != &particle)
+        {
+          location = particle.location;
+          reference_location = particle.reference_location;
+          id = particle.id;
+          properties = particle.properties;
+        }
+      return *this;
+    }
+
+    template <int dim>
+    Particle<dim> &
+    Particle<dim>::operator=(Particle<dim> &&particle)
+    {
+      if (this != &particle)
+        {
+          location = particle.location;
+          reference_location = particle.reference_location;
+          id = particle.id;
+          properties = std::move(particle.properties);
+        }
+      return *this;
+    }
 #endif
 
 


### PR DESCRIPTION
This is the first of a series of pull requests optimizing some aspects of particle transfer. This one specifically:
- Adds a move constructor to particles that are generated from other particles that are not longer needed. @bangerth: I am not sure if what I implemented in the constructor is already optimal, but at least it is four times faster than the copy constructor (no more allocation of dynamic memory). Is there something I am missing?
- Reduces the number of particle constructor calls from `load_tracers` and if possible use the move-constructor
- Provides insertion hints inside `load_tracers` into the particles multimap (because all tracers of the same cell are inserted into the same region of the multimap), which improves the scaling behaviour of this function (but does not matter for models with few cells per process.