### PR TITLE
make screen output of nonlinear solver schemes more consistent

### DIFF
--- a/doc/modules/changes.h
+++ b/doc/modules/changes.h
@@ -7,6 +7,12 @@
  *
  * <ol>
  *
+ * <li> Changed: aspect now outputs only relative nonlinear residuals of
+ * nonlinear iterations in the screen output. In addition, the number of
+ * the nonlinear iteration is included in the screen output.
+ * <br>
+ * (Juliane Dannberg, 2017/04/13)
+ *
  * <li> New: aspect now provides as script that -- when used together with
  * the deal.II parameter GUI program -- allows for a graphical creation and 
  * modification of input parameter files. All available parameters are listed,

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1282,6 +1282,7 @@ namespace aspect
       double                                                    old_time_step;
       unsigned int                                              timestep_number;
       unsigned int                                              pre_refinement_step;
+      unsigned int                                              nonlinear_iteration;
       /**
        * @}
        */

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -788,6 +788,8 @@ namespace aspect
             << " seconds"
             << std::endl;
 
+    nonlinear_iteration = 0;
+
     // set global statistics about this time step
     statistics.add_value("Time step number", timestep_number);
     if (parameters.convert_to_years == true)
@@ -1943,6 +1945,7 @@ namespace aspect
     // start any scheme with an extrapolated value from the previous
     // two time steps if those are available
     current_linearization_point = old_solution;
+
     if (timestep_number > 1)
       {
         //TODO: Trilinos sadd does not like ghost vectors even as input. Copy
@@ -2016,7 +2019,6 @@ namespace aspect
         case NonlinearSolver::Stokes_only:
         {
           double initial_stokes_residual = 0.0;
-          unsigned int iteration = 0;
 
           do
             {
@@ -2044,14 +2046,14 @@ namespace aspect
               assemble_stokes_system();
               build_stokes_preconditioner();
 
-              if (iteration == 0)
+              if (nonlinear_iteration==0)
                 initial_stokes_residual = compute_initial_stokes_residual();
 
               const double stokes_residual = solve_stokes();
 
               const double relative_tolerance = (initial_stokes_residual > 0) ? stokes_residual/initial_stokes_residual : 0.0;
 
-              pcout << "      Relative Stokes residual after nonlinear iteration " << iteration+1
+              pcout << "      Relative Stokes residual after nonlinear iteration " << nonlinear_iteration+1
                     << ": " << relative_tolerance
                     << std::endl;
 
@@ -2060,13 +2062,13 @@ namespace aspect
 
               current_linearization_point = solution;
 
-              ++iteration;
+              ++nonlinear_iteration;
             }
-          while (! ((iteration >= parameters.max_nonlinear_iterations) // regular timestep
+          while (! ((nonlinear_iteration >= parameters.max_nonlinear_iterations) // regular timestep
                     ||
                     ((pre_refinement_step < parameters.initial_adaptive_refinement) // pre-refinement
                      &&
-                     (iteration >= parameters.max_nonlinear_iterations_in_prerefinement))));
+                     (nonlinear_iteration >= parameters.max_nonlinear_iterations_in_prerefinement))));
           break;
         }
 
@@ -2077,21 +2079,25 @@ namespace aspect
           double initial_stokes_residual      = 0;
           std::vector<double> initial_composition_residual (parameters.n_compositional_fields,0);
 
-          unsigned int iteration = 0;
-
           do
             {
               assemble_advection_system(AdvectionField::temperature());
 
-              if (iteration == 0)
+              if (nonlinear_iteration == 0)
                 initial_temperature_residual = system_rhs.block(introspection.block_indices.temperature).l2_norm();
 
               const double temperature_residual = solve_advection(AdvectionField::temperature());
+              const double relative_temperature_residual = (initial_temperature_residual > 0)
+                                                           ?
+                                                           temperature_residual/initial_temperature_residual
+                                                           :
+                                                           0.0;
 
               current_linearization_point.block(introspection.block_indices.temperature)
                 = solution.block(introspection.block_indices.temperature);
               rebuild_stokes_matrix = true;
               std::vector<double> composition_residual (parameters.n_compositional_fields,0);
+              std::vector<double> relative_composition_residual (parameters.n_compositional_fields,0);
 
               for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
                 {
@@ -2102,11 +2108,18 @@ namespace aspect
                       case Parameters<dim>::AdvectionFieldMethod::fem_field:
                         assemble_advection_system (adv_field);
 
-                        if (iteration == 0)
+                        if (nonlinear_iteration == 0)
                           initial_composition_residual[c] = system_rhs.block(introspection.block_indices.compositional_fields[c]).l2_norm();
 
                         composition_residual[c]
                           = solve_advection(adv_field);
+
+                        relative_composition_residual[c] = (initial_composition_residual[c] > 0)
+                                                           ?
+                                                           composition_residual[c]/initial_composition_residual[c]
+                                                           :
+                                                           0.0;
+
                         break;
 
                       case Parameters<dim>::AdvectionFieldMethod::particles:
@@ -2135,10 +2148,11 @@ namespace aspect
               assemble_stokes_system();
               build_stokes_preconditioner();
 
-              if (iteration == 0)
+              if (nonlinear_iteration == 0)
                 initial_stokes_residual = compute_initial_stokes_residual();
 
               const double stokes_residual = solve_stokes();
+              const double relative_stokes_residual = (initial_stokes_residual > 0) ? stokes_residual/initial_stokes_residual : 0.0;
 
               current_linearization_point = solution;
 
@@ -2151,6 +2165,13 @@ namespace aspect
 
               pcout << ", " << stokes_residual;
 
+              pcout << std::endl;
+
+              // output relative residuals
+              pcout << "      Relative nonlinear residuals: " << relative_temperature_residual;
+              for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
+                pcout << ", " << initial_composition_residual[c];
+              pcout << ", " << relative_stokes_residual;
               pcout << std::endl;
 
               double max = 0.0;
@@ -2173,20 +2194,21 @@ namespace aspect
                 max = std::max(stokes_residual/initial_stokes_residual, max);
               if (initial_temperature_residual>0)
                 max = std::max(temperature_residual/initial_temperature_residual, max);
-              pcout << "      Total relative nonlinear residual: " << max << std::endl;
+              pcout << "      Total relative residual after nonlinear iteration " << nonlinear_iteration+1 << ": " << max << std::endl;
               pcout << std::endl
                     << std::endl;
               if (max < parameters.nonlinear_tolerance)
                 break;
 
-              ++iteration;
+              ++nonlinear_iteration;
+
 //TODO: terminate here if the number of iterations is too large and we see no convergence
             }
-          while (! ((iteration >= parameters.max_nonlinear_iterations) // regular timestep
+          while (! ((nonlinear_iteration >= parameters.max_nonlinear_iterations) // regular timestep
                     ||
                     ((pre_refinement_step < parameters.initial_adaptive_refinement) // pre-refinement
                      &&
-                     (iteration >= parameters.max_nonlinear_iterations_in_prerefinement))));
+                     (nonlinear_iteration >= parameters.max_nonlinear_iterations_in_prerefinement))));
 
           break;
         }
@@ -2232,11 +2254,11 @@ namespace aspect
 
           // ...and then iterate the solution of the Stokes system
           double initial_stokes_residual = 0;
-          for (unsigned int i=0; (! ((i >= parameters.max_nonlinear_iterations) // regular timestep
-                                     ||
-                                     ((pre_refinement_step < parameters.initial_adaptive_refinement) // pre-refinement
-                                      &&
-                                      (i >= parameters.max_nonlinear_iterations_in_prerefinement)))); ++i)
+          for (nonlinear_iteration=0; (! ((nonlinear_iteration >= parameters.max_nonlinear_iterations) // regular timestep
+                                          ||
+                                          ((pre_refinement_step < parameters.initial_adaptive_refinement) // pre-refinement
+                                           &&
+                                           (nonlinear_iteration >= parameters.max_nonlinear_iterations_in_prerefinement)))); ++nonlinear_iteration)
             {
               // rebuild the matrix if it actually depends on the solution
               // of the previous iteration.
@@ -2248,12 +2270,16 @@ namespace aspect
               assemble_stokes_system();
               build_stokes_preconditioner();
 
-              if (i==0)
+              if (nonlinear_iteration==0)
                 initial_stokes_residual = compute_initial_stokes_residual();
 
               const double stokes_residual = solve_stokes();
+              const double relative_stokes_residual = (initial_stokes_residual > 0) ? stokes_residual/initial_stokes_residual : 0.0;
 
-              pcout << "   Residual after nonlinear iteration " << i+1 << ": " << stokes_residual/initial_stokes_residual << std::endl;
+              pcout << "      Relative Stokes residual after nonlinear iteration " << nonlinear_iteration+1
+                    << ": " << relative_stokes_residual
+                    << std::endl;
+
               if (stokes_residual/initial_stokes_residual < parameters.nonlinear_tolerance)
                 {
                   break; // convergence reached, exit nonlinear iterations.
@@ -2397,7 +2423,6 @@ namespace aspect
 
     // start the timer for periodic checkpoints after the setup above
     time_t last_checkpoint_time = std::time(NULL);
-
 
   start_time_iteration:
 

--- a/tests/adiabatic_boundary/screen-output
+++ b/tests/adiabatic_boundary/screen-output
@@ -1,10 +1,3 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.0-pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 8 (on 2 levels)
 Number of degrees of freedom: 527 (375+27+125)
@@ -13,10 +6,10 @@ Number of degrees of freedom: 527 (375+27+125)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
-   Residual after nonlinear iteration 1: 1
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Solving Stokes system... 0+0 iterations.
-   Residual after nonlinear iteration 2: 4.01961e-06
+      Relative Stokes residual after nonlinear iteration 2: 4.14038e-06
 
    Postprocessing:
      RMS, max velocity: 0.00495 m/year, 0.00881 m/year
@@ -25,18 +18,6 @@ Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      2.46s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |     0.511s |        21% |
-| Assemble temperature system     |         1 |     0.433s |        18% |
-| Build Stokes preconditioner     |         1 |     0.311s |        13% |
-| Build temperature preconditioner|         1 |   0.00172s |      0.07% |
-| Solve Stokes system             |         2 |     0.181s |       7.3% |
-| Solve temperature system        |         1 |     0.021s |      0.85% |
-| Initialization                  |         2 |     0.388s |        16% |
-| Postprocessing                  |         1 |    0.0316s |       1.3% |
-| Setup dof systems               |         1 |     0.352s |        14% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/adiabatic_heating_with_melt/screen-output
+++ b/tests/adiabatic_heating_with_melt/screen-output
@@ -9,8 +9,7 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 57+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 49.1231, 8.38837e-09, 0, 2.06449e+13
-      Relative nonlinear residuals: 1.80908e-16, 8.74936e+07, 0, 1
+      Relative nonlinear residuals: 1.80908e-16, 9.58741e-17, 0, 1
       Total relative residual after nonlinear iteration 1: 1
 
 
@@ -20,8 +19,7 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 49.1231, 8.38837e-09, 0, 13.9256
-      Relative nonlinear residuals: 1.80908e-16, 8.74936e+07, 0, 6.74528e-13
+      Relative nonlinear residuals: 1.80908e-16, 9.58741e-17, 0, 6.74528e-13
       Total relative residual after nonlinear iteration 2: 6.74528e-13
 
 
@@ -37,8 +35,7 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 5.57493e+11, 1.36181e-08, 0, 13748.3
-      Relative nonlinear residuals: 2.0391e-06, 8.77922e+07, 0, 4.87025e-09
+      Relative nonlinear residuals: 2.0391e-06, 1.55118e-16, 0, 4.87025e-09
       Total relative residual after nonlinear iteration 1: 2.0391e-06
 
 
@@ -54,8 +51,7 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 9.06786e+11, 3.02187e-08, 0, 11860.1
-      Relative nonlinear residuals: 2.21934e-06, 1.31556e+08, 0, 4.20136e-09
+      Relative nonlinear residuals: 2.21934e-06, 2.29702e-16, 0, 4.20136e-09
       Total relative residual after nonlinear iteration 1: 2.21934e-06
 
 
@@ -71,8 +67,7 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 1.50175e+10, 1.76599e-08, 0, 2403.85
-      Relative nonlinear residuals: 4.7975e-08, 1.00852e+08, 0, 8.5155e-10
+      Relative nonlinear residuals: 4.7975e-08, 1.75107e-16, 0, 8.5155e-10
       Total relative residual after nonlinear iteration 1: 4.7975e-08
 
 

--- a/tests/adiabatic_heating_with_melt/screen-output
+++ b/tests/adiabatic_heating_with_melt/screen-output
@@ -10,7 +10,8 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Solving Stokes system... 57+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 49.1231, 8.38837e-09, 0, 2.06449e+13
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 1.80908e-16, 8.74936e+07, 0, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
@@ -20,7 +21,8 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Solving Stokes system... 4+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 49.1231, 8.38837e-09, 0, 13.9256
-      Total relative nonlinear residual: 6.74528e-13
+      Relative nonlinear residuals: 1.80908e-16, 8.74936e+07, 0, 6.74528e-13
+      Total relative residual after nonlinear iteration 2: 6.74528e-13
 
 
 
@@ -36,7 +38,8 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Solving Stokes system... 18+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 5.57493e+11, 1.36181e-08, 0, 13748.3
-      Total relative nonlinear residual: 2.0391e-06
+      Relative nonlinear residuals: 2.0391e-06, 8.77922e+07, 0, 4.87025e-09
+      Total relative residual after nonlinear iteration 1: 2.0391e-06
 
 
 
@@ -52,7 +55,8 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Solving Stokes system... 21+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 9.06786e+11, 3.02187e-08, 0, 11860.1
-      Total relative nonlinear residual: 2.21934e-06
+      Relative nonlinear residuals: 2.21934e-06, 1.31556e+08, 0, 4.20136e-09
+      Total relative residual after nonlinear iteration 1: 2.21934e-06
 
 
 
@@ -68,7 +72,8 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Solving Stokes system... 17+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 1.50175e+10, 1.76599e-08, 0, 2403.85
-      Total relative nonlinear residual: 4.7975e-08
+      Relative nonlinear residuals: 4.7975e-08, 1.00852e+08, 0, 8.5155e-10
+      Total relative residual after nonlinear iteration 1: 4.7975e-08
 
 
 

--- a/tests/composition_reaction_iterated_IMPES/screen-output
+++ b/tests/composition_reaction_iterated_IMPES/screen-output
@@ -12,7 +12,8 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 52+0 iterations.
       Nonlinear residuals: 1.37468e-11, 0, 0.0346137, 0, 22.3625
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 1.63386e-16, 0, 0.0346137, 0, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
@@ -21,7 +22,8 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_3 system ... 11 iterations.
    Solving Stokes system... 37+0 iterations.
       Nonlinear residuals: 1.48472e-11, 0.0346137, 1.97946e-14, 0.0346137, 0.172797
-      Total relative nonlinear residual: 0.00772709
+      Relative nonlinear residuals: 1.76464e-16, 0, 0.0346137, 0, 0.00772709
+      Total relative residual after nonlinear iteration 2: 0.00772709
 
 
    Solving temperature system... 0 iterations.
@@ -30,7 +32,8 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_3 system ... 0 iterations.
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 1.50862e-11, 1.97939e-14, 1.97946e-14, 1.97939e-14, 1.86386e-06
-      Total relative nonlinear residual: 8.33478e-08
+      Relative nonlinear residuals: 1.79305e-16, 0, 0.0346137, 0, 8.33478e-08
+      Total relative residual after nonlinear iteration 3: 8.33478e-08
 
 
 
@@ -46,7 +49,8 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
       Nonlinear residuals: 331.725, 0.0346137, 0.0346137, 0.0346137, 2.57943e-05
-      Total relative nonlinear residual: 0.5
+      Relative nonlinear residuals: 0.003938, 0.0692274, 0.0692274, 0.0692274, 1.16923e-06
+      Total relative residual after nonlinear iteration 1: 0.5
 
 
    Solving temperature system... 5 iterations.
@@ -55,7 +59,8 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_3 system ... 11 iterations.
    Solving Stokes system... 37+0 iterations.
       Nonlinear residuals: 0.0162437, 0.0346137, 6.51923e-14, 0.0346137, 0.172797
-      Total relative nonlinear residual: 0.5
+      Relative nonlinear residuals: 1.92834e-07, 0.0692274, 0.0692274, 0.0692274, 0.00783271
+      Total relative residual after nonlinear iteration 2: 0.5
 
 
    Solving temperature system... 5 iterations.
@@ -64,7 +69,8 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_3 system ... 0 iterations.
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 0.0118355, 6.52012e-14, 6.51925e-14, 6.52012e-14, 1.86577e-06
-      Total relative nonlinear residual: 1.40503e-07
+      Relative nonlinear residuals: 1.40503e-07, 0.0692274, 0.0692274, 0.0692274, 8.45733e-08
+      Total relative residual after nonlinear iteration 3: 1.40503e-07
 
 
 

--- a/tests/composition_reaction_iterated_IMPES/screen-output
+++ b/tests/composition_reaction_iterated_IMPES/screen-output
@@ -11,8 +11,7 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Skipping C_3 composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 52+0 iterations.
-      Nonlinear residuals: 1.37468e-11, 0, 0.0346137, 0, 22.3625
-      Relative nonlinear residuals: 1.63386e-16, 0, 0.0346137, 0, 1
+      Relative nonlinear residuals: 1.63386e-16, 0, 1, 0, 1
       Total relative residual after nonlinear iteration 1: 1
 
 
@@ -21,8 +20,7 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_2 system ... 0 iterations.
    Solving C_3 system ... 11 iterations.
    Solving Stokes system... 37+0 iterations.
-      Nonlinear residuals: 1.48472e-11, 0.0346137, 1.97946e-14, 0.0346137, 0.172797
-      Relative nonlinear residuals: 1.76464e-16, 0, 0.0346137, 0, 0.00772709
+      Relative nonlinear residuals: 1.76464e-16, 0, 5.7187e-13, 0, 0.00772709
       Total relative residual after nonlinear iteration 2: 0.00772709
 
 
@@ -31,8 +29,7 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_2 system ... 0 iterations.
    Solving C_3 system ... 0 iterations.
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 1.50862e-11, 1.97939e-14, 1.97946e-14, 1.97939e-14, 1.86386e-06
-      Relative nonlinear residuals: 1.79305e-16, 0, 0.0346137, 0, 8.33478e-08
+      Relative nonlinear residuals: 1.79305e-16, 0, 5.7187e-13, 0, 8.33478e-08
       Total relative residual after nonlinear iteration 3: 8.33478e-08
 
 
@@ -48,8 +45,7 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_3 system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Nonlinear residuals: 331.725, 0.0346137, 0.0346137, 0.0346137, 2.57943e-05
-      Relative nonlinear residuals: 0.003938, 0.0692274, 0.0692274, 0.0692274, 1.16923e-06
+      Relative nonlinear residuals: 0.003938, 0.5, 0.5, 0.5, 1.16923e-06
       Total relative residual after nonlinear iteration 1: 0.5
 
 
@@ -58,8 +54,7 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_2 system ... 0 iterations.
    Solving C_3 system ... 11 iterations.
    Solving Stokes system... 37+0 iterations.
-      Nonlinear residuals: 0.0162437, 0.0346137, 6.51923e-14, 0.0346137, 0.172797
-      Relative nonlinear residuals: 1.92834e-07, 0.0692274, 0.0692274, 0.0692274, 0.00783271
+      Relative nonlinear residuals: 1.92834e-07, 0.5, 9.41713e-13, 0.5, 0.00783271
       Total relative residual after nonlinear iteration 2: 0.5
 
 
@@ -68,8 +63,7 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_2 system ... 0 iterations.
    Solving C_3 system ... 0 iterations.
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 0.0118355, 6.52012e-14, 6.51925e-14, 6.52012e-14, 1.86577e-06
-      Relative nonlinear residuals: 1.40503e-07, 0.0692274, 0.0692274, 0.0692274, 8.45733e-08
+      Relative nonlinear residuals: 1.40503e-07, 9.41841e-13, 9.41716e-13, 9.41841e-13, 8.45733e-08
       Total relative residual after nonlinear iteration 3: 1.40503e-07
 
 

--- a/tests/compression_heating/screen-output
+++ b/tests/compression_heating/screen-output
@@ -12,7 +12,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 102+0 iterations.
    Solving for u_f in 10 iterations.
       Nonlinear residuals: 9.02718e-15, 6.72118e-18, 0, 0.629495
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 1.09007e-16, 0.0302734, 0, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
@@ -22,7 +23,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 10 iterations.
       Nonlinear residuals: 9.02718e-15, 6.72118e-18, 0, 3.91106e-13
-      Total relative nonlinear residual: 6.21302e-13
+      Relative nonlinear residuals: 1.09007e-16, 0.0302734, 0, 6.21302e-13
+      Total relative residual after nonlinear iteration 2: 6.21302e-13
 
 
 
@@ -39,7 +41,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 88+0 iterations.
    Solving for u_f in 10 iterations.
       Nonlinear residuals: 0.0109985, 0.00283814, 0, 0.0156617
-      Total relative nonlinear residual: 0.0833335
+      Relative nonlinear residuals: 0.000132795, 0.0340576, 0, 0.0258351
+      Total relative residual after nonlinear iteration 1: 0.0833335
 
 
    Solving temperature system... 7 iterations.
@@ -49,7 +52,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 38+0 iterations.
    Solving for u_f in 10 iterations.
       Nonlinear residuals: 0.000333429, 3.90659e-09, 0, 1.19331e-07
-      Total relative nonlinear residual: 4.02577e-06
+      Relative nonlinear residuals: 4.02577e-06, 0.0340576, 0, 1.96846e-07
+      Total relative residual after nonlinear iteration 2: 4.02577e-06
 
 
 
@@ -66,7 +70,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 71+0 iterations.
    Solving for u_f in 10 iterations.
       Nonlinear residuals: 0.00012379, 3.09574e-05, 0, 0.000126804
-      Total relative nonlinear residual: 0.00064094
+      Relative nonlinear residuals: 1.14229e-06, 0.0482999, 0, 0.000209255
+      Total relative residual after nonlinear iteration 1: 0.00064094
 
 
    Solving temperature system... 3 iterations.
@@ -76,7 +81,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 26+0 iterations.
    Solving for u_f in 10 iterations.
       Nonlinear residuals: 1.69546e-06, 1.71907e-11, 0, 3.50534e-10
-      Total relative nonlinear residual: 1.56452e-08
+      Relative nonlinear residuals: 1.56452e-08, 0.0482999, 0, 5.78459e-10
+      Total relative residual after nonlinear iteration 2: 1.56452e-08
 
 
 

--- a/tests/compression_heating/screen-output
+++ b/tests/compression_heating/screen-output
@@ -11,8 +11,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 102+0 iterations.
    Solving for u_f in 10 iterations.
-      Nonlinear residuals: 9.02718e-15, 6.72118e-18, 0, 0.629495
-      Relative nonlinear residuals: 1.09007e-16, 0.0302734, 0, 1
+      Relative nonlinear residuals: 1.09007e-16, 2.22016e-16, 0, 1
       Total relative residual after nonlinear iteration 1: 1
 
 
@@ -22,8 +21,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 10 iterations.
-      Nonlinear residuals: 9.02718e-15, 6.72118e-18, 0, 3.91106e-13
-      Relative nonlinear residuals: 1.09007e-16, 0.0302734, 0, 6.21302e-13
+      Relative nonlinear residuals: 1.09007e-16, 2.22016e-16, 0, 6.21302e-13
       Total relative residual after nonlinear iteration 2: 6.21302e-13
 
 
@@ -40,8 +38,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 88+0 iterations.
    Solving for u_f in 10 iterations.
-      Nonlinear residuals: 0.0109985, 0.00283814, 0, 0.0156617
-      Relative nonlinear residuals: 0.000132795, 0.0340576, 0, 0.0258351
+      Relative nonlinear residuals: 0.000132795, 0.0833335, 0, 0.0258351
       Total relative residual after nonlinear iteration 1: 0.0833335
 
 
@@ -51,8 +48,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 38+0 iterations.
    Solving for u_f in 10 iterations.
-      Nonlinear residuals: 0.000333429, 3.90659e-09, 0, 1.19331e-07
-      Relative nonlinear residuals: 4.02577e-06, 0.0340576, 0, 1.96846e-07
+      Relative nonlinear residuals: 4.02577e-06, 1.14705e-07, 0, 1.96846e-07
       Total relative residual after nonlinear iteration 2: 4.02577e-06
 
 
@@ -69,8 +65,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 71+0 iterations.
    Solving for u_f in 10 iterations.
-      Nonlinear residuals: 0.00012379, 3.09574e-05, 0, 0.000126804
-      Relative nonlinear residuals: 1.14229e-06, 0.0482999, 0, 0.000209255
+      Relative nonlinear residuals: 1.14229e-06, 0.00064094, 0, 0.000209255
       Total relative residual after nonlinear iteration 1: 0.00064094
 
 
@@ -80,8 +75,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
    Solving for u_f in 10 iterations.
-      Nonlinear residuals: 1.69546e-06, 1.71907e-11, 0, 3.50534e-10
-      Relative nonlinear residuals: 1.56452e-08, 0.0482999, 0, 5.78459e-10
+      Relative nonlinear residuals: 1.56452e-08, 3.55917e-10, 0, 5.78459e-10
       Total relative residual after nonlinear iteration 2: 1.56452e-08
 
 

--- a/tests/diffusion_dislocation/screen-output
+++ b/tests/diffusion_dislocation/screen-output
@@ -7,8 +7,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
    Solving depleted_lithosphere system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Nonlinear residuals: 231496, 5.96195e-06, 1.61778e+14
-      Relative nonlinear residuals: 2.38095e-16, 5.54969e+10, 1
+      Relative nonlinear residuals: 2.38095e-16, 1.07429e-16, 1
       Total relative residual after nonlinear iteration 1: 1
 
 
@@ -16,8 +15,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
    Solving depleted_lithosphere system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Nonlinear residuals: 231496, 5.96195e-06, 1.18708e+11
-      Relative nonlinear residuals: 2.38095e-16, 5.54969e+10, 0.000733771
+      Relative nonlinear residuals: 2.38095e-16, 1.07429e-16, 0.000733771
       Total relative residual after nonlinear iteration 2: 0.000733771
 
 
@@ -25,8 +23,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
    Solving depleted_lithosphere system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Nonlinear residuals: 231496, 5.96195e-06, 3.12882e+07
-      Relative nonlinear residuals: 2.38095e-16, 5.54969e+10, 1.93403e-07
+      Relative nonlinear residuals: 2.38095e-16, 1.07429e-16, 1.93403e-07
       Total relative residual after nonlinear iteration 3: 1.93403e-07
 
 

--- a/tests/diffusion_dislocation/screen-output
+++ b/tests/diffusion_dislocation/screen-output
@@ -8,7 +8,8 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
       Nonlinear residuals: 231496, 5.96195e-06, 1.61778e+14
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 2.38095e-16, 5.54969e+10, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
@@ -16,7 +17,8 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
       Nonlinear residuals: 231496, 5.96195e-06, 1.18708e+11
-      Total relative nonlinear residual: 0.000733771
+      Relative nonlinear residuals: 2.38095e-16, 5.54969e+10, 0.000733771
+      Total relative residual after nonlinear iteration 2: 0.000733771
 
 
    Solving temperature system... 0 iterations.
@@ -24,7 +26,8 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
       Nonlinear residuals: 231496, 5.96195e-06, 3.12882e+07
-      Total relative nonlinear residual: 1.93403e-07
+      Relative nonlinear residuals: 2.38095e-16, 5.54969e+10, 1.93403e-07
+      Total relative residual after nonlinear iteration 3: 1.93403e-07
 
 
 

--- a/tests/drucker_prager_compression/screen-output
+++ b/tests/drucker_prager_compression/screen-output
@@ -6,43 +6,43 @@ Number of degrees of freedom: 2,804 (2,210+297+297)
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+14 iterations.
-   Residual after nonlinear iteration 1: 1
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+20 iterations.
-   Residual after nonlinear iteration 2: 0.00977024
+      Relative Stokes residual after nonlinear iteration 2: 0.00977024
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+17 iterations.
-   Residual after nonlinear iteration 3: 0.00232696
+      Relative Stokes residual after nonlinear iteration 3: 0.00232696
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+13 iterations.
-   Residual after nonlinear iteration 4: 0.00102811
+      Relative Stokes residual after nonlinear iteration 4: 0.00102811
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Residual after nonlinear iteration 5: 0.000883826
+      Relative Stokes residual after nonlinear iteration 5: 0.000883826
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+10 iterations.
-   Residual after nonlinear iteration 6: 0.000797158
+      Relative Stokes residual after nonlinear iteration 6: 0.000797158
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
-   Residual after nonlinear iteration 7: 0.000729936
+      Relative Stokes residual after nonlinear iteration 7: 0.000729936
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
-   Residual after nonlinear iteration 8: 0.000677241
+      Relative Stokes residual after nonlinear iteration 8: 0.000677241
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
-   Residual after nonlinear iteration 9: 0.000633529
+      Relative Stokes residual after nonlinear iteration 9: 0.000633529
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
-   Residual after nonlinear iteration 10: 0.000597175
+      Relative Stokes residual after nonlinear iteration 10: 0.000597175
 
 
    Postprocessing:

--- a/tests/drucker_prager_extension/screen-output
+++ b/tests/drucker_prager_extension/screen-output
@@ -6,43 +6,43 @@ Number of degrees of freedom: 2,804 (2,210+297+297)
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+14 iterations.
-   Residual after nonlinear iteration 1: 1
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+19 iterations.
-   Residual after nonlinear iteration 2: 0.0114772
+      Relative Stokes residual after nonlinear iteration 2: 0.0114772
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+15 iterations.
-   Residual after nonlinear iteration 3: 0.001441
+      Relative Stokes residual after nonlinear iteration 3: 0.001441
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+13 iterations.
-   Residual after nonlinear iteration 4: 0.0011851
+      Relative Stokes residual after nonlinear iteration 4: 0.0011851
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Residual after nonlinear iteration 5: 0.00119301
+      Relative Stokes residual after nonlinear iteration 5: 0.00119301
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+12 iterations.
-   Residual after nonlinear iteration 6: 0.0015339
+      Relative Stokes residual after nonlinear iteration 6: 0.0015339
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Residual after nonlinear iteration 7: 0.00116625
+      Relative Stokes residual after nonlinear iteration 7: 0.00116625
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Residual after nonlinear iteration 8: 0.00101504
+      Relative Stokes residual after nonlinear iteration 8: 0.00101503
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Residual after nonlinear iteration 9: 0.000933714
+      Relative Stokes residual after nonlinear iteration 9: 0.000933709
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Residual after nonlinear iteration 10: 0.000859832
+      Relative Stokes residual after nonlinear iteration 10: 0.000859857
 
 
    Postprocessing:

--- a/tests/free_surface_iterated_stokes/screen-output
+++ b/tests/free_surface_iterated_stokes/screen-output
@@ -8,10 +8,10 @@ Number of free surface degrees of freedom: 1394
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+12 iterations.
-   Residual after nonlinear iteration 1: 1
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Solving Stokes system... 0+0 iterations.
-   Residual after nonlinear iteration 2: 4.3798e-08
+      Relative Stokes residual after nonlinear iteration 2: 4.3798e-08
 
 Number of active cells: 664 (on 5 levels)
 Number of degrees of freedom: 9,184 (5,634+733+2,817)
@@ -22,10 +22,10 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+12 iterations.
-   Residual after nonlinear iteration 1: 1
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Solving Stokes system... 0+0 iterations.
-   Residual after nonlinear iteration 2: 5.97035e-08
+      Relative Stokes residual after nonlinear iteration 2: 5.97035e-08
 
    Postprocessing:
 
@@ -43,7 +43,7 @@ Number of free surface degrees of freedom: 1466
      Reference thermal diffusivity (m^2/s):         1.13939e-06
      Rayleigh number:                               0
 
-     Topography min/max: 0 m, 0 m, 
+     Topography min/max: 0 m, 0 m
      RMS, max velocity:  0.000714 m/year, 0.00231 m/year
 
 *** Timestep 1:  t=135061 years
@@ -51,13 +51,13 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+14 iterations.
-   Residual after nonlinear iteration 1: 1.49063
+      Relative Stokes residual after nonlinear iteration 1: 1.49063
 
    Solving Stokes system... 0+0 iterations.
-   Residual after nonlinear iteration 2: 8.78595e-08
+      Relative Stokes residual after nonlinear iteration 2: 8.78595e-08
 
    Postprocessing:
-     Topography min/max: -78.72 m, 175.3 m, 
+     Topography min/max: -78.72 m, 175.3 m
      RMS, max velocity:  0.00055 m/year, 0.00136 m/year
 
 *** Timestep 2:  t=371284 years
@@ -65,13 +65,13 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+14 iterations.
-   Residual after nonlinear iteration 1: 1.60276
+      Relative Stokes residual after nonlinear iteration 1: 1.60276
 
    Solving Stokes system... 0+1 iterations.
-   Residual after nonlinear iteration 2: 8.04425e-08
+      Relative Stokes residual after nonlinear iteration 2: 8.04425e-08
 
    Postprocessing:
-     Topography min/max: -106.6 m, 83.69 m, 
+     Topography min/max: -106.6 m, 83.69 m
      RMS, max velocity:  0.000689 m/year, 0.00219 m/year
 
 *** Timestep 3:  t=513787 years
@@ -79,13 +79,13 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+14 iterations.
-   Residual after nonlinear iteration 1: 0.470828
+      Relative Stokes residual after nonlinear iteration 1: 0.470828
 
    Solving Stokes system... 0+1 iterations.
-   Residual after nonlinear iteration 2: 4.82789e-08
+      Relative Stokes residual after nonlinear iteration 2: 4.82789e-08
 
    Postprocessing:
-     Topography min/max: -12.79 m, 41.33 m, 
+     Topography min/max: -12.79 m, 41.33 m
      RMS, max velocity:  0.000456 m/year, 0.00177 m/year
 
 *** Timestep 4:  t=694325 years
@@ -93,13 +93,13 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+13 iterations.
-   Residual after nonlinear iteration 1: 0.364006
+      Relative Stokes residual after nonlinear iteration 1: 0.364006
 
    Solving Stokes system... 0+2 iterations.
-   Residual after nonlinear iteration 2: 7.54723e-08
+      Relative Stokes residual after nonlinear iteration 2: 7.54723e-08
 
    Postprocessing:
-     Topography min/max: -18.67 m, 58.42 m, 
+     Topography min/max: -18.67 m, 58.42 m
      RMS, max velocity:  0.000439 m/year, 0.00169 m/year
 
 *** Timestep 5:  t=884182 years
@@ -107,13 +107,13 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+14 iterations.
-   Residual after nonlinear iteration 1: 0.159617
+      Relative Stokes residual after nonlinear iteration 1: 0.159617
 
    Solving Stokes system... 0+0 iterations.
-   Residual after nonlinear iteration 2: 3.05077e-08
+      Relative Stokes residual after nonlinear iteration 2: 3.05077e-08
 
    Postprocessing:
-     Topography min/max: -14.4 m, 48.93 m, 
+     Topography min/max: -14.4 m, 48.93 m
      RMS, max velocity:  0.000444 m/year, 0.00169 m/year
 
 
@@ -127,13 +127,13 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+13 iterations.
-   Residual after nonlinear iteration 1: 0.10418
+      Relative Stokes residual after nonlinear iteration 1: 0.10418
 
    Solving Stokes system... 0+0 iterations.
-   Residual after nonlinear iteration 2: 6.62821e-08
+      Relative Stokes residual after nonlinear iteration 2: 6.62821e-08
 
    Postprocessing:
-     Topography min/max: -16.56 m, 53.6 m, 
+     Topography min/max: -16.56 m, 53.6 m
      RMS, max velocity:  0.000437 m/year, 0.00165 m/year
 
 *** Timestep 7:  t=1.26658e+06 years
@@ -141,13 +141,13 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+12 iterations.
-   Residual after nonlinear iteration 1: 0.0473456
+      Relative Stokes residual after nonlinear iteration 1: 0.0473456
 
    Solving Stokes system... 0+0 iterations.
-   Residual after nonlinear iteration 2: 8.8979e-08
+      Relative Stokes residual after nonlinear iteration 2: 8.8979e-08
 
    Postprocessing:
-     Topography min/max: -15.59 m, 51.61 m, 
+     Topography min/max: -15.59 m, 51.61 m
      RMS, max velocity:  0.000436 m/year, 0.00163 m/year
 
 *** Timestep 8:  t=1.46204e+06 years
@@ -155,13 +155,13 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+12 iterations.
-   Residual after nonlinear iteration 1: 0.0267511
+      Relative Stokes residual after nonlinear iteration 1: 0.0267511
 
    Solving Stokes system... 0+0 iterations.
-   Residual after nonlinear iteration 2: 3.89629e-08
+      Relative Stokes residual after nonlinear iteration 2: 3.89629e-08
 
    Postprocessing:
-     Topography min/max: -16.14 m, 52.83 m, 
+     Topography min/max: -16.14 m, 52.83 m
      RMS, max velocity:  0.000432 m/year, 0.0016 m/year
 
 *** Timestep 9:  t=1.66092e+06 years
@@ -169,13 +169,13 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+12 iterations.
-   Residual after nonlinear iteration 1: 0.0142383
+      Relative Stokes residual after nonlinear iteration 1: 0.0142383
 
    Solving Stokes system... 0+0 iterations.
-   Residual after nonlinear iteration 2: 2.29327e-08
+      Relative Stokes residual after nonlinear iteration 2: 2.29327e-08
 
    Postprocessing:
-     Topography min/max: -15.92 m, 52.4 m, 
+     Topography min/max: -15.92 m, 52.4 m
      RMS, max velocity:  0.00043 m/year, 0.00158 m/year
 
 *** Timestep 10:  t=1.8625e+06 years
@@ -183,13 +183,13 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Residual after nonlinear iteration 1: 0.00867112
+      Relative Stokes residual after nonlinear iteration 1: 0.00867112
 
    Solving Stokes system... 0+0 iterations.
-   Residual after nonlinear iteration 2: 6.26255e-08
+      Relative Stokes residual after nonlinear iteration 2: 6.26255e-08
 
    Postprocessing:
-     Topography min/max: -16.1 m, 52.83 m, 
+     Topography min/max: -16.1 m, 52.83 m
      RMS, max velocity:  0.000427 m/year, 0.00155 m/year
 
 

--- a/tests/global_melt/screen-output
+++ b/tests/global_melt/screen-output
@@ -9,7 +9,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 1.51616e+06, 0, 0, 1.12939e+16
       Relative nonlinear residuals: 1.77199e-16, 0, 0, 1
       Total relative residual after nonlinear iteration 1: 1
 
@@ -20,7 +19,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 2.08718e+06, 0, 0, 9.03249e+15
       Relative nonlinear residuals: 2.43935e-16, 0, 0, 0.799766
       Total relative residual after nonlinear iteration 2: 0.799766
 
@@ -31,7 +29,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 1.92093e+06, 0, 0, 1.95692e+15
       Relative nonlinear residuals: 2.24506e-16, 0, 0, 0.173272
       Total relative residual after nonlinear iteration 3: 0.173272
 
@@ -42,7 +39,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 1.85565e+06, 0, 0, 3.07213e+14
       Relative nonlinear residuals: 2.16876e-16, 0, 0, 0.0272016
       Total relative residual after nonlinear iteration 4: 0.0272016
 
@@ -53,7 +49,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 1.94809e+06, 0, 0, 3.67549e+13
       Relative nonlinear residuals: 2.2768e-16, 0, 0, 0.0032544
       Total relative residual after nonlinear iteration 5: 0.0032544
 
@@ -64,7 +59,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 1.95684e+06, 0, 0, 3.53395e+12
       Relative nonlinear residuals: 2.28703e-16, 0, 0, 0.000312907
       Total relative residual after nonlinear iteration 6: 0.000312907
 
@@ -75,7 +69,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 1.98082e+06, 0, 0, 2.83516e+11
       Relative nonlinear residuals: 2.31505e-16, 0, 0, 2.51035e-05
       Total relative residual after nonlinear iteration 7: 2.51035e-05
 
@@ -86,7 +79,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 1.84174e+06, 0, 0, 1.94575e+10
       Relative nonlinear residuals: 2.15251e-16, 0, 0, 1.72283e-06
       Total relative residual after nonlinear iteration 8: 1.72283e-06
 
@@ -106,7 +98,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 1.14715e+19, 0, 0, 1.75714e+12
       Relative nonlinear residuals: 0.000991159, 0, 0, 0.0240528
       Total relative residual after nonlinear iteration 1: 0.0240528
 
@@ -117,7 +108,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 1.55968e+17, 0, 0, 7.19255e+10
       Relative nonlinear residuals: 1.3476e-05, 0, 0, 0.000984559
       Total relative residual after nonlinear iteration 2: 0.000984559
 
@@ -128,7 +118,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 8.47978e+15, 0, 0, 1.36645e+10
       Relative nonlinear residuals: 7.32671e-07, 0, 0, 0.000187048
       Total relative residual after nonlinear iteration 3: 0.000187048
 
@@ -139,7 +128,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 3.94832e+14, 0, 0, 2.89588e+09
       Relative nonlinear residuals: 3.41143e-08, 0, 0, 3.96405e-05
       Total relative residual after nonlinear iteration 4: 3.96405e-05
 
@@ -150,7 +138,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 1.06265e+13, 0, 0, 4.19647e+08
       Relative nonlinear residuals: 9.18149e-10, 0, 0, 5.74438e-06
       Total relative residual after nonlinear iteration 5: 5.74438e-06
 
@@ -170,7 +157,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 2.39944e+18, 0, 0, 2.48742e+11
       Relative nonlinear residuals: 0.000138201, 0, 0, 0.0033994
       Total relative residual after nonlinear iteration 1: 0.0033994
 
@@ -181,7 +167,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 5.46586e+15, 0, 0, 1.7693e+10
       Relative nonlinear residuals: 3.14818e-07, 0, 0, 0.000241799
       Total relative residual after nonlinear iteration 2: 0.000241799
 
@@ -192,7 +177,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 6.49884e+14, 0, 0, 5.65e+09
       Relative nonlinear residuals: 3.74315e-08, 0, 0, 7.7215e-05
       Total relative residual after nonlinear iteration 3: 7.7215e-05
 
@@ -203,7 +187,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 3.47272e+13, 0, 0, 1.11366e+09
       Relative nonlinear residuals: 2.00019e-09, 0, 0, 1.52197e-05
       Total relative residual after nonlinear iteration 4: 1.52197e-05
 
@@ -214,7 +197,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 1.32552e+12, 0, 0, 1.57201e+08
       Relative nonlinear residuals: 7.63462e-11, 0, 0, 2.14836e-06
       Total relative residual after nonlinear iteration 5: 2.14836e-06
 
@@ -234,7 +216,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 2.24715e+17, 0, 0, 2.08659e+10
       Relative nonlinear residuals: 1.2938e-05, 0, 0, 0.000284218
       Total relative residual after nonlinear iteration 1: 0.000284218
 
@@ -245,7 +226,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 3.42207e+15, 0, 0, 3.94867e+09
       Relative nonlinear residuals: 1.97027e-07, 0, 0, 5.37855e-05
       Total relative residual after nonlinear iteration 2: 5.37855e-05
 
@@ -256,7 +236,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 6.88359e+12, 0, 0, 1.17352e+09
       Relative nonlinear residuals: 3.96324e-10, 0, 0, 1.59847e-05
       Total relative residual after nonlinear iteration 3: 1.59847e-05
 
@@ -267,7 +246,6 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 6.79009e+11, 0, 0, 2.23003e+08
       Relative nonlinear residuals: 3.90941e-11, 0, 0, 3.03757e-06
       Total relative residual after nonlinear iteration 4: 3.03757e-06
 

--- a/tests/global_melt/screen-output
+++ b/tests/global_melt/screen-output
@@ -10,7 +10,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 1.51616e+06, 0, 0, 1.12939e+16
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 1.77199e-16, 0, 0, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
@@ -20,7 +21,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 2.08718e+06, 0, 0, 9.03249e+15
-      Total relative nonlinear residual: 0.799766
+      Relative nonlinear residuals: 2.43935e-16, 0, 0, 0.799766
+      Total relative residual after nonlinear iteration 2: 0.799766
 
 
    Solving temperature system... 0 iterations.
@@ -30,7 +32,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 1.92093e+06, 0, 0, 1.95692e+15
-      Total relative nonlinear residual: 0.173272
+      Relative nonlinear residuals: 2.24506e-16, 0, 0, 0.173272
+      Total relative residual after nonlinear iteration 3: 0.173272
 
 
    Solving temperature system... 0 iterations.
@@ -40,7 +43,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+9 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 1.85565e+06, 0, 0, 3.07213e+14
-      Total relative nonlinear residual: 0.0272016
+      Relative nonlinear residuals: 2.16876e-16, 0, 0, 0.0272016
+      Total relative residual after nonlinear iteration 4: 0.0272016
 
 
    Solving temperature system... 0 iterations.
@@ -50,7 +54,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+9 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 1.94809e+06, 0, 0, 3.67549e+13
-      Total relative nonlinear residual: 0.0032544
+      Relative nonlinear residuals: 2.2768e-16, 0, 0, 0.0032544
+      Total relative residual after nonlinear iteration 5: 0.0032544
 
 
    Solving temperature system... 0 iterations.
@@ -60,7 +65,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 1.95684e+06, 0, 0, 3.53395e+12
-      Total relative nonlinear residual: 0.000312907
+      Relative nonlinear residuals: 2.28703e-16, 0, 0, 0.000312907
+      Total relative residual after nonlinear iteration 6: 0.000312907
 
 
    Solving temperature system... 0 iterations.
@@ -70,7 +76,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 1.98082e+06, 0, 0, 2.83516e+11
-      Total relative nonlinear residual: 2.51035e-05
+      Relative nonlinear residuals: 2.31505e-16, 0, 0, 2.51035e-05
+      Total relative residual after nonlinear iteration 7: 2.51035e-05
 
 
    Solving temperature system... 0 iterations.
@@ -80,7 +87,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 1.84174e+06, 0, 0, 1.94575e+10
-      Total relative nonlinear residual: 1.72283e-06
+      Relative nonlinear residuals: 2.15251e-16, 0, 0, 1.72283e-06
+      Total relative residual after nonlinear iteration 8: 1.72283e-06
 
 
 
@@ -99,7 +107,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 1.14715e+19, 0, 0, 1.75714e+12
-      Total relative nonlinear residual: 0.0240528
+      Relative nonlinear residuals: 0.000991159, 0, 0, 0.0240528
+      Total relative residual after nonlinear iteration 1: 0.0240528
 
 
    Solving temperature system... 9 iterations.
@@ -109,7 +118,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 1.55968e+17, 0, 0, 7.19255e+10
-      Total relative nonlinear residual: 0.000984559
+      Relative nonlinear residuals: 1.3476e-05, 0, 0, 0.000984559
+      Total relative residual after nonlinear iteration 2: 0.000984559
 
 
    Solving temperature system... 7 iterations.
@@ -119,7 +129,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 8.47978e+15, 0, 0, 1.36645e+10
-      Total relative nonlinear residual: 0.000187048
+      Relative nonlinear residuals: 7.32671e-07, 0, 0, 0.000187048
+      Total relative residual after nonlinear iteration 3: 0.000187048
 
 
    Solving temperature system... 6 iterations.
@@ -129,7 +140,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 3.94832e+14, 0, 0, 2.89588e+09
-      Total relative nonlinear residual: 3.96405e-05
+      Relative nonlinear residuals: 3.41143e-08, 0, 0, 3.96405e-05
+      Total relative residual after nonlinear iteration 4: 3.96405e-05
 
 
    Solving temperature system... 5 iterations.
@@ -139,7 +151,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 1.06265e+13, 0, 0, 4.19647e+08
-      Total relative nonlinear residual: 5.74438e-06
+      Relative nonlinear residuals: 9.18149e-10, 0, 0, 5.74438e-06
+      Total relative residual after nonlinear iteration 5: 5.74438e-06
 
 
 
@@ -158,7 +171,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 2.39944e+18, 0, 0, 2.48742e+11
-      Total relative nonlinear residual: 0.0033994
+      Relative nonlinear residuals: 0.000138201, 0, 0, 0.0033994
+      Total relative residual after nonlinear iteration 1: 0.0033994
 
 
    Solving temperature system... 7 iterations.
@@ -168,7 +182,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 5.46586e+15, 0, 0, 1.7693e+10
-      Total relative nonlinear residual: 0.000241799
+      Relative nonlinear residuals: 3.14818e-07, 0, 0, 0.000241799
+      Total relative residual after nonlinear iteration 2: 0.000241799
 
 
    Solving temperature system... 6 iterations.
@@ -178,7 +193,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 6.49884e+14, 0, 0, 5.65e+09
-      Total relative nonlinear residual: 7.7215e-05
+      Relative nonlinear residuals: 3.74315e-08, 0, 0, 7.7215e-05
+      Total relative residual after nonlinear iteration 3: 7.7215e-05
 
 
    Solving temperature system... 5 iterations.
@@ -188,7 +204,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 3.47272e+13, 0, 0, 1.11366e+09
-      Total relative nonlinear residual: 1.52197e-05
+      Relative nonlinear residuals: 2.00019e-09, 0, 0, 1.52197e-05
+      Total relative residual after nonlinear iteration 4: 1.52197e-05
 
 
    Solving temperature system... 4 iterations.
@@ -198,7 +215,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 1.32552e+12, 0, 0, 1.57201e+08
-      Total relative nonlinear residual: 2.14836e-06
+      Relative nonlinear residuals: 7.63462e-11, 0, 0, 2.14836e-06
+      Total relative residual after nonlinear iteration 5: 2.14836e-06
 
 
 
@@ -217,7 +235,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 2.24715e+17, 0, 0, 2.08659e+10
-      Total relative nonlinear residual: 0.000284218
+      Relative nonlinear residuals: 1.2938e-05, 0, 0, 0.000284218
+      Total relative residual after nonlinear iteration 1: 0.000284218
 
 
    Solving temperature system... 7 iterations.
@@ -227,7 +246,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 3.42207e+15, 0, 0, 3.94867e+09
-      Total relative nonlinear residual: 5.37855e-05
+      Relative nonlinear residuals: 1.97027e-07, 0, 0, 5.37855e-05
+      Total relative residual after nonlinear iteration 2: 5.37855e-05
 
 
    Solving temperature system... 4 iterations.
@@ -237,7 +257,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 6.88359e+12, 0, 0, 1.17352e+09
-      Total relative nonlinear residual: 1.59847e-05
+      Relative nonlinear residuals: 3.96324e-10, 0, 0, 1.59847e-05
+      Total relative residual after nonlinear iteration 3: 1.59847e-05
 
 
    Solving temperature system... 3 iterations.
@@ -247,7 +268,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 6.79009e+11, 0, 0, 2.23003e+08
-      Total relative nonlinear residual: 3.03757e-06
+      Relative nonlinear residuals: 3.90941e-11, 0, 0, 3.03757e-06
+      Total relative residual after nonlinear iteration 4: 3.03757e-06
 
 
 

--- a/tests/heat_advection_by_melt/screen-output
+++ b/tests/heat_advection_by_melt/screen-output
@@ -12,7 +12,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 28+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 1.78665e-17, 1.45347e-18, 0, 0.386669
-      Total relative nonlinear residual: 0.0526341
+      Relative nonlinear residuals: 1.78845e-16, 0.00594519, 0, 0.0526341
+      Total relative residual after nonlinear iteration 1: 0.0526341
 
 
    Solving temperature system... 0 iterations.
@@ -22,7 +23,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 1.78665e-17, 1.45347e-18, 0, 5.19241e-12
-      Total relative nonlinear residual: 7.06801e-13
+      Relative nonlinear residuals: 1.78845e-16, 0.00594519, 0, 7.06801e-13
+      Total relative residual after nonlinear iteration 2: 7.06801e-13
 
 
 
@@ -39,7 +41,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 5.96978e-15, 5.48889e-16, 0, 5.19239e-12
-      Total relative nonlinear residual: 7.06798e-13
+      Relative nonlinear residuals: 5.96675e-14, 0.00594519, 0, 7.06798e-13
+      Total relative residual after nonlinear iteration 1: 7.06798e-13
 
 
 
@@ -55,8 +58,9 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 5.97122e-15, 5.48821e-16, 0, 5.19239e-12
-      Total relative nonlinear residual: 7.06798e-13
+      Nonlinear residuals: 5.97121e-15, 5.48821e-16, 0, 5.19239e-12
+      Relative nonlinear residuals: 3.9808e-14, 0.00891779, 0, 7.06798e-13
+      Total relative residual after nonlinear iteration 1: 7.06798e-13
 
 
 
@@ -72,8 +76,9 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 5.97122e-15, 5.48821e-16, 0, 5.19239e-12
-      Total relative nonlinear residual: 7.06798e-13
+      Nonlinear residuals: 5.97121e-15, 5.48821e-16, 0, 5.19239e-12
+      Relative nonlinear residuals: 3.9808e-14, 0.00891779, 0, 7.06798e-13
+      Total relative residual after nonlinear iteration 1: 7.06798e-13
 
 
 
@@ -90,7 +95,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 1.19326e-15, 1.09777e-16, 0, 5.19497e-12
-      Total relative nonlinear residual: 7.07149e-13
+      Relative nonlinear residuals: 1.02356e-14, 0.00693606, 0, 7.07149e-13
+      Total relative residual after nonlinear iteration 1: 7.07149e-13
 
 
 

--- a/tests/heat_advection_by_melt/screen-output
+++ b/tests/heat_advection_by_melt/screen-output
@@ -11,8 +11,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 1.78665e-17, 1.45347e-18, 0, 0.386669
-      Relative nonlinear residuals: 1.78845e-16, 0.00594519, 0, 0.0526341
+      Relative nonlinear residuals: 1.78845e-16, 2.44479e-16, 0, 0.0526341
       Total relative residual after nonlinear iteration 1: 0.0526341
 
 
@@ -22,8 +21,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 1.78665e-17, 1.45347e-18, 0, 5.19241e-12
-      Relative nonlinear residuals: 1.78845e-16, 0.00594519, 0, 7.06801e-13
+      Relative nonlinear residuals: 1.78845e-16, 2.44479e-16, 0, 7.06801e-13
       Total relative residual after nonlinear iteration 2: 7.06801e-13
 
 
@@ -40,8 +38,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 5.96978e-15, 5.48889e-16, 0, 5.19239e-12
-      Relative nonlinear residuals: 5.96675e-14, 0.00594519, 0, 7.06798e-13
+      Relative nonlinear residuals: 5.96675e-14, 9.23249e-14, 0, 7.06798e-13
       Total relative residual after nonlinear iteration 1: 7.06798e-13
 
 
@@ -58,8 +55,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 5.97121e-15, 5.48821e-16, 0, 5.19239e-12
-      Relative nonlinear residuals: 3.9808e-14, 0.00891779, 0, 7.06798e-13
+      Relative nonlinear residuals: 3.9808e-14, 6.15423e-14, 0, 7.06798e-13
       Total relative residual after nonlinear iteration 1: 7.06798e-13
 
 
@@ -76,8 +72,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 5.97121e-15, 5.48821e-16, 0, 5.19239e-12
-      Relative nonlinear residuals: 3.9808e-14, 0.00891779, 0, 7.06798e-13
+      Relative nonlinear residuals: 3.9808e-14, 6.15423e-14, 0, 7.06798e-13
       Total relative residual after nonlinear iteration 1: 7.06798e-13
 
 
@@ -94,8 +89,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 1.19326e-15, 1.09777e-16, 0, 5.19497e-12
-      Relative nonlinear residuals: 1.02356e-14, 0.00693606, 0, 7.07149e-13
+      Relative nonlinear residuals: 1.02356e-14, 1.5827e-14, 0, 7.07149e-13
       Total relative residual after nonlinear iteration 1: 7.07149e-13
 
 

--- a/tests/iterated_IMPES/screen-output
+++ b/tests/iterated_IMPES/screen-output
@@ -8,14 +8,16 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 49+0 iterations.
       Nonlinear residuals: 1.00594e-09, 9.00346e-10, 8.98822e+07
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 2.00269e-16, 5.76437e+06, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... 2+0 iterations.
       Nonlinear residuals: 1.00594e-09, 9.00346e-10, 7.83583e-05
-      Total relative nonlinear residual: 8.71789e-13
+      Relative nonlinear residuals: 2.00269e-16, 5.76437e+06, 8.71789e-13
+      Total relative residual after nonlinear iteration 2: 8.71789e-13
 
 
 
@@ -26,56 +28,64 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 47+0 iterations.
       Nonlinear residuals: 1.30257e+07, 362042, 7.76212e+07
-      Total relative nonlinear residual: 0.821377
+      Relative nonlinear residuals: 0.821377, 6.33542e+06, 0.75783
+      Total relative residual after nonlinear iteration 1: 0.821377
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 45+0 iterations.
       Nonlinear residuals: 1.54989e+06, 23807.8, 1.16379e+07
-      Total relative nonlinear residual: 0.113623
+      Relative nonlinear residuals: 0.0977331, 6.33542e+06, 0.113623
+      Total relative residual after nonlinear iteration 2: 0.113623
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 42+0 iterations.
       Nonlinear residuals: 267787, 3251.24, 2.1001e+06
-      Total relative nonlinear residual: 0.0205037
+      Relative nonlinear residuals: 0.0168861, 6.33542e+06, 0.0205037
+      Total relative residual after nonlinear iteration 3: 0.0205037
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 40+0 iterations.
       Nonlinear residuals: 50859, 654.641, 402412
-      Total relative nonlinear residual: 0.00392882
+      Relative nonlinear residuals: 0.00320707, 6.33542e+06, 0.00392882
+      Total relative residual after nonlinear iteration 4: 0.00392882
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 37+0 iterations.
       Nonlinear residuals: 10042.3, 148.515, 79675.5
-      Total relative nonlinear residual: 0.000777886
+      Relative nonlinear residuals: 0.000633249, 6.33542e+06, 0.000777886
+      Total relative residual after nonlinear iteration 5: 0.000777886
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 35+0 iterations.
       Nonlinear residuals: 2028.44, 34.3545, 16133
-      Total relative nonlinear residual: 0.000157509
+      Relative nonlinear residuals: 0.000127909, 6.33542e+06, 0.000157509
+      Total relative residual after nonlinear iteration 6: 0.000157509
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 32+0 iterations.
       Nonlinear residuals: 416.177, 7.88745, 3319.9
-      Total relative nonlinear residual: 3.24128e-05
+      Relative nonlinear residuals: 2.62433e-05, 6.33542e+06, 3.24128e-05
+      Total relative residual after nonlinear iteration 7: 3.24128e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 29+0 iterations.
       Nonlinear residuals: 86.3598, 1.78676, 691.174
-      Total relative nonlinear residual: 6.74805e-06
+      Relative nonlinear residuals: 5.44567e-06, 6.33542e+06, 6.74805e-06
+      Total relative residual after nonlinear iteration 8: 6.74805e-06
 
 
 
@@ -86,56 +96,64 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 46+0 iterations.
       Nonlinear residuals: 8.74328e+06, 68345.8, 2.77541e+07
-      Total relative nonlinear residual: 0.455259
+      Relative nonlinear residuals: 0.247282, 8.65875e+06, 0.455259
+      Total relative residual after nonlinear iteration 1: 0.455259
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 43+0 iterations.
       Nonlinear residuals: 534360, 3864.78, 3.36554e+06
-      Total relative nonlinear residual: 0.055206
+      Relative nonlinear residuals: 0.015113, 8.65875e+06, 0.055206
+      Total relative residual after nonlinear iteration 2: 0.055206
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 41+0 iterations.
       Nonlinear residuals: 73992, 679.828, 562190
-      Total relative nonlinear residual: 0.00922176
+      Relative nonlinear residuals: 0.00209268, 8.65875e+06, 0.00922176
+      Total relative residual after nonlinear iteration 3: 0.00922176
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 38+0 iterations.
       Nonlinear residuals: 13458.8, 185.172, 102450
-      Total relative nonlinear residual: 0.00168053
+      Relative nonlinear residuals: 0.000380649, 8.65875e+06, 0.00168053
+      Total relative residual after nonlinear iteration 4: 0.00168053
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 35+0 iterations.
       Nonlinear residuals: 2554.88, 48.2406, 19327.3
-      Total relative nonlinear residual: 0.000317032
+      Relative nonlinear residuals: 7.22582e-05, 8.65875e+06, 0.000317032
+      Total relative residual after nonlinear iteration 5: 0.000317032
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 32+0 iterations.
       Nonlinear residuals: 494.904, 11.6979, 3733.66
-      Total relative nonlinear residual: 6.12444e-05
+      Relative nonlinear residuals: 1.39971e-05, 8.65875e+06, 6.12444e-05
+      Total relative residual after nonlinear iteration 6: 6.12444e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 30+0 iterations.
       Nonlinear residuals: 97.4349, 2.7041, 734.428
-      Total relative nonlinear residual: 1.2047e-05
+      Relative nonlinear residuals: 2.7557e-06, 8.65875e+06, 1.2047e-05
+      Total relative residual after nonlinear iteration 7: 1.2047e-05
 
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... 26+0 iterations.
       Nonlinear residuals: 19.4318, 0.605517, 146.478
-      Total relative nonlinear residual: 2.40272e-06
+      Relative nonlinear residuals: 5.4958e-07, 8.65875e+06, 2.40272e-06
+      Total relative residual after nonlinear iteration 8: 2.40272e-06
 
 
 
@@ -146,42 +164,48 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 46+0 iterations.
       Nonlinear residuals: 8.78636e+06, 52145.3, 3.96054e+07
-      Total relative nonlinear residual: 0.647102
+      Relative nonlinear residuals: 0.254258, 8.57204e+06, 0.647102
+      Total relative residual after nonlinear iteration 1: 0.647102
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 42+0 iterations.
       Nonlinear residuals: 298794, 3943.3, 1.66045e+06
-      Total relative nonlinear residual: 0.0271297
+      Relative nonlinear residuals: 0.00864642, 8.57204e+06, 0.0271297
+      Total relative residual after nonlinear iteration 2: 0.0271297
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 38+0 iterations.
       Nonlinear residuals: 13880.1, 184.183, 90098
-      Total relative nonlinear residual: 0.00147209
+      Relative nonlinear residuals: 0.000401659, 8.57204e+06, 0.00147209
+      Total relative residual after nonlinear iteration 3: 0.00147209
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 35+0 iterations.
       Nonlinear residuals: 1194.47, 24.9373, 8793.38
-      Total relative nonlinear residual: 0.000143673
+      Relative nonlinear residuals: 3.45653e-05, 8.57204e+06, 0.000143673
+      Total relative residual after nonlinear iteration 4: 0.000143673
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 31+0 iterations.
       Nonlinear residuals: 150.623, 2.9169, 1120.11
-      Total relative nonlinear residual: 1.83012e-05
+      Relative nonlinear residuals: 4.35868e-06, 8.57204e+06, 1.83012e-05
+      Total relative residual after nonlinear iteration 5: 1.83012e-05
 
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... 28+0 iterations.
       Nonlinear residuals: 20.2838, 0.314073, 150.152
-      Total relative nonlinear residual: 2.45329e-06
+      Relative nonlinear residuals: 5.86969e-07, 8.57204e+06, 2.45329e-06
+      Total relative residual after nonlinear iteration 6: 2.45329e-06
 
 
 
@@ -192,42 +216,48 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 47+0 iterations.
       Nonlinear residuals: 3.47276e+06, 55955.2, 3.10297e+07
-      Total relative nonlinear residual: 0.594093
+      Relative nonlinear residuals: 0.120332, 8.61043e+06, 0.594093
+      Total relative residual after nonlinear iteration 1: 0.594093
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 42+0 iterations.
       Nonlinear residuals: 121429, 7098.88, 787205
-      Total relative nonlinear residual: 0.0150718
+      Relative nonlinear residuals: 0.00420756, 8.61043e+06, 0.0150718
+      Total relative residual after nonlinear iteration 2: 0.0150718
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 38+0 iterations.
       Nonlinear residuals: 7066.23, 552.304, 54337
-      Total relative nonlinear residual: 0.00104033
+      Relative nonlinear residuals: 0.000244847, 8.61043e+06, 0.00104033
+      Total relative residual after nonlinear iteration 3: 0.00104033
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 34+0 iterations.
       Nonlinear residuals: 662.283, 56.8192, 5212.76
-      Total relative nonlinear residual: 9.98032e-05
+      Relative nonlinear residuals: 2.29483e-05, 8.61043e+06, 9.98032e-05
+      Total relative residual after nonlinear iteration 4: 9.98032e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 30+0 iterations.
       Nonlinear residuals: 68.9605, 6.20146, 551.256
-      Total relative nonlinear residual: 1.05543e-05
+      Relative nonlinear residuals: 2.3895e-06, 8.61043e+06, 1.05543e-05
+      Total relative residual after nonlinear iteration 5: 1.05543e-05
 
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... 26+0 iterations.
       Nonlinear residuals: 7.34032, 0.636452, 58.7242
-      Total relative nonlinear residual: 1.12433e-06
+      Relative nonlinear residuals: 2.54344e-07, 8.61043e+06, 1.12433e-06
+      Total relative residual after nonlinear iteration 6: 1.12433e-06
 
 
 
@@ -238,35 +268,40 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 47+0 iterations.
       Nonlinear residuals: 2.20444e+06, 56884.3, 1.81351e+07
-      Total relative nonlinear residual: 0.383226
+      Relative nonlinear residuals: 0.0801971, 8.74052e+06, 0.383226
+      Total relative residual after nonlinear iteration 1: 0.383226
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 42+0 iterations.
       Nonlinear residuals: 71532.3, 8058.52, 568086
-      Total relative nonlinear residual: 0.0120047
+      Relative nonlinear residuals: 0.00260234, 8.74052e+06, 0.0120047
+      Total relative residual after nonlinear iteration 2: 0.0120047
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 38+0 iterations.
       Nonlinear residuals: 5106.63, 1031.27, 43981.5
-      Total relative nonlinear residual: 0.000929408
+      Relative nonlinear residuals: 0.000185779, 8.74052e+06, 0.000929408
+      Total relative residual after nonlinear iteration 3: 0.000929408
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 34+0 iterations.
       Nonlinear residuals: 482.134, 107.856, 4266.08
-      Total relative nonlinear residual: 9.01498e-05
+      Relative nonlinear residuals: 1.754e-05, 8.74052e+06, 9.01498e-05
+      Total relative residual after nonlinear iteration 4: 9.01498e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 30+0 iterations.
       Nonlinear residuals: 47.948, 10.9268, 427.409
-      Total relative nonlinear residual: 9.03192e-06
+      Relative nonlinear residuals: 1.74434e-06, 8.74052e+06, 9.03192e-06
+      Total relative residual after nonlinear iteration 5: 9.03192e-06
 
 
 
@@ -277,35 +312,40 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 46+0 iterations.
       Nonlinear residuals: 1.47905e+06, 60360.2, 1.27436e+07
-      Total relative nonlinear residual: 0.258279
+      Relative nonlinear residuals: 0.0572412, 8.7487e+06, 0.258279
+      Total relative residual after nonlinear iteration 1: 0.258279
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 41+0 iterations.
       Nonlinear residuals: 45392.6, 9396.6, 397634
-      Total relative nonlinear residual: 0.00805902
+      Relative nonlinear residuals: 0.00175675, 8.7487e+06, 0.00805902
+      Total relative residual after nonlinear iteration 2: 0.00805902
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 37+0 iterations.
       Nonlinear residuals: 3292.31, 987.536, 31095.5
-      Total relative nonlinear residual: 0.000630225
+      Relative nonlinear residuals: 0.000127417, 8.7487e+06, 0.000630225
+      Total relative residual after nonlinear iteration 3: 0.000630225
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 33+0 iterations.
       Nonlinear residuals: 305.892, 98.0603, 2975.96
-      Total relative nonlinear residual: 6.03151e-05
+      Relative nonlinear residuals: 1.18384e-05, 8.7487e+06, 6.03151e-05
+      Total relative residual after nonlinear iteration 4: 6.03151e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 29+0 iterations.
       Nonlinear residuals: 29.6602, 9.63026, 293.926
-      Total relative nonlinear residual: 5.95712e-06
+      Relative nonlinear residuals: 1.14789e-06, 8.7487e+06, 5.95712e-06
+      Total relative residual after nonlinear iteration 5: 5.95712e-06
 
 
 
@@ -316,35 +356,40 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 46+0 iterations.
       Nonlinear residuals: 940943, 64026.9, 8.43616e+06
-      Total relative nonlinear residual: 0.159808
+      Relative nonlinear residuals: 0.038188, 8.7408e+06, 0.159808
+      Total relative residual after nonlinear iteration 1: 0.159808
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 41+0 iterations.
       Nonlinear residuals: 29828.2, 8702.28, 290743
-      Total relative nonlinear residual: 0.00550759
+      Relative nonlinear residuals: 0.00121057, 8.7408e+06, 0.00550759
+      Total relative residual after nonlinear iteration 2: 0.00550759
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 37+0 iterations.
       Nonlinear residuals: 2227.05, 826.532, 23200.1
-      Total relative nonlinear residual: 0.000439483
+      Relative nonlinear residuals: 9.03844e-05, 8.7408e+06, 0.000439483
+      Total relative residual after nonlinear iteration 3: 0.000439483
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 32+0 iterations.
       Nonlinear residuals: 202.163, 77.3229, 2177.95
-      Total relative nonlinear residual: 4.12574e-05
+      Relative nonlinear residuals: 8.20473e-06, 8.7408e+06, 4.12574e-05
+      Total relative residual after nonlinear iteration 4: 4.12574e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 29+0 iterations.
       Nonlinear residuals: 19.0298, 7.26265, 209.279
-      Total relative nonlinear residual: 3.96441e-06
+      Relative nonlinear residuals: 7.72319e-07, 8.7408e+06, 3.96441e-06
+      Total relative residual after nonlinear iteration 5: 3.96441e-06
 
 
 
@@ -355,35 +400,40 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 46+0 iterations.
       Nonlinear residuals: 595028, 66651.8, 5.46878e+06
-      Total relative nonlinear residual: 0.0961601
+      Relative nonlinear residuals: 0.0247562, 8.76738e+06, 0.0961601
+      Total relative residual after nonlinear iteration 1: 0.0961601
 
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 41+0 iterations.
       Nonlinear residuals: 21593.2, 7503.24, 227820
-      Total relative nonlinear residual: 0.00400586
+      Relative nonlinear residuals: 0.000898388, 8.76738e+06, 0.00400586
+      Total relative residual after nonlinear iteration 2: 0.00400586
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 36+0 iterations.
       Nonlinear residuals: 1686.01, 666.476, 18497.6
-      Total relative nonlinear residual: 0.000325253
+      Relative nonlinear residuals: 7.01468e-05, 8.76738e+06, 0.000325253
+      Total relative residual after nonlinear iteration 3: 0.000325253
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 32+0 iterations.
       Nonlinear residuals: 148.22, 58.9211, 1669.59
-      Total relative nonlinear residual: 2.93572e-05
+      Relative nonlinear residuals: 6.16673e-06, 8.76738e+06, 2.93572e-05
+      Total relative residual after nonlinear iteration 4: 2.93572e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 28+0 iterations.
       Nonlinear residuals: 13.3331, 5.25046, 152.216
-      Total relative nonlinear residual: 2.67649e-06
+      Relative nonlinear residuals: 5.54728e-07, 8.76738e+06, 2.67649e-06
+      Total relative residual after nonlinear iteration 5: 2.67649e-06
 
 
 
@@ -394,35 +444,40 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 45+0 iterations.
       Nonlinear residuals: 391929, 67395.2, 3.62238e+06
-      Total relative nonlinear residual: 0.0590716
+      Relative nonlinear residuals: 0.0164665, 8.79627e+06, 0.0590716
+      Total relative residual after nonlinear iteration 1: 0.0590716
 
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 40+0 iterations.
       Nonlinear residuals: 16341.4, 6246.86, 180512
-      Total relative nonlinear residual: 0.00294368
+      Relative nonlinear residuals: 0.00068657, 8.79627e+06, 0.00294368
+      Total relative residual after nonlinear iteration 2: 0.00294368
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 36+0 iterations.
       Nonlinear residuals: 1276.77, 509.508, 14484.8
-      Total relative nonlinear residual: 0.000236209
+      Relative nonlinear residuals: 5.36425e-05, 8.79627e+06, 0.000236209
+      Total relative residual after nonlinear iteration 3: 0.000236209
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 31+0 iterations.
       Nonlinear residuals: 106.113, 41.9686, 1230.69
-      Total relative nonlinear residual: 2.00694e-05
+      Relative nonlinear residuals: 4.45823e-06, 8.79627e+06, 2.00694e-05
+      Total relative residual after nonlinear iteration 4: 2.00694e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 27+0 iterations.
       Nonlinear residuals: 8.96327, 3.50569, 104.715
-      Total relative nonlinear residual: 1.70762e-06
+      Relative nonlinear residuals: 3.76583e-07, 8.79627e+06, 1.70762e-06
+      Total relative residual after nonlinear iteration 5: 1.70762e-06
 
 
 
@@ -433,35 +488,40 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 44+0 iterations.
       Nonlinear residuals: 292800, 67420, 2.74823e+06
-      Total relative nonlinear residual: 0.0416316
+      Relative nonlinear residuals: 0.0123146, 8.8457e+06, 0.0416316
+      Total relative residual after nonlinear iteration 1: 0.0416316
 
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 39+0 iterations.
       Nonlinear residuals: 13530.5, 5354.27, 148179
-      Total relative nonlinear residual: 0.00224469
+      Relative nonlinear residuals: 0.00056907, 8.8457e+06, 0.00224469
+      Total relative residual after nonlinear iteration 2: 0.00224469
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 35+0 iterations.
       Nonlinear residuals: 984.765, 390.394, 11239.9
-      Total relative nonlinear residual: 0.000170268
+      Relative nonlinear residuals: 4.14175e-05, 8.8457e+06, 0.000170268
+      Total relative residual after nonlinear iteration 3: 0.000170268
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 31+0 iterations.
       Nonlinear residuals: 75.5848, 29.5864, 878.747
-      Total relative nonlinear residual: 1.33117e-05
+      Relative nonlinear residuals: 3.17896e-06, 8.8457e+06, 1.33117e-05
+      Total relative residual after nonlinear iteration 4: 1.33117e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 26+0 iterations.
       Nonlinear residuals: 5.89606, 2.28764, 68.8876
-      Total relative nonlinear residual: 1.04354e-06
+      Relative nonlinear residuals: 2.47978e-07, 8.8457e+06, 1.04354e-06
+      Total relative residual after nonlinear iteration 5: 1.04354e-06
 
 
 
@@ -472,28 +532,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 43+0 iterations.
       Nonlinear residuals: 180228, 47625.4, 1.78002e+06
-      Total relative nonlinear residual: 0.0254169
+      Relative nonlinear residuals: 0.00785454, 8.56175e+06, 0.0254169
+      Total relative residual after nonlinear iteration 1: 0.0254169
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 38+0 iterations.
       Nonlinear residuals: 6885.83, 2763.18, 78122
-      Total relative nonlinear residual: 0.00111551
+      Relative nonlinear residuals: 0.000300093, 8.56175e+06, 0.00111551
+      Total relative residual after nonlinear iteration 2: 0.00111551
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 33+0 iterations.
       Nonlinear residuals: 382.885, 150.943, 4559.4
-      Total relative nonlinear residual: 6.51037e-05
+      Relative nonlinear residuals: 1.66866e-05, 8.56175e+06, 6.51037e-05
+      Total relative residual after nonlinear iteration 3: 6.51037e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 28+0 iterations.
       Nonlinear residuals: 22.6766, 8.80043, 274.304
-      Total relative nonlinear residual: 3.9168e-06
+      Relative nonlinear residuals: 9.88274e-07, 8.56175e+06, 3.9168e-06
+      Total relative residual after nonlinear iteration 4: 3.9168e-06
 
 
 

--- a/tests/iterated_IMPES/screen-output
+++ b/tests/iterated_IMPES/screen-output
@@ -7,16 +7,14 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 49+0 iterations.
-      Nonlinear residuals: 1.00594e-09, 9.00346e-10, 8.98822e+07
-      Relative nonlinear residuals: 2.00269e-16, 5.76437e+06, 1
+      Relative nonlinear residuals: 2.00269e-16, 1.56192e-16, 1
       Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... 2+0 iterations.
-      Nonlinear residuals: 1.00594e-09, 9.00346e-10, 7.83583e-05
-      Relative nonlinear residuals: 2.00269e-16, 5.76437e+06, 8.71789e-13
+      Relative nonlinear residuals: 2.00269e-16, 1.56192e-16, 8.71789e-13
       Total relative residual after nonlinear iteration 2: 8.71789e-13
 
 
@@ -27,64 +25,56 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 10 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 47+0 iterations.
-      Nonlinear residuals: 1.30257e+07, 362042, 7.76212e+07
-      Relative nonlinear residuals: 0.821377, 6.33542e+06, 0.75783
+      Relative nonlinear residuals: 0.821377, 0.0571457, 0.75783
       Total relative residual after nonlinear iteration 1: 0.821377
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 45+0 iterations.
-      Nonlinear residuals: 1.54989e+06, 23807.8, 1.16379e+07
-      Relative nonlinear residuals: 0.0977331, 6.33542e+06, 0.113623
+      Relative nonlinear residuals: 0.0977331, 0.00375789, 0.113623
       Total relative residual after nonlinear iteration 2: 0.113623
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 42+0 iterations.
-      Nonlinear residuals: 267787, 3251.24, 2.1001e+06
-      Relative nonlinear residuals: 0.0168861, 6.33542e+06, 0.0205037
+      Relative nonlinear residuals: 0.0168861, 0.000513186, 0.0205037
       Total relative residual after nonlinear iteration 3: 0.0205037
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 40+0 iterations.
-      Nonlinear residuals: 50859, 654.641, 402412
-      Relative nonlinear residuals: 0.00320707, 6.33542e+06, 0.00392882
+      Relative nonlinear residuals: 0.00320707, 0.00010333, 0.00392882
       Total relative residual after nonlinear iteration 4: 0.00392882
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 37+0 iterations.
-      Nonlinear residuals: 10042.3, 148.515, 79675.5
-      Relative nonlinear residuals: 0.000633249, 6.33542e+06, 0.000777886
+      Relative nonlinear residuals: 0.000633249, 2.34421e-05, 0.000777886
       Total relative residual after nonlinear iteration 5: 0.000777886
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 35+0 iterations.
-      Nonlinear residuals: 2028.44, 34.3545, 16133
-      Relative nonlinear residuals: 0.000127909, 6.33542e+06, 0.000157509
+      Relative nonlinear residuals: 0.000127909, 5.42261e-06, 0.000157509
       Total relative residual after nonlinear iteration 6: 0.000157509
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 32+0 iterations.
-      Nonlinear residuals: 416.177, 7.88745, 3319.9
-      Relative nonlinear residuals: 2.62433e-05, 6.33542e+06, 3.24128e-05
+      Relative nonlinear residuals: 2.62433e-05, 1.24498e-06, 3.24128e-05
       Total relative residual after nonlinear iteration 7: 3.24128e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 29+0 iterations.
-      Nonlinear residuals: 86.3598, 1.78676, 691.174
-      Relative nonlinear residuals: 5.44567e-06, 6.33542e+06, 6.74805e-06
+      Relative nonlinear residuals: 5.44567e-06, 2.82028e-07, 6.74805e-06
       Total relative residual after nonlinear iteration 8: 6.74805e-06
 
 
@@ -95,64 +85,56 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 46+0 iterations.
-      Nonlinear residuals: 8.74328e+06, 68345.8, 2.77541e+07
-      Relative nonlinear residuals: 0.247282, 8.65875e+06, 0.455259
+      Relative nonlinear residuals: 0.247282, 0.00789326, 0.455259
       Total relative residual after nonlinear iteration 1: 0.455259
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 43+0 iterations.
-      Nonlinear residuals: 534360, 3864.78, 3.36554e+06
-      Relative nonlinear residuals: 0.015113, 8.65875e+06, 0.055206
+      Relative nonlinear residuals: 0.015113, 0.000446344, 0.055206
       Total relative residual after nonlinear iteration 2: 0.055206
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 41+0 iterations.
-      Nonlinear residuals: 73992, 679.828, 562190
-      Relative nonlinear residuals: 0.00209268, 8.65875e+06, 0.00922176
+      Relative nonlinear residuals: 0.00209268, 7.85134e-05, 0.00922176
       Total relative residual after nonlinear iteration 3: 0.00922176
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 38+0 iterations.
-      Nonlinear residuals: 13458.8, 185.172, 102450
-      Relative nonlinear residuals: 0.000380649, 8.65875e+06, 0.00168053
+      Relative nonlinear residuals: 0.000380649, 2.13856e-05, 0.00168053
       Total relative residual after nonlinear iteration 4: 0.00168053
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 35+0 iterations.
-      Nonlinear residuals: 2554.88, 48.2406, 19327.3
-      Relative nonlinear residuals: 7.22582e-05, 8.65875e+06, 0.000317032
+      Relative nonlinear residuals: 7.22582e-05, 5.57131e-06, 0.000317032
       Total relative residual after nonlinear iteration 5: 0.000317032
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 32+0 iterations.
-      Nonlinear residuals: 494.904, 11.6979, 3733.66
-      Relative nonlinear residuals: 1.39971e-05, 8.65875e+06, 6.12444e-05
+      Relative nonlinear residuals: 1.39971e-05, 1.351e-06, 6.12444e-05
       Total relative residual after nonlinear iteration 6: 6.12444e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 30+0 iterations.
-      Nonlinear residuals: 97.4349, 2.7041, 734.428
-      Relative nonlinear residuals: 2.7557e-06, 8.65875e+06, 1.2047e-05
+      Relative nonlinear residuals: 2.7557e-06, 3.12297e-07, 1.2047e-05
       Total relative residual after nonlinear iteration 7: 1.2047e-05
 
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... 26+0 iterations.
-      Nonlinear residuals: 19.4318, 0.605517, 146.478
-      Relative nonlinear residuals: 5.4958e-07, 8.65875e+06, 2.40272e-06
+      Relative nonlinear residuals: 5.4958e-07, 6.99312e-08, 2.40272e-06
       Total relative residual after nonlinear iteration 8: 2.40272e-06
 
 
@@ -163,48 +145,42 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 46+0 iterations.
-      Nonlinear residuals: 8.78636e+06, 52145.3, 3.96054e+07
-      Relative nonlinear residuals: 0.254258, 8.57204e+06, 0.647102
+      Relative nonlinear residuals: 0.254258, 0.00608319, 0.647102
       Total relative residual after nonlinear iteration 1: 0.647102
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 42+0 iterations.
-      Nonlinear residuals: 298794, 3943.3, 1.66045e+06
-      Relative nonlinear residuals: 0.00864642, 8.57204e+06, 0.0271297
+      Relative nonlinear residuals: 0.00864642, 0.000460019, 0.0271297
       Total relative residual after nonlinear iteration 2: 0.0271297
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 38+0 iterations.
-      Nonlinear residuals: 13880.1, 184.183, 90098
-      Relative nonlinear residuals: 0.000401659, 8.57204e+06, 0.00147209
+      Relative nonlinear residuals: 0.000401659, 2.14864e-05, 0.00147209
       Total relative residual after nonlinear iteration 3: 0.00147209
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 35+0 iterations.
-      Nonlinear residuals: 1194.47, 24.9373, 8793.38
-      Relative nonlinear residuals: 3.45653e-05, 8.57204e+06, 0.000143673
+      Relative nonlinear residuals: 3.45653e-05, 2.90915e-06, 0.000143673
       Total relative residual after nonlinear iteration 4: 0.000143673
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 31+0 iterations.
-      Nonlinear residuals: 150.623, 2.9169, 1120.11
-      Relative nonlinear residuals: 4.35868e-06, 8.57204e+06, 1.83012e-05
+      Relative nonlinear residuals: 4.35868e-06, 3.40281e-07, 1.83012e-05
       Total relative residual after nonlinear iteration 5: 1.83012e-05
 
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... 28+0 iterations.
-      Nonlinear residuals: 20.2838, 0.314073, 150.152
-      Relative nonlinear residuals: 5.86969e-07, 8.57204e+06, 2.45329e-06
+      Relative nonlinear residuals: 5.86969e-07, 3.66392e-08, 2.45329e-06
       Total relative residual after nonlinear iteration 6: 2.45329e-06
 
 
@@ -215,48 +191,42 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 47+0 iterations.
-      Nonlinear residuals: 3.47276e+06, 55955.2, 3.10297e+07
-      Relative nonlinear residuals: 0.120332, 8.61043e+06, 0.594093
+      Relative nonlinear residuals: 0.120332, 0.00649854, 0.594093
       Total relative residual after nonlinear iteration 1: 0.594093
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 42+0 iterations.
-      Nonlinear residuals: 121429, 7098.88, 787205
-      Relative nonlinear residuals: 0.00420756, 8.61043e+06, 0.0150718
+      Relative nonlinear residuals: 0.00420756, 0.000824451, 0.0150718
       Total relative residual after nonlinear iteration 2: 0.0150718
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 38+0 iterations.
-      Nonlinear residuals: 7066.23, 552.304, 54337
-      Relative nonlinear residuals: 0.000244847, 8.61043e+06, 0.00104033
+      Relative nonlinear residuals: 0.000244847, 6.41437e-05, 0.00104033
       Total relative residual after nonlinear iteration 3: 0.00104033
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 34+0 iterations.
-      Nonlinear residuals: 662.283, 56.8192, 5212.76
-      Relative nonlinear residuals: 2.29483e-05, 8.61043e+06, 9.98032e-05
+      Relative nonlinear residuals: 2.29483e-05, 6.59889e-06, 9.98032e-05
       Total relative residual after nonlinear iteration 4: 9.98032e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 30+0 iterations.
-      Nonlinear residuals: 68.9605, 6.20146, 551.256
-      Relative nonlinear residuals: 2.3895e-06, 8.61043e+06, 1.05543e-05
+      Relative nonlinear residuals: 2.3895e-06, 7.20227e-07, 1.05543e-05
       Total relative residual after nonlinear iteration 5: 1.05543e-05
 
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... 26+0 iterations.
-      Nonlinear residuals: 7.34032, 0.636452, 58.7242
-      Relative nonlinear residuals: 2.54344e-07, 8.61043e+06, 1.12433e-06
+      Relative nonlinear residuals: 2.54344e-07, 7.39165e-08, 1.12433e-06
       Total relative residual after nonlinear iteration 6: 1.12433e-06
 
 
@@ -267,40 +237,35 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 47+0 iterations.
-      Nonlinear residuals: 2.20444e+06, 56884.3, 1.81351e+07
-      Relative nonlinear residuals: 0.0801971, 8.74052e+06, 0.383226
+      Relative nonlinear residuals: 0.0801971, 0.00650811, 0.383226
       Total relative residual after nonlinear iteration 1: 0.383226
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 42+0 iterations.
-      Nonlinear residuals: 71532.3, 8058.52, 568086
-      Relative nonlinear residuals: 0.00260234, 8.74052e+06, 0.0120047
+      Relative nonlinear residuals: 0.00260234, 0.000921972, 0.0120047
       Total relative residual after nonlinear iteration 2: 0.0120047
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 38+0 iterations.
-      Nonlinear residuals: 5106.63, 1031.27, 43981.5
-      Relative nonlinear residuals: 0.000185779, 8.74052e+06, 0.000929408
+      Relative nonlinear residuals: 0.000185779, 0.000117988, 0.000929408
       Total relative residual after nonlinear iteration 3: 0.000929408
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 34+0 iterations.
-      Nonlinear residuals: 482.134, 107.856, 4266.08
-      Relative nonlinear residuals: 1.754e-05, 8.74052e+06, 9.01498e-05
+      Relative nonlinear residuals: 1.754e-05, 1.23398e-05, 9.01498e-05
       Total relative residual after nonlinear iteration 4: 9.01498e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 30+0 iterations.
-      Nonlinear residuals: 47.948, 10.9268, 427.409
-      Relative nonlinear residuals: 1.74434e-06, 8.74052e+06, 9.03192e-06
+      Relative nonlinear residuals: 1.74434e-06, 1.25013e-06, 9.03192e-06
       Total relative residual after nonlinear iteration 5: 9.03192e-06
 
 
@@ -311,40 +276,35 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 46+0 iterations.
-      Nonlinear residuals: 1.47905e+06, 60360.2, 1.27436e+07
-      Relative nonlinear residuals: 0.0572412, 8.7487e+06, 0.258279
+      Relative nonlinear residuals: 0.0572412, 0.00689934, 0.258279
       Total relative residual after nonlinear iteration 1: 0.258279
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 41+0 iterations.
-      Nonlinear residuals: 45392.6, 9396.6, 397634
-      Relative nonlinear residuals: 0.00175675, 8.7487e+06, 0.00805902
+      Relative nonlinear residuals: 0.00175675, 0.00107406, 0.00805902
       Total relative residual after nonlinear iteration 2: 0.00805902
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 37+0 iterations.
-      Nonlinear residuals: 3292.31, 987.536, 31095.5
-      Relative nonlinear residuals: 0.000127417, 8.7487e+06, 0.000630225
+      Relative nonlinear residuals: 0.000127417, 0.000112878, 0.000630225
       Total relative residual after nonlinear iteration 3: 0.000630225
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 33+0 iterations.
-      Nonlinear residuals: 305.892, 98.0603, 2975.96
-      Relative nonlinear residuals: 1.18384e-05, 8.7487e+06, 6.03151e-05
+      Relative nonlinear residuals: 1.18384e-05, 1.12086e-05, 6.03151e-05
       Total relative residual after nonlinear iteration 4: 6.03151e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 29+0 iterations.
-      Nonlinear residuals: 29.6602, 9.63026, 293.926
-      Relative nonlinear residuals: 1.14789e-06, 8.7487e+06, 5.95712e-06
+      Relative nonlinear residuals: 1.14789e-06, 1.10076e-06, 5.95712e-06
       Total relative residual after nonlinear iteration 5: 5.95712e-06
 
 
@@ -355,40 +315,35 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 46+0 iterations.
-      Nonlinear residuals: 940943, 64026.9, 8.43616e+06
-      Relative nonlinear residuals: 0.038188, 8.7408e+06, 0.159808
+      Relative nonlinear residuals: 0.038188, 0.00732507, 0.159808
       Total relative residual after nonlinear iteration 1: 0.159808
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 41+0 iterations.
-      Nonlinear residuals: 29828.2, 8702.28, 290743
-      Relative nonlinear residuals: 0.00121057, 8.7408e+06, 0.00550759
+      Relative nonlinear residuals: 0.00121057, 0.000995593, 0.00550759
       Total relative residual after nonlinear iteration 2: 0.00550759
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 37+0 iterations.
-      Nonlinear residuals: 2227.05, 826.532, 23200.1
-      Relative nonlinear residuals: 9.03844e-05, 8.7408e+06, 0.000439483
+      Relative nonlinear residuals: 9.03844e-05, 9.45603e-05, 0.000439483
       Total relative residual after nonlinear iteration 3: 0.000439483
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 32+0 iterations.
-      Nonlinear residuals: 202.163, 77.3229, 2177.95
-      Relative nonlinear residuals: 8.20473e-06, 8.7408e+06, 4.12574e-05
+      Relative nonlinear residuals: 8.20473e-06, 8.8462e-06, 4.12574e-05
       Total relative residual after nonlinear iteration 4: 4.12574e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 29+0 iterations.
-      Nonlinear residuals: 19.0298, 7.26265, 209.279
-      Relative nonlinear residuals: 7.72319e-07, 8.7408e+06, 3.96441e-06
+      Relative nonlinear residuals: 7.72319e-07, 8.30891e-07, 3.96441e-06
       Total relative residual after nonlinear iteration 5: 3.96441e-06
 
 
@@ -399,40 +354,35 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 46+0 iterations.
-      Nonlinear residuals: 595028, 66651.8, 5.46878e+06
-      Relative nonlinear residuals: 0.0247562, 8.76738e+06, 0.0961601
+      Relative nonlinear residuals: 0.0247562, 0.00760225, 0.0961601
       Total relative residual after nonlinear iteration 1: 0.0961601
 
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 41+0 iterations.
-      Nonlinear residuals: 21593.2, 7503.24, 227820
-      Relative nonlinear residuals: 0.000898388, 8.76738e+06, 0.00400586
+      Relative nonlinear residuals: 0.000898388, 0.000855813, 0.00400586
       Total relative residual after nonlinear iteration 2: 0.00400586
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 36+0 iterations.
-      Nonlinear residuals: 1686.01, 666.476, 18497.6
-      Relative nonlinear residuals: 7.01468e-05, 8.76738e+06, 0.000325253
+      Relative nonlinear residuals: 7.01468e-05, 7.60177e-05, 0.000325253
       Total relative residual after nonlinear iteration 3: 0.000325253
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 32+0 iterations.
-      Nonlinear residuals: 148.22, 58.9211, 1669.59
-      Relative nonlinear residuals: 6.16673e-06, 8.76738e+06, 2.93572e-05
+      Relative nonlinear residuals: 6.16673e-06, 6.72049e-06, 2.93572e-05
       Total relative residual after nonlinear iteration 4: 2.93572e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 28+0 iterations.
-      Nonlinear residuals: 13.3331, 5.25046, 152.216
-      Relative nonlinear residuals: 5.54728e-07, 8.76738e+06, 2.67649e-06
+      Relative nonlinear residuals: 5.54728e-07, 5.98863e-07, 2.67649e-06
       Total relative residual after nonlinear iteration 5: 2.67649e-06
 
 
@@ -443,40 +393,35 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 45+0 iterations.
-      Nonlinear residuals: 391929, 67395.2, 3.62238e+06
-      Relative nonlinear residuals: 0.0164665, 8.79627e+06, 0.0590716
+      Relative nonlinear residuals: 0.0164665, 0.00766179, 0.0590716
       Total relative residual after nonlinear iteration 1: 0.0590716
 
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 40+0 iterations.
-      Nonlinear residuals: 16341.4, 6246.86, 180512
-      Relative nonlinear residuals: 0.00068657, 8.79627e+06, 0.00294368
+      Relative nonlinear residuals: 0.00068657, 0.000710171, 0.00294368
       Total relative residual after nonlinear iteration 2: 0.00294368
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 36+0 iterations.
-      Nonlinear residuals: 1276.77, 509.508, 14484.8
-      Relative nonlinear residuals: 5.36425e-05, 8.79627e+06, 0.000236209
+      Relative nonlinear residuals: 5.36425e-05, 5.79232e-05, 0.000236209
       Total relative residual after nonlinear iteration 3: 0.000236209
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 31+0 iterations.
-      Nonlinear residuals: 106.113, 41.9686, 1230.69
-      Relative nonlinear residuals: 4.45823e-06, 8.79627e+06, 2.00694e-05
+      Relative nonlinear residuals: 4.45823e-06, 4.77118e-06, 2.00694e-05
       Total relative residual after nonlinear iteration 4: 2.00694e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 27+0 iterations.
-      Nonlinear residuals: 8.96327, 3.50569, 104.715
-      Relative nonlinear residuals: 3.76583e-07, 8.79627e+06, 1.70762e-06
+      Relative nonlinear residuals: 3.76583e-07, 3.98543e-07, 1.70762e-06
       Total relative residual after nonlinear iteration 5: 1.70762e-06
 
 
@@ -487,40 +432,35 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 44+0 iterations.
-      Nonlinear residuals: 292800, 67420, 2.74823e+06
-      Relative nonlinear residuals: 0.0123146, 8.8457e+06, 0.0416316
+      Relative nonlinear residuals: 0.0123146, 0.00762178, 0.0416316
       Total relative residual after nonlinear iteration 1: 0.0416316
 
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 39+0 iterations.
-      Nonlinear residuals: 13530.5, 5354.27, 148179
-      Relative nonlinear residuals: 0.00056907, 8.8457e+06, 0.00224469
+      Relative nonlinear residuals: 0.00056907, 0.000605296, 0.00224469
       Total relative residual after nonlinear iteration 2: 0.00224469
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 35+0 iterations.
-      Nonlinear residuals: 984.765, 390.394, 11239.9
-      Relative nonlinear residuals: 4.14175e-05, 8.8457e+06, 0.000170268
+      Relative nonlinear residuals: 4.14175e-05, 4.41337e-05, 0.000170268
       Total relative residual after nonlinear iteration 3: 0.000170268
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 31+0 iterations.
-      Nonlinear residuals: 75.5848, 29.5864, 878.747
-      Relative nonlinear residuals: 3.17896e-06, 8.8457e+06, 1.33117e-05
+      Relative nonlinear residuals: 3.17896e-06, 3.34472e-06, 1.33117e-05
       Total relative residual after nonlinear iteration 4: 1.33117e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 26+0 iterations.
-      Nonlinear residuals: 5.89606, 2.28764, 68.8876
-      Relative nonlinear residuals: 2.47978e-07, 8.8457e+06, 1.04354e-06
+      Relative nonlinear residuals: 2.47978e-07, 2.58616e-07, 1.04354e-06
       Total relative residual after nonlinear iteration 5: 1.04354e-06
 
 
@@ -531,32 +471,28 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 43+0 iterations.
-      Nonlinear residuals: 180228, 47625.4, 1.78002e+06
-      Relative nonlinear residuals: 0.00785454, 8.56175e+06, 0.0254169
+      Relative nonlinear residuals: 0.00785454, 0.00556257, 0.0254169
       Total relative residual after nonlinear iteration 1: 0.0254169
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 38+0 iterations.
-      Nonlinear residuals: 6885.83, 2763.18, 78122
-      Relative nonlinear residuals: 0.000300093, 8.56175e+06, 0.00111551
+      Relative nonlinear residuals: 0.000300093, 0.000322736, 0.00111551
       Total relative residual after nonlinear iteration 2: 0.00111551
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 33+0 iterations.
-      Nonlinear residuals: 382.885, 150.943, 4559.4
-      Relative nonlinear residuals: 1.66866e-05, 8.56175e+06, 6.51037e-05
+      Relative nonlinear residuals: 1.66866e-05, 1.763e-05, 6.51037e-05
       Total relative residual after nonlinear iteration 3: 6.51037e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 28+0 iterations.
-      Nonlinear residuals: 22.6766, 8.80043, 274.304
-      Relative nonlinear residuals: 9.88274e-07, 8.56175e+06, 3.9168e-06
+      Relative nonlinear residuals: 9.88274e-07, 1.02788e-06, 3.9168e-06
       Total relative residual after nonlinear iteration 4: 3.9168e-06
 
 

--- a/tests/iterated_IMPES_direct_solver/screen-output
+++ b/tests/iterated_IMPES_direct_solver/screen-output
@@ -6,16 +6,14 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 1.00594e-09, 9.00346e-10, 8.98822e+07
-      Relative nonlinear residuals: 2.00269e-16, 5.76437e+06, 1
+      Relative nonlinear residuals: 2.00269e-16, 1.56192e-16, 1
       Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 1.00594e-09, 9.00346e-10, 0.000187616
-      Relative nonlinear residuals: 2.00269e-16, 5.76437e+06, 2.08736e-12
+      Relative nonlinear residuals: 2.00269e-16, 1.56192e-16, 2.08736e-12
       Total relative residual after nonlinear iteration 2: 2.08736e-12
 
 
@@ -26,64 +24,56 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 10 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 1.30257e+07, 362042, 7.76212e+07
-      Relative nonlinear residuals: 0.821377, 6.33542e+06, 0.75783
+      Relative nonlinear residuals: 0.821377, 0.0571457, 0.75783
       Total relative residual after nonlinear iteration 1: 0.821377
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 1.54989e+06, 23807.8, 1.16379e+07
-      Relative nonlinear residuals: 0.0977331, 6.33542e+06, 0.113623
+      Relative nonlinear residuals: 0.0977331, 0.00375789, 0.113623
       Total relative residual after nonlinear iteration 2: 0.113623
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 267787, 3251.24, 2.1001e+06
-      Relative nonlinear residuals: 0.0168861, 6.33542e+06, 0.0205037
+      Relative nonlinear residuals: 0.0168861, 0.000513186, 0.0205037
       Total relative residual after nonlinear iteration 3: 0.0205037
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 50859, 654.641, 402412
-      Relative nonlinear residuals: 0.00320707, 6.33542e+06, 0.00392882
+      Relative nonlinear residuals: 0.00320707, 0.00010333, 0.00392882
       Total relative residual after nonlinear iteration 4: 0.00392882
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 10042.3, 148.515, 79675.5
-      Relative nonlinear residuals: 0.000633249, 6.33542e+06, 0.000777886
+      Relative nonlinear residuals: 0.000633249, 2.34421e-05, 0.000777886
       Total relative residual after nonlinear iteration 5: 0.000777886
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 2028.44, 34.3545, 16133
-      Relative nonlinear residuals: 0.000127909, 6.33542e+06, 0.000157509
+      Relative nonlinear residuals: 0.000127909, 5.42261e-06, 0.000157509
       Total relative residual after nonlinear iteration 6: 0.000157509
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 416.177, 7.88745, 3319.9
-      Relative nonlinear residuals: 2.62433e-05, 6.33542e+06, 3.24128e-05
+      Relative nonlinear residuals: 2.62433e-05, 1.24498e-06, 3.24128e-05
       Total relative residual after nonlinear iteration 7: 3.24128e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 86.3598, 1.78676, 691.174
-      Relative nonlinear residuals: 5.44567e-06, 6.33542e+06, 6.74805e-06
+      Relative nonlinear residuals: 5.44567e-06, 2.82028e-07, 6.74805e-06
       Total relative residual after nonlinear iteration 8: 6.74805e-06
 
 
@@ -94,64 +84,56 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 8.74328e+06, 68345.8, 2.77541e+07
-      Relative nonlinear residuals: 0.247282, 8.65875e+06, 0.455259
+      Relative nonlinear residuals: 0.247282, 0.00789326, 0.455259
       Total relative residual after nonlinear iteration 1: 0.455259
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 534360, 3864.78, 3.36554e+06
-      Relative nonlinear residuals: 0.015113, 8.65875e+06, 0.055206
+      Relative nonlinear residuals: 0.015113, 0.000446344, 0.055206
       Total relative residual after nonlinear iteration 2: 0.055206
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 73992, 679.828, 562190
-      Relative nonlinear residuals: 0.00209268, 8.65875e+06, 0.00922176
+      Relative nonlinear residuals: 0.00209268, 7.85134e-05, 0.00922176
       Total relative residual after nonlinear iteration 3: 0.00922176
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 13458.8, 185.172, 102450
-      Relative nonlinear residuals: 0.000380649, 8.65875e+06, 0.00168053
+      Relative nonlinear residuals: 0.000380649, 2.13856e-05, 0.00168053
       Total relative residual after nonlinear iteration 4: 0.00168053
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 2554.88, 48.2406, 19327.3
-      Relative nonlinear residuals: 7.22582e-05, 8.65875e+06, 0.000317032
+      Relative nonlinear residuals: 7.22582e-05, 5.57131e-06, 0.000317032
       Total relative residual after nonlinear iteration 5: 0.000317032
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 494.904, 11.6979, 3733.66
-      Relative nonlinear residuals: 1.39971e-05, 8.65875e+06, 6.12444e-05
+      Relative nonlinear residuals: 1.39971e-05, 1.351e-06, 6.12444e-05
       Total relative residual after nonlinear iteration 6: 6.12444e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 97.4349, 2.7041, 734.428
-      Relative nonlinear residuals: 2.7557e-06, 8.65875e+06, 1.2047e-05
+      Relative nonlinear residuals: 2.7557e-06, 3.12297e-07, 1.2047e-05
       Total relative residual after nonlinear iteration 7: 1.2047e-05
 
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 19.4318, 0.605517, 146.478
-      Relative nonlinear residuals: 5.4958e-07, 8.65875e+06, 2.40272e-06
+      Relative nonlinear residuals: 5.4958e-07, 6.99312e-08, 2.40272e-06
       Total relative residual after nonlinear iteration 8: 2.40272e-06
 
 
@@ -162,48 +144,42 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 8.78636e+06, 52145.3, 3.96054e+07
-      Relative nonlinear residuals: 0.254258, 8.57204e+06, 0.647102
+      Relative nonlinear residuals: 0.254258, 0.00608319, 0.647102
       Total relative residual after nonlinear iteration 1: 0.647102
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 298794, 3943.3, 1.66045e+06
-      Relative nonlinear residuals: 0.00864642, 8.57204e+06, 0.0271297
+      Relative nonlinear residuals: 0.00864642, 0.000460019, 0.0271297
       Total relative residual after nonlinear iteration 2: 0.0271297
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 13880.1, 184.183, 90098
-      Relative nonlinear residuals: 0.000401659, 8.57204e+06, 0.00147209
+      Relative nonlinear residuals: 0.000401659, 2.14864e-05, 0.00147209
       Total relative residual after nonlinear iteration 3: 0.00147209
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 1194.47, 24.9373, 8793.38
-      Relative nonlinear residuals: 3.45653e-05, 8.57204e+06, 0.000143673
+      Relative nonlinear residuals: 3.45653e-05, 2.90915e-06, 0.000143673
       Total relative residual after nonlinear iteration 4: 0.000143673
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 150.623, 2.9169, 1120.11
-      Relative nonlinear residuals: 4.35868e-06, 8.57204e+06, 1.83012e-05
+      Relative nonlinear residuals: 4.35868e-06, 3.40281e-07, 1.83012e-05
       Total relative residual after nonlinear iteration 5: 1.83012e-05
 
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 20.2838, 0.314073, 150.152
-      Relative nonlinear residuals: 5.86969e-07, 8.57204e+06, 2.45329e-06
+      Relative nonlinear residuals: 5.86969e-07, 3.66392e-08, 2.45329e-06
       Total relative residual after nonlinear iteration 6: 2.45329e-06
 
 
@@ -214,48 +190,42 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 3.47276e+06, 55955.2, 3.10297e+07
-      Relative nonlinear residuals: 0.120332, 8.61043e+06, 0.594093
+      Relative nonlinear residuals: 0.120332, 0.00649854, 0.594093
       Total relative residual after nonlinear iteration 1: 0.594093
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 121429, 7098.88, 787205
-      Relative nonlinear residuals: 0.00420756, 8.61043e+06, 0.0150718
+      Relative nonlinear residuals: 0.00420756, 0.000824451, 0.0150718
       Total relative residual after nonlinear iteration 2: 0.0150718
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 7066.23, 552.304, 54337
-      Relative nonlinear residuals: 0.000244847, 8.61043e+06, 0.00104033
+      Relative nonlinear residuals: 0.000244847, 6.41437e-05, 0.00104033
       Total relative residual after nonlinear iteration 3: 0.00104033
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 662.283, 56.8192, 5212.76
-      Relative nonlinear residuals: 2.29483e-05, 8.61043e+06, 9.98032e-05
+      Relative nonlinear residuals: 2.29483e-05, 6.59889e-06, 9.98032e-05
       Total relative residual after nonlinear iteration 4: 9.98032e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 68.9605, 6.20146, 551.256
-      Relative nonlinear residuals: 2.3895e-06, 8.61043e+06, 1.05543e-05
+      Relative nonlinear residuals: 2.3895e-06, 7.20227e-07, 1.05543e-05
       Total relative residual after nonlinear iteration 5: 1.05543e-05
 
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 7.34032, 0.636452, 58.7242
-      Relative nonlinear residuals: 2.54344e-07, 8.61043e+06, 1.12433e-06
+      Relative nonlinear residuals: 2.54344e-07, 7.39165e-08, 1.12433e-06
       Total relative residual after nonlinear iteration 6: 1.12433e-06
 
 
@@ -266,40 +236,35 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 2.20444e+06, 56884.3, 1.81351e+07
-      Relative nonlinear residuals: 0.0801971, 8.74052e+06, 0.383226
+      Relative nonlinear residuals: 0.0801971, 0.00650811, 0.383226
       Total relative residual after nonlinear iteration 1: 0.383226
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 71532.3, 8058.52, 568086
-      Relative nonlinear residuals: 0.00260234, 8.74052e+06, 0.0120047
+      Relative nonlinear residuals: 0.00260234, 0.000921972, 0.0120047
       Total relative residual after nonlinear iteration 2: 0.0120047
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 5106.63, 1031.27, 43981.5
-      Relative nonlinear residuals: 0.000185779, 8.74052e+06, 0.000929408
+      Relative nonlinear residuals: 0.000185779, 0.000117988, 0.000929408
       Total relative residual after nonlinear iteration 3: 0.000929408
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 482.134, 107.856, 4266.08
-      Relative nonlinear residuals: 1.754e-05, 8.74052e+06, 9.01498e-05
+      Relative nonlinear residuals: 1.754e-05, 1.23398e-05, 9.01498e-05
       Total relative residual after nonlinear iteration 4: 9.01498e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 47.948, 10.9268, 427.409
-      Relative nonlinear residuals: 1.74434e-06, 8.74052e+06, 9.03192e-06
+      Relative nonlinear residuals: 1.74434e-06, 1.25013e-06, 9.03192e-06
       Total relative residual after nonlinear iteration 5: 9.03192e-06
 
 
@@ -310,40 +275,35 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 1.47905e+06, 60360.2, 1.27436e+07
-      Relative nonlinear residuals: 0.0572412, 8.7487e+06, 0.258279
+      Relative nonlinear residuals: 0.0572412, 0.00689934, 0.258279
       Total relative residual after nonlinear iteration 1: 0.258279
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 45392.6, 9396.6, 397634
-      Relative nonlinear residuals: 0.00175675, 8.7487e+06, 0.00805902
+      Relative nonlinear residuals: 0.00175675, 0.00107406, 0.00805902
       Total relative residual after nonlinear iteration 2: 0.00805902
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 3292.31, 987.536, 31095.5
-      Relative nonlinear residuals: 0.000127417, 8.7487e+06, 0.000630225
+      Relative nonlinear residuals: 0.000127417, 0.000112878, 0.000630225
       Total relative residual after nonlinear iteration 3: 0.000630225
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 305.892, 98.0603, 2975.96
-      Relative nonlinear residuals: 1.18384e-05, 8.7487e+06, 6.03151e-05
+      Relative nonlinear residuals: 1.18384e-05, 1.12086e-05, 6.03151e-05
       Total relative residual after nonlinear iteration 4: 6.03151e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 29.6602, 9.63026, 293.926
-      Relative nonlinear residuals: 1.14789e-06, 8.7487e+06, 5.95712e-06
+      Relative nonlinear residuals: 1.14789e-06, 1.10076e-06, 5.95712e-06
       Total relative residual after nonlinear iteration 5: 5.95712e-06
 
 
@@ -354,40 +314,35 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 940943, 64026.9, 8.43616e+06
-      Relative nonlinear residuals: 0.038188, 8.7408e+06, 0.159808
+      Relative nonlinear residuals: 0.038188, 0.00732507, 0.159808
       Total relative residual after nonlinear iteration 1: 0.159808
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 29828.2, 8702.28, 290743
-      Relative nonlinear residuals: 0.00121057, 8.7408e+06, 0.00550759
+      Relative nonlinear residuals: 0.00121057, 0.000995593, 0.00550759
       Total relative residual after nonlinear iteration 2: 0.00550759
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 2227.05, 826.532, 23200.1
-      Relative nonlinear residuals: 9.03844e-05, 8.7408e+06, 0.000439483
+      Relative nonlinear residuals: 9.03844e-05, 9.45603e-05, 0.000439483
       Total relative residual after nonlinear iteration 3: 0.000439483
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 202.163, 77.3229, 2177.95
-      Relative nonlinear residuals: 8.20473e-06, 8.7408e+06, 4.12574e-05
+      Relative nonlinear residuals: 8.20473e-06, 8.8462e-06, 4.12574e-05
       Total relative residual after nonlinear iteration 4: 4.12574e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 19.0298, 7.26265, 209.279
-      Relative nonlinear residuals: 7.72319e-07, 8.7408e+06, 3.96441e-06
+      Relative nonlinear residuals: 7.72319e-07, 8.30891e-07, 3.96441e-06
       Total relative residual after nonlinear iteration 5: 3.96441e-06
 
 
@@ -398,40 +353,35 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 595028, 66651.8, 5.46878e+06
-      Relative nonlinear residuals: 0.0247562, 8.76738e+06, 0.0961601
+      Relative nonlinear residuals: 0.0247562, 0.00760225, 0.0961601
       Total relative residual after nonlinear iteration 1: 0.0961601
 
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 21593.2, 7503.24, 227820
-      Relative nonlinear residuals: 0.000898388, 8.76738e+06, 0.00400586
+      Relative nonlinear residuals: 0.000898388, 0.000855813, 0.00400586
       Total relative residual after nonlinear iteration 2: 0.00400586
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 1686.01, 666.476, 18497.6
-      Relative nonlinear residuals: 7.01468e-05, 8.76738e+06, 0.000325253
+      Relative nonlinear residuals: 7.01468e-05, 7.60177e-05, 0.000325253
       Total relative residual after nonlinear iteration 3: 0.000325253
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 148.22, 58.9211, 1669.59
-      Relative nonlinear residuals: 6.16673e-06, 8.76738e+06, 2.93572e-05
+      Relative nonlinear residuals: 6.16673e-06, 6.72049e-06, 2.93572e-05
       Total relative residual after nonlinear iteration 4: 2.93572e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 13.3331, 5.25046, 152.216
-      Relative nonlinear residuals: 5.54728e-07, 8.76738e+06, 2.67649e-06
+      Relative nonlinear residuals: 5.54728e-07, 5.98863e-07, 2.67649e-06
       Total relative residual after nonlinear iteration 5: 2.67649e-06
 
 
@@ -442,40 +392,35 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 391929, 67395.2, 3.62238e+06
-      Relative nonlinear residuals: 0.0164665, 8.79627e+06, 0.0590716
+      Relative nonlinear residuals: 0.0164665, 0.00766179, 0.0590716
       Total relative residual after nonlinear iteration 1: 0.0590716
 
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 16341.4, 6246.86, 180512
-      Relative nonlinear residuals: 0.00068657, 8.79627e+06, 0.00294368
+      Relative nonlinear residuals: 0.00068657, 0.000710171, 0.00294368
       Total relative residual after nonlinear iteration 2: 0.00294368
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 1276.77, 509.508, 14484.8
-      Relative nonlinear residuals: 5.36425e-05, 8.79627e+06, 0.000236209
+      Relative nonlinear residuals: 5.36425e-05, 5.79232e-05, 0.000236209
       Total relative residual after nonlinear iteration 3: 0.000236209
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 106.113, 41.9686, 1230.69
-      Relative nonlinear residuals: 4.45823e-06, 8.79627e+06, 2.00694e-05
+      Relative nonlinear residuals: 4.45823e-06, 4.77118e-06, 2.00694e-05
       Total relative residual after nonlinear iteration 4: 2.00694e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 8.96327, 3.50569, 104.715
-      Relative nonlinear residuals: 3.76583e-07, 8.79627e+06, 1.70762e-06
+      Relative nonlinear residuals: 3.76583e-07, 3.98543e-07, 1.70762e-06
       Total relative residual after nonlinear iteration 5: 1.70762e-06
 
 
@@ -486,40 +431,35 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 292800, 67420, 2.74823e+06
-      Relative nonlinear residuals: 0.0123146, 8.8457e+06, 0.0416316
+      Relative nonlinear residuals: 0.0123146, 0.00762178, 0.0416316
       Total relative residual after nonlinear iteration 1: 0.0416316
 
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 13530.5, 5354.27, 148179
-      Relative nonlinear residuals: 0.00056907, 8.8457e+06, 0.00224469
+      Relative nonlinear residuals: 0.00056907, 0.000605296, 0.00224469
       Total relative residual after nonlinear iteration 2: 0.00224469
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 984.765, 390.394, 11239.9
-      Relative nonlinear residuals: 4.14175e-05, 8.8457e+06, 0.000170268
+      Relative nonlinear residuals: 4.14175e-05, 4.41337e-05, 0.000170268
       Total relative residual after nonlinear iteration 3: 0.000170268
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 75.5848, 29.5864, 878.747
-      Relative nonlinear residuals: 3.17896e-06, 8.8457e+06, 1.33117e-05
+      Relative nonlinear residuals: 3.17896e-06, 3.34472e-06, 1.33117e-05
       Total relative residual after nonlinear iteration 4: 1.33117e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 5.89606, 2.28764, 68.8876
-      Relative nonlinear residuals: 2.47978e-07, 8.8457e+06, 1.04355e-06
+      Relative nonlinear residuals: 2.47978e-07, 2.58616e-07, 1.04355e-06
       Total relative residual after nonlinear iteration 5: 1.04355e-06
 
 
@@ -530,32 +470,28 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 180228, 47625.4, 1.78002e+06
-      Relative nonlinear residuals: 0.00785454, 8.56175e+06, 0.0254169
+      Relative nonlinear residuals: 0.00785454, 0.00556257, 0.0254169
       Total relative residual after nonlinear iteration 1: 0.0254169
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 6885.83, 2763.18, 78122
-      Relative nonlinear residuals: 0.000300093, 8.56175e+06, 0.00111551
+      Relative nonlinear residuals: 0.000300093, 0.000322736, 0.00111551
       Total relative residual after nonlinear iteration 2: 0.00111551
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 382.885, 150.943, 4559.4
-      Relative nonlinear residuals: 1.66866e-05, 8.56175e+06, 6.51037e-05
+      Relative nonlinear residuals: 1.66866e-05, 1.763e-05, 6.51037e-05
       Total relative residual after nonlinear iteration 3: 6.51037e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Nonlinear residuals: 22.6766, 8.80043, 274.304
-      Relative nonlinear residuals: 9.88274e-07, 8.56175e+06, 3.9168e-06
+      Relative nonlinear residuals: 9.88274e-07, 1.02788e-06, 3.9168e-06
       Total relative residual after nonlinear iteration 4: 3.9168e-06
 
 

--- a/tests/iterated_IMPES_direct_solver/screen-output
+++ b/tests/iterated_IMPES_direct_solver/screen-output
@@ -7,14 +7,16 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 1.00594e-09, 9.00346e-10, 8.98822e+07
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 2.00269e-16, 5.76437e+06, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 1.00594e-09, 9.00346e-10, 0.000187616
-      Total relative nonlinear residual: 2.08736e-12
+      Relative nonlinear residuals: 2.00269e-16, 5.76437e+06, 2.08736e-12
+      Total relative residual after nonlinear iteration 2: 2.08736e-12
 
 
 
@@ -25,56 +27,64 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 1.30257e+07, 362042, 7.76212e+07
-      Total relative nonlinear residual: 0.821377
+      Relative nonlinear residuals: 0.821377, 6.33542e+06, 0.75783
+      Total relative residual after nonlinear iteration 1: 0.821377
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 1.54989e+06, 23807.8, 1.16379e+07
-      Total relative nonlinear residual: 0.113623
+      Relative nonlinear residuals: 0.0977331, 6.33542e+06, 0.113623
+      Total relative residual after nonlinear iteration 2: 0.113623
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 267787, 3251.24, 2.1001e+06
-      Total relative nonlinear residual: 0.0205037
+      Relative nonlinear residuals: 0.0168861, 6.33542e+06, 0.0205037
+      Total relative residual after nonlinear iteration 3: 0.0205037
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 50859, 654.641, 402412
-      Total relative nonlinear residual: 0.00392882
+      Relative nonlinear residuals: 0.00320707, 6.33542e+06, 0.00392882
+      Total relative residual after nonlinear iteration 4: 0.00392882
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 10042.3, 148.515, 79675.5
-      Total relative nonlinear residual: 0.000777886
+      Relative nonlinear residuals: 0.000633249, 6.33542e+06, 0.000777886
+      Total relative residual after nonlinear iteration 5: 0.000777886
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 2028.44, 34.3545, 16133
-      Total relative nonlinear residual: 0.000157509
+      Relative nonlinear residuals: 0.000127909, 6.33542e+06, 0.000157509
+      Total relative residual after nonlinear iteration 6: 0.000157509
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 416.177, 7.88745, 3319.9
-      Total relative nonlinear residual: 3.24128e-05
+      Relative nonlinear residuals: 2.62433e-05, 6.33542e+06, 3.24128e-05
+      Total relative residual after nonlinear iteration 7: 3.24128e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 86.3598, 1.78676, 691.174
-      Total relative nonlinear residual: 6.74805e-06
+      Relative nonlinear residuals: 5.44567e-06, 6.33542e+06, 6.74805e-06
+      Total relative residual after nonlinear iteration 8: 6.74805e-06
 
 
 
@@ -85,56 +95,64 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 8.74328e+06, 68345.8, 2.77541e+07
-      Total relative nonlinear residual: 0.455259
+      Relative nonlinear residuals: 0.247282, 8.65875e+06, 0.455259
+      Total relative residual after nonlinear iteration 1: 0.455259
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 534360, 3864.78, 3.36554e+06
-      Total relative nonlinear residual: 0.055206
+      Relative nonlinear residuals: 0.015113, 8.65875e+06, 0.055206
+      Total relative residual after nonlinear iteration 2: 0.055206
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 73992, 679.828, 562190
-      Total relative nonlinear residual: 0.00922176
+      Relative nonlinear residuals: 0.00209268, 8.65875e+06, 0.00922176
+      Total relative residual after nonlinear iteration 3: 0.00922176
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 13458.8, 185.172, 102450
-      Total relative nonlinear residual: 0.00168053
+      Relative nonlinear residuals: 0.000380649, 8.65875e+06, 0.00168053
+      Total relative residual after nonlinear iteration 4: 0.00168053
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 2554.88, 48.2406, 19327.3
-      Total relative nonlinear residual: 0.000317032
+      Relative nonlinear residuals: 7.22582e-05, 8.65875e+06, 0.000317032
+      Total relative residual after nonlinear iteration 5: 0.000317032
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 494.904, 11.6979, 3733.66
-      Total relative nonlinear residual: 6.12444e-05
+      Relative nonlinear residuals: 1.39971e-05, 8.65875e+06, 6.12444e-05
+      Total relative residual after nonlinear iteration 6: 6.12444e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 97.4349, 2.7041, 734.428
-      Total relative nonlinear residual: 1.2047e-05
+      Relative nonlinear residuals: 2.7557e-06, 8.65875e+06, 1.2047e-05
+      Total relative residual after nonlinear iteration 7: 1.2047e-05
 
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 19.4318, 0.605517, 146.478
-      Total relative nonlinear residual: 2.40272e-06
+      Relative nonlinear residuals: 5.4958e-07, 8.65875e+06, 2.40272e-06
+      Total relative residual after nonlinear iteration 8: 2.40272e-06
 
 
 
@@ -145,42 +163,48 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 8.78636e+06, 52145.3, 3.96054e+07
-      Total relative nonlinear residual: 0.647102
+      Relative nonlinear residuals: 0.254258, 8.57204e+06, 0.647102
+      Total relative residual after nonlinear iteration 1: 0.647102
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 298794, 3943.3, 1.66045e+06
-      Total relative nonlinear residual: 0.0271297
+      Relative nonlinear residuals: 0.00864642, 8.57204e+06, 0.0271297
+      Total relative residual after nonlinear iteration 2: 0.0271297
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 13880.1, 184.183, 90098
-      Total relative nonlinear residual: 0.00147209
+      Relative nonlinear residuals: 0.000401659, 8.57204e+06, 0.00147209
+      Total relative residual after nonlinear iteration 3: 0.00147209
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 1194.47, 24.9373, 8793.38
-      Total relative nonlinear residual: 0.000143673
+      Relative nonlinear residuals: 3.45653e-05, 8.57204e+06, 0.000143673
+      Total relative residual after nonlinear iteration 4: 0.000143673
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 150.623, 2.9169, 1120.11
-      Total relative nonlinear residual: 1.83012e-05
+      Relative nonlinear residuals: 4.35868e-06, 8.57204e+06, 1.83012e-05
+      Total relative residual after nonlinear iteration 5: 1.83012e-05
 
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 20.2838, 0.314073, 150.152
-      Total relative nonlinear residual: 2.45329e-06
+      Relative nonlinear residuals: 5.86969e-07, 8.57204e+06, 2.45329e-06
+      Total relative residual after nonlinear iteration 6: 2.45329e-06
 
 
 
@@ -191,42 +215,48 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 3.47276e+06, 55955.2, 3.10297e+07
-      Total relative nonlinear residual: 0.594093
+      Relative nonlinear residuals: 0.120332, 8.61043e+06, 0.594093
+      Total relative residual after nonlinear iteration 1: 0.594093
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 121429, 7098.88, 787205
-      Total relative nonlinear residual: 0.0150718
+      Relative nonlinear residuals: 0.00420756, 8.61043e+06, 0.0150718
+      Total relative residual after nonlinear iteration 2: 0.0150718
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 7066.23, 552.304, 54337
-      Total relative nonlinear residual: 0.00104033
+      Relative nonlinear residuals: 0.000244847, 8.61043e+06, 0.00104033
+      Total relative residual after nonlinear iteration 3: 0.00104033
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 662.283, 56.8192, 5212.76
-      Total relative nonlinear residual: 9.98032e-05
+      Relative nonlinear residuals: 2.29483e-05, 8.61043e+06, 9.98032e-05
+      Total relative residual after nonlinear iteration 4: 9.98032e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 68.9605, 6.20146, 551.256
-      Total relative nonlinear residual: 1.05543e-05
+      Relative nonlinear residuals: 2.3895e-06, 8.61043e+06, 1.05543e-05
+      Total relative residual after nonlinear iteration 5: 1.05543e-05
 
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 7.34032, 0.636452, 58.7242
-      Total relative nonlinear residual: 1.12433e-06
+      Relative nonlinear residuals: 2.54344e-07, 8.61043e+06, 1.12433e-06
+      Total relative residual after nonlinear iteration 6: 1.12433e-06
 
 
 
@@ -237,35 +267,40 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 2.20444e+06, 56884.3, 1.81351e+07
-      Total relative nonlinear residual: 0.383226
+      Relative nonlinear residuals: 0.0801971, 8.74052e+06, 0.383226
+      Total relative residual after nonlinear iteration 1: 0.383226
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 71532.3, 8058.52, 568086
-      Total relative nonlinear residual: 0.0120047
+      Relative nonlinear residuals: 0.00260234, 8.74052e+06, 0.0120047
+      Total relative residual after nonlinear iteration 2: 0.0120047
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 5106.63, 1031.27, 43981.5
-      Total relative nonlinear residual: 0.000929408
+      Relative nonlinear residuals: 0.000185779, 8.74052e+06, 0.000929408
+      Total relative residual after nonlinear iteration 3: 0.000929408
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 482.134, 107.856, 4266.08
-      Total relative nonlinear residual: 9.01498e-05
+      Relative nonlinear residuals: 1.754e-05, 8.74052e+06, 9.01498e-05
+      Total relative residual after nonlinear iteration 4: 9.01498e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 47.948, 10.9268, 427.409
-      Total relative nonlinear residual: 9.03192e-06
+      Relative nonlinear residuals: 1.74434e-06, 8.74052e+06, 9.03192e-06
+      Total relative residual after nonlinear iteration 5: 9.03192e-06
 
 
 
@@ -276,35 +311,40 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 1.47905e+06, 60360.2, 1.27436e+07
-      Total relative nonlinear residual: 0.258279
+      Relative nonlinear residuals: 0.0572412, 8.7487e+06, 0.258279
+      Total relative residual after nonlinear iteration 1: 0.258279
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 45392.6, 9396.6, 397634
-      Total relative nonlinear residual: 0.00805902
+      Relative nonlinear residuals: 0.00175675, 8.7487e+06, 0.00805902
+      Total relative residual after nonlinear iteration 2: 0.00805902
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 3292.31, 987.536, 31095.5
-      Total relative nonlinear residual: 0.000630225
+      Relative nonlinear residuals: 0.000127417, 8.7487e+06, 0.000630225
+      Total relative residual after nonlinear iteration 3: 0.000630225
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 305.892, 98.0603, 2975.96
-      Total relative nonlinear residual: 6.03151e-05
+      Relative nonlinear residuals: 1.18384e-05, 8.7487e+06, 6.03151e-05
+      Total relative residual after nonlinear iteration 4: 6.03151e-05
 
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 29.6602, 9.63026, 293.926
-      Total relative nonlinear residual: 5.95712e-06
+      Relative nonlinear residuals: 1.14789e-06, 8.7487e+06, 5.95712e-06
+      Total relative residual after nonlinear iteration 5: 5.95712e-06
 
 
 
@@ -315,35 +355,40 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 940943, 64026.9, 8.43616e+06
-      Total relative nonlinear residual: 0.159808
+      Relative nonlinear residuals: 0.038188, 8.7408e+06, 0.159808
+      Total relative residual after nonlinear iteration 1: 0.159808
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 29828.2, 8702.28, 290743
-      Total relative nonlinear residual: 0.00550759
+      Relative nonlinear residuals: 0.00121057, 8.7408e+06, 0.00550759
+      Total relative residual after nonlinear iteration 2: 0.00550759
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 2227.05, 826.532, 23200.1
-      Total relative nonlinear residual: 0.000439483
+      Relative nonlinear residuals: 9.03844e-05, 8.7408e+06, 0.000439483
+      Total relative residual after nonlinear iteration 3: 0.000439483
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 202.163, 77.3229, 2177.95
-      Total relative nonlinear residual: 4.12574e-05
+      Relative nonlinear residuals: 8.20473e-06, 8.7408e+06, 4.12574e-05
+      Total relative residual after nonlinear iteration 4: 4.12574e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 19.0298, 7.26265, 209.279
-      Total relative nonlinear residual: 3.96441e-06
+      Relative nonlinear residuals: 7.72319e-07, 8.7408e+06, 3.96441e-06
+      Total relative residual after nonlinear iteration 5: 3.96441e-06
 
 
 
@@ -354,35 +399,40 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 595028, 66651.8, 5.46878e+06
-      Total relative nonlinear residual: 0.0961601
+      Relative nonlinear residuals: 0.0247562, 8.76738e+06, 0.0961601
+      Total relative residual after nonlinear iteration 1: 0.0961601
 
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 21593.2, 7503.24, 227820
-      Total relative nonlinear residual: 0.00400586
+      Relative nonlinear residuals: 0.000898388, 8.76738e+06, 0.00400586
+      Total relative residual after nonlinear iteration 2: 0.00400586
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 1686.01, 666.476, 18497.6
-      Total relative nonlinear residual: 0.000325253
+      Relative nonlinear residuals: 7.01468e-05, 8.76738e+06, 0.000325253
+      Total relative residual after nonlinear iteration 3: 0.000325253
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 148.22, 58.9211, 1669.59
-      Total relative nonlinear residual: 2.93572e-05
+      Relative nonlinear residuals: 6.16673e-06, 8.76738e+06, 2.93572e-05
+      Total relative residual after nonlinear iteration 4: 2.93572e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 13.3331, 5.25046, 152.216
-      Total relative nonlinear residual: 2.67649e-06
+      Relative nonlinear residuals: 5.54728e-07, 8.76738e+06, 2.67649e-06
+      Total relative residual after nonlinear iteration 5: 2.67649e-06
 
 
 
@@ -393,35 +443,40 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 391929, 67395.2, 3.62238e+06
-      Total relative nonlinear residual: 0.0590716
+      Relative nonlinear residuals: 0.0164665, 8.79627e+06, 0.0590716
+      Total relative residual after nonlinear iteration 1: 0.0590716
 
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 16341.4, 6246.86, 180512
-      Total relative nonlinear residual: 0.00294368
+      Relative nonlinear residuals: 0.00068657, 8.79627e+06, 0.00294368
+      Total relative residual after nonlinear iteration 2: 0.00294368
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 1276.77, 509.508, 14484.8
-      Total relative nonlinear residual: 0.000236209
+      Relative nonlinear residuals: 5.36425e-05, 8.79627e+06, 0.000236209
+      Total relative residual after nonlinear iteration 3: 0.000236209
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 106.113, 41.9686, 1230.69
-      Total relative nonlinear residual: 2.00694e-05
+      Relative nonlinear residuals: 4.45823e-06, 8.79627e+06, 2.00694e-05
+      Total relative residual after nonlinear iteration 4: 2.00694e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 8.96327, 3.50569, 104.715
-      Total relative nonlinear residual: 1.70762e-06
+      Relative nonlinear residuals: 3.76583e-07, 8.79627e+06, 1.70762e-06
+      Total relative residual after nonlinear iteration 5: 1.70762e-06
 
 
 
@@ -432,35 +487,40 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 292800, 67420, 2.74823e+06
-      Total relative nonlinear residual: 0.0416316
+      Relative nonlinear residuals: 0.0123146, 8.8457e+06, 0.0416316
+      Total relative residual after nonlinear iteration 1: 0.0416316
 
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 13530.5, 5354.27, 148179
-      Total relative nonlinear residual: 0.00224469
+      Relative nonlinear residuals: 0.00056907, 8.8457e+06, 0.00224469
+      Total relative residual after nonlinear iteration 2: 0.00224469
 
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 984.765, 390.394, 11239.9
-      Total relative nonlinear residual: 0.000170268
+      Relative nonlinear residuals: 4.14175e-05, 8.8457e+06, 0.000170268
+      Total relative residual after nonlinear iteration 3: 0.000170268
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 75.5848, 29.5864, 878.747
-      Total relative nonlinear residual: 1.33117e-05
+      Relative nonlinear residuals: 3.17896e-06, 8.8457e+06, 1.33117e-05
+      Total relative residual after nonlinear iteration 4: 1.33117e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 5.89606, 2.28764, 68.8876
-      Total relative nonlinear residual: 1.04355e-06
+      Relative nonlinear residuals: 2.47978e-07, 8.8457e+06, 1.04355e-06
+      Total relative residual after nonlinear iteration 5: 1.04355e-06
 
 
 
@@ -471,28 +531,32 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 180228, 47625.4, 1.78002e+06
-      Total relative nonlinear residual: 0.0254169
+      Relative nonlinear residuals: 0.00785454, 8.56175e+06, 0.0254169
+      Total relative residual after nonlinear iteration 1: 0.0254169
 
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 6885.83, 2763.18, 78122
-      Total relative nonlinear residual: 0.00111551
+      Relative nonlinear residuals: 0.000300093, 8.56175e+06, 0.00111551
+      Total relative residual after nonlinear iteration 2: 0.00111551
 
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 382.885, 150.943, 4559.4
-      Total relative nonlinear residual: 6.51037e-05
+      Relative nonlinear residuals: 1.66866e-05, 8.56175e+06, 6.51037e-05
+      Total relative residual after nonlinear iteration 3: 6.51037e-05
 
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
       Nonlinear residuals: 22.6766, 8.80043, 274.304
-      Total relative nonlinear residual: 3.9168e-06
+      Relative nonlinear residuals: 9.88274e-07, 8.56175e+06, 3.9168e-06
+      Total relative residual after nonlinear iteration 4: 3.9168e-06
 
 
 

--- a/tests/iterated_IMPES_residual/screen-output
+++ b/tests/iterated_IMPES_residual/screen-output
@@ -7,7 +7,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 49+0 iterations.
-      Nonlinear residuals: 1.00594e-09, 0, 8.98822e+07
       Relative nonlinear residuals: 2.00269e-16, 0, 1
       Total relative residual after nonlinear iteration 1: 1
 
@@ -15,7 +14,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 2+0 iterations.
-      Nonlinear residuals: 1.00594e-09, 0, 7.83583e-05
       Relative nonlinear residuals: 2.00269e-16, 0, 8.71789e-13
       Total relative residual after nonlinear iteration 2: 8.71789e-13
 
@@ -27,7 +25,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 10 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 47+0 iterations.
-      Nonlinear residuals: 1.30257e+07, 0, 7.76212e+07
       Relative nonlinear residuals: 0.821377, 0, 0.75783
       Total relative residual after nonlinear iteration 1: 0.821377
 
@@ -35,7 +32,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 10 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 45+0 iterations.
-      Nonlinear residuals: 1.54989e+06, 0, 1.16379e+07
       Relative nonlinear residuals: 0.0977331, 0, 0.113623
       Total relative residual after nonlinear iteration 2: 0.113623
 
@@ -43,7 +39,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 42+0 iterations.
-      Nonlinear residuals: 267787, 0, 2.1001e+06
       Relative nonlinear residuals: 0.0168861, 0, 0.0205037
       Total relative residual after nonlinear iteration 3: 0.0205037
 
@@ -51,7 +46,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 40+0 iterations.
-      Nonlinear residuals: 50859, 0, 402412
       Relative nonlinear residuals: 0.00320707, 0, 0.00392882
       Total relative residual after nonlinear iteration 4: 0.00392882
 
@@ -59,7 +53,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 37+0 iterations.
-      Nonlinear residuals: 10042.3, 0, 79675.5
       Relative nonlinear residuals: 0.000633249, 0, 0.000777886
       Total relative residual after nonlinear iteration 5: 0.000777886
 
@@ -67,7 +60,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 35+0 iterations.
-      Nonlinear residuals: 2028.44, 0, 16133
       Relative nonlinear residuals: 0.000127909, 0, 0.000157509
       Total relative residual after nonlinear iteration 6: 0.000157509
 
@@ -75,7 +67,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Nonlinear residuals: 416.177, 0, 3319.9
       Relative nonlinear residuals: 2.62433e-05, 0, 3.24128e-05
       Total relative residual after nonlinear iteration 7: 3.24128e-05
 
@@ -83,7 +74,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Nonlinear residuals: 86.3598, 0, 691.174
       Relative nonlinear residuals: 5.44567e-06, 0, 6.74805e-06
       Total relative residual after nonlinear iteration 8: 6.74805e-06
 
@@ -95,7 +85,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 46+0 iterations.
-      Nonlinear residuals: 8.74328e+06, 0, 2.77541e+07
       Relative nonlinear residuals: 0.247282, 0, 0.455259
       Total relative residual after nonlinear iteration 1: 0.455259
 
@@ -103,7 +92,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 10 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 43+0 iterations.
-      Nonlinear residuals: 534360, 0, 3.36554e+06
       Relative nonlinear residuals: 0.015113, 0, 0.055206
       Total relative residual after nonlinear iteration 2: 0.055206
 
@@ -111,7 +99,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 41+0 iterations.
-      Nonlinear residuals: 73992, 0, 562190
       Relative nonlinear residuals: 0.00209268, 0, 0.00922176
       Total relative residual after nonlinear iteration 3: 0.00922176
 
@@ -119,7 +106,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 38+0 iterations.
-      Nonlinear residuals: 13458.8, 0, 102450
       Relative nonlinear residuals: 0.000380649, 0, 0.00168053
       Total relative residual after nonlinear iteration 4: 0.00168053
 
@@ -127,7 +113,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 35+0 iterations.
-      Nonlinear residuals: 2554.88, 0, 19327.3
       Relative nonlinear residuals: 7.22582e-05, 0, 0.000317032
       Total relative residual after nonlinear iteration 5: 0.000317032
 
@@ -135,7 +120,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Nonlinear residuals: 494.904, 0, 3733.66
       Relative nonlinear residuals: 1.39971e-05, 0, 6.12444e-05
       Total relative residual after nonlinear iteration 6: 6.12444e-05
 
@@ -143,7 +127,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Nonlinear residuals: 97.4349, 0, 734.428
       Relative nonlinear residuals: 2.7557e-06, 0, 1.2047e-05
       Total relative residual after nonlinear iteration 7: 1.2047e-05
 
@@ -151,7 +134,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 5 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Nonlinear residuals: 19.4318, 0, 146.478
       Relative nonlinear residuals: 5.4958e-07, 0, 2.40272e-06
       Total relative residual after nonlinear iteration 8: 2.40272e-06
 
@@ -163,7 +145,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 46+0 iterations.
-      Nonlinear residuals: 8.78636e+06, 0, 3.96054e+07
       Relative nonlinear residuals: 0.254258, 0, 0.647102
       Total relative residual after nonlinear iteration 1: 0.647102
 
@@ -171,7 +152,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 42+0 iterations.
-      Nonlinear residuals: 298794, 0, 1.66045e+06
       Relative nonlinear residuals: 0.00864642, 0, 0.0271297
       Total relative residual after nonlinear iteration 2: 0.0271297
 
@@ -179,7 +159,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 38+0 iterations.
-      Nonlinear residuals: 13880.1, 0, 90098
       Relative nonlinear residuals: 0.000401659, 0, 0.00147209
       Total relative residual after nonlinear iteration 3: 0.00147209
 
@@ -187,7 +166,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 35+0 iterations.
-      Nonlinear residuals: 1194.47, 0, 8793.38
       Relative nonlinear residuals: 3.45653e-05, 0, 0.000143673
       Total relative residual after nonlinear iteration 4: 0.000143673
 
@@ -195,7 +173,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Nonlinear residuals: 150.623, 0, 1120.11
       Relative nonlinear residuals: 4.35868e-06, 0, 1.83012e-05
       Total relative residual after nonlinear iteration 5: 1.83012e-05
 
@@ -203,7 +180,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 5 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Nonlinear residuals: 20.2838, 0, 150.152
       Relative nonlinear residuals: 5.86969e-07, 0, 2.45329e-06
       Total relative residual after nonlinear iteration 6: 2.45329e-06
 
@@ -215,7 +191,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 47+0 iterations.
-      Nonlinear residuals: 3.47276e+06, 0, 3.10297e+07
       Relative nonlinear residuals: 0.120332, 0, 0.594093
       Total relative residual after nonlinear iteration 1: 0.594093
 
@@ -223,7 +198,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 42+0 iterations.
-      Nonlinear residuals: 121429, 0, 787205
       Relative nonlinear residuals: 0.00420756, 0, 0.0150718
       Total relative residual after nonlinear iteration 2: 0.0150718
 
@@ -231,7 +205,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 38+0 iterations.
-      Nonlinear residuals: 7066.23, 0, 54337
       Relative nonlinear residuals: 0.000244847, 0, 0.00104033
       Total relative residual after nonlinear iteration 3: 0.00104033
 
@@ -239,7 +212,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 34+0 iterations.
-      Nonlinear residuals: 662.283, 0, 5212.76
       Relative nonlinear residuals: 2.29483e-05, 0, 9.98032e-05
       Total relative residual after nonlinear iteration 4: 9.98032e-05
 
@@ -247,7 +219,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Nonlinear residuals: 68.9605, 0, 551.256
       Relative nonlinear residuals: 2.3895e-06, 0, 1.05543e-05
       Total relative residual after nonlinear iteration 5: 1.05543e-05
 
@@ -255,7 +226,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 5 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Nonlinear residuals: 7.34032, 0, 58.7242
       Relative nonlinear residuals: 2.54344e-07, 0, 1.12433e-06
       Total relative residual after nonlinear iteration 6: 1.12433e-06
 
@@ -267,7 +237,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 47+0 iterations.
-      Nonlinear residuals: 2.20444e+06, 0, 1.81351e+07
       Relative nonlinear residuals: 0.0801971, 0, 0.383226
       Total relative residual after nonlinear iteration 1: 0.383226
 
@@ -275,7 +244,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 42+0 iterations.
-      Nonlinear residuals: 71532.3, 0, 568086
       Relative nonlinear residuals: 0.00260234, 0, 0.0120047
       Total relative residual after nonlinear iteration 2: 0.0120047
 
@@ -283,7 +251,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 38+0 iterations.
-      Nonlinear residuals: 5106.63, 0, 43981.5
       Relative nonlinear residuals: 0.000185779, 0, 0.000929408
       Total relative residual after nonlinear iteration 3: 0.000929408
 
@@ -291,7 +258,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 34+0 iterations.
-      Nonlinear residuals: 482.134, 0, 4266.08
       Relative nonlinear residuals: 1.754e-05, 0, 9.01498e-05
       Total relative residual after nonlinear iteration 4: 9.01498e-05
 
@@ -299,7 +265,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Nonlinear residuals: 47.948, 0, 427.409
       Relative nonlinear residuals: 1.74434e-06, 0, 9.03192e-06
       Total relative residual after nonlinear iteration 5: 9.03192e-06
 
@@ -311,7 +276,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 46+0 iterations.
-      Nonlinear residuals: 1.47905e+06, 0, 1.27436e+07
       Relative nonlinear residuals: 0.0572412, 0, 0.258279
       Total relative residual after nonlinear iteration 1: 0.258279
 
@@ -319,7 +283,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 41+0 iterations.
-      Nonlinear residuals: 45392.6, 0, 397634
       Relative nonlinear residuals: 0.00175675, 0, 0.00805902
       Total relative residual after nonlinear iteration 2: 0.00805902
 
@@ -327,7 +290,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 37+0 iterations.
-      Nonlinear residuals: 3292.31, 0, 31095.5
       Relative nonlinear residuals: 0.000127417, 0, 0.000630225
       Total relative residual after nonlinear iteration 3: 0.000630225
 
@@ -335,7 +297,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 33+0 iterations.
-      Nonlinear residuals: 305.892, 0, 2975.96
       Relative nonlinear residuals: 1.18384e-05, 0, 6.03151e-05
       Total relative residual after nonlinear iteration 4: 6.03151e-05
 
@@ -343,7 +304,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Nonlinear residuals: 29.6602, 0, 293.926
       Relative nonlinear residuals: 1.14789e-06, 0, 5.95712e-06
       Total relative residual after nonlinear iteration 5: 5.95712e-06
 
@@ -355,7 +315,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 46+0 iterations.
-      Nonlinear residuals: 940943, 0, 8.43616e+06
       Relative nonlinear residuals: 0.038188, 0, 0.159808
       Total relative residual after nonlinear iteration 1: 0.159808
 
@@ -363,7 +322,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 10 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 41+0 iterations.
-      Nonlinear residuals: 29828.2, 0, 290743
       Relative nonlinear residuals: 0.00121057, 0, 0.00550759
       Total relative residual after nonlinear iteration 2: 0.00550759
 
@@ -371,7 +329,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 37+0 iterations.
-      Nonlinear residuals: 2227.05, 0, 23200.1
       Relative nonlinear residuals: 9.03844e-05, 0, 0.000439483
       Total relative residual after nonlinear iteration 3: 0.000439483
 
@@ -379,7 +336,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Nonlinear residuals: 202.163, 0, 2177.95
       Relative nonlinear residuals: 8.20473e-06, 0, 4.12574e-05
       Total relative residual after nonlinear iteration 4: 4.12574e-05
 
@@ -387,7 +343,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Nonlinear residuals: 19.0298, 0, 209.279
       Relative nonlinear residuals: 7.72319e-07, 0, 3.96441e-06
       Total relative residual after nonlinear iteration 5: 3.96441e-06
 
@@ -399,7 +354,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 12 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 46+0 iterations.
-      Nonlinear residuals: 595028, 0, 5.46878e+06
       Relative nonlinear residuals: 0.0247562, 0, 0.0961601
       Total relative residual after nonlinear iteration 1: 0.0961601
 
@@ -407,7 +361,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 41+0 iterations.
-      Nonlinear residuals: 21593.2, 0, 227820
       Relative nonlinear residuals: 0.000898388, 0, 0.00400586
       Total relative residual after nonlinear iteration 2: 0.00400586
 
@@ -415,7 +368,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 36+0 iterations.
-      Nonlinear residuals: 1686.01, 0, 18497.6
       Relative nonlinear residuals: 7.01468e-05, 0, 0.000325253
       Total relative residual after nonlinear iteration 3: 0.000325253
 
@@ -423,7 +375,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Nonlinear residuals: 148.22, 0, 1669.59
       Relative nonlinear residuals: 6.16673e-06, 0, 2.93572e-05
       Total relative residual after nonlinear iteration 4: 2.93572e-05
 
@@ -431,7 +382,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Nonlinear residuals: 13.3331, 0, 152.216
       Relative nonlinear residuals: 5.54728e-07, 0, 2.67649e-06
       Total relative residual after nonlinear iteration 5: 2.67649e-06
 
@@ -443,7 +393,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 12 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 45+0 iterations.
-      Nonlinear residuals: 391929, 0, 3.62238e+06
       Relative nonlinear residuals: 0.0164665, 0, 0.0590716
       Total relative residual after nonlinear iteration 1: 0.0590716
 
@@ -451,7 +400,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 40+0 iterations.
-      Nonlinear residuals: 16341.4, 0, 180512
       Relative nonlinear residuals: 0.00068657, 0, 0.00294368
       Total relative residual after nonlinear iteration 2: 0.00294368
 
@@ -459,7 +407,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 36+0 iterations.
-      Nonlinear residuals: 1276.77, 0, 14484.8
       Relative nonlinear residuals: 5.36425e-05, 0, 0.000236209
       Total relative residual after nonlinear iteration 3: 0.000236209
 
@@ -467,7 +414,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Nonlinear residuals: 106.113, 0, 1230.69
       Relative nonlinear residuals: 4.45823e-06, 0, 2.00694e-05
       Total relative residual after nonlinear iteration 4: 2.00694e-05
 
@@ -475,7 +421,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Nonlinear residuals: 8.96327, 0, 104.715
       Relative nonlinear residuals: 3.76583e-07, 0, 1.70762e-06
       Total relative residual after nonlinear iteration 5: 1.70762e-06
 
@@ -487,7 +432,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 12 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 44+0 iterations.
-      Nonlinear residuals: 292800, 0, 2.74823e+06
       Relative nonlinear residuals: 0.0123146, 0, 0.0416316
       Total relative residual after nonlinear iteration 1: 0.0416316
 
@@ -495,7 +439,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 39+0 iterations.
-      Nonlinear residuals: 13530.5, 0, 148179
       Relative nonlinear residuals: 0.00056907, 0, 0.00224469
       Total relative residual after nonlinear iteration 2: 0.00224469
 
@@ -503,7 +446,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 35+0 iterations.
-      Nonlinear residuals: 984.765, 0, 11239.9
       Relative nonlinear residuals: 4.14175e-05, 0, 0.000170268
       Total relative residual after nonlinear iteration 3: 0.000170268
 
@@ -511,7 +453,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Nonlinear residuals: 75.5848, 0, 878.747
       Relative nonlinear residuals: 3.17896e-06, 0, 1.33117e-05
       Total relative residual after nonlinear iteration 4: 1.33117e-05
 
@@ -519,7 +460,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Nonlinear residuals: 5.89606, 0, 68.8876
       Relative nonlinear residuals: 2.47978e-07, 0, 1.04354e-06
       Total relative residual after nonlinear iteration 5: 1.04354e-06
 
@@ -531,7 +471,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 43+0 iterations.
-      Nonlinear residuals: 180228, 0, 1.78002e+06
       Relative nonlinear residuals: 0.00785454, 0, 0.0254169
       Total relative residual after nonlinear iteration 1: 0.0254169
 
@@ -539,7 +478,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 10 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 38+0 iterations.
-      Nonlinear residuals: 6885.83, 0, 78122
       Relative nonlinear residuals: 0.000300093, 0, 0.00111551
       Total relative residual after nonlinear iteration 2: 0.00111551
 
@@ -547,7 +485,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 33+0 iterations.
-      Nonlinear residuals: 382.885, 0, 4559.4
       Relative nonlinear residuals: 1.66866e-05, 0, 6.51037e-05
       Total relative residual after nonlinear iteration 3: 6.51037e-05
 
@@ -555,7 +492,6 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Nonlinear residuals: 22.6766, 0, 274.304
       Relative nonlinear residuals: 9.88274e-07, 0, 3.9168e-06
       Total relative residual after nonlinear iteration 4: 3.9168e-06
 

--- a/tests/iterated_IMPES_residual/screen-output
+++ b/tests/iterated_IMPES_residual/screen-output
@@ -8,14 +8,16 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 49+0 iterations.
       Nonlinear residuals: 1.00594e-09, 0, 8.98822e+07
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 2.00269e-16, 0, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 2+0 iterations.
       Nonlinear residuals: 1.00594e-09, 0, 7.83583e-05
-      Total relative nonlinear residual: 8.71789e-13
+      Relative nonlinear residuals: 2.00269e-16, 0, 8.71789e-13
+      Total relative residual after nonlinear iteration 2: 8.71789e-13
 
 
 
@@ -26,56 +28,64 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 47+0 iterations.
       Nonlinear residuals: 1.30257e+07, 0, 7.76212e+07
-      Total relative nonlinear residual: 0.821377
+      Relative nonlinear residuals: 0.821377, 0, 0.75783
+      Total relative residual after nonlinear iteration 1: 0.821377
 
 
    Solving temperature system... 10 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 45+0 iterations.
       Nonlinear residuals: 1.54989e+06, 0, 1.16379e+07
-      Total relative nonlinear residual: 0.113623
+      Relative nonlinear residuals: 0.0977331, 0, 0.113623
+      Total relative residual after nonlinear iteration 2: 0.113623
 
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 42+0 iterations.
       Nonlinear residuals: 267787, 0, 2.1001e+06
-      Total relative nonlinear residual: 0.0205037
+      Relative nonlinear residuals: 0.0168861, 0, 0.0205037
+      Total relative residual after nonlinear iteration 3: 0.0205037
 
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 40+0 iterations.
       Nonlinear residuals: 50859, 0, 402412
-      Total relative nonlinear residual: 0.00392882
+      Relative nonlinear residuals: 0.00320707, 0, 0.00392882
+      Total relative residual after nonlinear iteration 4: 0.00392882
 
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 37+0 iterations.
       Nonlinear residuals: 10042.3, 0, 79675.5
-      Total relative nonlinear residual: 0.000777886
+      Relative nonlinear residuals: 0.000633249, 0, 0.000777886
+      Total relative residual after nonlinear iteration 5: 0.000777886
 
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 35+0 iterations.
       Nonlinear residuals: 2028.44, 0, 16133
-      Total relative nonlinear residual: 0.000157509
+      Relative nonlinear residuals: 0.000127909, 0, 0.000157509
+      Total relative residual after nonlinear iteration 6: 0.000157509
 
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
       Nonlinear residuals: 416.177, 0, 3319.9
-      Total relative nonlinear residual: 3.24128e-05
+      Relative nonlinear residuals: 2.62433e-05, 0, 3.24128e-05
+      Total relative residual after nonlinear iteration 7: 3.24128e-05
 
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
       Nonlinear residuals: 86.3598, 0, 691.174
-      Total relative nonlinear residual: 6.74805e-06
+      Relative nonlinear residuals: 5.44567e-06, 0, 6.74805e-06
+      Total relative residual after nonlinear iteration 8: 6.74805e-06
 
 
 
@@ -86,56 +96,64 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 46+0 iterations.
       Nonlinear residuals: 8.74328e+06, 0, 2.77541e+07
-      Total relative nonlinear residual: 0.455259
+      Relative nonlinear residuals: 0.247282, 0, 0.455259
+      Total relative residual after nonlinear iteration 1: 0.455259
 
 
    Solving temperature system... 10 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 43+0 iterations.
       Nonlinear residuals: 534360, 0, 3.36554e+06
-      Total relative nonlinear residual: 0.055206
+      Relative nonlinear residuals: 0.015113, 0, 0.055206
+      Total relative residual after nonlinear iteration 2: 0.055206
 
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 41+0 iterations.
       Nonlinear residuals: 73992, 0, 562190
-      Total relative nonlinear residual: 0.00922176
+      Relative nonlinear residuals: 0.00209268, 0, 0.00922176
+      Total relative residual after nonlinear iteration 3: 0.00922176
 
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 38+0 iterations.
       Nonlinear residuals: 13458.8, 0, 102450
-      Total relative nonlinear residual: 0.00168053
+      Relative nonlinear residuals: 0.000380649, 0, 0.00168053
+      Total relative residual after nonlinear iteration 4: 0.00168053
 
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 35+0 iterations.
       Nonlinear residuals: 2554.88, 0, 19327.3
-      Total relative nonlinear residual: 0.000317032
+      Relative nonlinear residuals: 7.22582e-05, 0, 0.000317032
+      Total relative residual after nonlinear iteration 5: 0.000317032
 
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
       Nonlinear residuals: 494.904, 0, 3733.66
-      Total relative nonlinear residual: 6.12444e-05
+      Relative nonlinear residuals: 1.39971e-05, 0, 6.12444e-05
+      Total relative residual after nonlinear iteration 6: 6.12444e-05
 
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
       Nonlinear residuals: 97.4349, 0, 734.428
-      Total relative nonlinear residual: 1.2047e-05
+      Relative nonlinear residuals: 2.7557e-06, 0, 1.2047e-05
+      Total relative residual after nonlinear iteration 7: 1.2047e-05
 
 
    Solving temperature system... 5 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
       Nonlinear residuals: 19.4318, 0, 146.478
-      Total relative nonlinear residual: 2.40272e-06
+      Relative nonlinear residuals: 5.4958e-07, 0, 2.40272e-06
+      Total relative residual after nonlinear iteration 8: 2.40272e-06
 
 
 
@@ -146,42 +164,48 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 46+0 iterations.
       Nonlinear residuals: 8.78636e+06, 0, 3.96054e+07
-      Total relative nonlinear residual: 0.647102
+      Relative nonlinear residuals: 0.254258, 0, 0.647102
+      Total relative residual after nonlinear iteration 1: 0.647102
 
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 42+0 iterations.
       Nonlinear residuals: 298794, 0, 1.66045e+06
-      Total relative nonlinear residual: 0.0271297
+      Relative nonlinear residuals: 0.00864642, 0, 0.0271297
+      Total relative residual after nonlinear iteration 2: 0.0271297
 
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 38+0 iterations.
       Nonlinear residuals: 13880.1, 0, 90098
-      Total relative nonlinear residual: 0.00147209
+      Relative nonlinear residuals: 0.000401659, 0, 0.00147209
+      Total relative residual after nonlinear iteration 3: 0.00147209
 
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 35+0 iterations.
       Nonlinear residuals: 1194.47, 0, 8793.38
-      Total relative nonlinear residual: 0.000143673
+      Relative nonlinear residuals: 3.45653e-05, 0, 0.000143673
+      Total relative residual after nonlinear iteration 4: 0.000143673
 
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
       Nonlinear residuals: 150.623, 0, 1120.11
-      Total relative nonlinear residual: 1.83012e-05
+      Relative nonlinear residuals: 4.35868e-06, 0, 1.83012e-05
+      Total relative residual after nonlinear iteration 5: 1.83012e-05
 
 
    Solving temperature system... 5 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
       Nonlinear residuals: 20.2838, 0, 150.152
-      Total relative nonlinear residual: 2.45329e-06
+      Relative nonlinear residuals: 5.86969e-07, 0, 2.45329e-06
+      Total relative residual after nonlinear iteration 6: 2.45329e-06
 
 
 
@@ -192,42 +216,48 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 47+0 iterations.
       Nonlinear residuals: 3.47276e+06, 0, 3.10297e+07
-      Total relative nonlinear residual: 0.594093
+      Relative nonlinear residuals: 0.120332, 0, 0.594093
+      Total relative residual after nonlinear iteration 1: 0.594093
 
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 42+0 iterations.
       Nonlinear residuals: 121429, 0, 787205
-      Total relative nonlinear residual: 0.0150718
+      Relative nonlinear residuals: 0.00420756, 0, 0.0150718
+      Total relative residual after nonlinear iteration 2: 0.0150718
 
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 38+0 iterations.
       Nonlinear residuals: 7066.23, 0, 54337
-      Total relative nonlinear residual: 0.00104033
+      Relative nonlinear residuals: 0.000244847, 0, 0.00104033
+      Total relative residual after nonlinear iteration 3: 0.00104033
 
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 34+0 iterations.
       Nonlinear residuals: 662.283, 0, 5212.76
-      Total relative nonlinear residual: 9.98032e-05
+      Relative nonlinear residuals: 2.29483e-05, 0, 9.98032e-05
+      Total relative residual after nonlinear iteration 4: 9.98032e-05
 
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
       Nonlinear residuals: 68.9605, 0, 551.256
-      Total relative nonlinear residual: 1.05543e-05
+      Relative nonlinear residuals: 2.3895e-06, 0, 1.05543e-05
+      Total relative residual after nonlinear iteration 5: 1.05543e-05
 
 
    Solving temperature system... 5 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
       Nonlinear residuals: 7.34032, 0, 58.7242
-      Total relative nonlinear residual: 1.12433e-06
+      Relative nonlinear residuals: 2.54344e-07, 0, 1.12433e-06
+      Total relative residual after nonlinear iteration 6: 1.12433e-06
 
 
 
@@ -238,35 +268,40 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 47+0 iterations.
       Nonlinear residuals: 2.20444e+06, 0, 1.81351e+07
-      Total relative nonlinear residual: 0.383226
+      Relative nonlinear residuals: 0.0801971, 0, 0.383226
+      Total relative residual after nonlinear iteration 1: 0.383226
 
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 42+0 iterations.
       Nonlinear residuals: 71532.3, 0, 568086
-      Total relative nonlinear residual: 0.0120047
+      Relative nonlinear residuals: 0.00260234, 0, 0.0120047
+      Total relative residual after nonlinear iteration 2: 0.0120047
 
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 38+0 iterations.
       Nonlinear residuals: 5106.63, 0, 43981.5
-      Total relative nonlinear residual: 0.000929408
+      Relative nonlinear residuals: 0.000185779, 0, 0.000929408
+      Total relative residual after nonlinear iteration 3: 0.000929408
 
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 34+0 iterations.
       Nonlinear residuals: 482.134, 0, 4266.08
-      Total relative nonlinear residual: 9.01498e-05
+      Relative nonlinear residuals: 1.754e-05, 0, 9.01498e-05
+      Total relative residual after nonlinear iteration 4: 9.01498e-05
 
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
       Nonlinear residuals: 47.948, 0, 427.409
-      Total relative nonlinear residual: 9.03192e-06
+      Relative nonlinear residuals: 1.74434e-06, 0, 9.03192e-06
+      Total relative residual after nonlinear iteration 5: 9.03192e-06
 
 
 
@@ -277,35 +312,40 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 46+0 iterations.
       Nonlinear residuals: 1.47905e+06, 0, 1.27436e+07
-      Total relative nonlinear residual: 0.258279
+      Relative nonlinear residuals: 0.0572412, 0, 0.258279
+      Total relative residual after nonlinear iteration 1: 0.258279
 
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 41+0 iterations.
       Nonlinear residuals: 45392.6, 0, 397634
-      Total relative nonlinear residual: 0.00805902
+      Relative nonlinear residuals: 0.00175675, 0, 0.00805902
+      Total relative residual after nonlinear iteration 2: 0.00805902
 
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 37+0 iterations.
       Nonlinear residuals: 3292.31, 0, 31095.5
-      Total relative nonlinear residual: 0.000630225
+      Relative nonlinear residuals: 0.000127417, 0, 0.000630225
+      Total relative residual after nonlinear iteration 3: 0.000630225
 
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 33+0 iterations.
       Nonlinear residuals: 305.892, 0, 2975.96
-      Total relative nonlinear residual: 6.03151e-05
+      Relative nonlinear residuals: 1.18384e-05, 0, 6.03151e-05
+      Total relative residual after nonlinear iteration 4: 6.03151e-05
 
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
       Nonlinear residuals: 29.6602, 0, 293.926
-      Total relative nonlinear residual: 5.95712e-06
+      Relative nonlinear residuals: 1.14789e-06, 0, 5.95712e-06
+      Total relative residual after nonlinear iteration 5: 5.95712e-06
 
 
 
@@ -316,35 +356,40 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 46+0 iterations.
       Nonlinear residuals: 940943, 0, 8.43616e+06
-      Total relative nonlinear residual: 0.159808
+      Relative nonlinear residuals: 0.038188, 0, 0.159808
+      Total relative residual after nonlinear iteration 1: 0.159808
 
 
    Solving temperature system... 10 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 41+0 iterations.
       Nonlinear residuals: 29828.2, 0, 290743
-      Total relative nonlinear residual: 0.00550759
+      Relative nonlinear residuals: 0.00121057, 0, 0.00550759
+      Total relative residual after nonlinear iteration 2: 0.00550759
 
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 37+0 iterations.
       Nonlinear residuals: 2227.05, 0, 23200.1
-      Total relative nonlinear residual: 0.000439483
+      Relative nonlinear residuals: 9.03844e-05, 0, 0.000439483
+      Total relative residual after nonlinear iteration 3: 0.000439483
 
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
       Nonlinear residuals: 202.163, 0, 2177.95
-      Total relative nonlinear residual: 4.12574e-05
+      Relative nonlinear residuals: 8.20473e-06, 0, 4.12574e-05
+      Total relative residual after nonlinear iteration 4: 4.12574e-05
 
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
       Nonlinear residuals: 19.0298, 0, 209.279
-      Total relative nonlinear residual: 3.96441e-06
+      Relative nonlinear residuals: 7.72319e-07, 0, 3.96441e-06
+      Total relative residual after nonlinear iteration 5: 3.96441e-06
 
 
 
@@ -355,35 +400,40 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 46+0 iterations.
       Nonlinear residuals: 595028, 0, 5.46878e+06
-      Total relative nonlinear residual: 0.0961601
+      Relative nonlinear residuals: 0.0247562, 0, 0.0961601
+      Total relative residual after nonlinear iteration 1: 0.0961601
 
 
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 41+0 iterations.
       Nonlinear residuals: 21593.2, 0, 227820
-      Total relative nonlinear residual: 0.00400586
+      Relative nonlinear residuals: 0.000898388, 0, 0.00400586
+      Total relative residual after nonlinear iteration 2: 0.00400586
 
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 36+0 iterations.
       Nonlinear residuals: 1686.01, 0, 18497.6
-      Total relative nonlinear residual: 0.000325253
+      Relative nonlinear residuals: 7.01468e-05, 0, 0.000325253
+      Total relative residual after nonlinear iteration 3: 0.000325253
 
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
       Nonlinear residuals: 148.22, 0, 1669.59
-      Total relative nonlinear residual: 2.93572e-05
+      Relative nonlinear residuals: 6.16673e-06, 0, 2.93572e-05
+      Total relative residual after nonlinear iteration 4: 2.93572e-05
 
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
       Nonlinear residuals: 13.3331, 0, 152.216
-      Total relative nonlinear residual: 2.67649e-06
+      Relative nonlinear residuals: 5.54728e-07, 0, 2.67649e-06
+      Total relative residual after nonlinear iteration 5: 2.67649e-06
 
 
 
@@ -394,35 +444,40 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 45+0 iterations.
       Nonlinear residuals: 391929, 0, 3.62238e+06
-      Total relative nonlinear residual: 0.0590716
+      Relative nonlinear residuals: 0.0164665, 0, 0.0590716
+      Total relative residual after nonlinear iteration 1: 0.0590716
 
 
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 40+0 iterations.
       Nonlinear residuals: 16341.4, 0, 180512
-      Total relative nonlinear residual: 0.00294368
+      Relative nonlinear residuals: 0.00068657, 0, 0.00294368
+      Total relative residual after nonlinear iteration 2: 0.00294368
 
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 36+0 iterations.
       Nonlinear residuals: 1276.77, 0, 14484.8
-      Total relative nonlinear residual: 0.000236209
+      Relative nonlinear residuals: 5.36425e-05, 0, 0.000236209
+      Total relative residual after nonlinear iteration 3: 0.000236209
 
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
       Nonlinear residuals: 106.113, 0, 1230.69
-      Total relative nonlinear residual: 2.00694e-05
+      Relative nonlinear residuals: 4.45823e-06, 0, 2.00694e-05
+      Total relative residual after nonlinear iteration 4: 2.00694e-05
 
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
       Nonlinear residuals: 8.96327, 0, 104.715
-      Total relative nonlinear residual: 1.70762e-06
+      Relative nonlinear residuals: 3.76583e-07, 0, 1.70762e-06
+      Total relative residual after nonlinear iteration 5: 1.70762e-06
 
 
 
@@ -433,35 +488,40 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 44+0 iterations.
       Nonlinear residuals: 292800, 0, 2.74823e+06
-      Total relative nonlinear residual: 0.0416316
+      Relative nonlinear residuals: 0.0123146, 0, 0.0416316
+      Total relative residual after nonlinear iteration 1: 0.0416316
 
 
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 39+0 iterations.
       Nonlinear residuals: 13530.5, 0, 148179
-      Total relative nonlinear residual: 0.00224469
+      Relative nonlinear residuals: 0.00056907, 0, 0.00224469
+      Total relative residual after nonlinear iteration 2: 0.00224469
 
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 35+0 iterations.
       Nonlinear residuals: 984.765, 0, 11239.9
-      Total relative nonlinear residual: 0.000170268
+      Relative nonlinear residuals: 4.14175e-05, 0, 0.000170268
+      Total relative residual after nonlinear iteration 3: 0.000170268
 
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
       Nonlinear residuals: 75.5848, 0, 878.747
-      Total relative nonlinear residual: 1.33117e-05
+      Relative nonlinear residuals: 3.17896e-06, 0, 1.33117e-05
+      Total relative residual after nonlinear iteration 4: 1.33117e-05
 
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
       Nonlinear residuals: 5.89606, 0, 68.8876
-      Total relative nonlinear residual: 1.04354e-06
+      Relative nonlinear residuals: 2.47978e-07, 0, 1.04354e-06
+      Total relative residual after nonlinear iteration 5: 1.04354e-06
 
 
 
@@ -472,28 +532,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 43+0 iterations.
       Nonlinear residuals: 180228, 0, 1.78002e+06
-      Total relative nonlinear residual: 0.0254169
+      Relative nonlinear residuals: 0.00785454, 0, 0.0254169
+      Total relative residual after nonlinear iteration 1: 0.0254169
 
 
    Solving temperature system... 10 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 38+0 iterations.
       Nonlinear residuals: 6885.83, 0, 78122
-      Total relative nonlinear residual: 0.00111551
+      Relative nonlinear residuals: 0.000300093, 0, 0.00111551
+      Total relative residual after nonlinear iteration 2: 0.00111551
 
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 33+0 iterations.
       Nonlinear residuals: 382.885, 0, 4559.4
-      Total relative nonlinear residual: 6.51037e-05
+      Relative nonlinear residuals: 1.66866e-05, 0, 6.51037e-05
+      Total relative residual after nonlinear iteration 3: 6.51037e-05
 
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
       Nonlinear residuals: 22.6766, 0, 274.304
-      Total relative nonlinear residual: 3.9168e-06
+      Relative nonlinear residuals: 9.88274e-07, 0, 3.9168e-06
+      Total relative residual after nonlinear iteration 4: 3.9168e-06
 
 
 

--- a/tests/melt_compressible_advection/screen-output
+++ b/tests/melt_compressible_advection/screen-output
@@ -10,7 +10,8 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
       Nonlinear residuals: 0, 3.21779e-18, 29.6476
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 0, 0.0147436, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Skipping temperature solve because RHS is zero.
@@ -18,7 +19,8 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
       Nonlinear residuals: 0, 3.21779e-18, 4.06546
-      Total relative nonlinear residual: 0.137126
+      Relative nonlinear residuals: 0, 0.0147436, 0.137126
+      Total relative residual after nonlinear iteration 2: 0.137126
 
 
    Skipping temperature solve because RHS is zero.
@@ -26,7 +28,8 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
       Nonlinear residuals: 0, 3.21779e-18, 0.0219483
-      Total relative nonlinear residual: 0.000740306
+      Relative nonlinear residuals: 0, 0.0147436, 0.000740306
+      Total relative residual after nonlinear iteration 3: 0.000740306
 
 
    Skipping temperature solve because RHS is zero.
@@ -34,7 +37,8 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
       Nonlinear residuals: 0, 3.21779e-18, 0.000611804
-      Total relative nonlinear residual: 2.06359e-05
+      Relative nonlinear residuals: 0, 0.0147436, 2.06359e-05
+      Total relative residual after nonlinear iteration 4: 2.06359e-05
 
 
 
@@ -50,7 +54,8 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
       Nonlinear residuals: 0, 3.65774e-07, 0.00060432
-      Total relative nonlinear residual: 2.4356e-05
+      Relative nonlinear residuals: 0, 0.0150178, 1.59784e-05
+      Total relative residual after nonlinear iteration 1: 2.4356e-05
 
 
 
@@ -66,7 +71,8 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
       Nonlinear residuals: 0, 2.70241e-08, 0.00062782
-      Total relative nonlinear residual: 1.65997e-05
+      Relative nonlinear residuals: 0, 0.0212974, 1.65997e-05
+      Total relative residual after nonlinear iteration 1: 1.65997e-05
 
 
 

--- a/tests/melt_compressible_advection/screen-output
+++ b/tests/melt_compressible_advection/screen-output
@@ -9,8 +9,7 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
-      Nonlinear residuals: 0, 3.21779e-18, 29.6476
-      Relative nonlinear residuals: 0, 0.0147436, 1
+      Relative nonlinear residuals: 0, 2.1825e-16, 1
       Total relative residual after nonlinear iteration 1: 1
 
 
@@ -18,8 +17,7 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
-      Nonlinear residuals: 0, 3.21779e-18, 4.06546
-      Relative nonlinear residuals: 0, 0.0147436, 0.137126
+      Relative nonlinear residuals: 0, 2.1825e-16, 0.137126
       Total relative residual after nonlinear iteration 2: 0.137126
 
 
@@ -27,8 +25,7 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
-      Nonlinear residuals: 0, 3.21779e-18, 0.0219483
-      Relative nonlinear residuals: 0, 0.0147436, 0.000740306
+      Relative nonlinear residuals: 0, 2.1825e-16, 0.000740306
       Total relative residual after nonlinear iteration 3: 0.000740306
 
 
@@ -36,8 +33,7 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
-      Nonlinear residuals: 0, 3.21779e-18, 0.000611804
-      Relative nonlinear residuals: 0, 0.0147436, 2.06359e-05
+      Relative nonlinear residuals: 0, 2.1825e-16, 2.06359e-05
       Total relative residual after nonlinear iteration 4: 2.06359e-05
 
 
@@ -53,8 +49,7 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
-      Nonlinear residuals: 0, 3.65774e-07, 0.00060432
-      Relative nonlinear residuals: 0, 0.0150178, 1.59784e-05
+      Relative nonlinear residuals: 0, 2.4356e-05, 1.59784e-05
       Total relative residual after nonlinear iteration 1: 2.4356e-05
 
 
@@ -70,8 +65,7 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
-      Nonlinear residuals: 0, 2.70241e-08, 0.00062782
-      Relative nonlinear residuals: 0, 0.0212974, 1.65997e-05
+      Relative nonlinear residuals: 0, 1.26889e-06, 1.65997e-05
       Total relative residual after nonlinear iteration 1: 1.65997e-05
 
 

--- a/tests/melt_material_4/screen-output
+++ b/tests/melt_material_4/screen-output
@@ -10,7 +10,8 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving Stokes system... done.
    Solving for u_f in 8 iterations.
       Nonlinear residuals: 9.21357e-18, 2.93693e-18, 17248
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 1.9817e-16, 0.0152754, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 3 iterations.
@@ -18,7 +19,8 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving Stokes system... done.
    Solving for u_f in 8 iterations.
       Nonlinear residuals: 1.11865e-17, 1.99208e-18, 9.33209e-12
-      Total relative nonlinear residual: 5.41055e-16
+      Relative nonlinear residuals: 2.40604e-16, 0.0152754, 5.41055e-16
+      Total relative residual after nonlinear iteration 2: 5.41055e-16
 
 
 

--- a/tests/melt_material_4/screen-output
+++ b/tests/melt_material_4/screen-output
@@ -9,8 +9,7 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving porosity system ... 3 iterations.
    Solving Stokes system... done.
    Solving for u_f in 8 iterations.
-      Nonlinear residuals: 9.21357e-18, 2.93693e-18, 17248
-      Relative nonlinear residuals: 1.9817e-16, 0.0152754, 1
+      Relative nonlinear residuals: 1.9817e-16, 1.92266e-16, 1
       Total relative residual after nonlinear iteration 1: 1
 
 
@@ -18,8 +17,7 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving porosity system ... 3 iterations.
    Solving Stokes system... done.
    Solving for u_f in 8 iterations.
-      Nonlinear residuals: 1.11865e-17, 1.99208e-18, 9.33209e-12
-      Relative nonlinear residuals: 2.40604e-16, 0.0152754, 5.41055e-16
+      Relative nonlinear residuals: 2.40604e-16, 1.30411e-16, 5.41055e-16
       Total relative residual after nonlinear iteration 2: 5.41055e-16
 
 

--- a/tests/melt_property_visualization/screen-output
+++ b/tests/melt_property_visualization/screen-output
@@ -10,7 +10,8 @@ Number of degrees of freedom: 112,521 (41,732+33,282+4,225+16,641+16,641)
    Solving Stokes system... done.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 8.70027e-19, 21.6796
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 0, 0.0043675, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Skipping temperature solve because RHS is zero.
@@ -18,7 +19,8 @@ Number of degrees of freedom: 112,521 (41,732+33,282+4,225+16,641+16,641)
    Solving Stokes system... done.
    Solving for u_f in 10 iterations.
       Nonlinear residuals: 0, 8.70027e-19, 1.28186
-      Total relative nonlinear residual: 0.0591275
+      Relative nonlinear residuals: 0, 0.0043675, 0.0591275
+      Total relative residual after nonlinear iteration 2: 0.0591275
 
 
    Skipping temperature solve because RHS is zero.
@@ -26,7 +28,8 @@ Number of degrees of freedom: 112,521 (41,732+33,282+4,225+16,641+16,641)
    Solving Stokes system... done.
    Solving for u_f in 10 iterations.
       Nonlinear residuals: 0, 8.70027e-19, 8.13878e-05
-      Total relative nonlinear residual: 3.75412e-06
+      Relative nonlinear residuals: 0, 0.0043675, 3.75412e-06
+      Total relative residual after nonlinear iteration 3: 3.75412e-06
 
 
 

--- a/tests/melt_property_visualization/screen-output
+++ b/tests/melt_property_visualization/screen-output
@@ -9,8 +9,7 @@ Number of degrees of freedom: 112,521 (41,732+33,282+4,225+16,641+16,641)
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 8.70027e-19, 21.6796
-      Relative nonlinear residuals: 0, 0.0043675, 1
+      Relative nonlinear residuals: 0, 1.99205e-16, 1
       Total relative residual after nonlinear iteration 1: 1
 
 
@@ -18,8 +17,7 @@ Number of degrees of freedom: 112,521 (41,732+33,282+4,225+16,641+16,641)
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 10 iterations.
-      Nonlinear residuals: 0, 8.70027e-19, 1.28186
-      Relative nonlinear residuals: 0, 0.0043675, 0.0591275
+      Relative nonlinear residuals: 0, 1.99205e-16, 0.0591275
       Total relative residual after nonlinear iteration 2: 0.0591275
 
 
@@ -27,8 +25,7 @@ Number of degrees of freedom: 112,521 (41,732+33,282+4,225+16,641+16,641)
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 10 iterations.
-      Nonlinear residuals: 0, 8.70027e-19, 8.13878e-05
-      Relative nonlinear residuals: 0, 0.0043675, 3.75412e-06
+      Relative nonlinear residuals: 0, 1.99205e-16, 3.75412e-06
       Total relative residual after nonlinear iteration 3: 3.75412e-06
 
 

--- a/tests/melt_transport_adaptive/screen-output
+++ b/tests/melt_transport_adaptive/screen-output
@@ -11,7 +11,8 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Solving Stokes system... 0+23 iterations.
    Solving for u_f in 12 iterations.
       Nonlinear residuals: 0, 1.69718e-18, 81.7677
-      Total relative nonlinear residual: 0.997001
+      Relative nonlinear residuals: 0, 0.00774796, 0.997001
+      Total relative residual after nonlinear iteration 1: 0.997001
 
 
    Skipping temperature solve because RHS is zero.
@@ -19,8 +20,9 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 0, 1.69718e-18, 5.33713e-11
-      Total relative nonlinear residual: 6.50761e-13
+      Nonlinear residuals: 0, 1.69718e-18, 5.33695e-11
+      Relative nonlinear residuals: 0, 0.00774796, 6.5074e-13
+      Total relative residual after nonlinear iteration 2: 6.5074e-13
 
 
 
@@ -40,7 +42,8 @@ Number of degrees of freedom: 9,414 (2,774+728+2,774+364+1,387+1,387)
    Solving Stokes system... 0+23 iterations.
    Solving for u_f in 12 iterations.
       Nonlinear residuals: 0, 1.05619e-18, 81.5062
-      Total relative nonlinear residual: 0.996549
+      Relative nonlinear residuals: 0, 0.00551177, 0.996549
+      Total relative residual after nonlinear iteration 1: 0.996549
 
 
    Skipping temperature solve because RHS is zero.
@@ -48,8 +51,9 @@ Number of degrees of freedom: 9,414 (2,774+728+2,774+364+1,387+1,387)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 0, 1.05619e-18, 8.15625e-11
-      Total relative nonlinear residual: 9.97238e-13
+      Nonlinear residuals: 0, 1.05619e-18, 8.15577e-11
+      Relative nonlinear residuals: 0, 0.00551177, 9.97179e-13
+      Total relative residual after nonlinear iteration 2: 9.97179e-13
 
 
 
@@ -69,7 +73,8 @@ Number of degrees of freedom: 13,239 (3,906+1,014+3,906+507+1,953+1,953)
    Solving Stokes system... 0+23 iterations.
    Solving for u_f in 12 iterations.
       Nonlinear residuals: 0, 8.41747e-19, 80.7384
-      Total relative nonlinear residual: 0.994442
+      Relative nonlinear residuals: 0, 0.00407744, 0.994442
+      Total relative residual after nonlinear iteration 1: 0.994442
 
 
    Skipping temperature solve because RHS is zero.
@@ -77,8 +82,9 @@ Number of degrees of freedom: 13,239 (3,906+1,014+3,906+507+1,953+1,953)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 0, 8.41747e-19, 6.88473e-11
-      Total relative nonlinear residual: 8.47982e-13
+      Nonlinear residuals: 0, 8.41747e-19, 6.88417e-11
+      Relative nonlinear residuals: 0, 0.00407744, 8.47912e-13
+      Total relative residual after nonlinear iteration 2: 8.47912e-13
 
 
 

--- a/tests/melt_transport_adaptive/screen-output
+++ b/tests/melt_transport_adaptive/screen-output
@@ -10,8 +10,7 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+23 iterations.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 0, 1.69718e-18, 81.7677
-      Relative nonlinear residuals: 0, 0.00774796, 0.997001
+      Relative nonlinear residuals: 0, 2.19049e-16, 0.997001
       Total relative residual after nonlinear iteration 1: 0.997001
 
 
@@ -20,8 +19,7 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 0, 1.69718e-18, 5.33695e-11
-      Relative nonlinear residuals: 0, 0.00774796, 6.5074e-13
+      Relative nonlinear residuals: 0, 2.19049e-16, 6.5074e-13
       Total relative residual after nonlinear iteration 2: 6.5074e-13
 
 
@@ -41,8 +39,7 @@ Number of degrees of freedom: 9,414 (2,774+728+2,774+364+1,387+1,387)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+23 iterations.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 0, 1.05619e-18, 81.5062
-      Relative nonlinear residuals: 0, 0.00551177, 0.996549
+      Relative nonlinear residuals: 0, 1.91625e-16, 0.996549
       Total relative residual after nonlinear iteration 1: 0.996549
 
 
@@ -51,8 +48,7 @@ Number of degrees of freedom: 9,414 (2,774+728+2,774+364+1,387+1,387)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 0, 1.05619e-18, 8.15577e-11
-      Relative nonlinear residuals: 0, 0.00551177, 9.97179e-13
+      Relative nonlinear residuals: 0, 1.91625e-16, 9.97179e-13
       Total relative residual after nonlinear iteration 2: 9.97179e-13
 
 
@@ -72,8 +68,7 @@ Number of degrees of freedom: 13,239 (3,906+1,014+3,906+507+1,953+1,953)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+23 iterations.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 0, 8.41747e-19, 80.7384
-      Relative nonlinear residuals: 0, 0.00407744, 0.994442
+      Relative nonlinear residuals: 0, 2.0644e-16, 0.994442
       Total relative residual after nonlinear iteration 1: 0.994442
 
 
@@ -82,8 +77,7 @@ Number of degrees of freedom: 13,239 (3,906+1,014+3,906+507+1,953+1,953)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 0, 8.41747e-19, 6.88417e-11
-      Relative nonlinear residuals: 0, 0.00407744, 8.47912e-13
+      Relative nonlinear residuals: 0, 2.0644e-16, 8.47912e-13
       Total relative residual after nonlinear iteration 2: 8.47912e-13
 
 

--- a/tests/melt_transport_compressible/screen-output
+++ b/tests/melt_transport_compressible/screen-output
@@ -10,7 +10,8 @@ Number of degrees of freedom: 112,521 (41,732+33,282+4,225+16,641+16,641)
    Solving Stokes system... done.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 8.70027e-19, 21.6796
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 0, 0.0043675, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Skipping temperature solve because RHS is zero.
@@ -18,7 +19,8 @@ Number of degrees of freedom: 112,521 (41,732+33,282+4,225+16,641+16,641)
    Solving Stokes system... done.
    Solving for u_f in 10 iterations.
       Nonlinear residuals: 0, 8.70027e-19, 1.28186
-      Total relative nonlinear residual: 0.0591275
+      Relative nonlinear residuals: 0, 0.0043675, 0.0591275
+      Total relative residual after nonlinear iteration 2: 0.0591275
 
 
    Skipping temperature solve because RHS is zero.
@@ -26,7 +28,8 @@ Number of degrees of freedom: 112,521 (41,732+33,282+4,225+16,641+16,641)
    Solving Stokes system... done.
    Solving for u_f in 10 iterations.
       Nonlinear residuals: 0, 8.70027e-19, 8.13878e-05
-      Total relative nonlinear residual: 3.75412e-06
+      Relative nonlinear residuals: 0, 0.0043675, 3.75412e-06
+      Total relative residual after nonlinear iteration 3: 3.75412e-06
 
 
 

--- a/tests/melt_transport_compressible/screen-output
+++ b/tests/melt_transport_compressible/screen-output
@@ -9,8 +9,7 @@ Number of degrees of freedom: 112,521 (41,732+33,282+4,225+16,641+16,641)
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 8.70027e-19, 21.6796
-      Relative nonlinear residuals: 0, 0.0043675, 1
+      Relative nonlinear residuals: 0, 1.99205e-16, 1
       Total relative residual after nonlinear iteration 1: 1
 
 
@@ -18,8 +17,7 @@ Number of degrees of freedom: 112,521 (41,732+33,282+4,225+16,641+16,641)
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 10 iterations.
-      Nonlinear residuals: 0, 8.70027e-19, 1.28186
-      Relative nonlinear residuals: 0, 0.0043675, 0.0591275
+      Relative nonlinear residuals: 0, 1.99205e-16, 0.0591275
       Total relative residual after nonlinear iteration 2: 0.0591275
 
 
@@ -27,8 +25,7 @@ Number of degrees of freedom: 112,521 (41,732+33,282+4,225+16,641+16,641)
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 10 iterations.
-      Nonlinear residuals: 0, 8.70027e-19, 8.13878e-05
-      Relative nonlinear residuals: 0, 0.0043675, 3.75412e-06
+      Relative nonlinear residuals: 0, 1.99205e-16, 3.75412e-06
       Total relative residual after nonlinear iteration 3: 3.75412e-06
 
 

--- a/tests/melt_transport_compressible_iterative/screen-output
+++ b/tests/melt_transport_compressible_iterative/screen-output
@@ -10,8 +10,7 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1012 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.58597e-18, 18.0037
-      Relative nonlinear residuals: 0, 0.0171195, 0.123457
+      Relative nonlinear residuals: 0, 2.09467e-16, 0.123457
       Total relative residual after nonlinear iteration 1: 0.123457
 
 
@@ -20,8 +19,7 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+176 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.58597e-18, 18.0477
-      Relative nonlinear residuals: 0, 0.0171195, 0.123758
+      Relative nonlinear residuals: 0, 2.09467e-16, 0.123758
       Total relative residual after nonlinear iteration 2: 0.123758
 
 
@@ -30,8 +28,7 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+29 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.58597e-18, 0.114756
-      Relative nonlinear residuals: 0, 0.0171195, 0.000786918
+      Relative nonlinear residuals: 0, 2.09467e-16, 0.000786918
       Total relative residual after nonlinear iteration 3: 0.000786918
 
 
@@ -40,8 +37,7 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+29 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.58597e-18, 0.0178046
-      Relative nonlinear residuals: 0, 0.0171195, 0.000122092
+      Relative nonlinear residuals: 0, 2.09467e-16, 0.000122092
       Total relative residual after nonlinear iteration 4: 0.000122092
 
 
@@ -50,8 +46,7 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+27 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.58597e-18, 0.00962905
-      Relative nonlinear residuals: 0, 0.0171195, 6.60292e-05
+      Relative nonlinear residuals: 0, 2.09467e-16, 6.60292e-05
       Total relative residual after nonlinear iteration 5: 6.60292e-05
 
 

--- a/tests/melt_transport_compressible_iterative/screen-output
+++ b/tests/melt_transport_compressible_iterative/screen-output
@@ -11,7 +11,8 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Solving Stokes system... 0+1012 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 3.58597e-18, 18.0037
-      Total relative nonlinear residual: 0.123457
+      Relative nonlinear residuals: 0, 0.0171195, 0.123457
+      Total relative residual after nonlinear iteration 1: 0.123457
 
 
    Skipping temperature solve because RHS is zero.
@@ -20,7 +21,8 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Solving Stokes system... 0+176 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 3.58597e-18, 18.0477
-      Total relative nonlinear residual: 0.123758
+      Relative nonlinear residuals: 0, 0.0171195, 0.123758
+      Total relative residual after nonlinear iteration 2: 0.123758
 
 
    Skipping temperature solve because RHS is zero.
@@ -29,7 +31,8 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Solving Stokes system... 0+29 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 3.58597e-18, 0.114756
-      Total relative nonlinear residual: 0.000786918
+      Relative nonlinear residuals: 0, 0.0171195, 0.000786918
+      Total relative residual after nonlinear iteration 3: 0.000786918
 
 
    Skipping temperature solve because RHS is zero.
@@ -38,7 +41,8 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Solving Stokes system... 0+29 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 3.58597e-18, 0.0178046
-      Total relative nonlinear residual: 0.000122092
+      Relative nonlinear residuals: 0, 0.0171195, 0.000122092
+      Total relative residual after nonlinear iteration 4: 0.000122092
 
 
    Skipping temperature solve because RHS is zero.
@@ -47,7 +51,8 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Solving Stokes system... 0+27 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 3.58597e-18, 0.00962905
-      Total relative nonlinear residual: 6.60292e-05
+      Relative nonlinear residuals: 0, 0.0171195, 6.60292e-05
+      Total relative residual after nonlinear iteration 5: 6.60292e-05
 
 
 

--- a/tests/melt_transport_convergence_simple/screen-output
+++ b/tests/melt_transport_convergence_simple/screen-output
@@ -10,8 +10,7 @@ Number of degrees of freedom: 28,617 (8,450+2,178+8,450+1,089+4,225+4,225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+30 iterations.
    Solving for u_f in 7 iterations.
-      Nonlinear residuals: 0, 2.30581e-16, 63.9047
-      Relative nonlinear residuals: 0, 1.63759, 1.00154
+      Relative nonlinear residuals: 0, 1.40805e-16, 1.00154
       Total relative residual after nonlinear iteration 1: 1.00154
 
 
@@ -20,8 +19,7 @@ Number of degrees of freedom: 28,617 (8,450+2,178+8,450+1,089+4,225+4,225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 7 iterations.
-      Nonlinear residuals: 0, 2.30581e-16, 5.46331e-09
-      Relative nonlinear residuals: 0, 1.63759, 8.56233e-11
+      Relative nonlinear residuals: 0, 1.40805e-16, 8.56233e-11
       Total relative residual after nonlinear iteration 2: 8.56233e-11
 
 

--- a/tests/melt_transport_convergence_simple/screen-output
+++ b/tests/melt_transport_convergence_simple/screen-output
@@ -11,7 +11,8 @@ Number of degrees of freedom: 28,617 (8,450+2,178+8,450+1,089+4,225+4,225)
    Solving Stokes system... 0+30 iterations.
    Solving for u_f in 7 iterations.
       Nonlinear residuals: 0, 2.30581e-16, 63.9047
-      Total relative nonlinear residual: 1.00154
+      Relative nonlinear residuals: 0, 1.63759, 1.00154
+      Total relative residual after nonlinear iteration 1: 1.00154
 
 
    Skipping temperature solve because RHS is zero.
@@ -20,7 +21,8 @@ Number of degrees of freedom: 28,617 (8,450+2,178+8,450+1,089+4,225+4,225)
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 7 iterations.
       Nonlinear residuals: 0, 2.30581e-16, 5.46331e-09
-      Total relative nonlinear residual: 8.56233e-11
+      Relative nonlinear residuals: 0, 1.63759, 8.56233e-11
+      Total relative residual after nonlinear iteration 2: 8.56233e-11
 
 
 

--- a/tests/melt_transport_convergence_test/screen-output
+++ b/tests/melt_transport_convergence_test/screen-output
@@ -10,8 +10,7 @@ Number of degrees of freedom: 28,617 (8,450+2,178+8,450+1,089+4,225+4,225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+18 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.11564e-17, 468.027
-      Relative nonlinear residuals: 0, 0.209743, 1
+      Relative nonlinear residuals: 0, 1.48546e-16, 1
       Total relative residual after nonlinear iteration 1: 1
 
 
@@ -20,8 +19,7 @@ Number of degrees of freedom: 28,617 (8,450+2,178+8,450+1,089+4,225+4,225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.11564e-17, 0.000461228
-      Relative nonlinear residuals: 0, 0.209743, 9.85471e-07
+      Relative nonlinear residuals: 0, 1.48546e-16, 9.85471e-07
       Total relative residual after nonlinear iteration 2: 9.85471e-07
 
 

--- a/tests/melt_transport_convergence_test/screen-output
+++ b/tests/melt_transport_convergence_test/screen-output
@@ -11,7 +11,8 @@ Number of degrees of freedom: 28,617 (8,450+2,178+8,450+1,089+4,225+4,225)
    Solving Stokes system... 0+18 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 3.11564e-17, 468.027
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 0, 0.209743, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Skipping temperature solve because RHS is zero.
@@ -20,7 +21,8 @@ Number of degrees of freedom: 28,617 (8,450+2,178+8,450+1,089+4,225+4,225)
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 3.11564e-17, 0.000461228
-      Total relative nonlinear residual: 9.85471e-07
+      Relative nonlinear residuals: 0, 0.209743, 9.85471e-07
+      Total relative residual after nonlinear iteration 2: 9.85471e-07
 
 
 

--- a/tests/melting_rate/screen-output
+++ b/tests/melting_rate/screen-output
@@ -10,8 +10,7 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 442.11, 1.45653e-09, 1.45653e-09, 3.65147e+13
-      Relative nonlinear residuals: 1.63037e-16, 1.2259e+07, 1.2259e+07, 1
+      Relative nonlinear residuals: 1.63037e-16, 1.18813e-16, 1.18813e-16, 1
       Total relative residual after nonlinear iteration 1: 1
 
 
@@ -20,8 +19,7 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 442.11, 1.45653e-09, 1.45653e-09, 0.742407
-      Relative nonlinear residuals: 1.63037e-16, 1.2259e+07, 1.2259e+07, 2.03318e-14
+      Relative nonlinear residuals: 1.63037e-16, 1.18813e-16, 1.18813e-16, 2.03318e-14
       Total relative residual after nonlinear iteration 2: 2.03318e-14
 
 
@@ -36,8 +34,7 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 8 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 2.22892e+13, 14810, 6109.22, 1.15596e+11
-      Relative nonlinear residuals: 8.21938e-06, 1.22653e+07, 1.22652e+07, 0.0644058
+      Relative nonlinear residuals: 8.21938e-06, 0.00120747, 0.000498096, 0.0644058
       Total relative residual after nonlinear iteration 1: 0.0644058
 
 
@@ -46,8 +43,7 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 6 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 3.02885e+11, 725.302, 48.0814, 3.58558e+08
-      Relative nonlinear residuals: 1.11692e-07, 1.22653e+07, 1.22652e+07, 0.000199776
+      Relative nonlinear residuals: 1.11692e-07, 5.91343e-05, 3.92016e-06, 0.000199776
       Total relative residual after nonlinear iteration 2: 0.000199776
 
 
@@ -56,8 +52,7 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 3 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 3.35878e+08, 1.61086, 0.0589186, 840378
-      Relative nonlinear residuals: 1.23859e-10, 1.22653e+07, 1.22652e+07, 4.68229e-07
+      Relative nonlinear residuals: 1.23859e-10, 1.31334e-07, 4.80374e-09, 4.68229e-07
       Total relative residual after nonlinear iteration 3: 4.68229e-07
 
 
@@ -72,8 +67,7 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 7 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 9.81188e+11, 2123.64, 1814.83, 3.61519e+10
-      Relative nonlinear residuals: 2.55762e-07, 1.73618e+07, 1.73596e+07, 0.0201335
+      Relative nonlinear residuals: 2.55762e-07, 0.000122317, 0.000104543, 0.0201335
       Total relative residual after nonlinear iteration 1: 0.0201335
 
 
@@ -82,8 +76,7 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 5 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 6.28662e+10, 156.257, 10.5419, 5.53386e+07
-      Relative nonlinear residuals: 1.63871e-08, 1.73618e+07, 1.73596e+07, 3.08189e-05
+      Relative nonlinear residuals: 1.63871e-08, 9.00004e-06, 6.07269e-07, 3.08189e-05
       Total relative residual after nonlinear iteration 2: 3.08189e-05
 
 
@@ -92,8 +85,7 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 2 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Nonlinear residuals: 3.45812e+07, 0.166928, 0.00613047, 63421.4
-      Relative nonlinear residuals: 9.01415e-12, 1.73618e+07, 1.73596e+07, 3.53203e-08
+      Relative nonlinear residuals: 9.01415e-12, 9.61468e-09, 3.53146e-10, 3.53203e-08
       Total relative residual after nonlinear iteration 3: 3.53203e-08
 
 

--- a/tests/melting_rate/screen-output
+++ b/tests/melting_rate/screen-output
@@ -11,7 +11,8 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
       Nonlinear residuals: 442.11, 1.45653e-09, 1.45653e-09, 3.65147e+13
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 1.63037e-16, 1.2259e+07, 1.2259e+07, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
@@ -20,7 +21,8 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
       Nonlinear residuals: 442.11, 1.45653e-09, 1.45653e-09, 0.742407
-      Total relative nonlinear residual: 2.03318e-14
+      Relative nonlinear residuals: 1.63037e-16, 1.2259e+07, 1.2259e+07, 2.03318e-14
+      Total relative residual after nonlinear iteration 2: 2.03318e-14
 
 
 
@@ -35,7 +37,8 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
       Nonlinear residuals: 2.22892e+13, 14810, 6109.22, 1.15596e+11
-      Total relative nonlinear residual: 0.0644058
+      Relative nonlinear residuals: 8.21938e-06, 1.22653e+07, 1.22652e+07, 0.0644058
+      Total relative residual after nonlinear iteration 1: 0.0644058
 
 
    Solving temperature system... 5 iterations.
@@ -44,7 +47,8 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
       Nonlinear residuals: 3.02885e+11, 725.302, 48.0814, 3.58558e+08
-      Total relative nonlinear residual: 0.000199776
+      Relative nonlinear residuals: 1.11692e-07, 1.22653e+07, 1.22652e+07, 0.000199776
+      Total relative residual after nonlinear iteration 2: 0.000199776
 
 
    Solving temperature system... 2 iterations.
@@ -53,7 +57,8 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
       Nonlinear residuals: 3.35878e+08, 1.61086, 0.0589186, 840378
-      Total relative nonlinear residual: 4.68229e-07
+      Relative nonlinear residuals: 1.23859e-10, 1.22653e+07, 1.22652e+07, 4.68229e-07
+      Total relative residual after nonlinear iteration 3: 4.68229e-07
 
 
 
@@ -68,7 +73,8 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
       Nonlinear residuals: 9.81188e+11, 2123.64, 1814.83, 3.61519e+10
-      Total relative nonlinear residual: 0.0201335
+      Relative nonlinear residuals: 2.55762e-07, 1.73618e+07, 1.73596e+07, 0.0201335
+      Total relative residual after nonlinear iteration 1: 0.0201335
 
 
    Solving temperature system... 4 iterations.
@@ -77,7 +83,8 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
       Nonlinear residuals: 6.28662e+10, 156.257, 10.5419, 5.53386e+07
-      Total relative nonlinear residual: 3.08189e-05
+      Relative nonlinear residuals: 1.63871e-08, 1.73618e+07, 1.73596e+07, 3.08189e-05
+      Total relative residual after nonlinear iteration 2: 3.08189e-05
 
 
    Solving temperature system... 1 iterations.
@@ -86,7 +93,8 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
       Nonlinear residuals: 3.45812e+07, 0.166928, 0.00613047, 63421.4
-      Total relative nonlinear residual: 3.53203e-08
+      Relative nonlinear residuals: 9.01415e-12, 1.73618e+07, 1.73596e+07, 3.53203e-08
+      Total relative residual after nonlinear iteration 3: 3.53203e-08
 
 
 

--- a/tests/no_adiabatic_heating_03/screen-output
+++ b/tests/no_adiabatic_heating_03/screen-output
@@ -8,23 +8,23 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-   Residual after nonlinear iteration 1: 1
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-   Residual after nonlinear iteration 2: 0.0245986
+      Relative Stokes residual after nonlinear iteration 2: 0.0245986
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-   Residual after nonlinear iteration 3: 0.00133812
+      Relative Stokes residual after nonlinear iteration 3: 0.00133812
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Residual after nonlinear iteration 4: 4.59626e-05
+      Relative Stokes residual after nonlinear iteration 4: 4.59626e-05
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Residual after nonlinear iteration 5: 2.11502e-06
+      Relative Stokes residual after nonlinear iteration 5: 2.11502e-06
 
    Postprocessing:
 
@@ -50,7 +50,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 17 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Residual after nonlinear iteration 1: 2.20604e-07
+      Relative Stokes residual after nonlinear iteration 1: 2.20604e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0.003202 K, 0.003462 K
@@ -60,7 +60,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Residual after nonlinear iteration 1: 2.09902e-07
+      Relative Stokes residual after nonlinear iteration 1: 2.09902e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0.006333 K, 0.006918 K
@@ -70,7 +70,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Residual after nonlinear iteration 1: 2.12359e-07
+      Relative Stokes residual after nonlinear iteration 1: 2.12359e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0.009376 K, 0.01037 K
@@ -80,7 +80,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 13 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Residual after nonlinear iteration 1: 1.12424e-07
+      Relative Stokes residual after nonlinear iteration 1: 1.12424e-07
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0.01093 K, 0.01215 K

--- a/tests/nonlinear_convergence_for_small_composition/screen-output
+++ b/tests/nonlinear_convergence_for_small_composition/screen-output
@@ -11,7 +11,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
       Nonlinear residuals: 1.42313e+06, 0, 0, 2.94296e+13
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 1.79171e-16, 0, 0, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
@@ -20,7 +21,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 1.42313e+06, 0, 0, 10691
-      Total relative nonlinear residual: 3.63275e-10
+      Relative nonlinear residuals: 1.79171e-16, 0, 0, 3.63275e-10
+      Total relative residual after nonlinear iteration 2: 3.63275e-10
 
 
 
@@ -34,7 +36,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
       Nonlinear residuals: 1.4598e+20, 5.68522, 5.68522, 1.00324e+13
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 0.0181737, 5.68522, 5.68522, 0.552867
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 14 iterations.
@@ -43,7 +46,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
       Nonlinear residuals: 8.97357e+18, 55.8979, 55.8979, 6.98359e+11
-      Total relative nonlinear residual: 9.83214
+      Relative nonlinear residuals: 0.00111716, 5.68522, 5.68522, 0.0384851
+      Total relative residual after nonlinear iteration 2: 9.83214
 
 
    Solving temperature system... 14 iterations.
@@ -52,7 +56,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
       Nonlinear residuals: 2.17449e+18, 55.066, 55.066, 1.62685e+11
-      Total relative nonlinear residual: 9.68581
+      Relative nonlinear residuals: 0.000270712, 5.68522, 5.68522, 0.00896525
+      Total relative residual after nonlinear iteration 3: 9.68581
 
 
    Solving temperature system... 13 iterations.
@@ -61,7 +66,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
       Nonlinear residuals: 7.00349e+17, 15.2994, 15.2994, 5.0951e+10
-      Total relative nonlinear residual: 2.69109
+      Relative nonlinear residuals: 8.71897e-05, 5.68522, 5.68522, 0.0028078
+      Total relative residual after nonlinear iteration 4: 2.69109
 
 
    Solving temperature system... 12 iterations.
@@ -70,7 +76,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
       Nonlinear residuals: 2.35563e+17, 13.7038, 13.7038, 1.69676e+10
-      Total relative nonlinear residual: 2.41042
+      Relative nonlinear residuals: 2.93263e-05, 5.68522, 5.68522, 0.000935051
+      Total relative residual after nonlinear iteration 5: 2.41042
 
 
    Solving temperature system... 12 iterations.
@@ -79,7 +86,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
       Nonlinear residuals: 7.82296e+16, 10.6102, 10.6102, 5.61983e+09
-      Total relative nonlinear residual: 1.86628
+      Relative nonlinear residuals: 9.73916e-06, 5.68522, 5.68522, 0.000309697
+      Total relative residual after nonlinear iteration 6: 1.86628
 
 
    Solving temperature system... 11 iterations.
@@ -88,7 +96,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
       Nonlinear residuals: 2.55608e+16, 46.6841, 46.6841, 1.84012e+09
-      Total relative nonlinear residual: 8.21147
+      Relative nonlinear residuals: 3.18218e-06, 5.68522, 5.68522, 0.000101405
+      Total relative residual after nonlinear iteration 7: 8.21147
 
 
    Solving temperature system... 11 iterations.
@@ -97,7 +106,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
       Nonlinear residuals: 8.25741e+15, 39.1263, 39.1263, 5.98614e+08
-      Total relative nonlinear residual: 6.8821
+      Relative nonlinear residuals: 1.028e-06, 5.68522, 5.68522, 3.29883e-05
+      Total relative residual after nonlinear iteration 8: 6.8821
 
 
    Solving temperature system... 10 iterations.
@@ -106,7 +116,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
       Nonlinear residuals: 2.65491e+15, 43.0605, 43.0605, 1.94648e+08
-      Total relative nonlinear residual: 7.57411
+      Relative nonlinear residuals: 3.30522e-07, 5.68522, 5.68522, 1.07267e-05
+      Total relative residual after nonlinear iteration 9: 7.57411
 
 
    Solving temperature system... 9 iterations.
@@ -115,7 +126,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+3 iterations.
       Nonlinear residuals: 8.5443e+14, 31.4608, 31.4608, 6.34711e+07
-      Total relative nonlinear residual: 5.53379
+      Relative nonlinear residuals: 1.06372e-07, 5.68522, 5.68522, 3.49776e-06
+      Total relative residual after nonlinear iteration 10: 5.53379
 
 
    Solving temperature system... 9 iterations.
@@ -124,7 +136,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+3 iterations.
       Nonlinear residuals: 2.76217e+14, 50.4664, 50.4664, 2.07471e+07
-      Total relative nonlinear residual: 8.87677
+      Relative nonlinear residuals: 3.43875e-08, 5.68522, 5.68522, 1.14333e-06
+      Total relative residual after nonlinear iteration 11: 8.87677
 
 
    Solving temperature system... 8 iterations.
@@ -133,7 +146,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
       Nonlinear residuals: 8.90346e+13, 38.7651, 38.7651, 6.73081e+06
-      Total relative nonlinear residual: 6.81857
+      Relative nonlinear residuals: 1.10843e-08, 5.68522, 5.68522, 3.70921e-07
+      Total relative residual after nonlinear iteration 12: 6.81857
 
 
    Solving temperature system... 7 iterations.
@@ -142,7 +156,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
       Nonlinear residuals: 2.87126e+13, 32.7063, 32.7063, 2.16941e+06
-      Total relative nonlinear residual: 5.75286
+      Relative nonlinear residuals: 3.57457e-09, 5.68522, 5.68522, 1.19552e-07
+      Total relative residual after nonlinear iteration 13: 5.75286
 
 
    Solving temperature system... 7 iterations.
@@ -151,7 +166,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
       Nonlinear residuals: 9.01426e+12, 25.9431, 25.9431, 677432
-      Total relative nonlinear residual: 4.56325
+      Relative nonlinear residuals: 1.12223e-09, 5.68522, 5.68522, 3.73318e-08
+      Total relative residual after nonlinear iteration 14: 4.56325
 
 
    Solving temperature system... 6 iterations.
@@ -160,7 +176,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
       Nonlinear residuals: 2.79031e+12, 7.90726, 7.90726, 207681
-      Total relative nonlinear residual: 1.39084
+      Relative nonlinear residuals: 3.47379e-10, 5.68522, 5.68522, 1.14448e-08
+      Total relative residual after nonlinear iteration 15: 1.39084
 
 
    Solving temperature system... 5 iterations.
@@ -169,7 +186,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
       Nonlinear residuals: 1.19272e+12, 45.2257, 45.2257, 145505
-      Total relative nonlinear residual: 7.95495
+      Relative nonlinear residuals: 1.48487e-10, 5.68522, 5.68522, 8.01848e-09
+      Total relative residual after nonlinear iteration 16: 7.95495
 
 
    Solving temperature system... 5 iterations.
@@ -178,7 +196,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 5.40042e+11, 12.908, 12.908, 113042
-      Total relative nonlinear residual: 2.27044
+      Relative nonlinear residuals: 6.72323e-11, 5.68522, 5.68522, 6.22953e-09
+      Total relative residual after nonlinear iteration 17: 2.27044
 
 
    Solving temperature system... 1 iterations.
@@ -187,7 +206,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 2.1625e+08, 2.06288e-13, 2.06288e-13, 113044
-      Total relative nonlinear residual: 6.22964e-09
+      Relative nonlinear residuals: 2.6922e-14, 5.68522, 5.68522, 6.22964e-09
+      Total relative residual after nonlinear iteration 18: 6.22964e-09
 
 
    Solving temperature system... 0 iterations.
@@ -196,7 +216,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 3.45757e+07, 2.06288e-13, 2.06288e-13, 113044
-      Total relative nonlinear residual: 6.22964e-09
+      Relative nonlinear residuals: 4.30448e-15, 5.68522, 5.68522, 6.22964e-09
+      Total relative residual after nonlinear iteration 19: 6.22964e-09
 
 
    Solving temperature system... 0 iterations.
@@ -205,7 +226,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 3.45757e+07, 2.06288e-13, 2.06288e-13, 113044
-      Total relative nonlinear residual: 6.22964e-09
+      Relative nonlinear residuals: 4.30448e-15, 5.68522, 5.68522, 6.22964e-09
+      Total relative residual after nonlinear iteration 20: 6.22964e-09
 
 
 
@@ -219,7 +241,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
       Nonlinear residuals: 3.09271e+19, 12.755, 12.755, 1.94698e+12
-      Total relative nonlinear residual: 0.151867
+      Relative nonlinear residuals: 0.00283237, 127.753, 127.753, 0.151867
+      Total relative residual after nonlinear iteration 1: 0.151867
 
 
    Solving temperature system... 15 iterations.
@@ -228,7 +251,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
       Nonlinear residuals: 2.17181e+18, 64.0505, 64.0505, 1.45129e+11
-      Total relative nonlinear residual: 0.501361
+      Relative nonlinear residuals: 0.000198899, 127.753, 127.753, 0.0113202
+      Total relative residual after nonlinear iteration 2: 0.501361
 
 
    Solving temperature system... 14 iterations.
@@ -237,7 +261,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
       Nonlinear residuals: 3.70011e+17, 29.0619, 29.0619, 2.47726e+10
-      Total relative nonlinear residual: 0.227484
+      Relative nonlinear residuals: 3.38864e-05, 127.753, 127.753, 0.00193229
+      Total relative residual after nonlinear iteration 3: 0.227484
 
 
    Solving temperature system... 12 iterations.
@@ -246,7 +271,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
       Nonlinear residuals: 6.75048e+16, 12.2438, 12.2438, 4.50243e+09
-      Total relative nonlinear residual: 0.0958392
+      Relative nonlinear residuals: 6.18224e-06, 127.753, 127.753, 0.000351195
+      Total relative residual after nonlinear iteration 4: 0.0958392
 
 
    Solving temperature system... 11 iterations.
@@ -255,7 +281,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
       Nonlinear residuals: 1.24535e+16, 13.9613, 13.9613, 8.27896e+08
-      Total relative nonlinear residual: 0.109283
+      Relative nonlinear residuals: 1.14052e-06, 127.753, 127.753, 6.45768e-05
+      Total relative residual after nonlinear iteration 5: 0.109283
 
 
    Solving temperature system... 10 iterations.
@@ -264,7 +291,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
       Nonlinear residuals: 2.29033e+15, 34.185, 34.185, 1.51896e+08
-      Total relative nonlinear residual: 0.267586
+      Relative nonlinear residuals: 2.09753e-07, 127.753, 127.753, 1.1848e-05
+      Total relative residual after nonlinear iteration 6: 0.267586
 
 
    Solving temperature system... 9 iterations.
@@ -273,7 +301,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+3 iterations.
       Nonlinear residuals: 4.18488e+14, 25.6009, 25.6009, 2.7709e+07
-      Total relative nonlinear residual: 0.200393
+      Relative nonlinear residuals: 3.8326e-08, 127.753, 127.753, 2.16133e-06
+      Total relative residual after nonlinear iteration 7: 0.200393
 
 
    Solving temperature system... 8 iterations.
@@ -282,7 +311,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
       Nonlinear residuals: 7.60659e+13, 15.8028, 15.8028, 5.03117e+06
-      Total relative nonlinear residual: 0.123698
+      Relative nonlinear residuals: 6.96628e-09, 127.753, 127.753, 3.92437e-07
+      Total relative residual after nonlinear iteration 8: 0.123698
 
 
    Solving temperature system... 7 iterations.
@@ -291,7 +321,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
       Nonlinear residuals: 1.36806e+13, 14.2755, 14.2755, 906721
-      Total relative nonlinear residual: 0.111743
+      Relative nonlinear residuals: 1.2529e-09, 127.753, 127.753, 7.07252e-08
+      Total relative residual after nonlinear iteration 9: 0.111743
 
 
    Solving temperature system... 6 iterations.
@@ -300,7 +331,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
       Nonlinear residuals: 2.39695e+12, 14.1138, 14.1138, 158383
-      Total relative nonlinear residual: 0.110477
+      Relative nonlinear residuals: 2.19517e-10, 127.753, 127.753, 1.23541e-08
+      Total relative residual after nonlinear iteration 10: 0.110477
 
 
    Solving temperature system... 5 iterations.
@@ -309,7 +341,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 5.76546e+11, 24.2244, 24.2244, 111019
-      Total relative nonlinear residual: 0.189619
+      Relative nonlinear residuals: 5.28014e-11, 127.753, 127.753, 8.6596e-09
+      Total relative residual after nonlinear iteration 11: 0.189619
 
 
    Solving temperature system... 1 iterations.
@@ -318,7 +351,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 1.24861e+08, 7.04349e-14, 7.04349e-14, 111015
-      Total relative nonlinear residual: 8.6593e-09
+      Relative nonlinear residuals: 1.1435e-14, 127.753, 127.753, 8.6593e-09
+      Total relative residual after nonlinear iteration 12: 8.6593e-09
 
 
    Solving temperature system... 0 iterations.
@@ -327,7 +361,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Total relative nonlinear residual: 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Total relative residual after nonlinear iteration 13: 8.6593e-09
 
 
    Solving temperature system... 0 iterations.
@@ -336,7 +371,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Total relative nonlinear residual: 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Total relative residual after nonlinear iteration 14: 8.6593e-09
 
 
    Solving temperature system... 0 iterations.
@@ -345,7 +381,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Total relative nonlinear residual: 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Total relative residual after nonlinear iteration 15: 8.6593e-09
 
 
    Solving temperature system... 0 iterations.
@@ -354,7 +391,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Total relative nonlinear residual: 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Total relative residual after nonlinear iteration 16: 8.6593e-09
 
 
    Solving temperature system... 0 iterations.
@@ -363,7 +401,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Total relative nonlinear residual: 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Total relative residual after nonlinear iteration 17: 8.6593e-09
 
 
    Solving temperature system... 0 iterations.
@@ -372,7 +411,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Total relative nonlinear residual: 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Total relative residual after nonlinear iteration 18: 8.6593e-09
 
 
    Solving temperature system... 0 iterations.
@@ -381,7 +421,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Total relative nonlinear residual: 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Total relative residual after nonlinear iteration 19: 8.6593e-09
 
 
    Solving temperature system... 0 iterations.
@@ -390,7 +431,8 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Total relative nonlinear residual: 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Total relative residual after nonlinear iteration 20: 8.6593e-09
 
 
 

--- a/tests/nonlinear_convergence_for_small_composition/screen-output
+++ b/tests/nonlinear_convergence_for_small_composition/screen-output
@@ -10,7 +10,6 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
-      Nonlinear residuals: 1.42313e+06, 0, 0, 2.94296e+13
       Relative nonlinear residuals: 1.79171e-16, 0, 0, 1
       Total relative residual after nonlinear iteration 1: 1
 
@@ -20,7 +19,6 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 1.42313e+06, 0, 0, 10691
       Relative nonlinear residuals: 1.79171e-16, 0, 0, 3.63275e-10
       Total relative residual after nonlinear iteration 2: 3.63275e-10
 
@@ -35,8 +33,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
-      Nonlinear residuals: 1.4598e+20, 5.68522, 5.68522, 1.00324e+13
-      Relative nonlinear residuals: 0.0181737, 5.68522, 5.68522, 0.552867
+      Relative nonlinear residuals: 0.0181737, 1, 1, 0.552867
       Total relative residual after nonlinear iteration 1: 1
 
 
@@ -45,8 +42,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
-      Nonlinear residuals: 8.97357e+18, 55.8979, 55.8979, 6.98359e+11
-      Relative nonlinear residuals: 0.00111716, 5.68522, 5.68522, 0.0384851
+      Relative nonlinear residuals: 0.00111716, 9.83214, 9.83214, 0.0384851
       Total relative residual after nonlinear iteration 2: 9.83214
 
 
@@ -55,8 +51,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
-      Nonlinear residuals: 2.17449e+18, 55.066, 55.066, 1.62685e+11
-      Relative nonlinear residuals: 0.000270712, 5.68522, 5.68522, 0.00896525
+      Relative nonlinear residuals: 0.000270712, 9.68581, 9.68581, 0.00896525
       Total relative residual after nonlinear iteration 3: 9.68581
 
 
@@ -65,8 +60,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
-      Nonlinear residuals: 7.00349e+17, 15.2994, 15.2994, 5.0951e+10
-      Relative nonlinear residuals: 8.71897e-05, 5.68522, 5.68522, 0.0028078
+      Relative nonlinear residuals: 8.71897e-05, 2.69109, 2.69109, 0.0028078
       Total relative residual after nonlinear iteration 4: 2.69109
 
 
@@ -75,8 +69,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
-      Nonlinear residuals: 2.35563e+17, 13.7038, 13.7038, 1.69676e+10
-      Relative nonlinear residuals: 2.93263e-05, 5.68522, 5.68522, 0.000935051
+      Relative nonlinear residuals: 2.93263e-05, 2.41042, 2.41042, 0.000935051
       Total relative residual after nonlinear iteration 5: 2.41042
 
 
@@ -85,8 +78,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
-      Nonlinear residuals: 7.82296e+16, 10.6102, 10.6102, 5.61983e+09
-      Relative nonlinear residuals: 9.73916e-06, 5.68522, 5.68522, 0.000309697
+      Relative nonlinear residuals: 9.73916e-06, 1.86628, 1.86628, 0.000309697
       Total relative residual after nonlinear iteration 6: 1.86628
 
 
@@ -95,8 +87,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
-      Nonlinear residuals: 2.55608e+16, 46.6841, 46.6841, 1.84012e+09
-      Relative nonlinear residuals: 3.18218e-06, 5.68522, 5.68522, 0.000101405
+      Relative nonlinear residuals: 3.18218e-06, 8.21147, 8.21147, 0.000101405
       Total relative residual after nonlinear iteration 7: 8.21147
 
 
@@ -105,8 +96,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-      Nonlinear residuals: 8.25741e+15, 39.1263, 39.1263, 5.98614e+08
-      Relative nonlinear residuals: 1.028e-06, 5.68522, 5.68522, 3.29883e-05
+      Relative nonlinear residuals: 1.028e-06, 6.8821, 6.8821, 3.29883e-05
       Total relative residual after nonlinear iteration 8: 6.8821
 
 
@@ -115,8 +105,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-      Nonlinear residuals: 2.65491e+15, 43.0605, 43.0605, 1.94648e+08
-      Relative nonlinear residuals: 3.30522e-07, 5.68522, 5.68522, 1.07267e-05
+      Relative nonlinear residuals: 3.30522e-07, 7.57411, 7.57411, 1.07267e-05
       Total relative residual after nonlinear iteration 9: 7.57411
 
 
@@ -125,8 +114,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+3 iterations.
-      Nonlinear residuals: 8.5443e+14, 31.4608, 31.4608, 6.34711e+07
-      Relative nonlinear residuals: 1.06372e-07, 5.68522, 5.68522, 3.49776e-06
+      Relative nonlinear residuals: 1.06372e-07, 5.53379, 5.53379, 3.49776e-06
       Total relative residual after nonlinear iteration 10: 5.53379
 
 
@@ -135,8 +123,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+3 iterations.
-      Nonlinear residuals: 2.76217e+14, 50.4664, 50.4664, 2.07471e+07
-      Relative nonlinear residuals: 3.43875e-08, 5.68522, 5.68522, 1.14333e-06
+      Relative nonlinear residuals: 3.43875e-08, 8.87677, 8.87677, 1.14333e-06
       Total relative residual after nonlinear iteration 11: 8.87677
 
 
@@ -145,8 +132,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-      Nonlinear residuals: 8.90346e+13, 38.7651, 38.7651, 6.73081e+06
-      Relative nonlinear residuals: 1.10843e-08, 5.68522, 5.68522, 3.70921e-07
+      Relative nonlinear residuals: 1.10843e-08, 6.81857, 6.81857, 3.70921e-07
       Total relative residual after nonlinear iteration 12: 6.81857
 
 
@@ -155,8 +141,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-      Nonlinear residuals: 2.87126e+13, 32.7063, 32.7063, 2.16941e+06
-      Relative nonlinear residuals: 3.57457e-09, 5.68522, 5.68522, 1.19552e-07
+      Relative nonlinear residuals: 3.57457e-09, 5.75286, 5.75286, 1.19552e-07
       Total relative residual after nonlinear iteration 13: 5.75286
 
 
@@ -165,8 +150,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-      Nonlinear residuals: 9.01426e+12, 25.9431, 25.9431, 677432
-      Relative nonlinear residuals: 1.12223e-09, 5.68522, 5.68522, 3.73318e-08
+      Relative nonlinear residuals: 1.12223e-09, 4.56325, 4.56325, 3.73318e-08
       Total relative residual after nonlinear iteration 14: 4.56325
 
 
@@ -175,8 +159,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
-      Nonlinear residuals: 2.79031e+12, 7.90726, 7.90726, 207681
-      Relative nonlinear residuals: 3.47379e-10, 5.68522, 5.68522, 1.14448e-08
+      Relative nonlinear residuals: 3.47379e-10, 1.39084, 1.39084, 1.14448e-08
       Total relative residual after nonlinear iteration 15: 1.39084
 
 
@@ -185,8 +168,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
-      Nonlinear residuals: 1.19272e+12, 45.2257, 45.2257, 145505
-      Relative nonlinear residuals: 1.48487e-10, 5.68522, 5.68522, 8.01848e-09
+      Relative nonlinear residuals: 1.48487e-10, 7.95495, 7.95495, 8.01848e-09
       Total relative residual after nonlinear iteration 16: 7.95495
 
 
@@ -195,8 +177,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 5.40042e+11, 12.908, 12.908, 113042
-      Relative nonlinear residuals: 6.72323e-11, 5.68522, 5.68522, 6.22953e-09
+      Relative nonlinear residuals: 6.72323e-11, 2.27044, 2.27044, 6.22953e-09
       Total relative residual after nonlinear iteration 17: 2.27044
 
 
@@ -205,8 +186,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 2.1625e+08, 2.06288e-13, 2.06288e-13, 113044
-      Relative nonlinear residuals: 2.6922e-14, 5.68522, 5.68522, 6.22964e-09
+      Relative nonlinear residuals: 2.6922e-14, 3.6285e-14, 3.6285e-14, 6.22964e-09
       Total relative residual after nonlinear iteration 18: 6.22964e-09
 
 
@@ -215,8 +195,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 3.45757e+07, 2.06288e-13, 2.06288e-13, 113044
-      Relative nonlinear residuals: 4.30448e-15, 5.68522, 5.68522, 6.22964e-09
+      Relative nonlinear residuals: 4.30448e-15, 3.6285e-14, 3.6285e-14, 6.22964e-09
       Total relative residual after nonlinear iteration 19: 6.22964e-09
 
 
@@ -225,8 +204,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 3.45757e+07, 2.06288e-13, 2.06288e-13, 113044
-      Relative nonlinear residuals: 4.30448e-15, 5.68522, 5.68522, 6.22964e-09
+      Relative nonlinear residuals: 4.30448e-15, 3.6285e-14, 3.6285e-14, 6.22964e-09
       Total relative residual after nonlinear iteration 20: 6.22964e-09
 
 
@@ -240,8 +218,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
-      Nonlinear residuals: 3.09271e+19, 12.755, 12.755, 1.94698e+12
-      Relative nonlinear residuals: 0.00283237, 127.753, 127.753, 0.151867
+      Relative nonlinear residuals: 0.00283237, 0.0998405, 0.0998405, 0.151867
       Total relative residual after nonlinear iteration 1: 0.151867
 
 
@@ -250,8 +227,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
-      Nonlinear residuals: 2.17181e+18, 64.0505, 64.0505, 1.45129e+11
-      Relative nonlinear residuals: 0.000198899, 127.753, 127.753, 0.0113202
+      Relative nonlinear residuals: 0.000198899, 0.501361, 0.501361, 0.0113202
       Total relative residual after nonlinear iteration 2: 0.501361
 
 
@@ -260,8 +236,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
-      Nonlinear residuals: 3.70011e+17, 29.0619, 29.0619, 2.47726e+10
-      Relative nonlinear residuals: 3.38864e-05, 127.753, 127.753, 0.00193229
+      Relative nonlinear residuals: 3.38864e-05, 0.227484, 0.227484, 0.00193229
       Total relative residual after nonlinear iteration 3: 0.227484
 
 
@@ -270,8 +245,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
-      Nonlinear residuals: 6.75048e+16, 12.2438, 12.2438, 4.50243e+09
-      Relative nonlinear residuals: 6.18224e-06, 127.753, 127.753, 0.000351195
+      Relative nonlinear residuals: 6.18224e-06, 0.0958392, 0.0958392, 0.000351195
       Total relative residual after nonlinear iteration 4: 0.0958392
 
 
@@ -280,8 +254,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-      Nonlinear residuals: 1.24535e+16, 13.9613, 13.9613, 8.27896e+08
-      Relative nonlinear residuals: 1.14052e-06, 127.753, 127.753, 6.45768e-05
+      Relative nonlinear residuals: 1.14052e-06, 0.109283, 0.109283, 6.45768e-05
       Total relative residual after nonlinear iteration 5: 0.109283
 
 
@@ -290,8 +263,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-      Nonlinear residuals: 2.29033e+15, 34.185, 34.185, 1.51896e+08
-      Relative nonlinear residuals: 2.09753e-07, 127.753, 127.753, 1.1848e-05
+      Relative nonlinear residuals: 2.09753e-07, 0.267586, 0.267586, 1.1848e-05
       Total relative residual after nonlinear iteration 6: 0.267586
 
 
@@ -300,8 +272,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+3 iterations.
-      Nonlinear residuals: 4.18488e+14, 25.6009, 25.6009, 2.7709e+07
-      Relative nonlinear residuals: 3.8326e-08, 127.753, 127.753, 2.16133e-06
+      Relative nonlinear residuals: 3.8326e-08, 0.200393, 0.200393, 2.16133e-06
       Total relative residual after nonlinear iteration 7: 0.200393
 
 
@@ -310,8 +281,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-      Nonlinear residuals: 7.60659e+13, 15.8028, 15.8028, 5.03117e+06
-      Relative nonlinear residuals: 6.96628e-09, 127.753, 127.753, 3.92437e-07
+      Relative nonlinear residuals: 6.96628e-09, 0.123698, 0.123698, 3.92437e-07
       Total relative residual after nonlinear iteration 8: 0.123698
 
 
@@ -320,8 +290,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-      Nonlinear residuals: 1.36806e+13, 14.2755, 14.2755, 906721
-      Relative nonlinear residuals: 1.2529e-09, 127.753, 127.753, 7.07252e-08
+      Relative nonlinear residuals: 1.2529e-09, 0.111743, 0.111743, 7.07252e-08
       Total relative residual after nonlinear iteration 9: 0.111743
 
 
@@ -330,8 +299,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
-      Nonlinear residuals: 2.39695e+12, 14.1138, 14.1138, 158383
-      Relative nonlinear residuals: 2.19517e-10, 127.753, 127.753, 1.23541e-08
+      Relative nonlinear residuals: 2.19517e-10, 0.110477, 0.110477, 1.23541e-08
       Total relative residual after nonlinear iteration 10: 0.110477
 
 
@@ -340,8 +308,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 5.76546e+11, 24.2244, 24.2244, 111019
-      Relative nonlinear residuals: 5.28014e-11, 127.753, 127.753, 8.6596e-09
+      Relative nonlinear residuals: 5.28014e-11, 0.189619, 0.189619, 8.6596e-09
       Total relative residual after nonlinear iteration 11: 0.189619
 
 
@@ -350,8 +317,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 1.24861e+08, 7.04349e-14, 7.04349e-14, 111015
-      Relative nonlinear residuals: 1.1435e-14, 127.753, 127.753, 8.6593e-09
+      Relative nonlinear residuals: 1.1435e-14, 5.51336e-16, 5.51336e-16, 8.6593e-09
       Total relative residual after nonlinear iteration 12: 8.6593e-09
 
 
@@ -360,8 +326,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 5.51336e-16, 5.51336e-16, 8.6593e-09
       Total relative residual after nonlinear iteration 13: 8.6593e-09
 
 
@@ -370,8 +335,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 5.51336e-16, 5.51336e-16, 8.6593e-09
       Total relative residual after nonlinear iteration 14: 8.6593e-09
 
 
@@ -380,8 +344,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 5.51336e-16, 5.51336e-16, 8.6593e-09
       Total relative residual after nonlinear iteration 15: 8.6593e-09
 
 
@@ -390,8 +353,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 5.51336e-16, 5.51336e-16, 8.6593e-09
       Total relative residual after nonlinear iteration 16: 8.6593e-09
 
 
@@ -400,8 +362,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 5.51336e-16, 5.51336e-16, 8.6593e-09
       Total relative residual after nonlinear iteration 17: 8.6593e-09
 
 
@@ -410,8 +371,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 5.51336e-16, 5.51336e-16, 8.6593e-09
       Total relative residual after nonlinear iteration 18: 8.6593e-09
 
 
@@ -420,8 +380,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 5.51336e-16, 5.51336e-16, 8.6593e-09
       Total relative residual after nonlinear iteration 19: 8.6593e-09
 
 
@@ -430,8 +389,7 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 1.46257e+07, 7.04349e-14, 7.04349e-14, 111015
-      Relative nonlinear residuals: 1.33945e-15, 127.753, 127.753, 8.6593e-09
+      Relative nonlinear residuals: 1.33945e-15, 5.51336e-16, 5.51336e-16, 8.6593e-09
       Total relative residual after nonlinear iteration 20: 8.6593e-09
 
 

--- a/tests/segregation_heating/screen-output
+++ b/tests/segregation_heating/screen-output
@@ -12,7 +12,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 33+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 9.32273e-15, 6.92618e-18, 0, 5.43999
-      Total relative nonlinear residual: 0.333482
+      Relative nonlinear residuals: 1.13147e-16, 0.029726, 0, 0.333482
+      Total relative residual after nonlinear iteration 1: 0.333482
 
 
    Solving temperature system... 0 iterations.
@@ -22,7 +23,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 9.32273e-15, 6.92618e-18, 0, 1.37996e-11
-      Total relative nonlinear residual: 8.45942e-13
+      Relative nonlinear residuals: 1.13147e-16, 0.029726, 0, 8.45942e-13
+      Total relative residual after nonlinear iteration 2: 8.45942e-13
 
 
 
@@ -39,7 +41,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 18+0 iterations.
    Solving for u_f in 3 iterations.
       Nonlinear residuals: 0.00269148, 3.79655e-15, 0, 1.36735e-05
-      Total relative nonlinear residual: 3.24316e-05
+      Relative nonlinear residuals: 3.24316e-05, 0.029726, 0, 8.38259e-07
+      Total relative residual after nonlinear iteration 1: 3.24316e-05
 
 
    Solving temperature system... 2 iterations.
@@ -49,7 +52,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 11+0 iterations.
    Solving for u_f in 3 iterations.
       Nonlinear residuals: 2.05175e-09, 4.09634e-10, 0, 1.26555e-07
-      Total relative nonlinear residual: 1.37804e-08
+      Relative nonlinear residuals: 2.47231e-11, 0.029726, 0, 7.75851e-09
+      Total relative residual after nonlinear iteration 2: 1.37804e-08
 
 
 
@@ -66,7 +70,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 12+0 iterations.
    Solving for u_f in 3 iterations.
       Nonlinear residuals: 9.92962e-05, 4.09568e-10, 0, 1.0372e-06
-      Total relative nonlinear residual: 7.99666e-07
+      Relative nonlinear residuals: 7.99666e-07, 0.0445889, 0, 6.35859e-08
+      Total relative residual after nonlinear iteration 1: 7.99666e-07
 
 
 
@@ -83,7 +88,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 12+0 iterations.
    Solving for u_f in 3 iterations.
       Nonlinear residuals: 0.000136821, 5.46528e-10, 0, 1.41337e-06
-      Total relative nonlinear residual: 1.10183e-06
+      Relative nonlinear residuals: 1.10183e-06, 0.0445889, 0, 8.66472e-08
+      Total relative residual after nonlinear iteration 1: 1.10183e-06
 
 
 
@@ -100,7 +106,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 12+0 iterations.
    Solving for u_f in 4 iterations.
       Nonlinear residuals: 0.000150361, 5.92535e-10, 0, 1.46142e-06
-      Total relative nonlinear residual: 1.21083e-06
+      Relative nonlinear residuals: 1.21083e-06, 0.0445889, 0, 8.95932e-08
+      Total relative residual after nonlinear iteration 1: 1.21083e-06
 
 
 
@@ -117,7 +124,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 12+0 iterations.
    Solving for u_f in 4 iterations.
       Nonlinear residuals: 0.000151967, 6.07981e-10, 0, 1.30301e-06
-      Total relative nonlinear residual: 1.22373e-06
+      Relative nonlinear residuals: 1.22373e-06, 0.0445889, 0, 7.98819e-08
+      Total relative residual after nonlinear iteration 1: 1.22373e-06
 
 
 
@@ -134,7 +142,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 4 iterations.
       Nonlinear residuals: 9.05236e-11, 3.76062e-16, 0, 1.10981e-11
-      Total relative nonlinear residual: 1.09849e-12
+      Relative nonlinear residuals: 1.09849e-12, 0.029726, 0, 6.80376e-13
+      Total relative residual after nonlinear iteration 1: 1.09849e-12
 
 
 

--- a/tests/segregation_heating/screen-output
+++ b/tests/segregation_heating/screen-output
@@ -11,8 +11,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 9.32273e-15, 6.92618e-18, 0, 5.43999
-      Relative nonlinear residuals: 1.13147e-16, 0.029726, 0, 0.333482
+      Relative nonlinear residuals: 1.13147e-16, 2.33001e-16, 0, 0.333482
       Total relative residual after nonlinear iteration 1: 0.333482
 
 
@@ -22,8 +21,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 9.32273e-15, 6.92618e-18, 0, 1.37996e-11
-      Relative nonlinear residuals: 1.13147e-16, 0.029726, 0, 8.45942e-13
+      Relative nonlinear residuals: 1.13147e-16, 2.33001e-16, 0, 8.45942e-13
       Total relative residual after nonlinear iteration 2: 8.45942e-13
 
 
@@ -40,8 +38,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
    Solving for u_f in 3 iterations.
-      Nonlinear residuals: 0.00269148, 3.79655e-15, 0, 1.36735e-05
-      Relative nonlinear residuals: 3.24316e-05, 0.029726, 0, 8.38259e-07
+      Relative nonlinear residuals: 3.24316e-05, 1.27718e-13, 0, 8.38259e-07
       Total relative residual after nonlinear iteration 1: 3.24316e-05
 
 
@@ -51,8 +48,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
    Solving for u_f in 3 iterations.
-      Nonlinear residuals: 2.05175e-09, 4.09634e-10, 0, 1.26555e-07
-      Relative nonlinear residuals: 2.47231e-11, 0.029726, 0, 7.75851e-09
+      Relative nonlinear residuals: 2.47231e-11, 1.37804e-08, 0, 7.75851e-09
       Total relative residual after nonlinear iteration 2: 1.37804e-08
 
 
@@ -69,8 +65,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
    Solving for u_f in 3 iterations.
-      Nonlinear residuals: 9.92962e-05, 4.09568e-10, 0, 1.0372e-06
-      Relative nonlinear residuals: 7.99666e-07, 0.0445889, 0, 6.35859e-08
+      Relative nonlinear residuals: 7.99666e-07, 9.18543e-09, 0, 6.35859e-08
       Total relative residual after nonlinear iteration 1: 7.99666e-07
 
 
@@ -87,8 +82,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
    Solving for u_f in 3 iterations.
-      Nonlinear residuals: 0.000136821, 5.46528e-10, 0, 1.41337e-06
-      Relative nonlinear residuals: 1.10183e-06, 0.0445889, 0, 8.66472e-08
+      Relative nonlinear residuals: 1.10183e-06, 1.2257e-08, 0, 8.66472e-08
       Total relative residual after nonlinear iteration 1: 1.10183e-06
 
 
@@ -105,8 +99,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
    Solving for u_f in 4 iterations.
-      Nonlinear residuals: 0.000150361, 5.92535e-10, 0, 1.46142e-06
-      Relative nonlinear residuals: 1.21083e-06, 0.0445889, 0, 8.95932e-08
+      Relative nonlinear residuals: 1.21083e-06, 1.32888e-08, 0, 8.95932e-08
       Total relative residual after nonlinear iteration 1: 1.21083e-06
 
 
@@ -123,8 +116,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
    Solving for u_f in 4 iterations.
-      Nonlinear residuals: 0.000151967, 6.07981e-10, 0, 1.30301e-06
-      Relative nonlinear residuals: 1.22373e-06, 0.0445889, 0, 7.98819e-08
+      Relative nonlinear residuals: 1.22373e-06, 1.36352e-08, 0, 7.98819e-08
       Total relative residual after nonlinear iteration 1: 1.22373e-06
 
 
@@ -141,8 +133,7 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 4 iterations.
-      Nonlinear residuals: 9.05236e-11, 3.76062e-16, 0, 1.10981e-11
-      Relative nonlinear residuals: 1.09849e-12, 0.029726, 0, 6.80376e-13
+      Relative nonlinear residuals: 1.09849e-12, 1.2651e-14, 0, 6.80376e-13
       Total relative residual after nonlinear iteration 1: 1.09849e-12
 
 

--- a/tests/shear_bands/screen-output
+++ b/tests/shear_bands/screen-output
@@ -10,8 +10,7 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 5.18034e-25, 5070.52
-      Relative nonlinear residuals: 0, 3.46127e-09, 1
+      Relative nonlinear residuals: 0, 1.49666e-16, 1
       Total relative residual after nonlinear iteration 1: 1
 
 
@@ -20,8 +19,7 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.89102e-25, 151.787
-      Relative nonlinear residuals: 0, 3.46127e-09, 0.0299352
+      Relative nonlinear residuals: 0, 1.12416e-16, 0.0299352
       Total relative residual after nonlinear iteration 2: 0.0299352
 
 
@@ -30,8 +28,7 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.65305e-25, 93.2862
-      Relative nonlinear residuals: 0, 3.46127e-09, 0.0183978
+      Relative nonlinear residuals: 0, 1.05541e-16, 0.0183978
       Total relative residual after nonlinear iteration 3: 0.0183978
 
 
@@ -40,8 +37,7 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.55928e-25, 67.6632
-      Relative nonlinear residuals: 0, 3.46127e-09, 0.0133444
+      Relative nonlinear residuals: 0, 1.02832e-16, 0.0133444
       Total relative residual after nonlinear iteration 4: 0.0133444
 
 
@@ -50,8 +46,7 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.51868e-25, 50.9306
-      Relative nonlinear residuals: 0, 3.46127e-09, 0.0100444
+      Relative nonlinear residuals: 0, 1.01659e-16, 0.0100444
       Total relative residual after nonlinear iteration 5: 0.0100444
 
 
@@ -67,8 +62,7 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 9.36797e-12, 114.632
-      Relative nonlinear residuals: 0, 3.46128e-09, 0.000714511
+      Relative nonlinear residuals: 0, 0.0027065, 0.000714511
       Total relative residual after nonlinear iteration 1: 0.000714511
 
 
@@ -77,8 +71,7 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 2.76384e-12, 72.4415
-      Relative nonlinear residuals: 0, 3.46128e-09, 0.000451533
+      Relative nonlinear residuals: 0, 0.000798501, 0.000451533
       Total relative residual after nonlinear iteration 2: 0.000451533
 
 
@@ -87,8 +80,7 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 1.75195e-12, 62.8794
-      Relative nonlinear residuals: 0, 3.46128e-09, 0.000391932
+      Relative nonlinear residuals: 0, 0.000506156, 0.000391932
       Total relative residual after nonlinear iteration 3: 0.000391932
 
 
@@ -97,8 +89,7 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 1.5811e-12, 57.7565
-      Relative nonlinear residuals: 0, 3.46128e-09, 0.000360001
+      Relative nonlinear residuals: 0, 0.000456797, 0.000360001
       Total relative residual after nonlinear iteration 4: 0.000360001
 
 
@@ -107,8 +98,7 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 1.48441e-12, 53.864
-      Relative nonlinear residuals: 0, 3.46128e-09, 0.000335738
+      Relative nonlinear residuals: 0, 0.000428861, 0.000335738
       Total relative residual after nonlinear iteration 5: 0.000335738
 
 
@@ -124,8 +114,7 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.47977e-12, 63.146
-      Relative nonlinear residuals: 0, 4.80272e-09, 0.000393432
+      Relative nonlinear residuals: 0, 0.000724542, 0.000393432
       Total relative residual after nonlinear iteration 1: 0.000393432
 
 
@@ -134,8 +123,7 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 1.18907e-12, 49.4201
-      Relative nonlinear residuals: 0, 4.80272e-09, 0.000307913
+      Relative nonlinear residuals: 0, 0.000247583, 0.000307913
       Total relative residual after nonlinear iteration 2: 0.000307913
 
 
@@ -144,8 +132,7 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 9.00504e-13, 39.4513
-      Relative nonlinear residuals: 0, 4.80272e-09, 0.000245802
+      Relative nonlinear residuals: 0, 0.000187499, 0.000245802
       Total relative residual after nonlinear iteration 3: 0.000245802
 
 
@@ -154,8 +141,7 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 6.94504e-13, 31.8081
-      Relative nonlinear residuals: 0, 4.80272e-09, 0.000198181
+      Relative nonlinear residuals: 0, 0.000144606, 0.000198181
       Total relative residual after nonlinear iteration 4: 0.000198181
 
 
@@ -164,8 +150,7 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 5.3983e-13, 25.841
-      Relative nonlinear residuals: 0, 4.80272e-09, 0.000161003
+      Relative nonlinear residuals: 0, 0.000112401, 0.000161003
       Total relative residual after nonlinear iteration 5: 0.000161003
 
 

--- a/tests/shear_bands/screen-output
+++ b/tests/shear_bands/screen-output
@@ -10,8 +10,9 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 5.12712e-25, 5070.52
-      Total relative nonlinear residual: 1
+      Nonlinear residuals: 0, 5.18034e-25, 5070.52
+      Relative nonlinear residuals: 0, 3.46127e-09, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Skipping temperature solve because RHS is zero.
@@ -19,8 +20,9 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.85412e-25, 151.787
-      Total relative nonlinear residual: 0.0299352
+      Nonlinear residuals: 0, 3.89102e-25, 151.787
+      Relative nonlinear residuals: 0, 3.46127e-09, 0.0299352
+      Total relative residual after nonlinear iteration 2: 0.0299352
 
 
    Skipping temperature solve because RHS is zero.
@@ -28,8 +30,9 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.59772e-25, 93.2862
-      Total relative nonlinear residual: 0.0183978
+      Nonlinear residuals: 0, 3.65305e-25, 93.2862
+      Relative nonlinear residuals: 0, 3.46127e-09, 0.0183978
+      Total relative residual after nonlinear iteration 3: 0.0183978
 
 
    Skipping temperature solve because RHS is zero.
@@ -37,8 +40,9 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.55987e-25, 67.6632
-      Total relative nonlinear residual: 0.0133444
+      Nonlinear residuals: 0, 3.55928e-25, 67.6632
+      Relative nonlinear residuals: 0, 3.46127e-09, 0.0133444
+      Total relative residual after nonlinear iteration 4: 0.0133444
 
 
    Skipping temperature solve because RHS is zero.
@@ -46,8 +50,9 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
-      Nonlinear residuals: 0, 3.5562e-25, 50.9306
-      Total relative nonlinear residual: 0.0100444
+      Nonlinear residuals: 0, 3.51868e-25, 50.9306
+      Relative nonlinear residuals: 0, 3.46127e-09, 0.0100444
+      Total relative residual after nonlinear iteration 5: 0.0100444
 
 
 
@@ -63,7 +68,8 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 9.36797e-12, 114.632
-      Total relative nonlinear residual: 0.000714511
+      Relative nonlinear residuals: 0, 3.46128e-09, 0.000714511
+      Total relative residual after nonlinear iteration 1: 0.000714511
 
 
    Skipping temperature solve because RHS is zero.
@@ -72,7 +78,8 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 2.76384e-12, 72.4415
-      Total relative nonlinear residual: 0.000451533
+      Relative nonlinear residuals: 0, 3.46128e-09, 0.000451533
+      Total relative residual after nonlinear iteration 2: 0.000451533
 
 
    Skipping temperature solve because RHS is zero.
@@ -81,7 +88,8 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 1.75195e-12, 62.8794
-      Total relative nonlinear residual: 0.000391932
+      Relative nonlinear residuals: 0, 3.46128e-09, 0.000391932
+      Total relative residual after nonlinear iteration 3: 0.000391932
 
 
    Skipping temperature solve because RHS is zero.
@@ -90,7 +98,8 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 1.5811e-12, 57.7565
-      Total relative nonlinear residual: 0.000360001
+      Relative nonlinear residuals: 0, 3.46128e-09, 0.000360001
+      Total relative residual after nonlinear iteration 4: 0.000360001
 
 
    Skipping temperature solve because RHS is zero.
@@ -99,7 +108,8 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 1.48441e-12, 53.864
-      Total relative nonlinear residual: 0.000335738
+      Relative nonlinear residuals: 0, 3.46128e-09, 0.000335738
+      Total relative residual after nonlinear iteration 5: 0.000335738
 
 
 
@@ -115,7 +125,8 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 3.47977e-12, 63.146
-      Total relative nonlinear residual: 0.000393432
+      Relative nonlinear residuals: 0, 4.80272e-09, 0.000393432
+      Total relative residual after nonlinear iteration 1: 0.000393432
 
 
    Skipping temperature solve because RHS is zero.
@@ -124,7 +135,8 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 1.18907e-12, 49.4201
-      Total relative nonlinear residual: 0.000307913
+      Relative nonlinear residuals: 0, 4.80272e-09, 0.000307913
+      Total relative residual after nonlinear iteration 2: 0.000307913
 
 
    Skipping temperature solve because RHS is zero.
@@ -133,7 +145,8 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 9.00504e-13, 39.4513
-      Total relative nonlinear residual: 0.000245802
+      Relative nonlinear residuals: 0, 4.80272e-09, 0.000245802
+      Total relative residual after nonlinear iteration 3: 0.000245802
 
 
    Skipping temperature solve because RHS is zero.
@@ -142,7 +155,8 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 6.94504e-13, 31.8081
-      Total relative nonlinear residual: 0.000198181
+      Relative nonlinear residuals: 0, 4.80272e-09, 0.000198181
+      Total relative residual after nonlinear iteration 4: 0.000198181
 
 
    Skipping temperature solve because RHS is zero.
@@ -151,7 +165,8 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
       Nonlinear residuals: 0, 5.3983e-13, 25.841
-      Total relative nonlinear residual: 0.000161003
+      Relative nonlinear residuals: 0, 4.80272e-09, 0.000161003
+      Total relative residual after nonlinear iteration 5: 0.000161003
 
 
 

--- a/tests/shear_heating_with_melt/screen-output
+++ b/tests/shear_heating_with_melt/screen-output
@@ -10,7 +10,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 97.0322, 0, 0, 2.02856e+13
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 1.93436e-16, 0, 0, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
@@ -20,7 +21,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 11+0 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 80.4678, 0, 0, 1.24869e+11
-      Total relative nonlinear residual: 0.00615557
+      Relative nonlinear residuals: 1.60415e-16, 0, 0, 0.00615557
+      Total relative residual after nonlinear iteration 2: 0.00615557
 
 
    Solving temperature system... 0 iterations.
@@ -30,7 +32,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 12+0 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 79.121, 0, 0, 1.67332e+09
-      Total relative nonlinear residual: 8.24879e-05
+      Relative nonlinear residuals: 1.5773e-16, 0, 0, 8.24879e-05
+      Total relative residual after nonlinear iteration 3: 8.24879e-05
 
 
    Solving temperature system... 0 iterations.
@@ -40,7 +43,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 5+0 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 74.8131, 0, 0, 1.63296e+07
-      Total relative nonlinear residual: 8.04984e-07
+      Relative nonlinear residuals: 1.49142e-16, 0, 0, 8.04984e-07
+      Total relative residual after nonlinear iteration 4: 8.04984e-07
 
 
 
@@ -55,7 +59,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 97.0322, 0, 0, 2.02856e+13
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 1.93436e-16, 0, 0, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
@@ -65,7 +70,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 11+0 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 80.4678, 0, 0, 1.24869e+11
-      Total relative nonlinear residual: 0.00615557
+      Relative nonlinear residuals: 1.60415e-16, 0, 0, 0.00615557
+      Total relative residual after nonlinear iteration 2: 0.00615557
 
 
    Solving temperature system... 0 iterations.
@@ -75,7 +81,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 12+0 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 79.121, 0, 0, 1.67332e+09
-      Total relative nonlinear residual: 8.24879e-05
+      Relative nonlinear residuals: 1.5773e-16, 0, 0, 8.24879e-05
+      Total relative residual after nonlinear iteration 3: 8.24879e-05
 
 
    Solving temperature system... 0 iterations.
@@ -85,7 +92,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 5+0 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 74.8131, 0, 0, 1.63296e+07
-      Total relative nonlinear residual: 8.04984e-07
+      Relative nonlinear residuals: 1.49142e-16, 0, 0, 8.04984e-07
+      Total relative residual after nonlinear iteration 4: 8.04984e-07
 
 
 
@@ -104,7 +112,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 14+0 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 9.18354e+16, 0, 0, 1.85534e+10
-      Total relative nonlinear residual: 0.164007
+      Relative nonlinear residuals: 0.164007, 0, 0, 0.000917996
+      Total relative residual after nonlinear iteration 1: 0.164007
 
 
    Solving temperature system... 13 iterations.
@@ -114,7 +123,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 5+0 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 1.02319e+14, 0, 0, 5.03046e+07
-      Total relative nonlinear residual: 0.00018273
+      Relative nonlinear residuals: 0.00018273, 0, 0, 2.48901e-06
+      Total relative residual after nonlinear iteration 2: 0.00018273
 
 
    Solving temperature system... 9 iterations.
@@ -124,7 +134,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 1.16384e+11, 0, 0, 1.99503e+06
-      Total relative nonlinear residual: 2.07848e-07
+      Relative nonlinear residuals: 2.07848e-07, 0, 0, 9.87114e-08
+      Total relative residual after nonlinear iteration 3: 2.07848e-07
 
 
 
@@ -143,7 +154,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 16+0 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 1.64174e+17, 0, 0, 7.20957e+09
-      Total relative nonlinear residual: 0.0873494
+      Relative nonlinear residuals: 0.0873494, 0, 0, 0.000356921
+      Total relative residual after nonlinear iteration 1: 0.0873494
 
 
    Solving temperature system... 12 iterations.
@@ -153,7 +165,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 17+0 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 6.90347e+15, 0, 0, 8.66538e+08
-      Total relative nonlinear residual: 0.00367302
+      Relative nonlinear residuals: 0.00367302, 0, 0, 4.28992e-05
+      Total relative residual after nonlinear iteration 2: 0.00367302
 
 
    Solving temperature system... 8 iterations.
@@ -163,7 +176,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 7.69432e+12, 0, 0, 1.70529e+06
-      Total relative nonlinear residual: 4.0938e-06
+      Relative nonlinear residuals: 4.0938e-06, 0, 0, 8.44229e-08
+      Total relative residual after nonlinear iteration 3: 4.0938e-06
 
 
 
@@ -182,7 +196,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 32+0 iterations.
    Solving for u_f in 0 iterations.
       Nonlinear residuals: 9.14555e+16, 40885.2, 40885.2, 1.10453e+10
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 0.0773542, 40885.2, 40885.2, 0.000547004
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 12 iterations.
@@ -192,7 +207,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 32+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 7.17671e+14, 28907.1, 28908.1, 6.162e+09
-      Total relative nonlinear residual: 0.707054
+      Relative nonlinear residuals: 0.000607015, 40885.2, 40885.2, 0.000305165
+      Total relative residual after nonlinear iteration 2: 0.707054
 
 
    Solving temperature system... 11 iterations.
@@ -202,7 +218,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 30+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 9.69403e+13, 12070.3, 4215.36, 1.5549e+09
-      Total relative nonlinear residual: 0.295223
+      Relative nonlinear residuals: 8.19932e-05, 40885.2, 40885.2, 7.70047e-05
+      Total relative residual after nonlinear iteration 3: 0.295223
 
 
    Solving temperature system... 9 iterations.
@@ -212,7 +229,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 22+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 1.24579e+13, 570.223, 555.821, 6.86772e+07
-      Total relative nonlinear residual: 0.0139469
+      Relative nonlinear residuals: 1.0537e-05, 40885.2, 40885.2, 3.40115e-06
+      Total relative residual after nonlinear iteration 4: 0.0139469
 
 
    Solving temperature system... 8 iterations.
@@ -222,7 +240,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 20+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 1.6192e+12, 74.2309, 71.6473, 8.99842e+06
-      Total relative nonlinear residual: 0.00181559
+      Relative nonlinear residuals: 1.36954e-06, 40885.2, 40885.2, 4.45635e-07
+      Total relative residual after nonlinear iteration 5: 0.00181559
 
 
    Solving temperature system... 7 iterations.
@@ -232,7 +251,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 2.1003e+11, 9.05315, 9.35286, 1.70539e+06
-      Total relative nonlinear residual: 0.000228759
+      Relative nonlinear residuals: 1.77646e-07, 40885.2, 40885.2, 8.4457e-08
+      Total relative residual after nonlinear iteration 6: 0.000228759
 
 
    Solving temperature system... 5 iterations.
@@ -242,7 +262,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 2.74651e+10, 1.21373, 1.21347, 1.81027e+06
-      Total relative nonlinear residual: 2.96862e-05
+      Relative nonlinear residuals: 2.32303e-08, 40885.2, 40885.2, 8.96513e-08
+      Total relative residual after nonlinear iteration 7: 2.96862e-05
 
 
    Solving temperature system... 4 iterations.
@@ -252,7 +273,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 3.55047e+09, 0.156932, 0.156938, 1.82423e+06
-      Total relative nonlinear residual: 3.83849e-06
+      Relative nonlinear residuals: 3.00303e-09, 40885.2, 40885.2, 9.03427e-08
+      Total relative residual after nonlinear iteration 8: 3.83849e-06
 
 
 
@@ -271,7 +293,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 26+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 1.03361e+17, 474659, 471829, 1.29214e+11
-      Total relative nonlinear residual: 0.805388
+      Relative nonlinear residuals: 0.0406273, 595142, 585840, 0.00640353
+      Total relative residual after nonlinear iteration 1: 0.805388
 
 
    Solving temperature system... 10 iterations.
@@ -281,7 +304,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 24+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 3.79882e+15, 144627, 129073, 2.2094e+10
-      Total relative nonlinear residual: 0.243012
+      Relative nonlinear residuals: 0.00149317, 595142, 585840, 0.00109493
+      Total relative residual after nonlinear iteration 2: 0.243012
 
 
    Solving temperature system... 10 iterations.
@@ -291,7 +315,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 26+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 3.17988e+14, 54438.6, 64368.4, 1.95452e+09
-      Total relative nonlinear residual: 0.109874
+      Relative nonlinear residuals: 0.000124989, 595142, 585840, 9.68616e-05
+      Total relative residual after nonlinear iteration 3: 0.109874
 
 
    Solving temperature system... 8 iterations.
@@ -301,7 +326,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 25+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 1.99647e+14, 13271.3, 13286.7, 5.40314e+08
-      Total relative nonlinear residual: 0.0226798
+      Relative nonlinear residuals: 7.84732e-05, 595142, 585840, 2.67767e-05
+      Total relative residual after nonlinear iteration 4: 0.0226798
 
 
    Solving temperature system... 7 iterations.
@@ -311,7 +337,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 25+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 2.4279e+13, 5230.24, 5235.12, 2.18492e+08
-      Total relative nonlinear residual: 0.0089361
+      Relative nonlinear residuals: 9.54309e-06, 595142, 585840, 1.0828e-05
+      Total relative residual after nonlinear iteration 5: 0.0089361
 
 
    Solving temperature system... 6 iterations.
@@ -321,7 +348,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 24+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 1.33009e+13, 2881.02, 2882.96, 1.22514e+08
-      Total relative nonlinear residual: 0.00492108
+      Relative nonlinear residuals: 5.22807e-06, 595142, 585840, 6.07151e-06
+      Total relative residual after nonlinear iteration 6: 0.00492108
 
 
    Solving temperature system... 6 iterations.
@@ -331,7 +359,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 18+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 9.34326e+12, 2031.82, 2032.88, 8.70858e+07
-      Total relative nonlinear residual: 0.00347002
+      Relative nonlinear residuals: 3.67246e-06, 595142, 585840, 4.31576e-06
+      Total relative residual after nonlinear iteration 7: 0.00347002
 
 
    Solving temperature system... 6 iterations.
@@ -341,7 +370,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 17+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 8.31541e+12, 1815.89, 1816.61, 7.82552e+07
-      Total relative nonlinear residual: 0.00310086
+      Relative nonlinear residuals: 3.26846e-06, 595142, 585840, 3.87814e-06
+      Total relative residual after nonlinear iteration 8: 0.00310086
 
 
    Solving temperature system... 6 iterations.
@@ -351,7 +381,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 18+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 1.01246e+13, 2221.43, 2222.12, 9.7416e+07
-      Total relative nonlinear residual: 0.00379305
+      Relative nonlinear residuals: 3.97958e-06, 595142, 585840, 4.82771e-06
+      Total relative residual after nonlinear iteration 9: 0.00379305
 
 
    Solving temperature system... 8 iterations.
@@ -361,7 +392,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 24+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 2.20042e+15, 127997, 128001, 5.93291e+09
-      Total relative nonlinear residual: 0.218491
+      Relative nonlinear residuals: 0.000864897, 595142, 585840, 0.000294021
+      Total relative residual after nonlinear iteration 10: 0.218491
 
 
 
@@ -380,7 +412,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 31+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 3.54382e+16, 959088, 960600, 1.05582e+11
-      Total relative nonlinear residual: 0.552505
+      Relative nonlinear residuals: 0.016246, 1.74068e+06, 1.73863e+06, 0.00520671
+      Total relative residual after nonlinear iteration 1: 0.552505
 
 
    Solving temperature system... 8 iterations.
@@ -390,7 +423,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 33+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 7.48641e+15, 393359, 384432, 2.11009e+10
-      Total relative nonlinear residual: 0.225981
+      Relative nonlinear residuals: 0.003432, 1.74068e+06, 1.73863e+06, 0.00104058
+      Total relative residual after nonlinear iteration 2: 0.225981
 
 
    Solving temperature system... 8 iterations.
@@ -400,7 +434,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 21+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 4.10388e+14, 144964, 145887, 5.04307e+09
-      Total relative nonlinear residual: 0.0839091
+      Relative nonlinear residuals: 0.000188135, 1.74068e+06, 1.73863e+06, 0.000248696
+      Total relative residual after nonlinear iteration 3: 0.0839091
 
 
    Solving temperature system... 7 iterations.
@@ -410,7 +445,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 22+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 8.41775e+13, 57883.8, 57126.1, 2.20647e+09
-      Total relative nonlinear residual: 0.0332536
+      Relative nonlinear residuals: 3.85896e-05, 1.74068e+06, 1.73863e+06, 0.000108811
+      Total relative residual after nonlinear iteration 4: 0.0332536
 
 
    Solving temperature system... 6 iterations.
@@ -420,7 +456,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 20+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 2.93318e+12, 1523.67, 1164.8, 5.40296e+07
-      Total relative nonlinear residual: 0.00087533
+      Relative nonlinear residuals: 1.34466e-06, 1.74068e+06, 1.73863e+06, 2.66444e-06
+      Total relative residual after nonlinear iteration 5: 0.00087533
 
 
    Solving temperature system... 4 iterations.
@@ -430,7 +467,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 14+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 4.61513e+11, 243.298, 251.831, 9.18021e+06
-      Total relative nonlinear residual: 0.000144845
+      Relative nonlinear residuals: 2.11572e-07, 1.74068e+06, 1.73863e+06, 4.52716e-07
+      Total relative residual after nonlinear iteration 6: 0.000144845
 
 
    Solving temperature system... 4 iterations.
@@ -440,7 +478,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 7+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 1.03295e+11, 54.9518, 56.255, 2.79763e+06
-      Total relative nonlinear residual: 3.23559e-05
+      Relative nonlinear residuals: 4.73538e-08, 1.74068e+06, 1.73863e+06, 1.37964e-07
+      Total relative residual after nonlinear iteration 7: 3.23559e-05
 
 
    Solving temperature system... 3 iterations.
@@ -450,7 +489,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Solving Stokes system... 2+0 iterations.
    Solving for u_f in 1 iterations.
       Nonlinear residuals: 2.40688e+10, 14.2494, 14.3712, 2.09176e+06
-      Total relative nonlinear residual: 8.26583e-06
+      Relative nonlinear residuals: 1.10339e-08, 1.74068e+06, 1.73863e+06, 1.03154e-07
+      Total relative residual after nonlinear iteration 8: 8.26583e-06
 
 
 

--- a/tests/shear_heating_with_melt/screen-output
+++ b/tests/shear_heating_with_melt/screen-output
@@ -9,7 +9,6 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 97.0322, 0, 0, 2.02856e+13
       Relative nonlinear residuals: 1.93436e-16, 0, 0, 1
       Total relative residual after nonlinear iteration 1: 1
 
@@ -20,7 +19,6 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 80.4678, 0, 0, 1.24869e+11
       Relative nonlinear residuals: 1.60415e-16, 0, 0, 0.00615557
       Total relative residual after nonlinear iteration 2: 0.00615557
 
@@ -31,7 +29,6 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 79.121, 0, 0, 1.67332e+09
       Relative nonlinear residuals: 1.5773e-16, 0, 0, 8.24879e-05
       Total relative residual after nonlinear iteration 3: 8.24879e-05
 
@@ -42,7 +39,6 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 74.8131, 0, 0, 1.63296e+07
       Relative nonlinear residuals: 1.49142e-16, 0, 0, 8.04984e-07
       Total relative residual after nonlinear iteration 4: 8.04984e-07
 
@@ -58,7 +54,6 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 97.0322, 0, 0, 2.02856e+13
       Relative nonlinear residuals: 1.93436e-16, 0, 0, 1
       Total relative residual after nonlinear iteration 1: 1
 
@@ -69,7 +64,6 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 80.4678, 0, 0, 1.24869e+11
       Relative nonlinear residuals: 1.60415e-16, 0, 0, 0.00615557
       Total relative residual after nonlinear iteration 2: 0.00615557
 
@@ -80,7 +74,6 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 79.121, 0, 0, 1.67332e+09
       Relative nonlinear residuals: 1.5773e-16, 0, 0, 8.24879e-05
       Total relative residual after nonlinear iteration 3: 8.24879e-05
 
@@ -91,7 +84,6 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 74.8131, 0, 0, 1.63296e+07
       Relative nonlinear residuals: 1.49142e-16, 0, 0, 8.04984e-07
       Total relative residual after nonlinear iteration 4: 8.04984e-07
 
@@ -111,7 +103,6 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 9.18354e+16, 0, 0, 1.85534e+10
       Relative nonlinear residuals: 0.164007, 0, 0, 0.000917996
       Total relative residual after nonlinear iteration 1: 0.164007
 
@@ -122,7 +113,6 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 1.02319e+14, 0, 0, 5.03046e+07
       Relative nonlinear residuals: 0.00018273, 0, 0, 2.48901e-06
       Total relative residual after nonlinear iteration 2: 0.00018273
 
@@ -133,7 +123,6 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 1.16384e+11, 0, 0, 1.99503e+06
       Relative nonlinear residuals: 2.07848e-07, 0, 0, 9.87114e-08
       Total relative residual after nonlinear iteration 3: 2.07848e-07
 
@@ -153,7 +142,6 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 1.64174e+17, 0, 0, 7.20957e+09
       Relative nonlinear residuals: 0.0873494, 0, 0, 0.000356921
       Total relative residual after nonlinear iteration 1: 0.0873494
 
@@ -164,7 +152,6 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 6.90347e+15, 0, 0, 8.66538e+08
       Relative nonlinear residuals: 0.00367302, 0, 0, 4.28992e-05
       Total relative residual after nonlinear iteration 2: 0.00367302
 
@@ -175,7 +162,6 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 7.69432e+12, 0, 0, 1.70529e+06
       Relative nonlinear residuals: 4.0938e-06, 0, 0, 8.44229e-08
       Total relative residual after nonlinear iteration 3: 4.0938e-06
 
@@ -195,8 +181,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 32+0 iterations.
    Solving for u_f in 0 iterations.
-      Nonlinear residuals: 9.14555e+16, 40885.2, 40885.2, 1.10453e+10
-      Relative nonlinear residuals: 0.0773542, 40885.2, 40885.2, 0.000547004
+      Relative nonlinear residuals: 0.0773542, 1, 1, 0.000547004
       Total relative residual after nonlinear iteration 1: 1
 
 
@@ -206,8 +191,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 32+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 7.17671e+14, 28907.1, 28908.1, 6.162e+09
-      Relative nonlinear residuals: 0.000607015, 40885.2, 40885.2, 0.000305165
+      Relative nonlinear residuals: 0.000607015, 0.707031, 0.707054, 0.000305165
       Total relative residual after nonlinear iteration 2: 0.707054
 
 
@@ -217,8 +201,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 9.69403e+13, 12070.3, 4215.36, 1.5549e+09
-      Relative nonlinear residuals: 8.19932e-05, 40885.2, 40885.2, 7.70047e-05
+      Relative nonlinear residuals: 8.19932e-05, 0.295223, 0.103102, 7.70047e-05
       Total relative residual after nonlinear iteration 3: 0.295223
 
 
@@ -228,8 +211,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 1.24579e+13, 570.223, 555.821, 6.86772e+07
-      Relative nonlinear residuals: 1.0537e-05, 40885.2, 40885.2, 3.40115e-06
+      Relative nonlinear residuals: 1.0537e-05, 0.0139469, 0.0135947, 3.40115e-06
       Total relative residual after nonlinear iteration 4: 0.0139469
 
 
@@ -239,8 +221,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 1.6192e+12, 74.2309, 71.6473, 8.99842e+06
-      Relative nonlinear residuals: 1.36954e-06, 40885.2, 40885.2, 4.45635e-07
+      Relative nonlinear residuals: 1.36954e-06, 0.00181559, 0.0017524, 4.45635e-07
       Total relative residual after nonlinear iteration 5: 0.00181559
 
 
@@ -250,8 +231,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 2.1003e+11, 9.05315, 9.35286, 1.70539e+06
-      Relative nonlinear residuals: 1.77646e-07, 40885.2, 40885.2, 8.4457e-08
+      Relative nonlinear residuals: 1.77646e-07, 0.000221428, 0.000228759, 8.4457e-08
       Total relative residual after nonlinear iteration 6: 0.000228759
 
 
@@ -261,8 +241,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 2.74651e+10, 1.21373, 1.21347, 1.81027e+06
-      Relative nonlinear residuals: 2.32303e-08, 40885.2, 40885.2, 8.96513e-08
+      Relative nonlinear residuals: 2.32303e-08, 2.96862e-05, 2.968e-05, 8.96513e-08
       Total relative residual after nonlinear iteration 7: 2.96862e-05
 
 
@@ -272,8 +251,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 3.55047e+09, 0.156932, 0.156938, 1.82423e+06
-      Relative nonlinear residuals: 3.00303e-09, 40885.2, 40885.2, 9.03427e-08
+      Relative nonlinear residuals: 3.00303e-09, 3.83835e-06, 3.83849e-06, 9.03427e-08
       Total relative residual after nonlinear iteration 8: 3.83849e-06
 
 
@@ -292,8 +270,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 1.03361e+17, 474659, 471829, 1.29214e+11
-      Relative nonlinear residuals: 0.0406273, 595142, 585840, 0.00640353
+      Relative nonlinear residuals: 0.0406273, 0.797556, 0.805388, 0.00640353
       Total relative residual after nonlinear iteration 1: 0.805388
 
 
@@ -303,8 +280,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 3.79882e+15, 144627, 129073, 2.2094e+10
-      Relative nonlinear residuals: 0.00149317, 595142, 585840, 0.00109493
+      Relative nonlinear residuals: 0.00149317, 0.243012, 0.220322, 0.00109493
       Total relative residual after nonlinear iteration 2: 0.243012
 
 
@@ -314,8 +290,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 3.17988e+14, 54438.6, 64368.4, 1.95452e+09
-      Relative nonlinear residuals: 0.000124989, 595142, 585840, 9.68616e-05
+      Relative nonlinear residuals: 0.000124989, 0.0914715, 0.109874, 9.68616e-05
       Total relative residual after nonlinear iteration 3: 0.109874
 
 
@@ -325,8 +300,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 1.99647e+14, 13271.3, 13286.7, 5.40314e+08
-      Relative nonlinear residuals: 7.84732e-05, 595142, 585840, 2.67767e-05
+      Relative nonlinear residuals: 7.84732e-05, 0.0222993, 0.0226798, 2.67767e-05
       Total relative residual after nonlinear iteration 4: 0.0226798
 
 
@@ -336,8 +310,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 2.4279e+13, 5230.24, 5235.12, 2.18492e+08
-      Relative nonlinear residuals: 9.54309e-06, 595142, 585840, 1.0828e-05
+      Relative nonlinear residuals: 9.54309e-06, 0.00878821, 0.0089361, 1.0828e-05
       Total relative residual after nonlinear iteration 5: 0.0089361
 
 
@@ -347,8 +320,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 1.33009e+13, 2881.02, 2882.96, 1.22514e+08
-      Relative nonlinear residuals: 5.22807e-06, 595142, 585840, 6.07151e-06
+      Relative nonlinear residuals: 5.22807e-06, 0.0048409, 0.00492108, 6.07151e-06
       Total relative residual after nonlinear iteration 6: 0.00492108
 
 
@@ -358,8 +330,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 9.34326e+12, 2031.82, 2032.88, 8.70858e+07
-      Relative nonlinear residuals: 3.67246e-06, 595142, 585840, 4.31576e-06
+      Relative nonlinear residuals: 3.67246e-06, 0.00341401, 0.00347002, 4.31576e-06
       Total relative residual after nonlinear iteration 7: 0.00347002
 
 
@@ -369,8 +340,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 8.31541e+12, 1815.89, 1816.61, 7.82552e+07
-      Relative nonlinear residuals: 3.26846e-06, 595142, 585840, 3.87814e-06
+      Relative nonlinear residuals: 3.26846e-06, 0.00305118, 0.00310086, 3.87814e-06
       Total relative residual after nonlinear iteration 8: 0.00310086
 
 
@@ -380,8 +350,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 1.01246e+13, 2221.43, 2222.12, 9.7416e+07
-      Relative nonlinear residuals: 3.97958e-06, 595142, 585840, 4.82771e-06
+      Relative nonlinear residuals: 3.97958e-06, 0.0037326, 0.00379305, 4.82771e-06
       Total relative residual after nonlinear iteration 9: 0.00379305
 
 
@@ -391,8 +360,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 2.20042e+15, 127997, 128001, 5.93291e+09
-      Relative nonlinear residuals: 0.000864897, 595142, 585840, 0.000294021
+      Relative nonlinear residuals: 0.000864897, 0.21507, 0.218491, 0.000294021
       Total relative residual after nonlinear iteration 10: 0.218491
 
 
@@ -411,8 +379,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 3.54382e+16, 959088, 960600, 1.05582e+11
-      Relative nonlinear residuals: 0.016246, 1.74068e+06, 1.73863e+06, 0.00520671
+      Relative nonlinear residuals: 0.016246, 0.550986, 0.552505, 0.00520671
       Total relative residual after nonlinear iteration 1: 0.552505
 
 
@@ -422,8 +389,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 7.48641e+15, 393359, 384432, 2.11009e+10
-      Relative nonlinear residuals: 0.003432, 1.74068e+06, 1.73863e+06, 0.00104058
+      Relative nonlinear residuals: 0.003432, 0.225981, 0.221112, 0.00104058
       Total relative residual after nonlinear iteration 2: 0.225981
 
 
@@ -433,8 +399,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 4.10388e+14, 144964, 145887, 5.04307e+09
-      Relative nonlinear residuals: 0.000188135, 1.74068e+06, 1.73863e+06, 0.000248696
+      Relative nonlinear residuals: 0.000188135, 0.08328, 0.0839091, 0.000248696
       Total relative residual after nonlinear iteration 3: 0.0839091
 
 
@@ -444,8 +409,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 8.41775e+13, 57883.8, 57126.1, 2.20647e+09
-      Relative nonlinear residuals: 3.85896e-05, 1.74068e+06, 1.73863e+06, 0.000108811
+      Relative nonlinear residuals: 3.85896e-05, 0.0332536, 0.032857, 0.000108811
       Total relative residual after nonlinear iteration 4: 0.0332536
 
 
@@ -455,8 +419,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 2.93318e+12, 1523.67, 1164.8, 5.40296e+07
-      Relative nonlinear residuals: 1.34466e-06, 1.74068e+06, 1.73863e+06, 2.66444e-06
+      Relative nonlinear residuals: 1.34466e-06, 0.00087533, 0.000669951, 2.66444e-06
       Total relative residual after nonlinear iteration 5: 0.00087533
 
 
@@ -466,8 +429,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 4.61513e+11, 243.298, 251.831, 9.18021e+06
-      Relative nonlinear residuals: 2.11572e-07, 1.74068e+06, 1.73863e+06, 4.52716e-07
+      Relative nonlinear residuals: 2.11572e-07, 0.000139772, 0.000144845, 4.52716e-07
       Total relative residual after nonlinear iteration 6: 0.000144845
 
 
@@ -477,8 +439,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 1.03295e+11, 54.9518, 56.255, 2.79763e+06
-      Relative nonlinear residuals: 4.73538e-08, 1.74068e+06, 1.73863e+06, 1.37964e-07
+      Relative nonlinear residuals: 4.73538e-08, 3.15692e-05, 3.23559e-05, 1.37964e-07
       Total relative residual after nonlinear iteration 7: 3.23559e-05
 
 
@@ -488,8 +449,7 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
    Solving for u_f in 1 iterations.
-      Nonlinear residuals: 2.40688e+10, 14.2494, 14.3712, 2.09176e+06
-      Relative nonlinear residuals: 1.10339e-08, 1.74068e+06, 1.73863e+06, 1.03154e-07
+      Relative nonlinear residuals: 1.10339e-08, 8.18611e-06, 8.26583e-06, 1.03154e-07
       Total relative residual after nonlinear iteration 8: 8.26583e-06
 
 

--- a/tests/solitary_wave/screen-output
+++ b/tests/solitary_wave/screen-output
@@ -11,8 +11,7 @@ Number of degrees of freedom: 74,049 (21,794+5,778+21,794+2,889+10,897+10,897)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+23 iterations.
    Solving for u_f in 10 iterations.
-      Nonlinear residuals: 0, 3.05006e-17, 3.10506e+10
-      Relative nonlinear residuals: 0, 0.204637, 0.999786
+      Relative nonlinear residuals: 0, 1.49047e-16, 0.999786
       Total relative residual after nonlinear iteration 1: 0.999786
 
 
@@ -21,8 +20,7 @@ Number of degrees of freedom: 74,049 (21,794+5,778+21,794+2,889+10,897+10,897)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 10 iterations.
-      Nonlinear residuals: 0, 3.05006e-17, 2.96142
-      Relative nonlinear residuals: 0, 0.204637, 9.53538e-11
+      Relative nonlinear residuals: 0, 1.49047e-16, 9.53538e-11
       Total relative residual after nonlinear iteration 2: 9.53538e-11
 
 
@@ -39,8 +37,7 @@ Number of degrees of freedom: 74,049 (21,794+5,778+21,794+2,889+10,897+10,897)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
    Solving for u_f in 10 iterations.
-      Nonlinear residuals: 0, 2.8881e-05, 24323
-      Relative nonlinear residuals: 0, 0.204653, 7.83167e-07
+      Relative nonlinear residuals: 0, 0.000141122, 7.83167e-07
       Total relative residual after nonlinear iteration 1: 7.83167e-07
 
 
@@ -56,8 +53,7 @@ Number of degrees of freedom: 74,049 (21,794+5,778+21,794+2,889+10,897+10,897)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
    Solving for u_f in 10 iterations.
-      Nonlinear residuals: 0, 5.50413e-07, 446.237
-      Relative nonlinear residuals: 0, 0.306965, 1.43682e-08
+      Relative nonlinear residuals: 0, 1.79308e-06, 1.43682e-08
       Total relative residual after nonlinear iteration 1: 1.43682e-08
 
 
@@ -73,8 +69,7 @@ Number of degrees of freedom: 74,049 (21,794+5,778+21,794+2,889+10,897+10,897)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
    Solving for u_f in 10 iterations.
-      Nonlinear residuals: 0, 1.45965e-07, 141.087
-      Relative nonlinear residuals: 0, 0.287073, 4.54282e-09
+      Relative nonlinear residuals: 0, 5.0846e-07, 4.54282e-09
       Total relative residual after nonlinear iteration 1: 4.54282e-09
 
 

--- a/tests/solitary_wave/screen-output
+++ b/tests/solitary_wave/screen-output
@@ -12,7 +12,8 @@ Number of degrees of freedom: 74,049 (21,794+5,778+21,794+2,889+10,897+10,897)
    Solving Stokes system... 0+23 iterations.
    Solving for u_f in 10 iterations.
       Nonlinear residuals: 0, 3.05006e-17, 3.10506e+10
-      Total relative nonlinear residual: 0.999786
+      Relative nonlinear residuals: 0, 0.204637, 0.999786
+      Total relative residual after nonlinear iteration 1: 0.999786
 
 
    Skipping temperature solve because RHS is zero.
@@ -21,7 +22,8 @@ Number of degrees of freedom: 74,049 (21,794+5,778+21,794+2,889+10,897+10,897)
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 10 iterations.
       Nonlinear residuals: 0, 3.05006e-17, 2.96142
-      Total relative nonlinear residual: 9.53538e-11
+      Relative nonlinear residuals: 0, 0.204637, 9.53538e-11
+      Total relative residual after nonlinear iteration 2: 9.53538e-11
 
 
 
@@ -38,7 +40,8 @@ Number of degrees of freedom: 74,049 (21,794+5,778+21,794+2,889+10,897+10,897)
    Solving Stokes system... 0+9 iterations.
    Solving for u_f in 10 iterations.
       Nonlinear residuals: 0, 2.8881e-05, 24323
-      Total relative nonlinear residual: 7.83167e-07
+      Relative nonlinear residuals: 0, 0.204653, 7.83167e-07
+      Total relative residual after nonlinear iteration 1: 7.83167e-07
 
 
 
@@ -54,7 +57,8 @@ Number of degrees of freedom: 74,049 (21,794+5,778+21,794+2,889+10,897+10,897)
    Solving Stokes system... 0+5 iterations.
    Solving for u_f in 10 iterations.
       Nonlinear residuals: 0, 5.50413e-07, 446.237
-      Total relative nonlinear residual: 1.43682e-08
+      Relative nonlinear residuals: 0, 0.306965, 1.43682e-08
+      Total relative residual after nonlinear iteration 1: 1.43682e-08
 
 
 
@@ -70,7 +74,8 @@ Number of degrees of freedom: 74,049 (21,794+5,778+21,794+2,889+10,897+10,897)
    Solving Stokes system... 0+4 iterations.
    Solving for u_f in 10 iterations.
       Nonlinear residuals: 0, 1.45965e-07, 141.087
-      Total relative nonlinear residual: 4.54282e-09
+      Relative nonlinear residuals: 0, 0.287073, 4.54282e-09
+      Total relative residual after nonlinear iteration 1: 4.54282e-09
 
 
 

--- a/tests/stokes_residual/screen-output
+++ b/tests/stokes_residual/screen-output
@@ -7,13 +7,15 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 42+0 iterations.
       Nonlinear residuals: 9.66723e-15, 8.54747e-07
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 1.81035e-16, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 8+0 iterations.
       Nonlinear residuals: 9.66723e-15, 5.38733e-14
-      Total relative nonlinear residual: 6.30283e-08
+      Relative nonlinear residuals: 1.81035e-16, 6.30283e-08
+      Total relative residual after nonlinear iteration 2: 6.30283e-08
 
 
 
@@ -28,7 +30,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 4 iterations.
    Solving Stokes system... 6+0 iterations.
       Nonlinear residuals: 7.73448e-07, 1.29799e-14
-      Total relative nonlinear residual: 2.43008e-07
+      Relative nonlinear residuals: 1.44841e-08, 2.43008e-07
+      Total relative residual after nonlinear iteration 1: 2.43008e-07
 
 
 

--- a/tests/stokes_residual/screen-output
+++ b/tests/stokes_residual/screen-output
@@ -6,14 +6,12 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 42+0 iterations.
-      Nonlinear residuals: 9.66723e-15, 8.54747e-07
       Relative nonlinear residuals: 1.81035e-16, 1
       Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 8+0 iterations.
-      Nonlinear residuals: 9.66723e-15, 5.38733e-14
       Relative nonlinear residuals: 1.81035e-16, 6.30283e-08
       Total relative residual after nonlinear iteration 2: 6.30283e-08
 
@@ -29,7 +27,6 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 1:  t=0.1 seconds
    Solving temperature system... 4 iterations.
    Solving Stokes system... 6+0 iterations.
-      Nonlinear residuals: 7.73448e-07, 1.29799e-14
       Relative nonlinear residuals: 1.44841e-08, 2.43008e-07
       Total relative residual after nonlinear iteration 1: 2.43008e-07
 

--- a/tests/traction_ascii_data/screen-output
+++ b/tests/traction_ascii_data/screen-output
@@ -16,7 +16,6 @@ Number of degrees of freedom: 61,140 (37,570+4,785+18,785)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 200+49 iterations.
-      Nonlinear residuals: 14928.8, 1.24366e+14
       Relative nonlinear residuals: 1.5591e-16, 1
       Total relative residual after nonlinear iteration 1: 1
 
@@ -24,7 +23,6 @@ Number of degrees of freedom: 61,140 (37,570+4,785+18,785)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 200+32 iterations.
-      Nonlinear residuals: 14928.8, 2.14388e+13
       Relative nonlinear residuals: 1.5591e-16, 0.172385
       Total relative residual after nonlinear iteration 2: 0.172385
 
@@ -32,7 +30,6 @@ Number of degrees of freedom: 61,140 (37,570+4,785+18,785)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 200+34 iterations.
-      Nonlinear residuals: 14928.8, 2.9141e+12
       Relative nonlinear residuals: 1.5591e-16, 0.0234317
       Total relative residual after nonlinear iteration 3: 0.0234317
 

--- a/tests/traction_ascii_data/screen-output
+++ b/tests/traction_ascii_data/screen-output
@@ -17,21 +17,24 @@ Number of degrees of freedom: 61,140 (37,570+4,785+18,785)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 200+49 iterations.
       Nonlinear residuals: 14928.8, 1.24366e+14
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 1.5591e-16, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 200+32 iterations.
       Nonlinear residuals: 14928.8, 2.14388e+13
-      Total relative nonlinear residual: 0.172385
+      Relative nonlinear residuals: 1.5591e-16, 0.172385
+      Total relative residual after nonlinear iteration 2: 0.172385
 
 
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 200+34 iterations.
       Nonlinear residuals: 14928.8, 2.9141e+12
-      Total relative nonlinear residual: 0.0234317
+      Relative nonlinear residuals: 1.5591e-16, 0.0234317
+      Total relative residual after nonlinear iteration 3: 0.0234317
 
 
 

--- a/tests/velocity_divergence/screen-output
+++ b/tests/velocity_divergence/screen-output
@@ -10,7 +10,8 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
       Nonlinear residuals: 0.0139872, 2.52544e-15, 8.39449e+12
-      Total relative nonlinear residual: 1
+      Relative nonlinear residuals: 2.13333e-16, 10.762, 1
+      Total relative residual after nonlinear iteration 1: 1
 
 
    Solving temperature system... 0 iterations.
@@ -18,7 +19,8 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 0.0139872, 2.52544e-15, 350035
-      Total relative nonlinear residual: 4.16982e-08
+      Relative nonlinear residuals: 2.13333e-16, 10.762, 4.16982e-08
+      Total relative residual after nonlinear iteration 2: 4.16982e-08
 
 
 
@@ -34,7 +36,8 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 3.54769e+10, 104.922, 350035
-      Total relative nonlinear residual: 0.994792
+      Relative nonlinear residuals: 0.000540361, 105.471, 4.16921e-08
+      Total relative residual after nonlinear iteration 1: 0.994792
 
 
    Solving temperature system... 0 iterations.
@@ -42,7 +45,8 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 21.0037, 9.02321e-09, 350035
-      Total relative nonlinear residual: 4.16921e-08
+      Relative nonlinear residuals: 3.19914e-13, 105.471, 4.16921e-08
+      Total relative residual after nonlinear iteration 2: 4.16921e-08
 
 
 
@@ -58,7 +62,8 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 4.4425e+09, 98.6819, 350035
-      Total relative nonlinear residual: 0.381263
+      Relative nonlinear residuals: 4.51621e-05, 258.829, 4.16921e-08
+      Total relative residual after nonlinear iteration 1: 0.381263
 
 
    Solving temperature system... 0 iterations.
@@ -66,7 +71,8 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 65.1758, 1.15254e-08, 350035
-      Total relative nonlinear residual: 4.16921e-08
+      Relative nonlinear residuals: 6.62571e-13, 258.829, 4.16921e-08
+      Total relative residual after nonlinear iteration 2: 4.16921e-08
 
 
 
@@ -82,7 +88,8 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 2.13596e+09, 25.7677, 350035
-      Total relative nonlinear residual: 0.07342
+      Relative nonlinear residuals: 2.17141e-05, 350.963, 4.16921e-08
+      Total relative residual after nonlinear iteration 1: 0.07342
 
 
    Solving temperature system... 0 iterations.
@@ -90,7 +97,8 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 56.824, 2.09445e-08, 350035
-      Total relative nonlinear residual: 4.16921e-08
+      Relative nonlinear residuals: 5.7767e-13, 350.963, 4.16921e-08
+      Total relative residual after nonlinear iteration 2: 4.16921e-08
 
 
 
@@ -106,7 +114,8 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 8.57235e+08, 10.2565, 350035
-      Total relative nonlinear residual: 0.0272824
+      Relative nonlinear residuals: 9.36119e-06, 375.94, 4.16921e-08
+      Total relative residual after nonlinear iteration 1: 0.0272824
 
 
    Solving temperature system... 0 iterations.
@@ -114,7 +123,8 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
       Nonlinear residuals: 83.1388, 3.32189e-08, 350035
-      Total relative nonlinear residual: 4.16921e-08
+      Relative nonlinear residuals: 9.07893e-13, 375.94, 4.16921e-08
+      Total relative residual after nonlinear iteration 2: 4.16921e-08
 
 
 

--- a/tests/velocity_divergence/screen-output
+++ b/tests/velocity_divergence/screen-output
@@ -9,8 +9,7 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
-      Nonlinear residuals: 0.0139872, 2.52544e-15, 8.39449e+12
-      Relative nonlinear residuals: 2.13333e-16, 10.762, 1
+      Relative nonlinear residuals: 2.13333e-16, 2.34662e-16, 1
       Total relative residual after nonlinear iteration 1: 1
 
 
@@ -18,8 +17,7 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 0.0139872, 2.52544e-15, 350035
-      Relative nonlinear residuals: 2.13333e-16, 10.762, 4.16982e-08
+      Relative nonlinear residuals: 2.13333e-16, 2.34662e-16, 4.16982e-08
       Total relative residual after nonlinear iteration 2: 4.16982e-08
 
 
@@ -35,8 +33,7 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Solving porosity system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 3.54769e+10, 104.922, 350035
-      Relative nonlinear residuals: 0.000540361, 105.471, 4.16921e-08
+      Relative nonlinear residuals: 0.000540361, 0.994792, 4.16921e-08
       Total relative residual after nonlinear iteration 1: 0.994792
 
 
@@ -44,8 +41,7 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 21.0037, 9.02321e-09, 350035
-      Relative nonlinear residuals: 3.19914e-13, 105.471, 4.16921e-08
+      Relative nonlinear residuals: 3.19914e-13, 8.55517e-11, 4.16921e-08
       Total relative residual after nonlinear iteration 2: 4.16921e-08
 
 
@@ -61,8 +57,7 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Solving porosity system ... 18 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 4.4425e+09, 98.6819, 350035
-      Relative nonlinear residuals: 4.51621e-05, 258.829, 4.16921e-08
+      Relative nonlinear residuals: 4.51621e-05, 0.381263, 4.16921e-08
       Total relative residual after nonlinear iteration 1: 0.381263
 
 
@@ -70,8 +65,7 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 65.1758, 1.15254e-08, 350035
-      Relative nonlinear residuals: 6.62571e-13, 258.829, 4.16921e-08
+      Relative nonlinear residuals: 6.62571e-13, 4.45291e-11, 4.16921e-08
       Total relative residual after nonlinear iteration 2: 4.16921e-08
 
 
@@ -87,8 +81,7 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Solving porosity system ... 17 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 2.13596e+09, 25.7677, 350035
-      Relative nonlinear residuals: 2.17141e-05, 350.963, 4.16921e-08
+      Relative nonlinear residuals: 2.17141e-05, 0.07342, 4.16921e-08
       Total relative residual after nonlinear iteration 1: 0.07342
 
 
@@ -96,8 +89,7 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 56.824, 2.09445e-08, 350035
-      Relative nonlinear residuals: 5.7767e-13, 350.963, 4.16921e-08
+      Relative nonlinear residuals: 5.7767e-13, 5.96772e-11, 4.16921e-08
       Total relative residual after nonlinear iteration 2: 4.16921e-08
 
 
@@ -113,8 +105,7 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Solving porosity system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 8.57235e+08, 10.2565, 350035
-      Relative nonlinear residuals: 9.36119e-06, 375.94, 4.16921e-08
+      Relative nonlinear residuals: 9.36119e-06, 0.0272824, 4.16921e-08
       Total relative residual after nonlinear iteration 1: 0.0272824
 
 
@@ -122,8 +113,7 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Nonlinear residuals: 83.1388, 3.32189e-08, 350035
-      Relative nonlinear residuals: 9.07893e-13, 375.94, 4.16921e-08
+      Relative nonlinear residuals: 9.07893e-13, 8.83623e-11, 4.16921e-08
       Total relative residual after nonlinear iteration 2: 4.16921e-08
 
 

--- a/tests/visco_plastic/screen-output
+++ b/tests/visco_plastic/screen-output
@@ -6,7 +6,7 @@ Number of degrees of freedom: 1,444 (882+121+441)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-   Residual after nonlinear iteration 1: 1
+      Relative Stokes residual after nonlinear iteration 1: 1
 
 
    Postprocessing:

--- a/tests/visco_plastic_complex/screen-output
+++ b/tests/visco_plastic_complex/screen-output
@@ -6,7 +6,7 @@ Number of degrees of freedom: 3,208 (882+121+441+441+441+441+441)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+10 iterations.
-   Residual after nonlinear iteration 1: 1
+      Relative Stokes residual after nonlinear iteration 1: 1
 
 
    Postprocessing:

--- a/tests/visco_plastic_yield/screen-output
+++ b/tests/visco_plastic_yield/screen-output
@@ -6,7 +6,7 @@ Number of degrees of freedom: 1,444 (882+121+441)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-   Residual after nonlinear iteration 1: 1
+      Relative Stokes residual after nonlinear iteration 1: 1
 
 
    Postprocessing:

--- a/tests/visco_plastic_yield_strain_weakening/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening/screen-output
@@ -6,7 +6,7 @@ Number of degrees of freedom: 2,767 (882+121+441+441+441+441)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-   Residual after nonlinear iteration 1: 1
+      Relative Stokes residual after nonlinear iteration 1: 1
 
 
    Postprocessing:

--- a/tests/zero_RHS/screen-output
+++ b/tests/zero_RHS/screen-output
@@ -8,19 +8,19 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
    Solving C_2 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
-   Residual after nonlinear iteration 1: 1
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-   Residual after nonlinear iteration 2: 0.00375062
+      Relative Stokes residual after nonlinear iteration 2: 0.00375062
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Residual after nonlinear iteration 3: 7.22703e-05
+      Relative Stokes residual after nonlinear iteration 3: 7.22703e-05
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Residual after nonlinear iteration 4: 9.38643e-07
+      Relative Stokes residual after nonlinear iteration 4: 9.38643e-07
 
    Postprocessing:
      Writing graphical output: output-zero_RHS/solution/solution-00000
@@ -32,7 +32,7 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
    Solving C_2 system ... 18 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Residual after nonlinear iteration 1: 9.45741e-08
+      Relative Stokes residual after nonlinear iteration 1: 9.45741e-08
 
    Postprocessing:
      Writing graphical output: output-zero_RHS/solution/solution-00001
@@ -44,7 +44,7 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
    Solving C_2 system ... 20 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Residual after nonlinear iteration 1: 9.45741e-08
+      Relative Stokes residual after nonlinear iteration 1: 9.45741e-08
 
    Postprocessing:
      Writing graphical output: output-zero_RHS/solution/solution-00002
@@ -56,7 +56,7 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
    Solving C_2 system ... 19 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Residual after nonlinear iteration 1: 9.45741e-08
+      Relative Stokes residual after nonlinear iteration 1: 9.45741e-08
 
    Postprocessing:
      Writing graphical output: output-zero_RHS/solution/solution-00003
@@ -68,7 +68,7 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
    Solving C_2 system ... 18 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Residual after nonlinear iteration 1: 9.45741e-08
+      Relative Stokes residual after nonlinear iteration 1: 9.45741e-08
 
    Postprocessing:
      Writing graphical output: output-zero_RHS/solution/solution-00004
@@ -80,7 +80,7 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
    Solving C_2 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Residual after nonlinear iteration 1: 9.45741e-08
+      Relative Stokes residual after nonlinear iteration 1: 9.45741e-08
 
    Postprocessing:
      Writing graphical output: output-zero_RHS/solution/solution-00005

--- a/tests/zero_matrix/screen-output
+++ b/tests/zero_matrix/screen-output
@@ -8,19 +8,19 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
    Solving C_2 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
-   Residual after nonlinear iteration 1: 1
+      Relative Stokes residual after nonlinear iteration 1: 1
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-   Residual after nonlinear iteration 2: 0.00375062
+      Relative Stokes residual after nonlinear iteration 2: 0.00375062
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Residual after nonlinear iteration 3: 7.22703e-05
+      Relative Stokes residual after nonlinear iteration 3: 7.22703e-05
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Residual after nonlinear iteration 4: 9.38643e-07
+      Relative Stokes residual after nonlinear iteration 4: 9.38643e-07
 
    Postprocessing:
      Writing graphical output: output-zero_matrix/solution/solution-00000


### PR DESCRIPTION
This is a suggestion for making the screen output of the different nonlinear solver schemes more consistent. They now all output the relative nonlinear residual (which is probably more useful than the absolute residual in most cases) and the number of the current nonlinear iteration. 

The member variable `nonlinear_iteration` I added to the simulator is not really needed for this change, but I will need it for a follow-up pull request that addresses issue #300 and makes it possible to run all postprocessors also on nonlinear iterations, and it might also be useful to have the same style everywhere if we plan to mix and match solver schemes in the future.