### PR TITLE
bug fixed for time-dependent boundary condition with DG approach

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -919,15 +919,15 @@ namespace aspect
         }
     }
 
+    // If there is a fixed boundary temperature,
+    // update the temperature boundary condition.
+    if (boundary_temperature.get())
+      boundary_temperature->update();
+
     // if using continuous temperature FE, do the same for the temperature variable:
     // evaluate the current boundary temperature and add these constraints as well
     if (!parameters.use_discontinuous_temperature_discretization)
       {
-        // If there is a fixed boundary temperature,
-        // update the temperature boundary condition.
-        if (boundary_temperature.get())
-          boundary_temperature->update();
-
         // obtain the boundary indicators that belong to Dirichlet-type
         // temperature boundary conditions and interpolate the temperature
         // there
@@ -950,14 +950,14 @@ namespace aspect
           }
       }
 
+    // If there are fixed boundary compositions,
+    // update the composition boundary condition.
+    if (boundary_composition.get())
+      boundary_composition->update();
+
     // now do the same for the composition variable:
     if (!parameters.use_discontinuous_composition_discretization)
       {
-        // If there are fixed boundary compositions,
-        // update the composition boundary condition.
-        if (boundary_composition.get())
-          boundary_composition->update();
-
         // obtain the boundary indicators that belong to Dirichlet-type
         // composition boundary conditions and interpolate the composition
         // there


### PR DESCRIPTION
When working on a test problem for #1177, I found a bug of current code that the time dependent boundary condition doesn't update for the temperature/composition if use the discontinuous discretization. This patch fixes this bug.