### PR TITLE
fixes to compile without cxx11

### DIFF
--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -574,7 +574,7 @@ namespace aspect
       // particle map.
       if (status == parallel::distributed::Triangulation<dim>::CELL_PERSIST)
         {
-          typename std::multimap<types::LevelInd,Particle<dim> >::const_iterator position_hint = particles.end();
+          typename std::multimap<types::LevelInd,Particle<dim> >::iterator position_hint = particles.end();
           for (unsigned int i = 0; i < *n_particles_in_cell_ptr; ++i)
             {
               // Use std::multimap::emplace_hint to speed up insertion of
@@ -619,7 +619,7 @@ namespace aspect
         }
       else if (status == parallel::distributed::Triangulation<dim>::CELL_REFINE)
         {
-          std::vector<typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator > position_hints(GeometryInfo<dim>::max_children_per_cell);
+          std::vector<typename std::multimap<types::LevelInd, Particle<dim> >::iterator > position_hints(GeometryInfo<dim>::max_children_per_cell);
           for (unsigned int child_index=0; child_index<GeometryInfo<dim>::max_children_per_cell; ++child_index)
             {
               const typename parallel::distributed::Triangulation<dim>::cell_iterator child = cell->child(child_index);

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -113,15 +113,15 @@ namespace aspect
      * computation.
      */
     template <int dim>
-    std_cxx11::unique_ptr<Mapping<dim> > construct_mapping(const GeometryModel::Interface<dim> &geometry_model,
-                                                           const InitialTopographyModel::Interface<dim> &initial_topography_model)
+    Mapping<dim> *construct_mapping(const GeometryModel::Interface<dim> &geometry_model,
+                                    const InitialTopographyModel::Interface<dim> &initial_topography_model)
     {
       if (geometry_model.has_curved_elements())
-        return std_cxx11::unique_ptr<Mapping<dim> >(new MappingQ<dim>(4, true));
+        return new MappingQ<dim>(4, true);
       if (dynamic_cast<const InitialTopographyModel::ZeroTopography<dim>*>(&initial_topography_model) != 0)
-        return std_cxx11::unique_ptr<Mapping<dim> >(new MappingCartesian<dim>());
+        return new MappingCartesian<dim>();
 
-      return std_cxx11::unique_ptr<Mapping<dim> >(new MappingQ1<dim>());
+      return new MappingQ1<dim>();
     }
   }
 


### PR DESCRIPTION
1. boost::scoped_ptr can not be returned from a function
2. std::multimap::insert(hint) takes a non-const iterator pre cxx11