### PR TITLE
Added a reinit function to MaterialModelInputs.

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -186,14 +186,24 @@ namespace aspect
 
 
       /**
-       * Constructor. Both initialize and populate the various arrays of this
+       * Constructor. Initializes the various arrays of this
        * structure with the FEValues and introspection objects and
-       * the solution_vector.
+       * the solution_vector. This constructor calls the function
+       * reinit to populate the newly created arrays.
        */
       MaterialModelInputs(const FEValuesBase<dim,dim> &fe_values,
                           const typename DoFHandler<dim>::active_cell_iterator *cell,
                           const Introspection<dim> &introspection,
                           const LinearAlgebra::BlockVector &solution_vector);
+
+      /**
+       * Function to re-initialize and populate the pre-existing arrays
+       * created by the constructor MaterialModelInputs.
+       */
+      void reinit(const FEValuesBase<dim,dim> &fe_values,
+                  const typename DoFHandler<dim>::active_cell_iterator *cell,
+                  const Introspection<dim> &introspection,
+                  const LinearAlgebra::BlockVector &solution_vector);
 
 
       /**

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -256,6 +256,18 @@ namespace aspect
       strain_rate(fe_values.n_quadrature_points, numbers::signaling_nan<SymmetricTensor<2,dim> >()),
       cell(cell_x)
     {
+      // Call the function reinit to populate the new arrays.
+      this->reinit(fe_values, cell, introspection, solution_vector);
+    }
+
+
+    template <int dim>
+    void
+    MaterialModelInputs<dim>::reinit(const FEValuesBase<dim,dim> &fe_values,
+                                     const typename DoFHandler<dim>::active_cell_iterator *cell_x,
+                                     const Introspection<dim> &introspection,
+                                     const LinearAlgebra::BlockVector &solution_vector)
+    {
       // Populate the newly allocated arrays
       fe_values[introspection.extractors.temperature].get_function_values (solution_vector, this->temperature);
       fe_values[introspection.extractors.velocities].get_function_values (solution_vector, this->velocity);


### PR DESCRIPTION
This patch adds a function to reinitialize and populate the arrays created by
the MaterialModelInputs constructor. The MaterialModelInputs constructor with the
same arguments creates the arrays, then calls this function to populate them.
This function is intended to be called within loops over cells so that arrays
are not recreated more than necessary.