### PR TITLE
Use nonlinear solver tolerance for "Stokes only" solver scheme

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,14 @@
  *
  * <ol>
  *
+ * <li> Changed: The 'Stokes only' nonlinear solver scheme now uses
+ * the nonlinear solver tolerance parameter (previously it was hard-
+ * coded to 1e-8), and it computes the nonlinear residual as current
+ * residual divided by initial residual, consistent with the 'iterated
+ * Stokes' solver scheme.
+ * <br>
+ * (Juliane Dannberg, Rene Gassmoeller, 2016/11/22)
+ * 
  * <li> Changed: The adiabatic profile now contains a reference density
  * profile, and the derivative of this reference density profile. The
  * InitialProfile adiabatic profile now relies on the adiabatic heating

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -2046,11 +2046,13 @@ namespace aspect
 
               const double stokes_residual = solve_stokes();
 
+              const double relative_tolerance = (initial_stokes_residual > 0) ? stokes_residual/initial_stokes_residual : 0.0;
+
               pcout << "      Relative Stokes residual after nonlinear iteration " << iteration+1
-                    << ": " << stokes_residual/initial_stokes_residual
+                    << ": " << relative_tolerance
                     << std::endl;
 
-              if (stokes_residual/initial_stokes_residual < parameters.nonlinear_tolerance)
+              if (relative_tolerance < parameters.nonlinear_tolerance)
                 break;
 
               current_linearization_point = solution;

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -2009,8 +2009,10 @@ namespace aspect
 
           break;
         }
+
         case NonlinearSolver::Stokes_only:
         {
+          double initial_stokes_residual = 0.0;
           unsigned int iteration = 0;
 
           do
@@ -2038,12 +2040,20 @@ namespace aspect
 
               assemble_stokes_system();
               build_stokes_preconditioner();
-              const double stokes_residual = solve_stokes();
-              current_linearization_point = solution;
 
-              pcout << "      Nonlinear Stokes residual: " << stokes_residual << std::endl;
-              if (stokes_residual < 1e-8)
+              if (iteration == 0)
+                initial_stokes_residual = compute_initial_stokes_residual();
+
+              const double stokes_residual = solve_stokes();
+
+              pcout << "      Relative Stokes residual after nonlinear iteration " << iteration+1
+                    << ": " << stokes_residual/initial_stokes_residual
+                    << std::endl;
+
+              if (stokes_residual/initial_stokes_residual < parameters.nonlinear_tolerance)
                 break;
+
+              current_linearization_point = solution;
 
               ++iteration;
             }

--- a/tests/anisotropic_viscosity/screen-output
+++ b/tests/anisotropic_viscosity/screen-output
@@ -1,10 +1,3 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in OPTIMIZED mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Loading shared library <./libanisotropic_viscosity.so>
 
@@ -14,7 +7,7 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+15 iterations.
-      Nonlinear Stokes residual: 21.6582
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Postprocessing:
      Heating rate (average/total):  4.71 W/kg, 6.193 W
@@ -25,15 +18,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      1.42s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         1 |    0.0947s |       6.7% |
-| Build Stokes preconditioner     |         1 |      0.05s |       3.5% |
-| Solve Stokes system             |         1 |      1.12s |        79% |
-| Initialization                  |         2 |    0.0871s |       6.2% |
-| Postprocessing                  |         1 |     0.017s |       1.2% |
-| Setup dof systems               |         1 |    0.0358s |       2.5% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/burstedde/screen-output
+++ b/tests/burstedde/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 3,041 (2,187+125+729)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+XYZ iterations.
-      Nonlinear Stokes residual: 111.63
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+XYZ iterations.
-      Nonlinear Stokes residual: 9.88547e-11
+      Relative Stokes residual after nonlinear iteration 2: 9.71521e-12
 
    Postprocessing:
      RMS, max velocity:             4.3 m/s, 13.2 m/s

--- a/tests/compressibility/screen-output
+++ b/tests/compressibility/screen-output
@@ -7,7 +7,7 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
-      Nonlinear Stokes residual: 21.2064
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Postprocessing:
      Top/bottom flux:          1/2.718

--- a/tests/compressibility_iterated_stokes/screen-output
+++ b/tests/compressibility_iterated_stokes/screen-output
@@ -7,15 +7,15 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
-      Nonlinear Stokes residual: 21.2064
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 21+0 iterations.
-      Nonlinear Stokes residual: 0.293292
+      Relative Stokes residual after nonlinear iteration 2: 0.0138303
    Solving Stokes system... 15+0 iterations.
-      Nonlinear Stokes residual: 0.0159071
+      Relative Stokes residual after nonlinear iteration 3: 0.000750107
    Solving Stokes system... 10+0 iterations.
-      Nonlinear Stokes residual: 0.000575262
+      Relative Stokes residual after nonlinear iteration 4: 2.71268e-05
    Solving Stokes system... 5+0 iterations.
-      Nonlinear Stokes residual: 1.44605e-05
+      Relative Stokes residual after nonlinear iteration 5: 6.81892e-07
 
    Postprocessing:
      Top/bottom flux: 1/1

--- a/tests/compressibility_iterated_stokes_direct_solver/screen-output
+++ b/tests/compressibility_iterated_stokes_direct_solver/screen-output
@@ -1,10 +1,3 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.2.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Loading shared library <./libcompressibility_iterated_stokes_direct_solver.so>
 
@@ -13,15 +6,15 @@ Number of degrees of freedom: 13,764 (9,539+4,225)
 
 *** Timestep 0:  t=0 seconds
    Solving Stokes system... done.
-      Nonlinear Stokes residual: 21.2064
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... done.
-      Nonlinear Stokes residual: 0.293292
+      Relative Stokes residual after nonlinear iteration 2: 0.0138303
    Solving Stokes system... done.
-      Nonlinear Stokes residual: 0.0159069
+      Relative Stokes residual after nonlinear iteration 3: 0.000750098
    Solving Stokes system... done.
-      Nonlinear Stokes residual: 0.000575267
+      Relative Stokes residual after nonlinear iteration 4: 2.7127e-05
    Solving Stokes system... done.
-      Nonlinear Stokes residual: 1.42992e-05
+      Relative Stokes residual after nonlinear iteration 5: 6.74287e-07
 
    Postprocessing:
      Top/bottom flux: 1/1
@@ -30,14 +23,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      1.68s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         5 |     0.793s |        47% |
-| Solve Stokes system             |         5 |       0.7s |        42% |
-| Initialization                  |         2 |     0.045s |       2.7% |
-| Postprocessing                  |         1 |   0.00193s |      0.11% |
-| Setup dof systems               |         1 |    0.0792s |       4.7% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/conservative_with_mpi/screen-output
+++ b/tests/conservative_with_mpi/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 291 (162+48+81)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.04867e-09
+      Relative Stokes residual after nonlinear iteration 2: 4.56923e-08
 
    Postprocessing:
 

--- a/tests/graphical_output/screen-output
+++ b/tests/graphical_output/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.40627e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.60395e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174943e-01, 1.069688e-04, 1.192654e-01

--- a/tests/graphical_output_hdf5/screen-output
+++ b/tests/graphical_output_hdf5/screen-output
@@ -1,5 +1,3 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 
 Loading shared library <./libgraphical_output_hdf5.so>
 
@@ -9,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.40627e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.60395e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174943e-01, 1.069688e-04, 1.192654e-01

--- a/tests/inclusion_2/screen-output
+++ b/tests/inclusion_2/screen-output
@@ -7,7 +7,7 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Nonlinear Stokes residual: 60.9328
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Postprocessing:
      Writing graphical output:      output-inclusion_2/solution/solution-00000

--- a/tests/inclusion_4/screen-output
+++ b/tests/inclusion_4/screen-output
@@ -7,7 +7,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+11 iterations.
-      Nonlinear Stokes residual: 50.0854
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Postprocessing:
      Writing graphical output:      output-inclusion_4/solution/solution-00000

--- a/tests/inclusion_adaptive/screen-output
+++ b/tests/inclusion_adaptive/screen-output
@@ -7,7 +7,7 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-      Nonlinear Stokes residual: 54.8383
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Postprocessing:
      Writing graphical output:      output-inclusion_adaptive/solution/solution-00000
@@ -19,7 +19,7 @@ Number of degrees of freedom: 1,156 (706+97+353)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
-      Nonlinear Stokes residual: 54.8383
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Postprocessing:
      Writing graphical output:      output-inclusion_adaptive/solution/solution-00001
@@ -31,7 +31,7 @@ Number of degrees of freedom: 1,520 (930+125+465)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
-      Nonlinear Stokes residual: 54.8383
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Postprocessing:
      Writing graphical output:      output-inclusion_adaptive/solution/solution-00002
@@ -43,7 +43,7 @@ Number of degrees of freedom: 2,664 (1,634+213+817)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-      Nonlinear Stokes residual: 54.8383
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Postprocessing:
      Writing graphical output:      output-inclusion_adaptive/solution/solution-00003
@@ -55,7 +55,7 @@ Number of degrees of freedom: 4,172 (2,562+329+1,281)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+13 iterations.
-      Nonlinear Stokes residual: 54.8383
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Postprocessing:
      Writing graphical output:      output-inclusion_adaptive/solution/solution-00004
@@ -67,7 +67,7 @@ Number of degrees of freedom: 6,772 (4,162+529+2,081)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+11 iterations.
-      Nonlinear Stokes residual: 54.8383
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Postprocessing:
      Writing graphical output:      output-inclusion_adaptive/solution/solution-00005

--- a/tests/material_model_dependencies_burstedde/screen-output
+++ b/tests/material_model_dependencies_burstedde/screen-output
@@ -6,10 +6,10 @@ Number of degrees of freedom: 3,041 (2,187+125+729)
 
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+56 iterations.
-      Nonlinear Stokes residual: 111.63
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.29793e-11
+   Solving Stokes system... 0+47 iterations.
+      Relative Stokes residual after nonlinear iteration 1: 1
+   Solving Stokes system... 0+5 iterations.
+      Relative Stokes residual after nonlinear iteration 2: 9.71521e-12
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_burstedde/screen-output
+++ b/tests/material_model_dependencies_burstedde/screen-output
@@ -6,10 +6,10 @@ Number of degrees of freedom: 3,041 (2,187+125+729)
 
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+47 iterations.
+   Solving Stokes system... 0+56 iterations.
       Relative Stokes residual after nonlinear iteration 1: 1
-   Solving Stokes system... 0+5 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 9.71521e-12
+   Solving Stokes system... 0+0 iterations.
+      Relative Stokes residual after nonlinear iteration 2: 3.85015e-13
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_composition_reaction/screen-output
+++ b/tests/material_model_dependencies_composition_reaction/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.00903878
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 5+0 iterations.
-      Nonlinear Stokes residual: 5.17622e-10
+      Relative Stokes residual after nonlinear iteration 2: 5.72668e-08
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_cookbooks_freesurface_with_crust/screen-output
+++ b/tests/material_model_dependencies_cookbooks_freesurface_with_crust/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.00903878
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 5+0 iterations.
-      Nonlinear Stokes residual: 5.17622e-10
+      Relative Stokes residual after nonlinear iteration 2: 5.72668e-08
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_diffusion_dislocation/screen-output
+++ b/tests/material_model_dependencies_diffusion_dislocation/screen-output
@@ -7,10 +7,10 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Nonlinear Stokes residual: 0.00882742
+      Relative Stokes residual after nonlinear iteration 1: 1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 2.96991e-10
+      Relative Stokes residual after nonlinear iteration 2: 3.36442e-08
 
    Postprocessing:
 viscosity depends on pressure temperature strainrate composition

--- a/tests/material_model_dependencies_inclusion_2/screen-output
+++ b/tests/material_model_dependencies_inclusion_2/screen-output
@@ -7,7 +7,7 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 0
+      Relative Stokes residual after nonlinear iteration 1: 0
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_latent_heat/screen-output
+++ b/tests/material_model_dependencies_latent_heat/screen-output
@@ -7,34 +7,34 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Nonlinear Stokes residual: 5.75778
+      Relative Stokes residual after nonlinear iteration 1: 1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Nonlinear Stokes residual: 0.167567
+      Relative Stokes residual after nonlinear iteration 2: 0.0291028
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Nonlinear Stokes residual: 0.22561
+      Relative Stokes residual after nonlinear iteration 3: 0.0391836
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Nonlinear Stokes residual: 0.232292
+      Relative Stokes residual after nonlinear iteration 4: 0.0403441
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Nonlinear Stokes residual: 0.141763
+      Relative Stokes residual after nonlinear iteration 5: 0.0246211
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Nonlinear Stokes residual: 0.133049
+      Relative Stokes residual after nonlinear iteration 6: 0.0231077
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.163726
+      Relative Stokes residual after nonlinear iteration 7: 0.0284356
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Nonlinear Stokes residual: 0.138607
+      Relative Stokes residual after nonlinear iteration 8: 0.024073
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Nonlinear Stokes residual: 0.152346
+      Relative Stokes residual after nonlinear iteration 9: 0.0264592
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Nonlinear Stokes residual: 0.14749
+      Relative Stokes residual after nonlinear iteration 10: 0.0256158
 
    Postprocessing:
 viscosity depends on temperature composition

--- a/tests/material_model_dependencies_latent_heat_melt/screen-output
+++ b/tests/material_model_dependencies_latent_heat_melt/screen-output
@@ -7,10 +7,10 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Nonlinear Stokes residual: 0.0180776
+      Relative Stokes residual after nonlinear iteration 1: 1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Nonlinear Stokes residual: 1.04628e-09
+      Relative Stokes residual after nonlinear iteration 2: 5.7877e-08
 
    Postprocessing:
 viscosity depends on temperature composition

--- a/tests/material_model_dependencies_morency_doin/screen-output
+++ b/tests/material_model_dependencies_morency_doin/screen-output
@@ -7,10 +7,10 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-      Nonlinear Stokes residual: 0.0158179
+      Relative Stokes residual after nonlinear iteration 1: 1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Nonlinear Stokes residual: 1.28113e-09
+      Relative Stokes residual after nonlinear iteration 2: 8.09925e-08
 
    Postprocessing:
 viscosity depends on temperature strainrate composition

--- a/tests/material_model_dependencies_multicomponent/screen-output
+++ b/tests/material_model_dependencies_multicomponent/screen-output
@@ -7,10 +7,10 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.0180776
+      Relative Stokes residual after nonlinear iteration 1: 1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-      Nonlinear Stokes residual: 1.03522e-09
+      Relative Stokes residual after nonlinear iteration 2: 5.72656e-08
 
    Postprocessing:
 viscosity depends on composition

--- a/tests/material_model_dependencies_shear_thinning/screen-output
+++ b/tests/material_model_dependencies_shear_thinning/screen-output
@@ -7,10 +7,10 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 2.73902e-06
+      Relative Stokes residual after nonlinear iteration 1: 1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Nonlinear Stokes residual: 2.33624e-13
+      Relative Stokes residual after nonlinear iteration 2: 8.52948e-08
 
    Postprocessing:
 viscosity depends on strainrate

--- a/tests/material_model_dependencies_simple/screen-output
+++ b/tests/material_model_dependencies_simple/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.00903878
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 5+0 iterations.
-      Nonlinear Stokes residual: 5.17622e-10
+      Relative Stokes residual after nonlinear iteration 2: 5.72668e-08
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_simple_compressible/screen-output
+++ b/tests/material_model_dependencies_simple_compressible/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Nonlinear Stokes residual: 0.00903878
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 4+0 iterations.
-      Nonlinear Stokes residual: 5.20073e-10
+      Relative Stokes residual after nonlinear iteration 2: 5.7538e-08
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_simpler/screen-output
+++ b/tests/material_model_dependencies_simpler/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.00903878
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 5+0 iterations.
-      Nonlinear Stokes residual: 5.17622e-10
+      Relative Stokes residual after nonlinear iteration 2: 5.72668e-08
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_solcx/screen-output
+++ b/tests/material_model_dependencies_solcx/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.40627e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.60395e-08
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_solkz/screen-output
+++ b/tests/material_model_dependencies_solkz/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Nonlinear Stokes residual: 0.0670283
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.20581e-09
+      Relative Stokes residual after nonlinear iteration 2: 4.78278e-08
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_steinberger/screen-output
+++ b/tests/material_model_dependencies_steinberger/screen-output
@@ -10,16 +10,16 @@ Number of degrees of freedom: 740 (450+65+225)
       Relative Stokes residual after nonlinear iteration 1: 1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 0.0154884
+      Relative Stokes residual after nonlinear iteration 2: 0.0155363
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 0.0041517
+      Relative Stokes residual after nonlinear iteration 3: 0.00416092
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 1.07288e-05
+      Relative Stokes residual after nonlinear iteration 4: 1.08037e-05
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative Stokes residual after nonlinear iteration 5: 2.33605e-07
+      Relative Stokes residual after nonlinear iteration 5: 2.34165e-07
 
    Postprocessing:
 viscosity depends on temperature

--- a/tests/material_model_dependencies_steinberger/screen-output
+++ b/tests/material_model_dependencies_steinberger/screen-output
@@ -7,34 +7,19 @@ Number of degrees of freedom: 740 (450+65+225)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Nonlinear Stokes residual: 5.11006e+15
+      Relative Stokes residual after nonlinear iteration 1: 1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Nonlinear Stokes residual: 7.93914e+13
+      Relative Stokes residual after nonlinear iteration 2: 0.0154884
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 2.12625e+13
+      Relative Stokes residual after nonlinear iteration 3: 0.0041517
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Nonlinear Stokes residual: 5.52075e+10
+      Relative Stokes residual after nonlinear iteration 4: 1.07288e-05
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Nonlinear Stokes residual: 1.1966e+09
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 7.10145e+06
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.14611e+06
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.14611e+06
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.14611e+06
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.14611e+06
+      Relative Stokes residual after nonlinear iteration 5: 2.33605e-07
 
    Postprocessing:
 viscosity depends on temperature

--- a/tests/material_model_dependencies_tangurnis/screen-output
+++ b/tests/material_model_dependencies_tangurnis/screen-output
@@ -7,25 +7,19 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Nonlinear Stokes residual: 0.0863665
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 10+0 iterations.
-      Nonlinear Stokes residual: 0.160777
+      Relative Stokes residual after nonlinear iteration 2: 1.86156
    Solving Stokes system... 7+0 iterations.
-      Nonlinear Stokes residual: 0.00387072
+      Relative Stokes residual after nonlinear iteration 3: 0.0448174
    Solving Stokes system... 6+0 iterations.
-      Nonlinear Stokes residual: 0.000311007
+      Relative Stokes residual after nonlinear iteration 4: 0.00360101
    Solving Stokes system... 4+0 iterations.
-      Nonlinear Stokes residual: 1.11422e-05
+      Relative Stokes residual after nonlinear iteration 5: 0.000129011
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 8.65502e-07
+      Relative Stokes residual after nonlinear iteration 6: 1.00213e-05
    Solving Stokes system... 2+0 iterations.
-      Nonlinear Stokes residual: 3.04244e-08
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.57379e-08
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.57379e-08
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.57379e-08
+      Relative Stokes residual after nonlinear iteration 7: 3.52271e-07
 
    Postprocessing:
 viscosity depends on

--- a/tests/no_adiabatic_heating/screen-output
+++ b/tests/no_adiabatic_heating/screen-output
@@ -7,15 +7,15 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-      Nonlinear Stokes residual: 23.467
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 21+0 iterations.
-      Nonlinear Stokes residual: 0.577255
+      Relative Stokes residual after nonlinear iteration 2: 0.0245986
    Solving Stokes system... 15+0 iterations.
-      Nonlinear Stokes residual: 0.0312043
+      Relative Stokes residual after nonlinear iteration 3: 0.00132971
    Solving Stokes system... 11+0 iterations.
-      Nonlinear Stokes residual: 0.00111979
+      Relative Stokes residual after nonlinear iteration 4: 4.77177e-05
    Solving Stokes system... 5+0 iterations.
-      Nonlinear Stokes residual: 2.75572e-05
+      Relative Stokes residual after nonlinear iteration 5: 1.1743e-06
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -23,15 +23,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 1:  t=0.0284091 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Nonlinear Stokes residual: 2.41317e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.17897e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.17897e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.17897e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.17897e-06
+      Relative Stokes residual after nonlinear iteration 1: 1.02389e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -39,15 +31,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 2:  t=0.0568182 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Nonlinear Stokes residual: 2.39744e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.00299e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.00299e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.00299e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.00299e-06
+      Relative Stokes residual after nonlinear iteration 1: 1.01722e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -55,15 +39,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 3:  t=0.0852272 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.14507e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.14507e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.14507e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.14507e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.14507e-06
+      Relative Stokes residual after nonlinear iteration 1: 9.09435e-08
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -71,15 +47,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 4:  t=0.113636 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Nonlinear Stokes residual: 3.94242e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.89752e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.89752e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.89752e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.89752e-07
+      Relative Stokes residual after nonlinear iteration 1: 1.67135e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -87,15 +55,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 5:  t=0.142045 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.22058e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.22058e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.22058e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.22058e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.22058e-06
+      Relative Stokes residual after nonlinear iteration 1: 9.41443e-08
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -103,15 +63,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 6:  t=0.170454 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Nonlinear Stokes residual: 4.31892e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.30575e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.30575e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.30575e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.30575e-06
+      Relative Stokes residual after nonlinear iteration 1: 1.83104e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -119,15 +71,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 7:  t=0.198864 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 3.88185e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.89635e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.89635e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.89635e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.89635e-07
+      Relative Stokes residual after nonlinear iteration 1: 1.64641e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -135,15 +79,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 8:  t=0.227273 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Nonlinear Stokes residual: 2.69521e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.09173e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.09173e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.09173e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.09173e-06
+      Relative Stokes residual after nonlinear iteration 1: 1.14814e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -151,15 +87,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 9:  t=0.255682 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 4.27082e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.1577e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.1577e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.1577e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.1577e-07
+      Relative Stokes residual after nonlinear iteration 1: 1.81399e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -167,15 +95,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 10:  t=0.284091 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.19352e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.19352e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.19352e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.19352e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.19352e-06
+      Relative Stokes residual after nonlinear iteration 1: 9.32674e-08
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -186,15 +106,7 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 11:  t=0.3125 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 0.000214503
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.62487e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.62487e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.62487e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.62487e-06
+      Relative Stokes residual after nonlinear iteration 1: 7.06759e-06
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -202,15 +114,7 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 12:  t=0.369318 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 4.35686e-05
-   Solving Stokes system... 2+0 iterations.
-      Nonlinear Stokes residual: 3.37046e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.55298e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.55298e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.55298e-06
+      Relative Stokes residual after nonlinear iteration 1: 1.43633e-06
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -218,31 +122,15 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 13:  t=0.426136 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 6.62885e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 7.02651e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 7.02651e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 7.02651e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 7.02651e-07
+      Relative Stokes residual after nonlinear iteration 1: 2.67638e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
 
 *** Timestep 14:  t=0.482954 seconds
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.40203e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.40203e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.40203e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.40203e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.40203e-06
+   Solving Stokes system... 2+0 iterations.
+      Relative Stokes residual after nonlinear iteration 1: 1.06694e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -250,15 +138,7 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 15:  t=0.539772 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 4.72755e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 5.38198e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 5.38198e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 5.38198e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 5.38198e-07
+      Relative Stokes residual after nonlinear iteration 1: 1.6185e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -266,15 +146,7 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 16:  t=0.59659 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.58728e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.58728e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.58728e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.58728e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.58728e-06
+      Relative Stokes residual after nonlinear iteration 1: 8.26501e-08
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -282,15 +154,7 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 17:  t=0.653409 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 4.99824e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.84729e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.84729e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.84729e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.84729e-07
+      Relative Stokes residual after nonlinear iteration 1: 1.61514e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -298,31 +162,15 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 18:  t=0.710227 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.79399e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.79399e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.79399e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.79399e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.79399e-06
+      Relative Stokes residual after nonlinear iteration 1: 8.94958e-08
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
 
 *** Timestep 19:  t=0.767045 seconds
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 2+0 iterations.
-      Nonlinear Stokes residual: 5.35786e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.92503e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.92503e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.92503e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.92503e-06
+   Solving Stokes system... 3+0 iterations.
+      Relative Stokes residual after nonlinear iteration 1: 1.71033e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -330,15 +178,7 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 20:  t=0.823863 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Nonlinear Stokes residual: 4.91542e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.91218e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.91218e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.91218e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.91218e-06
+      Relative Stokes residual after nonlinear iteration 1: 1.00444e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -349,15 +189,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 21:  t=0.880681 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Nonlinear Stokes residual: 0.00122158
+      Relative Stokes residual after nonlinear iteration 1: 2.98292e-05
    Solving Stokes system... 2+0 iterations.
-      Nonlinear Stokes residual: 4.52042e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.04991e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.04991e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.04991e-06
+      Relative Stokes residual after nonlinear iteration 2: 1.25305e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -365,31 +199,15 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 22:  t=0.994317 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Nonlinear Stokes residual: 0.000287997
-   Solving Stokes system... 2+0 iterations.
-      Nonlinear Stokes residual: 8.57207e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.37397e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.37397e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.37397e-06
+      Relative Stokes residual after nonlinear iteration 1: 7.03547e-06
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
 
 *** Timestep 23:  t=1 seconds
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.64246e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.64246e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.64246e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.64246e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.64246e-06
+   Solving Stokes system... 2+0 iterations.
+      Relative Stokes residual after nonlinear iteration 1: 2.2235e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K

--- a/tests/no_adiabatic_heating_02/screen-output
+++ b/tests/no_adiabatic_heating_02/screen-output
@@ -7,15 +7,15 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-      Nonlinear Stokes residual: 23.467
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 21+0 iterations.
-      Nonlinear Stokes residual: 0.577255
+      Relative Stokes residual after nonlinear iteration 2: 0.0245986
    Solving Stokes system... 15+0 iterations.
-      Nonlinear Stokes residual: 0.0312043
+      Relative Stokes residual after nonlinear iteration 3: 0.00132971
    Solving Stokes system... 11+0 iterations.
-      Nonlinear Stokes residual: 0.00111979
+      Relative Stokes residual after nonlinear iteration 4: 4.77177e-05
    Solving Stokes system... 5+0 iterations.
-      Nonlinear Stokes residual: 2.75572e-05
+      Relative Stokes residual after nonlinear iteration 5: 1.1743e-06
 
    Postprocessing:
 
@@ -37,15 +37,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 1:  t=0.0284091 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Nonlinear Stokes residual: 2.41317e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.17897e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.17897e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.17897e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.17897e-06
+      Relative Stokes residual after nonlinear iteration 1: 1.02389e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -54,15 +46,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 2:  t=0.0568182 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Nonlinear Stokes residual: 2.39744e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.00299e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.00299e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.00299e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.00299e-06
+      Relative Stokes residual after nonlinear iteration 1: 1.01722e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -71,15 +55,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 3:  t=0.0852272 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.14507e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.14507e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.14507e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.14507e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.14507e-06
+      Relative Stokes residual after nonlinear iteration 1: 9.09435e-08
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -88,15 +64,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 4:  t=0.113636 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Nonlinear Stokes residual: 3.94242e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.89752e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.89752e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.89752e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.89752e-07
+      Relative Stokes residual after nonlinear iteration 1: 1.67135e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -105,15 +73,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 5:  t=0.142045 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.22058e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.22058e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.22058e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.22058e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.22058e-06
+      Relative Stokes residual after nonlinear iteration 1: 9.41443e-08
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -122,15 +82,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 6:  t=0.170454 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Nonlinear Stokes residual: 4.31892e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.30575e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.30575e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.30575e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.30575e-06
+      Relative Stokes residual after nonlinear iteration 1: 1.83104e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -139,15 +91,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 7:  t=0.198864 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 3.88185e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.89635e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.89635e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.89635e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.89635e-07
+      Relative Stokes residual after nonlinear iteration 1: 1.64641e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -156,15 +100,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 8:  t=0.227273 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Nonlinear Stokes residual: 2.69521e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.09173e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.09173e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.09173e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.09173e-06
+      Relative Stokes residual after nonlinear iteration 1: 1.14814e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -173,15 +109,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 9:  t=0.255682 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 4.27082e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.1577e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.1577e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.1577e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.1577e-07
+      Relative Stokes residual after nonlinear iteration 1: 1.81399e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -190,15 +118,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 10:  t=0.284091 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.19352e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.19352e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.19352e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.19352e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.19352e-06
+      Relative Stokes residual after nonlinear iteration 1: 9.32674e-08
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -210,15 +130,7 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 11:  t=0.3125 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 0.000214503
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.62487e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.62487e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.62487e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.62487e-06
+      Relative Stokes residual after nonlinear iteration 1: 7.06759e-06
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -227,15 +139,7 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 12:  t=0.369318 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 4.35686e-05
-   Solving Stokes system... 2+0 iterations.
-      Nonlinear Stokes residual: 3.37046e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.55298e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.55298e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.55298e-06
+      Relative Stokes residual after nonlinear iteration 1: 1.43633e-06
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -244,15 +148,7 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 13:  t=0.426136 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 6.62885e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 7.02651e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 7.02651e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 7.02651e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 7.02651e-07
+      Relative Stokes residual after nonlinear iteration 1: 2.67638e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -260,16 +156,8 @@ Number of degrees of freedom: 948 (578+81+289)
 
 *** Timestep 14:  t=0.482954 seconds
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.40203e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.40203e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.40203e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.40203e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.40203e-06
+   Solving Stokes system... 2+0 iterations.
+      Relative Stokes residual after nonlinear iteration 1: 1.06694e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -278,15 +166,7 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 15:  t=0.539772 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 4.72755e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 5.38198e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 5.38198e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 5.38198e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 5.38198e-07
+      Relative Stokes residual after nonlinear iteration 1: 1.6185e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -295,15 +175,7 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 16:  t=0.59659 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.58728e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.58728e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.58728e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.58728e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.58728e-06
+      Relative Stokes residual after nonlinear iteration 1: 8.26501e-08
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -312,15 +184,7 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 17:  t=0.653409 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Nonlinear Stokes residual: 4.99824e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.84729e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.84729e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.84729e-07
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 6.84729e-07
+      Relative Stokes residual after nonlinear iteration 1: 1.61514e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -329,15 +193,7 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 18:  t=0.710227 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.79399e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.79399e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.79399e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.79399e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.79399e-06
+      Relative Stokes residual after nonlinear iteration 1: 8.94958e-08
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -345,16 +201,8 @@ Number of degrees of freedom: 948 (578+81+289)
 
 *** Timestep 19:  t=0.767045 seconds
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 2+0 iterations.
-      Nonlinear Stokes residual: 5.35786e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.92503e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.92503e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.92503e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.92503e-06
+   Solving Stokes system... 3+0 iterations.
+      Relative Stokes residual after nonlinear iteration 1: 1.71033e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -363,15 +211,7 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 20:  t=0.823863 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Nonlinear Stokes residual: 4.91542e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.91218e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.91218e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.91218e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.91218e-06
+      Relative Stokes residual after nonlinear iteration 1: 1.00444e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -383,15 +223,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 21:  t=0.880681 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Nonlinear Stokes residual: 0.00122158
+      Relative Stokes residual after nonlinear iteration 1: 2.98292e-05
    Solving Stokes system... 2+0 iterations.
-      Nonlinear Stokes residual: 4.52042e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.04991e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.04991e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.04991e-06
+      Relative Stokes residual after nonlinear iteration 2: 1.25305e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -400,15 +234,7 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 22:  t=0.994317 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Nonlinear Stokes residual: 0.000287997
-   Solving Stokes system... 2+0 iterations.
-      Nonlinear Stokes residual: 8.57207e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.37397e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.37397e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.37397e-06
+      Relative Stokes residual after nonlinear iteration 1: 7.03547e-06
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -416,16 +242,8 @@ Number of degrees of freedom: 268 (162+25+81)
 
 *** Timestep 23:  t=1 seconds
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.64246e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.64246e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.64246e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.64246e-06
-   Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.64246e-06
+   Solving Stokes system... 2+0 iterations.
+      Relative Stokes residual after nonlinear iteration 1: 2.2235e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K

--- a/tests/non_conservative_with_mpi/screen-output
+++ b/tests/non_conservative_with_mpi/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.40627e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.60395e-08
 
    Postprocessing:
 

--- a/tests/particle_count_statistics/screen-output
+++ b/tests/particle_count_statistics/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+4 iterations.
-      Nonlinear Stokes residual: 0.0172385
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 2: 1.74731e-08
 
    Postprocessing:
      Number of advected particles:        1000
@@ -17,7 +17,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 1:  t=8.80814 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Number of advected particles:        1000
@@ -25,7 +25,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 2:  t=17.6163 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Number of advected particles:        1000
@@ -33,7 +33,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 3:  t=26.4244 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Number of advected particles:        1000
@@ -41,7 +41,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 4:  t=35.2326 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Number of advected particles:        1000
@@ -49,7 +49,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 5:  t=44.0407 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Number of advected particles:        1000
@@ -57,7 +57,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 6:  t=52.8489 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Number of advected particles:        1000
@@ -65,7 +65,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 7:  t=61.657 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Number of advected particles:        1000
@@ -73,7 +73,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 8:  t=70.4652 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Number of advected particles:        1000
@@ -81,7 +81,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 9:  t=79.2733 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Number of advected particles:        1000
@@ -89,7 +89,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 10:  t=88.0814 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Number of advected particles:        1000
@@ -101,9 +101,9 @@ Number of degrees of freedom: 3,379 (2,070+274+1,035)
 *** Timestep 11:  t=96.8896 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-      Nonlinear Stokes residual: 0.00859464
+      Relative Stokes residual after nonlinear iteration 1: 0.337215
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.93775e-09
+      Relative Stokes residual after nonlinear iteration 2: 7.47449e-08
 
    Postprocessing:
      Number of advected particles:        1000
@@ -111,9 +111,9 @@ Number of degrees of freedom: 3,379 (2,070+274+1,035)
 
 *** Timestep 12:  t=100 seconds
    Solving Stokes system... 27+0 iterations.
-      Nonlinear Stokes residual: 0.00303502
+      Relative Stokes residual after nonlinear iteration 1: 0.101315
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.00346e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.55627e-08
 
    Postprocessing:
      Number of advected particles:        1000

--- a/tests/plugin_dependency/screen-output
+++ b/tests/plugin_dependency/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.40627e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.60395e-08
 
    Postprocessing:
      RMS, max velocity:             0.00125 m/s, 0.00345 m/s

--- a/tests/plugin_dependency_redundant/screen-output
+++ b/tests/plugin_dependency_redundant/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.40627e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.60395e-08
 
    Postprocessing:
      RMS, max velocity:             0.00125 m/s, 0.00345 m/s

--- a/tests/plugin_dependency_redundant_02/screen-output
+++ b/tests/plugin_dependency_redundant_02/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.40627e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.60395e-08
 
    Postprocessing:
      RMS, max velocity:             0.00125 m/s, 0.00345 m/s

--- a/tests/prescribed_velocity_boundary/screen-output
+++ b/tests/prescribed_velocity_boundary/screen-output
@@ -183,7 +183,7 @@ Boundary_velocity called with boundary_id =3
 Boundary_velocity called with boundary_id =3
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 0
+      Relative Stokes residual after nonlinear iteration 1: 0
 
    Postprocessing:
      Writing graphical output:      output-prescribed_velocity_boundary/solution/solution-00000

--- a/tests/prmbackslash_2/screen-output
+++ b/tests/prmbackslash_2/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.40627e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.60395e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174943e-01, 1.069688e-04, 1.192654e-01

--- a/tests/quick_mpi/screen-output
+++ b/tests/quick_mpi/screen-output
@@ -1,10 +1,3 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 2 MPI processes
---     . using Trilinos
------------------------------------------------------------------------------
 
 Loading shared library <./libquick_mpi.so>
 
@@ -14,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... XYZ iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... XYZ iterations.
-      Nonlinear Stokes residual: 4.40627e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.60395e-08
 
    Postprocessing:
 
@@ -24,15 +17,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.272s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |     0.013s |       4.8% |
-| Build Stokes preconditioner     |         1 |    0.0381s |        14% |
-| Solve Stokes system             |         2 |    0.0374s |        14% |
-| Initialization                  |         2 |    0.0932s |        34% |
-| Postprocessing                  |         1 |  0.000189s |     0.069% |
-| Setup dof systems               |         1 |    0.0468s |        17% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/refinement_topography/screen-output
+++ b/tests/refinement_topography/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.40627e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.60395e-08
 
 Number of active cells: 22 (on 4 levels)
 Number of degrees of freedom: 392 (238+35+119)
@@ -17,9 +17,9 @@ Number of degrees of freedom: 392 (238+35+119)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
-      Nonlinear Stokes residual: 0.0972383
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 8.84825e-09
+      Relative Stokes residual after nonlinear iteration 2: 9.09956e-08
 
 Number of active cells: 46 (on 5 levels)
 Number of degrees of freedom: 791 (482+68+241)
@@ -27,9 +27,9 @@ Number of degrees of freedom: 791 (482+68+241)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-      Nonlinear Stokes residual: 0.097189
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 9.004e-09
+      Relative Stokes residual after nonlinear iteration 2: 9.26442e-08
 
    Postprocessing:
 

--- a/tests/simple_compressibility_iterated_stokes/screen-output
+++ b/tests/simple_compressibility_iterated_stokes/screen-output
@@ -7,15 +7,15 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
-      Nonlinear Stokes residual: 21.2064
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 21+0 iterations.
-      Nonlinear Stokes residual: 0.293292
+      Relative Stokes residual after nonlinear iteration 2: 0.0138303
    Solving Stokes system... 15+0 iterations.
-      Nonlinear Stokes residual: 0.0159071
+      Relative Stokes residual after nonlinear iteration 3: 0.000750107
    Solving Stokes system... 10+0 iterations.
-      Nonlinear Stokes residual: 0.000575262
+      Relative Stokes residual after nonlinear iteration 4: 2.71268e-05
    Solving Stokes system... 5+0 iterations.
-      Nonlinear Stokes residual: 1.44605e-05
+      Relative Stokes residual after nonlinear iteration 5: 6.81892e-07
 
    Postprocessing:
      Top/bottom flux: 1/1

--- a/tests/sol_cx_2/screen-output
+++ b/tests/sol_cx_2/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.40627e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.60395e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174943e-01, 1.069688e-04, 1.192654e-01

--- a/tests/sol_cx_2_conservative/screen-output
+++ b/tests/sol_cx_2_conservative/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 291 (162+48+81)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.04867e-09
+      Relative Stokes residual after nonlinear iteration 2: 4.56923e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 6.986210e-05, 1.148187e-01, 1.007147e-04, 1.149644e-01

--- a/tests/sol_cx_2_normalized_pressure/screen-output
+++ b/tests/sol_cx_2_normalized_pressure/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.40627e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.60395e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.146308e-02, 1.069688e-04, 2.047717e-02

--- a/tests/sol_cx_2_q3/screen-output
+++ b/tests/sol_cx_2_q3/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 500 (338+81+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Nonlinear Stokes residual: 0.0425537
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.73844e-09
+      Relative Stokes residual after nonlinear iteration 2: 8.78524e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 6.425271e-06, 1.103958e-01, 8.407109e-06, 1.110898e-01

--- a/tests/sol_cx_4/screen-output
+++ b/tests/sol_cx_4/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+4 iterations.
-      Nonlinear Stokes residual: 0.0172385
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 2: 1.74731e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 1.125998e-06, 1.101883e-01, 1.670011e-06, 1.106214e-01

--- a/tests/sol_cx_4_conservative/screen-output
+++ b/tests/sol_cx_4_conservative/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 4,035 (2,178+768+1,089)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+4 iterations.
-      Nonlinear Stokes residual: 0.0172385
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.18789e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.89095e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 1.120287e-06, 1.097680e-01, 1.662153e-06, 1.097686e-01

--- a/tests/sol_cx_4_normalized_pressure/screen-output
+++ b/tests/sol_cx_4_normalized_pressure/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+4 iterations.
-      Nonlinear Stokes residual: 0.0172385
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 2: 1.74731e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 1.125998e-06, 2.994139e-03, 1.670011e-06, 9.778440e-03

--- a/tests/sol_cx_4_normalized_pressure_large_static_pressure/screen-output
+++ b/tests/sol_cx_4_normalized_pressure_large_static_pressure/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+8 iterations.
-      Nonlinear Stokes residual: 0.0172385
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 5+0 iterations.
-      Nonlinear Stokes residual: 7.14492e-11
+      Relative Stokes residual after nonlinear iteration 2: 4.14475e-09
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 1.125999e-06, 2.994139e-03, 1.670011e-06, 9.778441e-03

--- a/tests/sol_cx_4_normalized_pressure_low_solver_tolerance/screen-output
+++ b/tests/sol_cx_4_normalized_pressure_low_solver_tolerance/screen-output
@@ -7,7 +7,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Nonlinear Stokes residual: 0.0172385
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 2.005296e-06, 2.986431e-03, 2.624342e-06, 9.764480e-03

--- a/tests/sol_cx_mpi_2/screen-output
+++ b/tests/sol_cx_mpi_2/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.40627e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.60395e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174943e-01, 1.069688e-04, 1.192654e-01

--- a/tests/sol_cx_tracers/screen-output
+++ b/tests/sol_cx_tracers/screen-output
@@ -7,79 +7,79 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+4 iterations.
-      Nonlinear Stokes residual: 0.0172385
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 2: 1.74731e-08
 
    Postprocessing:
      Writing particle output: output-sol_cx_tracers/particles/particles-00000
 
 *** Timestep 1:  t=8.80814 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Writing particle output: output-sol_cx_tracers/particles/particles-00001
 
 *** Timestep 2:  t=17.6163 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Writing particle output: output-sol_cx_tracers/particles/particles-00002
 
 *** Timestep 3:  t=26.4244 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Writing particle output: output-sol_cx_tracers/particles/particles-00003
 
 *** Timestep 4:  t=35.2326 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Writing particle output: output-sol_cx_tracers/particles/particles-00004
 
 *** Timestep 5:  t=44.0407 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Writing particle output: output-sol_cx_tracers/particles/particles-00005
 
 *** Timestep 6:  t=52.8489 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Writing particle output: output-sol_cx_tracers/particles/particles-00006
 
 *** Timestep 7:  t=61.657 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Writing particle output: output-sol_cx_tracers/particles/particles-00007
 
 *** Timestep 8:  t=70.4652 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Writing particle output: output-sol_cx_tracers/particles/particles-00008
 
 *** Timestep 9:  t=79.2733 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Writing particle output: output-sol_cx_tracers/particles/particles-00009
 
 *** Timestep 10:  t=88.0814 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.01209e-10
+      Relative Stokes residual after nonlinear iteration 1: 1.37649e-08
 
    Postprocessing:
      Writing particle output: output-sol_cx_tracers/particles/particles-00010
@@ -90,18 +90,18 @@ Number of degrees of freedom: 3,379 (2,070+274+1,035)
 *** Timestep 11:  t=96.8896 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-      Nonlinear Stokes residual: 0.00859464
+      Relative Stokes residual after nonlinear iteration 1: 0.337215
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.93775e-09
+      Relative Stokes residual after nonlinear iteration 2: 7.47449e-08
 
    Postprocessing:
      Writing particle output: output-sol_cx_tracers/particles/particles-00011
 
 *** Timestep 12:  t=100 seconds
    Solving Stokes system... 27+0 iterations.
-      Nonlinear Stokes residual: 0.00303502
+      Relative Stokes residual after nonlinear iteration 1: 0.101315
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 2.00346e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.55627e-08
 
    Postprocessing:
      Writing particle output: output-sol_cx_tracers/particles/particles-00012

--- a/tests/sol_kz_2/screen-output
+++ b/tests/sol_kz_2/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Nonlinear Stokes residual: 0.0670283
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.20581e-09
+      Relative Stokes residual after nonlinear iteration 2: 4.78278e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 5.054536e-06, 1.492379e-02, 7.343796e-06, 1.994004e-02

--- a/tests/sol_kz_2_cheaper_first_phase_solver/screen-output
+++ b/tests/sol_kz_2_cheaper_first_phase_solver/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Nonlinear Stokes residual: 0.0670283
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.20581e-09
+      Relative Stokes residual after nonlinear iteration 2: 4.78278e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 5.054536e-06, 1.492379e-02, 7.343796e-06, 1.994004e-02

--- a/tests/sol_kz_2_conservative/screen-output
+++ b/tests/sol_kz_2_conservative/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Nonlinear Stokes residual: 0.0670283
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.20581e-09
+      Relative Stokes residual after nonlinear iteration 2: 4.78278e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 5.054536e-06, 1.492379e-02, 7.343796e-06, 1.994004e-02

--- a/tests/sol_kz_2_no_first_phase_solver/screen-output
+++ b/tests/sol_kz_2_no_first_phase_solver/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+10 iterations.
-      Nonlinear Stokes residual: 0.0670283
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 3.30164e-09
+      Relative Stokes residual after nonlinear iteration 2: 4.92574e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 5.054533e-06, 1.492380e-02, 7.343793e-06, 1.994001e-02

--- a/tests/sol_kz_2_q3/screen-output
+++ b/tests/sol_kz_2_q3/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 500 (338+81+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
-      Nonlinear Stokes residual: 0.0474325
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.77156e-09
+      Relative Stokes residual after nonlinear iteration 2: 3.73491e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 7.274379e-07, 2.219142e-03, 1.423558e-06, 3.234704e-03

--- a/tests/sol_kz_4/screen-output
+++ b/tests/sol_kz_4/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+7 iterations.
-      Nonlinear Stokes residual: 0.0186602
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.6063e-09
+      Relative Stokes residual after nonlinear iteration 2: 8.60815e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 9.024097e-08, 6.588228e-04, 2.330070e-07, 1.068890e-03

--- a/tests/sol_kz_4_conservative/screen-output
+++ b/tests/sol_kz_4_conservative/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+7 iterations.
-      Nonlinear Stokes residual: 0.0186602
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.6063e-09
+      Relative Stokes residual after nonlinear iteration 2: 8.60815e-08
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 9.024097e-08, 6.588228e-04, 2.330070e-07, 1.068890e-03

--- a/tests/tangurnis/screen-output
+++ b/tests/tangurnis/screen-output
@@ -7,19 +7,19 @@ Number of degrees of freedom: 54,148 (33,282+4,225+16,641)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+2 iterations.
-      Nonlinear Stokes residual: 0.0056096
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 26+0 iterations.
-      Nonlinear Stokes residual: 0.0126531
+      Relative Stokes residual after nonlinear iteration 2: 2.25562
    Solving Stokes system... 20+0 iterations.
-      Nonlinear Stokes residual: 0.000344376
+      Relative Stokes residual after nonlinear iteration 3: 0.0613904
    Solving Stokes system... 15+0 iterations.
-      Nonlinear Stokes residual: 2.54573e-05
+      Relative Stokes residual after nonlinear iteration 4: 0.00453817
    Solving Stokes system... 10+0 iterations.
-      Nonlinear Stokes residual: 1.03201e-06
+      Relative Stokes residual after nonlinear iteration 5: 0.000183972
    Solving Stokes system... 6+0 iterations.
-      Nonlinear Stokes residual: 7.38617e-08
+      Relative Stokes residual after nonlinear iteration 6: 1.3167e-05
    Solving Stokes system... 2+0 iterations.
-      Nonlinear Stokes residual: 3.43053e-09
+      Relative Stokes residual after nonlinear iteration 7: 6.11547e-07
 
    Postprocessing:
      writing:                  output.csv
@@ -27,7 +27,7 @@ Number of degrees of freedom: 54,148 (33,282+4,225+16,641)
 
 *** Timestep 1:  t=0.0001 seconds
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 1.11606e-09
+      Relative Stokes residual after nonlinear iteration 1: 8.42171e-08
 
    Postprocessing:
      writing:                  output.csv

--- a/tests/viz_plugin_dependency/screen-output
+++ b/tests/viz_plugin_dependency/screen-output
@@ -7,9 +7,9 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Nonlinear Stokes residual: 0.0667217
+      Relative Stokes residual after nonlinear iteration 1: 1
    Solving Stokes system... 0+0 iterations.
-      Nonlinear Stokes residual: 4.40627e-09
+      Relative Stokes residual after nonlinear iteration 2: 6.60395e-08
 
    Postprocessing:
      RMS, max velocity:        0.00125 m/s, 0.00345 m/s


### PR DESCRIPTION
See changes.h entry. We used a hard-coded value instead of an input parameter, and we computed the residual not consistently with the other nonlinear solver schemes. @MFraters maybe you can take a look? You have the most experience with these solver schemes.