### PR TITLE
[WIP] Chunk geometry follow-up

### DIFF
--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -21,6 +21,349 @@
 #ifndef __aspect__compat_h
 #define __aspect__compat_h
 
-#include <aspect/global.h>
+//#include <aspect/global.h>
+
+#include <deal.II/grid/tria_boundary_lib.h>
+
+namespace dealii
+{
+  template <int dim>
+  class SpecialConeBoundary : public StraightBoundary<dim>
+  {
+    public:
+
+      /**
+       * Constructor. Here the boundary object is constructed. The points
+       * <tt>x_0</tt> and <tt>x_1</tt> describe the starting and ending points of
+       * the axis of the (truncated) cone. <tt>radius_0</tt> denotes the radius
+       * corresponding to <tt>x_0</tt> and <tt>radius_1</tt> the one corresponding
+       * to <tt>x_1</tt>.
+       */
+      SpecialConeBoundary (const double radius_0,
+                           const double radius_1,
+                           const Point<dim> x_0,
+                           const Point<dim> x_1);
+
+      /**
+       * Return the radius of the (truncated) cone at given point <tt>x</tt> on
+       * the axis.
+       */
+      double get_radius (const Point<dim> x) const;
+
+      /**
+       * Refer to the general documentation of this class and the documentation of
+       * the base class.
+       */
+      virtual
+      Point<dim>
+      get_new_point_on_line (const typename Triangulation<dim>::line_iterator &line) const;
+
+      /**
+       * Refer to the general documentation of this class and the documentation of
+       * the base class.
+       */
+      virtual
+      Point<dim>
+      get_new_point_on_quad (const typename Triangulation<dim>::quad_iterator &quad) const;
+
+      /**
+       * Refer to the general documentation of this class and the documentation of
+       * the base class.
+       *
+       * Calls @p get_intermediate_points_between_points.
+       */
+      virtual
+      void
+      get_intermediate_points_on_line (const typename Triangulation<dim>::line_iterator &line,
+                                       std::vector<Point<dim> > &points) const;
+
+      virtual
+      Tensor<1,dim>
+      normal_vector (const typename Triangulation<dim>::face_iterator &face,
+                     const Point<dim> &p) const;
+
+
+      /**
+       * Refer to the general documentation of this class and the documentation of
+       * the base class.
+       *
+       * Only implemented for <tt>dim=3</tt> and for <tt>points.size()==1</tt>.
+       */
+      virtual
+      void
+      get_intermediate_points_on_quad (const typename Triangulation<dim>::quad_iterator &quad,
+                                       std::vector<Point<dim> > &points) const;
+
+      /**
+       * Compute the normals to the boundary at the vertices of the given face.
+       *
+       * Refer to the general documentation of this class and the documentation of
+       * the base class.
+       */
+      virtual
+      void
+      get_normals_at_vertices (const typename Triangulation<dim>::face_iterator &face,
+                               typename Boundary<dim>::FaceVertexNormals &face_vertex_normals) const;
+
+    protected:
+      /**
+       * First radius of the (truncated) cone.
+       */
+      const double radius_0;
+
+      /**
+       * Second radius of the (truncated) cone.
+       */
+      const double radius_1;
+
+      /**
+       * Starting point of the axis.
+       */
+      const Point<dim> x_0;
+
+      /**
+       * Ending point of the axis.
+       */
+      const Point<dim> x_1;
+
+    private:
+      /**
+       * Called by @p get_intermediate_points_on_line and by @p
+       * get_intermediate_points_on_quad.
+       *
+       * Refer to the general documentation of @p get_intermediate_points_on_line
+       * in the documentation of the base class.
+       */
+      void
+      get_intermediate_points_between_points (const Point<dim> &p0,
+                                              const Point<dim> &p1,
+                                              std::vector<Point<dim> > &points) const;
+  };
+
+
+
+
+}
+namespace dealii
+{
+  template<int dim>
+  SpecialConeBoundary<dim>::SpecialConeBoundary (const double radius_0,
+                                                 const double radius_1,
+                                                 const Point<dim> x_0,
+                                                 const Point<dim> x_1)
+    :
+    radius_0 (radius_0),
+    radius_1 (radius_1),
+    x_0 (x_0),
+    x_1 (x_1)
+  {}
+
+
+
+  template<int dim>
+  double SpecialConeBoundary<dim>::get_radius (Point<dim> x) const
+  {
+    for (unsigned int i = 0; i < dim; ++i)
+      if ((x_1 (i) - x_0 (i)) != 0)
+        return (radius_1 - radius_0) * (x (i) - x_0 (i)) / (x_1 (i) - x_0 (i)) + radius_0;
+
+    return 0;
+  }
+
+
+
+  template<int dim>
+  void
+  SpecialConeBoundary<dim>::
+  get_intermediate_points_between_points (const Point<dim> &p0,
+                                          const Point<dim> &p1,
+                                          std::vector<Point<dim> > &points) const
+  {
+    const unsigned int n = points.size ();
+    const Tensor<1,dim> axis = x_1 - x_0;
+
+    Assert (n > 0, ExcInternalError ());
+
+    const std::vector<Point<1> > &line_points = this->get_line_support_points(n);
+
+    for (unsigned int i=0; i<n; ++i)
+      {
+        const double x = line_points[i+1][0];
+
+        // Compute the current point.
+        const Point<dim> x_i = (1-x)*p0 + x*p1;
+        // To project this point on the boundary of the cone we first compute
+        // the orthogonal projection of this point onto the axis of the cone.
+        const double c = (x_i - x_0) * axis / (axis*axis);
+        const Point<dim> x_ip = x_0 + c * axis;
+        // Compute the projection of the middle point on the boundary of the
+        // cone.
+        points[i] = x_ip + get_radius (x_ip) *  (x_i - x_ip) / (x_i - x_ip).norm ();
+      }
+  }
+
+  template<int dim>
+  Point<dim>
+  SpecialConeBoundary<dim>::
+  get_new_point_on_line (const typename Triangulation<dim>::line_iterator &line) const
+  {
+    const Tensor<1,dim> axis = x_1 - x_0;
+    // Compute the middle point of the line.
+    const Point<dim> middle = StraightBoundary<dim>::get_new_point_on_line (line);
+    // To project it on the boundary of the cone we first compute the orthogonal
+    // projection of the middle point onto the axis of the cone.
+    const double c = (middle - x_0) * axis / (axis*axis);
+    const Point<dim> middle_p = x_0 + c * axis;
+    // Compute the projection of the middle point on the boundary of the cone.
+    return middle_p + get_radius (middle_p) * (middle - middle_p) / (middle - middle_p).norm ();
+  }
+
+
+
+  template <>
+  Point<3>
+  SpecialConeBoundary<3>::
+  get_new_point_on_quad (const Triangulation<3>::quad_iterator &quad) const
+  {
+    const int dim = 3;
+
+    const Tensor<1,dim> axis = x_1 - x_0;
+    // Compute the middle point of the quad.
+    const Point<dim> middle = StraightBoundary<3,3>::get_new_point_on_quad (quad);
+    // Same algorithm as above: To project it on the boundary of the cone we
+    // first compute the orthogonal projection of the middle point onto the axis
+    // of the cone.
+    const double c = (middle - x_0) * axis / (axis*axis);
+    const Point<dim> middle_p = x_0 + c * axis;
+    // Compute the projection of the middle point on the boundary of the cone.
+    return middle_p + get_radius (middle_p) * (middle - middle_p) / (middle - middle_p).norm ();
+  }
+
+
+
+//template<int dim>
+//Point<dim>
+//SpecialConeBoundary<dim>::
+//get_new_point_on_quad (const typename Triangulation<dim>::quad_iterator &) const
+//{
+//  Assert (false, ExcImpossibleInDim (dim));
+//
+//  return Point<dim>();
+//}
+//
+
+
+  template<int dim>
+  void
+  SpecialConeBoundary<dim>::
+  get_intermediate_points_on_line (const typename Triangulation<dim>::line_iterator &line,
+                                   std::vector<Point<dim> > &points) const
+  {
+    if (points.size () == 1)
+      points[0] = get_new_point_on_line (line);
+    else
+      get_intermediate_points_between_points (line->vertex (0), line->vertex (1), points);
+  }
+
+
+  template<>
+  void
+  SpecialConeBoundary<3>::
+  get_intermediate_points_on_quad (const Triangulation<3>::quad_iterator &quad,
+                                   std::vector<Point<3> > &points) const
+  {
+    if (points.size () == 1)
+      points[0] = get_new_point_on_quad (quad);
+    else
+      {
+        unsigned int n = static_cast<unsigned int> (std::sqrt (static_cast<double> (points.size ())));
+
+        Assert (points.size () == n * n, ExcInternalError ());
+
+        std::vector<Point<3> > points_line_0 (n);
+        std::vector<Point<3> > points_line_1 (n);
+
+        get_intermediate_points_on_line (quad->line (0), points_line_0);
+        get_intermediate_points_on_line (quad->line (1), points_line_1);
+
+        std::vector<Point<3> > points_line_segment (n);
+
+        for (unsigned int i = 0; i < n; ++i)
+          {
+            get_intermediate_points_between_points (points_line_0[i],
+                                                    points_line_1[i],
+                                                    points_line_segment);
+
+            for (unsigned int j = 0; j < n; ++j)
+              points[i * n + j] = points_line_segment[j];
+          }
+      }
+  }
+
+
+
+//template <int dim>
+//void
+//SpecialConeBoundary<dim>::
+//get_intermediate_points_on_quad (const typename Triangulation<dim>::quad_iterator &,
+//                                 std::vector<Point<dim> > &) const
+//{
+//  Assert (false, ExcImpossibleInDim (dim));
+//}
+//
+//
+//template<>
+//void
+//SpecialConeBoundary<1>::
+//get_normals_at_vertices (const Triangulation<1>::face_iterator &,
+//                         Boundary<1,1>::FaceVertexNormals &) const
+//{
+//  Assert (false, ExcImpossibleInDim (1));
+//}
+
+
+
+  template<int dim>
+  void
+  SpecialConeBoundary<dim>::
+  get_normals_at_vertices (const typename Triangulation<dim>::face_iterator &face,
+                           typename Boundary<dim>::FaceVertexNormals &face_vertex_normals) const
+  {
+    const Tensor<1,dim> axis = x_1 - x_0;
+
+    for (unsigned int vertex = 0; vertex < GeometryInfo<dim>::vertices_per_face; ++vertex)
+      {
+        // Compute the orthogonal projection of the vertex onto the axis of the
+        // cone.
+        const double c = (face->vertex (vertex) - x_0) * axis / (axis*axis);
+        const Point<dim> vertex_p = x_0 + c * axis;
+        // Then compute the vector pointing from the point <tt>vertex_p</tt> on
+        // the axis to the vertex.
+        const Tensor<1,dim> axis_to_vertex = face->vertex (vertex) - vertex_p;
+
+        face_vertex_normals[vertex] = axis_to_vertex / axis_to_vertex.norm ();
+      }
+  }
+
+
+  template<int dim>
+  Tensor<1,dim>
+  SpecialConeBoundary<dim>::
+  normal_vector (const typename Triangulation<dim>::face_iterator &,
+                 const Point<dim> &p) const
+  {
+    // TODO only for cone opening along z-axis
+    AssertThrow (dim == 3, ExcInternalError());
+    AssertThrow (radius_0 == 0., ExcInternalError());
+    AssertThrow (x_0[0] == 0., ExcInternalError());
+    const double c_squared = (radius_1 / x_1[dim-1])*(radius_1 / x_1[dim-1]);
+    Tensor<1,dim> normal = p;
+    normal[0] *= -2.0/c_squared;
+    normal[1] *= -2.0/c_squared;
+    normal[dim-1] *= 2.0;
+
+    return normal/normal.norm();
+  }
+}
 
 #endif

--- a/include/aspect/geometry_model/chunk_3.h
+++ b/include/aspect/geometry_model/chunk_3.h
@@ -1,0 +1,293 @@
+/*
+  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef __aspect__geometry_model_chunk3_h
+#define __aspect__geometry_model_chunk3_h
+
+#include <aspect/geometry_model/interface.h>
+#include <deal.II/grid/manifold.h>
+#include <deal.II/base/function_lib.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+  namespace GeometryModel
+  {
+    using namespace dealii;
+
+    /**
+     * A geometry model class that describes a chunk of a spherical shell.
+     * In 2D, this class simulates a sector with inner and outer radius, and
+     * minimum and maximum longitude. Longitude increases anticlockwise
+     * from the positive x-axis, as per the mathematical convention of phi.
+     * In 3D, the class simulates a chunk of a sphere, bounded by arbitrary
+     * lines of longitude, latitude and radius. Boundary indicator names are
+     * west, east, south, north, inner and outer.
+     *
+     * The parameters that describe this geometry and that are read from the
+     * input file are the inner and outer radii of the shell, the minimum
+     * and maximum longitude, minimum and maximum latitude, and the
+     * number of cells initialised in each dimension.
+     */
+    template <int dim>
+    class Chunk3 : public Interface<dim>, public SimulatorAccess<dim>
+    {
+      public:
+
+
+        void initialize ();
+
+        /**
+         * Generate a coarse mesh for the geometry described by this class.
+         */
+        virtual
+        void create_coarse_mesh (parallel::distributed::Triangulation<dim> &coarse_grid) const;
+
+        /**
+         * Return the set of boundary indicators that are used by this model.
+         * This information is used to determine what boundary indicators can
+         * be used in the input file.
+         *
+         * The chunk model uses boundary indicators zero through 2*dim-1, with
+         * the first two being the faces perpendicular to the radius of the shell,
+         * the next two along lines of longitude and, in 3d, the next two
+         * along lines of latitude.
+         */
+        virtual
+        std::set<types::boundary_id>
+        get_used_boundary_indicators () const;
+
+        /**
+         * Return a mapping from symbolic names of each part of the boundary
+         * to the corresponding boundary indicator. This allows users to
+         * specify *names*, not just *numbers* in their input files when
+         * describing which parts of the boundary have to satisfy which
+         * boundary conditions.
+         *
+         * This geometry returns the map <code>{{"inner"->0}, {"outer"->1},
+         * {"west"->2}, {"east"->3}}</code> in 2d, and <code>{{"inner"->0},
+         * {"outer"->1}, {"west"->2}, {"east"->3}, {"south"->4},
+         * {"north"->5}}</code> in 3d.
+         */
+        virtual
+        std::map<std::string,types::boundary_id>
+        get_symbolic_boundary_names_map () const;
+
+
+        /**
+         * Return the typical length scale one would expect of features in
+         * this geometry, assuming realistic parameters.
+         *
+         * As described in the first ASPECT paper, a length scale of
+         * 10km = 1e4m works well for the pressure scaling for earth
+         * sized spherical shells. use a length scale that
+         * yields this value for the R0,R1 corresponding to earth
+         * but otherwise scales like (R1-R0)
+         */
+        virtual
+        double length_scale () const;
+
+        /**
+         * Return the depth that corresponds to the given
+         * position. The documentation of the base class (see
+         * GeometryModel::Interface::depth()) describes in detail how
+         * "depth" is interpreted in general.
+         *
+         * Computing a depth requires a geometry model to define a
+         * "vertical" direction. The current class considers the
+         * radial vector away from the origin as vertical and
+         * considers the "outer" boundary as the "surface". In almost
+         * all cases one will use a gravity model that also matches
+         * these definitions.
+         */
+        virtual
+        double depth(const Point<dim> &position) const;
+
+        virtual
+        Point<dim> representative_point(const double depth) const;
+
+        /**
+         * Return the longitude at the western edge of the chunk
+         * Measured in radians
+         */
+        virtual
+        double west_longitude() const;
+
+        /**
+         * Return the longitude at the eastern edge of the chunk
+         * Measured in radians
+         */
+        virtual
+        double east_longitude() const;
+
+        /**
+         * Returns the longitude range of the chunk
+         * Measured in radians
+         */
+        virtual
+        double longitude_range() const;
+
+        /**
+         * Return the latitude at the southern edge of the chunk
+         * Measured in radians from the equator
+         */
+        virtual
+        double south_latitude() const;
+
+        /**
+         * Return the latitude at the northern edge of the chunk
+         * Measured in radians from the equator
+         */
+        virtual
+        double north_latitude() const;
+
+        /**
+         * Return the latitude range of the chunk
+         * Measured in radians
+         */
+        virtual
+        double latitude_range() const;
+
+        /**
+         * Return the maximum depth from the surface of the model
+         * Measured in meters
+         */
+        virtual
+        double maximal_depth() const;
+
+        /**
+         * Return the inner radius of the chunk
+         * Measured in meters
+         */
+        virtual
+        double inner_radius() const;
+
+        /**
+         * Return the outer radius of the chunk
+         * Measured in meters
+         */
+        virtual
+        double outer_radius() const;
+
+
+        /**
+         * @copydoc Interface::has_curved_elements()
+         *
+         * A chunk has curved boundaries and cells, so return true.
+         */
+        virtual
+        bool
+        has_curved_elements() const;
+
+
+        /**
+         * Return whether the given point lies within the domain specified
+         * by the geometry. This function does not take into account
+         * initial or dynamic surface topography.
+         */
+        virtual
+        bool
+        point_is_in_domain(const Point<dim> &p) const;
+
+        /**
+         * Declare the parameters this class takes through input files.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         */
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
+
+        /**
+         * Connect the set/clear manifold id functions to the post/pre_compute_no_normal_flux signals.
+         */
+        void
+        connect_to_signal(SimulatorSignals<dim> &signals);
+
+
+
+      private:
+        /**
+         * Minimum radius-longitude or
+         * radius-longitude-latitude point
+         */
+        Point<dim> point1;
+
+        /**
+         * Maximum radius-longitude or
+         * radius-longitude-latitude point
+         */
+        Point<dim> point2;
+
+        /**
+         * The number of cells in each coordinate direction
+         */
+        unsigned int repetitions[dim];
+
+        /**
+         * ChunkGeometry is a class that implements the interface of
+         * ChartManifold. The function push_forward takes a point
+         * in the reference (radius,long,lat) domain and transforms
+         * it into real space (cartesian). The inverse function
+         * pull_back reverses this operation.
+         */
+
+        class ChunkGeometry : public ChartManifold<dim,dim>
+        {
+          public:
+            ChunkGeometry();
+
+            virtual
+            Point<dim>
+            pull_back(const Point<dim> &space_point) const;
+
+            virtual
+            Point<dim>
+            push_forward(const Point<dim> &chart_point) const;
+
+            virtual
+            void
+            set_min_longitude(const double p1_lon);
+
+          private:
+            // The minimum longitude of the domain
+            double point1_lon;
+        };
+
+        /**
+         * An object that describes the geometry.
+         */
+        ChunkGeometry manifold;
+
+        void set_manifold_ids (typename parallel::distributed::Triangulation<dim> &triangulation);
+        void clear_manifold_ids (typename parallel::distributed::Triangulation<dim> &triangulation);
+
+    };
+  }
+}
+
+
+#endif

--- a/include/aspect/geometry_model/chunk_4.h
+++ b/include/aspect/geometry_model/chunk_4.h
@@ -1,0 +1,292 @@
+/*
+  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef __aspect__geometry_model_chunk_4_h
+#define __aspect__geometry_model_chunk_4_h
+
+#include <aspect/geometry_model/interface.h>
+#include <aspect/simulator_access.h>
+
+#include <deal.II/grid/manifold.h>
+#include <deal.II/base/function_lib.h>
+#include <deal.II/grid/grid_out.h>
+
+namespace aspect
+{
+  namespace GeometryModel
+  {
+    using namespace dealii;
+
+    /**
+     * A geometry model class that describes a chunk of a spherical shell.
+     * In 2D, this class simulates a sector with inner and outer radius, and
+     * minimum and maximum longitude. Longitude increases anticlockwise
+     * from the positive x-axis, as per the mathematical convention of phi.
+     * In 3D, the class simulates a chunk of a sphere, bounded by arbitrary
+     * lines of longitude, latitude and radius. Boundary indicator names are
+     * west, east, south, north, inner and outer.
+     *
+     * The parameters that describe this geometry and that are read from the
+     * input file are the inner and outer radii of the shell, the minimum
+     * and maximum longitude, minimum and maximum longitude, and the
+     * number of cells initialised in each dimension.
+     */
+    template <int dim>
+    class Chunk4 : public Interface<dim>, public SimulatorAccess<dim>
+    {
+      public:
+
+        /**
+         * Generate a coarse mesh for the geometry described by this class.
+         */
+        virtual
+        void create_coarse_mesh (parallel::distributed::Triangulation<dim> &coarse_grid) const;
+
+        /**
+         * Return the set of boundary indicators that are used by this model.
+         * This information is used to determine what boundary indicators can
+         * be used in the input file.
+         *
+         * The chunk model uses boundary indicators zero through 2*dim-1, with
+         * the first two being the faces perpendicular to the radius of the shell,
+         * the next two along lines of longitude and, in 3d, the next two
+         * along lines of latitude.
+         */
+        virtual
+        std::set<types::boundary_id>
+        get_used_boundary_indicators () const;
+
+        /**
+         * Return a mapping from symbolic names of each part of the boundary
+         * to the corresponding boundary indicator. This allows users to
+         * specify *names*, not just *numbers* in their input files when
+         * describing which parts of the boundary have to satisfy which
+         * boundary conditions.
+         *
+         * This geometry returns the map <code>{{"inner"->0}, {"outer"->1},
+         * {"west"->2}, {"east"->3}}</code> in 2d, and <code>{{"inner"->0},
+         * {"outer"->1}, {"west"->2}, {"east"->3}, {"south"->4},
+         * {"north"->5}}</code> in 3d.
+         */
+        virtual
+        std::map<std::string,types::boundary_id>
+        get_symbolic_boundary_names_map () const;
+
+
+        /**
+         * Return the typical length scale one would expect of features in
+         * this geometry, assuming realistic parameters.
+         *
+         * As described in the first ASPECT paper, a length scale of
+         * 10km = 1e4m works well for the pressure scaling for earth
+         * sized spherical shells. use a length scale that
+         * yields this value for the R0,R1 corresponding to earth
+         * but otherwise scales like (R1-R0)
+         */
+        virtual
+        double length_scale () const;
+
+        /**
+         * Return the depth that corresponds to the given
+         * position. The documentation of the base class (see
+         * GeometryModel::Interface::depth()) describes in detail how
+         * "depth" is interpreted in general.
+         *
+         * Computing a depth requires a geometry model to define a
+         * "vertical" direction. The current class considers the
+         * radial vector away from the origin as vertical and
+         * considers the "outer" boundary as the "surface". In almost
+         * all cases one will use a gravity model that also matches
+         * these definitions.
+         */
+        virtual
+        double depth(const Point<dim> &position) const;
+
+        virtual
+        Point<dim> representative_point(const double depth) const;
+
+        /**
+         * Return the longitude at the western edge of the chunk
+         * Measured in radians
+         */
+        virtual
+        double west_longitude() const;
+
+        /**
+         * Return the longitude at the eastern edge of the chunk
+         * Measured in radians
+         */
+        virtual
+        double east_longitude() const;
+
+        /**
+         * Returns the longitude range of the chunk
+         * Measured in radians
+         */
+        virtual
+        double longitude_range() const;
+
+        /**
+         * Return the latitude at the southern edge of the chunk
+         * Measured in radians from the equator
+         */
+        virtual
+        double south_latitude() const;
+
+        /**
+         * Return the latitude at the northern edge of the chunk
+         * Measured in radians from the equator
+         */
+        virtual
+        double north_latitude() const;
+
+        /**
+         * Return the latitude range of the chunk
+         * Measured in radians
+         */
+        virtual
+        double latitude_range() const;
+
+        /**
+         * Return the maximum depth from the surface of the model
+         * Measured in meters
+         */
+        virtual
+        double maximal_depth() const;
+
+        /**
+         * Return the inner radius of the chunk
+         * Measured in meters
+         */
+        virtual
+        double inner_radius() const;
+
+        /**
+         * Return the outer radius of the chunk
+         * Measured in meters
+         */
+        virtual
+        double outer_radius() const;
+
+
+        /**
+         * @copydoc Interface::has_curved_elements()
+         *
+         * A chunk has curved boundaries and cells, so return true.
+         */
+        virtual
+        bool
+        has_curved_elements() const;
+
+        /**
+         * Return whether the given point lies within the domain specified
+         * by the geometry. This function does not take into account
+         * initial or dynamic surface topography.
+         */
+        virtual
+        bool
+        point_is_in_domain(const Point<dim> &p) const;
+
+        /**
+         * Declare the parameters this class takes through input files.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         */
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
+
+      private:
+        /**
+         * Minimum depth, longitude-depth or
+         * longitude-latitude-depth point
+         */
+        Point<dim> point1;
+
+        /**
+         * Maximum depth, longitude-depth or
+         * longitude-latitude-depth point
+         */
+        Point<dim> point2;
+
+        /**
+         * The number of cells in each coordinate direction
+         */
+        unsigned int repetitions[dim];
+
+        /**
+         * ChunkGeometry is a class that implements the interface of
+         * ChartManifold. The function push_forward takes a point
+         * in the reference (lat,long,radius) domain and transforms
+         * it into real space (cartesian). The inverse function
+         * pull_back reverses this operation.
+         */
+
+        class ChunkGeometry : public ChartManifold<dim,dim>
+        {
+          public:
+            ChunkGeometry();
+
+            virtual
+            Point<dim>
+            pull_back(const Point<dim> &space_point) const;
+
+            virtual
+            Point<dim>
+            push_forward(const Point<dim> &chart_point) const;
+
+            virtual
+            DerivativeForm<1, dim, dim>
+            push_forward_gradient(const Point<dim> &chart_point) const;
+
+            virtual
+            void
+            set_min_longitude(const double p1_lon);
+
+          private:
+            // The minimum longitude of the domain
+            double point1_lon;
+        };
+
+        // Remove?
+        Point<dim> pull_back(const Point<dim>) const;
+        Point<dim> push_forward(const Point<dim>) const;
+
+        /**
+         * An object that describes the geometry.
+         */
+        ChunkGeometry manifold;
+
+        // Remove?
+        static void set_manifold_ids (Triangulation<dim> &triangulation);
+        static void clear_manifold_ids (Triangulation<dim> &triangulation);
+
+    };
+  }
+}
+
+
+#endif

--- a/include/aspect/geometry_model/chunk_4.h
+++ b/include/aspect/geometry_model/chunk_4.h
@@ -271,18 +271,10 @@ namespace aspect
             double point1_lon;
         };
 
-        // Remove?
-        Point<dim> pull_back(const Point<dim>) const;
-        Point<dim> push_forward(const Point<dim>) const;
-
         /**
          * An object that describes the geometry.
          */
         ChunkGeometry manifold;
-
-        // Remove?
-        static void set_manifold_ids (Triangulation<dim> &triangulation);
-        static void clear_manifold_ids (Triangulation<dim> &triangulation);
 
     };
   }

--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -40,7 +40,6 @@
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/multithread_info.h>
 
-#include <aspect/compat.h>
 
 namespace aspect
 {

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -512,6 +512,12 @@ namespace aspect
       get_traction_boundary_conditions () const;
 
       /**
+       * Return the map of traction_boundary_conditions
+       */
+      const std::set<types::boundary_id>
+      get_traction_boundary_indicators () const;
+
+      /**
        * Return a pointer to the object that describes the temperature initial
        * values.
        */

--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -158,6 +158,29 @@ namespace aspect
     boost::signals2::signal<void (typename parallel::distributed::Triangulation<dim> &)>  pre_checkpoint_store_user_data;
 
     /**
+     * A signal that is called before the computation of tangential boundary
+     * conditions for which normal vectors are needed.
+     *
+     * The functions that connect to this signal must take a reference
+     * to a parallel::distributed::Triangulation object as
+     * argument. This argument will point to the triangulation used by
+     * the Simulator class.
+     */
+    boost::signals2::signal<void (typename parallel::distributed::Triangulation<dim> &)>  pre_compute_no_normal_flux_constraints;
+
+    /**
+     * A signal that is called after the computation of tangential boundary
+     * conditions for which normal vectors are needed.
+     *
+     * The functions that connect to this signal must take a reference
+     * to a parallel::distributed::Triangulation object as
+     * argument. This argument will point to the triangulation used by
+     * the Simulator class.
+     */
+    boost::signals2::signal<void (typename parallel::distributed::Triangulation<dim> &)>  post_compute_no_normal_flux_constraints;
+
+
+    /**
     * A signal that is called after resuming from a checkpoint.
     * This signal allows for registering functions that load data
     * related to mesh cells that was previously stored in the checkpoint.

--- a/include/aspect/velocity_boundary_conditions/gplates.h
+++ b/include/aspect/velocity_boundary_conditions/gplates.h
@@ -24,7 +24,7 @@
 
 #include <aspect/velocity_boundary_conditions/interface.h>
 #include <aspect/simulator_access.h>
-#include <aspect/compat.h>
+//#include <aspect/compat.h>
 
 #include <deal.II/base/std_cxx11/array.h>
 #include <deal.II/base/function_lib.h>

--- a/source/boundary_temperature/spherical_constant.cc
+++ b/source/boundary_temperature/spherical_constant.cc
@@ -23,6 +23,7 @@
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/sphere.h>
 #include <aspect/geometry_model/chunk.h>
+#include <aspect/geometry_model/chunk_3.h>
 #include <aspect/geometry_model/ellipsoidal_chunk.h>
 
 #include <utility>
@@ -48,6 +49,7 @@ namespace aspect
       Assert ((dynamic_cast<const GeometryModel::SphericalShell<dim>*>(geometry_model) != 0
                || dynamic_cast<const GeometryModel::Sphere<dim>*>(geometry_model) != 0
                || dynamic_cast<const GeometryModel::Chunk<dim>*>(geometry_model) != 0
+               || dynamic_cast<const GeometryModel::Chunk3<dim>*>(geometry_model) != 0
                || dynamic_cast<const GeometryModel::EllipsoidalChunk<dim>*>(geometry_model) != 0),
               ExcMessage ("This boundary model is only implemented if the geometry "
                           "is a spherical shell, sphere, ellipsoidal chunk or chunk."));

--- a/source/geometry_model/chunk_3.cc
+++ b/source/geometry_model/chunk_3.cc
@@ -1,0 +1,611 @@
+/*
+  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/geometry_model/chunk_3.h>
+#include <aspect/geometry_model/initial_topography_model/zero_topography.h>
+#include <aspect/compat.h>
+
+#include <aspect/simulator_signals.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/manifold_lib.h>
+
+namespace aspect
+{
+  namespace GeometryModel
+  {
+    template <int dim>
+    Chunk3<dim>::ChunkGeometry::ChunkGeometry()
+      :
+      point1_lon(0.0)
+    {}
+
+    template <int dim>
+    Point<dim>
+    Chunk3<dim>::ChunkGeometry::
+    push_forward(const Point<dim> &input_vertex) const
+    {
+      Point<dim> output_vertex;
+      switch (dim)
+        {
+          case 2:
+          {
+            output_vertex[0] = input_vertex[0]*std::cos(input_vertex[1]); // x=rcosphi
+            output_vertex[1] = input_vertex[0]*std::sin(input_vertex[1]); // z=rsinphi
+            break;
+          }
+          case 3:
+          {
+            output_vertex[0] = input_vertex[0]*std::cos(input_vertex[2])*std::cos(input_vertex[1]); // x=rsinthetacosphi
+            output_vertex[1] = input_vertex[0]*std::cos(input_vertex[2])*std::sin(input_vertex[1]); // y=rsinthetasinphi
+            output_vertex[2] = input_vertex[0]*std::sin(input_vertex[2]); // z=rcostheta
+            break;
+          }
+          default:
+            Assert (false, ExcNotImplemented ());
+        }
+      return output_vertex;
+    }
+
+    template <int dim>
+    Point<dim>
+    Chunk3<dim>::ChunkGeometry::
+    pull_back(const Point<dim> &v) const
+    {
+      Point<dim> output_vertex;
+      switch (dim)
+        {
+          case 2:
+          {
+            output_vertex[1] = std::atan2(v[1], v[0]);
+            output_vertex[0] = v.norm();
+
+            // We must garantee that all points have a longitude coordinate
+            // VALUE that is larger than the longitude of point1: in other words,
+            // if the domain runs from longitude -10 to 200 degrees, atan2 will return
+            // a negative value (-160 to -180) for the points with longitude
+            // 180 to 200. These points must be corrected so that they are larger
+            // than the minimum longitude value of -10, by adding 360 degrees.
+            if (output_vertex[1] < 0.0)
+              if (output_vertex[1] < point1_lon - std::abs(point1_lon)*std::numeric_limits<double>::epsilon())
+                output_vertex[1] += 2.0 * numbers::PI;
+            break;
+          }
+          case 3:
+          {
+            const double radius=v.norm();
+            output_vertex[0] = radius;
+            output_vertex[1] = std::atan2(v[1], v[0]);
+            // See 2D case
+            if (output_vertex[1] < 0.0)
+              if (output_vertex[1] < point1_lon - std::abs(point1_lon)*std::numeric_limits<double>::epsilon())
+                output_vertex[1] += 2.0 * numbers::PI;
+            output_vertex[2] = std::asin(v[2]/radius);
+            break;
+          }
+          default:
+            Assert (false, ExcNotImplemented ());
+        }
+      return output_vertex;
+    }
+
+    template <int dim>
+    void
+    Chunk3<dim>::initialize ()
+    {
+      // Call function to connect the set/clear manifold id functions
+      // to the right signal
+      connect_to_signal(this->get_signals());
+
+    }
+
+    template <int dim>
+    void
+    Chunk3<dim>::ChunkGeometry::
+    set_min_longitude(const double p1_lon)
+    {
+      point1_lon = p1_lon;
+    }
+
+
+    template <int dim>
+    void
+    Chunk3<dim>::
+    create_coarse_mesh (parallel::distributed::Triangulation<dim> &coarse_grid) const
+    {
+      
+      std::vector<unsigned int> rep_vec(repetitions, repetitions+dim);
+      GridGenerator::subdivided_hyper_rectangle (coarse_grid,
+                                                 rep_vec,
+                                                 point1,
+                                                 point2,
+                                                 true);
+
+      // At this point, all boundary faces have their correct boundary
+      // indicators, but the edges do not. We want the edges of curved
+      // faces to be curved as well, so we set the edge boundary indicators
+      // to the same boundary indicators as their faces.
+      for (typename Triangulation<dim>::active_cell_iterator
+           cell = coarse_grid.begin_active();
+           cell != coarse_grid.end(); ++cell)
+        for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          if (cell->face(f)->at_boundary())
+            // Set edges on the radial faces; both adjacent faces
+            // should agree on where new points along the boundary lie
+            // for these edges, so the order of the boundaries does not matter
+            // TODO: merge ids 2,3,4 and 5
+            if ((cell->face(f)->boundary_id() == 2)
+                ||
+                (cell->face(f)->boundary_id() == 3))
+              cell->face(f)->set_all_boundary_ids(cell->face(f)->boundary_id());
+
+      for (typename Triangulation<dim>::active_cell_iterator
+           cell = coarse_grid.begin_active();
+           cell != coarse_grid.end(); ++cell)
+        for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          if (cell->face(f)->at_boundary())
+            if ((cell->face(f)->boundary_id() == 4)
+                ||
+                (cell->face(f)->boundary_id() == 5))
+              cell->face(f)->set_all_boundary_ids(cell->face(f)->boundary_id());
+
+      for (typename Triangulation<dim>::active_cell_iterator
+           cell = coarse_grid.begin_active();
+           cell != coarse_grid.end(); ++cell)
+        for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          if (cell->face(f)->at_boundary())
+            // (Re-)Set edges on the spherical shells to ensure that
+            // they are all curved as expected
+            if ((cell->face(f)->boundary_id() == 0)
+                ||
+                (cell->face(f)->boundary_id() == 1))
+              cell->face(f)->set_all_boundary_ids(cell->face(f)->boundary_id());
+
+      // Transform box into spherical chunk
+      GridTools::transform (std_cxx11::bind(&ChunkGeometry::push_forward,
+                                            std_cxx11::cref(manifold),
+                                            std_cxx11::_1),
+                            coarse_grid);
+
+      // Deal with a curved mesh:
+      // Attach the real manifold to slot 15.
+      // We set manifold_ids for all cells, faces and edges.
+      coarse_grid.set_manifold (15, manifold);
+      //set_manifold_ids(coarse_grid);
+      for (typename Triangulation<dim>::active_cell_iterator cell =
+             coarse_grid.begin_active(); cell != coarse_grid.end(); ++cell)
+        cell->set_all_manifold_ids (15);
+
+      // On the boundary faces, set boundary objects.
+      // The east and west boundaries are straight,
+      // the inner and outer boundary are part of
+      // a spherical shell. In 3D, the north and south boundaries
+      // are part of a cone with the tip at the origin.
+      static const StraightBoundary<dim> boundary_straight;
+
+      // Attach boundary objects to the straight east and west boundaries
+      coarse_grid.set_boundary(2, boundary_straight);
+      coarse_grid.set_boundary(3, boundary_straight);
+
+      if (dim == 3)
+        {
+          // Define the center point of the greater radius end of the
+          // north and south boundary cones.
+          // These lie along the z-axis.
+          Point<dim> center;
+          Point<dim> north, south;
+          const double outer_radius = point2[0];
+          north[dim-1] = outer_radius * std::sin(point2[2]);
+          south[dim-1] = outer_radius * std::sin(point1[2]);
+          // Define the radius of the cones
+          const double north_radius = std::sqrt(outer_radius*outer_radius-north[dim-1]*north[dim-1]);
+          const double south_radius = std::sqrt(outer_radius*outer_radius-south[dim-1]*south[dim-1]);
+          static const SpecialConeBoundary<dim> boundary_cone_north(0.0,north_radius,center,north);
+          static const SpecialConeBoundary<dim> boundary_cone_south(0.0,south_radius,center,south);
+
+
+          // Attach boundary objects to the conical north and south boundaries
+          // If one of the boundaries lies at the equator,
+          // just use the straight boundary.
+          if (point2[2] != 0.0)
+            coarse_grid.set_boundary (5, boundary_cone_north);
+          else
+            coarse_grid.set_boundary (5, boundary_straight);
+
+          if (point1[2] != 0.0)
+            coarse_grid.set_boundary (4, boundary_cone_south);
+          else
+            coarse_grid.set_boundary (4, boundary_straight);
+        }
+
+      // Attach shell boundary objects to the curved inner and outer boundaries
+      static const HyperShellBoundary<dim> boundary_shell;
+      coarse_grid.set_boundary (0, boundary_shell);
+      coarse_grid.set_boundary (1, boundary_shell);
+    }
+
+
+
+    template <int dim>
+    std::set<types::boundary_id>
+    Chunk3<dim>::
+    get_used_boundary_indicators () const
+    {
+      // boundary indicators are zero through 2*dim-1
+      std::set<types::boundary_id> s;
+      for (unsigned int i=0; i<2*dim; ++i)
+        s.insert (i);
+      return s;
+    }
+
+
+
+    template <int dim>
+    std::map<std::string,types::boundary_id>
+    Chunk3<dim>::
+    get_symbolic_boundary_names_map () const
+    {
+      switch (dim)
+        {
+          case 2:
+          {
+            static const std::pair<std::string,types::boundary_id> mapping[]
+              = { std::pair<std::string,types::boundary_id>("inner",  0),
+                  std::pair<std::string,types::boundary_id>("outer",  1),
+                  std::pair<std::string,types::boundary_id>("west",   2),
+                  std::pair<std::string,types::boundary_id>("east",   3)
+                };
+
+            return std::map<std::string,types::boundary_id> (&mapping[0],
+                                                             &mapping[sizeof(mapping)/sizeof(mapping[0])]);
+          }
+
+          case 3:
+          {
+            static const std::pair<std::string,types::boundary_id> mapping[]
+              = { std::pair<std::string,types::boundary_id>("inner",  0),
+                  std::pair<std::string,types::boundary_id>("outer",  1),
+                  std::pair<std::string,types::boundary_id>("west",   2),
+                  std::pair<std::string,types::boundary_id>("east",   3),
+                  std::pair<std::string,types::boundary_id>("south",  4),
+                  std::pair<std::string,types::boundary_id>("north",  5)
+                };
+
+            return std::map<std::string,types::boundary_id> (&mapping[0],
+                                                             &mapping[sizeof(mapping)/sizeof(mapping[0])]);
+          }
+        }
+
+      Assert (false, ExcNotImplemented());
+      return std::map<std::string,types::boundary_id>();
+    }
+
+
+    template <int dim>
+    double
+    Chunk3<dim>::
+    length_scale () const
+    {
+      // As described in the first ASPECT paper, a length scale of
+      // 10km = 1e4m works well for the pressure scaling for earth
+      // sized spherical shells. use a length scale that
+      // yields this value for the R0,R1 corresponding to earth
+      // but otherwise scales like (R1-R0)
+      return 1e4 * maximal_depth() / (6336000.-3481000.);
+    }
+
+
+    template <int dim>
+    double
+    Chunk3<dim>::depth(const Point<dim> &position) const
+    {
+      return std::min (std::max (point2[0]-position.norm(), 0.), maximal_depth());
+    }
+
+
+    template <int dim>
+    Point<dim>
+    Chunk3<dim>::representative_point(const double depth) const
+    {
+      Assert (depth >= 0,
+              ExcMessage ("Given depth must be positive or zero."));
+      Assert (depth <= maximal_depth(),
+              ExcMessage ("Given depth must be less than or equal to the maximal depth of this geometry."));
+
+      // Choose a point at the mean longitude (and latitude)
+      Point<dim> p = 0.5*(point2+point1);
+      // at a depth beneath the top surface
+      p[0] = point2[0]-depth;
+
+      // Now convert to Cartesian coordinates
+      return manifold.push_forward(p);
+    }
+
+    template <int dim>
+    double
+    Chunk3<dim>::west_longitude () const
+    {
+      return point1[1];
+    }
+
+
+    template <int dim>
+    double
+    Chunk3<dim>::east_longitude () const
+    {
+      return point2[1];
+    }
+
+    template <int dim>
+    double
+    Chunk3<dim>::longitude_range () const
+    {
+      return point2[1] - point1[1];
+    }
+
+    template <int dim>
+    double
+    Chunk3<dim>::south_latitude () const
+    {
+      if (dim == 3)
+        return point1[2];
+      else
+        return 0;
+    }
+
+
+    template <int dim>
+    double
+    Chunk3<dim>::north_latitude () const
+    {
+      if (dim==3)
+        return point2[2];
+      else
+        return 0;
+    }
+
+
+    template <int dim>
+    double
+    Chunk3<dim>::latitude_range () const
+    {
+      if (dim==3)
+        return point2[2] - point1[2];
+      else
+        return 0;
+    }
+
+
+    template <int dim>
+    double
+    Chunk3<dim>::maximal_depth() const
+    {
+      return point2[0]-point1[0];
+    }
+
+    template <int dim>
+    double
+    Chunk3<dim>::inner_radius () const
+    {
+      return point1[0];
+    }
+
+    template <int dim>
+    double
+    Chunk3<dim>::outer_radius () const
+    {
+      return point2[0];
+    }
+
+    template <int dim>
+    bool
+    Chunk3<dim>::has_curved_elements() const
+    {
+      return true;
+    }
+
+    template <int dim>
+    void
+    Chunk3<dim>::set_manifold_ids (typename parallel::distributed::Triangulation<dim> &triangulation)
+    {
+      // Set all cells, faces and edges to manifold_id 15
+      for (typename Triangulation<dim>::active_cell_iterator cell =
+             triangulation.begin_active(); cell != triangulation.end(); ++cell)
+        cell->set_all_manifold_ids (15);
+    }
+
+    template <int dim>
+    void
+    Chunk3<dim>::clear_manifold_ids (typename parallel::distributed::Triangulation<dim> &triangulation)
+    {
+      // Clear the manifold_id from the faces and edges at the boundary
+      // so that the boundary objects can be used
+      for (typename Triangulation<dim>::active_cell_iterator cell =
+             triangulation.begin_active(); cell != triangulation.end(); ++cell)
+        for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          if (cell->face(f)->at_boundary())
+            cell->face(f)->set_all_manifold_ids (numbers::invalid_manifold_id);
+    }
+
+    template <int dim>
+    bool
+    Chunk3<dim>::point_is_in_domain(const Point<dim> &point) const
+    {
+      AssertThrow(this->get_free_surface_boundary_indicators().size() == 0 ||
+                  this->get_timestep_number() == 0,
+                  ExcMessage("After displacement of the free surface, this function can no longer be used to determine whether a point lies in the domain or not."));
+
+      AssertThrow(dynamic_cast<const InitialTopographyModel::ZeroTopography<dim>*>(&this->get_initial_topography_model()) != 0,
+                  ExcMessage("After adding topography, this function can no longer be used to determine whether a point lies in the domain or not."));
+
+      const Point<dim> spherical_point = manifold.pull_back(point);
+
+      for (unsigned int d = 0; d < dim; d++)
+        if (spherical_point[d] > point2[d]+std::numeric_limits<double>::epsilon()*std::abs(point2[d]) ||
+            spherical_point[d] < point1[d]-std::numeric_limits<double>::epsilon()*std::abs(point2[d]))
+          return false;
+
+      return true;
+    }
+
+    template <int dim>
+    void
+    Chunk3<dim>::
+    declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry model");
+      {
+        prm.enter_subsection("Chunk");
+        {
+          prm.declare_entry ("Chunk inner radius", "0",
+                             Patterns::Double (0),
+                             "Radius at the bottom surface of the chunk. Units: m.");
+          prm.declare_entry ("Chunk outer radius", "1",
+                             Patterns::Double (0),
+                             "Radius at the top surface of the chunk. Units: m.");
+
+          prm.declare_entry ("Chunk minimum longitude", "0",
+                             Patterns::Double (-180, 360), // enables crossing of either hemisphere
+                             "Minimum longitude of the chunk. Units: degrees.");
+          prm.declare_entry ("Chunk maximum longitude", "1",
+                             Patterns::Double (-180, 360), // enables crossing of either hemisphere
+                             "Maximum longitude of the chunk. Units: degrees.");
+
+          prm.declare_entry ("Chunk minimum latitude", "0",
+                             Patterns::Double (-90, 90),
+                             "Minimum latitude of the chunk. This value is ignored "
+                             "if the simulation is in 2d. Units: degrees.");
+          prm.declare_entry ("Chunk maximum latitude", "1",
+                             Patterns::Double (-90, 90),
+                             "Maximum latitude of the chunk. This value is ignored "
+                             "if the simulation is in 2d. Units: degrees.");
+
+          prm.declare_entry ("Radius repetitions", "1",
+                             Patterns::Integer (1),
+                             "Number of cells in radius.");
+          prm.declare_entry ("Longitude repetitions", "1",
+                             Patterns::Integer (1),
+                             "Number of cells in longitude.");
+          prm.declare_entry ("Latitude repetitions", "1",
+                             Patterns::Integer (1),
+                             "Number of cells in latitude. This value is ignored "
+                             "if the simulation is in 2d");
+
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+
+
+    template <int dim>
+    void
+    Chunk3<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      std::cout << "Using chunk3" << std::endl;
+      prm.enter_subsection("Geometry model");
+      {
+        prm.enter_subsection("Chunk");
+        {
+
+          const double degtorad = dealii::numbers::PI/180;
+
+          Assert (dim >= 2, ExcInternalError());
+          Assert (dim <= 3, ExcInternalError());
+
+          point1[0] = prm.get_double ("Chunk inner radius");
+          point2[0] = prm.get_double ("Chunk outer radius");
+          repetitions[0] = prm.get_integer ("Radius repetitions");
+          point1[1] = prm.get_double ("Chunk minimum longitude") * degtorad;
+          point2[1] = prm.get_double ("Chunk maximum longitude") * degtorad;
+          repetitions[1] = prm.get_integer ("Longitude repetitions");
+
+          AssertThrow (point1[0] < point2[0],
+                       ExcMessage ("Inner radius must be less than outer radius."));
+          AssertThrow (point1[1] < point2[1],
+                       ExcMessage ("Minimum longitude must be less than maximum longitude."));
+          AssertThrow (point2[1] - point1[1] < 2.*numbers::PI,
+                       ExcMessage ("Maximum - minimum longitude should be less than 360 degrees."));
+
+          // Inform the manifold about the minimum longitude
+          manifold.set_min_longitude(point1[1]);
+
+
+          if (dim == 3)
+            {
+              point1[2] = prm.get_double ("Chunk minimum latitude") * degtorad;
+              point2[2] = prm.get_double ("Chunk maximum latitude") * degtorad;
+              repetitions[2] = prm.get_integer ("Latitude repetitions");
+
+              AssertThrow (point1[2] < point2[2],
+                           ExcMessage ("Minimum latitude must be less than maximum latitude."));
+            }
+
+
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+    template <int dim>
+    void
+    Chunk3<dim>::connect_to_signal (SimulatorSignals<dim> &signals)
+    {
+      // Connect the topography function to the signal
+      signals.pre_compute_no_normal_flux_constraints.connect (std_cxx11::bind (&Chunk3<dim>::clear_manifold_ids,
+                                                                               std_cxx11::ref(*this),
+                                                                               std_cxx11::_1));
+      signals.post_compute_no_normal_flux_constraints.connect (std_cxx11::bind (&Chunk3<dim>::set_manifold_ids,
+                                                                                std_cxx11::ref(*this),
+                                                                                std_cxx11::_1));
+    }
+
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace GeometryModel
+  {
+    ASPECT_REGISTER_GEOMETRY_MODEL(Chunk3,
+                                   "chunk3",
+                                   "A geometry which can be described as a chunk of a spherical shell, "
+                                   "bounded by lines of longitude, latitude and radius. "
+                                   "The minimum and maximum longitude, (latitude) and depth of the chunk "
+                                   "is set in the parameter file. The chunk geometry labels its "
+                                   "2*dim sides as follows: ``west'' and ``east'': minimum and maximum "
+                                   "longitude, ``south'' and ``north'': minimum and maximum latitude, "
+                                   "``inner'' and ``outer'': minimum and maximum radii. "
+                                   "Names in the parameter files are as follows: "
+                                   "Chunk (minimum || maximum) (longitude || latitude): "
+                                   "edges of geographical quadrangle (in degrees)"
+                                   "Chunk (inner || outer) radius: Radii at bottom and top of chunk"
+                                   "(Longitude || Latitude || Radius) repetitions: "
+                                   "number of cells in each coordinate direction.")
+  }
+}
+

--- a/source/geometry_model/chunk_4.cc
+++ b/source/geometry_model/chunk_4.cc
@@ -45,48 +45,48 @@ namespace aspect
     Chunk4<dim>::ChunkGeometry::
     push_forward_gradient(const Point<dim> &chart_point) const
     {
-     const double R = chart_point[0]; // Radius
-     const double phi = chart_point[1]; // Longitude
-  
-     Assert (R > 0.0, ExcMessage("Negative radius for given point."));
+      const double R = chart_point[0]; // Radius
+      const double phi = chart_point[1]; // Longitude
 
-     DerivativeForm<1, dim, dim> DX;
+      Assert (R > 0.0, ExcMessage("Negative radius for given point."));
 
-     switch (dim)
-       {
-         case 2:
-         {
-         DX[0][0] =      std::cos(phi); 
-         DX[0][1] = -R * std::sin(phi);
-         DX[1][0] =      std::sin(phi);
-         DX[1][1] =  R * std::cos(phi);
-         break;
-         }
-         case 3:
-         {
-         const double theta = chart_point[2]; // Latitude (not colatitude)
+      DerivativeForm<1, dim, dim> DX;
 
-         DX[0][0] =      std::cos(theta) * std::cos(phi);
-         DX[0][1] = -R * std::cos(theta) * std::sin(phi);
-         DX[0][2] = -R * std::sin(theta) * std::cos(phi);
-         DX[1][0] =      std::cos(theta) * std::sin(phi);
-         DX[1][1] =  R * std::cos(theta) * std::cos(phi);
-         DX[1][2] = -R * std::sin(theta) * std::sin(phi);
-         DX[2][0] =      std::sin(theta);
-         DX[2][1] = 0;
-         DX[2][2] =  R * std::cos(theta);
-         break;
-         }
-         default:
-           Assert (false, ExcNotImplemented ());
+      switch (dim)
+        {
+          case 2:
+          {
+            DX[0][0] =      std::cos(phi);
+            DX[0][1] = -R * std::sin(phi);
+            DX[1][0] =      std::sin(phi);
+            DX[1][1] =  R * std::cos(phi);
+            break;
+          }
+          case 3:
+          {
+            const double theta = chart_point[2]; // Latitude (not colatitude)
+
+            DX[0][0] =      std::cos(theta) * std::cos(phi);
+            DX[0][1] = -R * std::cos(theta) * std::sin(phi);
+            DX[0][2] = -R * std::sin(theta) * std::cos(phi);
+            DX[1][0] =      std::cos(theta) * std::sin(phi);
+            DX[1][1] =  R * std::cos(theta) * std::cos(phi);
+            DX[1][2] = -R * std::sin(theta) * std::sin(phi);
+            DX[2][0] =      std::sin(theta);
+            DX[2][1] = 0;
+            DX[2][2] =  R * std::cos(theta);
+            break;
+          }
+          default:
+            Assert (false, ExcNotImplemented ());
 
 
-       }
-    
-     return DX;
+        }
+
+      return DX;
     }
 
- 
+
     template <int dim>
     Point<dim>
     Chunk4<dim>::ChunkGeometry::
@@ -186,19 +186,11 @@ namespace aspect
                             coarse_grid);
 
       // Deal with a curved mesh
-      // Attach the real manifold to slot 15. we won't use it
-      // during regular operation, but we set manifold_ids for all
-      // cells, faces and edges immediately before refinement and
-      // clear it again afterwards
+      // Attach the real manifold to slot 15.
       coarse_grid.set_manifold (15, manifold);
       for (typename Triangulation<dim>::active_cell_iterator cell =
              coarse_grid.begin_active(); cell != coarse_grid.end(); ++cell)
         cell->set_all_manifold_ids (15);
-
-//      coarse_grid.signals.pre_refinement.connect (std_cxx11::bind (&set_manifold_ids,
-//                                                                   std_cxx11::ref(coarse_grid)));
-//      coarse_grid.signals.post_refinement.connect (std_cxx11::bind (&clear_manifold_ids,
-//                                                                    std_cxx11::ref(coarse_grid)));
 
     }
 
@@ -401,23 +393,6 @@ namespace aspect
       return true;
     }
 
-    template <int dim>
-    void
-    Chunk4<dim>::set_manifold_ids (Triangulation<dim> &triangulation)
-    {
-      for (typename Triangulation<dim>::active_cell_iterator cell =
-             triangulation.begin_active(); cell != triangulation.end(); ++cell)
-        cell->set_all_manifold_ids (15);
-    }
-
-    template <int dim>
-    void
-    Chunk4<dim>::clear_manifold_ids (Triangulation<dim> &triangulation)
-    {
-      for (typename Triangulation<dim>::active_cell_iterator cell =
-             triangulation.begin_active(); cell != triangulation.end(); ++cell)
-        cell->set_all_manifold_ids (numbers::invalid_manifold_id);
-    }
 
     template <int dim>
     void

--- a/source/geometry_model/chunk_4.cc
+++ b/source/geometry_model/chunk_4.cc
@@ -1,0 +1,547 @@
+/*
+  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/geometry_model/chunk_4.h>
+#include <aspect/geometry_model/initial_topography_model/zero_topography.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/manifold_lib.h>
+
+
+namespace aspect
+{
+  namespace GeometryModel
+  {
+    template <int dim>
+    Chunk4<dim>::ChunkGeometry::ChunkGeometry()
+      :
+      point1_lon(0.0)
+    {}
+
+    template <int dim>
+    DerivativeForm<1,dim,dim>
+    Chunk4<dim>::ChunkGeometry::
+    push_forward_gradient(const Point<dim> &chart_point) const
+    {
+     const double R = chart_point[0]; // Radius
+     const double phi = chart_point[1]; // Longitude
+  
+     Assert (R > 0.0, ExcMessage("Negative radius for given point."));
+
+     DerivativeForm<1, dim, dim> DX;
+
+     switch (dim)
+       {
+         case 2:
+         {
+         DX[0][0] =      std::cos(phi); 
+         DX[0][1] = -R * std::sin(phi);
+         DX[1][0] =      std::sin(phi);
+         DX[1][1] =  R * std::cos(phi);
+         break;
+         }
+         case 3:
+         {
+         const double theta = chart_point[2]; // Latitude (not colatitude)
+
+         DX[0][0] =      std::cos(theta) * std::cos(phi);
+         DX[0][1] = -R * std::cos(theta) * std::sin(phi);
+         DX[0][2] = -R * std::sin(theta) * std::cos(phi);
+         DX[1][0] =      std::cos(theta) * std::sin(phi);
+         DX[1][1] =  R * std::cos(theta) * std::cos(phi);
+         DX[1][2] = -R * std::sin(theta) * std::sin(phi);
+         DX[2][0] =      std::sin(theta);
+         DX[2][1] = 0;
+         DX[2][2] =  R * std::cos(theta);
+         break;
+         }
+         default:
+           Assert (false, ExcNotImplemented ());
+
+
+       }
+    
+     return DX;
+    }
+
+ 
+    template <int dim>
+    Point<dim>
+    Chunk4<dim>::ChunkGeometry::
+    push_forward(const Point<dim> &input_vertex) const
+    {
+      Point<dim> output_vertex;
+      switch (dim)
+        {
+          case 2:
+          {
+            output_vertex[0] = input_vertex[0]*std::cos(input_vertex[1]); // x=rcosphi
+            output_vertex[1] = input_vertex[0]*std::sin(input_vertex[1]); // z=rsinphi
+            break;
+          }
+          case 3:
+          {
+            output_vertex[0] = input_vertex[0]*std::cos(input_vertex[2])*std::cos(input_vertex[1]); // x=rsinthetacosphi
+            output_vertex[1] = input_vertex[0]*std::cos(input_vertex[2])*std::sin(input_vertex[1]); // y=rsinthetasinphi
+            output_vertex[2] = input_vertex[0]*std::sin(input_vertex[2]); // z=rcostheta
+            break;
+          }
+          default:
+            Assert (false, ExcNotImplemented ());
+        }
+      return output_vertex;
+    }
+
+    template <int dim>
+    Point<dim>
+    Chunk4<dim>::ChunkGeometry::
+    pull_back(const Point<dim> &v) const
+    {
+      Point<dim> output_vertex;
+      switch (dim)
+        {
+          case 2:
+          {
+            output_vertex[1] = std::atan2(v[1], v[0]);
+            output_vertex[0] = v.norm();
+            // We must garantee that all returned points have a longitude coordinate
+            // value that is larger than (or equal to) the longitude of point1.
+            // For example:
+            // If the domain runs from longitude -10 to 200 degrees,
+            // atan2 will also return a negative value (-180 to -160) for the points
+            // with longitude 180 to 200. These values must be corrected
+            // so that they are larger than the minimum longitude value of -10,
+            // by adding 360 degrees.
+            if (output_vertex[1] < 0.0)
+              if (output_vertex[1] < point1_lon - std::abs(point1_lon)*std::numeric_limits<double>::epsilon())
+                output_vertex[1] += 2.0 * numbers::PI;
+            break;
+          }
+          case 3:
+          {
+            const double radius=v.norm();
+            output_vertex[0] = radius;
+            output_vertex[1] = std::atan2(v[1], v[0]);
+            // See 2D case
+            if (output_vertex[1] < 0.0)
+              if (output_vertex[1] < point1_lon - std::abs(point1_lon)*std::numeric_limits<double>::epsilon())
+                output_vertex[1] += 2.0 * numbers::PI;
+            output_vertex[2] = std::asin(v[2]/radius);
+            break;
+          }
+          default:
+            Assert (false, ExcNotImplemented ());
+        }
+      return output_vertex;
+    }
+
+    template <int dim>
+    void
+    Chunk4<dim>::ChunkGeometry::
+    set_min_longitude(const double p1_lon)
+    {
+      point1_lon = p1_lon;
+    }
+
+
+    template <int dim>
+    void
+    Chunk4<dim>::
+    create_coarse_mesh (parallel::distributed::Triangulation<dim> &coarse_grid) const
+    {
+      std::vector<unsigned int> rep_vec(repetitions, repetitions+dim);
+      GridGenerator::subdivided_hyper_rectangle (coarse_grid,
+                                                 rep_vec,
+                                                 point1,
+                                                 point2,
+                                                 true);
+
+
+      // Transform box into spherical chunk
+      GridTools::transform (std_cxx11::bind(&ChunkGeometry::push_forward,
+                                            std_cxx11::cref(manifold),
+                                            std_cxx11::_1),
+                            coarse_grid);
+
+      // Deal with a curved mesh
+      // Attach the real manifold to slot 15. we won't use it
+      // during regular operation, but we set manifold_ids for all
+      // cells, faces and edges immediately before refinement and
+      // clear it again afterwards
+      coarse_grid.set_manifold (15, manifold);
+      for (typename Triangulation<dim>::active_cell_iterator cell =
+             coarse_grid.begin_active(); cell != coarse_grid.end(); ++cell)
+        cell->set_all_manifold_ids (15);
+
+//      coarse_grid.signals.pre_refinement.connect (std_cxx11::bind (&set_manifold_ids,
+//                                                                   std_cxx11::ref(coarse_grid)));
+//      coarse_grid.signals.post_refinement.connect (std_cxx11::bind (&clear_manifold_ids,
+//                                                                    std_cxx11::ref(coarse_grid)));
+
+    }
+
+    template <int dim>
+    std::set<types::boundary_id>
+    Chunk4<dim>::
+    get_used_boundary_indicators () const
+    {
+      // boundary indicators are zero through 2*dim-1
+      std::set<types::boundary_id> s;
+      for (unsigned int i=0; i<2*dim; ++i)
+        s.insert (i);
+      return s;
+    }
+
+
+
+    template <int dim>
+    std::map<std::string,types::boundary_id>
+    Chunk4<dim>::
+    get_symbolic_boundary_names_map () const
+    {
+      switch (dim)
+        {
+          case 2:
+          {
+            static const std::pair<std::string,types::boundary_id> mapping[]
+              = { std::pair<std::string,types::boundary_id>("inner",  0),
+                  std::pair<std::string,types::boundary_id>("outer",  1),
+                  std::pair<std::string,types::boundary_id>("west",   2),
+                  std::pair<std::string,types::boundary_id>("east",   3)
+                };
+
+            return std::map<std::string,types::boundary_id> (&mapping[0],
+                                                             &mapping[sizeof(mapping)/sizeof(mapping[0])]);
+          }
+
+          case 3:
+          {
+            static const std::pair<std::string,types::boundary_id> mapping[]
+              = { std::pair<std::string,types::boundary_id>("inner",  0),
+                  std::pair<std::string,types::boundary_id>("outer",  1),
+                  std::pair<std::string,types::boundary_id>("west",   2),
+                  std::pair<std::string,types::boundary_id>("east",   3),
+                  std::pair<std::string,types::boundary_id>("south",  4),
+                  std::pair<std::string,types::boundary_id>("north",  5)
+                };
+
+            return std::map<std::string,types::boundary_id> (&mapping[0],
+                                                             &mapping[sizeof(mapping)/sizeof(mapping[0])]);
+          }
+        }
+
+      Assert (false, ExcNotImplemented());
+      return std::map<std::string,types::boundary_id>();
+    }
+
+
+    template <int dim>
+    double
+    Chunk4<dim>::
+    length_scale () const
+    {
+      // As described in the first ASPECT paper, a length scale of
+      // 10km = 1e4m works well for the pressure scaling for earth
+      // sized spherical shells. use a length scale that
+      // yields this value for the R0,R1 corresponding to earth
+      // but otherwise scales like (R1-R0)
+      return 1e4 * maximal_depth() / (6336000.-3481000.);
+    }
+
+
+    template <int dim>
+    double
+    Chunk4<dim>::depth(const Point<dim> &position) const
+    {
+      return std::min (std::max (point2[0]-position.norm(), 0.), maximal_depth());
+    }
+
+
+    template <int dim>
+    Point<dim>
+    Chunk4<dim>::representative_point(const double depth) const
+    {
+      Assert (depth >= 0,
+              ExcMessage ("Given depth must be positive or zero."));
+      Assert (depth <= maximal_depth(),
+              ExcMessage ("Given depth must be less than or equal to the maximal depth of this geometry."));
+
+      // Choose a point at the mean longitude (and latitude)
+      Point<dim> p = 0.5*(point2+point1);
+      // at a depth beneath the top surface
+      p[0] = point2[0]-depth;
+
+      // Now convert to Cartesian coordinates
+      return manifold.push_forward(p);
+    }
+
+    template <int dim>
+    double
+    Chunk4<dim>::west_longitude () const
+    {
+      return point1[1];
+    }
+
+
+    template <int dim>
+    double
+    Chunk4<dim>::east_longitude () const
+    {
+      return point2[1];
+    }
+
+    template <int dim>
+    double
+    Chunk4<dim>::longitude_range () const
+    {
+      return point2[1] - point1[1];
+    }
+
+    template <int dim>
+    double
+    Chunk4<dim>::south_latitude () const
+    {
+      if (dim == 3)
+        return point1[2];
+      else
+        return 0;
+    }
+
+
+    template <int dim>
+    double
+    Chunk4<dim>::north_latitude () const
+    {
+      if (dim==3)
+        return point2[2];
+      else
+        return 0;
+    }
+
+
+    template <int dim>
+    double
+    Chunk4<dim>::latitude_range () const
+    {
+      if (dim==3)
+        return point2[2] - point1[2];
+      else
+        return 0;
+    }
+
+
+    template <int dim>
+    double
+    Chunk4<dim>::maximal_depth() const
+    {
+      return point2[0]-point1[0];
+    }
+
+    template <int dim>
+    double
+    Chunk4<dim>::inner_radius () const
+    {
+      return point1[0];
+    }
+
+    template <int dim>
+    double
+    Chunk4<dim>::outer_radius () const
+    {
+      return point2[0];
+    }
+
+    template <int dim>
+    bool
+    Chunk4<dim>::has_curved_elements() const
+    {
+      return true;
+    }
+
+    template <int dim>
+    bool
+    Chunk4<dim>::point_is_in_domain(const Point<dim> &point) const
+    {
+      AssertThrow(this->get_free_surface_boundary_indicators().size() == 0 ||
+                  this->get_timestep_number() == 0,
+                  ExcMessage("After displacement of the free surface, this function can no longer be used to determine whether a point lies in the domain or not."));
+
+      AssertThrow(dynamic_cast<const InitialTopographyModel::ZeroTopography<dim>*>(&this->get_initial_topography_model()) != 0,
+                  ExcMessage("After adding topography, this function can no longer be used to determine whether a point lies in the domain or not."));
+
+      const Point<dim> spherical_point = manifold.pull_back(point);
+
+      for (unsigned int d = 0; d < dim; d++)
+        if (spherical_point[d] > point2[d]+std::numeric_limits<double>::epsilon()*std::abs(point2[d]) ||
+            spherical_point[d] < point1[d]-std::numeric_limits<double>::epsilon()*std::abs(point2[d]))
+          return false;
+
+      return true;
+    }
+
+    template <int dim>
+    void
+    Chunk4<dim>::set_manifold_ids (Triangulation<dim> &triangulation)
+    {
+      for (typename Triangulation<dim>::active_cell_iterator cell =
+             triangulation.begin_active(); cell != triangulation.end(); ++cell)
+        cell->set_all_manifold_ids (15);
+    }
+
+    template <int dim>
+    void
+    Chunk4<dim>::clear_manifold_ids (Triangulation<dim> &triangulation)
+    {
+      for (typename Triangulation<dim>::active_cell_iterator cell =
+             triangulation.begin_active(); cell != triangulation.end(); ++cell)
+        cell->set_all_manifold_ids (numbers::invalid_manifold_id);
+    }
+
+    template <int dim>
+    void
+    Chunk4<dim>::
+    declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry model");
+      {
+        prm.enter_subsection("Chunk");
+        {
+          prm.declare_entry ("Chunk inner radius", "0",
+                             Patterns::Double (0),
+                             "Radius at the bottom surface of the chunk. Units: m.");
+          prm.declare_entry ("Chunk outer radius", "1",
+                             Patterns::Double (0),
+                             "Radius at the top surface of the chunk. Units: m.");
+
+          prm.declare_entry ("Chunk minimum longitude", "0",
+                             Patterns::Double (-180, 360), // enables crossing of either hemisphere
+                             "Minimum longitude of the chunk. Units: degrees.");
+          prm.declare_entry ("Chunk maximum longitude", "1",
+                             Patterns::Double (-180, 360), // enables crossing of either hemisphere
+                             "Maximum longitude of the chunk. Units: degrees.");
+
+          prm.declare_entry ("Chunk minimum latitude", "0",
+                             Patterns::Double (-90, 90),
+                             "Minimum latitude of the chunk. This value is ignored "
+                             "if the simulation is in 2d. Units: degrees.");
+          prm.declare_entry ("Chunk maximum latitude", "1",
+                             Patterns::Double (-90, 90),
+                             "Maximum latitude of the chunk. This value is ignored "
+                             "if the simulation is in 2d. Units: degrees.");
+
+          prm.declare_entry ("Radius repetitions", "1",
+                             Patterns::Integer (1),
+                             "Number of cells in radius.");
+          prm.declare_entry ("Longitude repetitions", "1",
+                             Patterns::Integer (1),
+                             "Number of cells in longitude.");
+          prm.declare_entry ("Latitude repetitions", "1",
+                             Patterns::Integer (1),
+                             "Number of cells in latitude. This value is ignored "
+                             "if the simulation is in 2d");
+
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+
+
+    template <int dim>
+    void
+    Chunk4<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Geometry model");
+      {
+        prm.enter_subsection("Chunk");
+        {
+
+          const double degtorad = dealii::numbers::PI/180;
+
+          Assert (dim >= 2, ExcInternalError());
+          Assert (dim <= 3, ExcInternalError());
+
+          if (dim >= 2)
+            {
+              point1[0] = prm.get_double ("Chunk inner radius");
+              point2[0] = prm.get_double ("Chunk outer radius");
+              repetitions[0] = prm.get_integer ("Radius repetitions");
+              point1[1] = prm.get_double ("Chunk minimum longitude") * degtorad;
+              point2[1] = prm.get_double ("Chunk maximum longitude") * degtorad;
+              repetitions[1] = prm.get_integer ("Longitude repetitions");
+
+              AssertThrow (point1[0] < point2[0],
+                           ExcMessage ("Inner radius must be less than outer radius."));
+              AssertThrow (point1[1] < point2[1],
+                           ExcMessage ("Minimum longitude must be less than maximum longitude."));
+              AssertThrow (point2[1] - point1[1] < 2.*numbers::PI,
+                           ExcMessage ("Maximum - minimum longitude should be less than 360 degrees."));
+            }
+
+          // Inform the manifold about the minimum longitude
+          manifold.set_min_longitude(point1[1]);
+
+          if (dim == 3)
+            {
+              point1[2] = prm.get_double ("Chunk minimum latitude") * degtorad;
+              point2[2] = prm.get_double ("Chunk maximum latitude") * degtorad;
+              repetitions[2] = prm.get_integer ("Latitude repetitions");
+
+              AssertThrow (point1[2] < point2[2],
+                           ExcMessage ("Minimum latitude must be less than maximum latitude."));
+            }
+
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace GeometryModel
+  {
+    ASPECT_REGISTER_GEOMETRY_MODEL(Chunk4,
+                                   "chunk4",
+                                   "A geometry which can be described as a chunk of a spherical shell, "
+                                   "bounded by lines of longitude, latitude and radius. "
+                                   "The minimum and maximum longitude, (latitude) and depth of the chunk "
+                                   "is set in the parameter file. The chunk geometry labels its "
+                                   "2*dim sides as follows: ``west'' and ``east'': minimum and maximum "
+                                   "longitude, ``south'' and ``north'': minimum and maximum latitude, "
+                                   "``inner'' and ``outer'': minimum and maximum radii. "
+                                   "Names in the parameter files are as follows: "
+                                   "Chunk4 (minimum || maximum) (longitude || latitude): "
+                                   "edges of geographical quadrangle (in degrees)"
+                                   "Chunk4 (inner || outer) radius: Radii at bottom and top of chunk"
+                                   "(Longitude || Latitude || Radius) repetitions: "
+                                   "number of cells in each coordinate direction.")
+  }
+}
+

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -28,7 +28,6 @@
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>
 #include <boost/lexical_cast.hpp>
-#include <aspect/compat.h>
 
 
 /**

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -21,7 +21,6 @@
 #include <aspect/particle/world.h>
 #include <aspect/global.h>
 #include <aspect/utilities.h>
-#include <aspect/compat.h>
 #include <aspect/geometry_model/box.h>
 
 #include <deal.II/base/quadrature_lib.h>

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1411,6 +1411,7 @@ namespace aspect
     // addition, we may be computing constraints from boundary values for the
     // velocity that are different between time steps. these are then put
     // into current_constraints in start_timestep().
+    signals.pre_compute_no_normal_flux_constraints(triangulation);
     {
       // do the interpolation for zero velocity
       for (std::set<types::boundary_id>::const_iterator
@@ -1432,6 +1433,7 @@ namespace aspect
                                                        *mapping);
     }
     constraints.close();
+    signals.post_compute_no_normal_flux_constraints(triangulation);
 
     // finally initialize vectors, matrices, etc.
 

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -378,7 +378,24 @@ namespace aspect
     return simulator->traction_boundary_conditions;
   }
 
+  template <int dim>
+  const std::set<types::boundary_id >
+  SimulatorAccess<dim>::get_traction_boundary_indicators () const
+  {
+    std::map< types::boundary_id, std::pair<std::string, std::string> > map_indicators
+      = simulator->parameters.prescribed_traction_boundary_indicators;
+    std::map< types::boundary_id, std::pair<std::string, std::string> >::iterator it;
+    std::map< types::boundary_id, std::pair<std::string, std::string> >::iterator begin = map_indicators.begin();
+    std::map< types::boundary_id, std::pair<std::string, std::string> >::iterator end = map_indicators.end();
 
+    std::set<types::boundary_id> indicators;
+
+    for (it = begin; it != end; ++it)
+      {
+        indicators.insert(it->first);
+      }
+    return indicators;
+  }
 
   template <int dim>
   bool

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -32,6 +32,7 @@
 #include <aspect/geometry_model/box.h>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/chunk.h>
+#include <aspect/geometry_model/chunk_3.h>
 
 #include <fstream>
 #include <string>
@@ -1129,6 +1130,7 @@ namespace aspect
     {
       AssertThrow ((dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()))
                    || (dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model())) != 0
+                   || (dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model())) != 0
                    || (dynamic_cast<const GeometryModel::Box<dim>*> (&this->get_geometry_model())) != 0,
                    ExcMessage ("This ascii data plugin can only be used when using "
                                "a spherical shell, chunk or box geometry."));
@@ -1394,7 +1396,8 @@ namespace aspect
           Point<dim> internal_position = position;
 
           if (dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()) != 0
-              || dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model()) != 0)
+              || dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model()) != 0
+              || dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model()) != 0)
             {
               const std_cxx11::array<double,dim> spherical_position =
                 ::aspect::Utilities::Coordinates::cartesian_to_spherical_coordinates(position);
@@ -1498,6 +1501,7 @@ namespace aspect
     {
       AssertThrow ((dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()))
                    || (dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model())) != 0
+                   || (dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model())) != 0
                    || (dynamic_cast<const GeometryModel::Box<dim>*> (&this->get_geometry_model())) != 0,
                    ExcMessage ("This ascii data plugin can only be used when using "
                                "a spherical shell, chunk or box geometry."));
@@ -1531,7 +1535,8 @@ namespace aspect
       Point<dim> internal_position = position;
 
       if (dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()) != 0
-          || (dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model())) != 0)
+          || (dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model())) != 0
+          || (dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model())) != 0)
         {
           const std_cxx11::array<double,dim> spherical_position =
             ::aspect::Utilities::Coordinates::cartesian_to_spherical_coordinates(position);

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -33,6 +33,8 @@
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/chunk.h>
 #include <aspect/geometry_model/chunk_3.h>
+#include "/home/glerum/aspect/01092016/aspect/lib_chunk/chunk_3_layered.h"
+#include "/home/glerum/aspect/01092016/aspect/lib_aegean_ascii/two_merged_chunks.h"
 
 #include <fstream>
 #include <string>
@@ -1130,7 +1132,9 @@ namespace aspect
     {
       AssertThrow ((dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()))
                    || (dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model())) != 0
+                   || (dynamic_cast<const GeometryModel::TwoMergedChunks<dim>*> (&this->get_geometry_model())) != 0
                    || (dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model())) != 0
+                   || (dynamic_cast<const GeometryModel::Chunk3Layered<dim>*> (&this->get_geometry_model())) != 0
                    || (dynamic_cast<const GeometryModel::Box<dim>*> (&this->get_geometry_model())) != 0,
                    ExcMessage ("This ascii data plugin can only be used when using "
                                "a spherical shell, chunk or box geometry."));
@@ -1207,7 +1211,7 @@ namespace aspect
       switch (dim)
         {
           case 2:
-            if ((boundary_id == 2) || (boundary_id == 3))
+            if ((boundary_id == 2) || (boundary_id == 3)|| (boundary_id == 4) || (boundary_id == 5) )
               {
                 boundary_dimensions[0] = 0;
               }
@@ -1224,7 +1228,7 @@ namespace aspect
             break;
 
           case 3:
-            if ((boundary_id == 4) || (boundary_id == 5))
+            if ((boundary_id == 4) || (boundary_id == 5) || (boundary_id == 8) || (boundary_id == 9))
               {
                 boundary_dimensions[0] = 0;
                 boundary_dimensions[1] = 1;
@@ -1234,7 +1238,7 @@ namespace aspect
                 boundary_dimensions[0] = 1;
                 boundary_dimensions[1] = 2;
               }
-            else if ((boundary_id == 2) || (boundary_id == 3))
+            else if ((boundary_id == 2) || (boundary_id == 3) || (boundary_id == 6) || (boundary_id == 7))
               {
                 boundary_dimensions[0] = 0;
                 boundary_dimensions[1] = 2;
@@ -1397,7 +1401,9 @@ namespace aspect
 
           if (dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()) != 0
               || dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model()) != 0
-              || dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model()) != 0)
+              || dynamic_cast<const GeometryModel::TwoMergedChunks<dim>*> (&this->get_geometry_model()) != 0
+              || dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model()) != 0
+              || dynamic_cast<const GeometryModel::Chunk3Layered<dim>*> (&this->get_geometry_model()) != 0)
             {
               const std_cxx11::array<double,dim> spherical_position =
                 ::aspect::Utilities::Coordinates::cartesian_to_spherical_coordinates(position);
@@ -1506,7 +1512,9 @@ namespace aspect
     {
       AssertThrow ((dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()))
                    || (dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model())) != 0
+                   || (dynamic_cast<const GeometryModel::TwoMergedChunks<dim>*> (&this->get_geometry_model())) != 0
                    || (dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model())) != 0
+                   || (dynamic_cast<const GeometryModel::Chunk3Layered<dim>*> (&this->get_geometry_model())) != 0
                    || (dynamic_cast<const GeometryModel::Box<dim>*> (&this->get_geometry_model())) != 0,
                    ExcMessage ("This ascii data plugin can only be used when using "
                                "a spherical shell, chunk or box geometry."));
@@ -1541,7 +1549,9 @@ namespace aspect
 
       if (dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()) != 0
           || (dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model())) != 0
-          || (dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model())) != 0)
+          || (dynamic_cast<const GeometryModel::TwoMergedChunks<dim>*> (&this->get_geometry_model())) != 0
+          || (dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model())) != 0
+          || (dynamic_cast<const GeometryModel::Chunk3Layered<dim>*> (&this->get_geometry_model())) != 0)
         {
           const std_cxx11::array<double,dim> spherical_position =
             ::aspect::Utilities::Coordinates::cartesian_to_spherical_coordinates(position);

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -33,8 +33,6 @@
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/chunk.h>
 #include <aspect/geometry_model/chunk_3.h>
-#include "/home/glerum/aspect/01092016/aspect/lib_chunk/chunk_3_layered.h"
-#include "/home/glerum/aspect/01092016/aspect/lib_aegean_ascii/two_merged_chunks.h"
 
 #include <fstream>
 #include <string>
@@ -1132,9 +1130,7 @@ namespace aspect
     {
       AssertThrow ((dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()))
                    || (dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model())) != 0
-                   || (dynamic_cast<const GeometryModel::TwoMergedChunks<dim>*> (&this->get_geometry_model())) != 0
                    || (dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model())) != 0
-                   || (dynamic_cast<const GeometryModel::Chunk3Layered<dim>*> (&this->get_geometry_model())) != 0
                    || (dynamic_cast<const GeometryModel::Box<dim>*> (&this->get_geometry_model())) != 0,
                    ExcMessage ("This ascii data plugin can only be used when using "
                                "a spherical shell, chunk or box geometry."));
@@ -1401,9 +1397,7 @@ namespace aspect
 
           if (dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()) != 0
               || dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model()) != 0
-              || dynamic_cast<const GeometryModel::TwoMergedChunks<dim>*> (&this->get_geometry_model()) != 0
-              || dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model()) != 0
-              || dynamic_cast<const GeometryModel::Chunk3Layered<dim>*> (&this->get_geometry_model()) != 0)
+              || dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model()) != 0)
             {
               const std_cxx11::array<double,dim> spherical_position =
                 ::aspect::Utilities::Coordinates::cartesian_to_spherical_coordinates(position);
@@ -1512,9 +1506,7 @@ namespace aspect
     {
       AssertThrow ((dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()))
                    || (dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model())) != 0
-                   || (dynamic_cast<const GeometryModel::TwoMergedChunks<dim>*> (&this->get_geometry_model())) != 0
                    || (dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model())) != 0
-                   || (dynamic_cast<const GeometryModel::Chunk3Layered<dim>*> (&this->get_geometry_model())) != 0
                    || (dynamic_cast<const GeometryModel::Box<dim>*> (&this->get_geometry_model())) != 0,
                    ExcMessage ("This ascii data plugin can only be used when using "
                                "a spherical shell, chunk or box geometry."));
@@ -1549,9 +1541,7 @@ namespace aspect
 
       if (dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()) != 0
           || (dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model())) != 0
-          || (dynamic_cast<const GeometryModel::TwoMergedChunks<dim>*> (&this->get_geometry_model())) != 0
-          || (dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model())) != 0
-          || (dynamic_cast<const GeometryModel::Chunk3Layered<dim>*> (&this->get_geometry_model())) != 0)
+          || (dynamic_cast<const GeometryModel::Chunk3<dim>*> (&this->get_geometry_model())) != 0)
         {
           const std_cxx11::array<double,dim> spherical_position =
             ::aspect::Utilities::Coordinates::cartesian_to_spherical_coordinates(position);

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1404,6 +1404,11 @@ namespace aspect
 
               for (unsigned int i = 0; i < dim; i++)
                 internal_position[i] = spherical_position[i];
+
+              // Rescale phi to -angle if on western hemisphere
+              // TODO only of domain crosses 0 meridian
+              if (internal_position[1] > numbers::PI)
+                internal_position[1] -= 2*numbers::PI;
             }
 
           const std_cxx11::array<unsigned int,dim-1> boundary_dimensions =
@@ -1543,6 +1548,11 @@ namespace aspect
 
           for (unsigned int i = 0; i < dim; i++)
             internal_position[i] = spherical_position[i];
+
+              // Rescale phi to -angle if on western hemisphere
+              // TODO only of domain crosses 0 meridian
+              if (internal_position[1] > numbers::PI)
+                internal_position[1] -= 2*numbers::PI;
         }
       return lookup->get_data(internal_position,component);
     }

--- a/source/velocity_boundary_conditions/gplates.cc
+++ b/source/velocity_boundary_conditions/gplates.cc
@@ -19,7 +19,6 @@
 */
 
 
-#include <aspect/global.h>
 #include <aspect/velocity_boundary_conditions/gplates.h>
 #include <aspect/utilities.h>
 


### PR DESCRIPTION
Dear Wolfgang and Timo,

I’d like to come back to the chunk velocity anomalies of issues #822 and #1016 (and for shells #1077).

As a simple test case, I take the tests chunk_first_timestep_2d.prm and chunk_first_timestep_3d.prm and set all velocity boundary conditions to free-slip except for the zero velocity inner boundary. I add AMR with the following settings:

subsection Mesh refinement
    set Initial adaptive refinement     = 1
    set Initial global refinement          = 4
    set Strategy                                         = minimum refinement function
    subsection Minimum refinement function
     set Coordinate system                    = spherical
     set Variable names                          = r,phi, theta
     set Function expression                 = if(r>5250000.0&phi<45.0*pi/180.0,5,4) #or
   #set Function expression              = if(r>5250000&phi<45.0*pi/180.0&theta>45.0*pi/180.,5,4)
   end
 end

Because there are no driving forces in these test cases, velocity should be as low as possible. For comparison, I reproduce the chunk 2d model with the spherical shell geometry in 2d.  For the original chunk, the following velocity fields are the result (note the different scales; from left to right: shell 2d, chunk 2d, chunk 3d; top: no AMR, bottom: with AMR):
![original](https://cloud.githubusercontent.com/assets/7631624/22185934/7f2ca5d8-e0ee-11e6-9a92-97b4000ecc98.png)
![original_amr](https://cloud.githubusercontent.com/assets/7631624/22185936/88127718-e0ee-11e6-8eb2-3f1ac1ddf77c.png)

To improve the velocity fields I made the following changes:

1) Remove manifold id only on boundaries (pr #822)
Remove the manifold only on the domain boundaries, as we discussed at the Hackaton. This removes the anomalies in 2D, except on the cells along the boundaries (at high resolutions, these disappear).
![chunk0_amr](https://cloud.githubusercontent.com/assets/7631624/22185945/a37b9462-e0ee-11e6-813b-e64afc440e96.png)
2) Setting the proper boundary object (pr #1016)
Since the manifold id is removed on the boundaries, we need a boundary object. Therefore I set the inner and outer boundary to HyperBall, the east and west boundary to StraightBoundary and the north and south boundaries to ConeBoundary.
![chunk1_amr](https://cloud.githubusercontent.com/assets/7631624/22185951/c3ba81c0-e0ee-11e6-993e-3eee8ef6f37d.png)
3) Only using the boundary object for normal vectors
As the boundary objects are only necessary (I think) for the normal vectors needed for tangential boundary conditions, I’ve added a new signal around the ‘compute_no_normal_flux’ function in setup_dofs(). These signals are now used to remove the manifold id from the boundaries before the ‘compute_no_normal_flux’ function and set it again after, instead of the reverse before and after refinement. This seems to fix the problems in 2d sufficiently.
![chunk3_normalcone](https://cloud.githubusercontent.com/assets/7631624/22186489/117492f4-e0f7-11e6-8e76-b2894b9ef1ae.png)

4) ConeBoundary normal vectors
In 3D, there are still anomalies along the conical boundaries of the chunk. As the ConeBoundary object has no normal_vector function, it defers to the StraightBoundary normal_vector function. To give it a try, I’ve added a SpecialConeBoundary class in compat.h that computes normal vectors along a cone, and this reduces the anomalies. 
![chunk3_amr](https://cloud.githubusercontent.com/assets/7631624/22186491/28ddf106-e0f7-11e6-928a-cfcc570ed6df.png)

5) Convective pattern
However, we remain with a flow field of ~1e-5 m/yr even though there is no force to drive it. This flow is reduced by an increased resolution. A similar field is seen for no-slip conditions on all boundaries. It is also seen for the original chunk if we filter out the anomalies along mesh refinement boundaries.
When there are lateral variations in mesh refinement, differences in pressure, velocity and strain rate between the differently refined regions are significant. The convective pattern changes, see below. The velocity changes with gravity magnitude and a smaller length scale used for pressure scaling decreases the velocity.
![chunk3_noamr_amr](https://cloud.githubusercontent.com/assets/7631624/22186582/ec630a08-e0f7-11e6-9b8b-a9fdc6b860a6.png)
What is your opinion on the above and do you have an idea how to pursue this?

I’ve kept the new chunk model as a separate geometry model in this branch because I was comparing the different models. I’d like to hear what you think about these changes and then I’ll clean everything up. 



