### PR TITLE
Use consistent abbreviations of first names in the list of references.

### DIFF
--- a/doc/manual/manual.bib
+++ b/doc/manual/manual.bib
@@ -11224,7 +11224,7 @@ year = {1992}
 
 @article{buiter2008dissipation,
   title={Dissipation analysis as a guide to mode selection during crustal extension and implications for the styles of sedimentary basins},
-  author={Buiter, Susanne JH and Huismans, Ritske S and Beaumont, Christopher},
+  author={Buiter, S. J. H. and Huismans, R. S. and Beaumont, C.},
   journal={Journal of Geophysical Research: Solid Earth},
   volume={113},
   number={B6},


### PR DESCRIPTION
The manual currently uses a mix of abbreviated and non-abbreviated first names
in the list of references. Consistently use abbreviated first names for the
entry buiter2008dissipation.