### PR TITLE
Put some space between two rows of pictures.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -4587,7 +4587,7 @@ postprocessing section, using the \texttt{density} visualization plugin:
   \includegraphics[width=0.3\textwidth]{cookbooks/composition-active/visit0001.png}
   \hfill
   \includegraphics[width=0.3\textwidth]{cookbooks/composition-active/visit0002.png}
-  \\
+  \\[6pt]
   \includegraphics[width=0.3\textwidth]{cookbooks/composition-active/visit0003.png}
   \hfill
   \includegraphics[width=0.3\textwidth]{cookbooks/composition-active/visit0004.png}
@@ -4652,7 +4652,7 @@ Moreover, instead of the \texttt{simple} material model, we will use the \texttt
   \includegraphics[width=0.3\textwidth]{cookbooks/composition-reaction/2.png}
   \hfill
   \includegraphics[width=0.3\textwidth]{cookbooks/composition-reaction/4.png}
-  \\
+  \\[6pt]
   \includegraphics[width=0.3\textwidth]{cookbooks/composition-reaction/8.png}
   \hfill
   \includegraphics[width=0.3\textwidth]{cookbooks/composition-reaction/12.png}


### PR DESCRIPTION
In the current version, the figures are too close together to see that they are not supposed
to be part of the same.