### PR TITLE
Restrict assembly of face values to discontinuous fields

### DIFF
--- a/include/aspect/assembly.h
+++ b/include/aspect/assembly.h
@@ -610,12 +610,24 @@ namespace aspect
 
           /**
            * Whether or not at least one of the the assembler slots in
-           * a signal require the initialization and re-computation of
+           * a signal requires the initialization and re-computation of
            * a MaterialModelOutputs object for each face. This
            * property is only relevant to assemblers that operate on
            * boundary faces.
            */
           bool need_face_material_model_data;
+
+          /**
+           * Whether or not at least one of the assembler slots in a
+           * signal requires the evaluation of the FEFaceValues object.
+           */
+          bool need_face_finite_element_evaluation;
+
+          /**
+           * Whether or not at least one of the assembler slots in a
+           * signal requires the computation of the viscosity.
+           */
+          bool need_viscosity;
 
           /**
            * A list of FEValues UpdateFlags that are necessary for
@@ -634,9 +646,8 @@ namespace aspect
         Properties stokes_preconditioner_assembler_properties;
         Properties stokes_system_assembler_properties;
         Properties stokes_system_assembler_on_boundary_face_properties;
-        Properties advection_system_assembler_properties;
-        Properties advection_system_assembler_on_face_properties;
-
+        std::vector<Properties> advection_system_assembler_properties;
+        std::vector<Properties> advection_system_assembler_on_face_properties;
       };
     }
   }

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -264,6 +264,14 @@ namespace aspect
         unsigned int block_index(const Introspection<dim> &introspection) const;
 
         /**
+         * Returns an index that runs from 0 (temperature field) to n (nth
+         * compositional field), and uniquely identifies the current advection
+         * field among the list of all advection fields. Can be used to index
+         * vectors that contain entries for all advection fields.
+         */
+        unsigned int field_index() const;
+
+        /**
          * Look up the base element within the larger composite finite element
          * we used for everything, for this temperature or compositional field
          * See Introspection::base_elements for more information.

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1401,8 +1401,8 @@ namespace aspect
 
     // then also work on possible face terms. if necessary, initialize
     // the material model data on faces
-    const bool has_boundary_face_assemblers = !assemblers->local_assemble_advection_system_on_boundary_face.empty();
-    const bool has_interior_face_assemblers = !assemblers->local_assemble_advection_system_on_interior_face.empty();
+    const bool has_boundary_face_assemblers = !assemblers->local_assemble_advection_system_on_boundary_face.empty() && advection_field.is_discontinuous(introspection);
+    const bool has_interior_face_assemblers = !assemblers->local_assemble_advection_system_on_interior_face.empty() && advection_field.is_discontinuous(introspection);
 
     // skip the remainder if no work needs to be done on faces
     if (!has_boundary_face_assemblers && !has_interior_face_assemblers)

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -435,6 +435,8 @@ namespace aspect
       AssemblerLists<dim>::Properties::Properties ()
         :
         need_face_material_model_data (false),
+        need_face_finite_element_evaluation(false),
+        need_viscosity(false),
         needed_update_flags ()
       {}
 

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -140,6 +140,16 @@ namespace aspect
 
   template <int dim>
   unsigned int
+  Simulator<dim>::AdvectionField::field_index() const
+  {
+    if (this->is_temperature())
+      return 0;
+    else
+      return compositional_variable + 1;
+  }
+
+  template <int dim>
+  unsigned int
   Simulator<dim>::AdvectionField::base_element(const Introspection<dim> &introspection) const
   {
     if (this->is_temperature())


### PR DESCRIPTION
This is a workaround to an inefficiency in our current assembly system. We determine whether to assemble face terms by checking the number of face assemblers. These assemblers might only be necessary for a different advection system though (e.g. the discontinuous compositional fields in case of active particles). This slows down assembly unnecessarily by evaluating FeFaceValues in many unnecessary cases in models with mixed discontinuous/continuous advection elements.

I call this a workaround, because in the future we might have other reasons for assembling face terms for the advection assembly than just discontinuous elements, but since there is no case I am currently aware of, this is the easiest solution for now.