### PR TITLE
Provide a Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,90 @@
+FROM ubuntu:14.04
+
+MAINTAINER Rene Gassmoeller <r.gassmoeller@mailbox.org>
+
+ENV HOME /root
+
+RUN apt-get update
+RUN apt-get -yq install gcc \
+                        build-essential \
+                        wget \
+                        bzip2 \
+                        tar \
+                        g++ \
+                        gfortran \
+                        libblas-dev \
+                        liblapack-dev \
+                        libboost-dev \
+                        libopenmpi-dev \
+                        openmpi-bin \
+                        cmake \
+                        git
+
+#Build HDF5
+RUN wget http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.13.tar.bz2; \
+    tar xjvf hdf5-1.8.13.tar.bz2; \
+    cd hdf5-1.8.13; \
+    ./configure --enable-parallel \
+                --enable-shared \
+                --prefix=/usr/local/; \
+    make -j2 && make install; \
+    cd ..; \
+    rm -rf /hdf5-1.8.13 /hdf5-1.8.13.tar.bz2 
+
+#Build Trilinos
+RUN wget http://trilinos.sandia.gov/download/files/trilinos-11.8.1-Source.tar.bz2; \
+    tar xjvf trilinos-11.8.1-Source.tar.bz2; \
+    mkdir trilinos-11.8.1-Source/build; \
+    cd trilinos-11.8.1-Source/build; \
+    cmake -D Trilinos_ENABLE_Sacado=ON \
+          -D Trilinos_ENABLE_Stratimikos=ON \
+          -D CMAKE_BUILD_TYPE=RELEASE \
+          -D CMAKE_CXX_FLAGS="-O3" \
+          -D CMAKE_C_FLAGS="-O3" \
+          -D CMAKE_FORTRAN_FLAGS="-O5" \
+          -D Trilinos_EXTRA_LINK_FLAGS="-lgfortran" \
+          -D CMAKE_VERBOSE_MAKEFILE=FALSE \
+          -D Trilinos_VERBOSE_CONFIGURE=FALSE \
+          -D TPL_ENABLE_MPI=ON \
+          -D BUILD_SHARED_LIBS=ON \
+          .. ; \
+    make -j4 && make install; \
+    cd ../..; \
+    rm -rf trilinos-11.8.1-Source trilinos-11.8.1-Source.tar.bz2 
+
+#Build p4est
+RUN wget http://p4est.github.io/release/p4est-0.3.4.2.tar.gz; \
+    wget http://www.dealii.org/developer/external-libs/p4est-setup.sh; \
+    chmod +x p4est-setup.sh; \
+    ./p4est-setup.sh p4est-0.3.4.2.tar.gz /usr/local/p4est-0.3.4.2; \
+    rm -rf p4est-build p4est-0.3.4.2 p4est-setup.sh p4est-0.3.4.2.tar.gz
+
+#Build deal.II
+RUN wget http://www.ces.clemson.edu/dealii/deal.II-8.1.0.tar.gz; \
+    tar xzvf deal.II-8.1.0.tar.gz; \
+    mkdir deal.II/build; \
+    cd deal.II/build; \
+    cmake -DDEAL_II_WITH_MPI=ON \
+          -DDEAL_II_COMPONENT_COMPAT_FILES=OFF \
+          -DDEAL_II_COMPONENT_EXAMPLES=OFF \
+          -DCMAKE_INSTALL_PREFIX=/usr/local \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DP4EST_DIR=/usr/local/p4est-0.3.4.2/ \
+          .. ; \
+    make -j4 && make install; \
+    cd ../..; \
+    rm -rf deal.II deal.II-8.1.0.tar.gz
+
+#Build aspect
+RUN git clone https://github.com/geodynamics/aspect.git; \ 
+    mkdir aspect/build; \
+    cd aspect/build; \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+          -DDEAL_II_DIR=/usr/local/deal.II \
+          .. ; \
+    make -j4; \
+    mv aspect /usr/local/bin/; \
+    cd /\
+    rm -rf aspect
+
+CMD ["aspect"]

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2320,30 +2320,64 @@ docker pull gassmoeller/aspect
 Although it is possible to use the downloaded \aspect{} docker image in a number of different ways, we recommend the following workflow:
 
 \begin{enumerate}
-\item Create your \aspect{} input file in a folder of your choice (possibly also containing any input model data that is required by your model) and navigate in a terminal into that directory.
-\item Run the docker image and mount the current directory as a read-only volume into the docker container\footnote{Note that it is possible to mount a directory as writeable into the container. However it is often associated with file permission conflicts between the host system and the container. Therefore, we recommend this more cumbersome, but also more reliable workflow.}. 
-Make sure your parameter file specifies a model output directory \textbf{other} than the input directory, e.g. \texttt{/home/dealii/aspect/model\_output}. When you have started the container run the aspect model inside the container.
+\item Create your \aspect{} input file in a folder of your choice (possibly also containing any input data that is required by your model) and navigate in a terminal into that directory.
+\item Run the docker image and mount the current directory as a read-only volume into the docker container\footnote{Note that it is possible to mount a directory as writeable into the container. However it is often associated with file permission conflicts between the host system and the container. Therefore, we recommend this slightly more cumbersome, but also more reliable workflow.}. 
+Make sure your parameter file specifies a model output directory \textbf{other} than the input directory, e.g. \texttt{/home/dealii/aspect/model\_output}. When you have started the container run the aspect model inside the container. Note that there are two \aspect{} executables in the work directory of the container: texttt{aspect-debug} and \texttt{aspect-release}. For a discussion of the different version see Section~\ref{sec:debug-mode}, in essence: You should run texttt{aspect-debug} first to check your model for errors, then run \texttt{aspect-release} for a faster model run.
+
 \begin{verbatim}
 docker run -it -v "$(pwd):/home/dealii/aspect/model_input:ro" \
   gassmoeller/aspect:latest bash
-./aspect model_input/your_input_file.prm
+./aspect-debug model_input/your_input_file.prm
 \end{verbatim}
 
-\item After the model has finished (or during the model run if you want to check intermediate results) copy the model output out of the container into your current directory. For this you need to find the name or ID of the docker container by running \texttt{docker ps -a} in a separate terminal first.
+\item After the model has finished (or during the model run if you want to check intermediate results) copy the model output out of the container into your current directory. For this you need to find the name or ID of the docker container by running \texttt{docker ps -a} in a separate terminal first. Look for the most recently started container to identify your current \aspect{} container.
 
 \begin{verbatim}
-docker ps -a # Find the name of the running container in the output
+docker ps -a # Find the name of the running / recently closed container in the output
 docker cp CONTAINER_NAME:/home/dealii/aspect/model_output .
 \end{verbatim}
 
-\item The output data is saved inside your container even after the computation finishes and even when you stop the container. After you have copied out the data of the container you should therefore delete the container to avoid duplication of output data. Even after deleting you will always be able to start a new container from the downloaded image following step 2. Deleting the finished container can be achieved by the \texttt{docker container prune} command that removes any container that is not longer running (\textbf{Warning:} If you use other containers that you would like to keep only use \texttt{docker container rm CONTAINER\_NAME} to keep all other containers).
+\item The output data is saved inside your container even after the computation finishes and even when you stop the container. After you have copied out the data of the container you should therefore delete the container to avoid duplication of output data. Even after deleting you will always be able to start a new container from the downloaded image following step 2. Deleting the finished container can be achieved by the \texttt{docker container prune} command that removes any container that is not longer running (\textbf{Warning:} If you own other finished containers that you would like to keep only use \texttt{docker container rm CONTAINER\_NAME} to keep all other containers).
 
 \begin{verbatim}
 docker container prune
 \end{verbatim}
+or
+\begin{verbatim}
+docker container rm CONTAINER_NAME
+\end{verbatim}
 \end{enumerate}
 
 You are all set. Repeat steps 1-4 of this process as necessary when updating your model parameters. 
+
+\subsubsection{Developing \aspect{} within a container}
+
+The above given workflow does not include advice on how to modify \aspect{} inside the container. We recommend a slightly different workflow for advanced users that want to modify parts of \aspect{}. The \aspect{} docker container itself is build on top of a deal.II container that contains all dependencies for compiling \aspect{}. Therefore it is possible to run the deal.II container, mount an \aspect{} source directory from your host system and compile it inside of the container. An example workflow could look as following (assuming you navigated in a terminal into the modified \aspect{} source folder):
+
+\begin{verbatim}
+docker pull dealii/dealii:v8.5.pre.4-gcc-mpi-fulldepsmanual-debugrelease
+docker run -it -v "$(pwd):/home/dealii/aspect:ro" \
+  dealii/dealii:v8.5.pre.4-gcc-mpi-fulldepsmanual-debugrelease bash
+\end{verbatim}
+
+Inside of the container you now find a read-only \aspect{} directory that contains your modified source code. You can compile and run a model inside the container, e.g. in the following way:
+
+\begin{verbatim}
+mkdir aspect-build
+cd aspect-build
+cmake -DCMAKE_BUILD_TYPE=Debug -DDEAL_II_DIR=$HOME/deal.II-install $HOME/aspect
+./aspect $HOME/aspect/cookbooks/shell_simple_2d.prm
+\end{verbatim}
+
+To avoid repeated recompilations of the \aspect{} source folder we recommend to reuse the so prepared container instead of starting new containers based on the deal.II image. This can be achieved by the following commands outside of the container:
+
+\begin{verbatim}
+docker ps -a # Find the name of the running / recently closed container in the output
+docker restart CONTAINER_NAME
+docker attach CONTAINER_NAME
+\end{verbatim}
+
+For more information on the differences between using images and containers, and how to attach additional terminals to a running container, we refer to the docker documentation (e.g. \url{https://docs.docker.com/engine/getstarted/step_two/}).
 
 \subsection{Virtual Machine}
 

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2383,13 +2383,35 @@ For more information on the differences between using images and containers, and
 
 \subsubsection{Installing VM software and setting up the virtual machine}
 
+We are providing an experimental virtual image for a fully configured version of \aspect{}. For this, you will need to install VirtualBox(\url{http://www.virtualbox.org/}) on your machine, and then import a virtual machine image that can be downloaded from \url{http://www.math.clemson.edu/~heister/dealvm/}. Note, however, that the machine image is several gigabytes in size and downloading will take a while. After downloading and installing the virtual image it is convenient to set up a shared folder between your host system and the virtual machine to exchange model files and outputs.
+
 \subsubsection{Running \aspect{} models}
 
+The internal setup of the virtual machine is similar to the Docker container discussed above, except that it contains a full-featured desktop environment. Also note that the user name is \texttt{ubuntu}, not \texttt{dealii} as in the Docker container. Again there are multiple ways to use the virtual machine, but we recommend the following workflow:
+
+\begin{enumerate}
+\item Create your \aspect{} input file in the shared folder and start the virtual machine.
+\item Navigate in a terminal to your model directory.
+\item Run your model using the provided \aspect{} executable:
+
+\begin{verbatim}
+~/aspect/aspect your_input_file.prm
+\end{verbatim}
+
+\item The model output should automatically appear on your host machine in the shared directory.
+
+\item After you have verified that your model setup is correct, you might want to consider recompiling \aspect{} in release mode to increase the speed of the computation. See Section~\ref{sec:debug-mode} for a discussion of debug and release mode.
+
+\item Visualize your model output either inside of the virtual machine (ParaView and VisIt are pre-installed), or outside on your host system.
+\end{enumerate}
+
+You are all set. Repeat steps 1-6 of this process as necessary when updating your model parameters. 
 
 \subsection{Local installation}
 
-This is a brief explanation of how to install all the required software and
-\aspect{} itself.
+This is a brief explanation of how to compile and install all the required software and
+\aspect{} itself. This installation procedure guarantees fastest runtimes, and largest flexibility,
+but might reveal incompatibilities with existing system libraries.
 
 \subsubsection{System prerequisites}
 
@@ -2458,16 +2480,6 @@ prerequisites:
     p4est installation instructions}. This is done using the
   {\tt{p4est-setup.sh}}; do not use the \pfrst{} stand-alone installation
   instructions.
-
-%\item  \textit{\dealii{}:}
-%  The current version of \aspect{} requires features of \dealii{} that have
-%  been developed after the 7.1 release. Since at the time of writing,
-%  \dealii{} 7.2 has not yet appears, we currently require the development
-%  version of \dealii{}, which can be obtained by running
-%\begin{verbatim}
-% svn checkout https://svn.dealii.org/trunk/deal.II
-%\end{verbatim}
-%  Once \dealii{} 7.2 is available, this will suffice as well.
 
 \item \textit{\dealii{}:}
   The current version of \aspect{} requires \dealii{} version 8.4.0 or later.

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2268,7 +2268,7 @@ discussed in great detail in \cite{GHPB17}.
 \section{Installation}
 \label{sec:installation}
 
-Currently, there are three distinct ways to install ASPECT -- compilation
+Currently, we offer three distinct ways to install ASPECT -- compilation
 from source, installing a virtual machine, and using a Docker container --
 each providing distinct advantages and disadvantages. In this section we
 describe all three options and start with a summary of their properties to
@@ -2289,8 +2289,8 @@ guide users to an informed decision about the best option for their purpose.
     Windows support          & No   & Yes     & Yes    \\
     Local parallelization & Yes & Yes & Yes            \\ 
     Massively parallel computations & Yes & No & No \\ 
-    Modification to ASPECT & possible & possible & possible \\
-    Configuration of dependencies & possible & No & No \\ \hline
+    Modifying ASPECT & possible & possible & possible \\
+    Configuring dependencies & possible & No & No \\ \hline
   \end{tabular}
   \caption{Features of the different installation options of \aspect{}.}
   \label{tab:install-options}
@@ -2299,28 +2299,44 @@ guide users to an informed decision about the best option for their purpose.
 The available options can be best presented in form of typical use cases:
 
 \begin{enumerate}
-\item Virtual Machine (\aspect{} beginner and tutorial participant): The virtual machine image provides a fully prepared user environment that contains installations of \aspect{}, all required libraries, and visualization software on top of a full Linux environment. This way tutorial participants can work in a unified  environment (minimizing installation time). Due to the overhead of virtualizing a full operating system this installation typically needs more space, and is approximately 30~\% slower than a native installation.
-\item Docker Container (advanced user with no need to configure / change the underlying libraries, possibly changing \aspect): Docker containers are lightweight packages that only encapsulate the minimal dependencies to run an application like \aspect{}. 
+\item Virtual Machine (\aspect{} beginner and tutorial participant): The virtual machine image provides a fully prepared user environment that contains installations of \aspect{}, all required libraries, and visualization software on top of a full Linux environment. This way beginning users and tutorial participants can work in a unified  environment, thus minimizing installation time and technical problems. Due to the overhead of virtualizing a full operating system this installation typically needs more space, and is approximately 30~\% slower than a native installation. Additionally working in a virtual machine 'feels' differently from working in your usual desktop environment.
 
-\item Compile \& Install (advanced user and developer with need to reconfigure underlying libraries): The most complicated option is to install the required 
+\item Docker Container (advanced user with no need to configure / change the underlying libraries, possibly changing parts of \aspect): Docker containers are lightweight packages that only encapsulate the minimal dependencies to run an application like \aspect{} on top of the host operating system. They allow easy installation and usage of \aspect{} in a unified environment, while relying on the user's operating system to provide visualization software and model input data. When compared to the virtual machine it is simple to exchange files between the host operating system and the docker container, and it provides the benefit to work in the desktop environment you are used to. They have very little overhead in terms of memory and speed compared to virtual machines, and allow for reproducible computations. The container is set up with a standard \aspect{} installation, but this can be modified by advanced users (source code development within the container is possible).
+
+\item Compile \& Install (advanced users and developers with the need to reconfigure underlying libraries or running massively parallel models): The most advanced option is to compile and install \aspect{} from source. This allows maximal control over the underlying libraries like Trilinos and deal.II, as well as easy modifications to \aspect{} by recompiling a modified source directory. Our installation instructions cover most Linux and MacOS operating systems, but incompatibilities on individual systems can always occur and make the installation more cumbersome. If you are planning to run massively parallel computations on a compute cluster this is likely your only option. Since clusters usually have a very individual setup, it is always a good advice to ask IT support staff for help when installing \aspect{}, to avoid hard to reproduce setup problems, and performance penalties.
 \end{enumerate}
 
 \subsection{Docker Container}
 
 \subsubsection{Installing Docker and pulling the \aspect{} container}
 
-\subsubsection{Running \aspect{} models}
-A typical workflow could look like: 
+Docker is a lightweight virtualization software that allows to ship applications with all their dependencies in a simple way. It is outside of the scope of this manual to explain all possible applications of Docker, and we refer to the https://www.docker.com/what-docker and https://www.docker.com/products/docker# for more detailed descriptions.
 
+\subsubsection{Running \aspect{} models}
+Although it is possible to use the \aspect{} docker container in a number of different ways, we recommend the following workflow:
+
+\begin{enumerate}
+\item Create your \aspect{} input file in a folder of your choice (possibly also containing any input model data that is required by your model)
+\item Run the docker container and mount the current directory as read-only into the docker container. When you have started the container start the aspect model inside the container.
 \begin{verbatim}
-docker run -it --rm -v "$(pwd):/source:ro" gassmoeller/aspect:latest /bin/bash
-docker cp CONTAINER:/home/bob/log/changes-BUILD.diff . # from outside
+docker run -it -v "$(pwd):/home/aspect_user/aspect/model_input:ro" \
+  gassmoeller/aspect:latest bash
+./aspect model_input/your_input_file.prm
 \end{verbatim}
 
-Remember to add the $-it$ flag, otherwise you have no way of interactively cancelling the job inside the container, except using $docker kill CONTAINER$. 
+\item After the model has finished (or during the model run if you want to check intermediate results) copy the output out of the container into your current directory. For this you need to find out the name or ID of the docker container by running $docker ps$ in a separate terminal first.
 
-\subsubsection{Modifying \aspect{} inside the container}
+\begin{verbatim}
+docker ps # Find out the name of the running container
+docker cp CONTAINER_NAME:/home/aspect_user/aspect/output .
+\end{verbatim}
 
+\item The output data is saved inside your container. After you have copied the data out of the container you should delete the container, to avoid duplication of output data (you will always be able to start a new container following step 2)
+
+\begin{verbatim}
+docker container prune
+\end{verbatim}
+\end{enumerate}
 
 \subsection{Virtual Machine}
 

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2268,10 +2268,75 @@ discussed in great detail in \cite{GHPB17}.
 \section{Installation}
 \label{sec:installation}
 
+Currently, there are three distinct ways to install ASPECT -- compilation
+from source, installing a virtual machine, and using a Docker container --
+each providing distinct advantages and disadvantages. In this section we
+describe all three options and start with a summary of their properties to
+guide users to an informed decision about the best option for their purpose.
+
+\begin{table}[htb]
+  \center
+  \begin{tabular}{|c|ccc|}
+    \hline
+    Feature & Compile \& Install & Virtual Machine & Docker Container \\
+    \hline
+    Speed overhead          & 0\%   & 30\%        & 0--5\%    \\
+    Disk space (debug+release, incl. libs) & 3.2~GB & 4~GB & 3.5~GB       \\
+    Knowledge required      & Much  & Very Little & Little    \\
+    Root privileges required & No & No (installed VM software) & Partially  \\
+    Embedded in native environment     & Yes  & No & Partially    \\
+    MacOS support            & Yes  & Yes     & Yes    \\
+    Windows support          & No   & Yes     & Yes    \\
+    Local parallelization & Yes & Yes & Yes            \\ 
+    Massively parallel computations & Yes & No & No \\ 
+    Modification to ASPECT & possible & possible & possible \\
+    Configuration of dependencies & possible & No & No \\ \hline
+  \end{tabular}
+  \caption{Features of the different installation options of \aspect{}.}
+  \label{tab:install-options}
+\end{table}
+
+The available options can be best presented in form of typical use cases:
+
+\begin{enumerate}
+\item Virtual Machine (\aspect{} beginner and tutorial participant): The virtual machine image provides a fully prepared user environment that contains installations of \aspect{}, all required libraries, and visualization software on top of a full Linux environment. This way tutorial participants can work in a unified  environment (minimizing installation time). Due to the overhead of virtualizing a full operating system this installation typically needs more space, and is approximately 30~\% slower than a native installation.
+\item Docker Container (advanced user with no need to configure / change the underlying libraries, possibly changing \aspect): Docker containers are lightweight packages that only encapsulate the minimal dependencies to run an application like \aspect{}. 
+
+\item Compile \& Install (advanced user and developer with need to reconfigure underlying libraries): The most complicated option is to install the required 
+\end{enumerate}
+
+\subsection{Docker Container}
+
+\subsubsection{Installing Docker and pulling the \aspect{} container}
+
+\subsubsection{Running \aspect{} models}
+A typical workflow could look like: 
+
+\begin{verbatim}
+docker run -it --rm -v "$(pwd):/source:ro" gassmoeller/aspect:latest /bin/bash
+docker cp CONTAINER:/home/bob/log/changes-BUILD.diff . # from outside
+\end{verbatim}
+
+Remember to add the $-it$ flag, otherwise you have no way of interactively cancelling the job inside the container, except using $docker kill CONTAINER$. 
+
+\subsubsection{Modifying \aspect{} inside the container}
+
+
+\subsection{Virtual Machine}
+
+\subsubsection{Installing VM software and setting up the virtual machine}
+
+\subsubsection{Running \aspect{} models}
+
+\subsubsection{Modifying \aspect{} inside the virtual machine}
+
+
+\subsection{Local installation}
+
 This is a brief explanation of how to install all the required software and
 \aspect{} itself.
 
-\subsection{System prerequisites}
+\subsubsection{System prerequisites}
 
 In order to install \aspect{} and its dependencies, you should
 have your system set up to be able to compile and link programs. Additionally,
@@ -2306,7 +2371,7 @@ sudo apt-get install build-essential \
                      zlib1g-dev
 \end{verbatim}
 
-\subsection{Software prerequisites}
+\subsubsection{Software prerequisites}
 
 \aspect{} builds on a few other libraries that are widely used in the
 computational science area and that provide most of the lower-level
@@ -2393,7 +2458,7 @@ cmake -DDEAL_II_WITH_MPI=ON \
 \end{enumerate}
 
 
-\subsection{Obtaining \aspect{} and initial configuration}
+\subsubsection{Obtaining \aspect{} and initial configuration}
 
 The development version of \aspect{} can be downloaded by executing the command
 \begin{verbatim}
@@ -2416,7 +2481,7 @@ specify an install directory using -DCMAKE\_INSTALL\_PREFIX. The
 instructions in the following sections assume an in-source build, so you need
 to adapt the location of the \aspect{} binary.
 
-\subsection{Compiling \aspect{} and generating documentation}
+\subsubsection{Compiling \aspect{} and generating documentation}
 \label{sec:compiling}
 
 After downloading \aspect{} and having built the libraries it builds on, you
@@ -2438,7 +2503,7 @@ installed. Most Linux distributions have packages for \texttt{doxygen}. The
 result will be the file \url{doc/doxygen/index.html} that is the starting
 point for exploring the documentation.
 
-\subsection{Compiling a static \aspect{} executable}
+\subsubsection{Compiling a static \aspect{} executable}
 \aspect{} defaults to a dynamically linked executable, which saves disk space and build time. In some circumstances however, it is preferred to generate a statically linked executable that incorporates all used libraries. This need may arise on large clusters on which libraries and loaded modules/variables on login nodes may be different from the ones available on compute nodes. The general build procedure in such a case equals the above explained instructions with the following differences:
 \begin{enumerate}
 \item \textit{Trilinos}: Add the following lines to your cmake call:
@@ -2460,7 +2525,7 @@ point for exploring the documentation.
 
 The here mentioned build was tested on a Cray XC30 cluster, which was set up for default static compiling and linking. On machines that default to dynamic linking additional compiler and/or linker flags may be required (e.g. "-fPIC" / "--static"). In case of questions send an email to the mailing list.
 
-\subsection{Installing and running \aspect{} on Mac OS X}
+\subsubsection{Installing and running \aspect{} on Mac OS X}
 OS X has some eccentricities which can complicate installation of \aspect{}. Currently the easiest and most reliable way to run \aspect{} under Mac OS X Mavericks (10.9), Yosemite (10.10) and El Capitan (10.11) is to install and run the binary package for \dealii{}. The step-by-step process is described in detail, with screenshots, here: \url{https://wiki.geodynamics.org/_media/software:aspect:aspect_yosemite_20150529.pdf}
 
 \begin{enumerate}

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2322,12 +2322,12 @@ Although it is possible to use the downloaded \aspect{} docker image in a number
 \begin{enumerate}
 \item Create your \aspect{} input file in a folder of your choice (possibly also containing any input data that is required by your model) and navigate in a terminal into that directory.
 \item Run the docker image and mount the current directory as a read-only volume into the docker container\footnote{Note that it is possible to mount a directory as writeable into the container. However it is often associated with file permission conflicts between the host system and the container. Therefore, we recommend this slightly more cumbersome, but also more reliable workflow.}. 
-Make sure your parameter file specifies a model output directory \textbf{other} than the input directory, e.g. \texttt{/home/dealii/aspect/model\_output}. When you have started the container run the aspect model inside the container. Note that there are two \aspect{} executables in the work directory of the container: texttt{aspect-debug} and \texttt{aspect-release}. For a discussion of the different version see Section~\ref{sec:debug-mode}, in essence: You should run texttt{aspect-debug} first to check your model for errors, then run \texttt{aspect-release} for a faster model run.
+Make sure your parameter file specifies a model output directory \textbf{other} than the input directory, e.g. \texttt{/home/dealii/aspect/model\_output}. When you have started the container run the aspect model inside the container. Note that there are two \aspect{} executables in the work directory of the container: texttt{aspect} and \texttt{aspect-release}. For a discussion of the different version see Section~\ref{sec:debug-mode}, in essence: You should run texttt{aspect} first to check your model for errors, then run \texttt{aspect-release} for a faster model run.
 
 \begin{verbatim}
 docker run -it -v "$(pwd):/home/dealii/aspect/model_input:ro" \
   gassmoeller/aspect:latest bash
-./aspect-debug model_input/your_input_file.prm
+./aspect model_input/your_input_file.prm
 \end{verbatim}
 
 \item After the model has finished (or during the model run if you want to check intermediate results) copy the model output out of the container into your current directory. For this you need to find the name or ID of the docker container by running \texttt{docker ps -a} in a separate terminal first. Look for the most recently started container to identify your current \aspect{} container.

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2280,17 +2280,17 @@ guide users to an informed decision about the best option for their purpose.
     \hline
     Feature & Compile \& Install & Virtual Machine & Docker Container \\
     \hline
-    Speed overhead          & 0\%   & 30\%        & 0--5\%    \\
-    Disk space (debug+release, incl. libs) & 3.2~GB & 4~GB & 3.5~GB       \\
+    Speed overhead          & 0\%   & 30\%     & 0--5\%    \\
+    Disk overhead           & 0~GB  & 1~GB     & 200~MB       \\
     Knowledge required      & Much  & Very Little & Little    \\
-    Root privileges required & No & No (installed VM software) & Partially  \\
-    Embedded in native environment     & Yes  & No & Partially    \\
-    MacOS support            & Yes  & Yes     & Yes    \\
-    Windows support          & No   & Yes     & Yes    \\
-    Local parallelization & Yes & Yes & Yes            \\ 
+    Root privileges required & No   & No (installed VM software) & Partially  \\
+    Embedded in native environment & Yes & No  & Partially    \\
+    MacOS support           & Yes   & Yes      & Yes    \\
+    Windows support         & No    & Yes      & Yes    \\
+    Local parallelization   & Yes   & Yes      & Yes            \\ 
     Massively parallel computations & Yes & No & No \\ 
-    Modifying ASPECT & possible & possible & possible \\
-    Configuring dependencies & possible & No & No \\ \hline
+    Modifying ASPECT        & possible & possible & possible \\
+    Configuring dependencies & possible & No   & No \\ \hline
   \end{tabular}
   \caption{Features of the different installation options of \aspect{}.}
   \label{tab:install-options}

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2308,30 +2308,34 @@ The available options can be best presented in form of typical use cases:
 
 \subsection{Docker Container}
 
-\subsubsection{Installing Docker and pulling the \aspect{} container}
+\subsubsection{Installing Docker and downloading the \aspect{} image}
 
-Docker is a lightweight virtualization software that allows to ship applications with all their dependencies in a simple way. It is outside of the scope of this manual to explain all possible applications of Docker, and we refer to the https://www.docker.com/what-docker and https://www.docker.com/products/docker# for more detailed descriptions.
+Docker is a lightweight virtualization software that allows to ship applications with all their dependencies in a simple way. It is outside of the scope of this manual to explain all possible applications of Docker, and we refer to the introduction (\url{https://www.docker.com/what-docker}) and installation and quickstart guides (\url{https://www.docker.com/products/docker}) on the Docker website for more detailed descriptions of how to set up and use the docker engine. More importantly Docker provides a marketplace for exchanging prepared docker images (called Docker Hub). After setting up the docker engine downloading a precompiled \aspect{} image from Docker Hub is as simple as typing in a terminal:
+
+\begin{verbatim}
+docker pull gassmoeller/aspect
+\end{verbatim}
 
 \subsubsection{Running \aspect{} models}
-Although it is possible to use the \aspect{} docker container in a number of different ways, we recommend the following workflow:
+Although it is possible to use the downloaded \aspect{} docker image in a number of different ways, we recommend the following workflow:
 
 \begin{enumerate}
 \item Create your \aspect{} input file in a folder of your choice (possibly also containing any input model data that is required by your model)
-\item Run the docker container and mount the current directory as read-only into the docker container. When you have started the container start the aspect model inside the container.
+\item Run the docker image and mount the current directory as a read-only volume into the docker container. When you have started the container run the aspect model inside the container.
 \begin{verbatim}
 docker run -it -v "$(pwd):/home/aspect_user/aspect/model_input:ro" \
   gassmoeller/aspect:latest bash
 ./aspect model_input/your_input_file.prm
 \end{verbatim}
 
-\item After the model has finished (or during the model run if you want to check intermediate results) copy the output out of the container into your current directory. For this you need to find out the name or ID of the docker container by running $docker ps$ in a separate terminal first.
+\item After the model has finished (or during the model run if you want to check intermediate results) copy the output out of the container into your current directory. For this you need to find the name or ID of the docker container by running \texttt{docker ps} in a separate terminal first.
 
 \begin{verbatim}
-docker ps # Find out the name of the running container
+docker ps # Find the name of the running container in the output
 docker cp CONTAINER_NAME:/home/aspect_user/aspect/output .
 \end{verbatim}
 
-\item The output data is saved inside your container. After you have copied the data out of the container you should delete the container, to avoid duplication of output data (you will always be able to start a new container following step 2)
+\item The output data is saved inside your container even after the computation finishes and even when you stop the container. After you have copied out the data of the container you should therefore delete the container to avoid duplication of output data. Even after deleting you will always be able to start a new container from the downloaded image following step 2. Deleting the finished container can be achieved by the $prune$ command that removes any container that is not longer running (\textbf{Warning:} If you use other containers that you would like to keep only use \texttt{docker container rm CONTAINER\_NAME} to keep all other containers).
 
 \begin{verbatim}
 docker container prune
@@ -2343,8 +2347,6 @@ docker container prune
 \subsubsection{Installing VM software and setting up the virtual machine}
 
 \subsubsection{Running \aspect{} models}
-
-\subsubsection{Modifying \aspect{} inside the virtual machine}
 
 
 \subsection{Local installation}

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2323,7 +2323,7 @@ Although it is possible to use the downloaded \aspect{} docker image in a number
 \item Create your \aspect{} input file in a folder of your choice (possibly also containing any input model data that is required by your model)
 \item Run the docker image and mount the current directory as a read-only volume into the docker container. When you have started the container run the aspect model inside the container.
 \begin{verbatim}
-docker run -it -v "$(pwd):/home/aspect_user/aspect/model_input:ro" \
+docker run -it -v "$(pwd):/home/dealii/aspect/model_input:ro" \
   gassmoeller/aspect:latest bash
 ./aspect model_input/your_input_file.prm
 \end{verbatim}
@@ -2332,7 +2332,7 @@ docker run -it -v "$(pwd):/home/aspect_user/aspect/model_input:ro" \
 
 \begin{verbatim}
 docker ps # Find the name of the running container in the output
-docker cp CONTAINER_NAME:/home/aspect_user/aspect/output .
+docker cp CONTAINER_NAME:/home/dealii/aspect/output .
 \end{verbatim}
 
 \item The output data is saved inside your container even after the computation finishes and even when you stop the container. After you have copied out the data of the container you should therefore delete the container to avoid duplication of output data. Even after deleting you will always be able to start a new container from the downloaded image following step 2. Deleting the finished container can be achieved by the $prune$ command that removes any container that is not longer running (\textbf{Warning:} If you use other containers that you would like to keep only use \texttt{docker container rm CONTAINER\_NAME} to keep all other containers).

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2320,27 +2320,30 @@ docker pull gassmoeller/aspect
 Although it is possible to use the downloaded \aspect{} docker image in a number of different ways, we recommend the following workflow:
 
 \begin{enumerate}
-\item Create your \aspect{} input file in a folder of your choice (possibly also containing any input model data that is required by your model)
-\item Run the docker image and mount the current directory as a read-only volume into the docker container. When you have started the container run the aspect model inside the container.
+\item Create your \aspect{} input file in a folder of your choice (possibly also containing any input model data that is required by your model) and navigate in a terminal into that directory.
+\item Run the docker image and mount the current directory as a read-only volume into the docker container\footnote{Note that it is possible to mount a directory as writeable into the container. However it is often associated with file permission conflicts between the host system and the container. Therefore, we recommend this more cumbersome, but also more reliable workflow.}. 
+Make sure your parameter file specifies a model output directory \textbf{other} than the input directory, e.g. \texttt{/home/dealii/aspect/model\_output}. When you have started the container run the aspect model inside the container.
 \begin{verbatim}
 docker run -it -v "$(pwd):/home/dealii/aspect/model_input:ro" \
   gassmoeller/aspect:latest bash
 ./aspect model_input/your_input_file.prm
 \end{verbatim}
 
-\item After the model has finished (or during the model run if you want to check intermediate results) copy the output out of the container into your current directory. For this you need to find the name or ID of the docker container by running \texttt{docker ps} in a separate terminal first.
+\item After the model has finished (or during the model run if you want to check intermediate results) copy the model output out of the container into your current directory. For this you need to find the name or ID of the docker container by running \texttt{docker ps -a} in a separate terminal first.
 
 \begin{verbatim}
-docker ps # Find the name of the running container in the output
-docker cp CONTAINER_NAME:/home/dealii/aspect/output .
+docker ps -a # Find the name of the running container in the output
+docker cp CONTAINER_NAME:/home/dealii/aspect/model_output .
 \end{verbatim}
 
-\item The output data is saved inside your container even after the computation finishes and even when you stop the container. After you have copied out the data of the container you should therefore delete the container to avoid duplication of output data. Even after deleting you will always be able to start a new container from the downloaded image following step 2. Deleting the finished container can be achieved by the $prune$ command that removes any container that is not longer running (\textbf{Warning:} If you use other containers that you would like to keep only use \texttt{docker container rm CONTAINER\_NAME} to keep all other containers).
+\item The output data is saved inside your container even after the computation finishes and even when you stop the container. After you have copied out the data of the container you should therefore delete the container to avoid duplication of output data. Even after deleting you will always be able to start a new container from the downloaded image following step 2. Deleting the finished container can be achieved by the \texttt{docker container prune} command that removes any container that is not longer running (\textbf{Warning:} If you use other containers that you would like to keep only use \texttt{docker container rm CONTAINER\_NAME} to keep all other containers).
 
 \begin{verbatim}
 docker container prune
 \end{verbatim}
 \end{enumerate}
+
+You are all set. Repeat steps 1-4 of this process as necessary when updating your model parameters. 
 
 \subsection{Virtual Machine}
 

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2268,7 +2268,7 @@ discussed in great detail in \cite{GHPB17}.
 \section{Installation}
 \label{sec:installation}
 
-Currently, we offer three distinct ways to install ASPECT -- compilation
+There are three distinct ways to install ASPECT -- compilation
 from source, installing a virtual machine, and using a Docker container --
 each providing distinct advantages and disadvantages. In this section we
 describe all three options and start with a summary of their properties to
@@ -2289,8 +2289,8 @@ guide users to an informed decision about the best option for their purpose.
     Windows support         & No    & Yes      & Yes    \\
     Local parallelization   & Yes   & Yes      & Yes            \\ 
     Massively parallel computations & Yes & No & No \\ 
-    Modifying ASPECT        & possible & possible & possible \\
-    Configuring dependencies & possible & No   & No \\ \hline
+    Modifying ASPECT        & Possible & Possible & Possible \\
+    Configuring dependencies & Possible & No   & No \\ \hline
   \end{tabular}
   \caption{Features of the different installation options of \aspect{}.}
   \label{tab:install-options}
@@ -2299,113 +2299,228 @@ guide users to an informed decision about the best option for their purpose.
 The available options can be best presented in form of typical use cases:
 
 \begin{enumerate}
-\item Virtual Machine (\aspect{} beginner and tutorial participant): The virtual machine image provides a fully prepared user environment that contains installations of \aspect{}, all required libraries, and visualization software on top of a full Linux environment. This way beginning users and tutorial participants can work in a unified  environment, thus minimizing installation time and technical problems. Due to the overhead of virtualizing a full operating system this installation typically needs more space, and is approximately 30~\% slower than a native installation. Additionally working in a virtual machine 'feels' differently from working in your usual desktop environment.
+\item Virtual Machine (\aspect{} beginner and tutorial participant): The
+virtual machine image provides a fully prepared user environment that contains
+installations of \aspect{}, all required libraries, and visualization software
+on top of a full Linux environment. This way beginning users and tutorial
+participants can work in a unified  environment, thus minimizing installation
+time and technical problems. Due to the overhead of virtualizing a full
+operating system this installation typically needs more space, and is
+approximately 30~\% slower than a native installation. Additionally working in a
+virtual machine `feels' differently from working in your usual desktop
+environment. The virtual machine can be run on all host operating systems that
+can run a virtualization software like VirtualBox (e.g. Linux, Apple MacOS,
+Microsoft Windows).
 
-\item Docker Container (advanced user with no need to configure / change the underlying libraries, possibly changing parts of \aspect): Docker containers are lightweight packages that only encapsulate the minimal dependencies to run an application like \aspect{} on top of the host operating system. They allow easy installation and usage of \aspect{} in a unified environment, while relying on the user's operating system to provide visualization software and model input data. When compared to the virtual machine it is simple to exchange files between the host operating system and the docker container, and it provides the benefit to work in the desktop environment you are used to. They have very little overhead in terms of memory and speed compared to virtual machines, and allow for reproducible computations. The container is set up with a standard \aspect{} installation, but this can be modified by advanced users (source code development within the container is possible).
+\item Docker Container (advanced user with no need to configure/change the
+underlying libraries, possibly changing parts of \aspect): Docker containers are
+lightweight packages that only encapsulate the minimal dependencies to run an
+application like \aspect{} on top of the host operating system. They allow easy
+installation and usage of \aspect{} in a unified environment, while relying on
+the user's operating system to provide visualization software and model input
+data. When compared to the virtual machine it is simple to exchange files
+between the host operating system and the docker container, and it provides the
+benefit to work in the desktop environment you are used to. They have very
+little overhead in terms of memory and speed compared to virtual machines, and
+allow for reproducible computations. The container is set up with a standard
+\aspect{} installation, but this can be modified by advanced users (source code
+development within the container is possible).
 
-\item Compile \& Install (advanced users and developers with the need to reconfigure underlying libraries or running massively parallel models): The most advanced option is to compile and install \aspect{} from source. This allows maximal control over the underlying libraries like Trilinos and deal.II, as well as easy modifications to \aspect{} by recompiling a modified source directory. Our installation instructions cover most Linux and MacOS operating systems, but incompatibilities on individual systems can always occur and make the installation more cumbersome. If you are planning to run massively parallel computations on a compute cluster this is likely your only option. Since clusters usually have a very individual setup, it is always a good advice to ask IT support staff for help when installing \aspect{}, to avoid hard to reproduce setup problems, and performance penalties.
+\item Compile \& Install (advanced users and developers with the need to
+reconfigure underlying libraries or running massively parallel models): The most
+advanced option is to compile and install \aspect{} from source. This allows
+maximal control over the underlying libraries like \trilinos{} and \dealii{}, as
+well as easy modifications to \aspect{} by recompiling a modified source
+directory. Our installation instructions cover most Linux and MacOS operating
+systems, but incompatibilities on individual systems can always occur and make
+the installation more cumbersome. If you are planning to run massively parallel
+computations on a compute cluster this is likely your only option. Since
+clusters usually have a very individual setup, it is always a good idea to ask
+IT support staff for help when installing \aspect{}, to avoid hard to reproduce
+setup problems, and performance penalties.
 \end{enumerate}
 
 \subsection{Docker Container}
 
 \subsubsection{Installing Docker and downloading the \aspect{} image}
 
-Docker is a lightweight virtualization software that allows to ship applications with all their dependencies in a simple way. It is outside of the scope of this manual to explain all possible applications of Docker, and we refer to the introduction (\url{https://www.docker.com/what-docker}) and installation and quickstart guides (\url{https://www.docker.com/products/docker}) on the Docker website for more detailed descriptions of how to set up and use the docker engine. More importantly Docker provides a marketplace for exchanging prepared docker images (called Docker Hub). After setting up the docker engine downloading a precompiled \aspect{} image from Docker Hub is as simple as typing in a terminal:
+Docker is a lightweight virtualization software that allows to ship
+applications with all their dependencies in a simple way. It is outside of the
+scope of this manual to explain all possible applications of Docker, and we
+refer to the introduction (\url{https://www.docker.com/what-docker}) and
+installation and quickstart guides
+(\url{https://www.docker.com/products/docker}) on the Docker website for more
+detailed descriptions of how to set up and use the docker engine. More
+importantly Docker provides a marketplace for exchanging prepared docker images
+(called Docker Hub). After setting up the docker engine downloading a
+precompiled \aspect{} image from Docker Hub is as simple as typing in a
+terminal:
 
-\begin{verbatim}
+\begin{lstlisting}[frame=single,language=ksh]
 docker pull gassmoeller/aspect
-\end{verbatim}
+\end{lstlisting}
+
+Note that the transfer size of the compressed image containing \aspect{} and
+all its dependencies is about 900~MB. When extracted the image requires about
+3.2~GB of disk space.
 
 \subsubsection{Running \aspect{} models}
-Although it is possible to use the downloaded \aspect{} docker image in a number of different ways, we recommend the following workflow:
+Although it is possible to use the downloaded \aspect{} docker image in a
+number of different ways, we recommend the following workflow:
 
 \begin{enumerate}
-\item Create your \aspect{} input file in a folder of your choice (possibly also containing any input data that is required by your model) and navigate in a terminal into that directory.
-\item Run the docker image and mount the current directory as a read-only volume into the docker container\footnote{Note that it is possible to mount a directory as writeable into the container. However it is often associated with file permission conflicts between the host system and the container. Therefore, we recommend this slightly more cumbersome, but also more reliable workflow.}. 
-Make sure your parameter file specifies a model output directory \textbf{other} than the input directory, e.g. \texttt{/home/dealii/aspect/model\_output}. When you have started the container run the aspect model inside the container. Note that there are two \aspect{} executables in the work directory of the container: texttt{aspect} and \texttt{aspect-release}. For a discussion of the different version see Section~\ref{sec:debug-mode}, in essence: You should run texttt{aspect} first to check your model for errors, then run \texttt{aspect-release} for a faster model run.
+\item Create your \aspect{} input file in a folder of your choice (possibly
+also containing any input data that is required by your model) and navigate in a
+terminal into that directory.
+\item Run the docker image and mount the current directory as a read-only
+volume into the docker container\footnote{Note that it is possible to mount a
+directory as writeable into the container. However, this is often associated
+with file permission conflicts between the host system and the container.
+Therefore, we recommend this slightly more cumbersome, but also more reliable
+workflow.}. 
+Make sure your parameter file specifies a model output directory \textit{other}
+than the input directory, e.g. \texttt{/home/dealii/aspect/model\_output}. When
+you have started the container run the aspect model inside the container. Note
+that there are two \aspect{} executables in the work directory of the container:
+\texttt{aspect} and \texttt{aspect-release}. For a discussion of the
+different versions see Section~\ref{sec:debug-mode}, in essence: You should run
+texttt{aspect} first to check your model for errors, then run
+\texttt{aspect-release} for a faster model run.
 
-\begin{verbatim}
+To sum up, the steps you will want to execute are:
+\begin{lstlisting}[frame=single,language=ksh]
 docker run -it -v "$(pwd):/home/dealii/aspect/model_input:ro" \
   gassmoeller/aspect:latest bash
 ./aspect model_input/your_input_file.prm
-\end{verbatim}
+\end{lstlisting}
 
-\item After the model has finished (or during the model run if you want to check intermediate results) copy the model output out of the container into your current directory. For this you need to find the name or ID of the docker container by running \texttt{docker ps -a} in a separate terminal first. Look for the most recently started container to identify your current \aspect{} container.
+\item After the model has finished (or during the model run if you want to check
+intermediate results) copy the model output out of the container into your
+current directory. For this you need to find the name or ID of the docker
+container by running \texttt{docker ps -a} in a separate terminal first. Look
+for the most recently started container to identify your current \aspect{}
+container.
 
-\begin{verbatim}
+Commands that copy the model output to the current directory could be:
+\begin{lstlisting}[frame=single,language=ksh]
 docker ps -a # Find the name of the running / recently closed container in the output
 docker cp CONTAINER_NAME:/home/dealii/aspect/model_output .
-\end{verbatim}
+\end{lstlisting}
 
-\item The output data is saved inside your container even after the computation finishes and even when you stop the container. After you have copied out the data of the container you should therefore delete the container to avoid duplication of output data. Even after deleting you will always be able to start a new container from the downloaded image following step 2. Deleting the finished container can be achieved by the \texttt{docker container prune} command that removes any container that is not longer running (\textbf{Warning:} If you own other finished containers that you would like to keep only use \texttt{docker container rm CONTAINER\_NAME} to keep all other containers).
+\item The output data is saved inside your container even after the computation
+finishes and even when you stop the container. After you have copied the data
+out of the container you should therefore delete the container to avoid
+duplication of output data. Even after deleting you will always be able to start
+a new container from the downloaded image following step 2. Deleting the
+finished container can be achieved by the \texttt{docker container prune}
+command that removes any container that is not longer running.
+\note{If you own other finished containers that you want to keep use
+\texttt{docker container rm CONTAINER\_NAME} to only remove the container named
+\texttt{CONTAINER\_NAME}.}
 
-\begin{verbatim}
+To remove all finished containers use the following command:
+\begin{lstlisting}[frame=single,language=ksh]
 docker container prune
-\end{verbatim}
-or
-\begin{verbatim}
+\end{lstlisting}
+Alternatively only remove a particular container:
+\begin{lstlisting}[frame=single,language=ksh]
 docker container rm CONTAINER_NAME
-\end{verbatim}
+\end{lstlisting}
 \end{enumerate}
 
-You are all set. Repeat steps 1-4 of this process as necessary when updating your model parameters. 
+You are all set. Repeat steps 1-4 of this process as necessary when updating
+your model parameters. 
 
 \subsubsection{Developing \aspect{} within a container}
 
-The above given workflow does not include advice on how to modify \aspect{} inside the container. We recommend a slightly different workflow for advanced users that want to modify parts of \aspect{}. The \aspect{} docker container itself is build on top of a deal.II container that contains all dependencies for compiling \aspect{}. Therefore it is possible to run the deal.II container, mount an \aspect{} source directory from your host system and compile it inside of the container. An example workflow could look as following (assuming you navigated in a terminal into the modified \aspect{} source folder):
+The above given workflow does not include advice on how to modify \aspect{}
+inside the container. We recommend a slightly different workflow for advanced
+users that want to modify parts of \aspect{}. The \aspect{} docker container
+itself is build on top of a \dealii{} container that contains all dependencies
+for compiling \aspect{}. Therefore it is possible to run the deal.II container,
+mount an \aspect{} source directory from your host system and compile it inside
+of the container. An example workflow could look as following (assuming you
+navigated in a terminal into the modified \aspect{} source folder):
 
-\begin{verbatim}
+\begin{lstlisting}[frame=single,language=ksh]
 docker pull dealii/dealii:v8.5.pre.4-gcc-mpi-fulldepsmanual-debugrelease
 docker run -it -v "$(pwd):/home/dealii/aspect:ro" \
   dealii/dealii:v8.5.pre.4-gcc-mpi-fulldepsmanual-debugrelease bash
-\end{verbatim}
+\end{lstlisting}
 
-Inside of the container you now find a read-only \aspect{} directory that contains your modified source code. You can compile and run a model inside the container, e.g. in the following way:
+Inside of the container you now find a read-only \aspect{} directory that
+contains your modified source code. You can compile and run a model inside the
+container, e.g. in the following way:
 
-\begin{verbatim}
+\begin{lstlisting}[frame=single,language=ksh]
 mkdir aspect-build
 cd aspect-build
 cmake -DCMAKE_BUILD_TYPE=Debug -DDEAL_II_DIR=$HOME/deal.II-install $HOME/aspect
 ./aspect $HOME/aspect/cookbooks/shell_simple_2d.prm
-\end{verbatim}
+\end{lstlisting}
 
-To avoid repeated recompilations of the \aspect{} source folder we recommend to reuse the so prepared container instead of starting new containers based on the deal.II image. This can be achieved by the following commands outside of the container:
+To avoid repeated recompilations of the \aspect{} source folder we recommend to
+reuse the so prepared container instead of starting new containers based on the
+\dealii{} image. This can be achieved by the following commands outside of the
+container:
 
-\begin{verbatim}
+\begin{lstlisting}[frame=single,language=ksh]
 docker ps -a # Find the name of the running / recently closed container in the output
 docker restart CONTAINER_NAME
 docker attach CONTAINER_NAME
-\end{verbatim}
+\end{lstlisting}
 
-For more information on the differences between using images and containers, and how to attach additional terminals to a running container, we refer to the docker documentation (e.g. \url{https://docs.docker.com/engine/getstarted/step_two/}).
+For more information on the differences between using images and containers,
+and how to attach additional terminals to a running container, we refer to the
+docker documentation (e.g.
+\url{https://docs.docker.com/engine/getstarted/step_two/}).
 
 \subsection{Virtual Machine}
 
 \subsubsection{Installing VM software and setting up the virtual machine}
 
-We are providing an experimental virtual image for a fully configured version of \aspect{}. For this, you will need to install VirtualBox(\url{http://www.virtualbox.org/}) on your machine, and then import a virtual machine image that can be downloaded from \url{http://www.math.clemson.edu/~heister/dealvm/}. Note, however, that the machine image is several gigabytes in size and downloading will take a while. After downloading and installing the virtual image it is convenient to set up a shared folder between your host system and the virtual machine to exchange model files and outputs.
+The \aspect{} project provides an experimental virtual machine containing a
+fully configured version of \aspect{}. To use this machine, you will need to
+install VirtualBox (\url{http://www.virtualbox.org/}) on your machine, and then
+import a virtual machine image that can be downloaded from
+\url{http://www.math.clemson.edu/~heister/dealvm/}. Note, however, that the
+machine image is several gigabytes in size and downloading will take a while.
+After downloading and installing the virtual image it is convenient to set up a
+shared folder between your host system and the virtual machine to exchange model
+files and outputs.
 
 \subsubsection{Running \aspect{} models}
 
-The internal setup of the virtual machine is similar to the Docker container discussed above, except that it contains a full-featured desktop environment. Also note that the user name is \texttt{ubuntu}, not \texttt{dealii} as in the Docker container. Again there are multiple ways to use the virtual machine, but we recommend the following workflow:
+The internal setup of the virtual machine is similar to the Docker container
+discussed above, except that it contains a full-featured desktop environment.
+Also note that the user name is \texttt{ubuntu}, not \texttt{dealii} as in the
+Docker container. Again there are multiple ways to use the virtual machine, but
+we recommend the following workflow:
 
 \begin{enumerate}
-\item Create your \aspect{} input file in the shared folder and start the virtual machine.
+\item Create your \aspect{} input file in the shared folder and start the
+virtual machine.
 \item Navigate in a terminal to your model directory.
 \item Run your model using the provided \aspect{} executable:
 
-\begin{verbatim}
+\begin{lstlisting}[frame=single,language=ksh]
 ~/aspect/aspect your_input_file.prm
-\end{verbatim}
+\end{lstlisting}
 
-\item The model output should automatically appear on your host machine in the shared directory.
+\item The model output should automatically appear on your host machine in the
+shared directory.
 
-\item After you have verified that your model setup is correct, you might want to consider recompiling \aspect{} in release mode to increase the speed of the computation. See Section~\ref{sec:debug-mode} for a discussion of debug and release mode.
+\item After you have verified that your model setup is correct, you might want
+to consider recompiling \aspect{} in release mode to increase the speed of the
+computation. See Section~\ref{sec:debug-mode} for a discussion of debug and
+release mode.
 
-\item Visualize your model output either inside of the virtual machine (ParaView and VisIt are pre-installed), or outside on your host system.
+\item Visualize your model output either inside of the virtual machine
+(ParaView and VisIt are pre-installed), or outside on your host system.
 \end{enumerate}
 
-You are all set. Repeat steps 1-6 of this process as necessary when updating your model parameters. 
+You are all set. Repeat steps 1-6 of this process as necessary when updating
+your model parameters. 
 
 \subsection{Local installation}
 

--- a/doc/release-tasklist
+++ b/doc/release-tasklist
@@ -4,6 +4,8 @@
     . go through the list of TODOs in the source code and see what can be done
     . make sure the description of the interfaces that need to be updated
       are up to date in the manual
+    . update the used deal.II version for the Docker container in docker/Dockerfile
+      and in the manual
     . check that readme.html is okay and the links to the mailinglists are
       working (also in manual.pdf)
     . run (and be patient):

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,9 +2,6 @@ FROM dealii/dealii:v8.5.pre.4-gcc-mpi-fulldepsmanual-debugrelease
 
 LABEL maintainer <rene.gassmoeller@mailbox.org>
 
-# We do not need the deal.II source in this image
-RUN rm -rf dealii-v8.4.2-src
-
 # Build aspect
 RUN git clone https://github.com/geodynamics/aspect.git ./aspect && \ 
     mkdir aspect/build && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,9 @@ RUN git clone https://github.com/geodynamics/aspect.git ./aspect && \
           -DDEAL_II_DIR=$HOME/deal.II-install \
           .. && \
     make -j4 >log 2>&1 && \
-    mv aspect $HOME/aspect/aspect-debug && \
+    mv aspect $HOME/aspect/aspect && \
     make clean
+
+ENV ASPECT_DIR /home/dealii/aspect/build-debug
 
 WORKDIR /home/dealii/aspect

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,19 +4,22 @@ LABEL maintainer <rene.gassmoeller@mailbox.org>
 
 # Build aspect
 RUN git clone https://github.com/geodynamics/aspect.git ./aspect && \ 
-    mkdir aspect/build && \
-    cd aspect/build && \
+    mkdir aspect/build-release && \
+    cd aspect/build-release && \
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DDEAL_II_DIR=$HOME/deal.II-install \
           .. && \
     make -j4 >log 2>&1 && \
-    mv aspect $HOME/aspect/aspect-release && \
+    mv aspect ../aspect-release && \
+    make clean && \
+    cd .. && \
+    mkdir build-debug && \
+    cd build-debug && \
     cmake -DCMAKE_BUILD_TYPE=Debug \
           -DDEAL_II_DIR=$HOME/deal.II-install \
           .. && \
     make -j4 >log 2>&1 && \
     mv aspect $HOME/aspect/aspect-debug && \
-    cd .. && \
-    rm -rf build
+    make clean
 
 WORKDIR /home/dealii/aspect

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,6 @@
 FROM ubuntu:14.04
 
-MAINTAINER Rene Gassmoeller <r.gassmoeller@mailbox.org>
-
-ENV HOME /root
+LABEL maintainer <rene.gassmoeller@mailbox.org>
 
 RUN apt-get update
 RUN apt-get -yq install gcc \
@@ -20,16 +18,22 @@ RUN apt-get -yq install gcc \
                         cmake \
                         git
 
+RUN adduser aspect_user
+USER aspect_user
+ENV HOME /home/aspect_user
+WORKDIR /home/aspect_user
+
 #Build HDF5
-RUN wget http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.13.tar.bz2; \
-    tar xjvf hdf5-1.8.13.tar.bz2; \
-    cd hdf5-1.8.13; \
+RUN wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.bz2; \
+    tar xjvf hdf5-1.10.0-patch1.tar.bz2; \
+    cd hdf5-1.10.0-patch1; \
     ./configure --enable-parallel \
                 --enable-shared \
-                --prefix=/usr/local/; \
-    make -j2 && make install; \
+                --prefix=$HOME/hdf5-1.10.0-install; \
+    make -j4 && make install; \
     cd ..; \
-    rm -rf /hdf5-1.8.13 /hdf5-1.8.13.tar.bz2 
+    rm -rf hdf5-1.10.0-patch1 hdf5-1.10.0-patch1.tar.bz2
+ENV HDF5_DIR /home/aspect_user/hdf5-1.10.0-install
 
 #Build Trilinos
 RUN wget http://trilinos.sandia.gov/download/files/trilinos-11.8.1-Source.tar.bz2; \
@@ -39,6 +43,7 @@ RUN wget http://trilinos.sandia.gov/download/files/trilinos-11.8.1-Source.tar.bz
     cmake -D Trilinos_ENABLE_Sacado=ON \
           -D Trilinos_ENABLE_Stratimikos=ON \
           -D CMAKE_BUILD_TYPE=RELEASE \
+          -D CMAKE_INSTALL_PREFIX=$HOME/trilinos-11.8.1-install \
           -D CMAKE_CXX_FLAGS="-O3" \
           -D CMAKE_C_FLAGS="-O3" \
           -D CMAKE_FORTRAN_FLAGS="-O5" \
@@ -51,40 +56,42 @@ RUN wget http://trilinos.sandia.gov/download/files/trilinos-11.8.1-Source.tar.bz
     make -j4 && make install; \
     cd ../..; \
     rm -rf trilinos-11.8.1-Source trilinos-11.8.1-Source.tar.bz2 
+ENV TRILINOS_DIR /home/aspect_user/trilinos-11.8.1-install
 
 #Build p4est
 RUN wget http://p4est.github.io/release/p4est-0.3.4.2.tar.gz; \
     wget http://www.dealii.org/developer/external-libs/p4est-setup.sh; \
     chmod +x p4est-setup.sh; \
-    ./p4est-setup.sh p4est-0.3.4.2.tar.gz /usr/local/p4est-0.3.4.2; \
+    ./p4est-setup.sh p4est-0.3.4.2.tar.gz $HOME/p4est-0.3.4.2-install; \
     rm -rf p4est-build p4est-0.3.4.2 p4est-setup.sh p4est-0.3.4.2.tar.gz
+ENV P4EST_DIR /home/aspect_user/p4est-0.3.4.2-install
 
 #Build deal.II
-RUN wget http://www.ces.clemson.edu/dealii/deal.II-8.1.0.tar.gz; \
-    tar xzvf deal.II-8.1.0.tar.gz; \
-    mkdir deal.II/build; \
-    cd deal.II/build; \
+RUN wget http://github.com/dealii/dealii/releases/download/v8.4.2/dealii-8.4.2.tar.gz && \
+    tar xzvf dealii-8.4.2.tar.gz && \
+    mkdir dealii-8.4.2/build && \
+    cd dealii-8.4.2/build && \
     cmake -DDEAL_II_WITH_MPI=ON \
           -DDEAL_II_COMPONENT_COMPAT_FILES=OFF \
           -DDEAL_II_COMPONENT_EXAMPLES=OFF \
-          -DCMAKE_INSTALL_PREFIX=/usr/local \
+          -DCMAKE_INSTALL_PREFIX=$HOME/deal.II-8.4.2-install \
           -DCMAKE_BUILD_TYPE=Release \
-          -DP4EST_DIR=/usr/local/p4est-0.3.4.2/ \
-          .. ; \
-    make -j4 && make install; \
-    cd ../..; \
-    rm -rf deal.II deal.II-8.1.0.tar.gz
+          .. && \
+    make -j4 && make install && \
+    cd ../.. && \
+    rm -rf dealii-8.4.2 dealii-8.4.2.tar.gz
+ENV DEAL_II_DIR /home/aspect_user/deal.II-8.4.2-install
 
 #Build aspect
-RUN git clone https://github.com/geodynamics/aspect.git; \ 
-    mkdir aspect/build; \
-    cd aspect/build; \
+RUN git clone https://github.com/geodynamics/aspect.git ./aspect && \ 
+    mkdir aspect/build && \
+    cd aspect/build && \
     cmake -DCMAKE_BUILD_TYPE=Release \
-          -DDEAL_II_DIR=/usr/local/deal.II \
-          .. ; \
-    make -j4; \
-    mv aspect /usr/local/bin/; \
-    cd /\
-    rm -rf aspect
+          -DDEAL_II_DIR=$HOME/deal.II-install \
+          .. && \
+    make -j4 && \
+    mv aspect $HOME/aspect/ && \
+    cd .. && \
+    rm -rf build
 
-CMD ["aspect"]
+WORKDIR /home/aspect_user/aspect

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM dealii/dealii:v8.4.2-gcc-mpi-fulldepsmanual-debugrelease
+FROM dealii/dealii:v8.5.pre.4-gcc-mpi-fulldepsmanual-debugrelease
 
 LABEL maintainer <rene.gassmoeller@mailbox.org>
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN git clone https://github.com/geodynamics/aspect.git ./aspect && \
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DDEAL_II_DIR=$HOME/deal.II-install \
           .. && \
-    make -j4 && \
+    make -j4 >log 2>&1 && \
     mv aspect $HOME/aspect/ && \
     cd .. && \
     rm -rf build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,12 @@ RUN git clone https://github.com/geodynamics/aspect.git ./aspect && \
           -DDEAL_II_DIR=$HOME/deal.II-install \
           .. && \
     make -j4 >log 2>&1 && \
-    mv aspect $HOME/aspect/ && \
+    mv aspect $HOME/aspect/aspect-release && \
+    cmake -DCMAKE_BUILD_TYPE=Debug \
+          -DDEAL_II_DIR=$HOME/deal.II-install \
+          .. && \
+    make -j4 >log 2>&1 && \
+    mv aspect $HOME/aspect/aspect-debug && \
     cd .. && \
     rm -rf build
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,88 +1,11 @@
-FROM ubuntu:14.04
+FROM dealii/dealii:v8.4.2-gcc-mpi-fulldepsmanual-debugrelease
 
 LABEL maintainer <rene.gassmoeller@mailbox.org>
 
-RUN apt-get update
-RUN apt-get -yq install gcc \
-                        build-essential \
-                        wget \
-                        bzip2 \
-                        tar \
-                        g++ \
-                        gfortran \
-                        libblas-dev \
-                        liblapack-dev \
-                        libboost-dev \
-                        libopenmpi-dev \
-                        openmpi-bin \
-                        cmake \
-                        git
+# We do not need the deal.II source in this image
+RUN rm -rf dealii-v8.4.2-src
 
-RUN adduser aspect_user
-USER aspect_user
-ENV HOME /home/aspect_user
-WORKDIR /home/aspect_user
-
-#Build HDF5
-RUN wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.bz2; \
-    tar xjvf hdf5-1.10.0-patch1.tar.bz2; \
-    cd hdf5-1.10.0-patch1; \
-    ./configure --enable-parallel \
-                --enable-shared \
-                --prefix=$HOME/hdf5-1.10.0-install; \
-    make -j4 && make install; \
-    cd ..; \
-    rm -rf hdf5-1.10.0-patch1 hdf5-1.10.0-patch1.tar.bz2
-ENV HDF5_DIR /home/aspect_user/hdf5-1.10.0-install
-
-#Build Trilinos
-RUN wget http://trilinos.sandia.gov/download/files/trilinos-11.8.1-Source.tar.bz2; \
-    tar xjvf trilinos-11.8.1-Source.tar.bz2; \
-    mkdir trilinos-11.8.1-Source/build; \
-    cd trilinos-11.8.1-Source/build; \
-    cmake -D Trilinos_ENABLE_Sacado=ON \
-          -D Trilinos_ENABLE_Stratimikos=ON \
-          -D CMAKE_BUILD_TYPE=RELEASE \
-          -D CMAKE_INSTALL_PREFIX=$HOME/trilinos-11.8.1-install \
-          -D CMAKE_CXX_FLAGS="-O3" \
-          -D CMAKE_C_FLAGS="-O3" \
-          -D CMAKE_FORTRAN_FLAGS="-O5" \
-          -D Trilinos_EXTRA_LINK_FLAGS="-lgfortran" \
-          -D CMAKE_VERBOSE_MAKEFILE=FALSE \
-          -D Trilinos_VERBOSE_CONFIGURE=FALSE \
-          -D TPL_ENABLE_MPI=ON \
-          -D BUILD_SHARED_LIBS=ON \
-          .. ; \
-    make -j4 && make install; \
-    cd ../..; \
-    rm -rf trilinos-11.8.1-Source trilinos-11.8.1-Source.tar.bz2 
-ENV TRILINOS_DIR /home/aspect_user/trilinos-11.8.1-install
-
-#Build p4est
-RUN wget http://p4est.github.io/release/p4est-0.3.4.2.tar.gz; \
-    wget http://www.dealii.org/developer/external-libs/p4est-setup.sh; \
-    chmod +x p4est-setup.sh; \
-    ./p4est-setup.sh p4est-0.3.4.2.tar.gz $HOME/p4est-0.3.4.2-install; \
-    rm -rf p4est-build p4est-0.3.4.2 p4est-setup.sh p4est-0.3.4.2.tar.gz
-ENV P4EST_DIR /home/aspect_user/p4est-0.3.4.2-install
-
-#Build deal.II
-RUN wget http://github.com/dealii/dealii/releases/download/v8.4.2/dealii-8.4.2.tar.gz && \
-    tar xzvf dealii-8.4.2.tar.gz && \
-    mkdir dealii-8.4.2/build && \
-    cd dealii-8.4.2/build && \
-    cmake -DDEAL_II_WITH_MPI=ON \
-          -DDEAL_II_COMPONENT_COMPAT_FILES=OFF \
-          -DDEAL_II_COMPONENT_EXAMPLES=OFF \
-          -DCMAKE_INSTALL_PREFIX=$HOME/deal.II-8.4.2-install \
-          -DCMAKE_BUILD_TYPE=Release \
-          .. && \
-    make -j4 && make install && \
-    cd ../.. && \
-    rm -rf dealii-8.4.2 dealii-8.4.2.tar.gz
-ENV DEAL_II_DIR /home/aspect_user/deal.II-8.4.2-install
-
-#Build aspect
+# Build aspect
 RUN git clone https://github.com/geodynamics/aspect.git ./aspect && \ 
     mkdir aspect/build && \
     cd aspect/build && \
@@ -94,4 +17,4 @@ RUN git clone https://github.com/geodynamics/aspect.git ./aspect && \
     cd .. && \
     rm -rf build
 
-WORKDIR /home/aspect_user/aspect
+WORKDIR /home/dealii/aspect

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,6 +5,6 @@
 # communicate with the docker daemon without root user privileges (see the docker
 # webpage for an explanation).
 # Note: This container is build from the developer version on Github, it does not use
-# the local ASPECT folder.
+# the local ASPECT folder. Therefore local changes are not included in the container.
 
-docker build -t geodynamics/aspect .
+docker build -t gassmoeller/aspect .

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script generates a docker image from the latest aspect development version.
+# It requires a docker installation on the local machine, and the ability to
+# communicate with the docker daemon without root user privileges (see the docker
+# webpage for an explanation).
+# Note: This container is build from the developer version on Github, it does not use
+# the local ASPECT folder.
+
+docker build -t geodynamics/aspect .


### PR DESCRIPTION
Following the recent discussion about docker containers on the mailing list, I thought it would be nice to have a more practical discussion, including an example for how such a image could look like, and how the workflow of running a model would look like. When reading into the topic again I noticed some improvements on Docker's side since I last read about it (~1-2 years ago). Installation on Ubuntu is now better explained, and some comfort features I was missing before have been added (like cleanup of finished containers and dangling images: `docker container prune` and `docker image prune`). Unfortunately they introduced the cool new Docker for Windows app that only runs on Win 10 Professional, and hide the legacy solution for Win 10 Home pretty well (it is called docker toolbox, if anyone is looking for it). Nevertheless, also docker-toolbox for Win10 Home is pretty easy to use.

With an installed docker engine installing and running aspect is super simple:
`docker pull gassmoeller/aspect` will download the image
`docker run -it gassmoeller/aspect bash` will start a shell in the container, with precompiled aspect and ready to do. Mounting a volume into the container is explained in the manual entry I wrote.

Things we should discuss:
1. Do we want to offer this option? This should be answered after discussing the remaining questions.
2. Is my description of a typical use case in the manual accurate? I remember several occasions, where I had 1-4 hrs to sit together with somebody and discuss how to run their problem in ASPECT. In each of these cases I would have loved to have the docker image, because it would have allowed to set up the user to further develop their model. So far I either: 1. created an input file on my machine, and after the session send them the file, more or less saying: Figure out how you install ASPECT on your machine, then you can use this file. Or 2. Download the virtual image if there is a fast enough internet connection, and set them up in the virtual machine (with the disadvantage described on the mailing list, that one does not usually like to work in a different desktop environment than one is used to).
3. Is the current setup a reasonable one? Should we rely on the deal.II docker files, or offer our own solution? Building on deal.II requires less work on our side, but as far as I understood the dealii files are not officially supported either, so they might change, or be removed at some point. 
4. For whatever reason the current Dockerfile does not automatically build on docker hub. As far as I can tell we do not violate their build limitations (1CPU, 2GB RAM, 2hrs build time), but for the moment I need to manually rebuild the image. I could do this on a regular basis (e.g. 1/day) to keep the image up-to-date with the master branch.
5. In the current form I only build ASPECT in release mode. If we decide to offer the image we should probably include compiled debug and release versions with the same advice as always: test debug mode, before running release mode.

Although I was skeptical 2 years ago, I have to say I think the docker option is an alternative for many users. Not necessarily for tutorial usage, but more for users with installation problems (I spent several days installing aspect on OpenSUSE, and I know of many people having issues with older MacOS versions, all of those would benefit from this option).