### PR TITLE
re-add test make target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,19 @@ IF(EXISTS ${CMAKE_SOURCE_DIR}/tests/CMakeLists.txt)
   IF(NOT test_cmake_result EQUAL 0)
     MESSAGE(FATAL_ERROR "ERROR: Test project could not be configured.")
   ENDIF()
+
+
+  IF(POLICY CMP0037)
+    # allow to override "test" target
+    CMAKE_POLICY(SET CMP0037 OLD)
+  ENDIF()
+
+  ADD_CUSTOM_TARGET(test
+    COMMAND ${CMAKE_COMMAND} --build . --target test
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests
+    DEPENDS aspect
+    COMMENT "Running tests ...")
+
 ENDIF()
 
 


### PR DESCRIPTION
The PR #1466 removed the test target by accident, which allows you to do
``make test`` in the ASPECT build directory.

This PR introduces a new 'test' target that builds aspect first and then runs
the 'test' target in the ``tests/`` subdirectory.

fixes #1479