### PR TITLE
Testing project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,9 +135,31 @@ ADD_CUSTOM_TARGET(setup_tests
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Enabling all tests ...")
 
+SET(ASPECT_TEST_GENERATOR "Unix Makefiles" CACHE STRING 
+  "Generator to use for the test cmake project. Using ninja instead of make is not recommended.")
+
 IF(EXISTS ${CMAKE_SOURCE_DIR}/tests/CMakeLists.txt)
-  ENABLE_TESTING()
-  ADD_SUBDIRECTORY(tests)
+  FILE(WRITE ${CMAKE_BINARY_DIR}/CTestTestfile.cmake "SUBDIRS(tests)")
+
+  FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests)
+
+  SET(aspect_binary ${CMAKE_BINARY_DIR}/aspect)
+
+  MESSAGE(STATUS "Setting up test project, see setup_tests.log for details.")
+  EXECUTE_PROCESS(
+    COMMAND ${CMAKE_COMMAND} -G ${ASPECT_TEST_GENERATOR}
+	-D ASPECT_RUN_ALL_TESTS=${ASPECT_RUN_ALL_TESTS}
+	-D ASPECT_DIR=${CMAKE_BINARY_DIR}
+	-D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+	-D ASPECT_BINARY=${aspect_binary}
+	${CMAKE_CURRENT_SOURCE_DIR}/tests
+    OUTPUT_FILE setup_tests.log
+    RESULT_VARIABLE test_cmake_result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests
+   )
+  IF(NOT test_cmake_result EQUAL 0)
+    MESSAGE(FATAL_ERROR "ERROR: Test project could not be configured.")
+  ENDIF()
 ENDIF()
 
 

--- a/doc/modules/changes/201704229_tjhei
+++ b/doc/modules/changes/201704229_tjhei
@@ -1,0 +1,6 @@
+Changed: The unit tests are now a separate cmake project that is
+configured automatically. To speed up scanning of dependencies,
+running ctest will no longer rebuild aspect if the binary is out of
+date. Issues with using "ninja" as the generator have been fixed.
+<br>
+(Timo Heister, 2017/04/29)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,18 @@
 ################### top matter ################
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.8)
+
+SET(ASPECT_BINARY "${ASPECT_BINARY}" CACHE STRING "" FORCE)
+SET(ASPECT_DIR "${ASPECT_DIR}" CACHE STRING "" FORCE)
+FIND_PACKAGE(Aspect 1.5.0 QUIET HINTS ${ASPECT_DIR})
+DEAL_II_INITIALIZE_CACHED_VARIABLES()
+
 FIND_PACKAGE(Perl)
+
+MESSAGE(STATUS "Setting up tests with CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}")
+
+PROJECT(testsuite CXX)
+
+ENABLE_TESTING()
 
 MACRO(SET_IF_EMPTY _variable _value)
   IF("${${_variable}}" STREQUAL "")
@@ -66,7 +79,7 @@ FUNCTION(SHOULD_ENABLE_TEST _filename)
 
   FILE(STRINGS ${_filename} _input_lines
        REGEX "QUICK_TEST")
-  IF(NOT ${ASPECT_RUN_ALL_TESTS} AND "${_input_lines}" STREQUAL "")
+  IF(NOT ASPECT_RUN_ALL_TESTS AND "${_input_lines}" STREQUAL "")
     SET(_use_test OFF PARENT_SCOPE)
   ENDIF()
 ENDFUNCTION()
@@ -147,26 +160,13 @@ FOREACH(_test ${_tests})
 
     IF(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${_test}.cc)
       ADD_LIBRARY(${_test} SHARED EXCLUDE_FROM_ALL ${_test}.cc)
-      IF (APPLE AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        # avoid linker errors about missing functions inside ASPECT:
-        SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -undefined dynamic_lookup")
+      ASPECT_SETUP_PLUGIN(${_test})
 
-        # make shared libraries end on .so not .dylib
-        SET_TARGET_PROPERTIES(${_test} PROPERTIES SUFFIX ".so")
-      ENDIF()
-
-      SET_PROPERTY(SOURCE ${_test}.cc
-                   APPEND PROPERTY COMPILE_DEFINITIONS ASPECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
-      IF (ASPECT_USE_PETSC)
-        SET_PROPERTY(SOURCE ${_test}.cc
-	             APPEND PROPERTY COMPILE_DEFINITIONS ASPECT_USE_PETSC="1")
-      ENDIF()
-      DEAL_II_SETUP_TARGET(${_test})
       SET(_testlib 'set Additional shared libraries = ./lib${_test}.so')
       SET(_testdepends ${_test})
     ELSE()
-      SET(_testdepends)
       SET(_testlib)
+      SET(_testdepends)
     ENDIF()
 
     # Create the output directory and subdirectories as needed. To do this, we
@@ -255,36 +255,24 @@ FOREACH(_test ${_tests})
 
     IF("${_mpi_count}" STREQUAL "1")
       ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output
-	COMMAND
-	  for i in ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/* \; do
-	    if echo \$i | grep -q -v .cmp.notime \; then
-	      rm -rf \$i \;
-	    fi \;
-	  done
-	COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run_test.sh ${EXPECT} ${CMAKE_BINARY_DIR}/aspect ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output.tmp
+	COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run_test.sh ${EXPECT} ${ASPECT_BINARY} ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output.tmp
 	COMMAND ${_replacement_script} screen-output <${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output.tmp >${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output
 	COMMAND ${PERL_EXECUTABLE} -pi
 		  ${CMAKE_CURRENT_SOURCE_DIR}/normalize.pl
 		  ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/*
 		  ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/*/*
-	DEPENDS aspect ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm ${_testdepends}
+	DEPENDS ${ASPECT_BINARY}   ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm ${_testdepends}
 	)
     ELSE()
       ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output
-	COMMAND
-	  for i in ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/* \; do
-	    if echo \$i | grep -q -v .cmp.notime \; then
-	      rm -rf \$i \;
-	    fi \;
-	  done
-	COMMAND mpirun -np ${_mpi_count} ${CMAKE_BINARY_DIR}/aspect ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm
+	COMMAND mpirun -np ${_mpi_count} ${ASPECT_BINARY} ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm
 		> ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output.tmp
 	COMMAND ${_replacement_script} screen-output <${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output.tmp >${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/screen-output
 	COMMAND ${PERL_EXECUTABLE} -pi
 		  ${CMAKE_CURRENT_SOURCE_DIR}/normalize.pl
 		  ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/*
 		  ${CMAKE_CURRENT_BINARY_DIR}/output-${_test}/*/*
-	DEPENDS aspect ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm ${_testdepends}
+	DEPENDS ${ASPECT_BINARY}  ${CMAKE_CURRENT_BINARY_DIR}/${_test}.x.prm ${_testdepends}
 	)
     ENDIF()
 
@@ -365,7 +353,7 @@ FOREACH(_test ${_tests})
 	    -DBINARY_DIR=${CMAKE_BINARY_DIR}
 	    -DTESTNAME=tests.${_test}
 	    -DERROR="Test ${_test} failed"
-	    -P ${CMAKE_SOURCE_DIR}/tests/run_test.cmake
+	    -P ${CMAKE_SOURCE_DIR}/run_test.cmake
 	  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       )
     SET_TESTS_PROPERTIES(${_test} PROPERTIES


### PR DESCRIPTION
- put the tests into a separate cmake project
- do not recompile aspect while running ctest
- always use make as the generator for the test project