### PR TITLE
Return particle properties as ArrayView

### DIFF
--- a/include/aspect/particle/particle.h
+++ b/include/aspect/particle/particle.h
@@ -25,6 +25,7 @@
 
 #include <deal.II/base/point.h>
 #include <deal.II/base/types.h>
+#include <deal.II/base/array_view.h>
 
 #include <boost/serialization/vector.hpp>
 
@@ -238,7 +239,8 @@ namespace aspect
         /**
          * Set the properties of this particle.
          *
-         * @param [in] new_properties The new properties for this particle.
+         * @param [in] new_properties A vector containing the
+         * new properties for this particle.
          */
         void
         set_properties (const std::vector<double> &new_properties);
@@ -246,17 +248,17 @@ namespace aspect
         /**
          * Get write-access to properties of this particle.
          *
-         * @return The properties of this particle.
+         * @return An ArrayView of the properties of this particle.
          */
-        std::vector<double> &
+        const ArrayView<double>
         get_properties ();
 
         /**
-         * Get the properties of this particle.
+         * Get read-access to properties of this particle.
          *
-         * @return The properties of this particle.
+         * @return An ArrayView of the properties of this particle.
          */
-        const std::vector<double> &
+        const ArrayView<const double>
         get_properties () const;
 
         /**

--- a/include/aspect/particle/property/integrated_strain.h
+++ b/include/aspect/particle/property/integrated_strain.h
@@ -86,7 +86,7 @@ namespace aspect
                                         const Point<dim> &position,
                                         const Vector<double> &solution,
                                         const std::vector<Tensor<1,dim> > &gradients,
-                                        std::vector<double> &particle_properties) const;
+                                        const ArrayView<double> &particle_properties) const;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -355,7 +355,7 @@ namespace aspect
                                         const Point<dim> &position,
                                         const Vector<double> &solution,
                                         const std::vector<Tensor<1,dim> > &gradients,
-                                        std::vector<double> &particle_properties) const;
+                                        const ArrayView<double> &particle_properties) const;
 
           /**
            * Returns an enum, which determines at what times particle properties

--- a/include/aspect/particle/property/pT_path.h
+++ b/include/aspect/particle/property/pT_path.h
@@ -86,7 +86,7 @@ namespace aspect
                                         const Point<dim> &position,
                                         const Vector<double> &solution,
                                         const std::vector<Tensor<1,dim> > &gradients,
-                                        std::vector<double> &particle_properties) const;
+                                        const ArrayView<double> &particle_properties) const;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/position.h
+++ b/include/aspect/particle/property/position.h
@@ -81,7 +81,7 @@ namespace aspect
                                         const Point<dim> &position,
                                         const Vector<double> &solution,
                                         const std::vector<Tensor<1,dim> > &gradients,
-                                        std::vector<double> &particle_properties) const;
+                                        const ArrayView<double> &particle_properties) const;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/velocity.h
+++ b/include/aspect/particle/property/velocity.h
@@ -82,7 +82,7 @@ namespace aspect
                                         const Point<dim> &position,
                                         const Vector<double> &solution,
                                         const std::vector<Tensor<1,dim> > &gradients,
-                                        std::vector<double> &particle_properties) const;
+                                        const ArrayView<double> &particle_properties) const;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -34,6 +34,7 @@
 #include <aspect/simulator_signals.h>
 
 #include <deal.II/base/timer.h>
+#include <deal.II/base/array_view.h>
 
 namespace aspect
 {

--- a/source/particle/interpolator/cell_average.cc
+++ b/source/particle/interpolator/cell_average.cc
@@ -82,7 +82,7 @@ namespace aspect
             for (typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator particle = particle_range.first;
                  particle != particle_range.second; ++particle)
               {
-                const std::vector<double> &particle_properties = particle->second.get_properties();
+                const ArrayView<const double> &particle_properties = particle->second.get_properties();
 
                 for (unsigned int i = 0; i < n_properties; ++i)
                   cell_properties[i] += particle_properties[i];

--- a/source/particle/output/ascii.cc
+++ b/source/particle/output/ascii.cc
@@ -91,7 +91,7 @@ namespace aspect
         // And print the data for each particle
         for (typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator it=particles.begin(); it!=particles.end(); ++it)
           {
-            const std::vector<double> properties = it->second.get_properties();
+            const ArrayView<const double> properties = it->second.get_properties();
 
             output << it->second.get_location();
             output << ' ' << it->second.get_id();

--- a/source/particle/output/hdf5.cc
+++ b/source/particle/output/hdf5.cc
@@ -131,7 +131,7 @@ namespace aspect
 
             index_data[i] = it->second.get_id();
 
-            const std::vector<double> properties = it->second.get_properties();
+            const ArrayView<const double> properties = it->second.get_properties();
             unsigned int particle_property_index = 0;
 
             unsigned int output_field_index = 0;

--- a/source/particle/output/vtu.cc
+++ b/source/particle/output/vtu.cc
@@ -135,7 +135,7 @@ namespace aspect
                 for (typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator
                      it=particles.begin(); it!=particles.end(); ++it)
                   {
-                    const std::vector<double> particle_data = it->second.get_properties();
+                    const ArrayView<const double> particle_data = it->second.get_properties();
 
                     output << "         ";
                     for (unsigned int d=0; d < n_components; ++d)
@@ -160,7 +160,7 @@ namespace aspect
                     for (typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator
                          it=particles.begin(); it!=particles.end(); ++it)
                       {
-                        const std::vector<double> particle_data = it->second.get_properties();
+                        const ArrayView<const double> particle_data = it->second.get_properties();
 
                         output << particle_data[data_offset+d] << "\n";
                       }

--- a/source/particle/particle.cc
+++ b/source/particle/particle.cc
@@ -199,17 +199,17 @@ namespace aspect
     }
 
     template <int dim>
-    const std::vector<double> &
+    const ArrayView<const double>
     Particle<dim>::get_properties () const
     {
-      return properties;
+      return ArrayView<const double>(&properties[0],properties.size());
     }
 
     template <int dim>
-    std::vector<double> &
+    const ArrayView<double>
     Particle<dim>::get_properties ()
     {
-      return properties;
+      return ArrayView<double>(&properties[0],properties.size());
     }
   }
 }

--- a/source/particle/property/integrated_strain.cc
+++ b/source/particle/property/integrated_strain.cc
@@ -41,7 +41,7 @@ namespace aspect
                                                           const Point<dim> &,
                                                           const Vector<double> &,
                                                           const std::vector<Tensor<1,dim> > &gradients,
-                                                          std::vector<double> &data) const
+                                                          const ArrayView<double> &data) const
       {
         SymmetricTensor<2,dim> old_strain;
         for (unsigned int i = 0; i < SymmetricTensor<2,dim>::n_independent_components ; ++i)

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -184,7 +184,7 @@ namespace aspect
                                                     const Point<dim> &,
                                                     const Vector<double> &,
                                                     const std::vector<Tensor<1,dim> > &,
-                                                    std::vector<double> &) const
+                                                    const ArrayView<double> &) const
       {}
 
       template <int dim>

--- a/source/particle/property/pT_path.cc
+++ b/source/particle/property/pT_path.cc
@@ -41,7 +41,7 @@ namespace aspect
                                                 const Point<dim> &,
                                                 const Vector<double> &solution,
                                                 const std::vector<Tensor<1,dim> > &,
-                                                std::vector<double> &data) const
+                                                const ArrayView<double> &data) const
       {
         data[data_position] = solution[this->introspection().component_indices.pressure];
         data[data_position+1] = solution[this->introspection().component_indices.temperature];

--- a/source/particle/property/position.cc
+++ b/source/particle/property/position.cc
@@ -41,7 +41,7 @@ namespace aspect
                                                   const Point<dim> &position,
                                                   const Vector<double> &,
                                                   const std::vector<Tensor<1,dim> > &,
-                                                  std::vector<double> &data) const
+                                                  const ArrayView<double> &data) const
       {
         for (unsigned int i = 0; i < dim; ++i)
           data[data_position+i] = position[i];

--- a/source/particle/property/velocity.cc
+++ b/source/particle/property/velocity.cc
@@ -41,7 +41,7 @@ namespace aspect
                                                   const Point<dim> &,
                                                   const Vector<double> &solution,
                                                   const std::vector<Tensor<1,dim> > &,
-                                                  std::vector<double> &data) const
+                                                  const ArrayView<double> &data) const
       {
         for (unsigned int i = 0; i < dim; ++i)
           data[data_position+i] = solution[this->introspection().component_indices.velocities[i]];


### PR DESCRIPTION
First part of #1220, only containing the interface changes to `Particle::get_properties`.
I was wondering if  `Particle::set_properties` should now also take an ArrayView instead of a vector? But on the other hand we do this change to hide the internal representation of the properties from the outside, and `set_properties` can simply convert the vector to something else in that case, so it should be fine to keep the vector?