### PR TITLE
Avoid a warning about an unused argument.

### DIFF
--- a/source/boundary_traction/interface.cc
+++ b/source/boundary_traction/interface.cc
@@ -73,7 +73,7 @@ namespace aspect
     DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
     template <int dim>
     Tensor<1,dim>
-    Interface<dim>::boundary_traction (const types::boundary_id boundary_indicator,
+    Interface<dim>::boundary_traction (const types::boundary_id /*boundary_indicator*/,
                                        const Point<dim> &position,
                                        const Tensor<1,dim> &normal_vector) const
     {


### PR DESCRIPTION
Fixes a problem reported in #1491 by @ian-r-rose.