### PR TITLE
rename include guards

### DIFF
--- a/include/aspect/adiabatic_conditions/function.h
+++ b/include/aspect/adiabatic_conditions/function.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__adiabatic_conditions_function_h
-#define __aspect__adiabatic_conditions_function_h
+#ifndef _aspect_adiabatic_conditions_function_h
+#define _aspect_adiabatic_conditions_function_h
 
 
 #include <aspect/adiabatic_conditions/interface.h>

--- a/include/aspect/adiabatic_conditions/initial_profile.h
+++ b/include/aspect/adiabatic_conditions/initial_profile.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__adiabatic_conditions_initial_profile_h
-#define __aspect__adiabatic_conditions_initial_profile_h
+#ifndef _aspect_adiabatic_conditions_initial_profile_h
+#define _aspect_adiabatic_conditions_initial_profile_h
 
 
 #include <aspect/adiabatic_conditions/interface.h>

--- a/include/aspect/adiabatic_conditions/interface.h
+++ b/include/aspect/adiabatic_conditions/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__adiabatic_conditions_interface_h
-#define __aspect__adiabatic_conditions_interface_h
+#ifndef _aspect_adiabatic_conditions_interface_h
+#define _aspect_adiabatic_conditions_interface_h
 
 #include <aspect/plugins.h>
 #include <aspect/geometry_model/interface.h>

--- a/include/aspect/assembly.h
+++ b/include/aspect/assembly.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__assembly_h
-#define __aspect__assembly_h
+#ifndef _aspect_assembly_h
+#define _aspect_assembly_h
 
 #include <aspect/global.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/boundary_composition/ascii_data.h
+++ b/include/aspect/boundary_composition/ascii_data.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__boundary_composition_ascii_data_h
-#define __aspect__boundary_composition_ascii_data_h
+#ifndef _aspect_boundary_composition_ascii_data_h
+#define _aspect_boundary_composition_ascii_data_h
 
 #include <aspect/boundary_composition/interface.h>
 

--- a/include/aspect/boundary_composition/box.h
+++ b/include/aspect/boundary_composition/box.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__boundary_composition_box_h
-#define __aspect__boundary_composition_box_h
+#ifndef _aspect_boundary_composition_box_h
+#define _aspect_boundary_composition_box_h
 
 #include <aspect/boundary_composition/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/boundary_composition/initial_composition.h
+++ b/include/aspect/boundary_composition/initial_composition.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__boundary_composition_initial_composition_h
-#define __aspect__boundary_composition_initial_composition_h
+#ifndef _aspect_boundary_composition_initial_composition_h
+#define _aspect_boundary_composition_initial_composition_h
 
 #include <aspect/boundary_composition/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__boundary_composition_interface_h
-#define __aspect__boundary_composition_interface_h
+#ifndef _aspect_boundary_composition_interface_h
+#define _aspect_boundary_composition_interface_h
 
 #include <aspect/plugins.h>
 #include <aspect/geometry_model/interface.h>

--- a/include/aspect/boundary_composition/spherical_constant.h
+++ b/include/aspect/boundary_composition/spherical_constant.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__boundary_composition_spherical_constant_h
-#define __aspect__boundary_composition_spherical_constant_h
+#ifndef _aspect_boundary_composition_spherical_constant_h
+#define _aspect_boundary_composition_spherical_constant_h
 
 #include <aspect/boundary_composition/interface.h>
 

--- a/include/aspect/boundary_composition/two_merged_boxes.h
+++ b/include/aspect/boundary_composition/two_merged_boxes.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__boundary_composition_two_merged_boxes_h
-#define __aspect__boundary_composition_two_merged_boxes_h
+#ifndef _aspect_boundary_composition_two_merged_boxes_h
+#define _aspect_boundary_composition_two_merged_boxes_h
 
 #include <aspect/boundary_composition/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/boundary_temperature/ascii_data.h
+++ b/include/aspect/boundary_temperature/ascii_data.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__boundary_temperature_ascii_data_h
-#define __aspect__boundary_temperature_ascii_data_h
+#ifndef _aspect_boundary_temperature_ascii_data_h
+#define _aspect_boundary_temperature_ascii_data_h
 
 #include <aspect/boundary_temperature/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/boundary_temperature/box.h
+++ b/include/aspect/boundary_temperature/box.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__boundary_temperature_box_h
-#define __aspect__boundary_temperature_box_h
+#ifndef _aspect_boundary_temperature_box_h
+#define _aspect_boundary_temperature_box_h
 
 #include <aspect/boundary_temperature/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/boundary_temperature/constant.h
+++ b/include/aspect/boundary_temperature/constant.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__boundary_temperature_constant_h
-#define __aspect__boundary_temperature_constant_h
+#ifndef _aspect_boundary_temperature_constant_h
+#define _aspect_boundary_temperature_constant_h
 
 #include <aspect/boundary_temperature/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/boundary_temperature/function.h
+++ b/include/aspect/boundary_temperature/function.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__boundary_temperature_function_h
-#define __aspect__boundary_temperature_function_h
+#ifndef _aspect_boundary_temperature_function_h
+#define _aspect_boundary_temperature_function_h
 
 #include <aspect/boundary_temperature/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/boundary_temperature/initial_temperature.h
+++ b/include/aspect/boundary_temperature/initial_temperature.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__boundary_temperature_initial_temperature_h
-#define __aspect__boundary_temperature_initial_temperature_h
+#ifndef _aspect_boundary_temperature_initial_temperature_h
+#define _aspect_boundary_temperature_initial_temperature_h
 
 #include <aspect/boundary_temperature/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__boundary_temperature_interface_h
-#define __aspect__boundary_temperature_interface_h
+#ifndef _aspect_boundary_temperature_interface_h
+#define _aspect_boundary_temperature_interface_h
 
 #include <aspect/plugins.h>
 #include <aspect/geometry_model/interface.h>

--- a/include/aspect/boundary_temperature/spherical_constant.h
+++ b/include/aspect/boundary_temperature/spherical_constant.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__boundary_temperature_spherical_constant_h
-#define __aspect__boundary_temperature_spherical_constant_h
+#ifndef _aspect_boundary_temperature_spherical_constant_h
+#define _aspect_boundary_temperature_spherical_constant_h
 
 #include <aspect/boundary_temperature/interface.h>
 

--- a/include/aspect/boundary_temperature/two_merged_boxes.h
+++ b/include/aspect/boundary_temperature/two_merged_boxes.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__boundary_temperature_two_merged_boxes_h
-#define __aspect__boundary_temperature_two_merged_boxes_h
+#ifndef _aspect_boundary_temperature_two_merged_boxes_h
+#define _aspect_boundary_temperature_two_merged_boxes_h
 
 #include <aspect/boundary_temperature/interface.h>
 

--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -18,8 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#ifndef __aspect__compat_h
-#define __aspect__compat_h
+#ifndef _aspect_compat_h
+#define _aspect_compat_h
 
 #include <aspect/global.h>
 

--- a/include/aspect/compositional_initial_conditions/ascii_data.h
+++ b/include/aspect/compositional_initial_conditions/ascii_data.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__compositional_initial_conditions_ascii_data_h
-#define __aspect__compositional_initial_conditions_ascii_data_h
+#ifndef _aspect_compositional_initial_conditions_ascii_data_h
+#define _aspect_compositional_initial_conditions_ascii_data_h
 
 #include <aspect/compositional_initial_conditions/interface.h>
 

--- a/include/aspect/compositional_initial_conditions/function.h
+++ b/include/aspect/compositional_initial_conditions/function.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__compositional_initial_conditions_function_h
-#define __aspect__compositional_initial_conditions_function_h
+#ifndef _aspect_compositional_initial_conditions_function_h
+#define _aspect_compositional_initial_conditions_function_h
 
 #include <aspect/compositional_initial_conditions/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/compositional_initial_conditions/interface.h
+++ b/include/aspect/compositional_initial_conditions/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__compositional_initial_conditions_interface_h
-#define __aspect__compositional_initial_conditions_interface_h
+#ifndef _aspect_compositional_initial_conditions_interface_h
+#define _aspect_compositional_initial_conditions_interface_h
 
 #include <aspect/plugins.h>
 #include <aspect/geometry_model/interface.h>

--- a/include/aspect/fe_variable_collection.h
+++ b/include/aspect/fe_variable_collection.h
@@ -18,8 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#ifndef __aspect__fe_variable_system_h
-#define __aspect__fe_variable_system_h
+#ifndef _aspect_fe_variable_system_h
+#define _aspect_fe_variable_system_h
 
 #include <aspect/global.h>
 #include <deal.II/fe/component_mask.h>

--- a/include/aspect/fluid_pressure_boundary_conditions/density.h
+++ b/include/aspect/fluid_pressure_boundary_conditions/density.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__fluid_pressure_boundary_conditions_density_h
-#define __aspect__fluid_pressure_boundary_conditions_density_h
+#ifndef _aspect_fluid_pressure_boundary_conditions_density_h
+#define _aspect_fluid_pressure_boundary_conditions_density_h
 
 #include <aspect/fluid_pressure_boundary_conditions/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/fluid_pressure_boundary_conditions/interface.h
+++ b/include/aspect/fluid_pressure_boundary_conditions/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__fluid_pressure_boundary_conditions_interface_h
-#define __aspect__fluid_pressure_boundary_conditions_interface_h
+#ifndef _aspect_fluid_pressure_boundary_conditions_interface_h
+#define _aspect_fluid_pressure_boundary_conditions_interface_h
 
 #include <aspect/plugins.h>
 #include <aspect/material_model/interface.h>

--- a/include/aspect/free_surface.h
+++ b/include/aspect/free_surface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__free_surface_h
-#define __aspect__free_surface_h
+#ifndef _aspect_free_surface_h
+#define _aspect_free_surface_h
 
 #include <aspect/simulator.h>
 

--- a/include/aspect/geometry_model/box.h
+++ b/include/aspect/geometry_model/box.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__geometry_model_box_h
-#define __aspect__geometry_model_box_h
+#ifndef _aspect_geometry_model_box_h
+#define _aspect_geometry_model_box_h
 
 #include <aspect/geometry_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__geometry_model_chunk_h
-#define __aspect__geometry_model_chunk_h
+#ifndef _aspect_geometry_model_chunk_h
+#define _aspect_geometry_model_chunk_h
 
 #include <aspect/geometry_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/geometry_model/ellipsoidal_chunk.h
+++ b/include/aspect/geometry_model/ellipsoidal_chunk.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__geometry_model_ellipsoidal_chunk_h
-#define __aspect__geometry_model_ellipsoidal_chunk_h
+#ifndef _aspect_geometry_model_ellipsoidal_chunk_h
+#define _aspect_geometry_model_ellipsoidal_chunk_h
 
 #include <aspect/geometry_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/geometry_model/initial_topography_model/ascii_data.h
+++ b/include/aspect/geometry_model/initial_topography_model/ascii_data.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__geometry_model__initial_topography_model_ascii_data_h
-#define __aspect__geometry_model__initial_topography_model_ascii_data_h
+#ifndef _aspect_geometry_model__initial_topography_model_ascii_data_h
+#define _aspect_geometry_model__initial_topography_model_ascii_data_h
 
 #include <aspect/geometry_model/initial_topography_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/geometry_model/initial_topography_model/interface.h
+++ b/include/aspect/geometry_model/initial_topography_model/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__geometry_model__initial_topography_model_interface_h
-#define __aspect__geometry_model__initial_topography_model_interface_h
+#ifndef _aspect_geometry_model__initial_topography_model_interface_h
+#define _aspect_geometry_model__initial_topography_model_interface_h
 
 #include <aspect/plugins.h>
 #include <deal.II/base/parameter_handler.h>

--- a/include/aspect/geometry_model/initial_topography_model/prm_polygon.h
+++ b/include/aspect/geometry_model/initial_topography_model/prm_polygon.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__geometry_model__initial_topography_prm_polygon_h
-#define __aspect__geometry_model__initial_topography_prm_polygon_h
+#ifndef _aspect_geometry_model__initial_topography_prm_polygon_h
+#define _aspect_geometry_model__initial_topography_prm_polygon_h
 
 #include <aspect/geometry_model/initial_topography_model/interface.h>
 

--- a/include/aspect/geometry_model/initial_topography_model/zero_topography.h
+++ b/include/aspect/geometry_model/initial_topography_model/zero_topography.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__geometry_model__initial_topography_model_zero_topography_h
-#define __aspect__geometry_model__initial_topography_model_zero_topography_h
+#ifndef _aspect_geometry_model__initial_topography_model_zero_topography_h
+#define _aspect_geometry_model__initial_topography_model_zero_topography_h
 
 #include <aspect/geometry_model/initial_topography_model/interface.h>
 

--- a/include/aspect/geometry_model/interface.h
+++ b/include/aspect/geometry_model/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__geometry_model_interface_h
-#define __aspect__geometry_model_interface_h
+#ifndef _aspect_geometry_model_interface_h
+#define _aspect_geometry_model_interface_h
 
 #include <aspect/plugins.h>
 #include <deal.II/base/parameter_handler.h>

--- a/include/aspect/geometry_model/sphere.h
+++ b/include/aspect/geometry_model/sphere.h
@@ -17,8 +17,8 @@
   along with ASPECT; see the file doc/COPYING.  If not see
   <http://www.gnu.org/licenses/>.
 */
-#ifndef __aspect__geometry_model_sphere_h
-#define __aspect__geometry_model_sphere_h
+#ifndef _aspect_geometry_model_sphere_h
+#define _aspect_geometry_model_sphere_h
 
 #include <aspect/geometry_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__geometry_model_spherical_shell_h
-#define __aspect__geometry_model_spherical_shell_h
+#ifndef _aspect_geometry_model_spherical_shell_h
+#define _aspect_geometry_model_spherical_shell_h
 
 #include <aspect/geometry_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/geometry_model/two_merged_boxes.h
+++ b/include/aspect/geometry_model/two_merged_boxes.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__geometry_model_two_merged_boxes_h
-#define __aspect__geometry_model_two_merged_boxes_h
+#ifndef _aspect_geometry_model_two_merged_boxes_h
+#define _aspect_geometry_model_two_merged_boxes_h
 
 #include <aspect/geometry_model/box.h>
 

--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__global_h
-#define __aspect__global_h
+#ifndef _aspect_global_h
+#define _aspect_global_h
 
 #ifdef ASPECT_USE_PETSC
 #  include <deal.II/lac/petsc_parallel_block_vector.h>

--- a/include/aspect/gravity_model/function.h
+++ b/include/aspect/gravity_model/function.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__gravity_model_function_h
-#define __aspect__gravity_model_function_h
+#ifndef _aspect_gravity_model_function_h
+#define _aspect_gravity_model_function_h
 
 #include <aspect/gravity_model/interface.h>
 

--- a/include/aspect/gravity_model/interface.h
+++ b/include/aspect/gravity_model/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__gravity_model_interface_h
-#define __aspect__gravity_model_interface_h
+#ifndef _aspect_gravity_model_interface_h
+#define _aspect_gravity_model_interface_h
 
 #include <aspect/plugins.h>
 #include <deal.II/base/point.h>

--- a/include/aspect/gravity_model/radial.h
+++ b/include/aspect/gravity_model/radial.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__gravity_model_radial_h
-#define __aspect__gravity_model_radial_h
+#ifndef _aspect_gravity_model_radial_h
+#define _aspect_gravity_model_radial_h
 
 #include <aspect/simulator_access.h>
 #include <aspect/gravity_model/interface.h>

--- a/include/aspect/gravity_model/vertical.h
+++ b/include/aspect/gravity_model/vertical.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__gravity_model_vertical_h
-#define __aspect__gravity_model_vertical_h
+#ifndef _aspect_gravity_model_vertical_h
+#define _aspect_gravity_model_vertical_h
 
 #include <aspect/gravity_model/interface.h>
 

--- a/include/aspect/heating_model/adiabatic_heating.h
+++ b/include/aspect/heating_model/adiabatic_heating.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__heating_model_adiabatic_heating_h
-#define __aspect__heating_model_adiabatic_heating_h
+#ifndef _aspect_heating_model_adiabatic_heating_h
+#define _aspect_heating_model_adiabatic_heating_h
 
 #include <aspect/heating_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/heating_model/adiabatic_heating_of_melt.h
+++ b/include/aspect/heating_model/adiabatic_heating_of_melt.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__heating_model_adiabatic_heating_of_melt_h
-#define __aspect__heating_model_adiabatic_heating_of_melt_h
+#ifndef _aspect_heating_model_adiabatic_heating_of_melt_h
+#define _aspect_heating_model_adiabatic_heating_of_melt_h
 
 #include <aspect/heating_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/heating_model/constant_heating.h
+++ b/include/aspect/heating_model/constant_heating.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__heating_model_constant_heating_h
-#define __aspect__heating_model_constant_heating_h
+#ifndef _aspect_heating_model_constant_heating_h
+#define _aspect_heating_model_constant_heating_h
 
 #include <aspect/heating_model/interface.h>
 

--- a/include/aspect/heating_model/function.h
+++ b/include/aspect/heating_model/function.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__heating_model_function_h
-#define __aspect__heating_model_function_h
+#ifndef _aspect_heating_model_function_h
+#define _aspect_heating_model_function_h
 
 #include <aspect/simulator_access.h>
 #include <aspect/heating_model/interface.h>

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__heating_model_interface_h
-#define __aspect__heating_model_interface_h
+#ifndef _aspect_heating_model_interface_h
+#define _aspect_heating_model_interface_h
 
 #include <aspect/plugins.h>
 #include <aspect/material_model/interface.h>

--- a/include/aspect/heating_model/latent_heat.h
+++ b/include/aspect/heating_model/latent_heat.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__heating_model_latent_heat_h
-#define __aspect__heating_model_latent_heat_h
+#ifndef _aspect_heating_model_latent_heat_h
+#define _aspect_heating_model_latent_heat_h
 
 #include <aspect/heating_model/interface.h>
 

--- a/include/aspect/heating_model/latent_heat_melt.h
+++ b/include/aspect/heating_model/latent_heat_melt.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__heating_model_latent_heat_melt_h
-#define __aspect__heating_model_latent_heat_melt_h
+#ifndef _aspect_heating_model_latent_heat_melt_h
+#define _aspect_heating_model_latent_heat_melt_h
 
 #include <aspect/heating_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/heating_model/radioactive_decay.h
+++ b/include/aspect/heating_model/radioactive_decay.h
@@ -20,8 +20,8 @@
 
 
 
-#ifndef __aspect__heating_model_radioactive_decay_h
-#define __aspect__heating_model_radioactive_decay_h
+#ifndef _aspect_heating_model_radioactive_decay_h
+#define _aspect_heating_model_radioactive_decay_h
 
 #include <aspect/simulator_access.h>
 #include <aspect/heating_model/interface.h>

--- a/include/aspect/heating_model/shear_heating.h
+++ b/include/aspect/heating_model/shear_heating.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__heating_model_shear_heating_h
-#define __aspect__heating_model_shear_heating_h
+#ifndef _aspect_heating_model_shear_heating_h
+#define _aspect_heating_model_shear_heating_h
 
 #include <aspect/heating_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/heating_model/shear_heating_with_melt.h
+++ b/include/aspect/heating_model/shear_heating_with_melt.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__heating_model_shear_heating_with_melt_h
-#define __aspect__heating_model_shear_heating_with_melt_h
+#ifndef _aspect_heating_model_shear_heating_with_melt_h
+#define _aspect_heating_model_shear_heating_with_melt_h
 
 #include <aspect/heating_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/initial_conditions/S40RTS_perturbation.h
+++ b/include/aspect/initial_conditions/S40RTS_perturbation.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__initial_conditions_S40RTS_perturbation_h
-#define __aspect__initial_conditions_S40RTS_perturbation_h
+#ifndef _aspect_initial_conditions_S40RTS_perturbation_h
+#define _aspect_initial_conditions_S40RTS_perturbation_h
 
 #include <aspect/simulator_access.h>
 #include <deal.II/base/std_cxx11/array.h>

--- a/include/aspect/initial_conditions/SAVANI_perturbation.h
+++ b/include/aspect/initial_conditions/SAVANI_perturbation.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__initial_conditions_SAVANI_perturbation_h
-#define __aspect__initial_conditions_SAVANI_perturbation_h
+#ifndef _aspect_initial_conditions_SAVANI_perturbation_h
+#define _aspect_initial_conditions_SAVANI_perturbation_h
 
 #include <aspect/simulator_access.h>
 #include <deal.II/base/std_cxx11/array.h>

--- a/include/aspect/initial_conditions/adiabatic.h
+++ b/include/aspect/initial_conditions/adiabatic.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__initial_conditions_adiabatic_h
-#define __aspect__initial_conditions_adiabatic_h
+#ifndef _aspect_initial_conditions_adiabatic_h
+#define _aspect_initial_conditions_adiabatic_h
 
 #include <aspect/initial_conditions/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/initial_conditions/ascii_data.h
+++ b/include/aspect/initial_conditions/ascii_data.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__initial_conditions_ascii_data_h
-#define __aspect__initial_conditions_ascii_data_h
+#ifndef _aspect_initial_conditions_ascii_data_h
+#define _aspect_initial_conditions_ascii_data_h
 
 #include <aspect/initial_conditions/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/initial_conditions/box.h
+++ b/include/aspect/initial_conditions/box.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__initial_conditions_box_h
-#define __aspect__initial_conditions_box_h
+#ifndef _aspect_initial_conditions_box_h
+#define _aspect_initial_conditions_box_h
 
 #include <aspect/initial_conditions/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/initial_conditions/function.h
+++ b/include/aspect/initial_conditions/function.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__initial_conditions_function_h
-#define __aspect__initial_conditions_function_h
+#ifndef _aspect_initial_conditions_function_h
+#define _aspect_initial_conditions_function_h
 
 #include <aspect/initial_conditions/interface.h>
 

--- a/include/aspect/initial_conditions/harmonic_perturbation.h
+++ b/include/aspect/initial_conditions/harmonic_perturbation.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__initial_conditions_harmonic_perturbation_h
-#define __aspect__initial_conditions_harmonic_perturbation_h
+#ifndef _aspect_initial_conditions_harmonic_perturbation_h
+#define _aspect_initial_conditions_harmonic_perturbation_h
 
 #include <aspect/initial_conditions/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/initial_conditions/interface.h
+++ b/include/aspect/initial_conditions/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__initial_conditions_interface_h
-#define __aspect__initial_conditions_interface_h
+#ifndef _aspect_initial_conditions_interface_h
+#define _aspect_initial_conditions_interface_h
 
 #include <aspect/plugins.h>
 

--- a/include/aspect/initial_conditions/solidus.h
+++ b/include/aspect/initial_conditions/solidus.h
@@ -20,8 +20,8 @@
 
 
 
-#ifndef __aspect__initial_conditions_solidus_h
-#define __aspect__initial_conditions_solidus_h
+#ifndef _aspect_initial_conditions_solidus_h
+#define _aspect_initial_conditions_solidus_h
 
 #include <aspect/initial_conditions/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/initial_conditions/spherical_shell.h
+++ b/include/aspect/initial_conditions/spherical_shell.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__initial_conditions_spherical_shell_h
-#define __aspect__initial_conditions_spherical_shell_h
+#ifndef _aspect_initial_conditions_spherical_shell_h
+#define _aspect_initial_conditions_spherical_shell_h
 
 #include <aspect/initial_conditions/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__introspection_h
-#define __aspect__introspection_h
+#ifndef _aspect_introspection_h
+#define _aspect_introspection_h
 
 #include <deal.II/base/index_set.h>
 #include <deal.II/fe/component_mask.h>

--- a/include/aspect/lateral_averaging.h
+++ b/include/aspect/lateral_averaging.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__lateral_averaging_h
-#define __aspect__lateral_averaging_h
+#ifndef _aspect_lateral_averaging_h
+#define _aspect_lateral_averaging_h
 
 #include <aspect/simulator_access.h>
 

--- a/include/aspect/material_model/averaging.h
+++ b/include/aspect/material_model/averaging.h
@@ -18,8 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#ifndef __aspect__averaging_h
-#define __aspect__averaging_h
+#ifndef _aspect_material_model_averaging_h
+#define _aspect_material_model_averaging_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/material_model/composition_reaction.h
+++ b/include/aspect/material_model/composition_reaction.h
@@ -18,9 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
-#ifndef __aspect__model_composition_reaction_h
-#define __aspect__model_composition_reaction_h
+#ifndef _aspect_material_model_composition_reaction_h
+#define _aspect_material_model_composition_reaction_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/material_model/depth_dependent.h
+++ b/include/aspect/material_model/depth_dependent.h
@@ -18,10 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
-
-#ifndef __aspect__model_depth_dependent_h
-#define __aspect__model_depth_dependent_h
+#ifndef _aspect_material_model_depth_dependent_h
+#define _aspect_material_model_depth_dependent_h
 
 #include <deal.II/base/function_lib.h>
 #include <aspect/material_model/interface.h>

--- a/include/aspect/material_model/diffusion_dislocation.h
+++ b/include/aspect/material_model/diffusion_dislocation.h
@@ -18,8 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#ifndef __aspect__model_diffusion_dislocation_h
-#define __aspect__model_diffusion_dislocation_h
+#ifndef _aspect_material_model_diffusion_dislocation_h
+#define _aspect_material_model_diffusion_dislocation_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/material_model/drucker_prager.h
+++ b/include/aspect/material_model/drucker_prager.h
@@ -18,9 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
-#ifndef __aspect__model_drucker_prager_h
-#define __aspect__model_drucker_prager_h
+#ifndef _aspect_material_model_drucker_prager_h
+#define _aspect_material_model_drucker_prager_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -18,9 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
-#ifndef __aspect__material_model_interface_h
-#define __aspect__material_model_interface_h
+#ifndef _aspect_material_model_interface_h
+#define _aspect_material_model_interface_h
 
 #include <aspect/plugins.h>
 #include <deal.II/base/point.h>

--- a/include/aspect/material_model/latent_heat.h
+++ b/include/aspect/material_model/latent_heat.h
@@ -18,9 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
-#ifndef __aspect__model_latent_heat_h
-#define __aspect__model_latent_heat_h
+#ifndef _aspect_material_model_latent_heat_h
+#define _aspect_material_model_latent_heat_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/material_model/latent_heat_melt.h
+++ b/include/aspect/material_model/latent_heat_melt.h
@@ -18,9 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
-#ifndef __aspect__model_latent_heat_melt_h
-#define __aspect__model_latent_heat_melt_h
+#ifndef _aspect_material_model_latent_heat_melt_h
+#define _aspect_material_model_latent_heat_melt_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/material_model/melt_global.h
+++ b/include/aspect/material_model/melt_global.h
@@ -18,9 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
-#ifndef __aspect__model_melt_global_h
-#define __aspect__model_melt_global_h
+#ifndef _aspect_material_model_melt_global_h
+#define _aspect_material_model_melt_global_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/material_model/melt_simple.h
+++ b/include/aspect/material_model/melt_simple.h
@@ -18,9 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
-#ifndef __aspect__model_melt_simple_h
-#define __aspect__model_melt_simple_h
+#ifndef _aspect_material_model_melt_simple_h
+#define _aspect_material_model_melt_simple_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/material_model/morency_doin.h
+++ b/include/aspect/material_model/morency_doin.h
@@ -18,8 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#ifndef __aspect__model_morency_doin_h
-#define __aspect__model_morency_doin_h
+#ifndef _aspect_material_model_morency_doin_h
+#define _aspect_material_model_morency_doin_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/material_model/multicomponent.h
+++ b/include/aspect/material_model/multicomponent.h
@@ -18,9 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
-#ifndef __aspect__model_multicomponent_h
-#define __aspect__model_multicomponent_h
+#ifndef _aspect_material_model_multicomponent_h
+#define _aspect_material_model_multicomponent_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/material_model/simple.h
+++ b/include/aspect/material_model/simple.h
@@ -18,9 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
-#ifndef __aspect__model_simple_h
-#define __aspect__model_simple_h
+#ifndef _aspect_material_model_simple_h
+#define _aspect_material_model_simple_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/material_model/simple_compressible.h
+++ b/include/aspect/material_model/simple_compressible.h
@@ -18,8 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#ifndef __aspect__model_simple_compressible_h
-#define __aspect__model_simple_compressible_h
+#ifndef _aspect_material_model_simple_compressible_h
+#define _aspect_material_model_simple_compressible_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/material_model/simpler.h
+++ b/include/aspect/material_model/simpler.h
@@ -16,11 +16,10 @@
   You should have received a copy of the GNU General Public License
   along with ASPECT; see the file doc/COPYING.  If not see
   <http://www.gnu.org/licenses/>.
- */
+*/
 
-
-#ifndef __aspect__model_simpler_h
-#define __aspect__model_simpler_h
+#ifndef _aspect_material_model_simpler_h
+#define _aspect_material_model_simpler_h
 
 #include <aspect/material_model/interface.h>
 

--- a/include/aspect/material_model/steinberger.h
+++ b/include/aspect/material_model/steinberger.h
@@ -18,9 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
-#ifndef __aspect__model_steinberger_h
-#define __aspect__model_steinberger_h
+#ifndef _aspect_material_model_steinberger_h
+#define _aspect_material_model_steinberger_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -18,8 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#ifndef __aspect__model_visco_plastic_h
-#define __aspect__model_visco_plastic_h
+#ifndef _aspect_material_model_visco_plastic_h
+#define _aspect_material_model_visco_plastic_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -19,8 +19,8 @@
  */
 
 
-#ifndef __aspect__melt_h
-#define __aspect__melt_h
+#ifndef _aspect_melt_h
+#define _aspect_melt_h
 
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>

--- a/include/aspect/mesh_refinement/artificial_viscosity.h
+++ b/include/aspect/mesh_refinement/artificial_viscosity.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_artificial_viscosity_h
-#define __aspect__mesh_refinement_artificial_viscosity_h
+#ifndef _aspect_mesh_refinement_artificial_viscosity_h
+#define _aspect_mesh_refinement_artificial_viscosity_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/boundary.h
+++ b/include/aspect/mesh_refinement/boundary.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_boundary_h
-#define __aspect__mesh_refinement_boundary_h
+#ifndef _aspect_mesh_refinement_boundary_h
+#define _aspect_mesh_refinement_boundary_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/composition.h
+++ b/include/aspect/mesh_refinement/composition.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_composition_h
-#define __aspect__mesh_refinement_composition_h
+#ifndef _aspect_mesh_refinement_composition_h
+#define _aspect_mesh_refinement_composition_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/composition_gradient.h
+++ b/include/aspect/mesh_refinement/composition_gradient.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_composition_gradient_h
-#define __aspect__mesh_refinement_composition_gradient_h
+#ifndef _aspect_mesh_refinement_composition_gradient_h
+#define _aspect_mesh_refinement_composition_gradient_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/composition_threshold.h
+++ b/include/aspect/mesh_refinement/composition_threshold.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_composition_threshold_h
-#define __aspect__mesh_refinement_composition_threshold_h
+#ifndef _aspect_mesh_refinement_composition_threshold_h
+#define _aspect_mesh_refinement_composition_threshold_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/density.h
+++ b/include/aspect/mesh_refinement/density.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_density_h
-#define __aspect__mesh_refinement_density_h
+#ifndef _aspect_mesh_refinement_density_h
+#define _aspect_mesh_refinement_density_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_interface_h
-#define __aspect__mesh_refinement_interface_h
+#ifndef _aspect_mesh_refinement_interface_h
+#define _aspect_mesh_refinement_interface_h
 
 #include <aspect/global.h>
 #include <aspect/plugins.h>

--- a/include/aspect/mesh_refinement/maximum_refinement_function.h
+++ b/include/aspect/mesh_refinement/maximum_refinement_function.h
@@ -20,8 +20,8 @@
 
 
 
-#ifndef __aspect__mesh_refinement_maximum_refinement_function_h
-#define __aspect__mesh_refinement_maximum_refinement_function_h
+#ifndef _aspect_mesh_refinement_maximum_refinement_function_h
+#define _aspect_mesh_refinement_maximum_refinement_function_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/minimum_refinement_function.h
+++ b/include/aspect/mesh_refinement/minimum_refinement_function.h
@@ -20,8 +20,8 @@
 
 
 
-#ifndef __aspect__mesh_refinement_minimum_refinement_function_h
-#define __aspect__mesh_refinement_minimum_refinement_function_h
+#ifndef _aspect_mesh_refinement_minimum_refinement_function_h
+#define _aspect_mesh_refinement_minimum_refinement_function_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/nonadiabatic_temperature.h
+++ b/include/aspect/mesh_refinement/nonadiabatic_temperature.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_nonadiabatic_temperature_h
-#define __aspect__mesh_refinement_nonadiabatic_temperature_h
+#ifndef _aspect_mesh_refinement_nonadiabatic_temperature_h
+#define _aspect_mesh_refinement_nonadiabatic_temperature_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/particle_density.h
+++ b/include/aspect/mesh_refinement/particle_density.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_particle_density_h
-#define __aspect__mesh_refinement_particle_density_h
+#ifndef _aspect_mesh_refinement_particle_density_h
+#define _aspect_mesh_refinement_particle_density_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/slope.h
+++ b/include/aspect/mesh_refinement/slope.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_slope_h
-#define __aspect__mesh_refinement_slope_h
+#ifndef _aspect_mesh_refinement_slope_h
+#define _aspect_mesh_refinement_slope_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/strain_rate.h
+++ b/include/aspect/mesh_refinement/strain_rate.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_strain_rate_h
-#define __aspect__mesh_refinement_strain_rate_h
+#ifndef _aspect_mesh_refinement_strain_rate_h
+#define _aspect_mesh_refinement_strain_rate_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/temperature.h
+++ b/include/aspect/mesh_refinement/temperature.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_temperature_h
-#define __aspect__mesh_refinement_temperature_h
+#ifndef _aspect_mesh_refinement_temperature_h
+#define _aspect_mesh_refinement_temperature_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/thermal_energy_density.h
+++ b/include/aspect/mesh_refinement/thermal_energy_density.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_thermal_energy_density_h
-#define __aspect__mesh_refinement_thermal_energy_density_h
+#ifndef _aspect_mesh_refinement_thermal_energy_density_h
+#define _aspect_mesh_refinement_thermal_energy_density_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/topography.h
+++ b/include/aspect/mesh_refinement/topography.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_topography_h
-#define __aspect__mesh_refinement_topography_h
+#ifndef _aspect_mesh_refinement_topography_h
+#define _aspect_mesh_refinement_topography_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/velocity.h
+++ b/include/aspect/mesh_refinement/velocity.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_velocity_h
-#define __aspect__mesh_refinement_velocity_h
+#ifndef _aspect_mesh_refinement_velocity_h
+#define _aspect_mesh_refinement_velocity_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/mesh_refinement/viscosity.h
+++ b/include/aspect/mesh_refinement/viscosity.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__mesh_refinement_viscosity_h
-#define __aspect__mesh_refinement_viscosity_h
+#ifndef _aspect_mesh_refinement_viscosity_h
+#define _aspect_mesh_refinement_viscosity_h
 
 #include <aspect/mesh_refinement/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__parameters_h
-#define __aspect__parameters_h
+#ifndef _aspect_parameters_h
+#define _aspect_parameters_h
 
 #include <deal.II/base/parameter_handler.h>
 

--- a/include/aspect/particle/generator/ascii_file.h
+++ b/include/aspect/particle/generator/ascii_file.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_generator_ascii_file_h
-#define __aspect__particle_generator_ascii_file_h
+#ifndef _aspect_particle_generator_ascii_file_h
+#define _aspect_particle_generator_ascii_file_h
 
 #include <aspect/particle/generator/interface.h>
 

--- a/include/aspect/particle/generator/interface.h
+++ b/include/aspect/particle/generator/interface.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_generator_interface_h
-#define __aspect__particle_generator_interface_h
+#ifndef _aspect_particle_generator_interface_h
+#define _aspect_particle_generator_interface_h
 
 #include <aspect/particle/particle.h>
 #include <aspect/plugins.h>

--- a/include/aspect/particle/generator/probability_density_function.h
+++ b/include/aspect/particle/generator/probability_density_function.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_generator_probability_density_function_h
-#define __aspect__particle_generator_probability_density_function_h
+#ifndef _aspect_particle_generator_probability_density_function_h
+#define _aspect_particle_generator_probability_density_function_h
 
 #include <aspect/particle/generator/interface.h>
 

--- a/include/aspect/particle/generator/quadrature_points.h
+++ b/include/aspect/particle/generator/quadrature_points.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_quadrature_points_h
-#define __aspect__particle_quadrature_points_h
+#ifndef _aspect_particle_generator_quadrature_points_h
+#define _aspect_particle_generator_quadrature_points_h
 
 #include <aspect/particle/generator/interface.h>
 

--- a/include/aspect/particle/generator/random_uniform.h
+++ b/include/aspect/particle/generator/random_uniform.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_generator_random_uniform_h
-#define __aspect__particle_generator_random_uniform_h
+#ifndef _aspect_particle_generator_random_uniform_h
+#define _aspect_particle_generator_random_uniform_h
 
 #include <aspect/particle/generator/probability_density_function.h>
 

--- a/include/aspect/particle/generator/reference_cell.h
+++ b/include/aspect/particle/generator/reference_cell.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_generator_reference_cell_h
-#define __aspect__particle_generator_reference_cell_h
+#ifndef _aspect_particle_generator_reference_cell_h
+#define _aspect_particle_generator_reference_cell_h
 
 #include <aspect/particle/generator/interface.h>
 

--- a/include/aspect/particle/generator/uniform_box.h
+++ b/include/aspect/particle/generator/uniform_box.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_generator_uniform_box_h
-#define __aspect__particle_generator_uniform_box_h
+#ifndef _aspect_particle_generator_uniform_box_h
+#define _aspect_particle_generator_uniform_box_h
 
 #include <aspect/particle/generator/interface.h>
 

--- a/include/aspect/particle/generator/uniform_radial.h
+++ b/include/aspect/particle/generator/uniform_radial.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_generator_uniform_radial_h
-#define __aspect__particle_generator_uniform_radial_h
+#ifndef _aspect_particle_generator_uniform_radial_h
+#define _aspect_particle_generator_uniform_radial_h
 
 #include <aspect/particle/generator/interface.h>
 

--- a/include/aspect/particle/integrator/euler.h
+++ b/include/aspect/particle/integrator/euler.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_integrator_euler_h
-#define __aspect__particle_integrator_euler_h
+#ifndef _aspect_particle_integrator_euler_h
+#define _aspect_particle_integrator_euler_h
 
 #include <aspect/particle/integrator/interface.h>
 

--- a/include/aspect/particle/integrator/interface.h
+++ b/include/aspect/particle/integrator/interface.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_integrator_interface_h
-#define __aspect__particle_integrator_interface_h
+#ifndef _aspect_particle_integrator_interface_h
+#define _aspect_particle_integrator_interface_h
 
 #include <aspect/particle/particle.h>
 #include <aspect/plugins.h>

--- a/include/aspect/particle/integrator/rk_2.h
+++ b/include/aspect/particle/integrator/rk_2.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_integrator_rk_2_h
-#define __aspect__particle_integrator_rk_2_h
+#ifndef _aspect_particle_integrator_rk_2_h
+#define _aspect_particle_integrator_rk_2_h
 
 #include <aspect/particle/integrator/interface.h>
 

--- a/include/aspect/particle/integrator/rk_4.h
+++ b/include/aspect/particle/integrator/rk_4.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_integrator_rk_4_h
-#define __aspect__particle_integrator_rk_4_h
+#ifndef _aspect_particle_integrator_rk_4_h
+#define _aspect_particle_integrator_rk_4_h
 
 #include <aspect/particle/integrator/interface.h>
 

--- a/include/aspect/particle/interpolator/cell_average.h
+++ b/include/aspect/particle/interpolator/cell_average.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_interpolator_cell_average_h
-#define __aspect__particle_interpolator_cell_average_h
+#ifndef _aspect_particle_interpolator_cell_average_h
+#define _aspect_particle_interpolator_cell_average_h
 
 #include <aspect/particle/interpolator/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/particle/interpolator/interface.h
+++ b/include/aspect/particle/interpolator/interface.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_interpolator_interface_h
-#define __aspect__particle_interpolator_interface_h
+#ifndef _aspect_particle_interpolator_interface_h
+#define _aspect_particle_interpolator_interface_h
 
 #include <aspect/particle/particle.h>
 #include <aspect/plugins.h>

--- a/include/aspect/particle/output/ascii.h
+++ b/include/aspect/particle/output/ascii.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_output_ascii_h
-#define __aspect__particle_output_ascii_h
+#ifndef _aspect_particle_output_ascii_h
+#define _aspect_particle_output_ascii_h
 
 #include <aspect/particle/output/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/particle/output/hdf5.h
+++ b/include/aspect/particle/output/hdf5.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_output_hdf5_h
-#define __aspect__particle_output_hdf5_h
+#ifndef _aspect_particle_output_hdf5_h
+#define _aspect_particle_output_hdf5_h
 
 #include <aspect/particle/output/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/particle/output/interface.h
+++ b/include/aspect/particle/output/interface.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_output_interface_h
-#define __aspect__particle_output_interface_h
+#ifndef _aspect_particle_output_interface_h
+#define _aspect_particle_output_interface_h
 
 #include <aspect/particle/particle.h>
 #include <aspect/particle/property/interface.h>

--- a/include/aspect/particle/output/vtu.h
+++ b/include/aspect/particle/output/vtu.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_output_vtu_h
-#define __aspect__particle_output_vtu_h
+#ifndef _aspect_particle_output_vtu_h
+#define _aspect_particle_output_vtu_h
 
 #include <aspect/particle/output/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/particle/particle.h
+++ b/include/aspect/particle/particle.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_particle_h
-#define __aspect__particle_particle_h
+#ifndef _aspect_particle_particle_h
+#define _aspect_particle_particle_h
 
 #include <aspect/global.h>
 #include <aspect/particle/property_pool.h>

--- a/include/aspect/particle/property/function.h
+++ b/include/aspect/particle/property/function.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_property_function_h
-#define __aspect__particle_property_function_h
+#ifndef _aspect_particle_property_function_h
+#define _aspect_particle_property_function_h
 
 #include <aspect/particle/property/interface.h>
 

--- a/include/aspect/particle/property/initial_composition.h
+++ b/include/aspect/particle/property/initial_composition.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_property_initial_composition_h
-#define __aspect__particle_property_initial_composition_h
+#ifndef _aspect_particle_property_initial_composition_h
+#define _aspect_particle_property_initial_composition_h
 
 #include <aspect/particle/property/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/particle/property/initial_position.h
+++ b/include/aspect/particle/property/initial_position.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_property_initial_position_h
-#define __aspect__particle_property_initial_position_h
+#ifndef _aspect_particle_property_initial_position_h
+#define _aspect_particle_property_initial_position_h
 
 #include <aspect/particle/property/interface.h>
 

--- a/include/aspect/particle/property/integrated_strain.h
+++ b/include/aspect/particle/property/integrated_strain.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_property_integrated_strain_h
-#define __aspect__particle_property_integrated_strain_h
+#ifndef _aspect_particle_property_integrated_strain_h
+#define _aspect_particle_property_integrated_strain_h
 
 #include <aspect/particle/property/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_property_interface_h
-#define __aspect__particle_property_interface_h
+#ifndef _aspect_particle_property_interface_h
+#define _aspect_particle_property_interface_h
 
 #include <aspect/particle/particle.h>
 #include <aspect/particle/interpolator/interface.h>

--- a/include/aspect/particle/property/pT_path.h
+++ b/include/aspect/particle/property/pT_path.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_property_pT_path_h
-#define __aspect__particle_property_pT_path_h
+#ifndef _aspect_particle_property_pT_path_h
+#define _aspect_particle_property_pT_path_h
 
 #include <aspect/particle/property/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/particle/property/position.h
+++ b/include/aspect/particle/property/position.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_property_position_h
-#define __aspect__particle_property_position_h
+#ifndef _aspect_particle_property_position_h
+#define _aspect_particle_property_position_h
 
 #include <aspect/particle/property/interface.h>
 

--- a/include/aspect/particle/property/velocity.h
+++ b/include/aspect/particle/property/velocity.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_property_velocity_h
-#define __aspect__particle_property_velocity_h
+#ifndef _aspect_particle_property_velocity_h
+#define _aspect_particle_property_velocity_h
 
 #include <aspect/particle/property/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/particle/property_pool.h
+++ b/include/aspect/particle/property_pool.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_property_pool_h
-#define __aspect__particle_property_pool_h
+#ifndef _aspect_particle_property_pool_h
+#define _aspect_particle_property_pool_h
 
 #include <aspect/global.h>
 

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_world_h
-#define __aspect__particle_world_h
+#ifndef _aspect_particle_world_h
+#define _aspect_particle_world_h
 
 #include <aspect/global.h>
 #include <aspect/particle/particle.h>

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__plugins_h
-#define __aspect__plugins_h
+#ifndef _aspect_plugins_h
+#define _aspect_plugins_h
 
 
 #include <deal.II/base/parameter_handler.h>

--- a/include/aspect/postprocess/basic_statistics.h
+++ b/include/aspect/postprocess/basic_statistics.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_basic_statistics_h
-#define __aspect__postprocess_basic_statistics_h
+#ifndef _aspect_postprocess_basic_statistics_h
+#define _aspect_postprocess_basic_statistics_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/boundary_densities.h
+++ b/include/aspect/postprocess/boundary_densities.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_boundary_densities_h
-#define __aspect__postprocess_boundary_densities_h
+#ifndef _aspect_postprocess_boundary_densities_h
+#define _aspect_postprocess_boundary_densities_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/boundary_pressures.h
+++ b/include/aspect/postprocess/boundary_pressures.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_boundary_pressures_h
-#define __aspect__postprocess_boundary_pressures_h
+#ifndef _aspect_postprocess_boundary_pressures_h
+#define _aspect_postprocess_boundary_pressures_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/command.h
+++ b/include/aspect/postprocess/command.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_command_h
-#define __aspect__postprocess_command_h
+#ifndef _aspect_postprocess_command_h
+#define _aspect_postprocess_command_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/composition_statistics.h
+++ b/include/aspect/postprocess/composition_statistics.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_composition_statistics_h
-#define __aspect__postprocess_composition_statistics_h
+#ifndef _aspect_postprocess_composition_statistics_h
+#define _aspect_postprocess_composition_statistics_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/depth_average.h
+++ b/include/aspect/postprocess/depth_average.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_depth_average_h
-#define __aspect__postprocess_depth_average_h
+#ifndef _aspect_postprocess_depth_average_h
+#define _aspect_postprocess_depth_average_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/dynamic_topography.h
+++ b/include/aspect/postprocess/dynamic_topography.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_surface_topography_h
-#define __aspect__postprocess_surface_topography_h
+#ifndef _aspect_postprocess_surface_topography_h
+#define _aspect_postprocess_surface_topography_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/heat_flux_map.h
+++ b/include/aspect/postprocess/heat_flux_map.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_heat_flux_map_h
-#define __aspect__postprocess_heat_flux_map_h
+#ifndef _aspect_postprocess_heat_flux_map_h
+#define _aspect_postprocess_heat_flux_map_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/heat_flux_statistics.h
+++ b/include/aspect/postprocess/heat_flux_statistics.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_heat_flux_statistics_h
-#define __aspect__postprocess_heat_flux_statistics_h
+#ifndef _aspect_postprocess_heat_flux_statistics_h
+#define _aspect_postprocess_heat_flux_statistics_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/heating_statistics.h
+++ b/include/aspect/postprocess/heating_statistics.h
@@ -20,8 +20,8 @@
 
 
 
-#ifndef __aspect__postprocess_heating_statistics_h
-#define __aspect__postprocess_heating_statistics_h
+#ifndef _aspect_postprocess_heating_statistics_h
+#define _aspect_postprocess_heating_statistics_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_interface_h
-#define __aspect__postprocess_interface_h
+#ifndef _aspect_postprocess_interface_h
+#define _aspect_postprocess_interface_h
 
 #include <aspect/global.h>
 #include <aspect/plugins.h>

--- a/include/aspect/postprocess/mass_flux_statistics.h
+++ b/include/aspect/postprocess/mass_flux_statistics.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_mass_flux_statistics_h
-#define __aspect__postprocess_mass_flux_statistics_h
+#ifndef _aspect_postprocess_mass_flux_statistics_h
+#define _aspect_postprocess_mass_flux_statistics_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/matrix_statistics.h
+++ b/include/aspect/postprocess/matrix_statistics.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_matrix_statistics_h
-#define __aspect__postprocess_matrix_statistics_h
+#ifndef _aspect_postprocess_matrix_statistics_h
+#define _aspect_postprocess_matrix_statistics_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/melt_statistics.h
+++ b/include/aspect/postprocess/melt_statistics.h
@@ -20,8 +20,8 @@
 
 
 
-#ifndef __aspect__postprocess_melt_statistics_h
-#define __aspect__postprocess_melt_statistics_h
+#ifndef _aspect_postprocess_melt_statistics_h
+#define _aspect_postprocess_melt_statistics_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/memory_statistics.h
+++ b/include/aspect/postprocess/memory_statistics.h
@@ -19,8 +19,8 @@
  */
 
 
-#ifndef __aspect__postprocess_memory_statistics_h
-#define __aspect__postprocess_memory_statistics_h
+#ifndef _aspect_postprocess_memory_statistics_h
+#define _aspect_postprocess_memory_statistics_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/particle_count_statistics.h
+++ b/include/aspect/postprocess/particle_count_statistics.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_particle_count_statistics_h
-#define __aspect__postprocess_particle_count_statistics_h
+#ifndef _aspect_postprocess_particle_count_statistics_h
+#define _aspect_postprocess_particle_count_statistics_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/point_values.h
+++ b/include/aspect/postprocess/point_values.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_point_values_h
-#define __aspect__postprocess_point_values_h
+#ifndef _aspect_postprocess_point_values_h
+#define _aspect_postprocess_point_values_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/pressure_statistics.h
+++ b/include/aspect/postprocess/pressure_statistics.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_pressure_statistics_h
-#define __aspect__postprocess_pressure_statistics_h
+#ifndef _aspect_postprocess_pressure_statistics_h
+#define _aspect_postprocess_pressure_statistics_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/spherical_velocity_statistics.h
+++ b/include/aspect/postprocess/spherical_velocity_statistics.h
@@ -20,8 +20,8 @@
 
 
 
-#ifndef __aspect__postprocess_spherical_velocity_statistics_h
-#define __aspect__postprocess_spherical_velocity_statistics_h
+#ifndef _aspect_postprocess_spherical_velocity_statistics_h
+#define _aspect_postprocess_spherical_velocity_statistics_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/stokes_residual.h
+++ b/include/aspect/postprocess/stokes_residual.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_stokes_residual_h
-#define __aspect__postprocess_stokes_residual_h
+#ifndef _aspect_postprocess_stokes_residual_h
+#define _aspect_postprocess_stokes_residual_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/temperature_statistics.h
+++ b/include/aspect/postprocess/temperature_statistics.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_temperature_statistics_h
-#define __aspect__postprocess_temperature_statistics_h
+#ifndef _aspect_postprocess_temperature_statistics_h
+#define _aspect_postprocess_temperature_statistics_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/topography.h
+++ b/include/aspect/postprocess/topography.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_topography_h
-#define __aspect__postprocess_topography_h
+#ifndef _aspect_postprocess_topography_h
+#define _aspect_postprocess_topography_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/tracers.h
+++ b/include/aspect/postprocess/tracers.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__postprocess_tracer_h
-#define __aspect__postprocess_tracer_h
+#ifndef _aspect_postprocess_tracer_h
+#define _aspect_postprocess_tracer_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/particle/world.h>

--- a/include/aspect/postprocess/velocity_boundary_statistics.h
+++ b/include/aspect/postprocess/velocity_boundary_statistics.h
@@ -20,8 +20,8 @@
 
 
 
-#ifndef __aspect__postprocess_velocity_boundary_statistics_h
-#define __aspect__postprocess_velocity_boundary_statistics_h
+#ifndef _aspect_postprocess_velocity_boundary_statistics_h
+#define _aspect_postprocess_velocity_boundary_statistics_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/velocity_statistics.h
+++ b/include/aspect/postprocess/velocity_statistics.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_velocity_statistics_h
-#define __aspect__postprocess_velocity_statistics_h
+#ifndef _aspect_postprocess_velocity_statistics_h
+#define _aspect_postprocess_velocity_statistics_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/viscous_dissipation_statistics.h
+++ b/include/aspect/postprocess/viscous_dissipation_statistics.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_viscous_dissipation_statistics_h
-#define __aspect__postprocess_viscous_dissipation_statistics_h
+#ifndef _aspect_postprocess_viscous_dissipation_statistics_h
+#define _aspect_postprocess_viscous_dissipation_statistics_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_h
-#define __aspect__postprocess_visualization_h
+#ifndef _aspect_postprocess_visualization_h
+#define _aspect_postprocess_visualization_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/adiabat.h
+++ b/include/aspect/postprocess/visualization/adiabat.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_adiabat_h
-#define __aspect__postprocess_visualization_adiabat_h
+#ifndef _aspect_postprocess_visualization_adiabat_h
+#define _aspect_postprocess_visualization_adiabat_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/artificial_viscosity.h
+++ b/include/aspect/postprocess/visualization/artificial_viscosity.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_artificial_viscosity_h
-#define __aspect__postprocess_visualization_artificial_viscosity_h
+#ifndef _aspect_postprocess_visualization_artificial_viscosity_h
+#define _aspect_postprocess_visualization_artificial_viscosity_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/artificial_viscosity_composition.h
+++ b/include/aspect/postprocess/visualization/artificial_viscosity_composition.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_artificial_viscosity_composition_h
-#define __aspect__postprocess_visualization_artificial_viscosity_composition_h
+#ifndef _aspect_postprocess_visualization_artificial_viscosity_composition_h
+#define _aspect_postprocess_visualization_artificial_viscosity_composition_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/boundary_indicator.h
+++ b/include/aspect/postprocess/visualization/boundary_indicator.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_boundary_indicator_h
-#define __aspect__postprocess_visualization_boundary_indicator_h
+#ifndef _aspect_postprocess_visualization_boundary_indicator_h
+#define _aspect_postprocess_visualization_boundary_indicator_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/compositional_vector.h
+++ b/include/aspect/postprocess/visualization/compositional_vector.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_compositional_vector_h
-#define __aspect__postprocess_visualization_compositional_vector_h
+#ifndef _aspect_postprocess_visualization_compositional_vector_h
+#define _aspect_postprocess_visualization_compositional_vector_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/density.h
+++ b/include/aspect/postprocess/visualization/density.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_density_h
-#define __aspect__postprocess_visualization_density_h
+#ifndef _aspect_postprocess_visualization_density_h
+#define _aspect_postprocess_visualization_density_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/depth.h
+++ b/include/aspect/postprocess/visualization/depth.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_depth_h
-#define __aspect__postprocess_visualization_depth_h
+#ifndef _aspect_postprocess_visualization_depth_h
+#define _aspect_postprocess_visualization_depth_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/dynamic_topography.h
+++ b/include/aspect/postprocess/visualization/dynamic_topography.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_dynamic_topography_h
-#define __aspect__postprocess_visualization_dynamic_topography_h
+#ifndef _aspect_postprocess_visualization_dynamic_topography_h
+#define _aspect_postprocess_visualization_dynamic_topography_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/error_indicator.h
+++ b/include/aspect/postprocess/visualization/error_indicator.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_error_indicator_h
-#define __aspect__postprocess_visualization_error_indicator_h
+#ifndef _aspect_postprocess_visualization_error_indicator_h
+#define _aspect_postprocess_visualization_error_indicator_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/friction_heating.h
+++ b/include/aspect/postprocess/visualization/friction_heating.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_friction_heating_h
-#define __aspect__postprocess_visualization_friction_heating_h
+#ifndef _aspect_postprocess_visualization_friction_heating_h
+#define _aspect_postprocess_visualization_friction_heating_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/gravity.h
+++ b/include/aspect/postprocess/visualization/gravity.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_gravity_h
-#define __aspect__postprocess_visualization_gravity_h
+#ifndef _aspect_postprocess_visualization_gravity_h
+#define _aspect_postprocess_visualization_gravity_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/heat_flux_map.h
+++ b/include/aspect/postprocess/visualization/heat_flux_map.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_heat_flux_map_h
-#define __aspect__postprocess_visualization_heat_flux_map_h
+#ifndef _aspect_postprocess_visualization_heat_flux_map_h
+#define _aspect_postprocess_visualization_heat_flux_map_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/heating.h
+++ b/include/aspect/postprocess/visualization/heating.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_heating_h
-#define __aspect__postprocess_visualization_heating_h
+#ifndef _aspect_postprocess_visualization_heating_h
+#define _aspect_postprocess_visualization_heating_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/material_properties.h
+++ b/include/aspect/postprocess/visualization/material_properties.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_material_properties_h
-#define __aspect__postprocess_visualization_material_properties_h
+#ifndef _aspect_postprocess_visualization_material_properties_h
+#define _aspect_postprocess_visualization_material_properties_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/maximum_horizontal_compressive_stress.h
+++ b/include/aspect/postprocess/visualization/maximum_horizontal_compressive_stress.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_maximum_horizontal_compressive_stress_h
-#define __aspect__postprocess_visualization_maximum_horizontal_compressive_stress_h
+#ifndef _aspect_postprocess_visualization_maximum_horizontal_compressive_stress_h
+#define _aspect_postprocess_visualization_maximum_horizontal_compressive_stress_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/melt.h
+++ b/include/aspect/postprocess/visualization/melt.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_melt_h
-#define __aspect__postprocess_visualization_melt_h
+#ifndef _aspect_postprocess_visualization_melt_h
+#define _aspect_postprocess_visualization_melt_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/melt_fraction.h
+++ b/include/aspect/postprocess/visualization/melt_fraction.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_melt_fraction_h
-#define __aspect__postprocess_visualization_melt_fraction_h
+#ifndef _aspect_postprocess_visualization_melt_fraction_h
+#define _aspect_postprocess_visualization_melt_fraction_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/nonadiabatic_pressure.h
+++ b/include/aspect/postprocess/visualization/nonadiabatic_pressure.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_nonadiabatic_pressure_h
-#define __aspect__postprocess_visualization_nonadiabatic_pressure_h
+#ifndef _aspect_postprocess_visualization_nonadiabatic_pressure_h
+#define _aspect_postprocess_visualization_nonadiabatic_pressure_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/nonadiabatic_temperature.h
+++ b/include/aspect/postprocess/visualization/nonadiabatic_temperature.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_nonadiabatic_temperature_h
-#define __aspect__postprocess_visualization_nonadiabatic_temperature_h
+#ifndef _aspect_postprocess_visualization_nonadiabatic_temperature_h
+#define _aspect_postprocess_visualization_nonadiabatic_temperature_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/particle_count.h
+++ b/include/aspect/postprocess/visualization/particle_count.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_particle_count_h
-#define __aspect__postprocess_visualization_particle_count_h
+#ifndef _aspect_postprocess_visualization_particle_count_h
+#define _aspect_postprocess_visualization_particle_count_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/partition.h
+++ b/include/aspect/postprocess/visualization/partition.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_partition_h
-#define __aspect__postprocess_visualization_partition_h
+#ifndef _aspect_postprocess_visualization_partition_h
+#define _aspect_postprocess_visualization_partition_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/seismic_anomalies.h
+++ b/include/aspect/postprocess/visualization/seismic_anomalies.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_seismic_anomalies_h
-#define __aspect__postprocess_visualization_seismic_anomalies_h
+#ifndef _aspect_postprocess_visualization_seismic_anomalies_h
+#define _aspect_postprocess_visualization_seismic_anomalies_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/seismic_vp.h
+++ b/include/aspect/postprocess/visualization/seismic_vp.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_seismic_vp_h
-#define __aspect__postprocess_visualization_seismic_vp_h
+#ifndef _aspect_postprocess_visualization_seismic_vp_h
+#define _aspect_postprocess_visualization_seismic_vp_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/seismic_vs.h
+++ b/include/aspect/postprocess/visualization/seismic_vs.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_seismic_vs_h
-#define __aspect__postprocess_visualization_seismic_vs_h
+#ifndef _aspect_postprocess_visualization_seismic_vs_h
+#define _aspect_postprocess_visualization_seismic_vs_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/shear_stress.h
+++ b/include/aspect/postprocess/visualization/shear_stress.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_shear_stress_h
-#define __aspect__postprocess_visualization_shear_stress_h
+#ifndef _aspect_postprocess_visualization_shear_stress_h
+#define _aspect_postprocess_visualization_shear_stress_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/specific_heat.h
+++ b/include/aspect/postprocess/visualization/specific_heat.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_specific_heat_h
-#define __aspect__postprocess_visualization_specific_heat_h
+#ifndef _aspect_postprocess_visualization_specific_heat_h
+#define _aspect_postprocess_visualization_specific_heat_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/strain_rate.h
+++ b/include/aspect/postprocess/visualization/strain_rate.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_strain_rate_h
-#define __aspect__postprocess_visualization_strain_rate_h
+#ifndef _aspect_postprocess_visualization_strain_rate_h
+#define _aspect_postprocess_visualization_strain_rate_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/stress.h
+++ b/include/aspect/postprocess/visualization/stress.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_stress_h
-#define __aspect__postprocess_visualization_stress_h
+#ifndef _aspect_postprocess_visualization_stress_h
+#define _aspect_postprocess_visualization_stress_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/thermal_conductivity.h
+++ b/include/aspect/postprocess/visualization/thermal_conductivity.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_thermal_conductivity_h
-#define __aspect__postprocess_visualization_thermal_conductivity_h
+#ifndef _aspect_postprocess_visualization_thermal_conductivity_h
+#define _aspect_postprocess_visualization_thermal_conductivity_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/thermal_diffusivity.h
+++ b/include/aspect/postprocess/visualization/thermal_diffusivity.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_thermal_diffusivity_h
-#define __aspect__postprocess_visualization_thermal_diffusivity_h
+#ifndef _aspect_postprocess_visualization_thermal_diffusivity_h
+#define _aspect_postprocess_visualization_thermal_diffusivity_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/thermal_expansivity.h
+++ b/include/aspect/postprocess/visualization/thermal_expansivity.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_thermal_expansivity_h
-#define __aspect__postprocess_visualization_thermal_expansivity_h
+#ifndef _aspect_postprocess_visualization_thermal_expansivity_h
+#define _aspect_postprocess_visualization_thermal_expansivity_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/thermodynamic_phase.h
+++ b/include/aspect/postprocess/visualization/thermodynamic_phase.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_thermodynamic_phase_h
-#define __aspect__postprocess_visualization_thermodynamic_phase_h
+#ifndef _aspect_postprocess_visualization_thermodynamic_phase_h
+#define _aspect_postprocess_visualization_thermodynamic_phase_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/vertical_heat_flux.h
+++ b/include/aspect/postprocess/visualization/vertical_heat_flux.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_vertical_heat_flux_h
-#define __aspect__postprocess_visualization_vertical_heat_flux_h
+#ifndef _aspect_postprocess_visualization_vertical_heat_flux_h
+#define _aspect_postprocess_visualization_vertical_heat_flux_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/viscosity.h
+++ b/include/aspect/postprocess/visualization/viscosity.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_viscosity_h
-#define __aspect__postprocess_visualization_viscosity_h
+#ifndef _aspect_postprocess_visualization_viscosity_h
+#define _aspect_postprocess_visualization_viscosity_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/viscosity_ratio.h
+++ b/include/aspect/postprocess/visualization/viscosity_ratio.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_viscosity_ratio_h
-#define __aspect__postprocess_visualization_viscosity_ratio_h
+#ifndef _aspect_postprocess_visualization_viscosity_ratio_h
+#define _aspect_postprocess_visualization_viscosity_ratio_h
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/prescribed_stokes_solution/ascii_data.h
+++ b/include/aspect/prescribed_stokes_solution/ascii_data.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__perscribed_stokes_solution_ascii_data_h
-#define __aspect__perscribed_stokes_solution_ascii_data_h
+#ifndef _aspect_prescribed_stokes_solution_ascii_data_h
+#define _aspect_prescribed_stokes_solution_ascii_data_h
 
 #include <aspect/prescribed_stokes_solution/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/prescribed_stokes_solution/circle.h
+++ b/include/aspect/prescribed_stokes_solution/circle.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__prescribed_stokes_solution_circle_h
-#define __aspect__prescribed_stokes_solution_circle_h
+#ifndef _aspect_prescribed_stokes_solution_circle_h
+#define _aspect_prescribed_stokes_solution_circle_h
 
 #include <aspect/prescribed_stokes_solution/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/prescribed_stokes_solution/function.h
+++ b/include/aspect/prescribed_stokes_solution/function.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__prescribed_stokes_solution_function_h
-#define __aspect__prescribed_stokes_solution_function_h
+#ifndef _aspect_prescribed_stokes_solution_function_h
+#define _aspect_prescribed_stokes_solution_function_h
 
 #include <aspect/prescribed_stokes_solution/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/prescribed_stokes_solution/interface.h
+++ b/include/aspect/prescribed_stokes_solution/interface.h
@@ -20,8 +20,8 @@
 
 
 
-#ifndef __aspect__prescribed_stokes_solution_interface_h
-#define __aspect__prescribed_stokes_solution_interface_h
+#ifndef _aspect_prescribed_stokes_solution_interface_h
+#define _aspect_prescribed_stokes_solution_interface_h
 
 #include <aspect/plugins.h>
 

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__simulator_h
-#define __aspect__simulator_h
+#ifndef _aspect_simulator_h
+#define _aspect_simulator_h
 
 #include <deal.II/base/timer.h>
 #include <deal.II/base/parameter_handler.h>

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__simulator_access_h
-#define __aspect__simulator_access_h
+#ifndef _aspect_simulator_access_h
+#define _aspect_simulator_access_h
 
 #include <deal.II/base/timer.h>
 #include <deal.II/base/conditional_ostream.h>

--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__simulator_signals_h
-#define __aspect__simulator_signals_h
+#ifndef _aspect_simulator_signals_h
+#define _aspect_simulator_signals_h
 
 #include <aspect/global.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/termination_criteria/end_step.h
+++ b/include/aspect/termination_criteria/end_step.h
@@ -18,8 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#ifndef __aspect__termination_criteria_end_step_h
-#define __aspect__termination_criteria_end_step_h
+#ifndef _aspect_termination_criteria_end_step_h
+#define _aspect_termination_criteria_end_step_h
 
 #include <aspect/termination_criteria/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/termination_criteria/end_time.h
+++ b/include/aspect/termination_criteria/end_time.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__termination_criteria_end_time_h
-#define __aspect__termination_criteria_end_time_h
+#ifndef _aspect_termination_criteria_end_time_h
+#define _aspect_termination_criteria_end_time_h
 
 #include <aspect/termination_criteria/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/termination_criteria/interface.h
+++ b/include/aspect/termination_criteria/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__termination_criteria_interface_h
-#define __aspect__termination_criteria_interface_h
+#ifndef _aspect_termination_criteria_interface_h
+#define _aspect_termination_criteria_interface_h
 
 #include <aspect/global.h>
 #include <aspect/plugins.h>

--- a/include/aspect/termination_criteria/steady_rms_velocity.h
+++ b/include/aspect/termination_criteria/steady_rms_velocity.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__termination_criteria_steady_rms_velocity_h
-#define __aspect__termination_criteria_steady_rms_velocity_h
+#ifndef _aspect_termination_criteria_steady_rms_velocity_h
+#define _aspect_termination_criteria_steady_rms_velocity_h
 
 #include <aspect/termination_criteria/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/termination_criteria/user_request.h
+++ b/include/aspect/termination_criteria/user_request.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__termination_criteria_user_request_h
-#define __aspect__termination_criteria_user_request_h
+#ifndef _aspect_termination_criteria_user_request_h
+#define _aspect_termination_criteria_user_request_h
 
 #include <aspect/termination_criteria/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/traction_boundary_conditions/ascii_data.h
+++ b/include/aspect/traction_boundary_conditions/ascii_data.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__traction_boundary_conditions_ascii_data_h
-#define __aspect__traction_boundary_conditions_ascii_data_h
+#ifndef _aspect_traction_boundary_conditions_ascii_data_h
+#define _aspect_traction_boundary_conditions_ascii_data_h
 
 #include <aspect/traction_boundary_conditions/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/traction_boundary_conditions/function.h
+++ b/include/aspect/traction_boundary_conditions/function.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__traction_boundary_conditions_function_h
-#define __aspect__traction_boundary_conditions_function_h
+#ifndef _aspect_traction_boundary_conditions_function_h
+#define _aspect_traction_boundary_conditions_function_h
 
 #include <aspect/traction_boundary_conditions/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/traction_boundary_conditions/interface.h
+++ b/include/aspect/traction_boundary_conditions/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__traction_boundary_conditions_interface_h
-#define __aspect__traction_boundary_conditions_interface_h
+#ifndef _aspect_traction_boundary_conditions_interface_h
+#define _aspect_traction_boundary_conditions_interface_h
 
 #include <aspect/plugins.h>
 #include <aspect/geometry_model/interface.h>

--- a/include/aspect/traction_boundary_conditions/zero_traction.h
+++ b/include/aspect/traction_boundary_conditions/zero_traction.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__traction_boundary_conditions_zero_traction_h
-#define __aspect__traction_boundary_conditions_zero_traction_h
+#ifndef _aspect_traction_boundary_conditions_zero_traction_h
+#define _aspect_traction_boundary_conditions_zero_traction_h
 
 #include <aspect/traction_boundary_conditions/interface.h>
 

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__utilities_h
-#define __aspect__utilities_h
+#ifndef _aspect_utilities_h
+#define _aspect_utilities_h
 
 #include <aspect/global.h>
 

--- a/include/aspect/velocity_boundary_conditions/ascii_data.h
+++ b/include/aspect/velocity_boundary_conditions/ascii_data.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__velocity_boundary_conditions_ascii_data_h
-#define __aspect__velocity_boundary_conditions_ascii_data_h
+#ifndef _aspect_velocity_boundary_conditions_ascii_data_h
+#define _aspect_velocity_boundary_conditions_ascii_data_h
 
 #include <aspect/velocity_boundary_conditions/interface.h>
 

--- a/include/aspect/velocity_boundary_conditions/function.h
+++ b/include/aspect/velocity_boundary_conditions/function.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__velocity_boundary_conditions_function_h
-#define __aspect__velocity_boundary_conditions_function_h
+#ifndef _aspect_velocity_boundary_conditions_function_h
+#define _aspect_velocity_boundary_conditions_function_h
 
 #include <aspect/velocity_boundary_conditions/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/velocity_boundary_conditions/gplates.h
+++ b/include/aspect/velocity_boundary_conditions/gplates.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__velocity_boundary_conditions_gplates_h
-#define __aspect__velocity_boundary_conditions_gplates_h
+#ifndef _aspect_velocity_boundary_conditions_gplates_h
+#define _aspect_velocity_boundary_conditions_gplates_h
 
 #include <aspect/velocity_boundary_conditions/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/velocity_boundary_conditions/interface.h
+++ b/include/aspect/velocity_boundary_conditions/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__velocity_boundary_conditions_interface_h
-#define __aspect__velocity_boundary_conditions_interface_h
+#ifndef _aspect_velocity_boundary_conditions_interface_h
+#define _aspect_velocity_boundary_conditions_interface_h
 
 #include <aspect/plugins.h>
 #include <aspect/geometry_model/interface.h>

--- a/include/aspect/velocity_boundary_conditions/zero_velocity.h
+++ b/include/aspect/velocity_boundary_conditions/zero_velocity.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__velocity_boundary_conditions_zero_velocity_h
-#define __aspect__velocity_boundary_conditions_zero_velocity_h
+#ifndef _aspect_velocity_boundary_conditions_zero_velocity_h
+#define _aspect_velocity_boundary_conditions_zero_velocity_h
 
 #include <aspect/velocity_boundary_conditions/interface.h>
 


### PR DESCRIPTION
- material model was missing "material"
- some typos (can you find them?)
- double-underscore is compiler reserved and as such illegal to use