### PR TITLE
Define thermal expansion coefficient alpha.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -754,6 +754,27 @@ Units $\frac{\textrm{J}}{\textrm{kg}\cdot\textrm{K}} =
   composition of material in the earth mantle. The literature suggests a value
   of $\gamma=7.4\cdot 10^{-12}\frac{\textrm{W}}{\textrm{kg}}$.
 
+\item \textit{The thermal expansion coefficient $\alpha=\alpha(p,T,\mathfrak c ,\mathbf x)$:} Units
+  $\frac{1}{\textrm{K}}$.
+
+  This term denotes by how much the material under consideration
+  expands due to temperature increases. This coefficient is defined as
+  $\alpha = -\frac{1}{\rho}\frac{\partial \rho}{\partial T}$, where
+  the negative sign is due the fact that the density
+  \textit{decreases} as a function of temperature. Alternatively, if
+  one considers the \textit{volume} $V=V(T)$ a piece of material of mass $M$
+  occupies, $V=\frac{M}{\rho}$, then the thermal expansion coefficient
+  is defined as the relative increase in volume,
+  $\alpha=\frac{1}{V}\frac{\partial V(T)}{\partial T}$, because 
+  $\frac{\partial V(T)}{\partial T} =
+   \frac{\partial \frac{M}{\rho}}{\partial T} =
+   -\frac{M}{\rho^2} \frac{\partial \rho}{\partial T} =
+   -\frac{V}{\rho} \frac{\partial \rho}{\partial T}$.
+
+   The literature suggests that values of $\alpha=1\cdot
+   10^{-5}\frac{1}{\textrm{K}}$ at the core-mantle boundary and $\alpha=4\cdot
+   10^{-5}\frac{1}{\textrm{K}}$ are appropriate for Earth.
+
 \item \textit{The change of entropy $\Delta S$ at a
   phase transition together with the derivatives of the phase function
   $X=X(p,T,\mathfrak c,\mathbf x)$ with regard to temperature and pressure:} Units


### PR DESCRIPTION
This was previously missing from the manual.

Fixes #1304. Also addresses in part #989.