### PR TITLE
Use the annotated version of a .prm snippet in the manual.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -3895,7 +3895,7 @@ specify the details of these geometries.
 
 Similarly, you describe boundary conditions using parameters such as this:
 %
-\lstinputlisting[language=prmfile]{cookbooks/overview/boundary-conditions.part.prm}
+\lstinputlisting[language=prmfile]{cookbooks/overview/boundary-conditions.part.prm.out}
 %
 This snippet describes which of the four boundaries of the two-dimensional box
 we have selected above should have a prescribed temperature or an insulating


### PR DESCRIPTION
This makes sure parameters are correctly cross-linked and the snippet appears in the
index of the manual.