### PR TITLE
Remove a wrong comment.

### DIFF
--- a/include/aspect/geometry_model/interface.h
+++ b/include/aspect/geometry_model/interface.h
@@ -273,7 +273,6 @@ namespace aspect
         /**
          * If true, the queried point (in Cartesian coordinates)
          * lies in the domain specified by the geometry.
-         * The default implementation of this function will return @p false.
          */
         virtual
         bool


### PR DESCRIPTION
The comment suggests that a function has a default implementation, but
it's actually abstract ('=0').