### PR TITLE
Use complete subsection paths in manual .prm snippets.

### DIFF
--- a/doc/manual/cookbooks/composition-active-tracers/tracers.part.prm
+++ b/doc/manual/cookbooks/composition-active-tracers/tracers.part.prm
@@ -1,9 +1,11 @@
-subsection Tracers
-  set Number of tracers         = 100000
-  set Time between data output  = 0
-  set Data output format        = vtu
-  set List of tracer properties = velocity, initial composition
-  set Interpolation scheme      = cell average
-  set Particle generator name   = random uniform
+subsection Postprocess
+  subsection Tracers
+    set Number of tracers         = 100000
+    set Time between data output  = 0
+    set Data output format        = vtu
+    set List of tracer properties = velocity, initial composition
+    set Interpolation scheme      = cell average
+    set Particle generator name   = random uniform
+  end
 end
 

--- a/doc/manual/cookbooks/composition-passive-tracers/tracer-properties.part.prm
+++ b/doc/manual/cookbooks/composition-passive-tracers/tracer-properties.part.prm
@@ -1,6 +1,10 @@
+subsection Postprocess
+  subsection Tracers
     set List of tracer properties = function, initial composition, initial position, pT path
 
     subsection Function
       set Variable names      = x,y
       set Function expression = if(y<0.2, 1, 0)
     end
+  end
+end


### PR DESCRIPTION
With the current versions of these two files, our scripts could not generate correct links
for each parameter to the section of the manual where the parameter is described. For this
to work, we need to use the complete set of surrounding sections.

Add these.