### PR TITLE
Fix the layout of the front page of the manual.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -173,12 +173,15 @@ COMPUTATIONAL INFRASTRUCTURE FOR GEODYNAMICS (CIG)
 \vspace{1em}
 }
 
+{\noindent
 {\fontfamily{\sfdefault}\selectfont \href{https://geodynamics.org}{geodynamics.org}}
-
+}
 
 %LINE%
+{\noindent
 \color{dark_grey}
 \rule{\textwidth}{2pt}
+}
 
 }
 


### PR DESCRIPTION
This fixes #1454. What was missing was just to use \noindent in a couple of places.