### PR TITLE
Add comment for mac

### DIFF
--- a/doc/update_prm_files_to_2.0.0.sed
+++ b/doc/update_prm_files_to_2.0.0.sed
@@ -8,6 +8,8 @@
 # Usage for a parameter file named FILENAME (possibly containing
 # wildcards such as '*.prm'):
 # sed -i -f update_prm_files_to_2.0.0.sed FILENAME
+# On MacOS:
+# sed -i "" -f update_source_files_to_2.0.0.sed FILENAME
 
 # Rename compositional initial conditions
 s/Compositional initial conditions/Initial composition model/g

--- a/doc/update_source_files_to_2.0.0.sed
+++ b/doc/update_source_files_to_2.0.0.sed
@@ -6,8 +6,10 @@
 # created by this script should be investigated to ensure a correct renaming.
 #
 # Usage for a c++ source or header file named FILENAME (possibly containing
-# wildcards such as '*.cc'):
+# wildcards such as '*.cc') on Linux:
 # sed -i -f update_source_files_to_2.0.0.sed FILENAME
+# On MacOS:
+# sed -i "" -f update_source_files_to_2.0.0.sed FILENAME
 
 # Rename fluid pressure boundary conditions
 s/fluid_pressure_boundary_conditions/boundary_fluid_pressure/g


### PR DESCRIPTION
On mac the command for sed inline replacement without a backup need quotes.