### PR TITLE
Also create a .visit record for all particle files.

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -6,6 +6,12 @@
  *
  * <ol>
  *
+ * <li> New: ASPECT now also generates a <code>output/particles.visit</code>
+ * file that allows Visit to read in all files from all processors and
+ * all time steps that contain particle data.
+ * <br>
+ * (Wolfgang Bangerth, 2016/12/02)
+ *
  * <li> Changed: The 'Stokes only' nonlinear solver scheme now uses
  * the nonlinear solver tolerance parameter (previously it was hard-
  * coded to 1e-8), and it computes the nonlinear residual as current

--- a/include/aspect/particle/output/vtu.h
+++ b/include/aspect/particle/output/vtu.h
@@ -117,9 +117,11 @@ namespace aspect
           std::vector<std::pair<double,std::string> > times_and_pvtu_file_names;
 
           /**
-           * Like the previous variable, but for the .visit file.
+           * A corresponding variable that we use for the .visit files created
+           * by DataOutInterface::write_visit_record. The second part of a
+           * pair contains all files that together form a time step.
            */
-          std::vector<std::string>                    vtu_file_names;
+          std::vector<std::pair<double,std::vector<std::string> > > times_and_vtu_file_names;
       };
     }
   }


### PR DESCRIPTION
We already created a .pvd file for Paraview, but not a .visit file.