### PR TITLE
Avoid using the deprecated class std::auto_ptr.

### DIFF
--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2016 by the authors of the ASPECT code.
+  Copyright (C) 2016, 2017 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -325,7 +325,7 @@ namespace aspect
        * initialization can be done together with the other objects related to melt
        * transport.
        */
-      std::auto_ptr<FluidPressureBoundaryConditions::Interface<dim> > fluid_pressure_boundary_conditions;
+      std_cxx11::unique_ptr<FluidPressureBoundaryConditions::Interface<dim> > fluid_pressure_boundary_conditions;
   };
 
 }


### PR DESCRIPTION
Use std::unique_ptr instead.