### PR TITLE
Add compositional heating model

### DIFF
--- a/include/aspect/heating_model/compositional_heating.h
+++ b/include/aspect/heating_model/compositional_heating.h
@@ -1,0 +1,95 @@
+/*
+  Copyright (C) 2014 - 2017 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+
+#ifndef _aspect_heating_model_compositional_heating_h
+#define _aspect_heating_model_compositional_heating_h
+
+#include <aspect/simulator_access.h>
+#include <aspect/heating_model/interface.h>
+
+#include <deal.II/base/parsed_function.h>
+
+namespace aspect
+{
+  namespace HeatingModel
+  {
+    using namespace dealii;
+
+    /**
+     * A class that implements a heating model based on radioactive decay.
+     *
+     * @ingroup HeatingModels
+     */
+    template <int dim>
+    class CompositionalHeating : public Interface<dim>, public SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * Constructor.
+         */
+        CompositionalHeating ();
+
+        /**
+         * Return the magnitude of heat production arising from values assigned
+         * to each compositional field.
+         */
+        virtual
+        void
+        evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+                  const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
+                  HeatingModel::HeatingModelOutputs &heating_model_outputs) const;
+
+        /**
+         * Declare the parameters this class takes through input files.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         */
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
+
+      private:
+
+        std::vector<double> compute_volume_fractions(
+          const std::vector<double> &compositional_fields) const;
+
+        /**
+         * Magnitude of heat production in each compositional field
+         */
+        std::vector<double> heating_values;
+
+        /**
+         * User can choose whether compositional field is used in heat production averaging
+         */
+        std::vector<int> field_used_in_heat_production_averaging;
+
+    };
+  }
+}
+
+
+#endif

--- a/include/aspect/heating_model/compositional_heating.h
+++ b/include/aspect/heating_model/compositional_heating.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2014 - 2017 by the authors of the ASPECT code.
+  Copyright (C) 2017 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -26,8 +26,6 @@
 #include <aspect/simulator_access.h>
 #include <aspect/heating_model/interface.h>
 
-#include <deal.II/base/parsed_function.h>
-
 namespace aspect
 {
   namespace HeatingModel
@@ -35,7 +33,8 @@ namespace aspect
     using namespace dealii;
 
     /**
-     * A class that implements a heating model based on radioactive decay.
+     * A class that implements a heating model where each compositional field
+     * is assigned a user-defined internal heating value.
      *
      * @ingroup HeatingModels
      */
@@ -74,6 +73,16 @@ namespace aspect
 
       private:
 
+        /**
+         * From a list of compositional fields of length N, we come up with an
+         * N+1 length list that which also includes the fraction of
+         * ``background mantle''. This list should sum to one, and is
+         * interpreted as volume fractions.  If the sum of the
+         * compositional_fields is greater than one, we assume that there is
+         * no background mantle (i.e., that field value is zero).  Otherwise,
+         * the difference between the sum of the compositional fields and 1.0
+         * is assumed to be the amount of background mantle.
+         */
         std::vector<double> compute_volume_fractions(
           const std::vector<double> &compositional_fields) const;
 
@@ -83,7 +92,12 @@ namespace aspect
         std::vector<double> heating_values;
 
         /**
-         * User can choose whether compositional field is used in heat production averaging
+         * User can choose whether the heat production value associated with
+         * each compositional field is used when the average value at each
+         * point is calculated. This is useful if some compositional fields
+         * are used to track properties like finite strain that should not
+         * contribute to material properties like viscosity, heat production,
+         * etc.
          */
         std::vector<int> field_used_in_heat_production_averaging;
 

--- a/source/heating_model/compositional_heating.cc
+++ b/source/heating_model/compositional_heating.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011 - 2017 by the authors of the ASPECT code.
+  Copyright (C) 2017 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -22,7 +22,6 @@
 
 #include <aspect/heating_model/compositional_heating.h>
 #include <aspect/utilities.h>
-#include <aspect/geometry_model/interface.h>
 #include <aspect/global.h>
 
 namespace aspect
@@ -87,7 +86,7 @@ namespace aspect
 
           // Calculate average compositional heat production
           double compositional_heat_production = 0.;
-          for (unsigned int c=0; c< volume_fractions.size(); ++c)
+          for (unsigned int c=0; c < volume_fractions.size(); ++c)
             {
               compositional_heat_production += volume_fractions[c] * heating_values[c];
             }

--- a/source/heating_model/compositional_heating.cc
+++ b/source/heating_model/compositional_heating.cc
@@ -1,0 +1,172 @@
+/*
+  Copyright (C) 2011 - 2017 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+
+#include <aspect/heating_model/compositional_heating.h>
+#include <aspect/utilities.h>
+#include <aspect/geometry_model/interface.h>
+#include <aspect/global.h>
+
+namespace aspect
+{
+  namespace HeatingModel
+  {
+    template <int dim>
+    CompositionalHeating<dim>::CompositionalHeating ()
+    {}
+
+    template <int dim>
+    std::vector<double>
+    CompositionalHeating<dim>::
+    compute_volume_fractions( const std::vector<double> &compositional_fields) const
+    {
+      std::vector<double> volume_fractions( compositional_fields.size()+1);
+      double sum_composition = 0.0;
+
+      std::vector<double> x_comp = compositional_fields;
+      for ( unsigned int i=0; i < x_comp.size(); ++i)
+        {
+          if (field_used_in_heat_production_averaging[i] == 1)
+            {
+              // clip the compositional fields so they are between zero and one
+              // and sum them for normalization purposes
+              x_comp[i] = std::min(std::max(x_comp[i], 0.0), 1.0);
+              sum_composition += x_comp[i];
+            }
+          else
+            x_comp[i] = 0.0;
+        }
+
+      if (sum_composition >= 1.0)
+        {
+          volume_fractions[0] = 0.0;  //background material
+          for ( unsigned int i=1; i <= x_comp.size(); ++i)
+            volume_fractions[i] = x_comp[i-1]/sum_composition;
+        }
+      else
+        {
+          volume_fractions[0] = 1.0 - sum_composition; //background material
+          for ( unsigned int i=1; i <= x_comp.size(); ++i)
+            volume_fractions[i] = x_comp[i-1];
+        }
+      return volume_fractions;
+    }
+
+
+    template <int dim>
+    void
+    CompositionalHeating<dim>::
+    evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+              const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
+              HeatingModel::HeatingModelOutputs &heating_model_outputs) const
+    {
+
+      for (unsigned int q = 0; q < heating_model_outputs.heating_source_terms.size(); ++q)
+        {
+
+          // Compute compositional volume fractions
+          const std::vector<double> volume_fractions = compute_volume_fractions(material_model_inputs.composition[q]);
+
+          // Calculate average compositional heat production
+          double compositional_heat_production = 0.;
+          for (unsigned int c=0; c< volume_fractions.size(); ++c)
+            {
+              compositional_heat_production += volume_fractions[c] * heating_values[c];
+            }
+
+          heating_model_outputs.heating_source_terms[q] = compositional_heat_production;
+
+          heating_model_outputs.lhs_latent_heat_terms[q] = 0.0;
+
+        }
+    }
+
+
+    template <int dim>
+    void
+    CompositionalHeating<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Heating model");
+      {
+        prm.enter_subsection("Compositional heating");
+        {
+          prm.declare_entry("Compositional heating values","0",
+                            Patterns::List (Patterns::Double(0)),
+                            "List of heat production per unit volume values for "
+                            "background and compositional fields, for a total of "
+                            "N+1 values, where N is the number of compositional fields. "
+                            "Units: W/m3.");
+          prm.declare_entry ("Use compositional field for heat production averaging", "1",
+                             Patterns::List(Patterns::Integer(0,1)),
+                             "List of integers, detailing for each compositional field if it should be included in the "
+                             "averaging scheme when the heat production is computed (if 1) or not (if 0).");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+
+    template <int dim>
+    void
+    CompositionalHeating<dim>::parse_parameters (ParameterHandler &prm)
+    {
+
+      //increment by one for background:
+      const unsigned int n_fields = this->n_compositional_fields() + 1;
+
+      prm.enter_subsection("Heating model");
+      {
+        prm.enter_subsection("Compositional heating");
+        {
+
+          field_used_in_heat_production_averaging = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_int(Utilities::split_string_list(prm.get("Use compositional field for heat production averaging"))),
+                                                    n_fields,
+                                                    "Use compositional field for heat production averaging");
+
+          heating_values = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Compositional heating values"))),
+                                                                   n_fields,
+                                                                   "Compositional heating values");
+
+
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace HeatingModel
+  {
+    ASPECT_REGISTER_HEATING_MODEL(CompositionalHeating,
+                                  "compositional heating",
+                                  "Implementation of a model in which magnitude of internal heat production"
+                                  "is determined from fixed values assigned to each compositional"
+                                  "field. These values are interpreted as having units W/m^3.")
+  }
+}
+
+

--- a/tests/compositional_heating.prm
+++ b/tests/compositional_heating.prm
@@ -1,0 +1,157 @@
+# Global parameters
+set Dimension                              = 2
+set Start time                             = 0
+set End time                               = 1e9
+set Use years in output instead of seconds = true
+set Nonlinear solver scheme                = IMPES
+set Number of cheap Stokes solver steps    = 200
+set Output directory                       = compositional_heating
+set Timing output frequency                = 1
+
+# Model geometry (100x100 km, 10 km spacing)
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X repetitions = 10
+    set Y repetitions = 10
+    set X extent      = 100e3
+    set Y extent      = 100e3
+  end
+end
+
+# Mesh refinement specifications 
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 0
+  set Time steps between mesh refinement = 0
+end
+
+
+# Boundary classifications (fixed T boundaries, prescribed velocity) 
+subsection Model settings
+  set Fixed temperature boundary indicators   = bottom, top
+  set Tangential velocity boundary indicators = bottom, top, left, right
+end
+
+# Temperature boundary conditions
+subsection Boundary temperature model
+  set Model name = box
+  subsection Box
+    set Bottom temperature = 1543
+    set Top temperature    =  273
+  end
+end
+
+# Initial temperature field
+# Typical continental geotherm based equations 4-6 from Chapman 1986 (Geol. Soc. Lon.):
+#   T(z) = Tt + (qt/k)*z - (A*z**2)/(2*k)    (eq 4)
+#   Tb = Tt + (qt/k)*dz - (A*dz**2)/(2*k)    (eq 5)
+#   qb = qt - A*dz                           (eq 6)
+#     T: Temperature, Ts: Layer surface temperature, Tb: layer basal temperature,
+#     qs: Layer surface heat flux, qb: Layer basal heat flux, A = heat production,
+#     dz: Layer thickness, k: thermal conductivity
+# The initial constraints are:
+#   Crust surface temperature (Tsc) = 273 K
+#   Crust surface heat flow   (qsc) = 0.07 W/m^2
+#   Crust heat production      (Ac) = 1.5e-6 W/m^3
+#   Crust thickness           (dzu) = 30.3 m  
+#   Mantle heat production     (Am) = 0. W/m^3
+#   Mantle thickness          (dzm) = 70.e3   
+#   Thermal conducitivty        (K) = 2.5 W/(m K)
+# These constraints allow us to calculate the following values:
+#   qbc = qsc - A*dzc = 0.07 - 1.5e-6*30.e3 = 0.025
+#   Tbc = Tsc + (qsc/k)*dzc - (A*dzc**2)/(2*k) = 
+#         273. + (0.07/2.5)*30.e3 - (1.5e-6 * 30.e3**2)/(2.*2.5) = 843
+#   qsm = qbc = 0.025
+#   Tsm = Tbc = 843
+#   qbm = qsm - A*dzm = 0.025 - 0.*70.e3 = 0.025
+#   Tbm = Tsm + (qts/k)*dzs - (A*dzm**2)/(2*k) = 
+#         843. + (0.025/2.5)*30.e3 - (0. * 70.e3**2)/(2.*2.5) = 1543
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Variable names = x,y
+    set Function constants = h=100e3,tsc=273,tsm=843,qsc=0.07,qsm=0.025,k=2.5,A=1.5e-6
+    set Function expression = if( (h-y)<=30.e3, \
+                                  tsc + (qsc/k)*(h-y) - (A*(h-y)*(h-y))/(2.0*k), \
+                                  tsm + (qsm/k)*(h-y-30.e3))                             
+  end
+end
+
+# Internal heating (user specifies heat flux in W/m^3)
+# Values below are for the background (mantle) and crust.
+# If one wishes to track a property through compositional fields that should
+# not be used to deteremine the heat flux (e.g. finite strain), set the
+# "Use compositional field for heat flux averaging" value for that field to 0. 
+# See Initial conditions section for relationship between heat flux, production
+# and initial temperature profile representative of a continental geotherm.
+subsection Heating model
+  set Model name = compositional heating
+  subsection Compositional heating
+    set Use compositional field for heat production averaging = 1, 1
+    set Compositional heating values = 0., 1.5e-6
+  end
+end
+
+# Compositional fields used to track upper and lower crust
+subsection Compositional fields
+  set Number of fields = 1
+  set Names of fields = upper
+end
+
+# Compositional initial conditions 
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Variable names      = x,y
+    set Function expression = if(y>=70.e3, 1, 0);
+  end
+end
+
+# Boundary composition specification
+subsection Boundary composition model
+  set Model name = initial composition
+end
+
+# Material model (values for background material (mantle) and crust)
+subsection Material model
+  set Model name = visco plastic
+  subsection Visco Plastic
+
+    # Reference values and viscosity averaging
+    set Minimum strain rate = 1.e-20
+    set Reference strain rate = 1.e-16
+    set Minimum viscosity = 1e18
+    set Maximum viscosity = 1e28
+    set Reference viscosity = 1e22
+    set Viscosity averaging scheme = harmonic
+
+    # Thermodynamic properties   
+    # Thermal diffusivity = thermal_conductivity/(density*heat_capacity)
+    set Thermal diffusivities = 1.010101e-6, 1.190476e-6
+    set Heat capacities = 750.
+    set Densities = 3300., 2800.
+    set Thermal expansivities = 0.
+
+    # Uniform viscosity
+    set Viscous flow law = dislocation
+    set Prefactors for dislocation creep = 5.e-23
+    set Stress exponents for dislocation creep = 1.0
+    set Activation energies for dislocation creep = 0.
+    set Activation volumes for dislocation creep = 0.
+
+  end
+end
+
+# Gravity model
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+end
+
+# Postprocessor
+subsection Postprocess
+  set List of postprocessors = heat flux statistics, temperature statistics
+end

--- a/tests/compositional_heating/screen-output
+++ b/tests/compositional_heating/screen-output
@@ -1,0 +1,130 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Number of active cells: 100 (on 1 levels)
+Number of degrees of freedom: 1,885 (882+121+441+441)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving upper system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 3+0 iterations.
+
+   Postprocessing:
+     Heat fluxes through boundary parts: 1.274e-11 W, 1.313e-11 W, -2500 W, 7000 W
+     Temperature min/avg/max:            273 K, 1016 K, 1543 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.088s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |    0.0104s |        12% |
+| Assemble composition system     |         1 |   0.00968s |        11% |
+| Assemble temperature system     |         1 |    0.0108s |        12% |
+| Build Stokes preconditioner     |         1 |   0.00993s |        11% |
+| Build composition preconditioner|         1 |  0.000487s |      0.55% |
+| Build temperature preconditioner|         1 |  0.000605s |      0.69% |
+| Solve Stokes system             |         1 |    0.0016s |       1.8% |
+| Solve composition system        |         1 |  0.000216s |      0.25% |
+| Solve temperature system        |         1 |  0.000288s |      0.33% |
+| Initialization                  |         1 |    0.0224s |        25% |
+| Postprocessing                  |         1 |   0.00159s |       1.8% |
+| Setup dof systems               |         1 |    0.0121s |        14% |
+| Setup initial conditions        |         1 |   0.00421s |       4.8% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=3.60914e+08 years
+   Solving temperature system... 50 iterations.
+   Solving upper system ... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 3+0 iterations.
+
+   Postprocessing:
+     Heat fluxes through boundary parts: -1.377e-09 W, 3.354e-09 W, -2422 W, 7185 W
+     Temperature min/avg/max:            273 K, 1027 K, 1543 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.142s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |    0.0213s |        15% |
+| Assemble composition system     |         2 |    0.0204s |        14% |
+| Assemble temperature system     |         2 |    0.0224s |        16% |
+| Build Stokes preconditioner     |         2 |    0.0206s |        15% |
+| Build composition preconditioner|         2 |  0.000989s |       0.7% |
+| Build temperature preconditioner|         2 |   0.00111s |      0.78% |
+| Solve Stokes system             |         2 |   0.00305s |       2.1% |
+| Solve composition system        |         2 |  0.000822s |      0.58% |
+| Solve temperature system        |         2 |    0.0028s |         2% |
+| Initialization                  |         1 |    0.0224s |        16% |
+| Postprocessing                  |         2 |   0.00309s |       2.2% |
+| Setup dof systems               |         1 |    0.0121s |       8.5% |
+| Setup initial conditions        |         1 |   0.00421s |         3% |
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 2:  t=1e+09 years
+   Solving temperature system... 52 iterations.
+   Solving upper system ... 11 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 3+0 iterations.
+
+   Postprocessing:
+     Heat fluxes through boundary parts: 7.503e-10 W, -1.774e-09 W, -2573 W, 6746 W
+     Temperature min/avg/max:            273 K, 1004 K, 1543 K
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.196s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         3 |    0.0322s |        16% |
+| Assemble composition system     |         3 |    0.0315s |        16% |
+| Assemble temperature system     |         3 |    0.0345s |        18% |
+| Build Stokes preconditioner     |         3 |    0.0303s |        15% |
+| Build composition preconditioner|         3 |   0.00148s |      0.76% |
+| Build temperature preconditioner|         3 |   0.00161s |      0.82% |
+| Solve Stokes system             |         3 |   0.00449s |       2.3% |
+| Solve composition system        |         3 |   0.00149s |      0.76% |
+| Solve temperature system        |         3 |   0.00524s |       2.7% |
+| Initialization                  |         1 |    0.0224s |        11% |
+| Postprocessing                  |         3 |    0.0046s |       2.3% |
+| Setup dof systems               |         1 |    0.0121s |       6.2% |
+| Setup initial conditions        |         1 |   0.00421s |       2.1% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.196s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         3 |    0.0322s |        16% |
+| Assemble composition system     |         3 |    0.0315s |        16% |
+| Assemble temperature system     |         3 |    0.0345s |        18% |
+| Build Stokes preconditioner     |         3 |    0.0303s |        15% |
+| Build composition preconditioner|         3 |   0.00148s |      0.76% |
+| Build temperature preconditioner|         3 |   0.00161s |      0.82% |
+| Solve Stokes system             |         3 |   0.00449s |       2.3% |
+| Solve composition system        |         3 |   0.00149s |      0.76% |
+| Solve temperature system        |         3 |   0.00524s |       2.7% |
+| Initialization                  |         1 |    0.0224s |        11% |
+| Postprocessing                  |         3 |    0.0046s |       2.3% |
+| Setup dof systems               |         1 |    0.0121s |       6.2% |
+| Setup initial conditions        |         1 |   0.00421s |       2.1% |
++---------------------------------+-----------+------------+------------+
+


### PR DESCRIPTION
Lithospheric-scale models often assign fixed heat generation (W/m^3) values to distinct materials. This pull request provides this functionality by adding a heating model where one may assign temporally constant values of heat production to compositional fields.