### PR TITLE
Fix cookbook and interpolator

### DIFF
--- a/cookbooks/composition-active-tracers.prm
+++ b/cookbooks/composition-active-tracers.prm
@@ -105,6 +105,7 @@ subsection Postprocess
     set Data output format = vtu 
     set List of tracer properties = velocity, initial composition
     set Interpolation scheme = cell average
+    set Update ghost particles = true
     set Particle generator name = random uniform
   end 
 

--- a/source/particle/interpolator/cell_average.cc
+++ b/source/particle/interpolator/cell_average.cc
@@ -38,9 +38,6 @@ namespace aspect
       {
         const Postprocess::Tracers<dim> *tracer_postprocessor = this->template find_postprocessor<Postprocess::Tracers<dim> >();
 
-        const std::multimap<aspect::Particle::types::LevelInd, aspect::Particle::Particle<dim> > &ghost_particles =
-          tracer_postprocessor->get_particle_world().get_ghost_particles();
-
         typename parallel::distributed::Triangulation<dim>::active_cell_iterator found_cell;
 
         if (cell == typename parallel::distributed::Triangulation<dim>::active_cell_iterator())
@@ -71,7 +68,7 @@ namespace aspect
                 ?
                 particles.equal_range(cell_index)
                 :
-                ghost_particles.equal_range(cell_index);
+                tracer_postprocessor->get_particle_world().get_ghost_particles().equal_range(cell_index);
 
         const unsigned int n_particles = std::distance(particle_range.first,particle_range.second);
         const unsigned int n_properties = particles.begin()->second.get_properties().size();
@@ -107,7 +104,8 @@ namespace aspect
                     && (particles.count(std::make_pair(neighbors[i]->level(),neighbors[i]->index())) == 0))
                   continue;
                 else if ((!neighbors[i]->is_locally_owned())
-                         && (ghost_particles.count(std::make_pair(neighbors[i]->level(),neighbors[i]->index())) == 0))
+                         && (tracer_postprocessor->get_particle_world().get_ghost_particles().count(
+                               std::make_pair(neighbors[i]->level(),neighbors[i]->index())) == 0))
                   continue;
 
                 std::vector<double> neighbor_properties = properties_at_points(particles,

--- a/tests/melt_material_1.cc
+++ b/tests/melt_material_1.cc
@@ -28,7 +28,7 @@ namespace aspect
         return 1.0;
       }
 
-     virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
+      virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
 


### PR DESCRIPTION
The `cell_average` particle property interpolator always tried to access the particles in ghost cells, even in serial computations. This is unnecessary, and I moved that call to the places where it is needed (if it encounters ghost cells). Additionally it is more save to just exchange ghost particles in the cookbook, in case it is run in parallel and there is an empty cell next to a ghost cell. Fixes #1376.