### PR TITLE
Implement make_pressure_rhs_compatible for compressible computations

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -12,5 +12,10 @@
  * <br>
  * (Timo Heister, 2017/03/24)
  *
+ * <li> New: Compressible computations now work with discontinuous pressure
+ * elements.
+ * <br>
+ * (Timo Heister, 2017/03/23)
+ *
  * </ol>
  */

--- a/tests/pressure_compatibility_dg.prm
+++ b/tests/pressure_compatibility_dg.prm
@@ -1,0 +1,8 @@
+# like pressure_compatibility.prm but with DG pressure
+# MPI: 2
+
+include $ASPECT_SOURCE_DIR/tests/pressure_compatibility.prm
+
+subsection Discretization
+  set Use locally conservative discretization = true
+end

--- a/tests/pressure_compatibility_dg/screen-output
+++ b/tests/pressure_compatibility_dg/screen-output
@@ -1,0 +1,41 @@
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 1,059 (578+192+289)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 21+0 iterations.
+
+   Postprocessing:
+     Temperature min/avg/max:            0 K, 0.5 K, 1 K
+     Heat fluxes through boundary parts: 2.506e-23 W, -6.746e-23 W, -2e-06 W, 2e-06 W
+     RMS, max velocity:                  0.352 m/s, 1.01 m/s
+
+*** Timestep 1:  t=0.0625 seconds
+   Solving temperature system... 13 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 16+0 iterations.
+
+   Postprocessing:
+     Temperature min/avg/max:            0 K, 0.4995 K, 1 K
+     Heat fluxes through boundary parts: 1.569e-08 W, 1.571e-08 W, -1.997e-06 W, 2.165e-06 W
+     RMS, max velocity:                  0.352 m/s, 1.01 m/s
+
+*** Timestep 2:  t=0.1 seconds
+   Solving temperature system... 12 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 20+0 iterations.
+
+   Postprocessing:
+     Temperature min/avg/max:            0 K, 0.4994 K, 1 K
+     Heat fluxes through boundary parts: 2.6e-08 W, 2.595e-08 W, -1.999e-06 W, 2.247e-06 W
+     RMS, max velocity:                  0.352 m/s, 1.01 m/s
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/pressure_compatibility_dg/statistics
+++ b/tests/pressure_compatibility_dg/statistics
@@ -1,0 +1,23 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Minimal temperature (K)
+# 12: Average temperature (K)
+# 13: Maximal temperature (K)
+# 14: Average nondimensional temperature (K)
+# 15: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 16: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 17: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 18: Outward heat flux through boundary with indicator 3 ("top") (W)
+# 19: RMS velocity (m/s)
+# 20: Max. velocity (m/s)
+0 0.000000000000e+00 0.000000000000e+00 64 770 289  0 21 22 22 0.00000000e+00 5.00000000e-01 1.00000000e+00 5.00000000e-01 2.50571169e-23 -6.74614685e-23 -2.00000000e-06 2.00000000e-06 3.51988910e-01 1.00549804e+00 
+1 6.250000000000e-02 6.250000000000e-02 64 770 289 13 16 17 17 0.00000000e+00 4.99516391e-01 1.00000000e+00 4.99516391e-01 1.56851952e-08  1.57080333e-08 -1.99734492e-06 2.16514368e-06 3.51688252e-01 1.00890949e+00 
+2 1.000000000000e-01 3.750000000000e-02 64 770 289 12 20 21 21 0.00000000e+00 4.99370188e-01 1.00000000e+00 4.99370188e-01 2.59995608e-08  2.59535675e-08 -1.99899395e-06 2.24710459e-06 3.51913433e-01 1.00809513e+00 

--- a/tests/pressure_compatibility_dg_direct.prm
+++ b/tests/pressure_compatibility_dg_direct.prm
@@ -1,0 +1,10 @@
+# like pressure_compatibility.prm but with DG pressure and a direct solver
+# MPI: 2
+
+include $ASPECT_SOURCE_DIR/tests/pressure_compatibility.prm
+
+set Use direct solver for Stokes system    = true
+
+subsection Discretization
+  set Use locally conservative discretization = true
+end

--- a/tests/pressure_compatibility_dg_direct/screen-output
+++ b/tests/pressure_compatibility_dg_direct/screen-output
@@ -1,0 +1,38 @@
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 1,059 (770+289)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving Stokes system... done.
+
+   Postprocessing:
+     Temperature min/avg/max:            0 K, 0.5 K, 1 K
+     Heat fluxes through boundary parts: 2.506e-23 W, -6.746e-23 W, -2e-06 W, 2e-06 W
+     RMS, max velocity:                  0.352 m/s, 1.01 m/s
+
+*** Timestep 1:  t=0.0625 seconds
+   Solving temperature system... 13 iterations.
+   Solving Stokes system... done.
+
+   Postprocessing:
+     Temperature min/avg/max:            0 K, 0.4995 K, 1 K
+     Heat fluxes through boundary parts: 1.569e-08 W, 1.571e-08 W, -1.997e-06 W, 2.165e-06 W
+     RMS, max velocity:                  0.352 m/s, 1.01 m/s
+
+*** Timestep 2:  t=0.1 seconds
+   Solving temperature system... 12 iterations.
+   Solving Stokes system... done.
+
+   Postprocessing:
+     Temperature min/avg/max:            0 K, 0.4994 K, 1 K
+     Heat fluxes through boundary parts: 2.6e-08 W, 2.595e-08 W, -1.999e-06 W, 2.247e-06 W
+     RMS, max velocity:                  0.352 m/s, 1.01 m/s
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/pressure_compatibility_dg_direct/statistics
+++ b/tests/pressure_compatibility_dg_direct/statistics
@@ -1,0 +1,20 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Minimal temperature (K)
+# 9: Average temperature (K)
+# 10: Maximal temperature (K)
+# 11: Average nondimensional temperature (K)
+# 12: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 13: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 14: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 15: Outward heat flux through boundary with indicator 3 ("top") (W)
+# 16: RMS velocity (m/s)
+# 17: Max. velocity (m/s)
+0 0.000000000000e+00 0.000000000000e+00 64 770 289  0 0.00000000e+00 5.00000000e-01 1.00000000e+00 5.00000000e-01 2.50571169e-23 -6.74614685e-23 -2.00000000e-06 2.00000000e-06 3.51988910e-01 1.00549804e+00 
+1 6.250000000000e-02 6.250000000000e-02 64 770 289 13 0.00000000e+00 4.99516391e-01 1.00000000e+00 4.99516391e-01 1.56851951e-08  1.57080335e-08 -1.99734492e-06 2.16514368e-06 3.51688276e-01 1.00890949e+00 
+2 1.000000000000e-01 3.750000000000e-02 64 770 289 12 0.00000000e+00 4.99370188e-01 1.00000000e+00 4.99370188e-01 2.59995621e-08  2.59535702e-08 -1.99899396e-06 2.24710459e-06 3.51913429e-01 1.00809513e+00 

--- a/tests/pressure_compatibility_direct.prm
+++ b/tests/pressure_compatibility_direct.prm
@@ -1,0 +1,7 @@
+# like pressure_compatibility.prm but with a direct solver
+# MPI: 2
+
+include $ASPECT_SOURCE_DIR/tests/pressure_compatibility.prm
+
+set Use direct solver for Stokes system    = true
+

--- a/tests/pressure_compatibility_direct/screen-output
+++ b/tests/pressure_compatibility_direct/screen-output
@@ -1,0 +1,38 @@
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 948 (659+289)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving Stokes system... done.
+
+   Postprocessing:
+     Temperature min/avg/max:            0 K, 0.5 K, 1 K
+     Heat fluxes through boundary parts: 2.506e-23 W, -6.746e-23 W, -2e-06 W, 2e-06 W
+     RMS, max velocity:                  0.353 m/s, 1.02 m/s
+
+*** Timestep 1:  t=0.0625 seconds
+   Solving temperature system... 13 iterations.
+   Solving Stokes system... done.
+
+   Postprocessing:
+     Temperature min/avg/max:            0 K, 0.4995 K, 1 K
+     Heat fluxes through boundary parts: 1.746e-08 W, 1.801e-08 W, -1.999e-06 W, 2.17e-06 W
+     RMS, max velocity:                  0.352 m/s, 1.02 m/s
+
+*** Timestep 2:  t=0.1 seconds
+   Solving temperature system... 12 iterations.
+   Solving Stokes system... done.
+
+   Postprocessing:
+     Temperature min/avg/max:            0 K, 0.4994 K, 1 K
+     Heat fluxes through boundary parts: 2.867e-08 W, 2.956e-08 W, -2.002e-06 W, 2.265e-06 W
+     RMS, max velocity:                  0.352 m/s, 1.02 m/s
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/pressure_compatibility_direct/statistics
+++ b/tests/pressure_compatibility_direct/statistics
@@ -1,0 +1,20 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Minimal temperature (K)
+# 9: Average temperature (K)
+# 10: Maximal temperature (K)
+# 11: Average nondimensional temperature (K)
+# 12: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 13: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 14: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 15: Outward heat flux through boundary with indicator 3 ("top") (W)
+# 16: RMS velocity (m/s)
+# 17: Max. velocity (m/s)
+0 0.000000000000e+00 0.000000000000e+00 64 659 289  0 0.00000000e+00 5.00000000e-01 1.00000000e+00 5.00000000e-01 2.50571169e-23 -6.74614685e-23 -2.00000000e-06 2.00000000e-06 3.52685341e-01 1.02187233e+00 
+1 6.250000000000e-02 6.250000000000e-02 64 659 289 13 0.00000000e+00 4.99525356e-01 1.00000000e+00 4.99525356e-01 1.74551452e-08  1.80066089e-08 -1.99882611e-06 2.16996117e-06 3.52353361e-01 1.02484046e+00 
+2 1.000000000000e-01 3.750000000000e-02 64 659 289 12 0.00000000e+00 4.99387196e-01 1.00000000e+00 4.99387196e-01 2.86714655e-08  2.95649259e-08 -2.00163357e-06 2.26450018e-06 3.52495632e-01 1.02339474e+00 


### PR DESCRIPTION
Completely re-implement make_pressure_rhs_compatible to handle all
combinations of
1. CG vs DG
2. direct vs iterative solver
3. melt vs no melt

(except melt and DG)

and add documentation and tests.

Bonus: remove wrong assert in denormalize_pressure that would trigger for parallel DG computations with a direct solver.