### PR TITLE
Provide better documentation for the AdditionalMaterialModelOutput class.

### DIFF
--- a/source/geometry_model/interface.cc
+++ b/source/geometry_model/interface.cc
@@ -39,6 +39,7 @@ namespace aspect
     {}
 
 
+
     template<int dim>
     std::map<std::string,types::boundary_id>
     Interface<dim>::get_symbolic_boundary_names_map() const
@@ -46,6 +47,7 @@ namespace aspect
       //return an empty map in the base class
       return std::map<std::string,types::boundary_id>();
     }
+
 
 
     template<int dim>
@@ -57,12 +59,15 @@ namespace aspect
     }
 
 
+
     template <int dim>
     bool
     Interface<dim>::has_curved_elements() const
     {
       return true;
     }
+
+
 
     template <int dim>
     std::array<double,dim>
@@ -73,6 +78,8 @@ namespace aspect
                           "not been implemented in this geometry model."));
       return std::array<double,dim>();
     }
+
+
 
     template <int dim>
     Point<dim>
@@ -85,11 +92,13 @@ namespace aspect
     }
 
 
+
     template <int dim>
     void
     Interface<dim>::
     declare_parameters (dealii::ParameterHandler &)
     {}
+
 
 
     template <int dim>

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -675,9 +675,17 @@ namespace aspect
 
 
     template<int dim>
-    NamedAdditionalMaterialOutputs<dim>::NamedAdditionalMaterialOutputs(const std::vector<std::string> output_names)
+    NamedAdditionalMaterialOutputs<dim>::
+    NamedAdditionalMaterialOutputs(const std::vector<std::string> &output_names)
       :
       names(output_names)
+    {}
+
+
+
+    template<int dim>
+    NamedAdditionalMaterialOutputs<dim>::
+    ~NamedAdditionalMaterialOutputs()
     {}
 
 
@@ -718,12 +726,15 @@ namespace aspect
     const std::vector<double> &
     SeismicAdditionalOutputs<dim>::get_nth_output(const unsigned int idx) const
     {
+      AssertIndexRange (idx, 2);
       switch (idx)
         {
           case 0:
             return vs;
+
           case 1:
             return vp;
+
           default:
             AssertThrow(false, ExcInternalError());
         }


### PR DESCRIPTION
Same for derived class NamedAdditionalMaterialOutputs. Also move a couple of
function definitions to the .cc file.

While there also clean up the spacing between functions in another file.