### PR TITLE
Update a few .prm fragments that go into the manual.

### DIFF
--- a/doc/manual/cookbooks/overview/simple.prm
+++ b/doc/manual/cookbooks/overview/simple.prm
@@ -1,5 +1,5 @@
 set Dimension                     = 2
-set End time                      = 2e9
+set End time                      = 1.5e9
 set Output directory              = output
 
 subsection Geometry model
@@ -12,5 +12,5 @@ subsection Mesh refinement
 end
 
 subsection Postprocess
-  set List of postprocessors      = all
+  set List of postprocessors      = visualization, velocity statistics, temperature statistics, heat flux statistics, depth average
 end

--- a/doc/manual/cookbooks/overview/structure.part.prm
+++ b/doc/manual/cookbooks/overview/structure.part.prm
@@ -2,7 +2,7 @@ set Dimension                     = 2
 set Resume computation            = false
 set End time                      = 1e10
 set CFL number                    = 1.0
-set Output directory              = bin
+set Output directory              = output
 
 subsection Mesh refinement
   set Initial adaptive refinement = 1


### PR DESCRIPTION
Specifically, align them with choices in the cookbooks. Also no longer use
'all' for postprocessors, since that is no longer allowed.