### PR TITLE
Removed particle index storage in particle generators reference cell and quadrature points

### DIFF
--- a/include/aspect/particle/generator/quadrature_points.h
+++ b/include/aspect/particle/generator/quadrature_points.h
@@ -40,11 +40,6 @@ namespace aspect
       {
         public:
           /**
-           * Constructor
-           */
-          QuadraturePoints();
-
-          /**
            * Generates particles at the quadrature points of each active cell of the triangulation.
            * Here, Gauss quadrature of degree, (velocity_degree + 1), is used similarly to the assembly of the
            * Stokes matrix.
@@ -69,14 +64,6 @@ namespace aspect
           virtual
           void
           parse_parameters (ParameterHandler &prm);
-
-        private:
-          /**
-          * To obtain unique particle indices across multiple MPI processes,
-          * this variable stores the starting index. This value is updated for each
-          * call to generate_particles().
-          */
-          types::particle_index starting_particle_index;
       };
     }
   }

--- a/include/aspect/particle/generator/reference_cell.h
+++ b/include/aspect/particle/generator/reference_cell.h
@@ -42,11 +42,6 @@ namespace aspect
       {
         public:
           /**
-          * Constructor.
-          */
-          ReferenceCell();
-
-          /**
            * Generate a uniform distribution of particles in the unit cell and transforms
            * each of the particles back to real region in the model domain.
            * Uniform here means the particles will be generated with
@@ -86,13 +81,6 @@ namespace aspect
            * specified within the parameter file.
            */
           std::vector<unsigned int> number_of_particles;
-
-          /**
-           * To obtain unique particle indices across multiple MPI processes,
-           * this variable stores the starting index. This value is updated for each
-           * call to generate_particles().
-           */
-          types::particle_index starting_particle_index;
       };
 
     }

--- a/source/particle/generator/quadrature_points.cc
+++ b/source/particle/generator/quadrature_points.cc
@@ -29,12 +29,6 @@ namespace aspect
     namespace Generator
     {
       template <int dim>
-      QuadraturePoints<dim>::QuadraturePoints()
-        :
-        starting_particle_index(0)
-      {}
-
-      template <int dim>
       void
       QuadraturePoints<dim>::generate_particles(std::multimap<types::LevelInd, Particle<dim> > &particles)
       {
@@ -42,6 +36,7 @@ namespace aspect
 
         types::particle_index n_particles_to_generate = quadrature_formula.size() * this->get_triangulation().n_locally_owned_active_cells();
         types::particle_index prefix_sum = 0;
+        types::particle_index particle_index = 0;
 
         FEValues<dim> fe_values(this->get_mapping(),
                                 this->get_fe(),
@@ -51,8 +46,7 @@ namespace aspect
 
         MPI_Scan(&n_particles_to_generate, &prefix_sum, 1, ASPECT_TRACER_INDEX_MPI_TYPE, MPI_SUM, this->get_mpi_communicator());
 
-        starting_particle_index += prefix_sum - n_particles_to_generate;
-        types::particle_index particle_index = starting_particle_index;
+        particle_index = prefix_sum - n_particles_to_generate;
 
         typename parallel::distributed::Triangulation<dim>::active_cell_iterator
         cell = this->get_triangulation().begin_active(), endc = this->get_triangulation().end();
@@ -71,8 +65,6 @@ namespace aspect
                   }
               }
           }
-
-        starting_particle_index = Utilities::MPI::max(particle_index, this->get_mpi_communicator());
       }
 
 

--- a/source/particle/generator/reference_cell.cc
+++ b/source/particle/generator/reference_cell.cc
@@ -29,12 +29,6 @@ namespace aspect
     namespace Generator
     {
       template <int dim>
-      ReferenceCell<dim>::ReferenceCell()
-        :
-        starting_particle_index(0)
-      {}
-
-      template <int dim>
       void
       ReferenceCell<dim>::generate_particles(std::multimap<types::LevelInd, Particle<dim> > &particles)
       {
@@ -45,8 +39,7 @@ namespace aspect
 
         MPI_Scan(&n_particles_to_generate, &prefix_sum, 1, ASPECT_TRACER_INDEX_MPI_TYPE, MPI_SUM, this->get_mpi_communicator());
 
-        starting_particle_index += prefix_sum - n_particles_to_generate;
-        types::particle_index particle_index = starting_particle_index;
+        types::particle_index particle_index = prefix_sum - n_particles_to_generate;
 
         typename Triangulation<dim>::active_cell_iterator
         cell = this->get_triangulation().begin_active(), endc = this->get_triangulation().end();
@@ -68,8 +61,6 @@ namespace aspect
                   }
               }
           }
-
-        starting_particle_index = Utilities::MPI::max(particle_index, this->get_mpi_communicator());
       }
 
 


### PR DESCRIPTION
Fix to #1302 

The particle generator code for storing particle index variables has been removed from 'quadrature points' and 'reference cell particle' generators after Wolfgang has pointed out that the function is not being called anywhere else and that the particle index is not being stored at checkpoints as well.
