### PR TITLE
Fix documentation of Utilities::fexists.

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2014, 2015, 2016 by the authors of the ASPECT code.
+  Copyright (C) 2014, 2015, 2016, 2017 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -209,7 +209,7 @@ namespace aspect
     };
 
     /**
-     * Checks whether a file named filename exists.
+     * Checks whether a file named @p filename exists and is readable.
      *
      * @param filename File to check existence
      */

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011 - 2016 by the authors of the ASPECT code.
+  Copyright (C) 2011 - 2017 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -348,7 +348,10 @@ namespace aspect
     fexists(const std::string &filename)
     {
       std::ifstream ifile(filename.c_str());
-      return static_cast<bool>(ifile); // only in c++11 you can convert to bool directly
+
+      // return whether construction of the input file has succeeded;
+      // success requires the file to exist and to be readable
+      return static_cast<bool>(ifile);
     }
 
 


### PR DESCRIPTION
While there, also fix an in-code comment that is grammatically incorrect and
only documents the history of a line, not what it does.