### PR TITLE
Add legacy includes to make compile with deal.II 9.0.pre

### DIFF
--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -23,4 +23,12 @@
 
 #include <aspect/global.h>
 
+// C++11 related includes. Can be removed when we require C++11.
+#include <deal.II/base/std_cxx11/array.h>
+#include <deal.II/base/std_cxx11/bind.h>
+#include <deal.II/base/std_cxx11/function.h>
+#include <deal.II/base/std_cxx11/shared_ptr.h>
+#include <deal.II/base/std_cxx11/unique_ptr.h>
+
+
 #endif

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -21,6 +21,7 @@
 #ifndef _aspect_material_model_interface_h
 #define _aspect_material_model_interface_h
 
+#include <aspect/global.h>
 #include <aspect/plugins.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/quadrature.h>


### PR DESCRIPTION
When trying some things regarding #1361 I noticed that our current development version depends in many places on some internal includes in deal.II that were removed after 8.5. Since I assume we want to require 8.5 (and not 9.0 + C++11) for our next ASPECT release, we should fix this. I would advocate for dropping non C++11 support for ASPECT after the next release.