### PR TITLE
update reference for user manual

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -306,14 +306,14 @@ this software:
 \end{lstlisting}
 Please also cite the User's Manual:
 \begin{lstlisting}[frame=single,language=tex]
-@Manual{aspectmanual,
-  title =        {\textsc{ASPECT}: {Advanced Solver for Problems in Earth's
-                  ConvecTion}},
-  author =       {W. Bangerth and J. Dannberg and
-                  R. Gassm{\"o}ller and T. Heister and others},
-  organization = {Computational Infrastructure for Geodynamics},
-  year =         {2017},
-  url =          {https://aspect.dealii.org/}
+@Article{aspectmanual,
+  Title         = {{\textsc{ASPECT}: Advanced Solver for Problems in Earth's ConvecTion, User Manual}},
+  Author        = {W. Bangerth and J. Dannberg and R. Gassm{\"o}ller and T. Heister and others},
+  Year          = {2017},
+  Month         = {4},
+  DOI           = {10.6084/m9.figshare.4865333},
+  Note          = {doi:10.6084/m9.figshare.4865333},
+  URL           = {https://doi.org/10.6084/m9.figshare.4865333}
 }
 \end{lstlisting}
 


### PR DESCRIPTION
Use figshare for the location of the manual so we have a citable version including a DOI.

The title is a little weird but I would like to have the word "manual" in the title. Also is it "user's manual" or "user manual"? Right now it is closest to what you actually see in the pdf.