### PR TITLE
require cxx14 for emplace_hint

### DIFF
--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -521,7 +521,7 @@ namespace aspect
           typename std::multimap<types::LevelInd,Particle<dim> >::const_iterator position_hint = particles.end();
           for (unsigned int i = 0; i < *n_particles_in_cell_ptr; ++i)
             {
-#ifdef DEAL_II_WITH_CXX11
+#ifdef DEAL_II_WITH_CXX14
               position_hint = particles.emplace_hint(position_hint,
                                                      std::make_pair(cell->level(),cell->index()),
                                                      Particle<dim>(pdata,property_manager->get_particle_size()));
@@ -539,7 +539,7 @@ namespace aspect
           typename std::multimap<types::LevelInd,Particle<dim> >::iterator position_hint = particles.end();
           for (unsigned int i = 0; i < *n_particles_in_cell_ptr; ++i)
             {
-#ifdef DEAL_II_WITH_CXX11
+#ifdef DEAL_II_WITH_CXX14
               position_hint = particles.emplace_hint(position_hint,
                                                      std::make_pair(cell->level(),cell->index()),
                                                      Particle<dim>(pdata,property_manager->get_particle_size()));
@@ -577,7 +577,7 @@ namespace aspect
                       if (GeometryInfo<dim>::is_inside_unit_cell(p_unit))
                         {
                           p.set_reference_location(p_unit);
-#ifdef DEAL_II_WITH_CXX11
+#ifdef DEAL_II_WITH_CXX14
                           position_hints[child_index] = particles.emplace_hint(position_hints[child_index],
                                                                                std::make_pair(child->level(),child->index()),
                                                                                std::move(p));

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -521,6 +521,10 @@ namespace aspect
           typename std::multimap<types::LevelInd,Particle<dim> >::const_iterator position_hint = particles.end();
           for (unsigned int i = 0; i < *n_particles_in_cell_ptr; ++i)
             {
+              // Use std::multimap::emplace_hint to speed up insertion of
+              // particles. This is a C++11 function, but not all compilers
+              // that report a -std=c++11 (like gcc 4.6) implement it, so
+              // require C++14 instead.
 #ifdef DEAL_II_WITH_CXX14
               position_hint = particles.emplace_hint(position_hint,
                                                      std::make_pair(cell->level(),cell->index()),
@@ -539,6 +543,10 @@ namespace aspect
           typename std::multimap<types::LevelInd,Particle<dim> >::iterator position_hint = particles.end();
           for (unsigned int i = 0; i < *n_particles_in_cell_ptr; ++i)
             {
+              // Use std::multimap::emplace_hint to speed up insertion of
+              // particles. This is a C++11 function, but not all compilers
+              // that report a -std=c++11 (like gcc 4.6) implement it, so
+              // require C++14 instead.
 #ifdef DEAL_II_WITH_CXX14
               position_hint = particles.emplace_hint(position_hint,
                                                      std::make_pair(cell->level(),cell->index()),
@@ -577,6 +585,10 @@ namespace aspect
                       if (GeometryInfo<dim>::is_inside_unit_cell(p_unit))
                         {
                           p.set_reference_location(p_unit);
+                          // Use std::multimap::emplace_hint to speed up insertion of
+                          // particles. This is a C++11 function, but not all compilers
+                          // that report a -std=c++11 (like gcc 4.6) implement it, so
+                          // require C++14 instead.
 #ifdef DEAL_II_WITH_CXX14
                           position_hints[child_index] = particles.emplace_hint(position_hints[child_index],
                                                                                std::make_pair(child->level(),child->index()),


### PR DESCRIPTION
emplace_hint is not supported in gcc 4.6.x and 4.7.x even though this is
part of cxx11. So we require cxx14 for this for now.


fixes #1260