### PR TITLE
Remove deprecated heating parameters from input files

### DIFF
--- a/benchmark/crameri_et_al/case_1/crameri_benchmark_1.prm
+++ b/benchmark/crameri_et_al/case_1/crameri_benchmark_1.prm
@@ -97,8 +97,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = bottom, top
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = left, right

--- a/benchmark/crameri_et_al/case_2/crameri_benchmark_2.prm
+++ b/benchmark/crameri_et_al/case_2/crameri_benchmark_2.prm
@@ -91,8 +91,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = bottom, top
   set Prescribed velocity boundary indicators = 
   set Tangential velocity boundary indicators = left, right

--- a/benchmark/davies_et_al/case-1.1.prm
+++ b/benchmark/davies_et_al/case-1.1.prm
@@ -26,8 +26,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators = 
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = 0,1
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 # Ra is determined by g*alpha

--- a/benchmark/davies_et_al/case-2.1.prm
+++ b/benchmark/davies_et_al/case-2.1.prm
@@ -38,8 +38,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators = 
   set Tangential velocity boundary indicators = 0,1
   set Zero velocity boundary indicators       = 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 subsection Gravity model

--- a/benchmark/davies_et_al/case-2.2.prm
+++ b/benchmark/davies_et_al/case-2.2.prm
@@ -38,8 +38,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators = 
   set Tangential velocity boundary indicators = 0,1
   set Zero velocity boundary indicators       = 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 subsection Gravity model

--- a/benchmark/davies_et_al/case-2.3.prm
+++ b/benchmark/davies_et_al/case-2.3.prm
@@ -41,8 +41,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators = 
   set Tangential velocity boundary indicators = 0,1
   set Zero velocity boundary indicators       = 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 subsection Gravity model

--- a/benchmark/shear_bands/magmatic_shear_bands.prm
+++ b/benchmark/shear_bands/magmatic_shear_bands.prm
@@ -150,7 +150,6 @@ subsection Model settings
   set Zero velocity boundary indicators       = 
 
   set Include melt transport                  = true
-  set Include shear heating                   = false
 end
 
 subsection Melt settings

--- a/benchmark/shear_bands/shear_bands.prm
+++ b/benchmark/shear_bands/shear_bands.prm
@@ -135,7 +135,6 @@ subsection Model settings
   set Zero velocity boundary indicators       = 
 
   set Include melt transport                  = true
-  set Include shear heating                   = false
 end
 
 subsection Melt settings

--- a/benchmark/solitary_wave/solitary_wave.prm
+++ b/benchmark/solitary_wave/solitary_wave.prm
@@ -146,7 +146,6 @@ subsection Model settings
   set Zero velocity boundary indicators       = 
 
   set Include melt transport                  = true
-  set Include shear heating                   = false
 end
 
 subsection Melt settings

--- a/benchmark/tangurnis/ba/tan.prm
+++ b/benchmark/tangurnis/ba/tan.prm
@@ -231,8 +231,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
   # A comma separated list of integers denoting those boundaries on which the
   # temperature is fixed and described by the boundary temperature object

--- a/benchmark/tangurnis/tala/tan.prm
+++ b/benchmark/tangurnis/tala/tan.prm
@@ -228,8 +228,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
   # A comma separated list of integers denoting those boundaries on which the
   # temperature is fixed and described by the boundary temperature object

--- a/benchmark/tangurnis/tala_c/tan.prm
+++ b/benchmark/tangurnis/tala_c/tan.prm
@@ -230,8 +230,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
   # A comma separated list of integers denoting those boundaries on which the
   # temperature is fixed and described by the boundary temperature object

--- a/cookbooks/S20RTS.prm
+++ b/cookbooks/S20RTS.prm
@@ -108,8 +108,6 @@ end
 subsection Model settings
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include adiabatic heating               = false 
-  set Include shear heating                   = false
 
   set Tangential velocity boundary indicators = 0,1
 end

--- a/cookbooks/convection-box-3d.prm
+++ b/cookbooks/convection-box-3d.prm
@@ -103,8 +103,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/cookbooks/convection-box.prm
+++ b/cookbooks/convection-box.prm
@@ -103,8 +103,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/cookbooks/convection-box.prm
+++ b/cookbooks/convection-box.prm
@@ -97,12 +97,6 @@ subsection Model settings
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = left, right, bottom, top
-
-  # The final part of this section describes whether we
-  # want to include adiabatic heating (from a small
-  # compressibility of the medium) or from shear friction,
-  # as well as the rate of internal heating. We do not
-  # want to use any of these options here:
 end
 
 

--- a/cookbooks/crustal_model_2D.prm
+++ b/cookbooks/crustal_model_2D.prm
@@ -28,8 +28,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Prescribed velocity boundary indicators = left: function, right:function, bottom:function
   set Free surface boundary indicators        = top
 end

--- a/cookbooks/crustal_model_3D.prm
+++ b/cookbooks/crustal_model_3D.prm
@@ -29,8 +29,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = front,back 
   set Prescribed velocity boundary indicators = left: function, right:function, bottom:function
   set Free surface boundary indicators        = top

--- a/cookbooks/finite_strain/finite_strain.prm
+++ b/cookbooks/finite_strain/finite_strain.prm
@@ -145,8 +145,6 @@ subsection Model settings
   set Zero velocity boundary indicators       =
 #  set Remove nullspace                        = net x translation
 
-  set Include adiabatic heating               = false
-  set Include latent heat                     = false
 end
 
 

--- a/cookbooks/free-surface-with-crust/free-surface-with-crust.prm
+++ b/cookbooks/free-surface-with-crust/free-surface-with-crust.prm
@@ -113,8 +113,6 @@ end
 # boundary conditions, as well as free slip boundary
 # conditions for the sides and bottom. 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 0,1,2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1,2

--- a/cookbooks/free-surface.prm
+++ b/cookbooks/free-surface.prm
@@ -104,8 +104,6 @@ end
 # boundary conditions, as well as free slip boundary
 # conditions for the sides and bottom. 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = left, right, bottom, top
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = left, right, bottom

--- a/cookbooks/future/netrot.prm
+++ b/cookbooks/future/netrot.prm
@@ -36,7 +36,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = inner, outer
 
-  set Include shear heating                   = true
 
   # net rotation|net translation|angular momentum|translational momentum
   set Remove nullspace = net rotation
@@ -82,4 +81,8 @@ subsection Postprocess
   subsection Depth average
     set Time between graphical output = 1e6
   end
+end
+
+subsection Heating model
+  set List of model names =  shear heating
 end

--- a/cookbooks/future/nettranslation.prm
+++ b/cookbooks/future/nettranslation.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = bottom, top
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = bottom, top

--- a/cookbooks/future/periodic_box.prm
+++ b/cookbooks/future/periodic_box.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = bottom, top
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = bottom, top

--- a/cookbooks/future/radiogenic_heating.prm
+++ b/cookbooks/future/radiogenic_heating.prm
@@ -41,9 +41,6 @@ subsection Model settings
 
   # As we only want to look at the effects of radiogenic, we disable all
   # the other heating terms. 
-  set Include adiabatic heating               = false
-  set Include latent heat                     = false
-  set Include shear heating                   = false
 
   # We only fix the temperature at the upper boundary, the other boundaries
   # are isolating. To guarantuee a steady downward flow, we fix the velocity

--- a/cookbooks/future/radiogenic_heating_function.prm
+++ b/cookbooks/future/radiogenic_heating_function.prm
@@ -43,9 +43,6 @@ subsection Model settings
 
   # As we only want to look at the effects of radiogenic, we disable all
   # the other heating terms. 
-  set Include adiabatic heating               = false
-  set Include latent heat                     = false
-  set Include shear heating                   = false
 
   # We only fix the temperature at the upper boundary, the other boundaries
   # are isolating. To guarantuee a steady downward flow, we fix the velocity

--- a/cookbooks/future/sphere.prm
+++ b/cookbooks/future/sphere.prm
@@ -28,7 +28,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = surface
   set Prescribed velocity boundary indicators =
   set Fixed temperature boundary indicators   = surface
-  set Include shear heating                   = false 
   set Remove nullspace = net rotation
 end
 

--- a/cookbooks/future/steinberger.prm
+++ b/cookbooks/future/steinberger.prm
@@ -286,11 +286,6 @@ subsection Model settings
   # no-flux (insulating) boundary conditions.
   set Fixed temperature boundary indicators   = inner, outer
 
-  # Whether to include shear heating into the model or not. From a physical
-  # viewpoint, shear heating should always be used but may be undesirable when
-  # comparing results with known benchmarks that do not include this term in
-  # the temperature equation.
-
   # A comma separated list of integers denoting those boundaries on which the
   # velocity is tangential but prescribed, i.e., where external forces act to
   # prescribe a particular velocity. This is often used to prescribe a

--- a/cookbooks/future/steinberger.prm
+++ b/cookbooks/future/steinberger.prm
@@ -290,7 +290,6 @@ subsection Model settings
   # viewpoint, shear heating should always be used but may be undesirable when
   # comparing results with known benchmarks that do not include this term in
   # the temperature equation.
-  set Include shear heating                   = false
 
   # A comma separated list of integers denoting those boundaries on which the
   # velocity is tangential but prescribed, i.e., where external forces act to

--- a/cookbooks/geomIO.prm
+++ b/cookbooks/geomIO.prm
@@ -59,8 +59,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/cookbooks/gplates-2d.prm
+++ b/cookbooks/gplates-2d.prm
@@ -35,7 +35,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = inner, outer
 
-  set Include shear heating                   = false
 end
 
 

--- a/cookbooks/gplates-3d.prm
+++ b/cookbooks/gplates-3d.prm
@@ -37,7 +37,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = inner, outer
 
-  set Include shear heating                   = false
 end
 
 

--- a/cookbooks/latent-heat.prm
+++ b/cookbooks/latent-heat.prm
@@ -34,9 +34,6 @@ subsection Model settings
 
   # As we only want to look at the effects of latent heating, we disable all
   # the other heating terms. 
-  set Include adiabatic heating               = false
-  set Include latent heat                     = true
-  set Include shear heating                   = false
 
   # We only fix the temperature at the upper boundary, the other boundaries
   # are isolating. To guarantuee a steady downward flow, we fix the velocity
@@ -154,4 +151,8 @@ subsection Postprocess
     set Time between graphical output = 5e17
     set List of output variables      = density
   end
+end
+
+subsection Heating model
+  set List of model names =  latent heat
 end

--- a/cookbooks/latent-heat.prm
+++ b/cookbooks/latent-heat.prm
@@ -30,11 +30,14 @@ subsection Gravity model
 end
 
 
-subsection Model settings
-
+subsection Heating model
   # As we only want to look at the effects of latent heating, we disable all
   # the other heating terms. 
+  set List of model names =  latent heat
+end
 
+
+subsection Model settings
   # We only fix the temperature at the upper boundary, the other boundaries
   # are isolating. To guarantuee a steady downward flow, we fix the velocity
   # at the top and bottom, and set it to free slip on the sides. 
@@ -151,8 +154,4 @@ subsection Postprocess
     set Time between graphical output = 5e17
     set List of output variables      = density
   end
-end
-
-subsection Heating model
-  set List of model names =  latent heat
 end

--- a/cookbooks/shell_simple_2d.prm
+++ b/cookbooks/shell_simple_2d.prm
@@ -36,7 +36,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = inner, outer
 
-  set Include shear heating                   = true
 end
 
 
@@ -79,4 +78,8 @@ subsection Postprocess
   subsection Depth average
     set Time between graphical output = 1e6
   end
+end
+
+subsection Heating model
+  set List of model names =  shear heating
 end

--- a/cookbooks/shell_simple_2d.prm
+++ b/cookbooks/shell_simple_2d.prm
@@ -33,9 +33,12 @@ subsection Model settings
   set Zero velocity boundary indicators       = inner
   set Tangential velocity boundary indicators = outer, left, right
   set Prescribed velocity boundary indicators =
-
   set Fixed temperature boundary indicators   = inner, outer
+end
 
+
+subsection Heating model
+  set List of model names =  shear heating
 end
 
 
@@ -78,8 +81,4 @@ subsection Postprocess
   subsection Depth average
     set Time between graphical output = 1e6
   end
-end
-
-subsection Heating model
-  set List of model names =  shear heating
 end

--- a/cookbooks/shell_simple_2d_smoothing.prm
+++ b/cookbooks/shell_simple_2d_smoothing.prm
@@ -56,7 +56,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = inner, outer
 
-  set Include shear heating                   = true
 end
 
 
@@ -100,3 +99,7 @@ subsection Postprocess
   end
 end
 
+
+subsection Heating model
+  set List of model names =  shear heating
+end

--- a/cookbooks/shell_simple_3d.prm
+++ b/cookbooks/shell_simple_3d.prm
@@ -35,7 +35,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = inner, outer
 
-  set Include shear heating                   = false
 end
 
 

--- a/cookbooks/sinker-with-averaging/sinker-with-averaging.prm
+++ b/cookbooks/sinker-with-averaging/sinker-with-averaging.prm
@@ -16,8 +16,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = left, right, bottom, top
 end

--- a/cookbooks/van-keken-discontinuous.prm
+++ b/cookbooks/van-keken-discontinuous.prm
@@ -17,8 +17,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/cookbooks/van-keken-smooth.prm
+++ b/cookbooks/van-keken-smooth.prm
@@ -18,8 +18,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/doc/manual/cookbooks/benchmarks/davies_et_al/case-2.1.prm
+++ b/doc/manual/cookbooks/benchmarks/davies_et_al/case-2.1.prm
@@ -5,6 +5,4 @@ subsection Model settings
   set Prescribed velocity boundary indicators = 
   set Tangential velocity boundary indicators = 0,1
   set Zero velocity boundary indicators       = 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false 
 end

--- a/doc/manual/cookbooks/convection-box/box.prm
+++ b/doc/manual/cookbooks/convection-box/box.prm
@@ -103,8 +103,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/doc/manual/cookbooks/convection-box/box.prm
+++ b/doc/manual/cookbooks/convection-box/box.prm
@@ -97,12 +97,6 @@ subsection Model settings
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = left, right, bottom, top
-
-  # The final part of this section describes whether we
-  # want to include adiabatic heating (from a small
-  # compressibility of the medium) or from shear friction,
-  # as well as the rate of internal heating. We do not
-  # want to use any of these options here:
 end
 
 

--- a/doc/manual/cookbooks/free_surface/freesurface.part.prm
+++ b/doc/manual/cookbooks/free_surface/freesurface.part.prm
@@ -13,8 +13,6 @@ subsection Free surface
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = left, right, bottom, top
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = left, right, bottom

--- a/doc/manual/cookbooks/gplates/gplates.part.prm
+++ b/doc/manual/cookbooks/gplates/gplates.part.prm
@@ -3,7 +3,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = inner
 
   set Fixed temperature boundary indicators   = inner, outer
-  set Include shear heating                   = false 
 end
 
 subsection Boundary velocity model

--- a/doc/manual/cookbooks/shell_simple_2d/shearheat.part.prm
+++ b/doc/manual/cookbooks/shell_simple_2d/shearheat.part.prm
@@ -1,2 +1,3 @@
-subsection Model settings
+subsection Heating model
+  set List of model names =
 end

--- a/doc/manual/cookbooks/shell_simple_2d/shearheat.part.prm
+++ b/doc/manual/cookbooks/shell_simple_2d/shearheat.part.prm
@@ -1,3 +1,2 @@
 subsection Model settings
-  set Include shear heating                   = false 
 end

--- a/doc/manual/cookbooks/shell_simple_2d/shell.prm
+++ b/doc/manual/cookbooks/shell_simple_2d/shell.prm
@@ -32,7 +32,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = inner, outer
 
-  set Include shear heating                   = true 
 end
 
 
@@ -76,4 +75,8 @@ subsection Postprocess
   subsection Depth average
     set Time between graphical output = 1e6 
   end
+end
+
+subsection Heating model
+  set List of model names =  shear heating
 end

--- a/doc/manual/cookbooks/shell_simple_2d/shell.prm
+++ b/doc/manual/cookbooks/shell_simple_2d/shell.prm
@@ -29,9 +29,7 @@ subsection Model settings
   set Zero velocity boundary indicators       = inner
   set Tangential velocity boundary indicators = outer, left, right
   set Prescribed velocity boundary indicators = 
-
   set Fixed temperature boundary indicators   = inner, outer
-
 end
 
 
@@ -41,6 +39,11 @@ subsection Boundary temperature model
     set Inner temperature = 4273 
     set Outer temperature = 973 
   end
+end
+
+
+subsection Heating model
+  set List of model names =  shear heating
 end
 
 
@@ -75,8 +78,4 @@ subsection Postprocess
   subsection Depth average
     set Time between graphical output = 1e6 
   end
-end
-
-subsection Heating model
-  set List of model names =  shear heating
 end

--- a/doc/manual/cookbooks/shell_simple_3d/part2.part.prm
+++ b/doc/manual/cookbooks/shell_simple_3d/part2.part.prm
@@ -15,5 +15,4 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = inner, outer
 
-  set Include shear heating                   = false 
 end

--- a/doc/manual/cookbooks/sinker-with-averaging/full.prm
+++ b/doc/manual/cookbooks/sinker-with-averaging/full.prm
@@ -16,8 +16,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = left, right, bottom, top
 end

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -524,8 +524,12 @@ due to $\mathbf g$ pointing downwards)
   & \approx -\alpha \rho T \mathbf u \cdot \mathbf g.
 \end{align*}
 While this simplification is possible, it is not necessary if you have access
-to the total pressure. \aspect{} therefore implements the original term
-without this simplification.
+to the total pressure. \aspect{} therefore by default implements the original 
+term without this simplification, but allows to simplify this term by setting
+the ``\texttt{Use simplified adiabatic heating}'' 
+\index[prmindex]{Use simplified adiabatic heating}
+\index[prmindexfull]{Heating model!Adiabatic heating!Use simplified adiabatic heating}
+parameter in section~\ref{parameters:Heating_20model/Adiabatic_20heating}.
 
 \subsubsection{Boundary conditions}
 Having discussed \eqref{eq:temperature}, let us come to the last one of the
@@ -5712,13 +5716,7 @@ In the following, let us pick apart this input file:
   spherical approximation of Earth.
 
   \item The second part of the model description and boundary values follows in
-  lines 28--45. There, we describe that we want a model where equation
-  \eqref{eq:temperature} contains the shear heating term $2\eta
-  \varepsilon(\mathbf u):\varepsilon(\mathbf u)$ (noting that the default is to
-  use an incompressible model for which the term $\frac{1}{3}(\nabla \cdot
-  \mathbf u)\mathbf 1$ in the shear heating contribution is zero).
-
-  The boundary conditions require us to look up how the geometry model
+  lines 28--42. The boundary conditions require us to look up how the geometry model
   we chose (the \texttt{spherical shell} model) assigns boundary indicators to
   the four sides of the domain. This is described in
   Section~\ref{parameters:Geometry_20model} where the model announces that
@@ -5736,6 +5734,15 @@ In the following, let us pick apart this input file:
   700 and 4000 degrees Celsius -- roughly realistic for the bottom of the crust
   and the core-mantle boundary.
 
+  \item Lines 45--47 describe that we want a model where equation
+  \eqref{eq:temperature} contains the shear heating term $2\eta
+  \varepsilon(\mathbf u):\varepsilon(\mathbf u)$ (noting that the default is to
+  use an incompressible model for which the term $\frac{1}{3}(\nabla \cdot
+  \mathbf u)\mathbf 1$ in the shear heating contribution is zero). Considering a
+  reasonable choice of heating terms is not the focus of this simple cookbook,
+  therefore we will leave a discussion of possible and reasonable heating terms
+  to another cookbook.
+
   \item The description of what we want to model is complete by specifying
   that the initial temperature is a perturbation with hexagonal symmetry from a
   linear interpolation between inner and outer temperatures (see
@@ -5744,8 +5751,8 @@ In the following, let us pick apart this input file:
   Section~\ref{parameters:Gravity_20model}).
 
   \item The remainder of the input file consists of a description of how to
-  choose the initial mesh and how to adapt it (lines 58--63) and what to do at
-  the end of each time step with the solution that \aspect{} computes for us (lines 66--79).
+  choose the initial mesh and how to adapt it (lines 60--65) and what to do at
+  the end of each time step with the solution that \aspect{} computes for us (lines 68--81).
   Here, we ask for a variety of statistical quantities and for graphical output
   in VTU format every million years.
 \end{enumerate}
@@ -5885,9 +5892,9 @@ computed quantity.}
 There are two issues one should notice here.
 The more obvious one is that the flux from the mantle to the air is consistently
 higher than the heat flux from core to mantle. Since we have no radiogenic
-heating model selected (see the \texttt{Model name}
-\index[prmindex]{Model name}
-\index[prmindexfull]{Heating model!Model name}
+heating model selected (see the \texttt{List of model names}
+\index[prmindex]{List of model names}
+\index[prmindexfull]{Heating model!List of model names}
 parameter in the \texttt{Heating model} section of the input file; see also
 Section~\ref{parameters:Heating_20model}), in the long run the heat output
 of the mantle must equal the input, unless is cools. Our misconception was that

--- a/tests/additional_outputs.prm
+++ b/tests/additional_outputs.prm
@@ -83,8 +83,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/additional_outputs_02.prm
+++ b/tests/additional_outputs_02.prm
@@ -79,8 +79,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/additional_outputs_03.prm
+++ b/tests/additional_outputs_03.prm
@@ -80,8 +80,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/adiabatic_boundary.prm
+++ b/tests/adiabatic_boundary.prm
@@ -54,8 +54,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1,2,3,4,5 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/adiabatic_initial_conditions_constant.prm
+++ b/tests/adiabatic_initial_conditions_constant.prm
@@ -86,7 +86,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0, 2, 3
   set Zero velocity boundary indicators       = 1
-  set Include adiabatic heating               = false
 end
 
 subsection Postprocess

--- a/tests/advect_mesh_vertically.prm
+++ b/tests/advect_mesh_vertically.prm
@@ -78,8 +78,6 @@ subsection Mesh refinement
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = left, right, bottom, top
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = left, right, bottom

--- a/tests/anisotropic_viscosity.prm
+++ b/tests/anisotropic_viscosity.prm
@@ -77,7 +77,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0, 1
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators = 2: function
-  set Include shear heating = false
 end
 
 subsection Boundary velocity model

--- a/tests/artificial_viscosity.prm
+++ b/tests/artificial_viscosity.prm
@@ -118,7 +118,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = 
 
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_boundary_member.prm
+++ b/tests/ascii_boundary_member.prm
@@ -39,8 +39,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_boundary_composition_2d_box_time.prm
+++ b/tests/ascii_data_boundary_composition_2d_box_time.prm
@@ -62,8 +62,6 @@ subsection Model settings
 
   set Prescribed velocity boundary indicators = top: function, bottom: function, left:function, right:function
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_boundary_composition_3d_box.prm
+++ b/tests/ascii_data_boundary_composition_3d_box.prm
@@ -52,8 +52,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_boundary_temperature_2d_box_time.prm
+++ b/tests/ascii_data_boundary_temperature_2d_box_time.prm
@@ -44,8 +44,6 @@ subsection Model settings
 
   set Prescribed velocity boundary indicators = top: function, bottom: function, left:function, right:function
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_boundary_temperature_3d_box.prm
+++ b/tests/ascii_data_boundary_temperature_3d_box.prm
@@ -42,8 +42,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_boundary_velocity_2d_box.prm
+++ b/tests/ascii_data_boundary_velocity_2d_box.prm
@@ -39,8 +39,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_boundary_velocity_2d_box_time.prm
+++ b/tests/ascii_data_boundary_velocity_2d_box_time.prm
@@ -38,8 +38,6 @@ subsection Model settings
 
   set Prescribed velocity boundary indicators = top: ascii data, bottom: function, left:ascii data, right:ascii data
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_boundary_velocity_2d_box_time_backward.prm
+++ b/tests/ascii_data_boundary_velocity_2d_box_time_backward.prm
@@ -38,8 +38,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators = top: ascii data, bottom: function
   set Tangential velocity boundary indicators = left,right
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_boundary_velocity_2d_chunk.prm
+++ b/tests/ascii_data_boundary_velocity_2d_chunk.prm
@@ -43,8 +43,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_boundary_velocity_2d_shell.prm
+++ b/tests/ascii_data_boundary_velocity_2d_shell.prm
@@ -43,8 +43,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_boundary_velocity_3d_box.prm
+++ b/tests/ascii_data_boundary_velocity_3d_box.prm
@@ -45,8 +45,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_boundary_velocity_3d_chunk.prm
+++ b/tests/ascii_data_boundary_velocity_3d_chunk.prm
@@ -45,8 +45,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = north, south, inner, outer
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_boundary_velocity_3d_shell.prm
+++ b/tests/ascii_data_boundary_velocity_3d_shell.prm
@@ -43,8 +43,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_initial_composition_2d_box.prm
+++ b/tests/ascii_data_initial_composition_2d_box.prm
@@ -51,8 +51,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_initial_composition_3d_chunk.prm
+++ b/tests/ascii_data_initial_composition_3d_chunk.prm
@@ -46,8 +46,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = north, south, east, west, inner, outer
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 subsection Boundary velocity model

--- a/tests/ascii_data_initial_composition_3d_shell.prm
+++ b/tests/ascii_data_initial_composition_3d_shell.prm
@@ -44,8 +44,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 subsection Boundary velocity model

--- a/tests/ascii_data_initial_temperature_2d_box.prm
+++ b/tests/ascii_data_initial_temperature_2d_box.prm
@@ -38,8 +38,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_initial_temperature_3d_chunk.prm
+++ b/tests/ascii_data_initial_temperature_3d_chunk.prm
@@ -34,8 +34,6 @@ subsection Model settings
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators = west:function, east:function, south:function, north:function, inner:function, outer:function
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 subsection Boundary velocity model

--- a/tests/ascii_data_initial_temperature_3d_shell.prm
+++ b/tests/ascii_data_initial_temperature_3d_shell.prm
@@ -35,8 +35,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 subsection Boundary velocity model

--- a/tests/ascii_data_nonuniform_initial_composition_2d_box.prm
+++ b/tests/ascii_data_nonuniform_initial_composition_2d_box.prm
@@ -55,8 +55,6 @@ subsection Model settings
 
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ascii_data_prescribed_stokes_2d_box.prm
+++ b/tests/ascii_data_prescribed_stokes_2d_box.prm
@@ -58,8 +58,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 
 
   
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/average_arithmetic.prm
+++ b/tests/average_arithmetic.prm
@@ -18,8 +18,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = left, right, bottom, top
 end

--- a/tests/average_geometric.prm
+++ b/tests/average_geometric.prm
@@ -18,8 +18,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = left, right, bottom, top
 end

--- a/tests/average_harmonic.prm
+++ b/tests/average_harmonic.prm
@@ -18,8 +18,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = left, right, bottom, top
 end

--- a/tests/average_log.prm
+++ b/tests/average_log.prm
@@ -18,8 +18,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = left, right, bottom, top
 end

--- a/tests/average_none.prm
+++ b/tests/average_none.prm
@@ -18,8 +18,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = left, right, bottom, top
 end

--- a/tests/average_nwd_arithmetic.prm
+++ b/tests/average_nwd_arithmetic.prm
@@ -18,8 +18,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = left, right, bottom, top
 end

--- a/tests/average_nwd_geometric.prm
+++ b/tests/average_nwd_geometric.prm
@@ -18,8 +18,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = left, right, bottom, top
 end

--- a/tests/average_nwd_harmonic.prm
+++ b/tests/average_nwd_harmonic.prm
@@ -18,8 +18,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = left, right, bottom, top
 end

--- a/tests/average_pick_largest.prm
+++ b/tests/average_pick_largest.prm
@@ -18,8 +18,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = left, right, bottom, top
 end

--- a/tests/average_project_to_q1.prm
+++ b/tests/average_project_to_q1.prm
@@ -18,8 +18,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = left, right, bottom, top
 end

--- a/tests/blankenbach.prm
+++ b/tests/blankenbach.prm
@@ -75,8 +75,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false 
   set Prescribed velocity boundary indicators = 
   set Tangential velocity boundary indicators = left, right, bottom, top
   set Zero velocity boundary indicators       = 

--- a/tests/compressibility.prm
+++ b/tests/compressibility.prm
@@ -110,7 +110,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0, 1
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators = 2: function
-  set Include shear heating = false
 end
 
 subsection Boundary velocity model

--- a/tests/compressibility_iterated_stokes.prm
+++ b/tests/compressibility_iterated_stokes.prm
@@ -98,7 +98,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0, 1
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators = 2: function
-  set Include shear heating = false
 end
 
 subsection Boundary velocity model

--- a/tests/compressibility_iterated_stokes_direct_solver.prm
+++ b/tests/compressibility_iterated_stokes_direct_solver.prm
@@ -79,7 +79,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0, 1
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators = 2: function
-  set Include shear heating = false
 end
 
 subsection Boundary velocity model

--- a/tests/conservative_with_mpi.prm
+++ b/tests/conservative_with_mpi.prm
@@ -90,8 +90,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/constant_composition_convergence.prm
+++ b/tests/constant_composition_convergence.prm
@@ -24,8 +24,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0, 1, 2 ,3
   set Prescribed velocity boundary indicators = 
 
-  set Include shear heating = false
-  set Include adiabatic heating = false
 end
 
 subsection Boundary temperature model

--- a/tests/coordinate_transformation.prm
+++ b/tests/coordinate_transformation.prm
@@ -83,8 +83,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/density_boundary.prm
+++ b/tests/density_boundary.prm
@@ -77,8 +77,6 @@ end
 subsection Model settings
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include adiabatic heating               = true
-  set Include shear heating                   = false
 
   set Tangential velocity boundary indicators = 0,2,3
   set Zero velocity boundary indicators       = 1
@@ -100,4 +98,8 @@ subsection Postprocess
     set Number of zones = 10
   end
 
+end
+
+subsection Heating model
+  set List of model names = adiabatic heating
 end

--- a/tests/depth_average_01.prm
+++ b/tests/depth_average_01.prm
@@ -66,8 +66,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/depth_average_02.prm
+++ b/tests/depth_average_02.prm
@@ -64,8 +64,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/depth_average_03.prm
+++ b/tests/depth_average_03.prm
@@ -67,8 +67,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/depth_average_04.prm
+++ b/tests/depth_average_04.prm
@@ -64,8 +64,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/depth_average_05.prm
+++ b/tests/depth_average_05.prm
@@ -54,8 +54,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1,2,3
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/depth_average_txt_output.prm
+++ b/tests/depth_average_txt_output.prm
@@ -54,8 +54,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1,2,3
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/depth_average_underres.prm
+++ b/tests/depth_average_underres.prm
@@ -68,8 +68,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/depth_dependent_3d_shell_list_simple.prm
+++ b/tests/depth_dependent_3d_shell_list_simple.prm
@@ -44,7 +44,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = inner, outer
 
-  set Include shear heating                   = false
 end
 
 

--- a/tests/depth_dependent_box_file_simple.prm
+++ b/tests/depth_dependent_box_file_simple.prm
@@ -106,8 +106,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/depth_dependent_box_function_simple.prm
+++ b/tests/depth_dependent_box_function_simple.prm
@@ -106,8 +106,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/depth_dependent_box_none_simple.prm
+++ b/tests/depth_dependent_box_none_simple.prm
@@ -106,8 +106,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/diffusion.prm
+++ b/tests/diffusion.prm
@@ -291,18 +291,6 @@ end
 
 
 subsection Model settings
-  # Whether to include adiabatic heating into the model or not. From a
-  # physical viewpoint, adiabatic heating should always be used but may be
-  # undesirable when comparing results with known benchmarks that do not
-  # include this term in the temperature equation.
-
-  # Whether to include shear heating into the model or not. From a physical
-  # viewpoint, shear heating should always be used but may be undesirable when
-  # comparing results with known benchmarks that do not include this term in
-  # the temperature equation.
-
-  # H0
-
   # A comma separated list of integers denoting those boundaries on which the
   # temperature is fixed and described by the boundary temperature object
   # selected in its own section of this input file. All boundary indicators

--- a/tests/diffusion.prm
+++ b/tests/diffusion.prm
@@ -295,13 +295,11 @@ subsection Model settings
   # physical viewpoint, adiabatic heating should always be used but may be
   # undesirable when comparing results with known benchmarks that do not
   # include this term in the temperature equation.
-  set Include adiabatic heating               = false
 
   # Whether to include shear heating into the model or not. From a physical
   # viewpoint, shear heating should always be used but may be undesirable when
   # comparing results with known benchmarks that do not include this term in
   # the temperature equation.
-  set Include shear heating                   = false # default: true
 
   # H0
 

--- a/tests/diffusion_velocity.prm
+++ b/tests/diffusion_velocity.prm
@@ -291,18 +291,6 @@ end
 
 
 subsection Model settings
-  # Whether to include adiabatic heating into the model or not. From a
-  # physical viewpoint, adiabatic heating should always be used but may be
-  # undesirable when comparing results with known benchmarks that do not
-  # include this term in the temperature equation.
-
-  # Whether to include shear heating into the model or not. From a physical
-  # viewpoint, shear heating should always be used but may be undesirable when
-  # comparing results with known benchmarks that do not include this term in
-  # the temperature equation.
-
-  # H0
-
   # A comma separated list of integers denoting those boundaries on which the
   # temperature is fixed and described by the boundary temperature object
   # selected in its own section of this input file. All boundary indicators

--- a/tests/diffusion_velocity.prm
+++ b/tests/diffusion_velocity.prm
@@ -295,13 +295,11 @@ subsection Model settings
   # physical viewpoint, adiabatic heating should always be used but may be
   # undesirable when comparing results with known benchmarks that do not
   # include this term in the temperature equation.
-  set Include adiabatic heating               = false
 
   # Whether to include shear heating into the model or not. From a physical
   # viewpoint, shear heating should always be used but may be undesirable when
   # comparing results with known benchmarks that do not include this term in
   # the temperature equation.
-  set Include shear heating                   = false # default: true
 
   # H0
 

--- a/tests/direct_solver_1.prm
+++ b/tests/direct_solver_1.prm
@@ -34,10 +34,6 @@ end
 
 
 subsection Model settings
-
-  # As we only want to look at the effects of latent heating, we disable all
-  # the other heating terms. 
-
   # We only fix the temperature at the upper boundary, the other boundaries
   # are isolating. To guarantuee a steady downward flow, we fix the velocity
   # at the top and bottom, and set it to free slip on the sides. 

--- a/tests/direct_solver_1.prm
+++ b/tests/direct_solver_1.prm
@@ -37,9 +37,6 @@ subsection Model settings
 
   # As we only want to look at the effects of latent heating, we disable all
   # the other heating terms. 
-  set Include adiabatic heating               = false
-  set Include latent heat                     = true
-  set Include shear heating                   = false
 
   # We only fix the temperature at the upper boundary, the other boundaries
   # are isolating. To guarantuee a steady downward flow, we fix the velocity
@@ -160,4 +157,8 @@ subsection Postprocess
     set Time between graphical output = 0
     set List of output variables      = density
   end
+end
+
+subsection Heating model
+  set List of model names =  latent heat
 end

--- a/tests/direct_solver_2.prm
+++ b/tests/direct_solver_2.prm
@@ -33,10 +33,6 @@ end
 
 
 subsection Model settings
-
-  # As we only want to look at the effects of latent heating, we disable all
-  # the other heating terms. 
-
   # We only fix the temperature at the upper boundary, the other boundaries
   # are isolating. To guarantuee a steady downward flow, we fix the velocity
   # at the top and bottom, and set it to free slip on the sides. 

--- a/tests/direct_solver_2.prm
+++ b/tests/direct_solver_2.prm
@@ -36,9 +36,6 @@ subsection Model settings
 
   # As we only want to look at the effects of latent heating, we disable all
   # the other heating terms. 
-  set Include adiabatic heating               = false
-  set Include latent heat                     = true
-  set Include shear heating                   = false
 
   # We only fix the temperature at the upper boundary, the other boundaries
   # are isolating. To guarantuee a steady downward flow, we fix the velocity
@@ -159,4 +156,8 @@ subsection Postprocess
     set Time between graphical output = 0
     set List of output variables      = density
   end
+end
+
+subsection Heating model
+  set List of model names =  latent heat
 end

--- a/tests/discontinuous_composition_bound_preserving_limiter.prm
+++ b/tests/discontinuous_composition_bound_preserving_limiter.prm
@@ -20,8 +20,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right, bottom, top
 end
 

--- a/tests/discontinuous_composition_bound_preserving_limiter_3d.prm
+++ b/tests/discontinuous_composition_bound_preserving_limiter_3d.prm
@@ -21,8 +21,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right, front, back, bottom, top
 end
 

--- a/tests/discontinuous_temperature_spherical_shell_3d.prm
+++ b/tests/discontinuous_temperature_spherical_shell_3d.prm
@@ -82,8 +82,6 @@ end
 subsection Model settings
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include adiabatic heating               = false 
-  set Include shear heating                   = false
 
   set Tangential velocity boundary indicators = 0,1
 end

--- a/tests/drucker_prager_compression.prm
+++ b/tests/drucker_prager_compression.prm
@@ -38,8 +38,6 @@ end
 
 subsection Model settings
   set Prescribed velocity boundary indicators = 0 x:function,1 x:function, 2: function
-  set Include adiabatic heating = false
-  set Include shear heating     = false 
 end
 
 

--- a/tests/drucker_prager_extension.prm
+++ b/tests/drucker_prager_extension.prm
@@ -38,8 +38,6 @@ end
 
 subsection Model settings
   set Prescribed velocity boundary indicators = 0 x:function,1 x:function, 2: function
-  set Include adiabatic heating = false
-  set Include shear heating     = false 
 end
 
 

--- a/tests/dynamic_topography.prm
+++ b/tests/dynamic_topography.prm
@@ -103,8 +103,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0,1,3
   set Zero velocity boundary indicators       = 2
 
-  set Include adiabatic heating           = false
-  set Include shear heating               = false
 end
 
 

--- a/tests/dynamic_topography2.prm
+++ b/tests/dynamic_topography2.prm
@@ -104,8 +104,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0,1,3
   set Zero velocity boundary indicators       = 2
 
-  set Include adiabatic heating           = false
-  set Include shear heating               = false
 end
 
 

--- a/tests/dynamic_topography3.prm
+++ b/tests/dynamic_topography3.prm
@@ -70,9 +70,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = inner,outer
   set Prescribed velocity boundary indicators =
   set Fixed temperature boundary indicators   = inner, outer
-  set Include shear heating                   = false
-  set Include adiabatic heating               = false
-  set Include latent heat                     = false
 end
 
 

--- a/tests/ellipsoidal_chunk_coordinate_parallel.prm
+++ b/tests/ellipsoidal_chunk_coordinate_parallel.prm
@@ -36,7 +36,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = inner, outer,north,south,east,west
 
-  set Include shear heating                   = false
 end
 
 

--- a/tests/ellipsoidal_chunk_noncoordinate_parallel.prm
+++ b/tests/ellipsoidal_chunk_noncoordinate_parallel.prm
@@ -38,7 +38,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = inner, outer, east, west, north, south
 
-  set Include shear heating                   = false
 end
 
 

--- a/tests/free_surface_adaptive_blob.prm
+++ b/tests/free_surface_adaptive_blob.prm
@@ -89,8 +89,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1

--- a/tests/free_surface_adaptive_blob_petsc.prm
+++ b/tests/free_surface_adaptive_blob_petsc.prm
@@ -89,8 +89,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1

--- a/tests/free_surface_blob.prm
+++ b/tests/free_surface_blob.prm
@@ -87,8 +87,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1

--- a/tests/free_surface_iterated_stokes.prm
+++ b/tests/free_surface_iterated_stokes.prm
@@ -88,8 +88,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1

--- a/tests/free_surface_relaxation.prm
+++ b/tests/free_surface_relaxation.prm
@@ -93,8 +93,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1

--- a/tests/gplates_1_3.prm
+++ b/tests/gplates_1_3.prm
@@ -35,7 +35,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include shear heating                   = false
 end
 
 

--- a/tests/gplates_1_4.prm
+++ b/tests/gplates_1_4.prm
@@ -38,7 +38,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include shear heating                   = false
 end
 
 

--- a/tests/gplates_3d.prm
+++ b/tests/gplates_3d.prm
@@ -34,7 +34,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include shear heating                   = false
 end
 
 

--- a/tests/gplates_rotation.prm
+++ b/tests/gplates_rotation.prm
@@ -35,7 +35,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include shear heating                   = false
 end
 
 

--- a/tests/graphical_output.prm
+++ b/tests/graphical_output.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/graphical_output_hdf5.prm
+++ b/tests/graphical_output_hdf5.prm
@@ -86,8 +86,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/heat_flux_map.prm
+++ b/tests/heat_flux_map.prm
@@ -47,8 +47,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = left, right, bottom, top
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/heat_flux_map_vis.prm
+++ b/tests/heat_flux_map_vis.prm
@@ -47,8 +47,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = left, right, bottom, top
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/inclusion_2.prm
+++ b/tests/inclusion_2.prm
@@ -89,8 +89,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/inclusion_4.prm
+++ b/tests/inclusion_4.prm
@@ -88,8 +88,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/inclusion_adaptive.prm
+++ b/tests/inclusion_adaptive.prm
@@ -98,8 +98,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/initial_condition_S20RTS.prm
+++ b/tests/initial_condition_S20RTS.prm
@@ -31,7 +31,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include shear heating                   = false
 end
 
 

--- a/tests/initial_condition_S40RTS.prm
+++ b/tests/initial_condition_S40RTS.prm
@@ -31,7 +31,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include shear heating                   = false
 end
 
 

--- a/tests/initial_condition_SAVANI.prm
+++ b/tests/initial_condition_SAVANI.prm
@@ -32,7 +32,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include shear heating                   = false
 end
 
 

--- a/tests/internal_heating_statistics.prm
+++ b/tests/internal_heating_statistics.prm
@@ -42,9 +42,6 @@ subsection Model settings
 
   # As we only want to look at the effects of radiogenic, we disable all
   # the other heating terms. 
-  set Include adiabatic heating               = false
-  set Include latent heat                     = false
-  set Include shear heating                   = false
 
   # We only fix the temperature at the upper boundary, the other boundaries
   # are isolating. To guarantuee a steady downward flow, we fix the velocity

--- a/tests/internal_heating_statistics.prm
+++ b/tests/internal_heating_statistics.prm
@@ -39,10 +39,6 @@ end
 
 
 subsection Model settings
-
-  # As we only want to look at the effects of radiogenic, we disable all
-  # the other heating terms. 
-
   # We only fix the temperature at the upper boundary, the other boundaries
   # are isolating. To guarantuee a steady downward flow, we fix the velocity
   # at the top and bottom, and set it to free slip on the sides. 

--- a/tests/iterated_IMPES.prm
+++ b/tests/iterated_IMPES.prm
@@ -126,7 +126,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0,1,2,3
   set Zero velocity boundary indicators       = 
 
-  set Include shear heating = false
 end
 
 

--- a/tests/iterated_IMPES_direct_solver.prm
+++ b/tests/iterated_IMPES_direct_solver.prm
@@ -129,7 +129,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0,1,2,3
   set Zero velocity boundary indicators       = 
 
-  set Include shear heating = false
 end
 
 

--- a/tests/iterated_IMPES_residual.prm
+++ b/tests/iterated_IMPES_residual.prm
@@ -125,7 +125,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0,1,2,3
   set Zero velocity boundary indicators       = 
 
-  set Include shear heating = false
 end
 
 

--- a/tests/latent_heat.prm
+++ b/tests/latent_heat.prm
@@ -30,10 +30,6 @@ end
 
 
 subsection Model settings
-
-  # As we only want to look at the effects of latent heating, we disable all
-  # the other heating terms. 
-
   # We only fix the temperature at the upper boundary, the other boundaries
   # are isolating. To guarantuee a steady downward flow, we fix the velocity
   # at the top and bottom, and set it to free slip on the sides. 

--- a/tests/latent_heat.prm
+++ b/tests/latent_heat.prm
@@ -33,9 +33,6 @@ subsection Model settings
 
   # As we only want to look at the effects of latent heating, we disable all
   # the other heating terms. 
-  set Include adiabatic heating               = false
-  set Include latent heat                     = true
-  set Include shear heating                   = false
 
   # We only fix the temperature at the upper boundary, the other boundaries
   # are isolating. To guarantuee a steady downward flow, we fix the velocity
@@ -143,4 +140,8 @@ end
 subsection Postprocess
 
   set List of postprocessors = temperature statistics
+end
+
+subsection Heating model
+  set List of model names =  latent heat
 end

--- a/tests/latent_heat_melt_statistics.prm
+++ b/tests/latent_heat_melt_statistics.prm
@@ -91,8 +91,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/latent_heat_melt_statistics.prm
+++ b/tests/latent_heat_melt_statistics.prm
@@ -85,12 +85,6 @@ subsection Model settings
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1,2,3
-
-  # The final part of this section describes whether we
-  # want to include adiabatic heating (from a small
-  # compressibility of the medium) or from shear friction,
-  # as well as the rate of internal heating. We do not
-  # want to use any of these options here:
 end
 
 

--- a/tests/lithosphere_boundary_indicator.prm
+++ b/tests/lithosphere_boundary_indicator.prm
@@ -93,7 +93,6 @@ subsection Model settings
   set Fixed composition boundary indicators   = 0, 1, 4, 5
   set Zero velocity boundary indicators       = 0, 1, 2
   set Prescribed velocity boundary indicators = 3: function, 4: function, 5: function
-  set Include shear heating                   = false
 end
 
 

--- a/tests/lithosphere_boundary_indicator_3d.prm
+++ b/tests/lithosphere_boundary_indicator_3d.prm
@@ -98,7 +98,6 @@ subsection Model settings
   set Zero velocity boundary indicators       = 0, 1, 4
   set Tangential velocity boundary indicators = 2, 3
   set Prescribed velocity boundary indicators = 5: function, 6: function, 7: function, 8:function, 9:function
-  set Include shear heating                   = false
 end
 
 

--- a/tests/material_model_dependencies_composition_reaction.prm
+++ b/tests/material_model_dependencies_composition_reaction.prm
@@ -78,8 +78,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/material_model_dependencies_cookbooks_freesurface_with_crust.prm
+++ b/tests/material_model_dependencies_cookbooks_freesurface_with_crust.prm
@@ -78,8 +78,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/material_model_dependencies_diffusion_dislocation.prm
+++ b/tests/material_model_dependencies_diffusion_dislocation.prm
@@ -82,8 +82,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/material_model_dependencies_inclusion_2.prm
+++ b/tests/material_model_dependencies_inclusion_2.prm
@@ -78,8 +78,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/material_model_dependencies_latent_heat.prm
+++ b/tests/material_model_dependencies_latent_heat.prm
@@ -114,8 +114,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/material_model_dependencies_latent_heat_melt.prm
+++ b/tests/material_model_dependencies_latent_heat_melt.prm
@@ -78,8 +78,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/material_model_dependencies_morency_doin.prm
+++ b/tests/material_model_dependencies_morency_doin.prm
@@ -78,8 +78,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/material_model_dependencies_multicomponent.prm
+++ b/tests/material_model_dependencies_multicomponent.prm
@@ -78,8 +78,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/material_model_dependencies_shear_thinning.prm
+++ b/tests/material_model_dependencies_shear_thinning.prm
@@ -87,8 +87,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/material_model_dependencies_simple.prm
+++ b/tests/material_model_dependencies_simple.prm
@@ -78,8 +78,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/material_model_dependencies_simple_compressible.prm
+++ b/tests/material_model_dependencies_simple_compressible.prm
@@ -78,8 +78,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/material_model_dependencies_simpler.prm
+++ b/tests/material_model_dependencies_simpler.prm
@@ -78,8 +78,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/material_model_dependencies_solcx.prm
+++ b/tests/material_model_dependencies_solcx.prm
@@ -78,8 +78,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/material_model_dependencies_solkz.prm
+++ b/tests/material_model_dependencies_solkz.prm
@@ -78,8 +78,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/material_model_dependencies_steinberger.prm
+++ b/tests/material_model_dependencies_steinberger.prm
@@ -97,8 +97,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/material_model_dependencies_tangurnis.prm
+++ b/tests/material_model_dependencies_tangurnis.prm
@@ -88,8 +88,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/melt_compressible_advection.prm
+++ b/tests/melt_compressible_advection.prm
@@ -131,7 +131,6 @@ subsection Model settings
   set Zero velocity boundary indicators       =           # default: 
 
   set Include melt transport                  = true
-  set Include shear heating                   = false
 end
 
 

--- a/tests/melt_introspection.prm
+++ b/tests/melt_introspection.prm
@@ -93,8 +93,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/melt_material_1.prm
+++ b/tests/melt_material_1.prm
@@ -114,7 +114,6 @@ subsection Model settings
   set Zero velocity boundary indicators       =           # default: 
 
   set Include melt transport                  = true
-  set Include shear heating                   = false
 
 end
 

--- a/tests/melt_postprocessor_peridotite.prm
+++ b/tests/melt_postprocessor_peridotite.prm
@@ -75,8 +75,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/melt_postprocessor_peridotite.prm
+++ b/tests/melt_postprocessor_peridotite.prm
@@ -69,12 +69,6 @@ subsection Model settings
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1,2,3
-
-  # The final part of this section describes whether we
-  # want to include adiabatic heating (from a small
-  # compressibility of the medium) or from shear friction,
-  # as well as the rate of internal heating. We do not
-  # want to use any of these options here:
 end
 
 

--- a/tests/melt_postprocessor_pyroxenite.prm
+++ b/tests/melt_postprocessor_pyroxenite.prm
@@ -98,8 +98,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/melt_postprocessor_pyroxenite.prm
+++ b/tests/melt_postprocessor_pyroxenite.prm
@@ -92,12 +92,6 @@ subsection Model settings
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1,2,3
-
-  # The final part of this section describes whether we
-  # want to include adiabatic heating (from a small
-  # compressibility of the medium) or from shear friction,
-  # as well as the rate of internal heating. We do not
-  # want to use any of these options here:
 end
 
 

--- a/tests/melt_statistics.prm
+++ b/tests/melt_statistics.prm
@@ -91,8 +91,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/melt_statistics.prm
+++ b/tests/melt_statistics.prm
@@ -85,12 +85,6 @@ subsection Model settings
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1,2,3
-
-  # The final part of this section describes whether we
-  # want to include adiabatic heating (from a small
-  # compressibility of the medium) or from shear friction,
-  # as well as the rate of internal heating. We do not
-  # want to use any of these options here:
 end
 
 

--- a/tests/mesh_velocity_output.prm
+++ b/tests/mesh_velocity_output.prm
@@ -87,8 +87,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1

--- a/tests/multicomponent_arithmetic.prm
+++ b/tests/multicomponent_arithmetic.prm
@@ -89,8 +89,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1,2,3

--- a/tests/multicomponent_geometric.prm
+++ b/tests/multicomponent_geometric.prm
@@ -89,8 +89,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1,2,3

--- a/tests/multicomponent_harmonic.prm
+++ b/tests/multicomponent_harmonic.prm
@@ -89,8 +89,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1,2,3

--- a/tests/multicomponent_max_composition.prm
+++ b/tests/multicomponent_max_composition.prm
@@ -89,8 +89,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1,2,3

--- a/tests/no_adiabatic_heating.prm
+++ b/tests/no_adiabatic_heating.prm
@@ -85,8 +85,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0, 1
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators = 2: function
-  set Include shear heating = false
-  set Include adiabatic heating = false
 end
 
 subsection Boundary velocity model

--- a/tests/no_adiabatic_heating_02.prm
+++ b/tests/no_adiabatic_heating_02.prm
@@ -81,8 +81,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0, 1
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators = 2: function
-  set Include shear heating = true
-  set Include adiabatic heating = false
 end
 
 subsection Boundary velocity model
@@ -98,4 +96,8 @@ subsection Postprocess
   subsection Visualization
     set Time between graphical output = 0.1
   end
+end
+
+subsection Heating model
+  set List of model names =  shear heating
 end

--- a/tests/no_adiabatic_heating_03.prm
+++ b/tests/no_adiabatic_heating_03.prm
@@ -105,8 +105,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0, 1
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators = 2: function
-  set Include shear heating = true
-  set Include adiabatic heating = false
 end
 
 subsection Boundary temperature model
@@ -130,4 +128,8 @@ subsection Postprocess
   subsection Visualization
     set Time between graphical output = 0.1
   end
+end
+
+subsection Heating model
+  set List of model names =  shear heating
 end

--- a/tests/no_conduction_timestep.prm
+++ b/tests/no_conduction_timestep.prm
@@ -27,8 +27,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0, 1, 2 ,3
   set Prescribed velocity boundary indicators = 
 
-  set Include shear heating = false
-  set Include adiabatic heating = false
 end
 
 subsection Boundary temperature model

--- a/tests/no_flow.prm
+++ b/tests/no_flow.prm
@@ -98,8 +98,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/non_conservative_with_mpi.prm
+++ b/tests/non_conservative_with_mpi.prm
@@ -87,8 +87,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/own_gravity.prm
+++ b/tests/own_gravity.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/parallel_output_group_0.prm
+++ b/tests/parallel_output_group_0.prm
@@ -36,7 +36,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = inner, outer
 
-  set Include shear heating                   = true
 end
 
 
@@ -79,4 +78,8 @@ subsection Postprocess
   subsection Depth average
     set Time between graphical output = 1e6
   end
+end
+
+subsection Heating model
+  set List of model names =  shear heating
 end

--- a/tests/parallel_output_group_1.prm
+++ b/tests/parallel_output_group_1.prm
@@ -36,7 +36,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = inner, outer
 
-  set Include shear heating                   = true
 end
 
 
@@ -79,4 +78,8 @@ subsection Postprocess
   subsection Depth average
     set Time between graphical output = 1e6
   end
+end
+
+subsection Heating model
+  set List of model names =  shear heating
 end

--- a/tests/parallel_output_group_2.prm
+++ b/tests/parallel_output_group_2.prm
@@ -36,7 +36,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = inner, outer
 
-  set Include shear heating                   = true
 end
 
 
@@ -79,4 +78,8 @@ subsection Postprocess
   subsection Depth average
     set Time between graphical output = 1e6
   end
+end
+
+subsection Heating model
+  set List of model names =  shear heating
 end

--- a/tests/particle_count_statistics.prm
+++ b/tests/particle_count_statistics.prm
@@ -87,8 +87,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/particle_generator_ascii.prm
+++ b/tests/particle_generator_ascii.prm
@@ -19,8 +19,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_generator_box.prm
+++ b/tests/particle_generator_box.prm
@@ -17,8 +17,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_generator_box_3d.prm
+++ b/tests/particle_generator_box_3d.prm
@@ -19,8 +19,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right, front, back
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_generator_quadrature_points.prm
+++ b/tests/particle_generator_quadrature_points.prm
@@ -19,8 +19,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_generator_radial.prm
+++ b/tests/particle_generator_radial.prm
@@ -17,8 +17,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_generator_reference_cell.prm
+++ b/tests/particle_generator_reference_cell.prm
@@ -19,8 +19,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_initial_adaptive_output.prm
+++ b/tests/particle_initial_adaptive_output.prm
@@ -16,8 +16,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_initial_adaptive_refinement.prm
+++ b/tests/particle_initial_adaptive_refinement.prm
@@ -17,8 +17,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_integrator_euler.prm
+++ b/tests/particle_integrator_euler.prm
@@ -17,8 +17,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_integrator_rk4.prm
+++ b/tests/particle_integrator_rk4.prm
@@ -17,8 +17,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_interpolator_cell_average.prm
+++ b/tests/particle_interpolator_cell_average.prm
@@ -17,8 +17,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_load_balancing_refinement.prm
+++ b/tests/particle_load_balancing_refinement.prm
@@ -15,8 +15,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_load_balancing_refinement_02.prm
+++ b/tests/particle_load_balancing_refinement_02.prm
@@ -15,8 +15,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_load_balancing_removal.prm
+++ b/tests/particle_load_balancing_removal.prm
@@ -15,8 +15,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_load_balancing_removal_addition.prm
+++ b/tests/particle_load_balancing_removal_addition.prm
@@ -17,8 +17,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_load_balancing_removal_addition_properties.prm
+++ b/tests/particle_load_balancing_removal_addition_properties.prm
@@ -16,8 +16,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_output_hdf5.prm
+++ b/tests/particle_output_hdf5.prm
@@ -15,8 +15,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_periodic_boundaries.prm
+++ b/tests/particle_periodic_boundaries.prm
@@ -20,8 +20,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators =
   set Zero velocity boundary indicators       = bottom, top
   set Remove nullspace                        = net x translation

--- a/tests/particle_property_function.prm
+++ b/tests/particle_property_function.prm
@@ -19,8 +19,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_property_initial_composition.prm
+++ b/tests/particle_property_initial_composition.prm
@@ -19,8 +19,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_property_integrated_strain_pure_shear.prm
+++ b/tests/particle_property_integrated_strain_pure_shear.prm
@@ -18,8 +18,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left,bottom
   set Prescribed velocity boundary indicators = top:function, right:function
 end

--- a/tests/particle_property_integrated_strain_simple_shear.prm
+++ b/tests/particle_property_integrated_strain_simple_shear.prm
@@ -18,8 +18,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Prescribed velocity boundary indicators = bottom:function, top:function
 end

--- a/tests/particle_property_multiple_functions.prm
+++ b/tests/particle_property_multiple_functions.prm
@@ -20,8 +20,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_property_multiple_functions_with_interpolation.prm
+++ b/tests/particle_property_multiple_functions_with_interpolation.prm
@@ -20,8 +20,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_timing_information.prm
+++ b/tests/particle_timing_information.prm
@@ -18,8 +18,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/particle_visualization_particle_count.prm
+++ b/tests/particle_visualization_particle_count.prm
@@ -15,8 +15,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/passive_comp.prm
+++ b/tests/passive_comp.prm
@@ -302,18 +302,11 @@ subsection Model settings
   # no-flux (insulating) boundary conditions.
   set Fixed temperature boundary indicators   = 0,1
 
-  # Whether to include shear heating into the model or not. From a physical
-  # viewpoint, shear heating should always be used but may be undesirable when
-  # comparing results with known benchmarks that do not include this term in
-  # the temperature equation.
-
   # A comma separated list of integers denoting those boundaries on which the
   # velocity is tangential but prescribed, i.e., where external forces act to
   # prescribe a particular velocity. This is often used to prescribe a
   # velocity that equals that of overlying plates.
   set Prescribed velocity boundary indicators =
-
-  # H0
 
   # A comma separated list of integers denoting those boundaries on which the
   # velocity is tangential and unrestrained, i.e., where no external forces

--- a/tests/passive_comp.prm
+++ b/tests/passive_comp.prm
@@ -306,7 +306,6 @@ subsection Model settings
   # viewpoint, shear heating should always be used but may be undesirable when
   # comparing results with known benchmarks that do not include this term in
   # the temperature equation.
-  set Include shear heating                   = true
 
   # A comma separated list of integers denoting those boundaries on which the
   # velocity is tangential but prescribed, i.e., where external forces act to
@@ -401,3 +400,7 @@ subsection Postprocess
 end
 
 
+
+subsection Heating model
+  set List of model names =  shear heating
+end

--- a/tests/periodic_box.prm
+++ b/tests/periodic_box.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 2,3

--- a/tests/periodic_box2.prm
+++ b/tests/periodic_box2.prm
@@ -87,8 +87,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 

--- a/tests/periodic_box_freesurface.prm
+++ b/tests/periodic_box_freesurface.prm
@@ -90,8 +90,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 2

--- a/tests/periodic_box_mpi10.prm
+++ b/tests/periodic_box_mpi10.prm
@@ -89,8 +89,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 

--- a/tests/periodic_linear_momentum.prm
+++ b/tests/periodic_linear_momentum.prm
@@ -84,8 +84,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 2,3

--- a/tests/petsc_refinement.prm
+++ b/tests/petsc_refinement.prm
@@ -98,8 +98,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/plugin.prm
+++ b/tests/plugin.prm
@@ -83,8 +83,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/plugin_dependency.prm
+++ b/tests/plugin_dependency.prm
@@ -84,8 +84,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/plugin_dependency_redundant.prm
+++ b/tests/plugin_dependency_redundant.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/plugin_dependency_redundant_02.prm
+++ b/tests/plugin_dependency_redundant_02.prm
@@ -84,8 +84,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/point_value_01.prm
+++ b/tests/point_value_01.prm
@@ -19,8 +19,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = left, right, bottom, top
 end

--- a/tests/point_value_02.prm
+++ b/tests/point_value_02.prm
@@ -21,8 +21,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = left, right, bottom, top
 end

--- a/tests/point_value_02_mpi.prm
+++ b/tests/point_value_02_mpi.prm
@@ -24,8 +24,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = 
   set Zero velocity boundary indicators       = left, right, bottom, top
 end

--- a/tests/prescribed_stokes_solution.prm
+++ b/tests/prescribed_stokes_solution.prm
@@ -66,8 +66,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/prescribed_velocity_boundary.prm
+++ b/tests/prescribed_velocity_boundary.prm
@@ -90,8 +90,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/pressure_compatibility_2.prm
+++ b/tests/pressure_compatibility_2.prm
@@ -79,8 +79,6 @@ end
 subsection Model settings
   set Fixed temperature boundary indicators   = 2,3
 
-  set Include adiabatic heating               = true
-  set Include shear heating                   = true
 
   set Tangential velocity boundary indicators = 0,1,3
   set Prescribed velocity boundary indicators = 2:function
@@ -96,4 +94,8 @@ end
 
 subsection Postprocess
   set List of postprocessors = velocity statistics, pressure statistics, temperature statistics
+end
+
+subsection Heating model
+  set List of model names = adiabatic heating, shear heating
 end

--- a/tests/pressure_compatibility_3.prm
+++ b/tests/pressure_compatibility_3.prm
@@ -78,8 +78,6 @@ end
 subsection Model settings
   set Fixed temperature boundary indicators   = 2,3
 
-  set Include adiabatic heating               = true
-  set Include shear heating                   = true
 
   set Tangential velocity boundary indicators = 0,1,3
   set Prescribed velocity boundary indicators = 2:function
@@ -95,4 +93,8 @@ end
 
 subsection Postprocess
   set List of postprocessors = velocity statistics, pressure statistics, temperature statistics, mass flux statistics
+end
+
+subsection Heating model
+  set List of model names = adiabatic heating, shear heating
 end

--- a/tests/pressure_compatibility_4.prm
+++ b/tests/pressure_compatibility_4.prm
@@ -79,8 +79,6 @@ end
 subsection Model settings
   set Fixed temperature boundary indicators   = 2,3
 
-  set Include adiabatic heating               = true
-  set Include shear heating                   = true
 
   set Tangential velocity boundary indicators = 0,1
   set Prescribed velocity boundary indicators = 2:function, 3:function
@@ -101,4 +99,8 @@ subsection Postprocess
     set List of output variables = density
     set Time between graphical output = 0
   end
+end
+
+subsection Heating model
+  set List of model names = adiabatic heating, shear heating
 end

--- a/tests/quick_mpi.prm
+++ b/tests/quick_mpi.prm
@@ -91,8 +91,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/radioactive_decay.prm
+++ b/tests/radioactive_decay.prm
@@ -61,7 +61,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include shear heating                   = false
 end
 
 

--- a/tests/radiogenic_heating.prm
+++ b/tests/radiogenic_heating.prm
@@ -36,10 +36,6 @@ end
 
 
 subsection Model settings
-
-  # As we only want to look at the effects of radiogenic, we disable all
-  # the other heating terms. 
-
   # We only fix the temperature at the upper boundary, the other boundaries
   # are isolating. To guarantuee a steady downward flow, we fix the velocity
   # at the top and bottom, and set it to free slip on the sides. 

--- a/tests/radiogenic_heating.prm
+++ b/tests/radiogenic_heating.prm
@@ -39,9 +39,6 @@ subsection Model settings
 
   # As we only want to look at the effects of radiogenic, we disable all
   # the other heating terms. 
-  set Include adiabatic heating               = false
-  set Include latent heat                     = false
-  set Include shear heating                   = false
 
   # We only fix the temperature at the upper boundary, the other boundaries
   # are isolating. To guarantuee a steady downward flow, we fix the velocity

--- a/tests/refinement_boundary.prm
+++ b/tests/refinement_boundary.prm
@@ -89,8 +89,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/refinement_switch.prm
+++ b/tests/refinement_switch.prm
@@ -51,8 +51,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = left, right, bottom, top
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/refinement_topography.prm
+++ b/tests/refinement_topography.prm
@@ -87,8 +87,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/remove_angular_momentum.prm
+++ b/tests/remove_angular_momentum.prm
@@ -32,7 +32,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0,1
   set Prescribed velocity boundary indicators =
   set Fixed temperature boundary indicators   = 0,1
-  set Include shear heating                   = false
   set Remove nullspace = angular momentum
 end
 

--- a/tests/remove_net_rotation.prm
+++ b/tests/remove_net_rotation.prm
@@ -32,7 +32,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0,1
   set Prescribed velocity boundary indicators =
   set Fixed temperature boundary indicators   = 0,1
-  set Include shear heating                   = false
   set Remove nullspace = net rotation
 end
 

--- a/tests/resume_free_surface.prm
+++ b/tests/resume_free_surface.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1

--- a/tests/shear_bands.prm
+++ b/tests/shear_bands.prm
@@ -129,7 +129,6 @@ subsection Model settings
   set Zero velocity boundary indicators       = 
 
   set Include melt transport                  = true
-  set Include shear heating                   = false
 end
 
 subsection Melt settings

--- a/tests/signal_fem.prm
+++ b/tests/signal_fem.prm
@@ -91,8 +91,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/signals.prm
+++ b/tests/signals.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/signals_connect.prm
+++ b/tests/signals_connect.prm
@@ -81,8 +81,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/signals_post_constraints.prm
+++ b/tests/signals_post_constraints.prm
@@ -68,8 +68,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false 
   set Prescribed velocity boundary indicators = 
   set Tangential velocity boundary indicators = left, right, bottom, top
   set Zero velocity boundary indicators       = 

--- a/tests/simple_compressibility_iterated_stokes.prm
+++ b/tests/simple_compressibility_iterated_stokes.prm
@@ -80,7 +80,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0, 1
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators = 2: function
-  set Include shear heating = false
 end
 
 subsection Boundary velocity model

--- a/tests/simple_compressible.prm
+++ b/tests/simple_compressible.prm
@@ -77,8 +77,6 @@ end
 subsection Model settings
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include adiabatic heating               = true
-  set Include shear heating                   = false
 
   set Tangential velocity boundary indicators = 0,2,3
   set Zero velocity boundary indicators       = 1
@@ -100,4 +98,8 @@ subsection Postprocess
     set Number of zones = 10
   end
 
+end
+
+subsection Heating model
+  set List of model names = adiabatic heating
 end

--- a/tests/simple_incompressible.prm
+++ b/tests/simple_incompressible.prm
@@ -74,8 +74,6 @@ end
 subsection Model settings
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 
   set Tangential velocity boundary indicators = 0,2,3
   set Zero velocity boundary indicators       = 1

--- a/tests/slope_refinement.prm
+++ b/tests/slope_refinement.prm
@@ -87,8 +87,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = 2,3
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 0,1

--- a/tests/smoothing.prm
+++ b/tests/smoothing.prm
@@ -69,8 +69,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = 
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/sol_cx_2.prm
+++ b/tests/sol_cx_2.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_cx_2_conservative.prm
+++ b/tests/sol_cx_2_conservative.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_cx_2_normalized_pressure.prm
+++ b/tests/sol_cx_2_normalized_pressure.prm
@@ -86,8 +86,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_cx_2_q3.prm
+++ b/tests/sol_cx_2_q3.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_cx_4.prm
+++ b/tests/sol_cx_4.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_cx_4_conservative.prm
+++ b/tests/sol_cx_4_conservative.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_cx_4_normalized_pressure.prm
+++ b/tests/sol_cx_4_normalized_pressure.prm
@@ -86,8 +86,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_cx_4_normalized_pressure_large_static_pressure.prm
+++ b/tests/sol_cx_4_normalized_pressure_large_static_pressure.prm
@@ -101,8 +101,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_cx_4_normalized_pressure_low_solver_tolerance.prm
+++ b/tests/sol_cx_4_normalized_pressure_low_solver_tolerance.prm
@@ -94,8 +94,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_cx_mpi_2.prm
+++ b/tests/sol_cx_mpi_2.prm
@@ -88,8 +88,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_cx_tracers.prm
+++ b/tests/sol_cx_tracers.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_kz_2.prm
+++ b/tests/sol_kz_2.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_kz_2_cheaper_first_phase_solver.prm
+++ b/tests/sol_kz_2_cheaper_first_phase_solver.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_kz_2_conservative.prm
+++ b/tests/sol_kz_2_conservative.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_kz_2_no_first_phase_solver.prm
+++ b/tests/sol_kz_2_no_first_phase_solver.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_kz_2_q3.prm
+++ b/tests/sol_kz_2_q3.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_kz_4.prm
+++ b/tests/sol_kz_4.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/sol_kz_4_conservative.prm
+++ b/tests/sol_kz_4_conservative.prm
@@ -85,8 +85,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/solidus_initial_conditions.prm
+++ b/tests/solidus_initial_conditions.prm
@@ -35,7 +35,6 @@ subsection Model settings
 
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include shear heating                   = true
 end
 
 
@@ -86,4 +85,8 @@ subsection Postprocess
     set Time between graphical output = 1e6
     set Number of zones = 10
   end
+end
+
+subsection Heating model
+  set List of model names =  shear heating
 end

--- a/tests/solitary_wave.prm
+++ b/tests/solitary_wave.prm
@@ -143,7 +143,6 @@ subsection Model settings
   set Zero velocity boundary indicators       = 
 
   set Include melt transport                  = true
-  set Include shear heating                   = false
 end
 
 subsection Melt settings

--- a/tests/steinberger_compressible.prm
+++ b/tests/steinberger_compressible.prm
@@ -78,8 +78,6 @@ end
 subsection Model settings
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include adiabatic heating               = true
-  set Include shear heating                   = false
 
   set Tangential velocity boundary indicators = 0,2,3
   set Zero velocity boundary indicators       = 1
@@ -101,4 +99,8 @@ subsection Postprocess
     set Number of zones = 10
  end
 
+end
+
+subsection Heating model
+  set List of model names = adiabatic heating
 end

--- a/tests/steinberger_incompressible.prm
+++ b/tests/steinberger_incompressible.prm
@@ -80,8 +80,6 @@ end
 subsection Model settings
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 
   set Tangential velocity boundary indicators = 0,2,3
   set Zero velocity boundary indicators       = 1

--- a/tests/steinberger_lateral_fail.prm
+++ b/tests/steinberger_lateral_fail.prm
@@ -82,8 +82,6 @@ end
 subsection Model settings
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include adiabatic heating               = true
-  set Include shear heating                   = false
 
   set Tangential velocity boundary indicators = 0,2,3
   set Zero velocity boundary indicators       = 1
@@ -105,4 +103,8 @@ subsection Postprocess
     set Number of zones = 10
  end
 
+end
+
+subsection Heating model
+  set List of model names = adiabatic heating
 end

--- a/tests/steinberger_viscosity_adiabatic.prm
+++ b/tests/steinberger_viscosity_adiabatic.prm
@@ -76,8 +76,6 @@ end
 subsection Model settings
   set Fixed temperature boundary indicators   = 0,1
 
-  set Include adiabatic heating               = true
-  set Include shear heating                   = false
 
   set Tangential velocity boundary indicators = 0,2,3
   set Zero velocity boundary indicators       = 1
@@ -99,4 +97,8 @@ subsection Postprocess
     set Number of zones = 10
   end
 
+end
+
+subsection Heating model
+  set List of model names = adiabatic heating
 end

--- a/tests/tangurnis.prm
+++ b/tests/tangurnis.prm
@@ -227,8 +227,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
   # A comma separated list of integers denoting those boundaries on which the
   # temperature is fixed and described by the boundary temperature object

--- a/tests/time_dependent_temperature_bc.prm
+++ b/tests/time_dependent_temperature_bc.prm
@@ -124,9 +124,7 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
 
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 2, 3

--- a/tests/time_dependent_temperature_bc_2.prm
+++ b/tests/time_dependent_temperature_bc_2.prm
@@ -121,9 +121,7 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
 
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 2, 3

--- a/tests/traction_ascii_data.prm
+++ b/tests/traction_ascii_data.prm
@@ -101,8 +101,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 1,2,3
   set Zero velocity boundary indicators       = 
 
-  set Include adiabatic heating               = false
-  set Include latent heat                     = true
 end
 
 subsection Boundary traction model
@@ -136,3 +134,7 @@ subsection Checkpointing
 end
 
 
+
+subsection Heating model
+  set List of model names =  latent heat
+end

--- a/tests/upwelling_melting_peridotite.prm
+++ b/tests/upwelling_melting_peridotite.prm
@@ -75,12 +75,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators = 2:function
   set Tangential velocity boundary indicators = 0,1
   set Fixed temperature boundary indicators   = 2
-
-  # The final part of this section describes whether we
-  # want to include adiabatic heating (from a small
-  # compressibility of the medium) or from shear friction,
-  # as well as the rate of internal heating. We do not
-  # want to use any of these options here:
 end
 
 

--- a/tests/upwelling_melting_peridotite.prm
+++ b/tests/upwelling_melting_peridotite.prm
@@ -81,9 +81,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = true
-  set Include latent heat                     = true
-  set Include shear heating                   = false
 end
 
 
@@ -153,3 +150,7 @@ subsection Postprocess
   end
 end
 
+
+subsection Heating model
+  set List of model names = adiabatic heating, latent heat
+end

--- a/tests/upwelling_melting_peridotite_compressible.prm
+++ b/tests/upwelling_melting_peridotite_compressible.prm
@@ -68,12 +68,6 @@ subsection Model settings
   set Prescribed velocity boundary indicators = 2:function
   set Tangential velocity boundary indicators = 0,1
   set Fixed temperature boundary indicators   = 2
-
-  # The final part of this section describes whether we
-  # want to include adiabatic heating (from a small
-  # compressibility of the medium) or from shear friction,
-  # as well as the rate of internal heating. We do not
-  # want to use any of these options here:
 end
 
 

--- a/tests/upwelling_melting_peridotite_compressible.prm
+++ b/tests/upwelling_melting_peridotite_compressible.prm
@@ -74,9 +74,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = true
-  set Include latent heat                     = true
-  set Include shear heating                   = false
 end
 
 
@@ -146,3 +143,7 @@ subsection Postprocess
   end
 end
 
+
+subsection Heating model
+  set List of model names = adiabatic heating, latent heat
+end

--- a/tests/upwelling_melting_pyroxenite.prm
+++ b/tests/upwelling_melting_pyroxenite.prm
@@ -113,9 +113,6 @@ subsection Model settings
   # compressibility of the medium) or from shear friction,
   # as well as the rate of internal heating. We do not
   # want to use any of these options here:
-  set Include adiabatic heating               = true
-  set Include latent heat                     = true
-  set Include shear heating                   = false
 end
 
 
@@ -176,3 +173,7 @@ subsection Postprocess
   set List of postprocessors = temperature statistics
 end
 
+
+subsection Heating model
+  set List of model names = adiabatic heating, latent heat
+end

--- a/tests/upwelling_melting_pyroxenite.prm
+++ b/tests/upwelling_melting_pyroxenite.prm
@@ -107,12 +107,6 @@ subsection Model settings
   set Tangential velocity boundary indicators = 0,1
   set Fixed temperature boundary indicators   = 2
   set Fixed composition boundary indicators   = 2
-
-  # The final part of this section describes whether we
-  # want to include adiabatic heating (from a small
-  # compressibility of the medium) or from shear friction,
-  # as well as the rate of internal heating. We do not
-  # want to use any of these options here:
 end
 
 

--- a/tests/van_keken_smooth_tracer.prm
+++ b/tests/van_keken_smooth_tracer.prm
@@ -17,8 +17,6 @@ subsection Geometry model
 end
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Tangential velocity boundary indicators = left, right
   set Zero velocity boundary indicators       = bottom, top
 end

--- a/tests/velocity_divergence.prm
+++ b/tests/velocity_divergence.prm
@@ -144,7 +144,6 @@ subsection Model settings
   set Zero velocity boundary indicators       = 
 
   set Include melt transport                  = false
-  set Include latent heat                     = false
 end
 
 

--- a/tests/visco_plastic.prm
+++ b/tests/visco_plastic.prm
@@ -46,8 +46,6 @@ end
 
 # Boundary classifications (free-slip, fixed T at top & bottom, insulating side) 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = bottom, top
   set Tangential velocity boundary indicators = bottom, top, left, right
 end

--- a/tests/visco_plastic_yield.prm
+++ b/tests/visco_plastic_yield.prm
@@ -46,8 +46,6 @@ end
 
 # Boundary classifications (free-slip, fixed T at top & bottom, insulating side) 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = bottom, top
   set Tangential velocity boundary indicators = bottom, top, left, right
 end

--- a/tests/visco_plastic_yield_strain_weakening.prm
+++ b/tests/visco_plastic_yield_strain_weakening.prm
@@ -46,8 +46,6 @@ end
 
 # Boundary classifications (free-slip, fixed T at top & bottom, insulating side) 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = bottom, top
   set Tangential velocity boundary indicators = bottom, top, left, right
 end

--- a/tests/visualization_vertical_heat_flux.prm
+++ b/tests/visualization_vertical_heat_flux.prm
@@ -51,8 +51,6 @@ subsection Model settings
   set Zero velocity boundary indicators       =
   set Prescribed velocity boundary indicators =
   set Tangential velocity boundary indicators = left, right, bottom, top
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
 end
 
 

--- a/tests/viz_plugin_dependency.prm
+++ b/tests/viz_plugin_dependency.prm
@@ -84,8 +84,6 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 0, 1

--- a/tests/zero_RHS.prm
+++ b/tests/zero_RHS.prm
@@ -101,8 +101,6 @@ end
 # boundary conditions, as well as free slip boundary
 # conditions for the sides and bottom. 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = left, right, bottom, top
   set Prescribed velocity boundary indicators = bottom:function
   set Tangential velocity boundary indicators = left, right 

--- a/tests/zero_matrix.prm
+++ b/tests/zero_matrix.prm
@@ -109,8 +109,6 @@ end
 # boundary conditions, as well as free slip boundary
 # conditions for the sides and bottom. 
 subsection Model settings
-  set Include adiabatic heating               = false
-  set Include shear heating                   = false
   set Fixed temperature boundary indicators   = left, right, bottom, top
   set Prescribed velocity boundary indicators = bottom:function
   set Tangential velocity boundary indicators = left, right 

--- a/tests/zero_temperature.prm
+++ b/tests/zero_temperature.prm
@@ -118,9 +118,7 @@ end
 
 
 subsection Model settings
-  set Include adiabatic heating               = false
 
-  set Include shear heating                   = false # default: true
 
 
   set Fixed temperature boundary indicators   = 2, 3


### PR DESCRIPTION
This removes the deprecated heating parameters (since Hackathon 2015) from all our input files. The options itself for now stay in the code. I am in favor of removing them after the next release. The changes were done by a script, and I need to test first if any tests break. Also some input files will now have comments that reference parameters that are not longer in the input files, and I need to take a look at all of those .part. ... files. Not ready for review yet.