### PR TITLE
fix a bug in the latent heat material & add min and max viscosity

### DIFF
--- a/include/aspect/material_model/latent_heat.h
+++ b/include/aspect/material_model/latent_heat.h
@@ -114,6 +114,8 @@ namespace aspect
         double thermal_alpha;
         double reference_specific_heat;
         double reference_compressibility;
+        double max_viscosity;
+        double min_viscosity;
 
         /**
          * The thermal conductivity.

--- a/source/material_model/latent_heat.cc
+++ b/source/material_model/latent_heat.cc
@@ -208,6 +208,7 @@ namespace aspect
             // this means, that there are no actual density "jumps", but gradual
             // transition between the materials
             double phase_dependence = 0.0;
+            double viscosity_phase_dependence = 1.0;
 
             // transitions defined by depth
             unsigned int number_of_phase_transitions;
@@ -228,6 +229,7 @@ namespace aspect
                                                                  i);
 
                     phase_dependence += phaseFunction * density_jumps[i];
+                    viscosity_phase_dependence *= 1 + phaseFunction * (phase_prefactors[i+1]-1);
                   }
               }
             else if (composition.size()>0)
@@ -242,6 +244,7 @@ namespace aspect
                       phase_dependence += phaseFunction * density_jumps[i] * (1.0 - composition[0]);
                     else if (transition_phases[i] == 1) // 2nd compositional field
                       phase_dependence += phaseFunction * density_jumps[i] * composition[0];
+                    viscosity_phase_dependence *= 1 + phaseFunction * (phase_prefactors[i]-1);
                   }
               }
             // fourth, pressure dependence of density
@@ -251,6 +254,7 @@ namespace aspect
             // in the end, all the influences are added up
             out.densities[i] = (reference_rho + density_composition_dependence + pressure_dependence + phase_dependence)
                                * density_temperature_dependence;
+            out.viscosities[i] = std::max(min_viscosity, std::min(max_viscosity, out.viscosities[i] * viscosity_phase_dependence));
           }
 
           // Calculate entropy derivative
@@ -449,6 +453,14 @@ namespace aspect
                              "viscosity for each phase. "
                              "List must have one more entry than Phase transition depths. "
                              "Units: non-dimensional.");
+          prm.declare_entry ("Minimum viscosity", "1e19",
+                             Patterns::List (Patterns::Double(0)),
+                             "Limit for the minimum viscosity in the model. "
+                             "Units: Pa s.");
+          prm.declare_entry ("Maximum viscosity", "1e24",
+                             Patterns::List (Patterns::Double(0)),
+                             "Limit for the maximum viscosity in the model. "
+                             "Units: Pa s.");
         }
         prm.leave_subsection();
       }
@@ -475,6 +487,9 @@ namespace aspect
           thermal_alpha              = prm.get_double ("Thermal expansion coefficient");
           reference_compressibility  = prm.get_double ("Compressibility");
           compositional_delta_rho    = prm.get_double ("Density differential for compositional field 1");
+          min_viscosity              = prm.get_double ("Minimum viscosity");
+          max_viscosity              = prm.get_double ("Maximum viscosity");
+
 
           transition_depths = Utilities::string_to_double
                               (Utilities::split_string_list(prm.get ("Phase transition depths")));
@@ -505,7 +520,10 @@ namespace aspect
                   density_jumps.size() != transition_depths.size() ||
                   transition_phases.size() != transition_depths.size() ||
                   phase_prefactors.size() != transition_depths.size()+1)
-                AssertThrow(false, ExcMessage("Error: At least one list that gives input parameters for the phase transitions has the wrong size. Currently checking against transition depths. If phase transitions in terms of pressure inputs are desired,check to make sure Define transition by depth instead of pressure = false. "));
+                AssertThrow(false, ExcMessage("Error: At least one list that gives input parameters for the phase "
+                                              "transitions has the wrong size. Currently checking against transition depths. "
+                                              "If phase transitions in terms of pressure inputs are desired, check to make sure "
+                                              "'Define transition by depth instead of pressure = false'."));
             }
           // make sure to check against the pressure lists for size errors,
           // since pressure is being used instead of depth.
@@ -517,8 +535,19 @@ namespace aspect
                   density_jumps.size() != transition_pressures.size() ||
                   transition_phases.size() != transition_pressures.size() ||
                   phase_prefactors.size() != transition_pressures.size()+1)
-                AssertThrow(false, ExcMessage("Error: At least one list that gives input parameters for the phase transitions has the wrong size. Currently checking against transition pressures. If phase transitions in terms of depth are desired, check to make sure Define transition by depth instead of pressure = true."));
+                AssertThrow(false, ExcMessage("Error: At least one list that gives input parameters for the phase "
+                                              "transitions has the wrong size. Currently checking against transition pressures. "
+                                              "If phase transitions in terms of depth inputs are desired, check to make sure "
+                                              "'Define transition by depth instead of pressure = true'."));
             }
+
+          // as the phase viscosity prefactors are all applied on top of each other, we have
+          // to scale them here so that they are relative gactors in comparison to the phase above
+          for (unsigned int phase=1; phase<phase_prefactors.size(); ++phase)
+            {
+              phase_prefactors[phase] /= phase_prefactors[phase-1];
+            }
+
           if (thermal_viscosity_exponent!=0.0 && reference_T == 0.0)
             AssertThrow(false, ExcMessage("Error: Material model latent heat with Thermal viscosity exponent can not have reference_T=0."));
         }

--- a/tests/latent_heat_viscosity.prm
+++ b/tests/latent_heat_viscosity.prm
@@ -1,0 +1,123 @@
+# A simple setup for for using the GPlates interface in a 2d shell
+# with the latent heat material model. It tests the feature of the
+# latent heat material model to use a layered viscosity profile. 
+
+set Dimension                              = 2
+set Use years in output instead of seconds = true
+set End time                               = 3e8
+set Output directory                       = output_energy_density
+set Adiabatic surface temperature          = 1600
+set Resume computation                     = false
+
+
+subsection Material model
+  set Model name = latent heat
+
+  subsection Latent heat
+    set Viscosity                     = 1e21
+    set Thermal viscosity exponent    = 15.0
+    set Reference temperature         = 1600
+    set Phase transition depths       = 410000, 660000
+    set Phase transition widths       = 20000, 20000
+    set Phase transition temperatures = 1600, 1600
+    set Phase transition Clapeyron slopes = 3e6, -2e6
+    set Phase transition density jumps = 100, 200
+    set Corresponding phase for density jump = 0, 0
+    set Viscosity prefactors          = 1, 10, 100
+  end
+end
+
+
+subsection Geometry model
+  set Model name = spherical shell
+
+  subsection Spherical shell
+    set Inner radius  = 3481000
+    set Outer radius  = 6336000
+  end
+end
+
+
+subsection Model settings
+  set Prescribed velocity boundary indicators = outer:gplates
+  set Tangential velocity boundary indicators = inner
+
+  set Fixed temperature boundary indicators   = inner, outer
+
+  set Include shear heating                   = false
+end
+
+
+subsection Boundary velocity model
+  subsection GPlates model
+    set Data directory = $ASPECT_SOURCE_DIR/data/velocity-boundary-conditions/gplates/
+    set Velocity file name = current_day.gpml
+    set Data file time step = 1e6
+    set Point one = 1.5708,4.87
+    set Point two = 1.5708,5.24
+  end
+end
+
+
+subsection Boundary temperature model
+  set Model name = spherical constant
+  subsection Spherical constant
+    set Inner temperature = 2600 
+    set Outer temperature = 273 
+  end
+end
+
+
+subsection Initial conditions
+  set Model name = adiabatic
+
+  subsection Adiabatic
+    set Age top boundary layer = 5e7
+  end
+end
+
+
+subsection Gravity model
+  set Model name = radial constant
+
+  subsection Radial constant
+    set Magnitude = 10
+  end
+end
+
+
+subsection Mesh refinement
+  set Refinement fraction                = 0.8
+  set Coarsening fraction                = 0.05
+  set Initial adaptive refinement        = 1
+  set Initial global refinement          = 3
+  set Strategy                           = thermal energy density
+  set Time steps between mesh refinement = 5
+end
+
+
+subsection Postprocess
+  set List of postprocessors = visualization, velocity statistics, temperature statistics, heat flux statistics, depth average
+
+  subsection Visualization
+    set Output format                 = vtu
+    set Time between graphical output = 1e6
+    set Number of grouped files       = 0
+    set List of output variables      = material properties
+  end
+
+  subsection Depth average
+    set Time between graphical output = 1e6
+  end
+end
+
+subsection Checkpointing
+  set Time between checkpoint  = 1800
+end
+
+subsection Termination criteria
+  set End step = 1
+  set Checkpoint on termination = true
+  set Termination criteria      = end step
+end
+

--- a/tests/latent_heat_viscosity/screen-output
+++ b/tests/latent_heat_viscosity/screen-output
@@ -1,0 +1,65 @@
+
+
+   Setting up GPlates boundary velocity plugin.
+
+   Input point 1 spherical coordinates: 1.571 4.870
+   Input point 1 normalized cartesian coordinates: 0.157 -0.988 0.000
+   Input point 1 rotated model coordinates: 0.157 -0.988 0.000
+   Input point 2 spherical coordinates: 1.571 5.240
+   Input point 2 normalized cartesian coordinates: 0.503 -0.864 0.000
+   Input point 2 rotated model coordinates: 0.503 -0.864 0.000
+
+   Model will be rotated by 0.00 degrees around axis 0.00 0.00 1.00
+   The ParaView rotation angles are: 0.00 0.00 0.00
+   The inverse ParaView rotation angles are: 0.00 0.00 0.00
+
+   Loading GPlates data boundary file ASPECT_DIR/data/velocity-boundary-conditions/gplates/current_day.gpml.
+
+
+   Loading new velocity file did not succeed.
+   Assuming constant boundary conditions for rest of model run.
+
+Number of active cells: 768 (on 4 levels)
+Number of degrees of freedom: 10,656 (6,528+864+3,264)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 170+0 iterations.
+
+Number of active cells: 2,754 (on 5 levels)
+Number of degrees of freedom: 38,446 (23,600+3,046+11,800)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 138+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:           output-latent_heat_viscosity/solution/solution-00000
+     RMS, max velocity:                  0.0168 m/year, 0.078 m/year
+     Temperature min/avg/max:            273 K, 1586 K, 2600 K
+     Heat fluxes through boundary parts: -8.798e+05 W, 1.98e+06 W
+     Writing depth average:              output-latent_heat_viscosity/depth_average.gnuplot
+
+*** Timestep 1:  t=1.15653e+06 years
+   Solving temperature system... 12 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 109+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:           output-latent_heat_viscosity/solution/solution-00001
+     RMS, max velocity:                  0.0192 m/year, 0.0775 m/year
+     Temperature min/avg/max:            273 K, 1583 K, 2600 K
+     Heat fluxes through boundary parts: -8.603e+05 W, 1.796e+06 W
+     Writing depth average:              output-latent_heat_viscosity/depth_average.gnuplot
+
+Termination requested by criterion: end step
+*** Snapshot created!
+
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/latent_heat_viscosity/statistics
+++ b/tests/latent_heat_viscosity/statistics
@@ -1,0 +1,22 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Visualization file name
+# 12: RMS velocity (m/year)
+# 13: Max. velocity (m/year)
+# 14: Minimal temperature (K)
+# 15: Average temperature (K)
+# 16: Maximal temperature (K)
+# 17: Average nondimensional temperature (K)
+# 18: Outward heat flux through boundary with indicator 0 ("inner") (W)
+# 19: Outward heat flux through boundary with indicator 1 ("outer") (W)
+0 0.000000000000e+00 0.000000000000e+00  768  7392  3264  0 170 174 593                                                   "" 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00  0.00000000e+00 0.00000000e+00 
+0 0.000000000000e+00 0.000000000000e+00 2754 26646 11800  0 138 141 612 output-latent_heat_viscosity/solution/solution-00000 1.67644322e-02 7.80206239e-02 2.73000000e+02 1.58649246e+03 2.60000000e+03 5.64457437e-01 -8.79759446e+05 1.98031829e+06 
+1 1.156529473847e+06 1.156529473847e+06 2754 26646 11800 12 109 112 483 output-latent_heat_viscosity/solution/solution-00001 1.91635076e-02 7.75318970e-02 2.73000000e+02 1.58283646e+03 2.60000000e+03 5.62886316e-01 -8.60302168e+05 1.79610713e+06 


### PR DESCRIPTION
This pull request fixes a bug in the latent heat material model: there was an input parameter `Viscosity prefactors` that was documented and could be set in the input file, but was never used in the code and hence had no actual effect. With these changes, the parameter now does what the documentation says. In addition, parameters for setting a min and max viscosity is introduced. This brings the material to the state we used in our manuscript about numerical methods in ASPECT. 

I also want to see if this changes any tests, if not, I will add one.   