### PR TITLE
Changed the convention for naming EGP in the manual author list.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@
 /tests/lib*.so
 /Testing
 
-# Added by EGP for Clion
+# used for clion:
 
 .idea/
 cmake-build-debug/

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@
 /tests/*.x.prm
 /tests/lib*.so
 /Testing
+
+# Added by EGP for Clion
+
+.idea/
+cmake-build-debug/

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -139,7 +139,7 @@ COMPUTATIONAL INFRASTRUCTURE FOR GEODYNAMICS (CIG)
 
 %AUTHOR(S) & WEBSITE%
 \null
-\vspace{18em}
+\vspace{17em}
 \color{dark_grey}
 {\fontfamily{\sfdefault}\selectfont
 % FILL: author list
@@ -164,14 +164,14 @@ COMPUTATIONAL INFRASTRUCTURE FOR GEODYNAMICS (CIG)
     Elvira Mulyukova,
     John Naliboff,
     Jonathan Perry-Houts,
-    E.~Gerry Puckett,
+    Elbridge Gerry Puckett,
     Tahiry Rajaonarison,
     Ian Rose,
     D.~Sarah Stamps,
     Cedric Thieulot,
     Iris van Zelst,
     Siqi Zhang \\
-\vspace{1em}
+\vspace{1.0em}
 }
 
 {\noindent


### PR DESCRIPTION
I prefer "Elbridge Gerry Puckett" to "E. Gerry Puckett".