### PR TITLE
Remove duplicated reference.

### DIFF
--- a/doc/manual/manual.bib
+++ b/doc/manual/manual.bib
@@ -646,16 +646,6 @@ YEAR = "2003"
   pages =        {1--23}
 }
 
-@Article{GHPB17,
-  author =       {R. Gassmoeller and E. Heien and E. G. Puckett and W. Bangerth},
-  title =        {Implementing flexible and scalable particle-in-cell
-                  methods for massively parallel computations},
-  journal =      {in preparation},
-  year =         {},
-  volume =       {},
-  pages =        {}
-}
-
 @Article{HGSLM03,
   author =       {Hall, C. E. and Gurnis, M. A. and Sdrolias, M. and
                   Lavier, L. L. and Mueller, D.},
@@ -11106,7 +11096,7 @@ year={2012}
 
 @article{GHPB17,
   Author = {R. Gassm{\"o}ller and E. Heien and E. G. Puckett and W. Bangerth},
-  Title = {Implementing flexible and scalable particle-in-cell methods for massively parallel computations},
+  Title = {Flexible and scalable particle-in-cell methods for massively parallel computations},
   Journal = {submitted},
   Year = {2017}
 }


### PR DESCRIPTION
Fix the title of the remaining copy.