### PR TITLE
[WIP] force vector

### DIFF
--- a/include/aspect/material_model/force_vector.h
+++ b/include/aspect/material_model/force_vector.h
@@ -1,0 +1,82 @@
+/*
+  Copyright (C) 2016 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef __aspect__material_model_force_vector_h
+#define __aspect__material_model_force_vector_h
+
+#include <aspect/material_model/interface.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/quadrature.h>
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/fe/mapping.h>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    using namespace dealii;
+
+    /**
+     * Additional material model output that supplies a force vector.
+     */
+    template<int dim>
+    class AdditionalMaterialOutputsForceVector: public AdditionalMaterialOutputs<dim>
+    {
+      public:
+        AdditionalMaterialOutputsForceVector(const unsigned int n_points)
+          : force_u(n_points), force_p(n_points), force_pc(n_points)
+        {}
+
+        virtual ~AdditionalMaterialOutputsForceVector()
+        {}
+
+        virtual void average (const MaterialAveraging::AveragingOperation /*operation*/,
+                              const FullMatrix<double>  &/*projection_matrix*/,
+                              const FullMatrix<double>  &/*expansion_matrix*/)
+        {
+          // TODO: not implemented
+        }
+
+        /**
+         * Force tensor for the conservation of momentum equation (first
+         * Stokes equation).
+         */
+        std::vector<Tensor<1,dim> > force_u;
+        /**
+         * Force for the conservation of mass equation (second Stokes
+         * equation).
+         */
+        std::vector<double> force_p;
+        /**
+         * Force for the compaction pressure equation (when using melt
+         * transport).
+         */
+        std::vector<double> force_pc;
+    };
+
+  }
+}
+
+
+#endif

--- a/tests/force_vector.cc
+++ b/tests/force_vector.cc
@@ -1,0 +1,742 @@
+#include <aspect/material_model/simple.h>
+#include <aspect/velocity_boundary_conditions/interface.h>
+#include <aspect/simulator_access.h>
+#include <aspect/global.h>
+#include <aspect/simulator.h>
+#include <aspect/assembly.h>
+#include <aspect/gravity_model/interface.h>
+
+
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/function_lib.h>
+#include <deal.II/numerics/error_estimator.h>
+#include <deal.II/numerics/vector_tools.h>
+
+
+
+namespace aspect
+{
+  double beta = 0.0;
+  
+  /**
+   * This is the "Burstedde" benchmark defined in the following paper:
+   * @code
+   *  @Article{busa13,
+   *    author =       {Burstedde, Carsten and Stadler, Georg and Alisic, Laura and Wilcox, Lucas C and Tan, Eh and Gurnis, Michael and Ghattas, Omar},
+   *    title =        {Large-scale adaptive mantle convection simulation},
+   *    journal =      {Geophysical Journal International},
+   *    year =         2013,
+   *    volume =       192,
+   *    number =       {3},
+   *    publisher =    {Oxford University Press},
+   *    pages =        {889--906}}
+   * @endcode
+   *
+   */
+  namespace BursteddeBenchmark
+  {
+    using namespace dealii;
+
+    namespace AnalyticSolutions
+    {
+      Tensor<1,3>
+      burstedde_velocity (const Point<3> &pos,
+                          const double eta)
+      {
+        const double x = pos[0];
+        const double y = pos[1];
+        const double z = pos[2];
+
+        // create a Point<3> (because it has a constructor that takes
+        // three doubles) and return it (it automatically converts to
+        // the necessary Tensor<1,3>).
+        return Point<3> (x+x*x+x*y+x*x*x*y,
+                         y+x*y+y*y+x*x*y*y,
+                         -2.*z-3.*x*z-3.*y*z-5.*x*x*y*z);
+      }
+
+      double
+      burstedde_pressure (const Point<3> &pos,
+                          const double eta)
+      {
+        const double x = pos[0];
+        const double y = pos[1];
+        const double z = pos[2];
+
+        const double min_eta = 1.0;
+        const double max_eta = eta;
+        const double A(min_eta*(max_eta-min_eta)/(max_eta+min_eta));
+
+        return x*y*z+x*x*x*y*y*y*z-5./32.;
+      }
+
+
+      /**
+       * The exact solution for the Burstedde benchmark.
+       */
+      template <int dim>
+      class FunctionBurstedde : public Function<dim>
+      {
+        public:
+          FunctionBurstedde (const double beta)
+            :
+            Function<dim>(dim+2),
+            beta_(beta)
+          {}
+
+          virtual void vector_value (const Point< dim >   &pos,
+                                     Vector< double >   &values) const
+          {
+            Assert (dim == 3, ExcNotImplemented());
+            Assert (values.size() >= 4, ExcInternalError());
+
+            const Point<3> p (pos[0], pos[1], pos[2]);
+
+            const Tensor<1,3> v = AnalyticSolutions::burstedde_velocity (p, beta_);
+            values[0] = v[0];
+            values[1] = v[1];
+            values[2] = v[2];
+
+            values[3] = AnalyticSolutions::burstedde_pressure (p, beta_);
+          }
+
+        private:
+          const double beta_;
+      };
+    }
+
+
+
+    template <int dim>
+    class BursteddeBoundary : public VelocityBoundaryConditions::Interface<dim>
+    {
+      public:
+        /**
+         * Constructor.
+         */
+        BursteddeBoundary();
+
+        /**
+         * Return the boundary velocity as a function of position.
+         */
+        virtual
+        Tensor<1,dim>
+        boundary_velocity (const types::boundary_id boundary_indicator,
+                           const Point<dim> &position) const;
+
+      private:
+        const double beta;
+    };
+
+    template <int dim>
+    BursteddeBoundary<dim>::BursteddeBoundary ()
+      :
+      beta (0)
+    {}
+
+
+
+    template <>
+    Tensor<1,2>
+    BursteddeBoundary<2>::
+    boundary_velocity (const types::boundary_id ,
+                       const Point<2> &p) const
+    {
+      Assert (false, ExcNotImplemented());
+      return Tensor<1,2>();
+    }
+
+
+
+    template <>
+    Tensor<1,3>
+    BursteddeBoundary<3>::
+    boundary_velocity (const types::boundary_id ,
+                       const Point<3> &p) const
+    {
+      return AnalyticSolutions::burstedde_velocity (p, beta);
+    }
+
+
+
+
+    /**
+     * @note This benchmark only talks about the flow field, not about a
+     * temperature field. All quantities related to the temperature are
+     * therefore set to zero in the implementation of this class.
+     *
+     * @ingroup MaterialModels
+     */
+    template <int dim>
+    class BursteddeMaterial : public MaterialModel::InterfaceCompatibility<dim>
+    {
+      public:
+        /**
+         * @name Physical parameters used in the basic equations
+         * @{
+         */
+        virtual double viscosity (const double                  temperature,
+                                  const double                  pressure,
+                                  const std::vector<double>    &compositional_fields,
+                                  const SymmetricTensor<2,dim> &strain_rate,
+                                  const Point<dim>             &position) const;
+
+        virtual double density (const double temperature,
+                                const double pressure,
+                                const std::vector<double> &compositional_fields,
+                                const Point<dim> &position) const;
+
+        virtual double compressibility (const double temperature,
+                                        const double pressure,
+                                        const std::vector<double> &compositional_fields,
+                                        const Point<dim> &position) const;
+
+        virtual double specific_heat (const double temperature,
+                                      const double pressure,
+                                      const std::vector<double> &compositional_fields,
+                                      const Point<dim> &position) const;
+
+        virtual double thermal_expansion_coefficient (const double      temperature,
+                                                      const double      pressure,
+                                                      const std::vector<double> &compositional_fields,
+                                                      const Point<dim> &position) const;
+
+        virtual double thermal_conductivity (const double temperature,
+                                             const double pressure,
+                                             const std::vector<double> &compositional_fields,
+                                             const Point<dim> &position) const;
+        /**
+         * @}
+         */
+
+        /**
+         * @name Qualitative properties one can ask a material model
+         * @{
+         */
+
+        /**
+         * Return whether the model is compressible or not.
+         * Incompressibility does not necessarily imply that the density is
+         * constant; rather, it may still depend on temperature or pressure.
+         * In the current context, compressibility means whether we should
+         * solve the continuity equation as $\nabla \cdot (\rho \mathbf u)=0$
+         * (compressible Stokes) or as $\nabla \cdot \mathbf{u}=0$
+         * (incompressible Stokes).
+         */
+        virtual bool is_compressible () const;
+        /**
+         * @}
+         */
+        /**
+         * Declare the parameters this class takes through input files.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         */
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
+
+
+
+        /**
+         * @name Reference quantities
+         * @{
+         */
+        virtual double reference_viscosity () const;
+        /**
+         * @}
+         */
+        /**
+         * Returns the viscosity value in the inclusion
+         */
+        double get_beta() const;
+
+    };
+
+    template <int dim>
+    double
+    BursteddeMaterial<dim>::
+    viscosity (const double,
+               const double,
+               const std::vector<double> &,       /*composition*/
+               const SymmetricTensor<2,dim> &,
+               const Point<dim> &p) const
+    {
+      const double mu = exp(1. - beta * (p(0)*(1.-p(0))+p(1)*(1.-p(1)) + p(2)*(1.-p(2))));
+      return mu;
+    }
+
+
+    template <int dim>
+    double
+    BursteddeMaterial<dim>::
+    reference_viscosity () const
+    {
+      return 1.;
+    }
+
+
+    template <int dim>
+    double
+    BursteddeMaterial<dim>::
+    specific_heat (const double,
+                   const double,
+                   const std::vector<double> &, /*composition*/
+                   const Point<dim> &) const
+    {
+      return 0;
+    }
+
+
+    template <int dim>
+    double
+    BursteddeMaterial<dim>::
+    thermal_conductivity (const double,
+                          const double,
+                          const std::vector<double> &, /*composition*/
+                          const Point<dim> &) const
+    {
+      return 0;
+    }
+
+
+    template <int dim>
+    double
+    BursteddeMaterial<dim>::
+    density (const double,
+             const double,
+             const std::vector<double> &, /*composition*/
+             const Point<dim> &p) const
+    {
+      return 1;
+    }
+
+
+    template <int dim>
+    double
+    BursteddeMaterial<dim>::
+    thermal_expansion_coefficient (const double temperature,
+                                   const double,
+                                   const std::vector<double> &, /*composition*/
+                                   const Point<dim> &) const
+    {
+      return 0;
+    }
+
+
+    template <int dim>
+    double
+    BursteddeMaterial<dim>::
+    compressibility (const double,
+                     const double,
+                     const std::vector<double> &, /*composition*/
+                     const Point<dim> &) const
+    {
+      return 0.0;
+    }
+
+
+    template <int dim>
+    bool
+    BursteddeMaterial<dim>::
+    is_compressible () const
+    {
+      return false;
+    }
+
+    template <int dim>
+    void
+    BursteddeMaterial<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      //create a global section in the parameter file for parameters
+      //that describe this benchmark. note that we declare them here
+      //in the material model, but other kinds of plugins (e.g., the gravity
+      //model below) may also read these parameters even though they do not
+      //declare them
+      prm.enter_subsection("Burstedde benchmark");
+      {
+        prm.declare_entry("Viscosity parameter", "20",
+                          Patterns::Double (0),
+                          "Viscosity in the Burstedde benchmark.");
+      }
+      prm.leave_subsection();
+    }
+
+
+    template <int dim>
+    void
+    BursteddeMaterial<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Burstedde benchmark");
+      {
+        beta = prm.get_double ("Viscosity parameter");
+      }
+      prm.leave_subsection();
+
+      // Declare dependencies on solution variables
+      this->model_dependence.viscosity = MaterialModel::NonlinearDependence::none;
+      this->model_dependence.density = MaterialModel::NonlinearDependence::none;
+      this->model_dependence.compressibility = MaterialModel::NonlinearDependence::none;
+      this->model_dependence.specific_heat = MaterialModel::NonlinearDependence::none;
+      this->model_dependence.thermal_conductivity = MaterialModel::NonlinearDependence::none;
+    }
+
+
+    template <int dim>
+    double
+    BursteddeMaterial<dim>::get_beta() const
+    {
+      return beta;
+    }
+
+    /**
+     *gravity model for the Burstedde benchmark
+    */
+
+    template <int dim>
+    class BursteddeGravity : public aspect::GravityModel::Interface<dim>
+    {
+      public:
+        virtual Tensor<1,dim> gravity_vector (const Point<dim> &pos) const;
+
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+        */
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
+
+        double beta;
+    };
+
+    template <int dim>
+    Tensor<1,dim>
+    BursteddeGravity<dim>::
+    gravity_vector(const Point<dim> &pos) const
+    {
+
+      const double x=pos[0];
+      const double y=pos[1];
+      const double z=pos[2];
+      const double mu=exp(1. - beta * (x*(1.-x)+y*(1.-y) + z*(1.-z)));
+
+      const double dmudx=-beta*(1.-2.*x)*mu;
+      const double dmudy=-beta*(1.-2.*y)*mu;
+      const double dmudz=-beta*(1.-2.*z)*mu;
+
+      Tensor<1,dim> g;
+      /*
+      g[0]=((y*z+3.*std::pow(x,2)*std::pow(y,3)*z)- mu*(2.+6.*x*y))
+           -dmudx*(2.+4.*x+2.*y+6.*std::pow(x,2)*y)
+           -dmudy*(x+std::pow(x,3)+y+2.*x*std::pow(y,2))
+           -dmudz*(-3.*z-10.*x*y*z);
+
+      g[1]=((x*z+3.*std::pow(x,3)*std::pow(y,2)*z)- mu*(2.+2.*std::pow(x,2)+2.*std::pow(y,2)))
+           -dmudx*(x+std::pow(x,3)+y+2.*x*std::pow(y,2))
+           -dmudy*(2.+2.*x+4.*y+4.*std::pow(x,2)*y)
+           -dmudz*(-3.*z-5.*std::pow(x,2)*z);
+
+      g[2]=((x*y+std::pow(x,3)*std::pow(y,3)) - mu*(-10.*y*z))
+           -dmudx*(-3.*z-10.*x*y*z)
+           -dmudy*(-3.*z-5.*std::pow(x,2)*z)
+           -dmudz*(-4.-6.*x-6.*y-10.*std::pow(x,2)*y);
+      */
+      return g;
+    }
+
+    template <int dim>
+    void
+    BursteddeGravity<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      //nothing to declare here. This plugin will however, read parameters
+      //declared by the material model in the "Burstedde benchmark" section
+    }
+
+    template <int dim>
+    void
+    BursteddeGravity<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Burstedde benchmark");
+      {
+        beta = prm.get_double ("Viscosity parameter");
+      }
+      prm.leave_subsection();
+    }
+
+
+    /**
+      * A postprocessor that evaluates the accuracy of the solution.
+      *
+      * The implementation of error evaluators that correspond to the
+      * benchmarks defined in the paper Duretz et al. reference above.
+      */
+    template <int dim>
+    class BursteddePostprocessor : public Postprocess::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * Generate graphical output from the current solution.
+         */
+        virtual
+        std::pair<std::string,std::string>
+        execute (TableHandler &statistics);
+    };
+
+    template <int dim>
+    std::pair<std::string,std::string>
+    BursteddePostprocessor<dim>::execute (TableHandler &statistics)
+    {
+      std_cxx1x::shared_ptr<Function<dim> > ref_func;
+      {
+        const BursteddeMaterial<dim> *
+        material_model
+          = dynamic_cast<const BursteddeMaterial<dim> *>(&this->get_material_model());
+
+        ref_func.reset (new AnalyticSolutions::FunctionBurstedde<dim>(material_model->get_beta()));
+      }
+
+      const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.velocities).degree+2);
+
+      Vector<float> cellwise_errors_u (this->get_triangulation().n_active_cells());
+      Vector<float> cellwise_errors_p (this->get_triangulation().n_active_cells());
+      Vector<float> cellwise_errors_ul2 (this->get_triangulation().n_active_cells());
+      Vector<float> cellwise_errors_pl2 (this->get_triangulation().n_active_cells());
+
+      ComponentSelectFunction<dim> comp_u(std::pair<unsigned int, unsigned int>(0,dim),
+                                          dim+2);
+      ComponentSelectFunction<dim> comp_p(dim, dim+2);
+
+      VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                         this->get_solution(),
+                                         *ref_func,
+                                         cellwise_errors_u,
+                                         quadrature_formula,
+                                         VectorTools::L1_norm,
+                                         &comp_u);
+      VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                         this->get_solution(),
+                                         *ref_func,
+                                         cellwise_errors_p,
+                                         quadrature_formula,
+                                         VectorTools::L1_norm,
+                                         &comp_p);
+      VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                         this->get_solution(),
+                                         *ref_func,
+                                         cellwise_errors_ul2,
+                                         quadrature_formula,
+                                         VectorTools::L2_norm,
+                                         &comp_u);
+      VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                         this->get_solution(),
+                                         *ref_func,
+                                         cellwise_errors_pl2,
+                                         quadrature_formula,
+                                         VectorTools::L2_norm,
+                                         &comp_p);
+
+      const double u_l1 = Utilities::MPI::sum(cellwise_errors_u.l1_norm(),MPI_COMM_WORLD);
+      const double p_l1 = Utilities::MPI::sum(cellwise_errors_p.l1_norm(),MPI_COMM_WORLD);
+      const double u_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_ul2.norm_sqr(),MPI_COMM_WORLD));
+      const double p_l2 = std::sqrt(Utilities::MPI::sum(cellwise_errors_pl2.norm_sqr(),MPI_COMM_WORLD));
+
+      std::ostringstream os;
+
+
+      os << std::scientific <<  u_l1
+         << ", " << p_l1
+         << ", " << u_l2
+         << ", " << p_l2;
+
+      return std::make_pair("Errors u_L1, p_L1, u_L2, p_L2:", os.str());
+    }
+
+  }
+
+   template <int dim>
+  class ForceAssembler :
+    public aspect::internal::Assembly::Assemblers::AssemblerBase<dim>,
+    public SimulatorAccess<dim>
+  {
+
+    public:
+
+      virtual
+      void
+      assemble (const typename DoFHandler<dim>::active_cell_iterator &/*cell*/,
+                const double                                     pressure_scaling,
+                const bool                                       rebuild_stokes_matrix,
+                internal::Assembly::Scratch::StokesSystem<dim>  &scratch,
+                internal::Assembly::CopyData::StokesSystem<dim> &data) const
+      {
+        const Introspection<dim> &introspection = this->introspection();
+        const FiniteElement<dim> &fe = this->get_fe();
+        const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
+        const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
+
+        for (unsigned int i=0, i_stokes=0; i_stokes<stokes_dofs_per_cell; /*increment at end of loop*/)
+          {
+            const unsigned int component_index_i = fe.system_to_component_index(i).first;
+
+            if (component_index_i == introspection.component_indices.pressure
+		||
+		(
+		component_index_i >= introspection.component_indices.velocities[0]
+		&&
+		component_index_i <= introspection.component_indices.velocities[dim-1]
+		))
+              {
+                data.local_dof_indices[i_stokes] = scratch.local_dof_indices[i];
+                ++i_stokes;
+              }
+            ++i;
+          }
+
+        for (unsigned int q=0; q<n_q_points; ++q)
+          {
+            const double x = scratch.finite_element_values.quadrature_point(q)[0];
+	    const double y = scratch.finite_element_values.quadrature_point(q)[1];
+            const double z = scratch.finite_element_values.quadrature_point(q)[2];
+
+            Tensor<1,dim> force_u;
+            const double force_p = 0.0;
+
+      const double mu=exp(1. - beta * (x*(1.-x)+y*(1.-y) + z*(1.-z)));
+
+      const double dmudx=-beta*(1.-2.*x)*mu;
+      const double dmudy=-beta*(1.-2.*y)*mu;
+      const double dmudz=-beta*(1.-2.*z)*mu;
+
+      Tensor<1,dim> g;
+      force_u[0]=((y*z+3.*std::pow(x,2)*std::pow(y,3)*z)- mu*(2.+6.*x*y))
+           -dmudx*(2.+4.*x+2.*y+6.*std::pow(x,2)*y)
+           -dmudy*(x+std::pow(x,3)+y+2.*x*std::pow(y,2))
+           -dmudz*(-3.*z-10.*x*y*z);
+
+      force_u[1]=((x*z+3.*std::pow(x,3)*std::pow(y,2)*z)- mu*(2.+2.*std::pow(x,2)+2.*std::pow(y,2)))
+           -dmudx*(x+std::pow(x,3)+y+2.*x*std::pow(y,2))
+           -dmudy*(2.+2.*x+4.*y+4.*std::pow(x,2)*y)
+           -dmudz*(-3.*z-5.*std::pow(x,2)*z);
+
+      force_u[2]=((x*y+std::pow(x,3)*std::pow(y,3)) - mu*(-10.*y*z))
+           -dmudx*(-3.*z-10.*x*y*z)
+           -dmudy*(-3.*z-5.*std::pow(x,2)*z)
+           -dmudz*(-4.-6.*x-6.*y-10.*std::pow(x,2)*y);
+
+
+
+
+	    
+            for (unsigned int i=0, i_stokes=0; i_stokes<stokes_dofs_per_cell; /*increment at end of loop*/)
+              {
+                const unsigned int component_index_i = fe.system_to_component_index(i).first;
+
+                if (component_index_i == introspection.component_indices.pressure
+		||
+		(
+		component_index_i >= introspection.component_indices.velocities[0]
+		&&
+		component_index_i <= introspection.component_indices.velocities[dim-1]
+		))
+                  {
+                    scratch.phi_u[i_stokes]   = scratch.finite_element_values[introspection.extractors.velocities].value (i,q);
+                    scratch.phi_p[i_stokes]   = scratch.finite_element_values[introspection.extractors.pressure].value (i, q);
+
+                    ++i_stokes;
+                  }
+                ++i;
+              }
+
+            const double JxW = scratch.finite_element_values.JxW(q);
+
+            for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
+              {
+                data.local_rhs(i) += (
+                                       (force_u * scratch.phi_u[i]
+                                        + pressure_scaling * force_p * scratch.phi_p[i])
+                                     )
+                                     * JxW;
+              }
+          }
+      }
+
+  };
+
+  template <int dim>
+  void add_force_assembler(const SimulatorAccess<dim> &simulator_access,
+                           internal::Assembly::AssemblerLists<dim> &assemblers,
+                           std::vector<dealii::std_cxx11::shared_ptr<
+                           internal::Assembly::Assemblers::AssemblerBase<dim> > > &assembler_objects)
+  {
+
+    std_cxx11::shared_ptr<ForceAssembler<dim> > assembler (new ForceAssembler<dim>());
+    assembler_objects.push_back (assembler);
+
+    // add the terms for phase change boundary conditions
+    assemblers.local_assemble_stokes_system.connect (
+      std_cxx11::bind(&ForceAssembler<dim>::assemble,
+                      std_cxx11::cref (*assembler),
+                      std_cxx11::_1,
+                      std_cxx11::_2,
+                      std_cxx11::_3,
+                      std_cxx11::_4,
+                      std_cxx11::_5));
+  }
+
+
+
+ 
+}
+
+
+
+
+
+template <int dim>
+void signal_connector (aspect::SimulatorSignals<dim> &signals)
+{
+  signals.set_assemblers.connect (&aspect::add_force_assembler<dim>);
+}
+
+ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
+                                  signal_connector<3>)
+
+// explicit instantiations
+namespace aspect
+{
+  namespace BursteddeBenchmark
+  {
+    ASPECT_REGISTER_MATERIAL_MODEL(BursteddeMaterial,
+                                   "BursteddeMaterial",
+                                   "A material model that corresponds to the `Burstedde' benchmark. "
+                                   "See the manual for more information.")
+
+    ASPECT_REGISTER_VELOCITY_BOUNDARY_CONDITIONS(BursteddeBoundary,
+                                                 "BursteddeBoundary",
+                                                 "Implementation of the velocity boundary conditions for the "
+                                                 "`Burstedde' benchmark. See the manual for more information about this "
+                                                 "benchmark.")
+
+    ASPECT_REGISTER_POSTPROCESSOR(BursteddePostprocessor,
+                                  "BursteddePostprocessor",
+                                  "A postprocessor that compares the solution of the `Burstedde' benchmark "
+                                  "with the one computed by ASPECT "
+                                  "and reports the error. See the manual for more information.")
+    ASPECT_REGISTER_GRAVITY_MODEL(BursteddeGravity,
+                                  "BursteddeGravity",
+                                  "A gravity model in corresponding to the `Burstedde' benchmark. "
+                                  "See the manual for more information.")
+  }
+}
+

--- a/tests/force_vector.prm
+++ b/tests/force_vector.prm
@@ -1,0 +1,101 @@
+# burstedde benchmark but using a force vector assembler plugin
+
+############### Global parameters
+# We use a 3d setup. Since we are only interested
+# in a steady state solution, we set the end time
+# equal to the start time to force a single time
+# step before the program terminates.
+set Additional shared libraries            = ./libburstedde.so
+set Linear solver tolerance                = 1e-12
+
+set Dimension                              = 3
+
+set Start time                             = 0
+set End time                               = 0
+set Use years in output instead of seconds = false
+
+set Nonlinear solver scheme                = Stokes only
+
+set Output directory                       = output
+
+set Pressure normalization                 = volume
+
+set Number of cheap Stokes solver steps = 0
+
+############### Parameters describing the model
+# The setup is a 3d unit cube.
+# Because the temperature plays no role in this model we need not
+# bother to describe temperature boundary conditions or
+# the material parameters that pertain to the temperature.
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent  = 1
+    set Y extent  = 1 
+    set Z extent  = 1
+  end
+end
+
+#Boundary conditions
+subsection Model settings
+  set Tangential velocity boundary indicators = 
+  set Prescribed velocity boundary indicators = 0:BursteddeBoundary, 1: BursteddeBoundary, 2: BursteddeBoundary, 3: BursteddeBoundary, 4: BursteddeBoundary, 5: BursteddeBoundary
+end
+
+
+subsection Material model
+  set Model name = BursteddeMaterial
+end
+
+
+subsection Gravity model
+  set Model name = BursteddeGravity
+end
+
+subsection Burstedde benchmark
+   #Viscosity parameter is beta  
+   set Viscosity parameter             = 20
+end 
+
+############### Parameters describing the temperature field
+# As above, there is no need to set anything for the
+# temperature boundary conditions.
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+subsection Initial conditions
+  set Model name = function
+
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+
+############### Parameters describing the discretization
+# The following parameters describe how often we want to refine
+# the mesh globally and adaptively, what fraction of cells should
+# be refined in each adaptive refinement step, and what refinement
+# indicator to use when refining the mesh adaptively. 
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 2
+  set Refinement fraction                = 0.2
+  set Strategy                           = velocity
+end
+
+
+############### Parameters describing what to do with the solution
+# The final section allows us to choose which postprocessors to
+# run at the end of each time step. 
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, BursteddePostprocessor
+end
+

--- a/tests/force_vector/screen-output
+++ b/tests/force_vector/screen-output
@@ -1,0 +1,24 @@
+
+Loading shared library <./libforce_vector.so>
+
+Number of active cells: 64 (on 3 levels)
+Number of degrees of freedom: 3,041 (2,187+125+729)
+
+*** Timestep 0:  t=0 seconds
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+      Relative Stokes residual after nonlinear iteration 1: 1
+   Solving Stokes system... 0+0 iterations.
+      Relative Stokes residual after nonlinear iteration 2: 8.85273e-13
+
+   Postprocessing:
+     RMS, max velocity:             4.3 m/s, 13.2 m/s
+     Errors u_L1, p_L1, u_L2, p_L2: 6.029937e-01, 1.448270e-03, 1.059164e+00, 3.023064e-03
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/melt_force_vector.cc
+++ b/tests/melt_force_vector.cc
@@ -1,0 +1,333 @@
+#include <aspect/melt.h>
+#include <aspect/material_model/force_vector.h>
+#include <aspect/velocity_boundary_conditions/interface.h>
+#include <aspect/fluid_pressure_boundary_conditions/interface.h>
+#include <aspect/simulator_access.h>
+#include <aspect/global.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/function_lib.h>
+#include <deal.II/numerics/error_estimator.h>
+#include <deal.II/numerics/vector_tools.h>
+
+namespace aspect
+{
+
+  template <int dim>
+  class TestMeltMaterial:
+    public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+  {
+  public:
+    virtual bool
+    viscosity_depends_on (const MaterialModel::NonlinearDependence::Dependence dependence) const
+    {
+      if ((dependence & MaterialModel::NonlinearDependence::compositional_fields) != MaterialModel::NonlinearDependence::none)
+        return true;
+      return false;
+    }
+
+    virtual bool
+    density_depends_on (const MaterialModel::NonlinearDependence::Dependence dependence) const
+    {
+      return false;
+    }
+
+
+    virtual bool
+    compressibility_depends_on (const MaterialModel::NonlinearDependence::Dependence dependence) const
+    {
+      return false;
+    }
+
+
+    virtual bool
+    specific_heat_depends_on (const MaterialModel::NonlinearDependence::Dependence dependence) const
+    {
+      return false;
+    }
+
+
+    virtual bool
+    thermal_conductivity_depends_on (const MaterialModel::NonlinearDependence::Dependence dependence) const
+    {
+      return false;
+    }
+
+    virtual bool is_compressible () const
+    {
+      return false;
+    }
+
+    virtual double reference_viscosity () const
+    {
+      return 1.0;
+    }
+
+    virtual double reference_density () const
+    {
+      return 1.0;
+    }
+    virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
+                          typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
+    {
+      const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
+      double c = 1.0;
+      aspect::MaterialModel::AdditionalMaterialOutputsForceVector<dim>
+      *force = out.template get_additional_output<aspect::MaterialModel::AdditionalMaterialOutputsForceVector<dim> >();
+      if (!force)
+        {
+          out.additional_outputs.push_back(std::make_shared<
+                                           aspect::MaterialModel::AdditionalMaterialOutputsForceVector<dim> >(in.position.size()));
+          force = out.template get_additional_output<aspect::MaterialModel::AdditionalMaterialOutputsForceVector<dim> >();
+        }
+
+
+      for (unsigned int i=0; i<in.position.size(); ++i)
+        {
+          const double porosity = in.composition[i][porosity_idx];
+          const double x = in.position[i](0);
+          const double z = in.position[i](1);
+          out.viscosities[i] = 1.0;
+          out.thermal_expansion_coefficients[i] = 0.0;
+          out.specific_heat[i] = 1.0;
+          out.thermal_conductivities[i] = 1.0;
+          out.compressibilities[i] = 0.0;
+          out.densities[i] = 1.0;
+
+          out.reaction_terms[i][porosity_idx] = 0;
+//**********
+// copy and paste here
+          force->force_u[i][0] = cos(z) - cos(x + z) + cos(x * z) * z;
+          force->force_u[i][1] = sin(x) - cos(x + z) + cos(x * z) * x;
+          force->force_p[i] = 0.4e1 * sin(x + z) - sin(x * z) * z * z - sin(x * z) * x * x;
+          force->force_pc[i] = -0.10e2 * sin(x + z) / (0.1e1 + exp(-0.20e2 * x * x - 0.20e2 * z * z + 0.1e1));
+//***********
+        }
+
+      // fill melt outputs if they exist
+      aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
+
+      if (melt_out != NULL)
+        for (unsigned int i=0; i<in.position.size(); ++i)
+          {
+            double porosity = in.composition[i][porosity_idx];
+            //porosity = 0.1000000000e-1 + 0.2000000000e0 * exp(-0.200e2 * pow(x + 0.2e1 * z, 0.2e1));
+            const double x = in.position[i](0);
+            const double z = in.position[i](1);
+            melt_out->compaction_viscosities[i] = 0.1e0 + 0.1e0 * exp(-0.20e2 * x * x - 0.20e2 * z * z + 0.1e1); // xi
+            melt_out->fluid_viscosities[i] = 1.0;
+            melt_out->permeabilities[i] = 1.0; // K_D
+            melt_out->fluid_density_gradients[i] = 0.0;
+            melt_out->fluid_densities[i] = 0.5;
+          }
+
+    }
+
+  };
+
+
+  template <int dim>
+  class Gravity : public aspect::GravityModel::Interface<dim>
+  {
+  public:
+    virtual Tensor<1,dim> gravity_vector (const Point<dim> &pos) const
+    {
+      Tensor<1,dim> gravity;
+      // zero when we have the force vector
+      gravity[0] = 0.0;
+      gravity[1] = 0.0;
+
+      return gravity;
+    }
+
+
+  };
+
+
+  template <int dim>
+  class RefFunction : public Function<dim>
+  {
+  public:
+    RefFunction () : Function<dim>(dim+2) {}
+    virtual void vector_value (const Point< dim >   &p,
+                               Vector< double >   &values) const
+    {
+      double x = p(0);
+      double z = p(1);
+//**********
+// copy and paste here (add "out.")
+      values[0] = cos(z);
+      values[1] = sin(x);
+      values[2] = -0.2e1 * sin(x + z) + sin(x * z);
+      values[3] = sin(x + z);
+      values[4] = 1;
+      values[5] = 1;
+      values[6] = sin(x * z);
+      values[7] = 0;
+      values[8] = 0.1000000000e-1 + 0.2000000000e0 * exp(-0.200e2 * pow(x + 0.20e1 * z, 0.2e1));
+//**********
+    }
+  };
+
+
+
+  /**
+    * A postprocessor that evaluates the accuracy of the solution
+    * by using the L2 norm.
+    */
+  template <int dim>
+  class ConvergenceMeltPostprocessor : public Postprocess::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+  {
+  public:
+    /**
+     * Generate graphical output from the current solution.
+     */
+    virtual
+    std::pair<std::string,std::string>
+    execute (TableHandler &statistics);
+
+  };
+
+  template <int dim>
+  std::pair<std::string,std::string>
+  ConvergenceMeltPostprocessor<dim>::execute (TableHandler &statistics)
+  {
+    RefFunction<dim> ref_func;
+    const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.velocities).degree+2);
+
+    const unsigned int n_total_comp = this->introspection().n_components;
+
+    Vector<float> cellwise_errors_u (this->get_triangulation().n_active_cells());
+    Vector<float> cellwise_errors_p_f (this->get_triangulation().n_active_cells());
+    Vector<float> cellwise_errors_p_c (this->get_triangulation().n_active_cells());
+    Vector<float> cellwise_errors_u_f (this->get_triangulation().n_active_cells());
+    Vector<float> cellwise_errors_p (this->get_triangulation().n_active_cells());
+    Vector<float> cellwise_errors_porosity (this->get_triangulation().n_active_cells());
+
+    ComponentSelectFunction<dim> comp_u(std::pair<unsigned int, unsigned int>(0,dim),
+                                        n_total_comp);
+    ComponentSelectFunction<dim> comp_p_f(dim, n_total_comp);
+    ComponentSelectFunction<dim> comp_p_c(dim+1, n_total_comp);
+    ComponentSelectFunction<dim> comp_u_f(std::pair<unsigned int, unsigned int>(dim+2,dim+2+
+                                          dim),
+                                          n_total_comp);
+    ComponentSelectFunction<dim> comp_p(dim+2+dim, n_total_comp);
+    ComponentSelectFunction<dim> comp_porosity(dim+2+dim+2, n_total_comp);
+
+    VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                       this->get_solution(),
+                                       ref_func,
+                                       cellwise_errors_u,
+                                       quadrature_formula,
+                                       VectorTools::L2_norm,
+                                       &comp_u);
+    VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                       this->get_solution(),
+                                       ref_func,
+                                       cellwise_errors_p_f,
+                                       quadrature_formula,
+                                       VectorTools::L2_norm,
+                                       &comp_p_f);
+    VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                       this->get_solution(),
+                                       ref_func,
+                                       cellwise_errors_p,
+                                       quadrature_formula,
+                                       VectorTools::L2_norm,
+                                       &comp_p);
+    VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                       this->get_solution(),
+                                       ref_func,
+                                       cellwise_errors_p_c,
+                                       quadrature_formula,
+                                       VectorTools::L2_norm,
+                                       &comp_p_c);
+    VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                       this->get_solution(),
+                                       ref_func,
+                                       cellwise_errors_porosity,
+                                       quadrature_formula,
+                                       VectorTools::L2_norm,
+                                       &comp_porosity);
+    VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                       this->get_solution(),
+                                       ref_func,
+                                       cellwise_errors_u_f,
+                                       quadrature_formula,
+                                       VectorTools::L2_norm,
+                                       &comp_u_f);
+
+    std::ostringstream os;
+    os << std::scientific
+       << " h = " << this->get_triangulation().begin_active()->diameter()
+       << " ndofs= " << this->get_solution().size()
+       << " u_L2= " << std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),MPI_COMM_WORLD))
+       << " p_L2= "  << std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),MPI_COMM_WORLD))
+       << " p_f_L2= " << std::sqrt(Utilities::MPI::sum(cellwise_errors_p_f.norm_sqr(),MPI_COMM_WORLD))
+       << " p_c_L= " << std::sqrt(Utilities::MPI::sum(cellwise_errors_p_c.norm_sqr(),MPI_COMM_WORLD))
+       << " phi_L2= " << std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),MPI_COMM_WORLD))
+       << " u_f_L2= " << std::sqrt(Utilities::MPI::sum(cellwise_errors_u_f.norm_sqr(),MPI_COMM_WORLD))
+       ;
+
+    return std::make_pair("Errors", os.str());
+  }
+
+
+  template <int dim>
+  class PressureBdry:
+
+    public FluidPressureBoundaryConditions::Interface<dim>
+  {
+  public:
+    virtual
+    void fluid_pressure_gradient (
+      const dealii::types::boundary_id,
+      const typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
+      const typename MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
+      const std::vector<Tensor<1,dim> > &normal_vectors,
+      std::vector<double> &output
+    ) const
+    {
+      for (unsigned int q=0; q<output.size(); ++q)
+        {
+          const double x = material_model_inputs.position[q][0];
+          const double z = material_model_inputs.position[q][1];
+          Tensor<1,dim> gradient;
+//**********
+// copy and paste here (add "out.")
+          gradient[0] = -0.2e1 * cos(x + z) + cos(x * z) * z;
+          gradient[1] = -0.2e1 * cos(x + z) + cos(x * z) * x;
+//**********
+          output[q] = gradient * normal_vectors[q];
+        }
+    }
+
+
+
+  };
+
+}
+
+// explicit instantiations
+namespace aspect
+{
+  ASPECT_REGISTER_GRAVITY_MODEL(Gravity,
+                                "MyGravity",
+                                "")
+
+  ASPECT_REGISTER_MATERIAL_MODEL(TestMeltMaterial,
+                                 "test melt material",
+                                 "")
+
+  ASPECT_REGISTER_POSTPROCESSOR(ConvergenceMeltPostprocessor,
+                                "melt error calculation",
+                                "A postprocessor that compares the numerical solution to the analytical solution")
+
+  ASPECT_REGISTER_FLUID_PRESSURE_BOUNDARY_CONDITIONS(PressureBdry,
+                                                     "PressureBdry",
+                                                     "A fluid pressure boundary condition that prescribes the "
+                                                     "gradient of the fluid pressure at the boundaries as "
+                                                     "calculated in the analytical solution. ")
+
+}

--- a/tests/melt_force_vector.prm
+++ b/tests/melt_force_vector.prm
@@ -1,0 +1,175 @@
+# A simple reference solution with RHS force vector with incompressible
+# melt transport
+
+set Nonlinear solver scheme                = IMPES
+set Max nonlinear iterations               = 50
+set Nonlinear solver tolerance             = 1e-10 #1e-10
+set Linear solver tolerance                = 1e-12
+
+set Use direct solver for Stokes system        = true
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 3
+  set Refinement fraction                      = 1.0
+  set Coarsening fraction                      = 0.0
+
+  set Strategy = velocity
+
+  set Time steps between mesh refinement       = 0
+  set Initial adaptive refinement              = 1
+  set Run postprocessors on initial refinement = true
+  set Normalize individual refinement criteria = false#true
+
+end
+
+
+set Adiabatic surface temperature          = 1623               # default: 0
+set CFL number                             = 1.0
+
+# The number of space dimensions you want to run this program in.
+set Dimension                              = 2
+
+# The end time of the simulation. Units: years if the 'Use years in output
+# instead of seconds' parameter is set; seconds otherwise.
+set End time                               = 0
+
+set Pressure normalization                 = volume
+set Surface pressure                       = 0#0.2746026940#3.992884522
+set Resume computation                     = false
+set Start time                             = 0
+
+set Use years in output instead of seconds = false
+set Number of cheap Stokes solver steps    = 0
+
+subsection Compositional fields
+  set Number of fields = 1
+  set Names of fields = porosity
+end
+
+subsection Boundary fluid pressure model
+ set Plugin name = PressureBdry
+end
+
+subsection Boundary temperature model
+  set Model name = initial temperature
+
+  subsection Initial temperature
+    # Temperature at the inner boundary (core mantle boundary). Units: K.
+    set Maximal temperature = 3773 # default: 6000
+
+    # Temperature at the outer boundary (lithosphere water/air). Units: K.
+    set Minimal temperature = 273  # default: 0
+  end
+
+end
+
+subsection Boundary composition model
+  set Model name = initial composition
+end
+
+
+subsection Geometry model
+  set Model name = box # default: 
+
+  subsection Box
+    set X extent  = 2
+    set Y extent  = 2
+    set Box origin X coordinate = -1
+    set Box origin Y coordinate = -1
+  end
+
+end
+
+
+subsection Gravity model
+  set Model name = MyGravity
+
+end
+
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = cos(z);sin(x)
+    set Variable names      = x,z
+  end
+end  
+
+
+subsection Initial conditions
+  set Model name = function # default: 
+  subsection Function
+    set Function expression = 0
+    set Variable names      = x,z
+  end
+end
+
+subsection Compositional initial conditions
+  set Model name = function # default: 
+  subsection Function
+    set Function constants = pi=3.14159265359
+#    set Function expression = if(abs(x)==1 || abs(z)==1, 0.1000000000e-1 + 0.1000000000e0 * exp(-0.40e1 * ((x + 0.20e1 * z)^ 0.2e1)), 0)
+#    set Function expression = 0.1000000000e-1 + 0.1000000000e0 * exp(-0.40e1 * ((x + 0.20e1 * z)^ 0.2e1))
+set Function expression = 0.1000000000e-1 + 0.2000000000e0 * exp(-0.200e2 * ((x + 0.2e1 * z)^ 0.2e1))
+    set Variable names      = x,z
+  end
+end
+
+
+subsection Material model
+
+  set Model name = test melt material
+  
+
+end
+
+
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = 2,3        # default: 
+  set Fixed composition boundary indicators   = 0,1,2,3   
+  set Prescribed velocity boundary indicators = 0:function, 1:function, 2:function, 3:function
+
+  set Tangential velocity boundary indicators = 
+  set Zero velocity boundary indicators       =           # default: 
+
+  set Include melt transport                  = true
+#  set Melt transport threshold = 0
+end
+
+
+subsection Postprocess
+
+  set List of postprocessors = visualization, velocity statistics, pressure statistics, velocity boundary statistics, melt error calculation
+
+  subsection Visualization
+
+    set List of output variables      = #melt density, permeability, melt viscosity, compaction viscosity, gravity, material properties, nonadiabatic pressure
+#    set List of output variables      = gravity, material properties, nonadiabatic pressure
+
+    subsection Material properties
+    set List of material properties   = density, viscosity, thermal expansivity, reaction terms
+    end
+
+    # VTU file output supports grouping files from several CPUs into one file
+    # using MPI I/O when writing on a parallel filesystem. Select 0 for no
+    # grouping. This will disable parallel file output and instead write one
+    # file per processor in a background thread. A value of 1 will generate
+    # one big file containing the whole solution.
+    set Number of grouped files       = 0
+
+    # The file format to be used for graphical output.
+    set Output format                 = vtu
+    set Interpolate output = true
+
+    # The time interval between each generation of graphical output files. A
+    # value of zero indicates that output should be generated in each time
+    # step. Units: years if the 'Use years in output instead of seconds'
+    # parameter is set; seconds otherwise.
+    set Time between graphical output = 0                                                                                # default: 1e8
+  end
+
+end
+
+
+

--- a/tests/melt_force_vector/screen-output
+++ b/tests/melt_force_vector/screen-output
@@ -1,0 +1,44 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libmelt_force_vector.so>
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 1,977 (740+578+81+289+289)
+
+*** Timestep 0:  t=0 seconds
+   Skipping temperature solve because RHS is zero.
+   Solving porosity system ... 0 iterations.
+   Solving Stokes system... done.
+   Solving for u_f in 1 iterations.
+
+   Postprocessing:
+     Writing graphical output:                  output-melt_force_vector/solution/solution-00000
+     RMS, max velocity:                         0.999 m/s, 1.3 m/s
+     Pressure min/avg/max:                      -0.9567 Pa, -3.107e-07 Pa, 1.749 Pa
+     Max and min velocity along boundary parts: 1.307 m/s, 1.013 m/s, 1.307 m/s, 1.013 m/s, 0.9869 m/s, 0.541 m/s, 0.9869 m/s, 0.541 m/s
+     Errors                                      h = 3.535534e-01 ndofs= 1977 u_L2= 2.853705e-03 p_L2= 1.230062e+00 p_f_L2= 1.427437e-02 p_c_L= 4.216512e-03 phi_L2= 1.736581e-02 u_f_L2= 4.884622e+02
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 7,401 (2,756+2,178+289+1,089+1,089)
+
+*** Timestep 0:  t=0 seconds
+   Skipping temperature solve because RHS is zero.
+   Solving porosity system ... 0 iterations.
+   Solving Stokes system... done.
+   Solving for u_f in 11 iterations.
+
+   Postprocessing:
+     Writing graphical output:                  output-melt_force_vector/solution/solution-00001
+     RMS, max velocity:                         1 m/s, 1.3 m/s
+     Pressure min/avg/max:                      -0.9547 Pa, -7.517e-08 Pa, 1.743 Pa
+     Max and min velocity along boundary parts: 1.307 m/s, 1.006 m/s, 1.307 m/s, 1.006 m/s, 0.9935 m/s, 0.5405 m/s, 0.9935 m/s, 0.5405 m/s
+     Errors                                      h = 1.767767e-01 ndofs= 7401 u_L2= 7.160918e-04 p_L2= 1.238271e+00 p_f_L2= 3.576420e-03 p_c_L= 1.046767e-03 phi_L2= 2.988517e-03 u_f_L2= 3.851425e+02
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/melt_force_vector2.cc
+++ b/tests/melt_force_vector2.cc
@@ -1,0 +1,460 @@
+#include <aspect/melt.h>
+#include <aspect/material_model/force_vector.h>
+#include <aspect/velocity_boundary_conditions/interface.h>
+#include <aspect/fluid_pressure_boundary_conditions/interface.h>
+#include <aspect/simulator_access.h>
+#include <aspect/global.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/function_lib.h>
+#include <deal.II/numerics/error_estimator.h>
+#include <deal.II/numerics/vector_tools.h>
+#include <aspect/assembly.h>
+#include <aspect/simulator.h>
+
+namespace aspect
+{
+
+  template <int dim>
+  class TestMeltMaterial:
+    public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+  {
+    public:
+      virtual bool
+      viscosity_depends_on (const MaterialModel::NonlinearDependence::Dependence dependence) const
+      {
+        if ((dependence & MaterialModel::NonlinearDependence::compositional_fields) != MaterialModel::NonlinearDependence::none)
+          return true;
+        return false;
+      }
+
+      virtual bool
+      density_depends_on (const MaterialModel::NonlinearDependence::Dependence dependence) const
+      {
+        return false;
+      }
+
+
+      virtual bool
+      compressibility_depends_on (const MaterialModel::NonlinearDependence::Dependence dependence) const
+      {
+        return false;
+      }
+
+
+      virtual bool
+      specific_heat_depends_on (const MaterialModel::NonlinearDependence::Dependence dependence) const
+      {
+        return false;
+      }
+
+
+      virtual bool
+      thermal_conductivity_depends_on (const MaterialModel::NonlinearDependence::Dependence dependence) const
+      {
+        return false;
+      }
+
+      virtual bool is_compressible () const
+      {
+        return false;
+      }
+
+      virtual double reference_viscosity () const
+      {
+        return 1.0;
+      }
+
+      virtual double reference_density () const
+      {
+        return 1.0;
+      }
+      virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
+                            typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
+      {
+        const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
+        double c = 1.0;
+
+        for (unsigned int i=0; i<in.position.size(); ++i)
+          {
+            const double porosity = in.composition[i][porosity_idx];
+            const double x = in.position[i](0);
+            const double z = in.position[i](1);
+            out.viscosities[i] = 1.0;
+            out.thermal_expansion_coefficients[i] = 0.0;
+            out.specific_heat[i] = 1.0;
+            out.thermal_conductivities[i] = 1.0;
+            out.compressibilities[i] = 0.0;
+            out.densities[i] = 1.0;
+
+            out.reaction_terms[i][porosity_idx] = 0;
+//**********
+// copy and paste here
+            /*    force->force_u[i][0] = cos(z) - cos(x + z) + cos(x * z) * z;
+                  force->force_u[i][1] = sin(x) - cos(x + z) + cos(x * z) * x;
+                  force->force_p[i] = 0.4e1 * sin(x + z) - sin(x * z) * z * z - sin(x * z) * x * x;
+                  force->force_pc[i] = -0.10e2 * sin(x + z) / (0.1e1 + exp(-0.20e2 * x * x - 0.20e2 * z * z + 0.1e1));*/
+//***********
+          }
+
+        // fill melt outputs if they exist
+        aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
+
+        if (melt_out != NULL)
+          for (unsigned int i=0; i<in.position.size(); ++i)
+            {
+              double porosity = in.composition[i][porosity_idx];
+              //porosity = 0.1000000000e-1 + 0.2000000000e0 * exp(-0.200e2 * pow(x + 0.2e1 * z, 0.2e1));
+              const double x = in.position[i](0);
+              const double z = in.position[i](1);
+              melt_out->compaction_viscosities[i] = 0.1e0 + 0.1e0 * exp(-0.20e2 * x * x - 0.20e2 * z * z + 0.1e1); // xi
+              melt_out->fluid_viscosities[i] = 1.0;
+              melt_out->permeabilities[i] = 1.0; // K_D
+              melt_out->fluid_density_gradients[i] = 0.0;
+              melt_out->fluid_densities[i] = 0.5;
+            }
+
+      }
+
+  };
+
+
+  template <int dim>
+  class Gravity : public aspect::GravityModel::Interface<dim>
+  {
+    public:
+      virtual Tensor<1,dim> gravity_vector (const Point<dim> &pos) const
+      {
+        Tensor<1,dim> gravity;
+        // zero when we have the force vector
+        gravity[0] = 0.0;
+        gravity[1] = 0.0;
+
+        return gravity;
+      }
+
+
+  };
+
+
+  template <int dim>
+  class RefFunction : public Function<dim>
+  {
+    public:
+      RefFunction () : Function<dim>(dim+2) {}
+      virtual void vector_value (const Point< dim >   &p,
+                                 Vector< double >   &values) const
+      {
+        double x = p(0);
+        double z = p(1);
+//**********
+// copy and paste here (add "out.")
+        values[0] = cos(z);
+        values[1] = sin(x);
+        values[2] = -0.2e1 * sin(x + z) + sin(x * z);
+        values[3] = sin(x + z);
+        values[4] = 1;
+        values[5] = 1;
+        values[6] = sin(x * z);
+        values[7] = 0;
+        values[8] = 0.1000000000e-1 + 0.2000000000e0 * exp(-0.200e2 * pow(x + 0.20e1 * z, 0.2e1));
+//**********
+      }
+  };
+
+
+
+  /**
+    * A postprocessor that evaluates the accuracy of the solution
+    * by using the L2 norm.
+    */
+  template <int dim>
+  class ConvergenceMeltPostprocessor : public Postprocess::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+  {
+    public:
+      /**
+       * Generate graphical output from the current solution.
+       */
+      virtual
+      std::pair<std::string,std::string>
+      execute (TableHandler &statistics);
+
+  };
+
+  template <int dim>
+  std::pair<std::string,std::string>
+  ConvergenceMeltPostprocessor<dim>::execute (TableHandler &statistics)
+  {
+    RefFunction<dim> ref_func;
+    const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.velocities).degree+2);
+
+    const unsigned int n_total_comp = this->introspection().n_components;
+
+    Vector<float> cellwise_errors_u (this->get_triangulation().n_active_cells());
+    Vector<float> cellwise_errors_p_f (this->get_triangulation().n_active_cells());
+    Vector<float> cellwise_errors_p_c (this->get_triangulation().n_active_cells());
+    Vector<float> cellwise_errors_u_f (this->get_triangulation().n_active_cells());
+    Vector<float> cellwise_errors_p (this->get_triangulation().n_active_cells());
+    Vector<float> cellwise_errors_porosity (this->get_triangulation().n_active_cells());
+
+    ComponentSelectFunction<dim> comp_u(std::pair<unsigned int, unsigned int>(0,dim),
+                                        n_total_comp);
+    ComponentSelectFunction<dim> comp_p_f(dim, n_total_comp);
+    ComponentSelectFunction<dim> comp_p_c(dim+1, n_total_comp);
+    ComponentSelectFunction<dim> comp_u_f(std::pair<unsigned int, unsigned int>(dim+2,dim+2+
+                                                                                dim),
+                                          n_total_comp);
+    ComponentSelectFunction<dim> comp_p(dim+2+dim, n_total_comp);
+    ComponentSelectFunction<dim> comp_porosity(dim+2+dim+2, n_total_comp);
+
+    VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                       this->get_solution(),
+                                       ref_func,
+                                       cellwise_errors_u,
+                                       quadrature_formula,
+                                       VectorTools::L2_norm,
+                                       &comp_u);
+    VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                       this->get_solution(),
+                                       ref_func,
+                                       cellwise_errors_p_f,
+                                       quadrature_formula,
+                                       VectorTools::L2_norm,
+                                       &comp_p_f);
+    VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                       this->get_solution(),
+                                       ref_func,
+                                       cellwise_errors_p,
+                                       quadrature_formula,
+                                       VectorTools::L2_norm,
+                                       &comp_p);
+    VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                       this->get_solution(),
+                                       ref_func,
+                                       cellwise_errors_p_c,
+                                       quadrature_formula,
+                                       VectorTools::L2_norm,
+                                       &comp_p_c);
+    VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                       this->get_solution(),
+                                       ref_func,
+                                       cellwise_errors_porosity,
+                                       quadrature_formula,
+                                       VectorTools::L2_norm,
+                                       &comp_porosity);
+    VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
+                                       this->get_solution(),
+                                       ref_func,
+                                       cellwise_errors_u_f,
+                                       quadrature_formula,
+                                       VectorTools::L2_norm,
+                                       &comp_u_f);
+
+    std::ostringstream os;
+    os << std::scientific
+       << " h = " << this->get_triangulation().begin_active()->diameter()
+       << " ndofs= " << this->get_solution().size()
+       << " u_L2= " << std::sqrt(Utilities::MPI::sum(cellwise_errors_u.norm_sqr(),MPI_COMM_WORLD))
+       << " p_L2= "  << std::sqrt(Utilities::MPI::sum(cellwise_errors_p.norm_sqr(),MPI_COMM_WORLD))
+       << " p_f_L2= " << std::sqrt(Utilities::MPI::sum(cellwise_errors_p_f.norm_sqr(),MPI_COMM_WORLD))
+       << " p_c_L= " << std::sqrt(Utilities::MPI::sum(cellwise_errors_p_c.norm_sqr(),MPI_COMM_WORLD))
+       << " phi_L2= " << std::sqrt(Utilities::MPI::sum(cellwise_errors_porosity.norm_sqr(),MPI_COMM_WORLD))
+       << " u_f_L2= " << std::sqrt(Utilities::MPI::sum(cellwise_errors_u_f.norm_sqr(),MPI_COMM_WORLD))
+       ;
+
+    return std::make_pair("Errors", os.str());
+  }
+
+
+  template <int dim>
+  class PressureBdry:
+
+    public FluidPressureBoundaryConditions::Interface<dim>
+  {
+    public:
+      virtual
+      void fluid_pressure_gradient (
+        const dealii::types::boundary_id,
+        const typename MaterialModel::Interface<dim>::MaterialModelInputs &material_model_inputs,
+        const typename MaterialModel::Interface<dim>::MaterialModelOutputs &material_model_outputs,
+        const std::vector<Tensor<1,dim> > &normal_vectors,
+        std::vector<double> &output
+      ) const
+      {
+        for (unsigned int q=0; q<output.size(); ++q)
+          {
+            const double x = material_model_inputs.position[q][0];
+            const double z = material_model_inputs.position[q][1];
+            Tensor<1,dim> gradient;
+//**********
+// copy and paste here (add "out.")
+            gradient[0] = -0.2e1 * cos(x + z) + cos(x * z) * z;
+            gradient[1] = -0.2e1 * cos(x + z) + cos(x * z) * x;
+//**********
+            output[q] = gradient * normal_vectors[q];
+          }
+      }
+
+
+
+  };
+
+
+
+  template <int dim>
+  class ForceAssembler :
+    public aspect::internal::Assembly::Assemblers::AssemblerBase<dim>,
+    public SimulatorAccess<dim>
+  {
+
+    public:
+
+      virtual
+      void
+      assemble (const typename DoFHandler<dim>::active_cell_iterator &/*cell*/,
+                const double                                     pressure_scaling,
+                const bool                                       rebuild_stokes_matrix,
+                internal::Assembly::Scratch::StokesSystem<dim>  &scratch,
+                internal::Assembly::CopyData::StokesSystem<dim> &data) const
+      {
+        const Introspection<dim> &introspection = this->introspection();
+        const FiniteElement<dim> &fe = this->get_fe();
+        const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
+        const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
+
+        const FEValuesExtractors::Scalar extractor_pressure = introspection.variable("fluid pressure").extractor_scalar();
+        const FEValuesExtractors::Scalar ex_p_c = introspection.variable("compaction pressure").extractor_scalar();
+
+        const unsigned int p_f_component_index = introspection.variable("fluid pressure").first_component_index;
+        const unsigned int p_c_component_index = introspection.variable("compaction pressure").first_component_index;
+
+        for (unsigned int i=0, i_stokes=0; i_stokes<stokes_dofs_per_cell; /*increment at end of loop*/)
+          {
+            const unsigned int component_index_i = fe.system_to_component_index(i).first;
+
+            if (component_index_i == p_c_component_index
+                ||
+                component_index_i == p_f_component_index
+                ||
+                (
+                  component_index_i >= introspection.component_indices.velocities[0]
+                  &&
+                  component_index_i <= introspection.component_indices.velocities[dim-1]
+                ))
+              {
+                data.local_dof_indices[i_stokes] = scratch.local_dof_indices[i];
+                ++i_stokes;
+              }
+            ++i;
+          }
+
+        for (unsigned int q=0; q<n_q_points; ++q)
+          {
+            const double x = scratch.finite_element_values.quadrature_point(q)[0];
+            const double z = scratch.finite_element_values.quadrature_point(q)[1];
+
+            Tensor<1,dim> force_u;
+            force_u[0] = cos(z) - cos(x + z) + cos(x * z) * z;
+            force_u[1] = sin(x) - cos(x + z) + cos(x * z) * x;
+            const double force_pf = 0.4e1 * sin(x + z) - sin(x * z) * z * z - sin(x * z) * x * x;
+            const double force_pc = -0.10e2 * sin(x + z) / (0.1e1 + exp(-0.20e2 * x * x - 0.20e2 * z * z + 0.1e1));
+
+            for (unsigned int i=0, i_stokes=0; i_stokes<stokes_dofs_per_cell; /*increment at end of loop*/)
+              {
+                const unsigned int component_index_i = fe.system_to_component_index(i).first;
+
+                if (component_index_i == p_c_component_index
+                    ||
+                    component_index_i == p_f_component_index
+                    ||
+                    (
+                      component_index_i >= introspection.component_indices.velocities[0]
+                      &&
+                      component_index_i <= introspection.component_indices.velocities[dim-1]
+                    ))
+                  {
+                    scratch.phi_u[i_stokes]   = scratch.finite_element_values[introspection.extractors.velocities].value (i,q);
+                    scratch.phi_p[i_stokes]   = scratch.finite_element_values[extractor_pressure].value (i, q);
+                    scratch.phi_p_c[i_stokes] = scratch.finite_element_values[ex_p_c].value (i, q);
+
+                    ++i_stokes;
+                  }
+                ++i;
+              }
+
+            const double JxW = scratch.finite_element_values.JxW(q);
+
+            for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
+              {
+                data.local_rhs(i) += (
+                                       (force_u * scratch.phi_u[i]
+                                        + pressure_scaling * force_pf * scratch.phi_p[i]
+                                        + pressure_scaling * force_pc * scratch.phi_p_c[i])
+                                     )
+                                     * JxW;
+              }
+          }
+      }
+
+  };
+
+  template <int dim>
+  void add_force_assembler(const SimulatorAccess<dim> &simulator_access,
+                           internal::Assembly::AssemblerLists<dim> &assemblers,
+                           std::vector<dealii::std_cxx11::shared_ptr<
+                           internal::Assembly::Assemblers::AssemblerBase<dim> > > &assembler_objects)
+  {
+
+    std_cxx11::shared_ptr<ForceAssembler<dim> > assembler (new ForceAssembler<dim>());
+    assembler_objects.push_back (assembler);
+
+    // add the terms for phase change boundary conditions
+    assemblers.local_assemble_stokes_system.connect (
+      std_cxx11::bind(&ForceAssembler<dim>::assemble,
+                      std_cxx11::cref (*assembler),
+                      std_cxx11::_1,
+                      std_cxx11::_2,
+                      std_cxx11::_3,
+                      std_cxx11::_4,
+                      std_cxx11::_5));
+  }
+
+
+
+}
+
+
+
+template <int dim>
+void signal_connector (aspect::SimulatorSignals<dim> &signals)
+{
+  signals.set_assemblers.connect (&aspect::add_force_assembler<dim>);
+}
+
+ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
+                                  signal_connector<3>)
+
+
+// explicit instantiations
+namespace aspect
+{
+  ASPECT_REGISTER_GRAVITY_MODEL(Gravity,
+                                "MyGravity",
+                                "")
+
+  ASPECT_REGISTER_MATERIAL_MODEL(TestMeltMaterial,
+                                 "test melt material",
+                                 "")
+
+  ASPECT_REGISTER_POSTPROCESSOR(ConvergenceMeltPostprocessor,
+                                "melt error calculation",
+                                "A postprocessor that compares the numerical solution to the analytical solution")
+
+  ASPECT_REGISTER_FLUID_PRESSURE_BOUNDARY_CONDITIONS(PressureBdry,
+                                                     "PressureBdry",
+                                                     "A fluid pressure boundary condition that prescribes the "
+                                                     "gradient of the fluid pressure at the boundaries as "
+                                                     "calculated in the analytical solution. ")
+
+}

--- a/tests/melt_force_vector2.prm
+++ b/tests/melt_force_vector2.prm
@@ -1,0 +1,175 @@
+# A simple reference solution with RHS force vector using an assembler plugin
+# with incompressible melt transport
+
+set Nonlinear solver scheme                = IMPES
+set Max nonlinear iterations               = 50
+set Nonlinear solver tolerance             = 1e-10 #1e-10
+set Linear solver tolerance                = 1e-12
+
+set Use direct solver for Stokes system        = true
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 3
+  set Refinement fraction                      = 1.0
+  set Coarsening fraction                      = 0.0
+
+  set Strategy = velocity
+
+  set Time steps between mesh refinement       = 0
+  set Initial adaptive refinement              = 1
+  set Run postprocessors on initial refinement = true
+  set Normalize individual refinement criteria = false#true
+
+end
+
+
+set Adiabatic surface temperature          = 1623               # default: 0
+set CFL number                             = 1.0
+
+# The number of space dimensions you want to run this program in.
+set Dimension                              = 2
+
+# The end time of the simulation. Units: years if the 'Use years in output
+# instead of seconds' parameter is set; seconds otherwise.
+set End time                               = 0
+
+set Pressure normalization                 = volume
+set Surface pressure                       = 0#0.2746026940#3.992884522
+set Resume computation                     = false
+set Start time                             = 0
+
+set Use years in output instead of seconds = false
+set Number of cheap Stokes solver steps    = 0
+
+subsection Compositional fields
+  set Number of fields = 1
+  set Names of fields = porosity
+end
+
+subsection Boundary fluid pressure model
+ set Plugin name = PressureBdry
+end
+
+subsection Boundary temperature model
+  set Model name = initial temperature
+
+  subsection Initial temperature
+    # Temperature at the inner boundary (core mantle boundary). Units: K.
+    set Maximal temperature = 3773 # default: 6000
+
+    # Temperature at the outer boundary (lithosphere water/air). Units: K.
+    set Minimal temperature = 273  # default: 0
+  end
+
+end
+
+subsection Boundary composition model
+  set Model name = initial composition
+end
+
+
+subsection Geometry model
+  set Model name = box # default: 
+
+  subsection Box
+    set X extent  = 2
+    set Y extent  = 2
+    set Box origin X coordinate = -1
+    set Box origin Y coordinate = -1
+  end
+
+end
+
+
+subsection Gravity model
+  set Model name = MyGravity
+
+end
+
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = cos(z);sin(x)
+    set Variable names      = x,z
+  end
+end  
+
+
+subsection Initial conditions
+  set Model name = function # default: 
+  subsection Function
+    set Function expression = 0
+    set Variable names      = x,z
+  end
+end
+
+subsection Compositional initial conditions
+  set Model name = function # default: 
+  subsection Function
+    set Function constants = pi=3.14159265359
+#    set Function expression = if(abs(x)==1 || abs(z)==1, 0.1000000000e-1 + 0.1000000000e0 * exp(-0.40e1 * ((x + 0.20e1 * z)^ 0.2e1)), 0)
+#    set Function expression = 0.1000000000e-1 + 0.1000000000e0 * exp(-0.40e1 * ((x + 0.20e1 * z)^ 0.2e1))
+set Function expression = 0.1000000000e-1 + 0.2000000000e0 * exp(-0.200e2 * ((x + 0.2e1 * z)^ 0.2e1))
+    set Variable names      = x,z
+  end
+end
+
+
+subsection Material model
+
+  set Model name = test melt material
+  
+
+end
+
+
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = 2,3        # default: 
+  set Fixed composition boundary indicators   = 0,1,2,3   
+  set Prescribed velocity boundary indicators = 0:function, 1:function, 2:function, 3:function
+
+  set Tangential velocity boundary indicators = 
+  set Zero velocity boundary indicators       =           # default: 
+
+  set Include melt transport                  = true
+#  set Melt transport threshold = 0
+end
+
+
+subsection Postprocess
+
+  set List of postprocessors = visualization, velocity statistics, pressure statistics, velocity boundary statistics, melt error calculation
+
+  subsection Visualization
+
+    set List of output variables      = #melt density, permeability, melt viscosity, compaction viscosity, gravity, material properties, nonadiabatic pressure
+#    set List of output variables      = gravity, material properties, nonadiabatic pressure
+
+    subsection Material properties
+    set List of material properties   = density, viscosity, thermal expansivity, reaction terms
+    end
+
+    # VTU file output supports grouping files from several CPUs into one file
+    # using MPI I/O when writing on a parallel filesystem. Select 0 for no
+    # grouping. This will disable parallel file output and instead write one
+    # file per processor in a background thread. A value of 1 will generate
+    # one big file containing the whole solution.
+    set Number of grouped files       = 0
+
+    # The file format to be used for graphical output.
+    set Output format                 = vtu
+    set Interpolate output = true
+
+    # The time interval between each generation of graphical output files. A
+    # value of zero indicates that output should be generated in each time
+    # step. Units: years if the 'Use years in output instead of seconds'
+    # parameter is set; seconds otherwise.
+    set Time between graphical output = 0                                                                                # default: 1e8
+  end
+
+end
+
+
+

--- a/tests/melt_force_vector2/screen-output
+++ b/tests/melt_force_vector2/screen-output
@@ -1,0 +1,44 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libmelt_force_vector2.so>
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 1,977 (740+578+81+289+289)
+
+*** Timestep 0:  t=0 seconds
+   Skipping temperature solve because RHS is zero.
+   Solving porosity system ... 0 iterations.
+   Solving Stokes system... done.
+   Solving for u_f in 1 iterations.
+
+   Postprocessing:
+     Writing graphical output:                  output-melt_force_vector2/solution/solution-00000
+     RMS, max velocity:                         0.999 m/s, 1.3 m/s
+     Pressure min/avg/max:                      -0.9567 Pa, -3.107e-07 Pa, 1.749 Pa
+     Max and min velocity along boundary parts: 1.307 m/s, 1.013 m/s, 1.307 m/s, 1.013 m/s, 0.9869 m/s, 0.541 m/s, 0.9869 m/s, 0.541 m/s
+     Errors                                      h = 3.535534e-01 ndofs= 1977 u_L2= 2.853705e-03 p_L2= 1.230062e+00 p_f_L2= 1.427437e-02 p_c_L= 4.216512e-03 phi_L2= 1.736581e-02 u_f_L2= 4.884622e+02
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 7,401 (2,756+2,178+289+1,089+1,089)
+
+*** Timestep 0:  t=0 seconds
+   Skipping temperature solve because RHS is zero.
+   Solving porosity system ... 0 iterations.
+   Solving Stokes system... done.
+   Solving for u_f in 11 iterations.
+
+   Postprocessing:
+     Writing graphical output:                  output-melt_force_vector2/solution/solution-00001
+     RMS, max velocity:                         1 m/s, 1.3 m/s
+     Pressure min/avg/max:                      -0.9547 Pa, -7.517e-08 Pa, 1.743 Pa
+     Max and min velocity along boundary parts: 1.307 m/s, 1.006 m/s, 1.307 m/s, 1.006 m/s, 0.9935 m/s, 0.5405 m/s, 0.9935 m/s, 0.5405 m/s
+     Errors                                      h = 1.767767e-01 ndofs= 7401 u_L2= 7.160918e-04 p_L2= 1.238271e+00 p_f_L2= 3.576420e-03 p_c_L= 1.046767e-03 phi_L2= 2.988517e-03 u_f_L2= 3.851425e+02
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+


### PR DESCRIPTION
This is one out of several PRs to get Stokes solver improvements (with and without melt) with @rrgrove6 into mainline.

This adds an optional material model output force vector to be applied to the RHS of the Stokes system. We need this to be able to construct manufactured solutions. 

Questions:
- Should I also add this to the non-melt assembly? It is not strictly needed, because one can abuse the "rho*g" in the RHS (like the burstedde test does). I feel like this approach would be much cleaner though.
- Is the creation of the instance inside ``evaluate()`` (see ``make_shared``) the best way to do this?