### PR TITLE
wrap boost include with DIAGNOSTICS macro

### DIFF
--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -34,8 +34,10 @@
 
 #include <deal.II/lac/generic_linear_algebra.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/multithread_info.h>


### PR DESCRIPTION
This disables a bunch of warnings inside boost we can not control (for
example new warnings produced by clang 3.9.1).