### PR TITLE
Avoid one warning about an unused variable.

### DIFF
--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -155,8 +155,6 @@ namespace aspect
       // p'(z) = rho(p,c,T) * |g| * delta_z
       double sum = delta_z * 0.5 * density0 * gravity0;
 
-      double z;
-
       for (unsigned int i=1; i<n_points; ++i)
         {
           AssertThrow (i < pressure.size(), ExcMessage(std::string("The current index ")


### PR DESCRIPTION
There are other warnings in this file, but this is the one that's easy to fix.
The others are about using deprecated functions like boundary_temperature() when
they should be using the corresponding manager.