### PR TITLE
report test output on test failure

### DIFF
--- a/tests/cmake/run_test.sh
+++ b/tests/cmake/run_test.sh
@@ -15,11 +15,16 @@ OUTPUT="$4"
 
 $BINARY $PRM >${OUTPUT} 2>&1
 ret=$?
-if [[ ( "$EXPECT_FAIL" == "0" && "$ret" == "0" ) 
+
+if [[ ( "$EXPECT_FAIL" == "0" && "$ret" == "0" )
 	    ||
       ( "$EXPECT_FAIL" == "1" && "$ret" != "0" ) ]]
 then
+  # success: ASPECT succeeded (or failed if we expect it to fail)
   exit 0
 fi
 
+# ASPECT failed (or succeeded even though it should not have), so report
+# failure. Before we do so, dump the screen-output to the screen:
+cat ${OUTPUT}
 exit 1


### PR DESCRIPTION
Print the screen-output when running ctest and ASPECT crashes. This way
it will show up on the tester as well.