### PR TITLE
Make normalize_pressure() return a value.

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -853,15 +853,14 @@ namespace aspect
        * surface or volume average is decided by a parameter in the
        * input file.
        *
-       * @note This function stores the pressure adjustment in the @p
-       * pressure_adjustment member variable of the current class. It
-       * is there so that we can later use the negative adjustment in
+       * @return This function returns the pressure adjustment by value.
+       * This is so that its negative can later be used again in
        * denormalize_pressure().
        *
        * This function is implemented in
        * <code>source/simulator/helper_functions.cc</code>.
        */
-      void normalize_pressure(LinearAlgebra::BlockVector &vector);
+      double normalize_pressure(LinearAlgebra::BlockVector &vector) const;
 
       /**
        * Invert the action of the normalize_pressure() function above.
@@ -874,13 +873,15 @@ namespace aspect
        * the correct pressure values.
        *
        * @note The adjustment made in this function is done using the
-       * negative of the @p pressure_adjustment member variable
-       * previously set in normalize_pressure().
+       * negative of the @p pressure_adjustment function argument that
+       * would typically have been computed and returned by the
+       * normalize_pressure() function.
        *
        * This function is implemented in
        * <code>source/simulator/helper_functions.cc</code>.
        */
-      void denormalize_pressure(LinearAlgebra::BlockVector &vector,
+      void denormalize_pressure(const double                      pressure_adjustment,
+                                LinearAlgebra::BlockVector       &vector,
                                 const LinearAlgebra::BlockVector &relevant_vector) const;
 
       /**

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -487,7 +487,7 @@ namespace aspect
 
     // normalize the pressure in such a way that the surface pressure
     // equals a known and desired value
-    normalize_pressure(old_solution);
+    this->pressure_adjustment = normalize_pressure(old_solution);
 
     // set all solution vectors to the same value as the previous solution
     solution = old_solution;

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -550,7 +550,7 @@ namespace aspect
         // TODO: if there was an easy way to know if the caller needs the
         // initial residual we could skip all of this stuff.
         distributed_stokes_solution.block(0) = solution.block(0);
-        denormalize_pressure (distributed_stokes_solution, solution);
+        denormalize_pressure (this->pressure_adjustment, distributed_stokes_solution, solution);
         current_constraints.set_zero (distributed_stokes_solution);
 
         // Undo the pressure scaling:
@@ -625,7 +625,7 @@ namespace aspect
 
         remove_nullspace(solution, distributed_stokes_solution);
 
-        normalize_pressure(solution);
+        this->pressure_adjustment = normalize_pressure(solution);
 
         pcout << "done." << std::endl;
 
@@ -668,7 +668,7 @@ namespace aspect
     remap.block (block_vel) = current_linearization_point.block (block_vel);
 
     remap.block (block_p) = current_linearization_point.block (block_p);
-    denormalize_pressure (remap, current_linearization_point);
+    denormalize_pressure (this->pressure_adjustment, remap, current_linearization_point);
 
     current_constraints.set_zero (remap);
     remap.block (block_p) /= pressure_scaling;
@@ -834,7 +834,7 @@ namespace aspect
 
     remove_nullspace(solution, distributed_stokes_solution);
 
-    normalize_pressure(solution);
+    this->pressure_adjustment = normalize_pressure(solution);
 
     // print the number of iterations to screen
     pcout << solver_control_cheap.last_step() << '+'


### PR DESCRIPTION
This makes the function a bit easier to understand because it returns the
pressure adjustment. All callers currently still store the result in the same
place where it was stored before, but at least the hidden side effect is
gone.

This addresses a part of #1229. I will follow up with more cleanups
later, but I want to see whether this one works first.

This is a candidate for a Puckett Bucket award. I'm not 100 per cent
sure it's going to work, but thought I'd punt it over to the tester
to see what happens.