### PR TITLE
Particle emplace cpp14

### DIFF
--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -577,6 +577,10 @@ namespace aspect
           typename std::multimap<types::LevelInd,Particle<dim> >::const_iterator position_hint = particles.end();
           for (unsigned int i = 0; i < *n_particles_in_cell_ptr; ++i)
             {
+              // Use std::multimap::emplace_hint to speed up insertion of
+              // particles. This is a C++11 function, but not all compilers
+              // that report a -std=c++11 (like gcc 4.6) implement it, so
+              // require C++14 instead.
 #ifdef DEAL_II_WITH_CXX14
               position_hint = particles.emplace_hint(position_hint,
                                                      std::make_pair(cell->level(),cell->index()),
@@ -595,6 +599,10 @@ namespace aspect
           typename std::multimap<types::LevelInd,Particle<dim> >::iterator position_hint = particles.end();
           for (unsigned int i = 0; i < *n_particles_in_cell_ptr; ++i)
             {
+              // Use std::multimap::emplace_hint to speed up insertion of
+              // particles. This is a C++11 function, but not all compilers
+              // that report a -std=c++11 (like gcc 4.6) implement it, so
+              // require C++14 instead.
 #ifdef DEAL_II_WITH_CXX14
               position_hint = particles.emplace_hint(position_hint,
                                                      std::make_pair(cell->level(),cell->index()),
@@ -633,6 +641,10 @@ namespace aspect
                       if (GeometryInfo<dim>::is_inside_unit_cell(p_unit))
                         {
                           p.set_reference_location(p_unit);
+                          // Use std::multimap::emplace_hint to speed up insertion of
+                          // particles. This is a C++11 function, but not all compilers
+                          // that report a -std=c++11 (like gcc 4.6) implement it, so
+                          // require C++14 instead.
 #ifdef DEAL_II_WITH_CXX14
                           position_hints[child_index] = particles.emplace_hint(position_hints[child_index],
                                                                                std::make_pair(child->level(),child->index()),

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -574,7 +574,7 @@ namespace aspect
           typename std::multimap<types::LevelInd,Particle<dim> >::const_iterator position_hint = particles.end();
           for (unsigned int i = 0; i < *n_particles_in_cell_ptr; ++i)
             {
-#ifdef DEAL_II_WITH_CXX11
+#ifdef DEAL_II_WITH_CXX14
               position_hint = particles.emplace_hint(position_hint,
                                                      std::make_pair(cell->level(),cell->index()),
                                                      Particle<dim>(pdata,property_manager->get_particle_size()));
@@ -592,7 +592,7 @@ namespace aspect
           typename std::multimap<types::LevelInd,Particle<dim> >::iterator position_hint = particles.end();
           for (unsigned int i = 0; i < *n_particles_in_cell_ptr; ++i)
             {
-#ifdef DEAL_II_WITH_CXX11
+#ifdef DEAL_II_WITH_CXX14
               position_hint = particles.emplace_hint(position_hint,
                                                      std::make_pair(cell->level(),cell->index()),
                                                      Particle<dim>(pdata,property_manager->get_particle_size()));
@@ -630,7 +630,7 @@ namespace aspect
                       if (GeometryInfo<dim>::is_inside_unit_cell(p_unit))
                         {
                           p.set_reference_location(p_unit);
-#ifdef DEAL_II_WITH_CXX11
+#ifdef DEAL_II_WITH_CXX14
                           position_hints[child_index] = particles.emplace_hint(position_hints[child_index],
                                                                                std::make_pair(child->level(),child->index()),
                                                                                std::move(p));

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -567,6 +567,9 @@ namespace aspect
       const unsigned int *n_particles_in_cell_ptr = static_cast<const unsigned int *> (data);
       const void *pdata = reinterpret_cast<const void *> (n_particles_in_cell_ptr + 1);
 
+      if (*n_particles_in_cell_ptr == 0)
+        return;
+
       // Load all particles from the data stream and store them in the local
       // particle map.
       if (status == parallel::distributed::Triangulation<dim>::CELL_PERSIST)
@@ -636,7 +639,7 @@ namespace aspect
                                                                                std::move(p));
 #else
                           position_hints[child_index] = particles.insert(position_hints[child_index],
-                                                                         std::make_pair(std::make_pair(cell->level(),cell->index()),
+                                                                         std::make_pair(std::make_pair(child->level(),child->index()),
                                                                                         p));
 #endif
                           ++position_hints[child_index];


### PR DESCRIPTION
Supersedes #1263 and includes a fix for a pre-existing bug.

emplace_hint is not supported in gcc 4.6.x and 4.7.x even though this is
part of cxx11. So we require cxx14 for this for now.