### PR TITLE
Fix King benchmark parameter file

### DIFF
--- a/benchmark/king2dcompressible/ala/ala.prm
+++ b/benchmark/king2dcompressible/ala/ala.prm
@@ -62,7 +62,7 @@ set Use direct solver for Stokes system    = false
 set Adiabatic surface temperature          = 0.091
 
 set Use years in output instead of seconds = false
-set End time                               = 1e20
+set End time                               = 10
 set Output directory                       = output
 
 subsection Discretization
@@ -73,12 +73,21 @@ subsection Discretization
   end
 end
 
-
-set Linear solver tolerance                = 1e-7
+set Linear solver tolerance                = 1e-9
 set Temperature solver tolerance           = 1e-10
 
 set Pressure normalization                 = surface
 set Surface pressure                       = 0
+
+subsection Termination criteria
+  set Checkpoint on termination = true
+  set Termination criteria = end time, steady state velocity
+
+  subsection Steady state velocity
+    set Maximum relative deviation = 1e-7
+    set Time in steady state       = 1
+  end
+end
 
 # In this section we define the adiabatic profiles of temperature, 
 # pressure and density. The temperature and density profiles are 
@@ -205,12 +214,11 @@ end
 # As we are only interested in the steady state, we start on a 
 # coarse mesh and refine once the solution is close to steady state.
 subsection Mesh refinement
-  set Initial global refinement                = 4
+  set Initial global refinement                = 7
   set Initial adaptive refinement              = 0
   set Time steps between mesh refinement       = 0
   set Coarsening fraction                      = 0.0
   set Refinement fraction                      = 1.0
-  set Additional refinement times              = 0.5, 1.0, 1.5, 2.0
 end
 
 
@@ -223,7 +231,7 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, visualization, depth average, heating statistics
 
   subsection Visualization
-    set Time between graphical output = 1e-3
+    set Time between graphical output = 1e-2
     set List of output variables      = material properties, adiabat, thermal conductivity, heating, artificial viscosity
   end
 end


### PR DESCRIPTION
When updating the run script I forgot to update the parameter file as well. No functional changes, only the termination criterion was wrong (the previous file would run forever). The change in linear solver tolerance does not change the result significantly, but I include it to exactly match the file we used for creating the official output.