### PR TITLE
remove macro double underscore

### DIFF
--- a/include/aspect/adiabatic_conditions/ascii_data.h
+++ b/include/aspect/adiabatic_conditions/ascii_data.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__adiabatic_conditions_ascii_data_h
-#define __aspect__adiabatic_conditions_ascii_data_h
+#ifndef _aspect__adiabatic_conditions_ascii_data_h
+#define _aspect__adiabatic_conditions_ascii_data_h
 
 
 #include <aspect/adiabatic_conditions/interface.h>

--- a/include/aspect/gravity_model/ascii_data.h
+++ b/include/aspect/gravity_model/ascii_data.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__gravity_model_ascii_data_h
-#define __aspect__gravity_model_ascii_data_h
+#ifndef _aspect__gravity_model_ascii_data_h
+#define _aspect__gravity_model_ascii_data_h
 
 #include <aspect/gravity_model/interface.h>
 #include <aspect/utilities.h>

--- a/include/aspect/material_model/ascii_reference_profile.h
+++ b/include/aspect/material_model/ascii_reference_profile.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__model_ascii_reference_profile_h
-#define __aspect__model_ascii_reference_profile_h
+#ifndef _aspect__model_ascii_reference_profile_h
+#define _aspect__model_ascii_reference_profile_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -19,8 +19,8 @@
  */
 
 
-#ifndef __aspect__newton_h
-#define __aspect__newton_h
+#ifndef _aspect__newton_h
+#define _aspect__newton_h
 
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>

--- a/include/aspect/particle/interpolator/nearest_neighbor.h
+++ b/include/aspect/particle/interpolator/nearest_neighbor.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __aspect__particle_interpolator_nearest_neighbor_h
-#define __aspect__particle_interpolator_nearest_neighbor_h
+#ifndef _aspect__particle_interpolator_nearest_neighbor_h
+#define _aspect__particle_interpolator_nearest_neighbor_h
 
 #include <aspect/particle/interpolator/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/geoid.h
+++ b/include/aspect/postprocess/geoid.h
@@ -19,8 +19,8 @@
  */
 
 
-#ifndef __aspect__postprocess_geoid_h
-#define __aspect__postprocess_geoid_h
+#ifndef _aspect__postprocess_geoid_h
+#define _aspect__postprocess_geoid_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>


### PR DESCRIPTION
Macros are not allowed to start with double underscores and my IDE warns
about this.