### PR TITLE
Remove requirement deal.ii.8.5.0 related statements

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -312,7 +312,6 @@ parse_parameters (const std::string &input_as_string,
   // try reading on processor 0
   bool success = true;
   if (dealii::Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
-#if DEAL_II_VERSION_GTE(8,5,0)
     try
       {
         prm.parse_input_from_string(input_as_string.c_str());
@@ -323,9 +322,6 @@ parse_parameters (const std::string &input_as_string,
         e.print_info(std::cerr);
         std::cerr << std::endl;
       }
-#else
-    success = prm.read_input_from_string(input_as_string.c_str());
-#endif
 
 
   // broadcast the result. we'd like to do this with a bool
@@ -353,12 +349,7 @@ parse_parameters (const std::string &input_as_string,
   // other processors will be ok as well
   if (dealii::Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) != 0)
     {
-#if DEAL_II_VERSION_GTE(8,5,0)
       prm.parse_input_from_string(input_as_string.c_str());
-#else
-      success = prm.read_input_from_string(input_as_string.c_str());
-      AssertThrow(success, dealii::ExcMessage ("Invalid input parameter file."));
-#endif
     }
 }
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1117,7 +1117,6 @@ namespace aspect
               }
           }
 
-#if DEAL_II_VERSION_GTE(8,5,0)
         DoFTools::make_flux_sparsity_pattern (dof_handler,
                                               sp,
                                               constraints, false,
@@ -1125,26 +1124,6 @@ namespace aspect
                                               face_coupling,
                                               Utilities::MPI::
                                               this_mpi_process(mpi_communicator));
-#else
-        if (Utilities::MPI::n_mpi_processes(mpi_communicator) == 1)
-          {
-            DoFTools::make_sparsity_pattern (dof_handler,
-                                             coupling, sp,
-                                             constraints, false,
-                                             Utilities::MPI::
-                                             this_mpi_process(mpi_communicator));
-            DoFTools::make_flux_sparsity_pattern (dof_handler,
-                                                  sp,
-                                                  coupling,
-                                                  face_coupling);
-          }
-        else
-          DoFTools::make_flux_sparsity_pattern (dof_handler,
-                                                sp,
-                                                constraints, false,
-                                                Utilities::MPI::
-                                                this_mpi_process(mpi_communicator));
-#endif
       }
     else
       DoFTools::make_sparsity_pattern (dof_handler,
@@ -1269,7 +1248,6 @@ namespace aspect
               }
           }
 
-#if DEAL_II_VERSION_GTE(8,5,0)
         DoFTools::make_flux_sparsity_pattern (dof_handler,
                                               sp,
                                               constraints, false,
@@ -1277,26 +1255,6 @@ namespace aspect
                                               face_coupling,
                                               Utilities::MPI::
                                               this_mpi_process(mpi_communicator));
-#else
-        if (Utilities::MPI::n_mpi_processes(mpi_communicator) == 1)
-          {
-            DoFTools::make_sparsity_pattern (dof_handler,
-                                             coupling, sp,
-                                             constraints, false,
-                                             Utilities::MPI::
-                                             this_mpi_process(mpi_communicator));
-            DoFTools::make_flux_sparsity_pattern (dof_handler,
-                                                  sp,
-                                                  coupling,
-                                                  face_coupling);
-          }
-        else
-          DoFTools::make_flux_sparsity_pattern (dof_handler,
-                                                sp,
-                                                constraints, false,
-                                                Utilities::MPI::
-                                                this_mpi_process(mpi_communicator));
-#endif
       }
     else
       DoFTools::make_sparsity_pattern (dof_handler,

--- a/source/simulator/free_surface.cc
+++ b/source/simulator/free_surface.cc
@@ -651,13 +651,8 @@ namespace aspect
     mesh_vertex_constraints.close();
 
     //Now reset the mapping of the simulator to be something that captures mesh deformation in time.
-#if DEAL_II_VERSION_GTE(8,5,0)
     sim.mapping.reset (new MappingQ1Eulerian<dim, LinearAlgebra::Vector> (free_surface_dof_handler,
                                                                           mesh_displacements));
-#else
-    sim.mapping.reset (new MappingQ1Eulerian<dim, LinearAlgebra::Vector> (mesh_displacements,
-                                                                          free_surface_dof_handler));
-#endif
   }
 
   template <int dim>


### PR DESCRIPTION
The #if DEAL_II_VERSION_GTE(8,5,0) #else statements were added when dealii.8.5.0 was not released. Now we can remove those statements as  it will be mandatory for aspect 2.0