### PR TITLE
Rename a variable in Simulator to make its intent clearer.

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1381,10 +1381,10 @@ namespace aspect
       ConstraintMatrix                                          current_constraints;
 
       /**
-       * The latest correction computed by normalize_pressure(). We store this
-       * so we can undo the correction in denormalize_pressure().
+       * A place to store the latest correction computed by normalize_pressure().
+       * We store this so we can undo the correction in denormalize_pressure().
        */
-      double                                                    pressure_adjustment;
+      double                                                    last_pressure_normalization_adjustment;
 
       /**
        * Scaling factor for the pressure as explained in the

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -338,7 +338,7 @@ namespace aspect
     ar &old_time_step;
     ar &timestep_number;
     ar &pre_refinement_step;
-    ar &pressure_adjustment;
+    ar &last_pressure_normalization_adjustment;
 
     ar &postprocess_manager &statistics;
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -31,6 +31,7 @@
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/signaling_nan.h>
 #include <deal.II/lac/constraint_matrix.h>
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/sparsity_tools.h>
@@ -211,6 +212,8 @@ namespace aspect
     finite_element(introspection.get_fes(), introspection.get_multiplicities()),
 
     dof_handler (triangulation),
+
+    last_pressure_normalization_adjustment (numbers::signaling_nan<double>()),
 
     rebuild_stokes_matrix (true),
     rebuild_stokes_preconditioner (true)

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1147,7 +1147,7 @@ namespace aspect
     // TODO for Timo: can we create the ghost vector inside of denormalize_pressure
     // (only in cases where we need it)
     ghosted.block(block_p) = remap.block(block_p);
-    denormalize_pressure (this->pressure_adjustment, remap, ghosted);
+    denormalize_pressure (this->last_pressure_normalization_adjustment, remap, ghosted);
     current_constraints.set_zero (remap);
 
     remap.block (block_p) /= pressure_scaling;

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -487,7 +487,7 @@ namespace aspect
 
     // normalize the pressure in such a way that the surface pressure
     // equals a known and desired value
-    this->pressure_adjustment = normalize_pressure(old_solution);
+    this->last_pressure_normalization_adjustment = normalize_pressure(old_solution);
 
     // set all solution vectors to the same value as the previous solution
     solution = old_solution;

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -550,7 +550,7 @@ namespace aspect
         // TODO: if there was an easy way to know if the caller needs the
         // initial residual we could skip all of this stuff.
         distributed_stokes_solution.block(0) = solution.block(0);
-        denormalize_pressure (this->pressure_adjustment, distributed_stokes_solution, solution);
+        denormalize_pressure (this->last_pressure_normalization_adjustment, distributed_stokes_solution, solution);
         current_constraints.set_zero (distributed_stokes_solution);
 
         // Undo the pressure scaling:
@@ -625,7 +625,7 @@ namespace aspect
 
         remove_nullspace(solution, distributed_stokes_solution);
 
-        this->pressure_adjustment = normalize_pressure(solution);
+        this->last_pressure_normalization_adjustment = normalize_pressure(solution);
 
         pcout << "done." << std::endl;
 
@@ -668,7 +668,7 @@ namespace aspect
     remap.block (block_vel) = current_linearization_point.block (block_vel);
 
     remap.block (block_p) = current_linearization_point.block (block_p);
-    denormalize_pressure (this->pressure_adjustment, remap, current_linearization_point);
+    denormalize_pressure (this->last_pressure_normalization_adjustment, remap, current_linearization_point);
 
     current_constraints.set_zero (remap);
     remap.block (block_p) /= pressure_scaling;
@@ -860,7 +860,7 @@ namespace aspect
 
     remove_nullspace(solution, distributed_stokes_solution);
 
-    this->pressure_adjustment = normalize_pressure(solution);
+    this->last_pressure_normalization_adjustment = normalize_pressure(solution);
 
     // print the number of iterations to screen
     pcout << solver_control_cheap.last_step() << '+'


### PR DESCRIPTION
This is follow-up to #1495 and another patch addressing #1229.
