### PR TITLE
Rename the variables in DataPostprocessor derived classes.

### DIFF
--- a/include/aspect/postprocess/visualization/adiabat.h
+++ b/include/aspect/postprocess/visualization/adiabat.h
@@ -59,9 +59,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/compositional_vector.h
+++ b/include/aspect/postprocess/visualization/compositional_vector.h
@@ -61,9 +61,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/density.h
+++ b/include/aspect/postprocess/visualization/density.h
@@ -52,9 +52,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/depth.h
+++ b/include/aspect/postprocess/visualization/depth.h
@@ -49,9 +49,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/friction_heating.h
+++ b/include/aspect/postprocess/visualization/friction_heating.h
@@ -53,9 +53,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/gravity.h
+++ b/include/aspect/postprocess/visualization/gravity.h
@@ -48,9 +48,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/heating.h
+++ b/include/aspect/postprocess/visualization/heating.h
@@ -67,9 +67,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/material_properties.h
+++ b/include/aspect/postprocess/visualization/material_properties.h
@@ -69,9 +69,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/maximum_horizontal_compressive_stress.h
+++ b/include/aspect/postprocess/visualization/maximum_horizontal_compressive_stress.h
@@ -52,9 +52,9 @@ namespace aspect
         public:
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/melt.h
+++ b/include/aspect/postprocess/visualization/melt.h
@@ -61,9 +61,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/melt_fraction.h
+++ b/include/aspect/postprocess/visualization/melt_fraction.h
@@ -53,9 +53,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/nonadiabatic_pressure.h
+++ b/include/aspect/postprocess/visualization/nonadiabatic_pressure.h
@@ -53,9 +53,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/nonadiabatic_temperature.h
+++ b/include/aspect/postprocess/visualization/nonadiabatic_temperature.h
@@ -53,9 +53,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/partition.h
+++ b/include/aspect/postprocess/visualization/partition.h
@@ -53,9 +53,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/seismic_vp.h
+++ b/include/aspect/postprocess/visualization/seismic_vp.h
@@ -53,9 +53,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/seismic_vs.h
+++ b/include/aspect/postprocess/visualization/seismic_vs.h
@@ -52,9 +52,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/shear_stress.h
+++ b/include/aspect/postprocess/visualization/shear_stress.h
@@ -57,9 +57,9 @@ namespace aspect
         public:
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/specific_heat.h
+++ b/include/aspect/postprocess/visualization/specific_heat.h
@@ -53,9 +53,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/strain_rate.h
+++ b/include/aspect/postprocess/visualization/strain_rate.h
@@ -55,9 +55,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/stress.h
+++ b/include/aspect/postprocess/visualization/stress.h
@@ -56,9 +56,9 @@ namespace aspect
         public:
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/thermal_conductivity.h
+++ b/include/aspect/postprocess/visualization/thermal_conductivity.h
@@ -53,9 +53,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/thermal_diffusivity.h
+++ b/include/aspect/postprocess/visualization/thermal_diffusivity.h
@@ -53,9 +53,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/thermal_expansivity.h
+++ b/include/aspect/postprocess/visualization/thermal_expansivity.h
@@ -53,9 +53,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/thermodynamic_phase.h
+++ b/include/aspect/postprocess/visualization/thermodynamic_phase.h
@@ -53,9 +53,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/vertical_heat_flux.h
+++ b/include/aspect/postprocess/visualization/vertical_heat_flux.h
@@ -52,9 +52,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/viscosity.h
+++ b/include/aspect/postprocess/visualization/viscosity.h
@@ -52,9 +52,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/include/aspect/postprocess/visualization/viscosity_ratio.h
+++ b/include/aspect/postprocess/visualization/viscosity_ratio.h
@@ -52,9 +52,9 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &duh,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &dduh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
                                              const std::vector<Point<dim> >                  &normals,
                                              const std::vector<Point<dim> >                  &evaluation_points,
                                              std::vector<Vector<double> >                    &computed_quantities) const;

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -51,7 +51,7 @@ namespace aspect
         public:
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
                                              const std::vector<std::vector<Tensor<1,dim> > > &,
                                              const std::vector<std::vector<Tensor<2,dim> > > &,
                                              const std::vector<Point<dim> > &,
@@ -60,7 +60,7 @@ namespace aspect
           {
             const double velocity_scaling_factor =
               this->convert_output_to_years() ? year_in_seconds : 1.0;
-            const unsigned int n_q_points = uh.size();
+            const unsigned int n_q_points = solution_values.size();
             for (unsigned int q=0; q<n_q_points; ++q)
               for (unsigned int i=0; i<computed_quantities[q].size(); ++i)
                 {
@@ -68,9 +68,9 @@ namespace aspect
                   if (this->introspection().component_masks.velocities[i] ||
                       (this->include_melt_transport()
                        && this->introspection().variable("fluid velocity").component_mask[i]))
-                    computed_quantities[q][i]=uh[q][i] * velocity_scaling_factor;
+                    computed_quantities[q][i]=solution_values[q][i] * velocity_scaling_factor;
                   else
-                    computed_quantities[q][i]=uh[q][i];
+                    computed_quantities[q][i]=solution_values[q][i];
                 }
           }
 
@@ -136,7 +136,7 @@ namespace aspect
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
                                              const std::vector<std::vector<Tensor<1,dim> > > &,
                                              const std::vector<std::vector<Tensor<2,dim> > > &,
                                              const std::vector<Point<dim> > &,
@@ -148,10 +148,10 @@ namespace aspect
                     ExcMessage("Unexpected dimension in mesh velocity postprocessor"));
             const double velocity_scaling_factor =
               this->convert_output_to_years() ? year_in_seconds : 1.0;
-            const unsigned int n_q_points = uh.size();
+            const unsigned int n_q_points = solution_values.size();
             for (unsigned int q=0; q<n_q_points; ++q)
               for (unsigned int i=0; i<dim; ++i)
-                computed_quantities[q][i]= uh[q][i] * velocity_scaling_factor;
+                computed_quantities[q][i]= solution_values[q][i] * velocity_scaling_factor;
           }
       };
     }

--- a/source/postprocess/visualization/adiabat.cc
+++ b/source/postprocess/visualization/adiabat.cc
@@ -70,14 +70,14 @@ namespace aspect
       template <int dim>
       void
       Adiabat<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
                                          const std::vector<std::vector<Tensor<1,dim> > > &,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 2,                   ExcInternalError());
 

--- a/source/postprocess/visualization/compositional_vector.cc
+++ b/source/postprocess/visualization/compositional_vector.cc
@@ -70,23 +70,23 @@ namespace aspect
       template <int dim>
       void
       CompositionalVector<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
                                          const std::vector<std::vector<Tensor<1,dim> > > &,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> > &,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points, ExcInternalError ());
-        Assert (uh[0].size() == this->introspection().n_components, ExcInternalError ());
+        Assert (solution_values[0].size() == this->introspection().n_components, ExcInternalError ());
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
             for (unsigned int i=0; i<vector_names.size(); ++i)
               for (unsigned int j=0; j<dim; ++j)
                 computed_quantities[q][i*dim+j] =
-                  uh[q][this->introspection().component_indices.compositional_fields[sets[i][j]]];
+                  solution_values[q][this->introspection().component_indices.compositional_fields[sets[i][j]]];
           }
       }
 

--- a/source/postprocess/visualization/density.cc
+++ b/source/postprocess/visualization/density.cc
@@ -42,17 +42,17 @@ namespace aspect
       template <int dim>
       void
       Density<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                         const std::vector<std::vector<Tensor<1,dim> > > &duh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                         const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
         MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
                                                    this->n_compositional_fields());
@@ -63,16 +63,16 @@ namespace aspect
         in.strain_rate.resize(0); // we do not need the viscosity
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
-            in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
-            in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            in.pressure[q]=solution_values[q][this->introspection().component_indices.pressure];
+            in.temperature[q]=solution_values[q][this->introspection().component_indices.temperature];
             for (unsigned int d = 0; d < dim; ++d)
               {
-                in.velocity[q][d]=uh[q][this->introspection().component_indices.velocities[d]];
-                in.pressure_gradient[q][d] = duh[q][this->introspection().component_indices.pressure][d];
+                in.velocity[q][d]=solution_values[q][this->introspection().component_indices.velocities[d]];
+                in.pressure_gradient[q][d] = solution_gradients[q][this->introspection().component_indices.pressure][d];
               }
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              in.composition[q][c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
           }
 
         this->get_material_model().evaluate(in, out);

--- a/source/postprocess/visualization/depth.cc
+++ b/source/postprocess/visualization/depth.cc
@@ -42,17 +42,17 @@ namespace aspect
       template <int dim>
       void
       Depth<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
                                          const std::vector<std::vector<Tensor<1,dim> > > &,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {

--- a/source/postprocess/visualization/friction_heating.cc
+++ b/source/postprocess/visualization/friction_heating.cc
@@ -42,18 +42,18 @@ namespace aspect
       template <int dim>
       void
       FrictionHeating<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                         const std::vector<std::vector<Tensor<1,dim> > > &duh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                         const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
-        Assert (duh[0].size() == this->introspection().n_components,          ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_gradients[0].size() == this->introspection().n_components,          ExcInternalError());
 
         MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
                                                    this->n_compositional_fields());
@@ -65,19 +65,19 @@ namespace aspect
           {
             Tensor<2,dim> grad_u;
             for (unsigned int d=0; d<dim; ++d)
-              grad_u[d] = duh[q][d];
+              grad_u[d] = solution_gradients[q][d];
             in.strain_rate[q] = symmetrize (grad_u);
 
-            in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
-            in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            in.pressure[q]=solution_values[q][this->introspection().component_indices.pressure];
+            in.temperature[q]=solution_values[q][this->introspection().component_indices.temperature];
             for (unsigned int d = 0; d < dim; ++d)
               {
-                in.velocity[q][d]=uh[q][this->introspection().component_indices.velocities[d]];
-                in.pressure_gradient[q][d] = duh[q][this->introspection().component_indices.pressure][d];
+                in.velocity[q][d]=solution_values[q][this->introspection().component_indices.velocities[d]];
+                in.pressure_gradient[q][d] = solution_gradients[q][this->introspection().component_indices.pressure][d];
               }
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              in.composition[q][c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
 
           }
 

--- a/source/postprocess/visualization/gravity.cc
+++ b/source/postprocess/visualization/gravity.cc
@@ -42,17 +42,17 @@ namespace aspect
       template <int dim>
       void
       Gravity<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
                                          const std::vector<std::vector<Tensor<1,dim> > > &,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == dim,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {

--- a/source/postprocess/visualization/material_properties.cc
+++ b/source/postprocess/visualization/material_properties.cc
@@ -90,16 +90,16 @@ namespace aspect
       template <int dim>
       void
       MaterialProperties<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                         const std::vector<std::vector<Tensor<1,dim> > > &duh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                         const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
         MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
                                                    this->n_compositional_fields());
@@ -112,18 +112,18 @@ namespace aspect
             Tensor<2,dim> grad_u;
             for (unsigned int d=0; d<dim; ++d)
               {
-                grad_u[d] = duh[q][d];
-                in.velocity[q][d] = uh[q][this->introspection().component_indices.velocities[d]];
-                in.pressure_gradient[q][d] = duh[q][this->introspection().component_indices.pressure][d];
+                grad_u[d] = solution_gradients[q][d];
+                in.velocity[q][d] = solution_values[q][this->introspection().component_indices.velocities[d]];
+                in.pressure_gradient[q][d] = solution_gradients[q][this->introspection().component_indices.pressure][d];
               }
 
             in.strain_rate[q] = symmetrize (grad_u);
 
-            in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
-            in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            in.pressure[q]=solution_values[q][this->introspection().component_indices.pressure];
+            in.temperature[q]=solution_values[q][this->introspection().component_indices.temperature];
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              in.composition[q][c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
           }
 
         this->get_material_model().evaluate(in, out);

--- a/source/postprocess/visualization/maximum_horizontal_compressive_stress.cc
+++ b/source/postprocess/visualization/maximum_horizontal_compressive_stress.cc
@@ -32,19 +32,19 @@ namespace aspect
       template <int dim>
       void
       MaximumHorizontalCompressiveStress<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                         const std::vector<std::vector<Tensor<1,dim> > > &duh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                         const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert ((computed_quantities[0].size() == dim),
                 ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,   ExcInternalError());
-        Assert (duh[0].size() == this->introspection().n_components,  ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,   ExcInternalError());
+        Assert (solution_gradients[0].size() == this->introspection().n_components,  ExcInternalError());
 
         MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
                                                    this->n_compositional_fields());
@@ -57,20 +57,20 @@ namespace aspect
           {
             Tensor<2,dim> grad_u;
             for (unsigned int d=0; d<dim; ++d)
-              grad_u[d] = duh[q][d];
+              grad_u[d] = solution_gradients[q][d];
             in.strain_rate[q] = symmetrize (grad_u);
 
-            in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
-            in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            in.pressure[q]=solution_values[q][this->introspection().component_indices.pressure];
+            in.temperature[q]=solution_values[q][this->introspection().component_indices.temperature];
 
             for (unsigned int d = 0; d < dim; ++d)
               {
-                in.velocity[q][d]=uh[q][this->introspection().component_indices.velocities[d]];
-                in.pressure_gradient[q][d] = duh[q][this->introspection().component_indices.pressure][d];
+                in.velocity[q][d]=solution_values[q][this->introspection().component_indices.velocities[d]];
+                in.pressure_gradient[q][d] = solution_gradients[q][this->introspection().component_indices.pressure][d];
               }
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              in.composition[q][c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
           }
 
         // then do compute the viscosity...

--- a/source/postprocess/visualization/melt.cc
+++ b/source/postprocess/visualization/melt.cc
@@ -93,9 +93,9 @@ namespace aspect
       template <int dim>
       void
       MeltMaterialProperties<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                         const std::vector<std::vector<Tensor<1,dim> > > &/*duh*/,
-                                         const std::vector<std::vector<Tensor<2,dim> > > &/*dduh*/,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                         const std::vector<std::vector<Tensor<1,dim> > > &/*solution_gradients*/,
+                                         const std::vector<std::vector<Tensor<2,dim> > > &/*solution_hessians*/,
                                          const std::vector<Point<dim> >                  &/*normals*/,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
@@ -103,9 +103,9 @@ namespace aspect
         AssertThrow(this->include_melt_transport()==true,
                     ExcMessage("'Include melt transport' has to be on when using melt transport postprocessors."));
 
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,   ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,   ExcInternalError());
 
         MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points, this->n_compositional_fields());
         MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points, this->n_compositional_fields());
@@ -115,11 +115,11 @@ namespace aspect
         in.strain_rate.resize(0); // we do not need the viscosity
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
-            in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
-            in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            in.pressure[q]=solution_values[q][this->introspection().component_indices.pressure];
+            in.temperature[q]=solution_values[q][this->introspection().component_indices.temperature];
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              in.composition[q][c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
           }
 
         this->get_material_model().evaluate(in, out);

--- a/source/postprocess/visualization/melt_fraction.cc
+++ b/source/postprocess/visualization/melt_fraction.cc
@@ -43,26 +43,26 @@ namespace aspect
       template <int dim>
       void
       MeltFraction<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
                                          const std::vector<std::vector<Tensor<1,dim> > > &,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> > &,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
-            const double pressure    = uh[q][this->introspection().component_indices.pressure];
-            const double temperature = uh[q][this->introspection().component_indices.temperature];
+            const double pressure    = solution_values[q][this->introspection().component_indices.pressure];
+            const double temperature = solution_values[q][this->introspection().component_indices.temperature];
             std::vector<double> composition(this->n_compositional_fields());
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              composition[c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              composition[c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
 
             // anhydrous melting of peridotite after Katz, 2003
             const double T_solidus  = A1 + 273.15

--- a/source/postprocess/visualization/nonadiabatic_pressure.cc
+++ b/source/postprocess/visualization/nonadiabatic_pressure.cc
@@ -42,21 +42,21 @@ namespace aspect
       template <int dim>
       void
       NonadiabaticPressure<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
                                          const std::vector<std::vector<Tensor<1,dim> > > &,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components, ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components, ExcInternalError());
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
-            const double pressure    = uh[q][this->introspection().component_indices.pressure];
+            const double pressure    = solution_values[q][this->introspection().component_indices.pressure];
 
             computed_quantities[q](0) = pressure - this->get_adiabatic_conditions().pressure(evaluation_points[q]);
           }

--- a/source/postprocess/visualization/nonadiabatic_temperature.cc
+++ b/source/postprocess/visualization/nonadiabatic_temperature.cc
@@ -42,21 +42,21 @@ namespace aspect
       template <int dim>
       void
       NonadiabaticTemperature<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
                                          const std::vector<std::vector<Tensor<1,dim> > > &,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
-            const double temperature = uh[q][this->introspection().component_indices.temperature];
+            const double temperature = solution_values[q][this->introspection().component_indices.temperature];
 
             computed_quantities[q](0) = temperature - this->get_adiabatic_conditions().temperature(evaluation_points[q]);
           }

--- a/source/postprocess/visualization/seismic_vp.cc
+++ b/source/postprocess/visualization/seismic_vp.cc
@@ -42,25 +42,25 @@ namespace aspect
       template <int dim>
       void
       SeismicVp<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
                                          const std::vector<std::vector<Tensor<1,dim> > > &,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
-            const double pressure    = uh[q][this->introspection().component_indices.pressure];
-            const double temperature = uh[q][this->introspection().component_indices.temperature];
+            const double pressure    = solution_values[q][this->introspection().component_indices.pressure];
+            const double temperature = solution_values[q][this->introspection().component_indices.temperature];
             std::vector<double> composition(this->n_compositional_fields());
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              composition[c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              composition[c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
 
             computed_quantities[q](0) = this->get_material_model().seismic_Vp(temperature,
                                                                               pressure,

--- a/source/postprocess/visualization/seismic_vs.cc
+++ b/source/postprocess/visualization/seismic_vs.cc
@@ -42,25 +42,25 @@ namespace aspect
       template <int dim>
       void
       SeismicVs<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
                                          const std::vector<std::vector<Tensor<1,dim> > > &,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
-            const double pressure    = uh[q][this->introspection().component_indices.pressure];
-            const double temperature = uh[q][this->introspection().component_indices.temperature];
+            const double pressure    = solution_values[q][this->introspection().component_indices.pressure];
+            const double temperature = solution_values[q][this->introspection().component_indices.temperature];
             std::vector<double> composition(this->n_compositional_fields());
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              composition[c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              composition[c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
 
             computed_quantities[q](0) = this->get_material_model().seismic_Vs(temperature,
                                                                               pressure,

--- a/source/postprocess/visualization/shear_stress.cc
+++ b/source/postprocess/visualization/shear_stress.cc
@@ -32,19 +32,19 @@ namespace aspect
       template <int dim>
       void
       ShearStress<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                         const std::vector<std::vector<Tensor<1,dim> > > &duh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                         const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert ((computed_quantities[0].size() == SymmetricTensor<2,dim>::n_independent_components),
                 ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,   ExcInternalError());
-        Assert (duh[0].size() == this->introspection().n_components,  ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,   ExcInternalError());
+        Assert (solution_gradients[0].size() == this->introspection().n_components,  ExcInternalError());
 
         MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
                                                    this->n_compositional_fields());
@@ -57,19 +57,19 @@ namespace aspect
           {
             Tensor<2,dim> grad_u;
             for (unsigned int d=0; d<dim; ++d)
-              grad_u[d] = duh[q][d];
+              grad_u[d] = solution_gradients[q][d];
             in.strain_rate[q] = symmetrize (grad_u);
 
-            in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
-            in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            in.pressure[q]=solution_values[q][this->introspection().component_indices.pressure];
+            in.temperature[q]=solution_values[q][this->introspection().component_indices.temperature];
             for (unsigned int d = 0; d < dim; ++d)
               {
-                in.velocity[q][d]=uh[q][this->introspection().component_indices.velocities[d]];
-                in.pressure_gradient[q][d] = duh[q][this->introspection().component_indices.pressure][d];
+                in.velocity[q][d]=solution_values[q][this->introspection().component_indices.velocities[d]];
+                in.pressure_gradient[q][d] = solution_gradients[q][this->introspection().component_indices.pressure][d];
               }
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              in.composition[q][c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
           }
 
         // then do compute the viscosity...

--- a/source/postprocess/visualization/specific_heat.cc
+++ b/source/postprocess/visualization/specific_heat.cc
@@ -42,17 +42,17 @@ namespace aspect
       template <int dim>
       void
       SpecificHeat<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                         const std::vector<std::vector<Tensor<1,dim> > > &duh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                         const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
         MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
                                                    this->n_compositional_fields());
@@ -63,16 +63,16 @@ namespace aspect
         in.strain_rate.resize(0); // we do not need the viscosity
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
-            in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
-            in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            in.pressure[q]=solution_values[q][this->introspection().component_indices.pressure];
+            in.temperature[q]=solution_values[q][this->introspection().component_indices.temperature];
             for (unsigned int d = 0; d < dim; ++d)
               {
-                in.velocity[q][d]=uh[q][this->introspection().component_indices.velocities[d]];
-                in.pressure_gradient[q][d] = duh[q][this->introspection().component_indices.pressure][d];
+                in.velocity[q][d]=solution_values[q][this->introspection().component_indices.velocities[d]];
+                in.pressure_gradient[q][d] = solution_gradients[q][this->introspection().component_indices.pressure][d];
               }
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              in.composition[q][c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
           }
 
         this->get_material_model().evaluate(in, out);

--- a/source/postprocess/visualization/strain_rate.cc
+++ b/source/postprocess/visualization/strain_rate.cc
@@ -42,25 +42,25 @@ namespace aspect
       template <int dim>
       void
       StrainRate<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                         const std::vector<std::vector<Tensor<1,dim> > > &duh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                         const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> > &,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
-        Assert (duh[0].size() == this->introspection().n_components,          ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_gradients[0].size() == this->introspection().n_components,          ExcInternalError());
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
             // extract the primal variables
             Tensor<2,dim> grad_u;
             for (unsigned int d=0; d<dim; ++d)
-              grad_u[d] = duh[q][d];
+              grad_u[d] = solution_gradients[q][d];
 
             const SymmetricTensor<2,dim> strain_rate = symmetrize (grad_u);
             const SymmetricTensor<2,dim> compressible_strain_rate

--- a/source/postprocess/visualization/stress.cc
+++ b/source/postprocess/visualization/stress.cc
@@ -32,19 +32,19 @@ namespace aspect
       template <int dim>
       void
       Stress<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                         const std::vector<std::vector<Tensor<1,dim> > > &duh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                         const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert ((computed_quantities[0].size() == SymmetricTensor<2,dim>::n_independent_components),
                 ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,   ExcInternalError());
-        Assert (duh[0].size() == this->introspection().n_components,  ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,   ExcInternalError());
+        Assert (solution_gradients[0].size() == this->introspection().n_components,  ExcInternalError());
 
         MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
                                                    this->n_compositional_fields());
@@ -57,20 +57,20 @@ namespace aspect
           {
             Tensor<2,dim> grad_u;
             for (unsigned int d=0; d<dim; ++d)
-              grad_u[d] = duh[q][d];
+              grad_u[d] = solution_gradients[q][d];
             in.strain_rate[q] = symmetrize (grad_u);
 
-            in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
-            in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            in.pressure[q]=solution_values[q][this->introspection().component_indices.pressure];
+            in.temperature[q]=solution_values[q][this->introspection().component_indices.temperature];
 
             for (unsigned int d = 0; d < dim; ++d)
               {
-                in.velocity[q][d]=uh[q][this->introspection().component_indices.velocities[d]];
-                in.pressure_gradient[q][d] = duh[q][this->introspection().component_indices.pressure][d];
+                in.velocity[q][d]=solution_values[q][this->introspection().component_indices.velocities[d]];
+                in.pressure_gradient[q][d] = solution_gradients[q][this->introspection().component_indices.pressure][d];
               }
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              in.composition[q][c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
           }
 
         // then do compute the viscosity...

--- a/source/postprocess/visualization/thermal_conductivity.cc
+++ b/source/postprocess/visualization/thermal_conductivity.cc
@@ -42,17 +42,17 @@ namespace aspect
       template <int dim>
       void
       ThermalConductivity<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
                                          const std::vector<std::vector<Tensor<1,dim> > > &,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
         MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
                                                    this->n_compositional_fields());
@@ -63,11 +63,11 @@ namespace aspect
         in.strain_rate.resize(0); // we do not need the viscosity
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
-            in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
-            in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            in.pressure[q]=solution_values[q][this->introspection().component_indices.pressure];
+            in.temperature[q]=solution_values[q][this->introspection().component_indices.temperature];
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              in.composition[q][c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
 
           }
 

--- a/source/postprocess/visualization/thermal_diffusivity.cc
+++ b/source/postprocess/visualization/thermal_diffusivity.cc
@@ -42,17 +42,17 @@ namespace aspect
       template <int dim>
       void
       ThermalDiffusivity<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
                                          const std::vector<std::vector<Tensor<1,dim> > > &,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
         MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
                                                    this->n_compositional_fields());
@@ -63,11 +63,11 @@ namespace aspect
         in.strain_rate.resize(0); // we do not need the viscosity
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
-            in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
-            in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            in.pressure[q]=solution_values[q][this->introspection().component_indices.pressure];
+            in.temperature[q]=solution_values[q][this->introspection().component_indices.temperature];
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              in.composition[q][c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
 
           }
 

--- a/source/postprocess/visualization/thermal_expansivity.cc
+++ b/source/postprocess/visualization/thermal_expansivity.cc
@@ -42,17 +42,17 @@ namespace aspect
       template <int dim>
       void
       ThermalExpansivity<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                         const std::vector<std::vector<Tensor<1,dim> > > &duh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                         const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
         MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
                                                    this->n_compositional_fields());
@@ -64,16 +64,16 @@ namespace aspect
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
             //in.strain_rate[q] =
-            in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
-            in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            in.pressure[q]=solution_values[q][this->introspection().component_indices.pressure];
+            in.temperature[q]=solution_values[q][this->introspection().component_indices.temperature];
             for (unsigned int d = 0; d < dim; ++d)
               {
-                in.velocity[q][d]=uh[q][this->introspection().component_indices.velocities[d]];
-                in.pressure_gradient[q][d] = duh[q][this->introspection().component_indices.pressure][d];
+                in.velocity[q][d]=solution_values[q][this->introspection().component_indices.velocities[d]];
+                in.pressure_gradient[q][d] = solution_gradients[q][this->introspection().component_indices.pressure][d];
               }
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              in.composition[q][c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
 
           }
 

--- a/source/postprocess/visualization/thermodynamic_phase.cc
+++ b/source/postprocess/visualization/thermodynamic_phase.cc
@@ -42,25 +42,25 @@ namespace aspect
       template <int dim>
       void
       ThermodynamicPhase<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
                                          const std::vector<std::vector<Tensor<1,dim> > > &,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> > &,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
-            const double pressure    = uh[q][this->introspection().component_indices.pressure];
-            const double temperature = uh[q][this->introspection().component_indices.temperature];
+            const double pressure    = solution_values[q][this->introspection().component_indices.pressure];
+            const double temperature = solution_values[q][this->introspection().component_indices.temperature];
             std::vector<double> composition(this->n_compositional_fields());
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              composition[c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              composition[c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
 
             computed_quantities[q](0) = this->get_material_model().thermodynamic_phase(temperature,
                                                                                        pressure,

--- a/source/postprocess/visualization/vertical_heat_flux.cc
+++ b/source/postprocess/visualization/vertical_heat_flux.cc
@@ -42,17 +42,17 @@ namespace aspect
       template <int dim>
       void
       VerticalHeatFlux<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                         const std::vector<std::vector<Tensor<1,dim> > > &duh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                         const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
         MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
                                                    this->n_compositional_fields());
@@ -67,17 +67,17 @@ namespace aspect
         in.strain_rate.resize(0); // we do not need the viscosity
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
-            in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
-            in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            in.pressure[q]=solution_values[q][this->introspection().component_indices.pressure];
+            in.temperature[q]=solution_values[q][this->introspection().component_indices.temperature];
             for (unsigned int d = 0; d < dim; ++d)
               {
-                in.velocity[q][d]=uh[q][this->introspection().component_indices.velocities[d]];
-                in.pressure_gradient[q][d] = duh[q][this->introspection().component_indices.pressure][d];
-                temperature_gradient[q][d] = duh[q][this->introspection().component_indices.temperature][d];
+                in.velocity[q][d]=solution_values[q][this->introspection().component_indices.velocities[d]];
+                in.pressure_gradient[q][d] = solution_gradients[q][this->introspection().component_indices.pressure][d];
+                temperature_gradient[q][d] = solution_gradients[q][this->introspection().component_indices.temperature][d];
               }
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              in.composition[q][c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
           }
 
         this->get_material_model().evaluate(in, out);

--- a/source/postprocess/visualization/viscosity.cc
+++ b/source/postprocess/visualization/viscosity.cc
@@ -42,18 +42,18 @@ namespace aspect
       template <int dim>
       void
       Viscosity<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                         const std::vector<std::vector<Tensor<1,dim> > > &duh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                         const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
-        Assert (duh[0].size() == this->introspection().n_components,          ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_gradients[0].size() == this->introspection().n_components,          ExcInternalError());
 
         MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
                                                    this->n_compositional_fields());
@@ -65,19 +65,19 @@ namespace aspect
           {
             Tensor<2,dim> grad_u;
             for (unsigned int d=0; d<dim; ++d)
-              grad_u[d] = duh[q][d];
+              grad_u[d] = solution_gradients[q][d];
             in.strain_rate[q] = symmetrize (grad_u);
 
-            in.pressure[q]=uh[q][this->introspection().component_indices.pressure];
-            in.temperature[q]=uh[q][this->introspection().component_indices.temperature];
+            in.pressure[q]=solution_values[q][this->introspection().component_indices.pressure];
+            in.temperature[q]=solution_values[q][this->introspection().component_indices.temperature];
             for (unsigned int d = 0; d < dim; ++d)
               {
-                in.velocity[q][d]=uh[q][this->introspection().component_indices.velocities[d]];
-                in.pressure_gradient[q][d] = duh[q][this->introspection().component_indices.pressure][d];
+                in.velocity[q][d]=solution_values[q][this->introspection().component_indices.velocities[d]];
+                in.pressure_gradient[q][d] = solution_gradients[q][this->introspection().component_indices.pressure][d];
               }
 
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              in.composition[q][c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              in.composition[q][c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
           }
 
         this->get_material_model().evaluate(in, out);

--- a/source/postprocess/visualization/viscosity_ratio.cc
+++ b/source/postprocess/visualization/viscosity_ratio.cc
@@ -42,34 +42,34 @@ namespace aspect
       template <int dim>
       void
       ViscosityRatio<dim>::
-      compute_derived_quantities_vector (const std::vector<Vector<double> >              &uh,
-                                         const std::vector<std::vector<Tensor<1,dim> > > &duh,
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                         const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
                                          const std::vector<std::vector<Tensor<2,dim> > > &,
                                          const std::vector<Point<dim> > &,
                                          const std::vector<Point<dim> >                  &evaluation_points,
                                          std::vector<Vector<double> >                    &computed_quantities) const
       {
-        const unsigned int n_quadrature_points = uh.size();
+        const unsigned int n_quadrature_points = solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
-        Assert (uh[0].size() == this->introspection().n_components,           ExcInternalError());
-        Assert (duh[0].size() == this->introspection().n_components,          ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_gradients[0].size() == this->introspection().n_components,          ExcInternalError());
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
             // extract the primal variables
             Tensor<2,dim> grad_u;
             for (unsigned int d=0; d<dim; ++d)
-              grad_u[d] = duh[q][d];
+              grad_u[d] = solution_gradients[q][d];
 
-            const double pressure    = uh[q][this->introspection().component_indices.pressure];
-            const double temperature = uh[q][this->introspection().component_indices.temperature];
+            const double pressure    = solution_values[q][this->introspection().component_indices.pressure];
+            const double temperature = solution_values[q][this->introspection().component_indices.temperature];
 
             const SymmetricTensor<2,dim> strain_rate = symmetrize (grad_u);
 
             std::vector<double> composition(this->n_compositional_fields());
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              composition[c] = uh[q][this->introspection().component_indices.compositional_fields[c]];
+              composition[c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
 
             computed_quantities[q](0) = this->get_material_model().viscosity_ratio(temperature,
                                                                                    pressure,


### PR DESCRIPTION
This follows a totally reasonable request by @drwells in https://github.com/dealii/dealii/pull/3333 .

(I created this PR on a system where I don't have a compilable version of ASPECT set up. I think it *should* compile, but bear with me if it doesn't.)