### PR TITLE
bib_fix_pt1

### DIFF
--- a/doc/manual/manual.bib
+++ b/doc/manual/manual.bib
@@ -15,7 +15,7 @@
 
 
 @Article{BRVMFG04,
-  author =       {J. Badro and J.-P. Rueff and G. Vank{\'o} and G. Monaco
+  author =       {Badro, J. and Rueff, J.-P. and Vank{\'o}, G. and Monaco, G.
                   and G. Fiquet and F. Guyot},
   title =        {Electronic Transitions in Perovskite: {P}ossible
                   Nonconvecting Layers in the Lower Mantle},
@@ -158,7 +158,7 @@ Year      = "2002"
 
 
 @Article{p4est,
-  author =       {C. Burstedde and L. C. Wilcox and O. Ghattas},
+  author =       {Burstedde, C. and Wilcox, L. C. and Ghattas, O.},
   title =        {\texttt{p4est}: {S}calable algorithms for parallel
                   adaptive mesh refinement on forests of octrees},
   journal =      {SIAM J. Sci. Comput.},
@@ -223,7 +223,7 @@ YEAR = "2003"
 
 
 @Article{AIAA2002-0841,
-  author =       {David W. Levy and Tom Zickuhr and John Vassberg and Shreekant Agrawal and Richard A. Wahls and Shahyar Pirzadeh and Michael J. Hemsch},
+  author =       {Levy, D. W. and Zickuhr, T. and Vassberg, J. and Agrawal, S. and Wahls, R. A. and Pirzadeh, S. and Hemsch, M. J.},
   title =        {Summary of Data from the First {AIAA} {CFD} Drag Prediction Workshop},
   journal =      {AIAA},
   year =         2002,
@@ -231,7 +231,7 @@ YEAR = "2003"
 }
 
 @Article{AIAA2002-0837,
-  author =       {Mark Rakowitz and Mark Sutcliffe and Bernhard Eisfeld and Dieter Schwamborn and Hans Bleecke and Jens Fassbender},
+  author =       {Rakowitz, M. and Sutcliffe, M. and Eisfeld, B. and Schwamborn, D. and Bleecke, H. and Fassbender, J.},
   title =        {Structured and Unstructured Computations of the {DLR-F4} Wing-Body Configuration},
   journal =      {AIAA},
   year =         2002,
@@ -240,7 +240,7 @@ YEAR = "2003"
 
 
 @Book{AD59,
-  author =       {Ira H. Abott and Albert E. von Doenhoff},
+  author =       {Abott, I. H. and von Doenhoff, A. E.},
   title =        {Theory of Wing Sections},
   publisher =    {Dover Publications, Inc., New York},
   year =         1959
@@ -256,7 +256,7 @@ YEAR = "2003"
 
 @article{BR86,
   title={Nonlinear waves in compacting media},
-  author={Barcilon, Victor and Richter, Frank M.},
+  author={Barcilon, V. and Richter, F. M.},
   journal={Journal of Fluid mechanics},
   volume={164},
   pages={429--448},
@@ -265,7 +265,7 @@ YEAR = "2003"
 }
 
 @Article{BR97,
-  author =       {F. Bassi and S. Rebay},
+  author =       {Bassi, F. and Rebay, S.},
   title =        {High-order accurate discontinuous finite element solution of the 2D
 {E}uler equations},
   journal =      {J. Comput. Phys.},
@@ -276,7 +276,7 @@ YEAR = "2003"
 
 
 @Article{BGP87,
-  author =       {M. O. Bristeau and R. Glowinski and J. Periaux},
+  author =       {Bristeau, M. O. and Glowinski, R. and Periaux, J.},
   title =        {Numerical methods for the {N}avier-{S}tokes equations:
                   {A}pplications to the simulation of compressible and incompressible
                   viscous flows},
@@ -286,7 +286,7 @@ YEAR = "2003"
 
 
 @Article{CHS90,
-  author =       {B. Cockburn and S. Hou and C.-W. Shu},
+  author =       {Cockburn, B. and Hou, S. and Shu, C. -W.},
   title =        {T{VB} {R}unge-{K}utta local projection discontinuous {G}alerkin
                  finite element method for conservation laws {IV}: The
                  multidimensional case},
@@ -297,7 +297,7 @@ YEAR = "2003"
 }
 
 @Article{CS98,
-  author =       {B. Cockburn and C.-W. Shu},
+  author =       {Cockburn, B. and Shu, C. -W.},
   title =        {The {R}unge--{K}utta discontinuous {G}alerkin finite element
                   method for conservation laws {V}: Multidimensional systems},
   journal =      {J. Comput. Phys.},
@@ -307,7 +307,7 @@ YEAR = "2003"
 }
 
 @InProceedings{CKS99,
-  author =       {B. Cockburn and G.E. Karniadakis and C.-W. Shu},
+  author =       {Cockburn, B. and Karniadakis, G. E. and Shu, C. -W.},
   title =        {The development of discontinuous {G}alerkin methods},
   booktitle =    {Discontinuous Galerkin Methods},
   pages =        {3--50},
@@ -319,7 +319,7 @@ YEAR = "2003"
 }
 
 @Article{KR94,
-  author =       {P. Kloucek and F. S. Rys},
+  author =       {Kloucek, P. and Rys, F. S.},
   title =        {On the stability of fractional step $\theta$-scheme for the
                   nonstationary {N}avier-{S}tokes equations},
   journal =      {SIAM J. Numer. Anal.},
@@ -331,14 +331,14 @@ YEAR = "2003"
 
 
 @Book{Tor97,
-  author =       {E. F. Toro},
+  author =       {Toro, E. F.},
   title =        {Riemann Solvers and Numerical Methods for Fluid Dynamics},
   publisher =    {Springer},
   year =         {1997},
 }
 
 @Article{CM08,
-  author =       {T. B. Cochran and M. G. McKinzie},
+  author =       {Cochran, T. B. and McKinzie, M. G.},
   title =        {Detecting nuclear smuggling},
   journal =      {Scientific American},
   year =         2008,
@@ -357,14 +357,14 @@ YEAR = "2003"
 }
 
 @Book{BB93,
-  author =       {Brady, B. H. G. and E. T. Brown},
+  author =       {Brady, B. H. G. and Brown, E. T.},
   title =        {Rock mechanics for underground mining},
   publisher =    {Chapman and Hall},
   year =         1993
 }
 
 @InBook{BG00,
-  author =       {R. {de Borst} and A. E. Groen},
+  author =       {{de Borst}, R. and Groen, A. E.},
   editor =       {M. Zaman and J. Booker and G. Gioda},
   title =        {Computational strategies for standard soil plasticity
                   models},
@@ -387,8 +387,8 @@ YEAR = "2003"
 }
 
 @Article{BSTOL02,
-  author =       {A. Yu. Babeyko and S. V. Sobolev and R. B. Trumbull and
-                  O. Oncken and L. L. Lavier},
+  author =       {Babeyko, A. Y. and Sobolev, S. V. and Trumbull, R. B. and
+                  Oncken, O. and Lavier, L. L.},
   title =        {Numerical models of crustal scale convection and partial
                   melting beneath the {A}ltiplano-{P}una plateau},
   journal =      {??},
@@ -405,7 +405,7 @@ YEAR = "2003"
 
 
 @Article{Bas91,
-  author =       {G. Bassi},
+  author =       {Bassi, G.},
   title =        {Factors controlling the style of continental
                   rifting: insights from numerical modeling},
   journal =      {Earth Planet. Sc. Lett.},
@@ -415,7 +415,7 @@ YEAR = "2003"
 }
 
 @Article{Bru14,
-  author =       {S. Brune and C. Heine and M. P\~{e}rez-Gussiny\~{e} and S. V. Sobolev},
+  author =       {Brune, S. and Heine, C. and P\~{e}rez-Gussiny\~{e}, M and Sobolev, S. V.},
   title =        {Rift migration explains continental margin asymmetry and crustal hyperextension},
   journal =      {Nat. Comm.},
   year =         2014,
@@ -424,7 +424,7 @@ YEAR = "2003"
 }
 
 @Article{Bas95,
-  author =       {G. Bassi},
+  author =       {Bassi, G.},
   title =        {Relative importance of strain rate and rheology
                   for the mode of continental extension},
   journal =      {Geoph. J. Int.},
@@ -434,7 +434,7 @@ YEAR = "2003"
 }
 
 @Article{Buc91,
-  author =       {W. R. Buck},
+  author =       {Buck, W. R.},
   title =        {Modes of continental lithospheric extension},
   journal =      {J. Geoph. Res.},
   year =         {1991},
@@ -449,7 +449,7 @@ YEAR = "2003"
 
 
 @Article{Buc93,
-  author =       {W. R. Buck},
+  author =       {Buck, W. R.},
   title =        {Effect of Lithospheric thickness on the formation
                   of high- and low-angle normal faults},
   journal =      {Geology},
@@ -459,7 +459,7 @@ YEAR = "2003"
 }
 
 @Article{Bye78,
-  author =       {J. D. Byerlee},
+  author =       {Byerlee, J. D.},
   title =        {Friction of rock},
   journal =      {Pageoph.},
   year =         1978,
@@ -468,7 +468,7 @@ YEAR = "2003"
 }
 
 @Article{CB01,
-  author =       {M. A. Christie and M. J. Blunt},
+  author =       {Christie, M. A. and Blunt, M. J.},
   title =        {Tenth {SPE} comparative solution project: {A} comparison of
                   upscaling techniques},
   journal =      {SPE Reservoir Eval. Engrg.},
@@ -478,7 +478,7 @@ YEAR = "2003"
 }
 
 @Article{CO92,
-  author =       {A. M. {Cuiti\~{n}o} and M. Ortiz},
+  author =       {{Cuiti\~{n}o}, A. M. and Ortiz, M.},
   title =        {Computational modelling of single crystals},
   journal =      {Modelling Simul. Mater. Sci. Eng.},
   year =         1992,
@@ -545,7 +545,7 @@ YEAR = "2003"
 }
 
 @Article{Cow98,
-  author =       {P. A. Cowie},
+  author =       {Cowie, P. A.},
   title =        {A healing-reloading feedback control on the
                   growth rate of seismogenic faults},
   journal =      {J. Struct. Geol.},
@@ -555,7 +555,7 @@ YEAR = "2003"
 }
 
 @Article{Cun89,
-  author =       {P. A. Cundall},
+  author =       {Cundall, P. A.},
   title =        {Numerical experiments on localization in
                   frictional materials},
   journal =      {Ing. Arch.},
@@ -594,7 +594,7 @@ YEAR = "2003"
 }
 
 @Article{Deguen2013,
-  author = {Deguen, Renaud and Alboussi\`{e}re, Thierry and Cardin, Philippe}, 
+  author = {Deguen, R. and Alboussi\`{e}re, T. and Cardin, P.}, 
   title = {Thermal convection in {E}arth's inner core with phase change at its boundary},
   volume = {194}, 
   number = {3}, 
@@ -605,7 +605,7 @@ YEAR = "2003"
 }
 
 @Article{EHE97,
-  author =       {Escartin, J. and G. Hirth and B. Evans},
+  author =       {Escartin, J. and Hirth, G. and Evans, B.},
   title =        {Nondilatant brittle deformation
                   of serpentinites: {I}mplications of {M}ohr-{C}oulomb
                   theory and the strength of faults},
@@ -617,7 +617,7 @@ YEAR = "2003"
 
 
 @Article{Eng83,
-  author =       {P. C. England},
+  author =       {England, P. C.},
   title =        {Constraints on extension of continental
                   lithosphere},
   journal =      {J. Geoph. Res.},
@@ -627,7 +627,7 @@ YEAR = "2003"
 }
 
 @Article{FH79,
-  author =       {Fletcher, R. C. and B. Hallet},
+  author =       {Fletcher, R. C. and Hallet, B.},
   title =        {Unstable extension of lithosphere:
                   a mechanical model for basin and range structure},
   journal =      {Eos Trans. A.G.U},
@@ -637,7 +637,7 @@ YEAR = "2003"
 }
 
 @Article{For92,
-  author =       {D. W. Forsyth},
+  author =       {Forsyth, D. W.},
   title =        {Finite extension and low- angle normal faulting},
   journal =      {Geology},
   year =         {1992},
@@ -651,7 +651,7 @@ YEAR = "2003"
 }
 
 @Article{Ful95,
-  author =       {P. Fullsack},
+  author =       {Fullsack, P.},
   title =        {An arbitrary Lagrangian-Eulerian formulation
      for creeping flows and its applications in tectonic models},
   journal =      {Geoph. J. Int.},
@@ -694,7 +694,7 @@ YEAR = "2003"
 
 
 @Article{Han03,
-  author =       {D. L. Hansen},
+  author =       {Hansen, D. L.},
   title =        {A meshless formulation for geodynamic modeling},
   journal =      {J. Geoph. Res.},
   year =         2003,
@@ -703,7 +703,7 @@ YEAR = "2003"
 }
 
 @InCollection{HK04,
-  author =       {G. Hirth and D. Kohlstedt },
+  author =       {Hirth, G. and Kohlstedt, D},
   title =        {Rheology of the upper mantle and the mantle wedge:a view from the experimentalists},
   booktitle =    {Inside the Subduction Factory},
   pages =        {83--105},
@@ -715,7 +715,7 @@ YEAR = "2003"
 }
 
 @Article{Hui11,
-  author =       {R. Huismans and C. Beaumont},
+  author =       {Huismans, R. and Beaumont, C.},
   title =        {Depth-dependent extension, two-stage breakup and cratonic underplating at rifted margins},
   journal =      {Nature},
   year =         2011,
@@ -724,7 +724,7 @@ YEAR = "2003"
 }
 
 @Book{Hyn01,
-  author =       {N. Hyne},
+  author =       {Hyne, N.},
   title =        {Nontechnical Guide to Petroleum Geology, Exploration, Drilling and Production},
   publisher =    {Pennwell Books},
   year =         2001,
@@ -812,7 +812,7 @@ YEAR = "2003"
 }
 
 @Article{MGF03,
-  author =       {R. Malservisi and C. Gans and K. P. Furlong},
+  author =       {Malservisi, R. and Gans, C. and Furlong, K. P.},
   title =        {Numerical modeling of strike-slip creeping faults
                   and implications for the {H}ayward fault, {C}alifornia},
   journal =      {Tectonophysics},
@@ -822,7 +822,7 @@ YEAR = "2003"
 }
 
 @Article{Mai96,
-  author =       {I. Main},
+  author =       {Main, I.},
   title =        {Statistical physics, seismogenesis, and seismic hazard},
   journal =      {Rev, Geoph.},
   year =         1996,
@@ -844,7 +844,7 @@ YEAR = "2003"
 }
 
 @Article{OQ91,
-  author =       {M. Ortiz and J. J. Quigley},
+  author =       {Ortiz, M. and Quigley, J. J.},
   title =        {Adaptive mesh refinement in strain localization problems},
   journal =      {Comput. Methods Appl. Mech. Engrg.},
   year =         1991,
@@ -853,7 +853,7 @@ YEAR = "2003"
 }
 
 @Article{Nal15,
-  author =       {J. Naliboff and S. Buiter},
+  author =       {Naliboff, J. and Buiter, S.},
   title =        {Rift Reactivation and migration during multiphase extension},
   journal =      {Earth Planet. Sci. Lett.},
   year =         2015,
@@ -862,7 +862,7 @@ YEAR = "2003"
 }
 
 @Article{OS99,
-  author =       {M. Ortiz and L. Stainier},
+  author =       {Ortiz, M. and Stainier, L.},
   title =        {The variational formulation of viscoplastic constitutive
                   updates},
   journal =      {Comput. Methods Appl. Mech. Engrg.},
@@ -907,7 +907,7 @@ YEAR = "2003"
 }
 
 @Article{RB04,
-  author =       {E. H. Rutter and K. H. Brodie},
+  author =       {Rutter, E. H. and Brodie, K. H.},
   title =        {Experimental grain size-sensitive flow of hot-pressed Brazilian quartz aggregates},
   journal =      {J. Struct. Geol.},
   year =         2004,
@@ -916,7 +916,7 @@ YEAR = "2003"
 }
 
 @Article{RGWD06,
-  author =       {E. Rybacki, M. Gottschalk, R. Wirth and G. Dresen},
+  author =       {Rybacki, E. and Gottschalk, M. and Wirth, R. and Dresen, G.},
   title =        {Influence of water fugacity and activation volume on the flow 
                   properties of fine-grained anorthite aggregates},
   journal =      {J. Geophys. Res.},
@@ -926,7 +926,7 @@ YEAR = "2003"
 }
 
 @Article{SC85,
-  author =       {Simo, J. C. and R. L. Taylor},
+  author =       {Simo, J. C. and Taylor, R. L.},
   title =        {Consistent tangent operators for rate-independent elastoplasticity},
   journal =      {Comp. Math. Appl. Mech. Engrg.},
   year =         1985,
@@ -935,14 +935,14 @@ YEAR = "2003"
 }
 
 @Book{SH98,
-  author =       {Simo, J. C., and T. J. R. Hughes},
+  author =       {Simo, J. C., and Hughes, T. J. R.},
   title =        {Computational Inelasticity},
   publisher =    {Springer},
   year =         1998
 }
 
 @Book{Sch90,
-  author =       {C. H. Scholz},
+  author =       {Scholz, C. H.},
   title =        {The mechanics of earthquakes and faulting},
   publisher =    {Cambridge University Press, Cambridge},
   year =         1990
@@ -1029,7 +1029,7 @@ YEAR = "2003"
 }
 
 @Article{ZPF86,
-  author =       {Zuber, M. T. and E. M. Parmentier and R.C. Fletcher},
+  author =       {Zuber, M. T. and Parmentier, E. M. and Fletcher, R. C},
   title =        {Extension of the continental lithosphere: {A} model for
                   two scales of {B}asin and {R}ange deformation},
   journal =      {J. Geoph. Res.},
@@ -1039,7 +1039,7 @@ YEAR = "2003"
 }
 
 @Book{ABM06,
-  author =       {H. Attouch and G. Buttazzo and G. Michaille},
+  author =       {Attouch, H. and Buttazzo, G. and Michaille, G.},
   title =        {Variational Analysis in Sobolev and BV spaces},
   publisher =    {SIAM-MPS},
   year =         2060,
@@ -1048,7 +1048,7 @@ YEAR = "2003"
 
 
 @Article{ACWY00,
-  author =       {T. Arbogast and L. C. Cowsar and M. F. Wheeler and I. Yotov},
+  author =       {Arbogast, T. and Cowsar, L. C. and Wheeler, M. F. and Yotov, I.},
   title =        {Mixed finite element methods on nonmatching grids},
   journal =      {SIAM J. Numer. Anal.},
   year =         2000,
@@ -1057,14 +1057,14 @@ YEAR = "2003"
 }
 
 @Book{AO00,
-  author =       {M. Ainsworth and J. T. Oden},
+  author =       {Ainsworth, M. and Oden, J. T.},
   title =        {A Posteriori Error Estimation in Finite Element Analysis},
   publisher =    {John Wiley and Sons},
   year =         2000
 }
 
 @Article{AO93,
-  author =       {M. Ainsworth and J. T. Oden},
+  author =       {Ainsworth, M. and Oden, J. T.},
   title =        {A unified approach to a posteriori error estimation using
                   element residual methods},
   journal =      {Numer. Math.},
@@ -1074,7 +1074,7 @@ YEAR = "2003"
 }
 
 @Book{Ada03,
-  author =   {R. A. Adams and J. J. F. Fournier},
+  author =   {Adams, R. A. and Fournier, J. J. F.},
   title =    {Sobolev Spaces},
   publisher =    {Academic Press},
   year =     2003,
@@ -1083,14 +1083,14 @@ YEAR = "2003"
 
 
 @Book{Ada75,
-  author =       {R. A. Adams},
+  author =       {Adams, R. A.},
   title =        {Sobolev Spaces},
   publisher =    {Academic Press},
   year =         {1975},
 }
 
 @Book{Alt85,
-  author =       {H. W. Alt},
+  author =       {Alt, H. W.},
   title =        {Lineare Funktionalanalysis},
   publisher =    {Springer},
   year =         1985,
@@ -1108,7 +1108,7 @@ YEAR = "2003"
 }
 
 @Article{BA76,
-  author =       {I. Babu{\v s}ka and A. K. Aziz},
+  author =       {Babu{\v s}ka, I. and Aziz, A. K.},
   title =        {On the Angle Condition in the Finite Element Method},
   journal =      {SIAM J. Numer. Anal.},
   year =         {1976},
@@ -1117,7 +1117,7 @@ YEAR = "2003"
 }
 
 @Article{BB73,
-  author  = {J. Boris and L. Book},
+  author  = {Boris, J. and Book, L.},
   title   = {Flux-Corrected Transport --- {SHASTA}, a Fluid Transport
              Algorithm That Works},
   journal = {J. Comp. Phys.},
@@ -1127,15 +1127,15 @@ YEAR = "2003"
 }
 
 @Book{BBCDDEPRV93,
-  author =       {R. Barrett and M. Berry and T. F. Chan and J. Demmel and J. Donato and
-                  J. Dongarra and V, Eijkhout and R. Pozo and C. Romine and H. van der Vorst},
+  author =       {Barrett, R. and Berry, M. and Chan, T. F. and Demmel, J. and Donato, J. and
+                  Dongarra, J. and Eijkhout, V. and Pozo, R. and Romine, C. and van der Vorst, H.},
   title =        {Templates for the Solution of Linear Systems: Building Blocks for Iterative Methods},
   publisher =    {SIAM},
   year =         1993
 }
 
 @Article{BBP81,
-  author  = {C. Bardos and M. Bercovier and O. Pironneau},
+  author  = {Bardos, C. and Bercovier, M. and Pironneau, O.},
   title   = {The Vortex Method with Finite Elements},
   journal = {Math. Comp.},
   volume  = 36,
@@ -1144,7 +1144,7 @@ YEAR = "2003"
 }
 
 @Article{BD04,
-  author =       {L. Borcea and V. Druskin},
+  author =       {Borcea, L. and Druskin, V.},
   title =        {Optimcal finite difference grids for direct and inverse {S}turm
                   {L}iouville problems},
   journal =      {Inverse Problems},
@@ -1156,7 +1156,7 @@ YEAR = "2003"
 
 
 @Article{BD87,
-  author  = {A. Bermudez and J. Durany},
+  author  = {Bermudez, A. and Durany, J.},
   title   = {La Methode des Characteristiques pour les Problemes de
              Covection--Diffusion Stationnaires},
   journal = {MMAN},
@@ -1167,7 +1167,7 @@ YEAR = "2003"
 }
 
 @Article{BDDF87,
-  author =       {F. Brezzi and J. Douglas and R. Duran and M. Fortin},
+  author =       {Brezzi, F. and Douglas, J. and Duran, R. and Fortin, M.},
   title =        {Mixed finite elements for second order elliptic problems in three variables},
   journal =      {Numer. Math.},
   year =         1987,
@@ -1176,7 +1176,7 @@ YEAR = "2003"
 }
 
 @Article{BDM85,
-  author =       {F. Brezzi and D. Marini and J. Douglas},
+  author =       {Brezzi, F. and Marini, D. and Douglas, J.},
   title =        {Two families of mixed finite elements for second order elliptic problems},
   journal =      {Numer. Math.},
   year =         1985,
@@ -1186,7 +1186,7 @@ YEAR = "2003"
 
 
 @Article{BDY88,
-  author =       {R. E. Bank and T. F. Dupont and H. Yserentant},
+  author =       {Bank, R. E. and Dupont, T. F. and Yserentant, H.},
   title =        {The Hierarchical Basis Multigrid Method},
   journal =      {Numer. Math.},
   year =         1988,
@@ -1196,7 +1196,7 @@ YEAR = "2003"
 
 
 @Article{BF79,
-  author  = {J. Boris and M. Fritts},
+  author  = {Boris, J. and Fritts, M.},
   title   = {The {L}agrangian Solution of Transient problems in Hydrodynamics
              Using a Triangular Mesh},
   journal = {J. Comp. Phys.},
@@ -1206,14 +1206,14 @@ YEAR = "2003"
 }
 
 @Book{BF91,
-  author =       {F. Brezzi and M. Fortin},
+  author =       {Brezzi, F. and Fortin, M.},
   title =        {Mixed and Hybrid Finite Element Methods},
   publisher =    {Springer},
   year =         1991
 }
 
 @InProceedings{BG99,
-  author =       {S. T. Barnard and M. J. Grote},
+  author =       {Barnard, S. T. and Grote, M. J.},
   title =        {A block version of the {SPAI} preconditioner},
   booktitle =    {Proceedings of the Ninth SIAM Conference on Parallel
                   Processing for Scientific Computing, San Antonio, Texas,
@@ -1223,7 +1223,7 @@ YEAR = "2003"
 }
 
 @Article{BH82,
-  author  = {A. Brooks and T. Hughes},
+  author  = {Brooks, A. and Hughes, T.},
   title   = {Streamline Upwind/{P}etrov-{G}alerkin Formulation for Convection
              Dominated Flows with Particular Emphasis on the Incompressible
              {N}avier-{S}tokes Equations },
@@ -1234,7 +1234,7 @@ YEAR = "2003"
 }
 
 @Book{BHM00,
-  author =       {W. L. Briggs and V. E. Henson and S. F. McCormick},
+  author =       {Briggs, W. L. and Henson, V. E. and McCormick, S. F.},
   title =        {A Multigrid Tutorial},
   publisher =    {SIAM},
   year =         2000,
@@ -1243,7 +1243,7 @@ YEAR = "2003"
 
 
 @Article{BHMS00,
-  author =       {F. Brezzi and P. Houston and D. Marini and E. S\"{u}li},
+  author =       {Brezzi, F. and Houston, P. and Marini, D. and S\"{u}li, E.},
   title =        {Modeling subgrid viscosity for advection-diffusion problems},
   journal =      {Comput. Meth. Appl. Mech. Engrg.},
   year =         {2000},
@@ -1254,7 +1254,7 @@ YEAR = "2003"
 
 
 @Article{BJ98,
-  author =       {F. Bouchut and F. James},
+  author =       {Bouchut, F. and James, F.},
   title =        {One-dimensional transport equations with discontinuous coefficients},
   journal =      {Nonlinear Analysis TMA},
   year =         1998,
@@ -1264,18 +1264,18 @@ YEAR = "2003"
 
 
 @InProceedings{BJLS93,
-  author =       {I. Babu{\v{s}}ka and K. Jerina and Y. Li and P. Smith},
+  author =       {Babu{\v{s}}ka, I. and Jerina, K. and Li, Y. and Smith, P.},
   title =        {Quantitative assessment of the accuracy of constitutive laws for plasticity with an emphasis on cyclic deformation},
   booktitle =    {Material Parameter Estimation for Modern Constitutive Equations, presented at the 1993 ASME Winter Annual Meeting, New Orleans, LA},
   year =         1993,
-  editor =       {L. A. Bertram and S. B. Brown and A. D. Freed}
+  editor =       {Bertram, L. A. and Brown, S. B. and Freed, A. D.}
 }
 
 
 
 
 @Article{BJT00,
-  author =       {E. B{\'e}cache and P. Joly and C. Tsogka},
+  author =       {B{\'e}cache, E. and Joly, P. and Tsogka, C.},
   title =        {An analysis of new mixed finite elements for the
                   approximation of wave propagation problems},
   journal =      {SIAM J. Numer. Anal.},
@@ -1286,7 +1286,7 @@ YEAR = "2003"
 
 
 @Article{BJT02,
-  author =       {E. B{\'e}cache and P. Joly and C. Tsogka},
+  author =       {B{\'e}cache, E. and Joly, P. and Tsogka, C.},
   title =        {A new family of mixed finite elements for the linear
                   elastodynamic problem},
   journal =      {SIAM J. Numer. Anal.},
@@ -1296,7 +1296,7 @@ YEAR = "2003"
 }
 
 @InProceedings{BK00,
-  author =       {O. Br{\"o}ker and M. J. Grote},
+  author =       {Br{\"o}ker, O. and Grote, M. J.},
   title =        {Parallel Algebraic Multigrid via Sparse Approximate Inverses},
   booktitle =    {Proceedings of the 16th IMACS World Congress 2000, Lausanne,
                   Switzerland, 2000},
@@ -1306,7 +1306,7 @@ YEAR = "2003"
 }
 
 @Article{BKP94,
-  author =       {J. H. Bramble and D. Y. Kwak and J. E. Pasciak},
+  author =       {Bramble, J. H. and Kwak, D. Y. and Pasciak, J. E.},
   title =        {Uniform Convergence of Multigrid {V}-Cycle Iterations for
                   Indefinite and Nonsymmetric Problems},
   journal =      {SIAM J. Num. Anal.},
@@ -1318,7 +1318,7 @@ YEAR = "2003"
 
 
 @Article{BL42,
-  author =       {J. M. Buckley and M.C. Leverett},
+  author =       {Buckley, J. M. and Leverett, M. C.},
   title =        {Mechanism of fluid displacement in sands},
   journal =      {Trans. AIME},
   year =         1942,
@@ -1328,7 +1328,7 @@ YEAR = "2003"
 
 
 @Article{BLP94,
-  author =       {J. Bramble and Z. Leyk and J. E. Pasciak},
+  author =       {Bramble, J. and Leyk, Z. and Pasciak, J. E.},
   title =        {The Analysis of multigrid algorithms for pseudo-differential operators of order minus one},
   journal =      {Math. Comp.},
   year =         1994,
@@ -1338,7 +1338,7 @@ YEAR = "2003"
 
 
 @Article{BLR82,
-  author  = {J. Benque and G. Labadie and J. Ronat},
+  author  = {Benque, J. and Labadie, G. and Ronat, J.},
   title   = {A New Finite Element Method for {N}avier-{S}tokes Equations coupled
              with a Temperature Equation},
   journal = {Proc. 4th Int. Symp. on FEM},
@@ -1347,7 +1347,7 @@ YEAR = "2003"
 }
 
 @TechReport{BM92,
-  author      = {K. Boukir and Y. Maday},
+  author      = {Boukir, K. and Maday, Y.},
   title       = {A High Order Characteristics/Finite Element Method for the
                  Incompressible {N}avier-{S}tokes Equations},
   institution = {Lab. Analyse Numerique},
@@ -1359,7 +1359,7 @@ YEAR = "2003"
 
 
 @Article{BP79,
-  author  = {M. Bercovier and O. Pironneau},
+  author  = {Bercovier, M. and Pironneau, O.},
   title   = {Error Estimates for Finite Element Solution of the {S}tokes Problem
              in Primitive Variables},
   journal = {Numer. Math.},
@@ -1370,7 +1370,7 @@ YEAR = "2003"
 
 
 @Article{BP82,
-  author  = {M. Bercovier and O. Pironneau},
+  author  = {Bercovier, M. and Pironneau, O.},
   title   = {Characteristics and the Finite Element method},
   journal = {Proc. 4th Int. Symp. on FEM},
   year    = 1982,
@@ -1380,7 +1380,7 @@ YEAR = "2003"
 
 
 @Book{BP86,
-  author =       {V. Barbu and T. Precupanu},
+  author =       {Barbu, V. and Precupanu, T.},
   title =        {Convexity and Optimization in Banach Spaces},
   publisher =    {Reidl Publishing, Dordrecht},
   year =         1986
@@ -1397,8 +1397,8 @@ YEAR = "2003"
 }
 
 @Article{BPX91,
-  author =       {J. H. Bramble and J. E. Pasciak and
-                  J. Xu},
+  author =       {Bramble, J. H. and Pasciak, J. E. and
+                  Xu, J.},
   title =        {The Analysis of Multigrid Algorithms with Nonnested
                   Spaces or Noninherited Quadratic Forms},
   journal =      {Math. Comp.},
@@ -1411,7 +1411,7 @@ YEAR = "2003"
 
 
 @Article{BR78,
-  author =       {I. Babu{\v s}ka and W. C. Rheinboldt},
+  author =       {Babu{\v s}ka, I. and Rheinboldt, W. C.},
   title =        {Error estimates for adaptive finite element computations},
   journal =      {SIAM J. Numer. Anal.},
   year =         1978,
@@ -1420,14 +1420,14 @@ YEAR = "2003"
 }
 
 @Book{BS01book,
-  author =       {I. Babu{\v s}ka and T. Strouboulis},
+  author =       {Babu{\v s}ka, I. and Strouboulis, T.},
   title =        {The Finite Element Method and its Reliability},
   publisher =    {Clarendon Press, New York},
   year =         2001
 }
 
 @Book{BS02,
-  author =       {S. C. Brenner and R. L. Scott},
+  author =       {Brenner, S. C. and Scott, R. L.},
   title =        {The Mathematical Theory of Finite Elements},
   publisher =    {Springer, Berlin-Heidelberg-New York},
   year =         2002,
@@ -1435,7 +1435,7 @@ YEAR = "2003"
 }
 
 @Article{BS93,
-  author  = {R. E. Bank and R. Santos},
+  author  = {Bank, R. E. and Santos, R.},
   title   = {Analysis of Some Moving Space-Time Finite Elements},
   journal = {SIAM J. Numer. Anal.},
   volume  = 30,
@@ -1445,7 +1445,7 @@ YEAR = "2003"
 }
 
 @Book{BS94,
-  author =       {S. C. Brenner and R. L. Scott},
+  author =       {Brenner, S. C. and Scott, R. L.},
   title =        {The Mathematical Theory of Finite Elements},
   publisher =    {Springer, Berlin-Heidelberg-New York},
   year =         {1994}
@@ -1453,7 +1453,7 @@ YEAR = "2003"
 
 
 @Article{BV96,
-  author =       {D. Braess and R. Verf{\"u}rth},
+  author =       {Braess, D. and Verf{\"u}rth, R.},
   title =        {A posteriori error estimators for the {R}aviart-{T}homas element},
   journal =      {SIAM J. Numer. Anal.},
   year =         1996,
@@ -1462,7 +1462,7 @@ YEAR = "2003"
 }
 
 @Article{BW85,
-  author =       {R. E. Bank and A. Weiser},
+  author =       {Bank, R. E. and Weiser, A.},
   title =        {Some A Posteriori Error Estimators for Elliptic Partial
                   Differential Equations},
   journal =      {Math. Comp.},
@@ -1472,7 +1472,7 @@ YEAR = "2003"
 }
 
 @Article{Bab81,
-  author =       {I. Babu{\v s}ka},
+  author =       {Babu{\v s}ka, I.},
   title =        {Error estimates for the combined $h$ and $p$ version of
                   finite element method},
   journal =      {Numer. Math.},
@@ -1482,7 +1482,7 @@ YEAR = "2003"
 }
 
 @Article{Ben99,
-  author =       {F. {Ben Belgacem}},
+  author =       {Belgacem, F. B.},
   title =        {The mortar finite element method with {L}agrange multipliers},
   journal =      {Numer. Math.},
   year =         1999,
@@ -1491,7 +1491,7 @@ YEAR = "2003"
 }
 
 @Article{Ber91,
-  author  = {R. Bermejo},
+  author  = {Bermejo, R.},
   title   = {Analysis of an Algorithm for the {G}alerkin-Characteristic Method},
   journal = {Numer. Math.},
   volume  = 60,
@@ -1500,7 +1500,7 @@ YEAR = "2003"
 }
 
 @PhdThesis{Blo92,
-  author = {C. Bl{\"o}mer},
+  author = {Bl{\"o}mer, C.},
   title  = {Eine neue {D}iskretisierung f{\"u}r zweidimensionale
                   {T}ransportprobleme mit dominanter {K}onvektion},
   school = {Ruhr-Universit{\"a}t Bochum},
@@ -1516,7 +1516,7 @@ YEAR = "2003"
 }
 
 @Book{Bra97,
-  author =       {D. Braess},
+  author =       {Braess, D.},
   title =        {Finite elements},
   publisher =    {Cambridge University Press},
   year =         1997
@@ -1524,7 +1524,7 @@ YEAR = "2003"
 
 
 @PhdThesis{Bro01,
-  author =       {E. Brooksbanks},
+  author =       {Brooksbanks, E.},
   title =        {A Numerical Investigation of Time Resolved Flows Around
 Turbine Blades},
   school =       {University of Leicester},
@@ -1542,7 +1542,7 @@ Turbine Blades},
 }
 
 @Article{CF00,
-  author =       {C. Carstensen and S. A. Funken},
+  author =       {Carstensen, C. and Funken, S. A.},
   title =        {Constants in {C}l{\'e}ment-interpolation error and residual
                   based a posteriori estimates in finite element methods},
   journal =      {East-West J. Num. Anal.},
@@ -1552,7 +1552,7 @@ Turbine Blades},
 }
 
 @Article{CFL28,
-  author =       {R. Courant and K. O. Friedrichs and H. Lewy},
+  author =       {Courant, R. and Friedrichs, K. O. and Lewy, H.},
   title =        {{\"U}ber die partiellen {D}ifferentialgleichungen der
                   {M}athematischen {P}hysik},
   journal =      {Mathematische Annalen},
@@ -1562,7 +1562,7 @@ Turbine Blades},
 }
 
 @Article{CG03,
-  author =       {B. Cockburn and J. Gopalakrishnan},
+  author =       {Cockburn, B. and Gopalakrishnan, J.},
   title =        {A characterization of hybridized mixed methods for
                   second order elliptic problems},
   journal =      {Math. Comp.},
@@ -1572,7 +1572,7 @@ Turbine Blades},
 }
 
 @Article{CIR52,
-  author =       {R. Courant and E. Isaacson and M. Rees},
+  author =       {Courant, R. and Isaacson, E. and Rees, M.},
   title =        {On the Solution of Nonlinear Hyperbolic Differential Equations
                   by Finite Differences},
   journal =      {Comm. Pure Appl. Math.},
@@ -1582,7 +1582,7 @@ Turbine Blades},
 }
 
 @TechReport{CJ97,
-  author =       {C. Carstensen and S. Jansche},
+  author =       {Carstensen, C. and Jansche, S.},
   title =        {A posteriori error estimates and adaptive
                   mesh-refining for non-conforming finite element methods},
   institution =  {Mathematisches Seminar der
@@ -1603,7 +1603,7 @@ Turbine Blades},
 
 
 @Article{CM90,
-  author  = {P. Childs and K. W. Morton},
+  author  = {Childs, P. and Morton, K. W.},
   title   = {Characteristic {G}alerkin Methods for Scalar Conservation
              Laws in One Dimension},
   journal = {SIAM J. Numer. Anal.},
@@ -1616,14 +1616,14 @@ Turbine Blades},
 
 
 @Book{CO84,
-  author =       {G. F. Carey and J. T. Oden},
+  author =       {Carey, G. F. and Oden, J. T.},
   title =        {Finite Elements: Computational Aspects},
   publisher =    {Prentice-Hall},
   year =         1984
 }
 
 @Article{CR73,
-  author  = {M. Crouzeix and P. Raviart},
+  author  = {Crouzeix, M. and Raviart, P.},
   title   = {Conforming and Nonconforming Finite Element Methods for
              Solving the Stationary {S}tokes Equations, Part {I}},
   journal = {RAIRO},
@@ -1634,7 +1634,7 @@ Turbine Blades},
 
 
 @Article{CS89,
-  author =       {B. Cockburn and C. W. Shu},
+  author =       {Cockburn, B. and Shu, C. W.},
   title =        {{TVB} {R}unge-{K}utta local projection discontinuous {G}alerkin finite element method for conservation laws {III}: One dimensional systems},
   journal =      {J. Comput. Phys.},
   year =         1989,
@@ -1643,7 +1643,7 @@ Turbine Blades},
 }
 
 @Article{CW84p,
-  author  = {P. Colella and P. Woodward},
+  author  = {Colella, P. and Woodward, P.},
   title   = {The Piecewise Parabolic Method for Gas-Dynamical Simulations},
   journal = {J. Comp. Phys.},
   volume  = 54,
@@ -1652,7 +1652,7 @@ Turbine Blades},
 }
 
 @Article{CW84s,
-  author  = {P. Colella and P. Woodward},
+  author  = {Colella, P. and Woodward, P.},
   title   = {The Numerical Simulation of Two-Dimensional Fluid Flow
              with Strong Shocks},
   journal = {J. Comp. Phys.},
@@ -1662,14 +1662,14 @@ Turbine Blades},
 }
 
 @book{Car97,
-  author = "G. F. Carey",
+  author = "Carey, G. F.",
   title = "Computational Grids:  Generation, Adaptation and Solution Strategies",
   publisher ="Taylor \& Francis",
   year = 1997
 }
 
 @Article{Che00,
-  author =       {X.-L. Cheng},
+  author =       {Cheng, X. -L.},
   title =        {On the nonlinear inexact {U}zawa algorithm for saddle-point problems},
   journal =      {SIAM J. Numer. Anal.},
   year =         2000,
@@ -1679,7 +1679,7 @@ Turbine Blades},
 
 
 @TechReport{Chi85,
-  author =       {G. Chiocchia},
+  author =       {Chiocchia, G.},
   title =        {Exact solutions to transonic and supersonic flows},
   institution =  {AGARD},
   year =         1985,
@@ -1688,7 +1688,7 @@ Turbine Blades},
 }
 
 @Book{Cia78,
-  author =       {P. G. Ciarlet},
+  author =       {Ciarlet, P. G.},
   title =        {The Finite Element Method for Elliptic Problems},
   publisher =    {North-Holland},
   year =         1978,
@@ -1699,7 +1699,7 @@ Turbine Blades},
 }
 
 @Article{DDPV96,
-  author =       {E. Dari and R. Duran and C. Padra and V. Vampa},
+  author =       {Dari, E. and Duran, R. and Padra, C. and Vampa, V.},
   title =        {A Posteriori Error Estimators for Nonconforming
                   Finite Element Methods},
   journal =      {RAIRO M$^2$AN},
@@ -1717,7 +1717,7 @@ Turbine Blades},
 }
 
 @Article{DR82,
-  author  = {J. Douglas and T. Russell},
+  author  = {Douglas, J. and Russell, T.},
   title   = {Numerical Methods for Convection-Dominated Diffusion Problems
              Based on Combining the Method of Characteristics with Finite Element
              or Finite Difference Procedures},
@@ -1728,7 +1728,7 @@ Turbine Blades},
 }
 
 @Article{DR83,
-  author =       {I. S. Duff and J. K. Reid},
+  author =       {Duff, I. S. and Reid, J. K.},
   title =        {The multifrontal solution of indefinite sparse
                   symmetric linear equations},
   journal =      {ACM Trans. Math. Softw.},
@@ -1739,7 +1739,7 @@ Turbine Blades},
 
 
 @TechReport{DR95,
-  author =       {I. S. Duff and J. K. Reid},
+  author =       {Duff, I. S. and Reid, J. K.},
   title =        {{M}{A}47, {A} {F}ortran code for the direct solution of
                   indefinite sparse symmetric systems},
   institution =  {Rutherford Appleton Laboratory, Oxfordshire, UK},
@@ -1748,7 +1748,7 @@ Turbine Blades},
 }
 
 @Article{DRW89,
-  author  = {C. Dawson and T. Russell and M. Wheeler},
+  author  = {Dawson, C. and Russell, T. and Wheeler, M.},
   title   = {Some Improved Error Estimates for the Modified Method of
              Characteristics},
   journal = {SIAM J. Numer. Anal.},
@@ -1758,7 +1758,7 @@ Turbine Blades},
 }
 
 @Book{DT93,
-  author =       {R. Dautray and J.-L. Lions},
+  author =       {Dautray, R. and Lions, J. -L.},
   title =        {Mathematical Analysis and Numerical Methods for
                   Science and Technology},
   publisher =    {Springer},
@@ -1768,7 +1768,7 @@ Turbine Blades},
 
 
 @Book{Dem06,
-  author =       {L. Demkowicz},
+  author =       {Demkowicz, L.},
   title =        {Computing with hp-adaptive finite elements. Volume 1: One
                   and Two Dimensional Elliptic and Maxwell Problems},
   publisher =    {Chapman \& Hall},
@@ -1796,7 +1796,7 @@ Turbine Blades},
 }
 
 @Article{Dul98,
-  author = {F. A. Dul},
+  author = {Dul, F. A.},
   title  = {{MINRES} and {MINERR} are better than {SYMMLQ} in Eigenpair computations},
   journal = {SIAM J. Sci. Comp.},
   year = 1998,
@@ -1805,7 +1805,7 @@ Turbine Blades},
 }
 
 @Article{EEHJ95a,
-  author =       {K. Eriksson and D. Estep and P. Hansbo and C. Johnson},
+  author =       {Eriksson, K. and Estep, D. and Hansbo, P. and Johnson, C.},
   title =        {Introduction to adaptive methods for differential equations},
   journal =      {Acta Numerica},
   year =         1995,
@@ -1813,21 +1813,21 @@ Turbine Blades},
 }
 
 @Book{EEHJ95b,
-  author =       {K. Eriksson and D. Estep and P. Hansbo and C. Johnson},
+  author =       {Eriksson, K. and Estep, D. and Hansbo, P. and Johnson, C.},
   title =        {Computational Differential Equations},
   publisher =    {Cambridge University Press},
   year =         1995
 }
 
 @Book{EEHJ96,
-  author =       {K. Eriksson and D. Estep and P. Hansbo and C. Johnson},
+  author =       {Eriksson, K. and Estep, D. and Hansbo, P. and Johnson, C.},
   title =        {Adaptive Finite Element Methods},
   publisher =    {North-Holland},
   year =         1996
 }
 
 @Article{EJ88,
-  author =       {K. Eriksson and C. Johnson},
+  author =       {Eriksson, K. and Johnson, C.},
   title =        {An adaptive finite element method for linear
                   elliptic problems},
   journal =      {Math. Comp.},
@@ -1837,7 +1837,7 @@ Turbine Blades},
 }
 
 @Article{EJ91,
-  author  = {K. Eriksson and C. Johnson},
+  author  = {Eriksson, K. and Johnson, C.},
   title   = {Adaptive Finite Element Methods for Parabolic Problems {I}: {A}
              Linear Model Problem},
   journal = {SIAM J. Numer. Anal.},
@@ -1847,7 +1847,7 @@ Turbine Blades},
 }
 
 @Article{EJ93,
-  author =       {K. Eriksson and C. Johnson},
+  author =       {Eriksson, K. and Johnson, C.},
   title =        {Adaptive Streamline Diffusion Finite Element Methods
                   for Convection-Diffusion Problems},
   journal =      {Math. Comput.},
@@ -1859,7 +1859,7 @@ Turbine Blades},
 
 
 @Article{EJ95II,
-  author      = {K. Eriksson and C. Johnson},
+  author      = {Eriksson, K and Johnson, C.},
   title       = {Adaptive Finite Element Methods for Parabolic Problems {II}:
                  Optimal Error Estimates in {$L_{\infty}L_2$} and
                  {$L_{\infty}L_{\infty}$}},
@@ -1871,7 +1871,7 @@ Turbine Blades},
 }
 
 @Article{EJ95V,
-  author      = {K. Eriksson and C. Johnson},
+  author      = {Eriksson, K. and Johnson, C.},
   title       = {Adaptive Finite Element Methods for Parabolic Problems {V}:
                  Long--Time Integration},
   journal =      {SIAM J. Numer. Anal.},
@@ -1882,7 +1882,7 @@ Turbine Blades},
 }
 
 @Article{EM90,
-  author =       {L. Elsner and V. Mehrmann},
+  author =       {Elsner, L. and Mehrmann, V.},
   title =        {Convergence of block iterative methods for linear systems arising in the numerical solution of {E}uler equations},
   journal =      {Numer. Math.},
   year =         1991,
@@ -1891,7 +1891,7 @@ Turbine Blades},
 }
 
 @Article{ER84,
-  author  = {R. Ewing and T. Russell},
+  author  = {Ewing, R. and Russell, T.},
   title   = {Convergence Analysis of an Approximation of Miscible Displacemant
              in Porous Media by Mixed Finite Elements and a Modified method
              of Characteristics},
@@ -1904,7 +1904,7 @@ Turbine Blades},
 
 
 @Article{FM99,
-  author =       {N. T. Folwell and S. A. Mitchell},
+  author =       {Folwell, N. T. and Mitchell, S. A.},
   title =        {Reliable whisker weaving via curve contraction},
   journal =      {Engineering with Computers},
   year =         1999,
@@ -1913,7 +1913,7 @@ Turbine Blades},
 }
 
 @Article{FN91,
-  author =       {R. W. Freund and N. M. Nachtigal},
+  author =       {Freund, R. W. and Nachtigal, N. M.},
   title =        {{QMR}: a quasi-minimal residual method for
                   non-{H}ermitian linear systems},
   journal =      {Num. Math.},
@@ -1923,7 +1923,7 @@ Turbine Blades},
 }
 
 @Article{FN94,
-  author =       {R. W. Freund and N. M. Nachtigal},
+  author =       {Freund, R. W. and Nachtigal, N. M.},
   title =        {An Implementation of the {QMR} Method Based on Coupled
                   Two--Term Recurrences},
   journal =      {SIAM J. Sci. Comp.},
@@ -1935,7 +1935,7 @@ Turbine Blades},
 }
 
 @InProceedings{FN94a,
-  author =       {R. W. Freund and N. M. Nachtigal},
+  author =       {Freund, R. W. and Nachtigal, N. M.},
   title =        {A new {K}rylov-subspace method for symmetric indefinite
                   linear systems},
   booktitle =    {Proceedings of the 14th IMACS World Congress on
@@ -1948,7 +1948,7 @@ Turbine Blades},
 
 
 @Article{FN95,
-  author =       {R. W. Freund and N. M. Nachtigal},
+  author =       {Freund, R. W. and Nachtigal, N. M.},
   title =        {Software for simplified {L}anczos and {QMR} algorithms},
   journal =      {Appl. Num. Math.},
   year =         1995,
@@ -1957,7 +1957,7 @@ Turbine Blades},
 }
 
 @Article{FO80,
-  author =       {R. S. Falk and J. E. Osborn},
+  author =       {Falk, R. S. and Osborn, J. E.},
   title =        {Error estimates for mixed methods},
   journal =      {RAIRO Anal.Numer.},
   year =         1980,
@@ -1967,7 +1967,7 @@ Turbine Blades},
 
 
 @Article{FV80,
-  author  = {W. Finn and E. Varoglu},
+  author  = {Finn, W. and Varoglu, E.},
   title   = {Finite Elements Incorporating Characteristics for One-Dimensional
              Diffusion-Convection Equations},
   journal = {J. Comp. Phys.},
@@ -1977,7 +1977,7 @@ Turbine Blades},
 }
 
 @Book{Fle97,
-  author =       {C. A. J. Fletcher},
+  author =       {Fletcher, C. A. J.},
   title =        {Computational Techniques for Fluid Dynamics},
   publisher =    {Springer},
   year =         1997,
@@ -1986,7 +1986,7 @@ Turbine Blades},
 
 
 @Article{GA02,
-  author =       {N. Guessous and M. Akhmouch},
+  author =       {Guessous, N. and Akhmouch, M.},
   title =        {Higher order analytical nodal methods in
                   response-matrix formulation for the multigroup neutron
                   diffusion equations},
@@ -1997,7 +1997,7 @@ Turbine Blades},
 
 
 @Article{GB86a,
-  author =       {B. Guo and I. Babu{\v s}ka},
+  author =       {Guo, B. and Babu{\v s}ka, I.},
   title =        {The h-p version of the finite element method. {P}art {I}:
                   {T}he basic approximation results},
   journal =      {Comp. Mech.},
@@ -2007,7 +2007,7 @@ Turbine Blades},
 }
 
 @Article{GB86b,
-  author =       {B. Guo and I. Babu{\v s}ka},
+  author =       {Guo, B. and Babu{\v s}ka, I.},
   title =        {The h-p version of the finite element method. {P}art {II}:
                   {T}he general results and application},
   journal =      {Comp. Mech.},
@@ -2017,7 +2017,7 @@ Turbine Blades},
 }
 
 @TechReport{GH89,
-  author      = {R. J. Gathmann and F. K. Hebeker},
+  author      = {Gathmann, R. J. and Hebeker, F. K.},
   title       = {On the Numerical Treatment of a One-Dimensional
                  Convection-Diffusion Problem with an {A}rrhenius Source Term},
   institution = {IBM Wiss. Zentr., Heidelberg},
@@ -2025,7 +2025,7 @@ Turbine Blades},
 }
 
 @Article{GH97,
-  author =       {M. J. Grote and T. Huckle},
+  author =       {Grote, M. J. and Huckle, T.},
   title =        {Parallel preconditioning with sparse approximate inverses},
   journal =      {SIAM J. Sci. Comput.},
   year =         1997,
@@ -2034,7 +2034,7 @@ Turbine Blades},
 }
 
 @Article{GKZB83,
-  author =       {Gago, J. P. de S. R. and Kelly, D. W. and Zienkiewicz, O. C.
+  author =       {de S. R. Gago, J. P. and Kelly, D. W. and Zienkiewicz, O. C.
                   and Babu\v{s}ka, I.},
   title =        {A posteriori error analysis and adaptive processes
                   in the finite element method:
@@ -2047,14 +2047,14 @@ Turbine Blades},
 
 
 @Book{GMW81,
-  author =       {P. E. Gill and W. Murray and M. H. Wright},
+  author =       {Gill, P. E. and Murray, W. and Wright, M. H.},
   title =        {Practical Optimization},
   publisher =    {Academic Press},
   year =         1981
 }
 
 @Article{GOR99,
-  author =       {E. Godlewski and M. Olazabal and P.-A. Raviart},
+  author =       {Godlewski, E. and Olazabal, M. and Raviart, P. -A.},
   title =        {On the linearization of systems of conservation laws for fluids
 at a material contact discontinuity},
   journal =      {J. Math. Pures Appl.},
@@ -2064,7 +2064,7 @@ at a material contact discontinuity},
 }
 
 @Article{GP00,
-  author =       {J. Gopalakrishnan and J. E. Pasciak},
+  author =       {Gopalakrishnan, J. and Pasciak, J. E.},
   title =        {Multigrid for the mortar finite element method},
   journal =      {SIAM J. Numer. Anal.},
   year =         2000,
@@ -2073,7 +2073,7 @@ at a material contact discontinuity},
 }
 
 @Book{GT83,
-  author =       {D. Gilbarg and N. S. Trudinger},
+  author =       {Gilbarg, D. and Trudinger, N. S.},
   title =        {Elliptic Partial Differential Equations of Second Order},
   publisher =    {Springer},
   year =         1983,
@@ -2091,7 +2091,7 @@ at a material contact discontinuity},
 }
 
 @InProceedings{GW88,
-  author =       {R. Glowinski and M. F. Wheeler},
+  author =       {Glowinski, R. and Wheeler, M. F.},
   title =        {Domain decomposition and mixed finite element methods for
                   elliptic problems},
   booktitle =    {Domain Decomposition Methods for Partial Differential
@@ -2102,7 +2102,7 @@ at a material contact discontinuity},
 }
 
 @Article{HFM86,
-  author  = {T. Hughes and L. Franca and M. Mallet},
+  author  = {Hughes, T. and Franca, L. and Mallet, M.},
   title   = {A New Finite Element Formulation for Computational Fluid
              Dynamics {I} --- Symmetric Forms of the Compressible {E}uler and
              {N}avier-{S}tokes Equations and the Second Law of Thermodynamics},
@@ -2113,8 +2113,8 @@ at a material contact discontinuity},
 }
 
 @Article{HIKVW98,
-  author =       {R. Hoppe and Y. Iliash and Y. Kuznetsov and Y. Vassilevski
-                  and B. Wohlmuth},
+  author =       {Hoppe, R. and Iliash, Y. and Kuznetsov, Y. and Vassilevski, Y.
+                  and Wohlmuth, B.},
   title =        {Analysis and parallel implementation of adaptive mortar
                   element methods},
   journal =      {East-West J. Numer. Math.},
@@ -2124,7 +2124,7 @@ at a material contact discontinuity},
 }
 
 @Article{HJ91,
-  author  = {P. Hansbo and C. Johnson},
+  author  = {Hansbo, P. and Johnson, C.},
   title   = {Adaptive Streamline Diffusion Methods for Compressible Flow Using
              Conservation Variables},
   journal = {Comp. Meth. Appl. Mech. Engrg.},
@@ -2134,7 +2134,7 @@ at a material contact discontinuity},
 }
 
 @Article{HK84,
-  author  = {L. Hayes and S. Krishnamachari},
+  author  = {Hayes, L. and Krishnamachari, S.},
   title   = {Alternating Direction Along Flow Lines in a Fluid Flow Problem},
   journal = {Comp. Meth. Appl. Mech. Engrg.},
   volume  = 47,
@@ -2144,7 +2144,7 @@ at a material contact discontinuity},
 
 
 @Article{HM86c,
-  author  = {T. Hughes and M. Mallet},
+  author  = {Hughes, T. and Mallet, M.},
   title   = {A New Finite Element Formulation for Computational Fluid
              Dynamics {III} --- The Generalized Streamline Operator for
              Multidimensional Advective-Diffusive Systems},
@@ -2156,7 +2156,7 @@ at a material contact discontinuity},
 
 
 @Article{HM86d,
-  author  = {T. Hughes and M. Mallet},
+  author  = {Hughes, T. and Mallet, M.},
   title   = {A New Finite Element Formulation for Computational Fluid
              Dynamics {IV} --- A Discontinuity--Capturing Operator for
              Multidimensional Advective--Diffusive Systems},
@@ -2167,7 +2167,7 @@ at a material contact discontinuity},
 }
 
 @Article{HMM86,
-  author  = {T. Hughes and M. Mallet and A. Mizukami},
+  author  = {Hughes, T. and Mallet, M. and Mizukami, A.},
   title   = {A New Finite Element Formulation for Computational Fluid
              Dynamics {II} --- Beyond {SUPG}},
   journal = {Comput. Methods Appl. Mech. Engrg.},
@@ -2177,7 +2177,7 @@ at a material contact discontinuity},
 }
 
 @Article{HS01,
-  author =       {P. Houston and E. S\"{u}li},
+  author =       {Houston, P. and S\"{u}li, E.},
   title =        {$hp$-Adaptive discontinuous {G}alerkin finite element methods for first-order hyperbolic problems},
   journal =      {SIAM J. Sci. Comp.},
   year =         2001,
@@ -2195,7 +2195,7 @@ at a material contact discontinuity},
 }
 
 @Article{HS90,
-  author  = {P. Hansbo and A. Szepessy},
+  author  = {Hansbo, P. and Szepessy, A.},
   title   = {A Velocity-Pressure Streamline Diffusion Finite Element Method for
              the Incompressible {N}avier-{S}tokes Equation},
   journal = {Comp. Meth. Appl. Mech. Engrg.},
@@ -2211,7 +2211,7 @@ at a material contact discontinuity},
 }
 
 @Article{HSS99,
-  author =       {P. Houston and C. Schwab and E. S\"{u}li},
+  author =       {Houston, P. and Schwab, C. and S\"{u}li, E.},
   title =        {Stabilized $hp$-finite element methods for first-order hyperbolic problems},
   journal =      {SIAM J. Numer. Anal.},
   year =         {2000},
@@ -2221,7 +2221,7 @@ at a material contact discontinuity},
 }
 
 @Article{HT84,
-  author  = {T. Hughes and T. Tezduyar},
+  author  = {Hughes, T. and Tezduyar, T.},
   title   = {Finite Element Methods for First-Order Hyperbolic Systems with
              Particular Emphasis on the Compressible {E}uler Equations},
   journal = {Comp. Meth. Appl. Mech. Engrg.},
@@ -2249,7 +2249,7 @@ at a material contact discontinuity},
 }
 
 @Book{Hac89,
-  author =       {W. Hackbusch},
+  author =       {Hackbusch, W.},
   title =        {Integralgleichungen},
   publisher =    {Teubner},
   year =         1989,
@@ -2259,7 +2259,7 @@ at a material contact discontinuity},
 }
 
 @Book{Hac93,
-  author =       {W. Hackbusch},
+  author =       {Hackbusch, W.},
   title =        {{I}terative {L\"o}sung gro{\ss}er, schwachbesetzter Gleichungssysteme},
   publisher =    {Teubner},
   year =         1993,
@@ -2269,7 +2269,7 @@ at a material contact discontinuity},
 
 
 @TechReport{Han92,
-  author      = {P. Hansbo},
+  author      = {Hansbo, P.},
   title       = {Space-Time Oriented Streamline Diffusion Methods for Nonlinear
                  Conservation Laws in One Dimension},
   institution = {Dept. of Math., Chalmers Univ., G{\"o}teborg},
@@ -2278,7 +2278,7 @@ at a material contact discontinuity},
 }
 
 @Article{Han92c,
-  author  = {P. Hansbo},
+  author  = {Hansbo, P.},
   title   = {The Characteristic Streamline Diffusion Method for
              Convection-Diffusion Problems},
   journal = {Comp. Meth. Appl. Mech. Engrg.},
@@ -2288,7 +2288,7 @@ at a material contact discontinuity},
 }
 
 @Article{Han92n,
-  author  = {P. Hansbo},
+  author  = {Hansbo, P.},
   title   = {The Characteristic Streamline Diffusion Method for the
              Time-Dependent Incompressible {N}avier-{S}tokes Equations},
   journal = {Comp. Meth. Appl. Mech. Engrg.},
@@ -2298,7 +2298,7 @@ at a material contact discontinuity},
 }
 
 @Article{Har83,
-  author  = {A. Harten},
+  author  = {Harten, A.},
   title   = {High Resolution Schemes for Hyperbolic Conservation Laws},
   journal = {J. Comp. Phys.},
   volume  = 49,
@@ -2307,7 +2307,7 @@ at a material contact discontinuity},
 }
 
 @Book{Hir88,
-  author =       {C. Hirsch},
+  author =       {Hirsch, C.},
   title =        {Numerical Computation of Internal and External Flows},
   publisher =    {Wiley},
   year =         {1988},
@@ -2323,7 +2323,7 @@ at a material contact discontinuity},
 }
 
 @Article{JJS95,
-  author =       {J. Jaffre and C. Johnson and A. Szepessy},
+  author =       {Jaffre, J. and Johnson, C. and Szepessy, A.},
   title =        {Convergence of the discontinuous {G}alerkin finite element method
                   for hyperbolic conservation laws},
   journal =      {Math. Models and Methods in Appl. Sciences},
@@ -2333,7 +2333,7 @@ at a material contact discontinuity},
 }
 
 @Article{JNP84,
-  author =       {C. Johnson and U. N{\"a}vert and J. Pitk{\"a}ranta},
+  author =       {Johnson, C. and N{\"a}vert, U. and Pitk{\"a}ranta, J.},
   title =        {Finite Element Methods for Linear Hyperbolic Problems},
   journal =      {Comp. Mech. in Appl. Mech. Engrg.},
   year =         1984,
@@ -2361,7 +2361,7 @@ at a material contact discontinuity},
 }
 
 @Article{JS86,
-  author  = {C. Johnson and J. Saranen},
+  author  = {Johnson, C. and Saranen, J.},
   title   = {Streamline Diffusion Methods for the Incompressible {E}uler and
              {N}avier-{S}tokes Equations},
   journal = {Math. Comp.},
@@ -2371,7 +2371,7 @@ at a material contact discontinuity},
 }
 
 @Article{JS87,
-  author  = {C. Johnson and A. Szepessy},
+  author  = {Johnson, C. and Szepessy, A.},
   title   = {On the Convergence of a Finite Element Method for a Nonlinear
              Hyperbolic Conservation Law},
   journal = {Math. Comp.},
@@ -2381,7 +2381,7 @@ at a material contact discontinuity},
 }
 
 @TechReport{JS92,
-  author =       {C. Johnson and A. Szepessy},
+  author =       {Johnson, C. and Szepessy, A.},
   title =        {Adaptive finite element methods for
 conservation laws based on a posteriori error estimates},
   institution =  {Chalmers Tekniska H{\"o}gskola},
@@ -2393,7 +2393,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{JSH90,
-  author  = {C. Johnson and A. Szepessy and P. Hansbo},
+  author  = {Johnson, C. and Szepessy, A. and Hansbo, P.},
   title   = {On the Convergence of Shock-Capturing Streamline Diffusion
              Finite Element methods for Hyperbolic Conservation Laws},
   journal = {Math. Comp.},
@@ -2404,7 +2404,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{Joh76,
-  author =       {C. Johnson},
+  author =       {Johnson, C.},
   title =        {Existence theorems for plasticity problems},
   journal =      {J. Math. Pures Appl.},
   year =         1976,
@@ -2413,7 +2413,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Book{Joh87,
-  author =       {C. Johnson},
+  author =       {Johnson, C.},
   title =        {Numerical Solutions of Partial Differential
                   Equations by the Finite Element Method},
   publisher =    {Cambridge University Press},
@@ -2422,7 +2422,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{Joh90c,
-  author  = {C. Johnson},
+  author  = {Johnson, C.},
   title   = {Adaptive Finite Element Methods for Diffusion and Convection
              Problems},
   journal = {Comp. Meth. Appl. Mech. Engrg.},
@@ -2432,7 +2432,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @TechReport{Joh90f,
-  author      = {C. Johnson},
+  author      = {Johnson, C.},
   title       = {A New Approach to Algorithms for Convection Problems which are
                  Based on Exact Transport + Projection},
   institution = {Dept. of Math., Chalmers Univ., G{\"o}teborg},
@@ -2441,7 +2441,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{Joh90p,
-  author  = {C. Johnson},
+  author  = {Johnson, C.},
   title   = {The Streamline Diffusion Finite Element Method for Compressible and
              Incompressible Fluid Flow},
   journal = {Pitman Res. Notes. Math. Ser.},
@@ -2451,7 +2451,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{Joh91,
-  author  = {C. Johnson},
+  author  = {Johnson, C.},
   title   = {The Characteristic Streamline Diffusion Method},
   journal = {Mat. Aplic. Comp.},
   volume  = 10,
@@ -2460,7 +2460,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Book{Joh93,
-  author =       {C. Johnson},
+  author =       {Johnson, C.},
   title =        {Finite Element Methods for Partial Differential Equations},
   publisher =    {Studentlitteratur},
   year =         1993,
@@ -2468,7 +2468,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Book{Joh93a,
-  author =       {C. Johnson},
+  author =       {Johnson, C.},
   title =        {Finite Element Methods for Partial Differential Equations},
   publisher =    {Cambridge University Press},
   year =         1993
@@ -2476,7 +2476,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{KGZB83,
-  author =       {Kelly, D. W. and Gago, J. P. de S. R. and Zienkiewicz, O. C.
+  author =       {Kelly, D. W. and de S. R. Gago, J. P. and Zienkiewicz, O. C.
                   and Babu\v{s}ka, I.},
   title =        {A posteriori error analysis and adaptive processes
                   in the finite element method: Part {I}--Error Analysis},
@@ -2487,7 +2487,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{KHR89,
-  author  = {S. Krishnamachari and L. Hayes and T. Russell},
+  author  = {Krishnamachari, S and Hayes, L. and Russell, T.},
   title   = {A Finite Element Alternating-Direction Method Combined
              with a Modified Method of Characteristics for Convection--Diffusion
              Problems},
@@ -2510,7 +2510,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{KK98,
-  author =       {G. Karypis and V. Kumar},
+  author =       {Karypis, G. and Kumar, V.},
   title =        {A fast and high quality multilevel scheme for partitioning
                   irregular graphs},
   journal =      {SIAM J. Sci. Comput.},
@@ -2520,7 +2520,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{KM01,
-  author =       {C. Kober and M. M{\"u}ller-Hannemann},
+  author =       {Kober, C. and M{\"u}ller-Hannemann, M.},
   title =        {A Case Study in Hexahedral Mesh Generation: Simulation
                   of the Human Mandible},
   journal =      {Engineering with Computers},
@@ -2530,7 +2530,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Book{Kel95,
-  author =       {C. T. Kelley},
+  author =       {Kelley, C. T.},
   title =        {Iterative Methods for Linear and Nonlinear Equations},
   publisher =    {SIAM},
   year =         1995,
@@ -2540,7 +2540,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{Koz94,
-  author =       {G. Kozlovsky},
+  author =       {Kozlovsky, G.},
   title =        {Solving partial differential equations using recursive grids},
   journal =      {Appl. Numer. Math.},
   year =         1994,
@@ -2549,7 +2549,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @InProceedings{Koz96,
-  author =       {G. Kozlovski},
+  author =       {Kozlovski, G.},
   title =        {High-order matching finite elements on recursive grids},
   booktitle =    {ICOSAHOM 95: Proceedings of the Third International Conference on
                   Spectral and High Order Methods},
@@ -2559,26 +2559,26 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Book{Kro97,
-  author =       {D. Kr{\"o}ner},
+  author =       {Kr{\"o}ner, D.},
   title =        {Numerical Schemes for Conservation Laws},
   publisher =    {Wiley-Teubner },
   year =         {1997},
 }
 
 @Book{Kyt96,
-  author =       {P. K. Kythe},
+  author =       {Kythe, P. K.},
   title =        {Fundamental Solutions for Differential Operators and Applications},
   publisher =    {Birkh"auser, Boston, Basel, Berlin},
   year =         {1996}
 }
 
 @InProceedings{LB00,
-  author =       {M. G. Larson and T. J. Barth},
+  author =       {Larson, M. G. and Barth, T. J.},
   title =        {A posteriori error estimation for adaptive discontinuous {G}alerkin approximations of hyperbolic systems},
   booktitle =    {Discontinuous Galerkin Methods},
   pages =        {363--368},
   year =         2000,
-  editor =       {B. Cockburn and G. Karniadakis and C.-W. Shu},
+  editor =       {Cockburn, B. and Karniadakis, G. and Shu, C. -W.},
   volume =       11,
   series =       {Lecture Notes in Computational Science and Engineering},
   publisher =    {Springer-Verlag}
@@ -2588,7 +2588,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{LL83,
-  author =       {P. Ladev\`eze and D. Leguillon},
+  author =       {Ladev\`eze, P. and Leguillon, D.},
   title =        {Error estimate procedure in the finite element method and
                   applications},
   journal =      {SIAM J. Numer. Anal.},
@@ -2605,7 +2605,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @InProceedings{LR74,
-  author =       {P. LeSaint and P. A. Raviart},
+  author =       {LeSaint, P. and Raviart, P. A.},
   title =        {On a Finite Element Method for Solving the
   Neutron Transport Equation},
   booktitle =    {Mathematical Aspects of Finite Elements in
@@ -2617,7 +2617,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @TechReport{LY88,
-  author      = {R. LeVeque and H. C. Yee},
+  author      = {LeVeque, R. and Yee, H. C.},
   title       = {A Study of Numerical Methods for Hyperbolic Conservation Laws
                  with Stiff Source Terms},
   institution = {Ames Research Center, NASA},
@@ -2626,7 +2626,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{Lev88,
-  author =       {R. LeVeque},
+  author =       {LeVeque, R.},
   title =        {High resolution finite volume methods on arbitrary
                   grids via wave propagation},
   journal =      {JCP},
@@ -2636,7 +2636,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Book{Lev92,
-  author =       {R. LeVeque},
+  author =       {LeVeque, R.},
   title =        {Numerical Methods for Conservation Laws},
   publisher =    {Birkh{\"a}user},
   year =         {1992},
@@ -2654,7 +2654,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{Luc86,
-  author  = {B. Lucier},
+  author  = {Lucier, B.},
   title   = {A Moving Mesh Numerical Method for Hyperbolic Conservation Laws},
   journal = {Math. Comp.},
   volume  = 46,
@@ -2663,7 +2663,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @InCollection{MM01,
-  author =       {H. G. Matthies and M. Meyer},
+  author =       {Matthies, H. G. and Meyer, M.},
   title =        {Dual-weighted-residual and non-linear {G}alerkin
                   methods in the simulation of the aeroelastic behaviour
                   of wind turbines},
@@ -2674,7 +2674,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{MM81,
-  author  = {K. Miller and R. Miller},
+  author  = {Miller, K. and Miller, R.},
   title   = {Moving Finite Elements {I}},
   journal = {SIAM J. Numer. Anal.},
   volume  = 18,
@@ -2683,7 +2683,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @TechReport{MPR94,
-  author      = {S. M{\"u}ller and A. Prohl and R. Rannacher},
+  author      = {M{\"u}ller, S. and Prohl, A. and Rannacher, R.},
   title       = {Implicit Time-Discretization of the Nonstationary
                  Incompressible {N}avier-{S}tokes Equations},
   institution = {IWR (SFB 359), Univ. Heidelberg},
@@ -2692,7 +2692,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{MPS88,
-  author  = {K. Morton and A. Priestley and E. S{\"u}li},
+  author  = {Morton, K. and Priestley, A. and S{\"u}li, E.},
   title   = {Stability of the {L}agrange-{G}alerkin Method with Non-Exact
              Integration},
   journal = {MMAN},
@@ -2703,7 +2703,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{MS87,
-  author  = {K. Morton and P. Sweby},
+  author  = {Morton, K. and Sweby, P.},
   title   = {A Comparison of Flux Limited Difference Methods and Characteristic
              {G}alerkin Methods for Shock Modelling},
   journal = {J. Comp. Phys.},
@@ -2720,7 +2720,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{Mil81,
-  author  = {K. Miller},
+  author  = {Miller, K.},
   title   = {Moving Finite Elements {II}},
   journal = {SIAM J. Numer. Anal.},
   volume  = 18,
@@ -2729,7 +2729,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @InProceedings{Mit96,
-  author =       {S. A. Mitchell},
+  author =       {Mitchell, S. A.},
   title =        {A characterization of the quadrilateral meshes of a surface
                   which admit a compatible hexahedral mesh of the enclosed
                   volume},
@@ -2742,7 +2742,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{Mor85,
-  author  = {K. Morton},
+  author  = {Morton, K.},
   title   = {Genaralized {G}alerkin Methods for Hyperbolic Problems},
   journal = {Comp. Meth. Appl. Mech. Engng.},
   volume  = 52,
@@ -2752,7 +2752,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{Mul99,
-  author =       {M. M{\"u}ller-Hannemann},
+  author =       {M{\"u}ller-Hannemann, M.},
   title =        {Hexahedral mesh generation by successive dual cycle
                   elimination},
   journal =      {Engineering with Computers},
@@ -2762,7 +2762,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{Ned80,
-  author =       {J.-C. Nedelec},
+  author =       {Nedelec, J. -C.},
   title =        {Mixed finite elements in {$R^3$}},
   journal =      {Numer. Math.},
   year =         1980,
@@ -2771,7 +2771,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{Neu81,
-  author  = {S. Neuman},
+  author  = {Neuman, S.},
   title   = {An {E}ulerian-{L}agrangian Numerical Scheme for the
              Dispersion-Convection Equation Using Conjugate Space-Time Grids},
   journal = {J. Comp. Phys.},
@@ -2781,7 +2781,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{Nit71,
-  author =       {J. Nitsche},
+  author =       {Nitsche, J.},
   title =        {{\"U}ber ein {V}ariationsprinzip zur {L\"o}sung von
                   {D}irichlet-{P}roblemen bei der {V}erwendung von
                   {T}eilr{\"a}umen, die keinen {R}andbedingungen
@@ -2793,7 +2793,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Misc{OP99,
-  author =       {J. T. Oden and S. Prudhomme},
+  author =       {Oden, J. T. and Prudhomme, S.},
   title =        {Goal-Oriented Error Estimation and Adaptivity for the Finite Element
                   Method. {T}{I}{C}{A}{M} {R}eport 99--15, {U}niversity of {T}exas, {A}ustin},
   month =        apr,
@@ -2801,7 +2801,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{PAS95,
-  author =       {M. A. Price and C. G. Armstrong and M. A. Sabin},
+  author =       {Price, M. A. and Armstrong, C. G. and Sabin, M. A.},
   title =        {Hexahedral mesh generation by medial surface subidvision:
                   {P}art {I}. {S}olids with convex edges},
   journal =      {Int. J. Numer. Methods Eng.},
@@ -2811,7 +2811,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @InProceedings{PP98,
-  author =       {J. Peraire and A. T. Patera},
+  author =       {Peraire, J. and Patera, A. T.},
   title =        {Bounds for linear-functional outputs of coercive partial
                   differential equations: {L}ocal indicators and adaptive
                   refinement},
@@ -2819,7 +2819,7 @@ conservation laws based on a posteriori error estimates},
                   Computational Methods in Mechanics, Cachan, 17--19 September 1997},
   year =         1998,
   pages =        {199--216},
-  editor =       {P. Ladev\`eze and J. T. Oden},
+  editor =       {Ladev\`eze, P. and Oden, J. T.},
   publisher =    {Elsevier}
 }
 
@@ -2827,7 +2827,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{PS75,
-  author =       {C. C. Paige and M. A. Saunders},
+  author =       {Paige, C. C. and Saunders, M. A.},
   title =        {Solution of sparse indefinite systems of linear equations},
   journal =      {SIAM J. Numer. Anal.},
   year =         1975,
@@ -2838,8 +2838,8 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{PSMJM06,
-  author =       {M. L. Parks and E. de Sturler and G. Mackey and D. D. Johnson
-                  and S. Maiti},
+  author =       {Parks, M. L. and de Sturler, E. and Mackey, G. and Johnson, D. D.
+                  and Maiti, S.},
   title =        {Recycling {K}rylov subspaces for sequences of linear
                   systems},
   journal =      {SIAM J. Sc. Comput.},
@@ -2854,7 +2854,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{PVMZ87,
-  author  = {J. Peraire and M. Vahdati and K. Morgan and O. Zienkiewicz},
+  author  = {Peraire, J. and Vahdati, M. and Morgan, K. and Zienkiewicz, O.},
   title   = {Adaptive Remeshing for Compressible Flow Computations},
   journal = {J. Comp. Phys.},
   volume  = 72,
@@ -2863,8 +2863,8 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{PSMJM06,
-  author =       {M. L. Parks and E. de Sturler and G. Mackey and
-                  D. D. Johnson and S. Maiti},
+  author =       {Parks, M. L. and de Sturler, E. and Mackey, G. and
+                  Johnson, D. D. and Maiti, S.},
   title =        {Recycling {K}rylov Subspaces for Sequences of
                   Linear Systems},
   journal =      {SIAM J. Sc. Comput.},
@@ -2874,7 +2874,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{Pet91,
-  author =       {T. E. Peterson},
+  author =       {Peterson, T. E.},
   title =        {A note on the convergence of the discontinuous {G}alerkin Method for a scalar hyperbolic equation},
   journal =      {SIAM J. Numer. Anal.},
   year =         {1991},
@@ -2886,7 +2886,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{Pir82,
-  author  = {O. Pironneau},
+  author  = {Pironneau, O.},
   title   = {On the Transport-Diffusion Algorithm and its Application to the
              {N}avier-{S}tokes Equations},
   journal = {Numer. Math.},
@@ -2907,7 +2907,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Book{QV94,
-  author =       {A. Quarteroni and A. Valli},
+  author =       {Quarteroni, A. and Valli, A.},
   title =        {Numerical Approximation of Partial Differential Equations},
   publisher =    {Springer},
   year =         1994,
@@ -2915,7 +2915,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Book{QV99,
-  author =       {A. Quarteroni and A. Valli},
+  author =       {Quarteroni, A. and Valli, A.},
   title =        {Domain Decomposition Methods for Partial Differential Equations},
   publisher =    {Clarendon Press, Oxford},
   year =         1999
@@ -2923,7 +2923,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @TechReport{RH73,
-  author =       {W. H. Reed and T. R. Hill},
+  author =       {Reed, W. H. and Hill, T. R.},
   title =        {Triangular mesh methods for the neutron transport equation},
   institution =  {Los Alamos Scientific Laboratory},
   year =         1973,
@@ -2933,7 +2933,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{RM80,
-  author =       {W. C. Rheinboldt and C. K. Mesztenyi},
+  author =       {Rheinboldt, W. C. and Mesztenyi, C. K.},
   title =        {On a Data Structure for Adaptive Finite Element Mesh
                   Refinements},
   journal =      {ACM Trans. Math. Software},
@@ -2955,19 +2955,19 @@ conservation laws based on a posteriori error estimates},
 
 
 @InProceedings{RT77,
-  author =       {P.A. Raviart and J.-M. Thomas},
+  author =       {Raviart, P. A. and Thomas, J. -M.},
   title =        {A mixed finite element method for second order elliptic problems},
   booktitle =    {Mathematical Aspects of the Finite Element Method},
   pages =        {292--315},
   year =         1977,
-  editor =       {I. Galligani and E. Magenes},
+  editor =       {Galligani, I. and Magenes, E.},
   address =      {New York},
   publisher =    {Springer}
 }
 
 
 @InCollection{RT91,
-  author =       {J.E. Roberts and  J.-M. Thomas},
+  author =       {Roberts, J. E. and  Thomas, J. -M.},
   title =        {Mixed and hybrid methods},
   booktitle =    {Handbook of Numerical Analysis},
   OPTcrossref =  {},
@@ -2975,7 +2975,7 @@ conservation laws based on a posteriori error estimates},
   pages =        {523--639},
   publisher =    {North-Holland},
   year =         {1991},
-  editor =       {Philippe G. Ciarlet and Jacques-Louis Lions},
+  editor =       {Ciarlet, P. G. and Lions, J. -L.},
   volume =       {II},
   OPTnumber =    {},
   OPTseries =    {},
@@ -2998,7 +2998,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{Ric88,
-  author =       {G. R. Richter},
+  author =       {Richter, G. R.},
   title =        {An optimal-order error estimate for the discontinuous {G}alerkin method},
   journal =      {Math. Comp.},
   year =         {1988},
@@ -3008,7 +3008,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{Rin40,
-  author =       {F. Ringleb},
+  author =       {Ringleb, F.},
   title =        {Exakte {L}\"osungen der {D}ifferentialgleichungen einer adiabatischen {G}asstr\"omung},
   journal =      {ZAMM},
   year =         1940,
@@ -3018,7 +3018,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{Riv84,
-  author =       {M. C. Rivara},
+  author =       {Rivara, M. C.},
   title =        {Mesh Refinement Processes Based on the Generalized Bisection of Simplices},
   journal =      {SIAM J. Numer. Anal.},
   year =         1984,
@@ -3028,7 +3028,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Book{Roe81,
-  author =       {P. Roe},
+  author =       {Roe, P.},
   title =        {The use of the {R}iemann problem in finite difference schemes},
   publisher =    {Springer},
   year =         1981,
@@ -3039,7 +3039,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{Rus85,
-  author  = {T. Russell},
+  author  = {Russell, T.},
   title   = {Time Stepping Along Characteristics with Incomplete Iteration
              for a {G}alerkin Approximation of Miscible Displacement in Porous
              Media},
@@ -3051,14 +3051,15 @@ conservation laws based on a posteriori error estimates},
 
 @Misc{SBES06,
   key =          {SBES},
-  author =       {J. T. Oden et al.},
+  author =       {Oden, J. T. and Belytschko, T. and Fish, J. and Hughes, T. J. and Johnson, C. 
+                  and Keyes, D. and Laub, A. and Petzold, L. and Srolovitz, D. and Yip, S.},
   title =        {Simulation-based engineering science},
   howpublished = {Report or the National Science Foundation Blue Ribbon Panel on Simulation-Base Engineering Science},
   year =         2006
 }
 
 @Article{SF93,
-  author =       {G. L. G. Sleijpen and D. R. Fokkema},
+  author =       {Sleijpen, G. L. G. and Fokkema, D. R.},
   title =        {Bicgstab(${L}$) for Linear Equations Involving
                   Unsymmetric Matrices with Complex Spectrum},
   journal =      {ETNA},
@@ -3069,7 +3070,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @TechReport{SH02,
-  author =       {E. S\"{u}li and P. Houston},
+  author =       {S\"{u}li, E. and Houston, P.},
   title =        {Adaptive Finite Element Approximation of Hyperbolic Problems},
   institution =  {Leicester University},
   year =         2002,
@@ -3080,7 +3081,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{SW81,
-  author =       {J. L. Steger and R.F. Warming},
+  author =       {Steger, J. L. and Warming, R. F.},
   title =        {Flux vector splitting of the inviscid gasdynamic equations with application to finite-difference methods.},
   journal =      {J. Comput. Phys.},
   year =         1981,
@@ -3088,7 +3089,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Article{SW94,
-  author =       {D. Silvester and A. Wathen},
+  author =       {Silvester, D. and Wathen, A.},
   title =        {Fast iterative solution of stabilised {S}tokes systems. {P}art
                   {II}: {U}sing general block preconditioners},
   journal =      {SIAM J. Numer. Anal.},
@@ -3104,14 +3105,14 @@ conservation laws based on a posteriori error estimates},
 }
 
 @Book{Sch91,
-  author =       {H. R. Schwarz},
+  author =       {Schwarz, H. R.},
   title =        {Methode der finite Elemente},
   publisher =    {B.G. Teubner Stuttgart},
   year =         1991
 }
 
 @Book{Sch98b,
-  author =       {C. Schwab},
+  author =       {Schwab, C.},
   title =        {$p$- and $hp$-Finite Element methods. Theory and Applications to Solid and Fluid Mechanics},
   publisher =    {Oxford University Press},
   year =         1998
@@ -3119,7 +3120,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{Sul92,
-  author =       {E. S{\"u}li},
+  author =       {S{\"u}li, E.},
   title =        {The accuracy of cell vertex finite volume methods on
                   quadrilateral meshes},
   journal =      {Math. Comp.},
@@ -3129,7 +3130,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @TechReport{Sul95,
-  author =       {E. S{\"u}li},
+  author =       {S{\"u}li, E.},
   title =        {A posteriori error analysis and global error control
                   for adaptive finite element approximations of
                   hyperbolic problems},
@@ -3141,7 +3142,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @InCollection{Sul98,
-  author =       {E. S\"uli},
+  author =       {S\"uli, E.},
   title =        {A posteriori error analysis and adaptivity for finite element
                   approximations of hyperbolic problems},
   booktitle =    {An introduction to recent developments in theory and numerics
@@ -3149,13 +3150,13 @@ conservation laws based on a posteriori error estimates},
   pages =        {123--194},
   publisher =    {Springer},
   year =         1998,
-  editor =       {D. Kr{\"o}ner and M. Ohlberger and C. Rhode},
+  editor =       {Kr{\"o}ner, D. and Ohlberger, M. and Rhode, C.},
   volume =       5,
   series =       {Lecture Notes in Comput. Sciences and Engrg.}
 }
 
 @Article{TR02,
-  author =       {A. J. Toreja and Rizwan-uddin},
+  author =       {Toreja, A. J. and Rizwan-uddin},
   title =        {Adaptive mesh refinement for the time-dependent
                   nodal integration method},
   journal =      {Nucl. Sc. Engrg.},
@@ -3167,7 +3168,7 @@ conservation laws based on a posteriori error estimates},
 
 
 @Article{Tad91,
-  author =       {E. Tadmor},
+  author =       {Tadmor, E.},
   title =        {Local error estimates for discontinuous solutions of nonlinear hyperbolic equations},
   journal =      {SIAM J. Numer. Anal.},
   year =         1991,
@@ -3176,7 +3177,7 @@ conservation laws based on a posteriori error estimates},
 }
 
 @PhdThesis{Ulb01,
-  author =       {S. Ulbrich},
+  author =       {Ulbrich, S.},
   title =        {Optimal control of nonlinear hyperbolic conservation laws with
 source terms},
   school =       {Faculty for Mathematics, Munich Technical University},
@@ -3196,7 +3197,7 @@ source terms},
 
 
 @Book{Var62,
-  author =       {Varga, Richard S.},
+  author =       {Varga, R. S.},
   title =        {Matrix Iterative Analysis},
   publisher =    {Prentice-Hall},
   year =         1962
@@ -3204,7 +3205,7 @@ source terms},
 
 
 @Article{Ver94,
-  author =       {R. Verf{\"u}rth},
+  author =       {Verf{\"u}rth, R.},
   title =        {A Posteriori Error Estimation and Adaptive Mesh-Refinement
                   Techniques},
   journal =      {J. Comp. Appl. Math.},
@@ -3214,7 +3215,7 @@ source terms},
 }
 
 @Book{Ver96,
-  author =       {R. Verf{\"u}rth},
+  author =       {Verf{\"u}rth, R.},
   title =        {A Review of A Posteriori Error Estimation and Adaptive Mesh Refinement
                   Techniques},
   publisher =    {Wiley/Teubner, New York, Stuttgart},
@@ -3222,7 +3223,7 @@ source terms},
 }
 
 @Article{Vor92,
-  author =       {H. van der Vorst},
+  author =       {van der Vorst, H.},
   title =        {{Bi-CGSTAB}: {A} Fast and Smoothly Converging Variant of
                   {Bi-CG} for the Solution of Nonsymmetric Linear Systems},
   journal =      {SIAM J. Sci. Stat. Comput.},
@@ -3234,7 +3235,7 @@ source terms},
 }
 
 @Article{WY00,
-  author =       {M. F. Wheeler and I. Yotov},
+  author =       {Wheeler, M. F. and Yotov, I.},
   title =        {Multigrid on the interface for mortar mixed finite element methods
                   for elliptic problems},
   journal =      {Comput. Methods Appl. Mech. Engrg.},
@@ -3245,7 +3246,7 @@ source terms},
 
 
 @Article{WY04,
-  author =       {M. F. Wheeler and I. Yotov},
+  author =       {Wheeler, M. F. and Yotov, I.},
   title =        {A posteriori error estimates for the mortar mixed finite
                   element method},
   journal =      {??},
@@ -3256,7 +3257,7 @@ source terms},
 
 
 @Book{Yos80,
-  author =       {K{\^o}saku Yosida},
+  author =       {Yosida, K.},
   title =        {Functional Analysis},
   publisher =    {Springer},
   year =         1980
@@ -3264,7 +3265,7 @@ source terms},
 
 
 @Article{Yot01,
-  author =       {I. Yotov},
+  author =       {Yotov, I.},
   title =        {Interface solvers and preconditioners of domain
                   decomposition type for multiphase flow in multiblock
                   porous media},
@@ -3275,14 +3276,14 @@ source terms},
 }
 
 @PhdThesis{Yot96,
-  author =       {I. Yotov},
+  author =       {Yotov, I.},
   title =        {Mixed finite element methods for flow in porous media},
   school =       {Rice University, Houston, Texas},
   year =         1996
 }
 
 @Article{Yse86,
-  author =       {H. Yserentant},
+  author =       {Yserentant, H.},
   title =        {On the Multi-Level Splitting of Finite Element Spaces},
   journal =      {Numer. Math.},
   year =         1986,
@@ -3292,7 +3293,7 @@ source terms},
 
 
 @Article{ZL01,
-  author =       {H. Zhang and E. E. Lewis},
+  author =       {Zhang, H. and Lewis, E. E.},
   title =        {An adaptive approach to variational nodeal diffusion
                   problems},
   journal =      {Nucl. Sc. Engrg.},
@@ -3302,7 +3303,7 @@ source terms},
 }
 
 @Article{ZL02,
-  author =       {H. Zhang and E. E. Lewis},
+  author =       {Zhang, H. and Lewis, E. E.},
   title =        {Spatial adaptivity applied to the variational nodel
                   $P_n$ equations},
   journal =      {Nucl. Sc. Engrg.},
@@ -3336,7 +3337,7 @@ source terms},
 
 
 @Article{ABC05,
-  author =       {M. Anderson and W. Bangerth and G. F. Carey},
+  author =       {Anderson, M. and Bangerth, W. and Carey, G. F.},
   title =        {Analysis of parameter sensitivity and experimental design
                   for a class of nonlinear partial differential equations},
   journal =      {Int. J. Numer. Meth. Fluids},
@@ -3347,7 +3348,7 @@ source terms},
 
 
 @InProceedings{BBR98,
-  author =       {R. Becker and M. Braack and R. Rannacher},
+  author =       {Becker, R. and Braack, M. and Rannacher, R.},
   title =        {Adaptive finite elements for reactive flows},
   bootitle =     {ENUMATH 97},
   crossref =     {enumath97},
@@ -3357,17 +3358,17 @@ source terms},
 
 
 @InProceedings{BBR98a,
-  author =       {R. Becker and M. Braack and R. Rannacher},
+  author =       {Becker, R. and Braack, M. and Rannacher, R.},
   title =        {An adaptive finite element method for combustion problems},
   booktitle =    {ENUMATH 97},
   pages =        {206--213},
   year =         1998,
-  editor =       {H. G. Bock, et al.},
+  editor =       {Bock, H. G. et al.},
   publisher =    {World Scientific Publ., Singapure}
 }
 
 @Article{BBR99a,
-  author =       {R. Becker and M. Braack and R. Rannacher},
+  author =       {Becker, R. and Braack, M. and Rannacher, R.},
   title =        {Numerical simulation of laminar
         flames at low {M}ach number by adaptive finite elements},
   journal =      {Combust. Theory Modelling},
@@ -3378,7 +3379,7 @@ source terms},
 
 
 @InProceedings{BBR99b,
-  author =       {R. Becker and M. Braack and R. Rannacher},
+  author =       {Becker, R. and Braack, M. and Rannacher, R.},
   title =        {Adaptive finite element methods for
         flow problems},
   booktitle =    {Proc. FoCM'99, Oxford, July 18-27},
@@ -3399,7 +3400,7 @@ source terms},
 }
 
 @Article{BBRW99b,
-  author =       {R. Becker and M. Braack and R. Rannacher and C. Waguet},
+  author =       {Becker, R. and Braack, M. and Rannacher, R. and Waguet, C.},
   title =        {Fast and reliable
         solution of the {N}avier-{S}tokes equations including chemistry},
   journal =      {Comput. Visual. Sci.},
@@ -3411,7 +3412,7 @@ source terms},
 
 
 @Article{BGH04,
-  author =       {W. Bangerth and M. Grote and C. Hohenegger},
+  author =       {Bangerth, W. and Grote, M. and Hohenegger, C.},
   title =        {Finite Element Method For Time Dependent Scattering:
                   Nonreflecting Boundary Condition, Adaptivity, and
                   Energy Decay},
@@ -3422,7 +3423,7 @@ source terms},
 }
 
 @TechReport{BHK06,
-  author =       {W. Bangerth and R. Hartmann and G. Kanschat},
+  author =       {Bangerth, W. and Hartmann, R. and Kanschat, G.},
   title =        {{deal.II} -- a General Purpose Object Oriented Finite Element Library},
   institution =  {Institute for Scientific Computation, Texas A\&M University},
   year =         2006,
@@ -3431,7 +3432,7 @@ source terms},
 
 
 @Article{BHK07,
-  author =       {W. Bangerth and R. Hartmann and G. Kanschat},
+  author =       {Bangerth, W. and Hartmann, R. and Kanschat, G.},
   title =        {{deal.II} -- a General Purpose Object Oriented Finite Element Library},
   journal =      {ACM Trans. Math. Softw.},
   year =         2007,
@@ -3443,7 +3444,7 @@ source terms},
 
 
 @Article{BJ08,
-  author =       {W. Bangerth and A. Joshi},
+  author =       {Bangerth, W. and Joshi, A.},
   title =        {Adaptive finite element methods for the solution of
                   inverse problems in optical tomography},
   journal =      {Inverse Problems},
@@ -3454,7 +3455,7 @@ source terms},
 
 
 @Article{BJR95,
-  author =       {R. Becker and C. Johnson and R. Rannacher},
+  author =       {Becker, R. and Johnson, C. and Rannacher, R.},
   title =        {Adaptive error control for multigrid finite element methods},
   journal =      {Computing},
   year =         1995,
@@ -3464,7 +3465,7 @@ source terms},
 
 
 @Article{BJS05,
-  author =       {W. Bangerth and A. Joshi and E. M. Sevick-Muraca},
+  author =       {Bangerth, W. and Joshi, A. and Sevick-Muraca, E. M.},
   title =        {Adaptive finite element methods for increased
                resolution in fluorescence optical tomography},
   journal =      {Progr. Biomed. Optics Imag.},
@@ -3475,7 +3476,7 @@ source terms},
 
 
 @InProceedings{BJS07b,
-  author =       {W. Bangerth and A. Joshi and E. M. Sevick-Muraca},
+  author =       {Bangerth, W. and Joshi, A. and Sevick-Muraca, E. M.},
   title =        {Inverse biomedical imaging using separately adapted meshes
                   for parameters and forward model variables},
   booktitle =    {Proceedings of the IEEE International Symposium on
@@ -3488,21 +3489,21 @@ source terms},
 @Manual{BK99m,
   title =        {{\tt deal.{I}{I}} Differential Equations Analysis Library,
                   Technical Reference},
-  author =       {W. Bangerth and T. Heister and G. Kanschat},
+  author =       {Bangerth, W. and Heister, T. and Kanschat. G.},
   year =         {2012},
   note =         {\texttt{http://www.dealii.org/}}
 }
 
 
 @Manual{deal.ii-publications,
-  author =       {W. Bangerth and G. Kanschat},
+  author =       {Bangerth W. and Kanschat, G.},
   title =        {Publications based on the {\tt deal.{I}{I}} library},
   note = {\texttt{http://www.dealii.org/developer/publications/toc.html}}
 }
 
 
 @TechReport{BK99tr,
-  author =       {W. Bangerth and G. Kanschat},
+  author =       {Bangerth, W. and Kanschat, G.},
   title =        {Concepts for Object-Oriented Finite Element Software -- the
                   \texttt{deal.II} library},
   institution =  {IWR Heidelberg},
@@ -3513,8 +3514,8 @@ source terms},
 
 
 @Article{BKMPW05,
-  author =       {W. Bangerth and H. Klie and V. Matossian
-                  and M. Parashar and M. Wheeler},
+  author =       {Bangerth, W. and Klie, H. and Matossian, V.
+                  and Parashar, M. and Wheeler, M.},
   title =        {An Autonomic Reservoir Framework for the Stochastic
                   Optimization of Well Placement},
   journal =      {Cluster Computing},
@@ -3524,7 +3525,7 @@ source terms},
 }
 
 @Article{BKR00,
-  author =       {R. Becker and H. Kapp and R. Rannacher},
+  author =       {Becker, R. and Kapp, H. and Rannacher, R.},
   title =        {Adaptive Finite Element Methods for Optimal Control
                   of Partial Differential Equations: {B}asic Concept},
   journal =      {SIAM J. Contr. Optim.},
@@ -3538,7 +3539,7 @@ source terms},
 
 
 @TechReport{BKS96,
-  author =       {R. Becker and G. Kanschat and F.-T. Suttmeier},
+  author =       {Becker, R. and Kanschat, G. and Suttmeier, F.-T.},
   title =        {Optimality Criteria for Adaptive Finite Element
                   Meshes},
   institution =  IWR,
@@ -3550,8 +3551,8 @@ source terms},
 
 
 @Article{BKWSS06,
-  author =       {W. Bangerth and H. Klie and M. F. Wheeler and
-                  P. Stoffa and M. Sen},
+  author =       {Bangerth, W. and Klie, H. and Wheeler, M. F. and
+                  Stoffa, P. and Sen, M.},
   title =        {On optimization algorithms for the reservoir oil
                   well placement problem},
   journal =      {Comp. Geosciences},
@@ -3561,7 +3562,7 @@ source terms},
 }
 
 @article{BR01,
-  author =       {R. Becker and R. Rannacher},
+  author =       {Becker, R. and Rannacher, R.},
   title =        {An optimal control approach to error estimation and mesh adaptation
 in finite element methods},
   journal =      {Acta Numerica},
@@ -3572,7 +3573,7 @@ in finite element methods},
 
 
 @Article{BR01a,
-  author =       {W. Bangerth and R. Rannacher},
+  author =       {Bangerth, W. and Rannacher, R.},
   title =        {Adaptive Finite Element Techniques for the Acoustic Wave Equation},
   journal =      {J. Comput. Acoustics},
   year =         2001,
@@ -3584,7 +3585,7 @@ in finite element methods},
 
 
 @Book{BR03,
-  author =       {W. Bangerth and R. Rannacher},
+  author =       {Bangerth, W. and Rannacher, R.},
   title =        {Adaptive Finite Element Methods for
                   Differential Equations},
   publisher =    {Birkh{\"a}user Verlag},
@@ -3594,12 +3595,12 @@ in finite element methods},
 
 
 @InProceedings{BR95,
-  author =       {R. Becker and R. Rannacher},
+  author =       {Becker, R. and Rannacher, R.},
   title =        {Weighted A Posteriori Error Control in {FE} Methods},
   booktitle =    {ENUMATH 95},
   pages =        {621--637},
   year =         1998,
-  editor =       {H. G. Bock, et al.},
+  editor =       {Bock, H. G., et al.},
   address =      {Paris},
   month =        {September},
   publisher = {World Scientific Publ., Singapure},
@@ -3609,17 +3610,17 @@ in finite element methods},
 
 
 @InProceedings{BR95short,
-  author =       {R. Becker and R. Rannacher},
+  author =       {Becker, R. and Rannacher, R.},
   title =        {Weighted A Posteriori Error Control in {FE} Methods},
   booktitle =    {Proc. of ENUMATH 95, in Proc. of ENUMATH 97},
   year =         1998,
-  editor =       {H. G. Bock and others},
+  editor =       {Bock, H. G. and others},
   address =      {Singapore},
   publisher =    {World Scientific},
 }
 
 @TechReport{BR96k,
-  author =       {K. B{\"o}ttcher and R. Rannacher},
+  author =       {B{\"o}ttcher, K. and Rannacher, R.},
   title =        {Adaptive error control in solving ordinary
                   differential equations by the discontinuous {G}alerkin
                   method},
@@ -3637,7 +3638,7 @@ in finite element methods},
 
 
 @Article{BR96r,
-  author =       {R. Becker and R. Rannacher},
+  author =       {Becker, R. and Rannacher, R.},
   title =        {A Feed-Back Approach to Error Control in Finite
                   Element Methods: {B}asic Analysis and Examples},
   journal =      EastWest,
@@ -3650,20 +3651,20 @@ in finite element methods},
 
 
 @InProceedings{BR98,
-  author =       {R. Becker and R. Rannacher},
+  author =       {Becker, R. and Rannacher, R.},
   title =        {A General Concept of Adaptivity in Finite Element
                   Methods with Applications to Problems in Fluid and
                   Structural Mechanics},
   booktitle =    {Grid Generation and Adaptive Algorithms},
   year =         1999,
-  editor =       {Marshall Bern and Joseph E. Flaherty and Mitchell Luskin},
+  editor =       {Bern, M. and Flaherty, J. E. and Luskin, M.},
   volume =       113,
   series =       {IMA Volumes in Mathematics and its Applications},
   publisher =    {Springer}
 }
 
 @Article{BR99b,
-  author =       {W. Bangerth and R. Rannacher},
+  author =       {Bangerth, W. and Rannacher, R.},
   title =        {Finite element approximation of the acoustic wave equation: {E}rror
                   control and mesh adaptation},
   journal =      {East--West J. Numer. Math.},
@@ -3675,12 +3676,12 @@ in finite element methods},
 
 
 @InProceedings{BR99c,
-  author =       {M. Braack and R. Rannacher},
+  author =       {Braack, M. and Rannacher, R.},
   title =        {Adaptive finite element methods for
         low-{M}ach-number flows with chemical reactions},
   booktitle =    {30th Computational Fluid Dynamics},
   year =         1999,
-  editor =       {H. Deconinck},
+  editor =       {Deconinck, H.},
   volume =       3,
   series =       {Lecture Series},
   publisher = {von Karman Institute of Fluid Dynamics, Brussels}
@@ -3688,7 +3689,7 @@ in finite element methods},
 
 
 @Article{BS00,
-  author =       {H. Blum and F.-T. Suttmeier},
+  author =       {Blum, H. and Suttmeier, F.-T.},
   title =        {Weighted Error Estimates for Finite Element Solutions
                   of Variational Inequalities},
   journal =      {Computing},
@@ -3699,7 +3700,7 @@ in finite element methods},
 
 
 @Misc{BV02,
-  author =       {R. Becker and B. Vexler},
+  author =       {Becker, R. and Vexler, B.},
   title =        {Mesh adaptation for parameter identification problems},
   howpublished = {Proceedings of ENUMATH 2001},
   year =         2002,
@@ -3710,7 +3711,7 @@ in finite element methods},
 
 
 @Article{BV03,
-  author =       {R. Becker and B. Vexler},
+  author =       {Becker, R. and Vexler, B.},
   title =        {A posteriori error estimation for finite element
                   discretization of parameter identification problems},
   journal =      {Numer. Math.},
@@ -3720,7 +3721,7 @@ in finite element methods},
 }
 
 @MastersThesis{Bac97,
-  author =       {E. Backes},
+  author =       {Backes, E.},
   title =        {{G}ewichtete a posteriori {F}ehleranalyse bei der adaptiven
                   {F}inite-{E}lemente-{M}ethode: Ein {V}ergleich zwischen {R}esiduen- und
                   {B}ank-{W}eiser-{S}ch{\"a}tzer},
@@ -3730,18 +3731,18 @@ in finite element methods},
 }
 
 @InProceedings{Ban00i,
-  author =       {W. Bangerth},
+  author =       {Bangerth, W.},
   title =        {Using Modern Features of {C}++ for Adaptive Finite Element Methods:
                   {D}imension-Independent Programming in deal.{I}{I}},
   booktitle =    {Proceedings of the 16th IMACS World Congress 2000, Lausanne,
                   Switzerland, 2000},
   year =         2000,
-  editor =       {Michel Deville and Robert Owens},
+  editor =       {Deville, M. and Owens, R.},
   note =         {{D}ocument Sessions/118-1}
 }
 
 @TechReport{Ban00mt,
-  author =       {W. Bangerth},
+  author =       {Bangerth, W.},
   title =        {Multi-threading support in \texttt{deal.II}},
   institution =  SFB,
   year =         2000,
@@ -3751,7 +3752,7 @@ in finite element methods},
 }
 
 @InProceedings{Ban00w,
-  author =       {W. Bangerth},
+  author =       {Bangerth, W.},
   title =        {Mesh Adaptivity and Error Control for a Finite Element
                   Approximation of the Elastic Wave
                   Equation},
@@ -3760,13 +3761,13 @@ in finite element methods},
                   de Compostela, Spain, 2000},
   pages =        {725--729},
   year =         2000,
-  editor =       {Alfredo Berm\'udez and Dolores G\'omez and Christophe Hazard and
-                  Patrick Joly and Jean E. Roberts},
+  editor =       {Berm\'udez, A. and G\'omez, D. and Hazard, C. and
+                  Joly, P. and Roberts, J. E.},
   publisher =    {SIAM}
 }
 
 @PhdThesis{Ban02,
-  author =       {W. Bangerth},
+  author =       {Bangerth, W.},
   title =        {Adaptive Finite Element Methods for the Identification
                   of Distributed Parameters in Partial Differential
                   Equations},
@@ -3775,7 +3776,7 @@ in finite element methods},
 }
 
 @Article{Ban03cuj,
-  author =       {W. Bangerth},
+  author =       {Bangerth, W.},
   title =        {Starting threads in a {C}++ compatible fashion},
   journal =      {C/C++ Users Journal},
   year =         2003,
@@ -3785,7 +3786,7 @@ in finite element methods},
 
 
 @TechReport{Ban03ip1,
-  author =       {W. Bangerth},
+  author =       {Bangerth, W.},
   title =        {A framework for the adaptive finite element solution of
                   large inverse problems. {I}. {B}asic techniques},
   institution =  {Institute for Computational Engineering and Sciences (ICES), University of Texas at Austin},
@@ -3795,7 +3796,7 @@ in finite element methods},
 
 
 @TechReport{Ban04,
-  author =       {W. Bangerth},
+  author =       {Bangerth, W.},
   title =        {A framework for the adaptive finite element solution of
                   large inverse problems. I. Basic techniques},
   institution =  {Institute for Computational Engineering and Sciences, The
@@ -3808,7 +3809,7 @@ in finite element methods},
 
 
 @Article{Ban08ip,
-  author =       {W. Bangerth},
+  author =       {Bangerth, W.},
   title =        {A framework for the adaptive finite element solution of
                   large inverse problems},
   journal =      {SIAM J. Sc. Comput.},
@@ -3820,7 +3821,7 @@ in finite element methods},
 
 
 @MastersThesis{Ban98,
-  author =       {W. Bangerth},
+  author =       {Bangerth, W.},
   title =        {{A}daptive {F}inite-{E}lemente-{M}ethoden zur {L}{\"o}sung der
                   {W}ellengleichung mit {A}nwendung in der {P}hysik der {S}onne},
   school =       {Institut f{\"u}r Angewandte Mathematik, Universit{\"a}t Heidelberg},
@@ -3830,7 +3831,7 @@ in finite element methods},
 
 
 @Misc{Bec01,
-  author =       {R. Becker},
+  author =       {Becker, R.},
   title =        {Adaptive finite elements for optimal control problems},
   howpublished = {Habilitation thesis, University of Heidelberg},
   year =         2001
@@ -3838,7 +3839,7 @@ in finite element methods},
 
 
 @PhdThesis{Bec95,
-  author =       {R. Becker},
+  author =       {Becker, R.},
   title =        {An Adaptive Finite Element Method for the
                   Incompressible {N}avier-{S}tokes Equations on
                   Time-dependent Domains},
@@ -3849,7 +3850,7 @@ in finite element methods},
 
 
 @TechReport{Bec98,
-  author =       {R. Becker},
+  author =       {Becker, R.},
   title =        {Weighted error estimators for finite element approximations of the
         incompressible {N}avier-{S}tokes equations},
   institution =  {SFB 359, Universit{\"a}t Heidelberg},
@@ -3861,7 +3862,7 @@ in finite element methods},
 
 
 @Article{Bel05,
-  author =       {W. Bell},
+  author =       {Bell, W.},
   title =        {Good prospects},
   journal =      {Access, the quarterly journal of NCSA},
   year =         2005,
@@ -3877,19 +3878,19 @@ in finite element methods},
 
 
 @InCollection{Boc81,
-  author =       {H. G. Bock},
+  author =       {Bock, H. G.},
   title =        {Numerical treatment of inverse problems in chemical reaction kinetics},
   booktitle =    {Modelling of Chemical Reaction Systems},
   publisher =    {Springer},
   year =         {1981},
-  editor =       {K. H. Ebert and P. Deufl\-hard and W. J{\"a}ger},
+  editor =       {Ebert, K. H. and Deufl\-hard, P. and J{\"a}ger, W.},
   volume =       {18},
   series =       {Springer Series in Chemical Physics},
   address =      {Heidelberg}
 }
 
 @Book{Boc87,
-  author =       {H. G. Bock},
+  author =       {Bock, H. G.},
   title  =       {Randwertproblemmethoden zur Parameteridentifizierung in
                   Systemen nichtlinearer Differentialgleichungen},
   publisher =    {University of Bonn},
@@ -3902,7 +3903,7 @@ in finite element methods},
 
 
 @PhdThesis{Bra98,
-  author =       {M. Braack},
+  author =       {Braack, M.},
   title =        {An Adaptive Finite Element Method for Reactive Flow Problems},
   school =       {Universit{\"a}t Heidelberg},
   year =         1998,
@@ -3911,9 +3912,9 @@ in finite element methods},
 
 
 @Article{CBWKACB04,
-  author =       {G. F. Carey and W. Barth and J. A. Woods
-                  and B. Kirk and M. L. Anderson and S. Chow
-                  and W. Bangerth},
+  author =       {Carey, G. F. and Barth, W. and Woods, J. A.
+                  and Kirk, B. and Anderson, M. L. and Chow, S.
+                  and Bangerth, W.},
   title =        {Modeling error and constitutive relations in simulation
                   of flow and transport},
   journal =      {International Journal for Numerical Methods in Fluids},
@@ -3924,8 +3925,8 @@ in finite element methods},
 
 
 @Article{CKPS01,
-  author =       {B. Cockburn and G. Kanschat and I. Perugia and
-                  D. Sch{\"o}tzau},
+  author =       {Cockburn, B. and Kanschat, G. and Perugia, I. and
+                  Sch{\"o}tzau, D.},
   title =        {Superconvergence of the Local Discontinuous {G}alerkin
                   Method for Elliptic Problems on Cartesian Grids},
   journal =      {SIAM J. Numer. Anal.},
@@ -3937,7 +3938,7 @@ in finite element methods},
 
 
 @Article{CKSS,
-  author =       {B. Cockburn and G. Kanschat and D. Sch{\"o}tzau and C. Schwab},
+  author =       {Cockburn, B. and Kanschat, G. and Sch{\"o}tzau, D. and Schwab, C.},
   title =        {Local discontinuous {G}alerkin methods for the {S}tokes
                       system},
   journal =      {SIAM J. Numer. Anal.},
@@ -3953,7 +3954,7 @@ in finite element methods},
 
 
 @TechReport{DBS01,
-  author =       {M. Diehl and H. G. Bock and J. P. Schl{\"o}der},
+  author =       {Diehl, M. and Bock, H. G. and Schl{\"o}der, J. P.},
   title =        {Newton Type Methods for the Approximate Solution
                   of Nonlinear Programming Problems in  Real-Time},
   institution = {University of Heidelberg},
@@ -3964,7 +3965,7 @@ in finite element methods},
 
 @Manual{DEAL,
   title =        {\texttt{deal.II} Homepage},
-  author =       {W. Bangerth and G. Kanschat},
+  author =       {Bangerth, W. and Kanschat, G.},
   address =      {{\texttt{http://gaia.iwr.uni-heidelberg.de/\~{}deal/}}}
 }
 
@@ -3972,7 +3973,7 @@ in finite element methods},
 
 
 @TechReport{Die01,
-  author =       {A. Dieses},
+  author =       {Dieses, A.},
   title =        {Numerical Methods for Optimization Problems in Water Flow and Reactive Solute Transport Processes of Xenobiotics in Soils},
   institution =  {University of Heidelberg},
   year =         2001,
@@ -3983,7 +3984,7 @@ in finite element methods},
 
 
 @Article{FK97,
-  author =       {C. F{\"u}hrer and G. Kanschat},
+  author =       {F{\"u}hrer, C. and Kanschat, G.},
   title =        {A Posteriori Error Control in Radiative Transfer},
   journal =      {Computing},
   year =         {1997},
@@ -3994,7 +3995,7 @@ in finite element methods},
 
 
 @Article{FR96,
-  author =       {C. F{\"u}hrer and R. Rannacher},
+  author =       {F{\"u}hrer, C. and Rannacher, R.},
   title =        {Error Analysis for the Finite Element Approximation
                   of a Radiative Transfer Model},
   journal =      {M$^2$AN},
@@ -4007,7 +4008,7 @@ in finite element methods},
 
 
 @Article{FR97,
-  author =       {C. F{\"u}hrer and R. Rannacher},
+  author =       {F{\"u}hrer, C. and Rannacher, R.},
   title =        {An adaptive streamline--diffusion finite element method for hyperbolic
         conservation laws},
   journal =      EastWest,
@@ -4019,7 +4020,7 @@ in finite element methods},
 
 
 @MastersThesis{Fuh93,
-  author =       {C. F{\"u}hrer},
+  author =       {F{\"u}hrer, C.},
   title =        {{F}inite--{E}lemente--{D}is\-kre\-ti\-sie\-run\-gen
                   der 2D--{S}trah\-lungs\-trans\-port\-gleich\-ung},
   school =       {Universit{\"a}t Heidelberg},
@@ -4031,7 +4032,7 @@ in finite element methods},
 
 
 @PhdThesis{Fuh97,
-  author =       {C. F{\"u}hrer},
+  author =       {F{\"u}hrer, C.},
   title =        {Adaptive Error Control for Hyperbolic Problems},
   school =       IAM,
   year =         1997,
@@ -4039,7 +4040,7 @@ in finite element methods},
 }
 
 @Article{GK,
-  author =       {J. Gopalakrishnan and G. Kanschat},
+  author =       {Gopalakrishnan, J. and Kanschat, G.},
   title =        {A Multilevel Discontinuous {G}alerkin Method},
   journal =      {Numer. Math},
   year =         {to appear},
@@ -4055,7 +4056,7 @@ in finite element methods},
 
 
 @Article{HH01,
-  author =       {R. Hartmann and P. Houston},
+  author =       {Hartmann, R. and Houston, P.},
   title =        {Adaptive Discontinuous {G}alerkin Finite Element Methods
                   for Nonlinear Hyperbolic Conservation Laws},
   journal =      {SIAM J. Sci. Comput.},
@@ -4065,7 +4066,7 @@ in finite element methods},
 }
 
 @InProceedings{HH01a,
-  author =       {P. Houston and R. Hartmann},
+  author =       {Houston, P. and Hartmann, R.},
   title =        {Goal--Oriented A Posteriori Error Estimation for Compressible Fluid Flows},
   booktitle =    {Proceedings of ENUMATH 2001},
   note =         {Submitted},
@@ -4073,7 +4074,7 @@ in finite element methods},
 }
 
 @Article{HH01b,
-  author =       {R. Hartmann and P. Houston},
+  author =       {Hartmann, R. and Houston, P.},
   title =        {Adaptive Discontinuous {G}alerkin Finite Element Methods for the Compressible {E}uler Equations},
   journal =      {J. Comput. Phys.},
   year =         2002,
@@ -4082,7 +4083,7 @@ in finite element methods},
 }
 
 @InProceedings{HH02a,
-  author =       {R. Hartmann and P. Houston},
+  author =       {Hartmann, R. and Houston, P.},
   title =        {Goal-Oriented A Posteriori Error Estimation for Multiple Target Functionals},
   booktitle =    {Hyperbolic problems: theory, numerics, applications: ninth international conference in Pasadena, California, 2002},
   year =         2002,
@@ -4091,14 +4092,14 @@ in finite element methods},
 }
 
 @Misc{HH02b,
-  author =       {R. Hartmann and P. Houston},
+  author =       {Hartmann, R. and Houston, P.},
   title =        {A posteriori error estimation for nonlinear hyperbolic conservation
 laws involving discontinuous solutions},
   note =         {In preparation}
 }
 
 @Article{HH06,
-  author =       {R. Hartmann and P. Houston},
+  author =       {Hartmann, R. and Houston, P.},
   title =        {Symmetric Interior Penalty DG Methods for the Compressible Navier-Stokes Equations II: Goal-Oriented A Posteriori Error Estimation},
   journal =      {Int. J. Numer. Anal. Model.},
   year =         2006,
@@ -4107,17 +4108,17 @@ laws involving discontinuous solutions},
 }
 
 @InProceedings{HHS01,
-  author =       {P. Houston and R. Hartmann and A. S{\"u}li},
+  author =       {Houston, P. and Hartmann, R. and S{\"u}li, A.},
   title =        {Adaptive Discontinuous {G}alerkin Finite Element Methods for compressible Fluid Flows.},
   booktitle =    {Numerical methods for Fluid Dynamics VII, ICFD},
   pages =        {347--353},
   year =         2001,
-  editor =       {M. Baines}
+  editor =       {Baines, M.}
 }
 
 @Article{HPJRBS06,
-  author =       {K. Hwang and T. Pan and A. Joshi and
-              J. C. Rasmussen and W. Bangerth and E. M. Sevick-Muraca},
+  author =       {Hwang, K. and Pan, T. and Joshi, A. and
+                  Rasmussen, J. C. and Bangerth, W. and Sevick-Muraca, E. M.},
   title =        {Influence of excitation light rejection on
               forward model mismatch in optical
               tomography},
@@ -4129,7 +4130,7 @@ laws involving discontinuous solutions},
 }
 
 @Article{HR00a,
-  author =       {A. Hujeirat and R. Rannacher},
+  author =       {Hujeirat, A. and Rannacher, R.},
   title =        {Towards implicit methods in computational astrophysics},
   journal =      {New Astronomy Review},
   year =         {2000},
@@ -4142,17 +4143,17 @@ laws involving discontinuous solutions},
 }
 
 @InCollection{HR00b,
-  author =       {V. Heuveline and R. Rannacher},
+  author =       {Heuveline, V. and Rannacher, R.},
   title =        {A numerical tool for flow simulation in a {W}ankel motor},
   booktitle =    {Mathematik: Schl{\"u}sseltechnologie f{\"u}r die Zukunft},
   publisher =    {Springer, Berlin-Heidelberg},
   year =         2000,
-  editor =       {K.-H.. Hoffmann, et al.},
+  editor =       {Hoffmann, K. -H. et al.},
   note =         {to appear}
 }
 
 @Article{HR82,
-  author =       {J. G. Heywood and R. Rannacher},
+  author =       {Heywood, J. G. and Rannacher, R.},
   title =        {Finite Element Approximation of the Nonstationary {N}avier-{S}tokes
                   Problem. {I}. {R}egularity of Solutions and Second-Order Error
                   Estimates for Spatial Discretization},
@@ -4163,7 +4164,7 @@ laws involving discontinuous solutions},
 }
 
 @Article{HR98,
-  author =       {A. Hujeirat and R. Rannacher},
+  author =       {Hujeirat, A. and Rannacher, R.},
   title =        {A Method for Computing Compressible, Highly
                   Stratified Flows in Astrophysics Based on Operator
                   Splitting},
@@ -4175,7 +4176,7 @@ laws involving discontinuous solutions},
 
 
 @Article{HR99,
-  author =       {F.-K. Hebeker and R. Rannacher},
+  author =       {Hebeker, F. -K. and Rannacher, R.},
   title =        {An adaptive finite element method for unsteady convection--dominated flows
         with stiff source terms},
   journal =      {SIAM J. Sci. Comp.},
@@ -4185,7 +4186,7 @@ laws involving discontinuous solutions},
 }
 
 @Misc{HRS98,
-  author =       {P. Houston and R. Rannacher and E. S{\"u}li},
+  author =       {Houston, P. and Rannacher, R. and S{\"u}li, E.},
   title =        {Adaptive finite
         element methods for stationary conservation laws},
   OPThowpublished = {},
@@ -4197,7 +4198,7 @@ laws involving discontinuous solutions},
 
 
 @Article{HRS99,
-  author =       {P. Houston and R. Rannacher and E. S{\"u}li},
+  author =       {Houston, P. and Rannacher, R. and S{\"u}li, E.},
   title =        {A posteriori error analysis for stabilised finite
                   element approximations of transport problems},
   journal =      {Comput. Meth. Appl. Mech. Engrg.},
@@ -4209,7 +4210,7 @@ laws involving discontinuous solutions},
 
 
 @Article{HRT96,
-  author =       {J. Heywood and R. Rannacher and S. Turek},
+  author =       {Heywood, J. and Rannacher, R. and Turek, S.},
   title =        {Artificial boundaries and Flux and Pressure
                   Conditions for the Incompressible {N}avier-{S}tokes
                   equations},
@@ -4221,11 +4222,11 @@ laws involving discontinuous solutions},
 
 
 @InProceedings{Har00a,
-  author =       {R. Hartmann},
+  author =       {Hartmann, R.},
   title =        {Adaptive {FE} {M}ethods for {C}onservation {E}quations},
   booktitle =    {Hyperbolic Problems: theory, numerics, applications: eighth international conference in {M}agdeburg, February, March 2000},
   year =         2001,
-  editor =       {Heinrich Freist{\"u}hler and Gerald Warnecke},
+  editor =       {Freist{\"u}hler, H. and Warnecke, G.},
   volume =       2,
   series =       {International series of numerical mathematics; Vol. 141},
   publisher =    {Birkh{\"a}user, Basel},
@@ -4233,7 +4234,7 @@ laws involving discontinuous solutions},
 }
 
 @TechReport{Har00b,
-  author =       {R. Hartmann},
+  author =       {Hartmann, R.},
   title =        {A comparison of adaptive {SDFEM} and {DG}(r) method for linear
   transport problems.},
   institution =  {Institut f{\"u}r Angewandte Mathematik, Universit{\"a}t
@@ -4243,21 +4244,21 @@ laws involving discontinuous solutions},
 }
 
 @PhdThesis{Har02,
-  author =       {R. Hartmann},
+  author =       {Hartmann, R.},
   title =        {Adaptive Finite Element Methods for the Compressible Euler Equations},
   school =       {University of Heidelberg},
   year =         2002
 }
 
 @Article{Har06,
-  author =       {R. Hartmann},
+  author =       {Hartmann, R.},
   title =        {Adaptive discontinuous Galerkin methods with shock-capturing for the compressible Navier-Stokes equations},
   journal =      {Int. J. Numer. Meth. Fluids},
   year =         {2006, to appear}
 }
 
 @MastersThesis{Har98,
-  author =       {R. Hartmann},
+  author =       {Hartmann, R.},
   title =        {A posteriori {F}ehlersch{\"a}tzung und adaptive {S}chrittweiten- und
         {O}rtsgittersteuerung bei {G}alerkin-{V}erfahren f{\"u}r die
                   {W}{\"a}rmeleitungsgleichung},
@@ -4267,8 +4268,8 @@ laws involving discontinuous solutions},
 }
 
 @Article{JBHRS06a,
-  author =       {A. Joshi and W. Bangerth and K. Hwang and J. C. Rasmussen
-                  and E. M. Sevick-Muraca},
+  author =       {Joshi, A. and Bangerth, W. and Hwang, K. and Rasmussen, J. C.
+                  and Sevick-Muraca, E. M.},
   title =        {Plane wave fluorescence tomography with adaptive finite elements},
   journal =      {Optics Letters},
   year =         2006,
@@ -4277,8 +4278,8 @@ laws involving discontinuous solutions},
 }
 
 @Article{JBHRS06b,
-  author =       {A. Joshi and W. Bangerth and K. Hwang and J. C. Rasmussen
-                  and E. M. Sevick-Muraca},
+  author =       {Joshi, A. and Bangerth, W. and Hwang, K. and Rasmussen, J. C.
+                  and Sevick-Muraca, E. M.},
   title =        {Fully adaptive {FEM} based fluorescence optical
               tomography from time-dependent measurements with area
               illumination and detection},
@@ -4291,7 +4292,7 @@ laws involving discontinuous solutions},
 
 
 @Article{JBS04,
-  author =       {A. Joshi and W. Bangerth and E. M. Sevick-Muraca},
+  author =       {Joshi, A. and Bangerth, W. and Sevick-Muraca, E. M.},
   title =        {Adaptive finite element modeling of optical
                   fluorescence-enhanced tomography},
   journal =      {Optics Express},
@@ -4304,7 +4305,7 @@ laws involving discontinuous solutions},
 
 
 @InProceedings{JBS06,
-  author =       {A. Joshi and W. Bangerth and E. M. Sevick-Muraca},
+  author =       {Joshi, A. and Bangerth, W. and Sevick-Muraca, E. M.},
   title =        {Non-contact fluorescence optical tomography with scanning
                   area illumination},
   booktitle =    {Proceedings of the IEEE International Symposium on
@@ -4316,7 +4317,7 @@ laws involving discontinuous solutions},
 
 
 @Article{JBS06a,
-  author =       {A. Joshi and W. Bangerth and E. M. Sevick-Muraca},
+  author =       {Joshi, A. and Bangerth, W. and Sevick-Muraca, E. M.},
   title =        {Non-contact fluorescence
                   optical tomography with scanning patterned illumination},
   journal =      {Optics Express},
@@ -4327,8 +4328,8 @@ laws involving discontinuous solutions},
 
 
 @InProceedings{JBSWS07,
-  author =       {A. Joshi and W. Bangerth and R. Sharma and
-                  W. Wang and E. M. Sevick-Muraca},
+  author =       {Joshi, A. and Bangerth, W. and Sharma, R. and
+                  Wang, W. and Sevick-Muraca, E. M.},
   title =        {Molecular tomographic imaging of lymph nodes with {NIR}
                   fluorescence},
   booktitle =    {Proceedings of the IEEE International Symposium on
@@ -4340,8 +4341,8 @@ laws involving discontinuous solutions},
 
 
 @InProceedings{JBTS04,
-  author =       {A. Joshi and W.
-                  Bangerth and A. B. Thompson and E. M. Sevick-Muraca},
+  author =       {Joshi A. and
+                  Bangerth, W. and Thompson, A. B. and Sevick-Muraca, E. M.},
   title =        {Adaptive finite element methods for
                   fluorescence enhanced frequency domain optical
                   tomography: Forward imaging problem},
@@ -4352,8 +4353,8 @@ laws involving discontinuous solutions},
 
 
 @Article{JBTS05,
-  author =       {A. Joshi and W. Bangerth and A. B. Thompson and
-                  E. M. Sevick-Muraca},
+  author =       {Joshi, A. and Bangerth, W. and Thompson, A. B. and
+                  Sevick-Muraca, E. M.},
   title =        {Experimental fluorescence optical tomography using
                   adaptive finite elements and planar illumination with
                   modulated excitation light},
@@ -4365,7 +4366,7 @@ laws involving discontinuous solutions},
 
 
 @Article{JRB95,
-  author =       {C. Johnson and R. Rannacher and M. Boman},
+  author =       {Johnson, C. and Rannacher. R. and Boman, M.},
   title =        {Numerics and Hydrodynamic Stability: Towards Error Control
                   in Computational Fluid Dynamics},
   journal =      {SIAM J. Numer. Anal.},
@@ -4376,8 +4377,8 @@ laws involving discontinuous solutions},
 
 
 @InProceedings{JTSB04,
-  author =       {A. Joshi and A. B. Thompson and E. M. Sevick-Muraca
-                  and W. Bangerth},
+  author =       {Joshi, A. and Thompson, A. B. and Sevick-Muraca, E. M.
+                  and Bangerth, W.},
   title =        {Adaptive finite element methods for forward modeling in
                   fluorescence enhanced frequency domain optical tomography},
   booktitle =    {Proceedings of the 2004 OSA Biomedical Topical Meetings},
@@ -4386,10 +4387,10 @@ laws involving discontinuous solutions},
 
 
 @Article{KBGWSSPCSK05,
-  author =       {H. Klie and W. Bangerth and X. Gai and
-                  M. F. Wheeler and P. L. Stoffa and M. Sen and
-                  M. Parashar and U. Catalyurek and J. Saltz and
-                  T. Kurc},
+  author =       {Klie, H. and Bangerth, W. and Gai, X. and
+                  Wheeler, M. F. and Stoffa, P. L. and Sen, M. and
+                  Parashar, M. and Catalyurek, U. and Saltz, J. and
+                  Kurc, T.},
   title =        {Models, methods and middleware for {G}rid-enabled
                   multiphysics oil reservoir management},
   journal =      {Engineering with Computers},
@@ -4405,8 +4406,8 @@ laws involving discontinuous solutions},
 
 
 @InProceedings{KBWPM04,
-  author =       {H. Klie and W. Bangerth and M. Wheeler
-                  and M. Parashar and V. Matossian},
+  author =       {Klie, H. and Bangerth, W. and Wheeler, M.
+                  and Parashar, M. and Matossian, V.},
   title =        {Parallel well location optimization using stochastic
                   algorithms on the Grid computational framework},
   booktitle =    {Proceedings of the 9th European Conference on the
@@ -4416,7 +4417,7 @@ laws involving discontinuous solutions},
 
 
 @TechReport{KR98,
-  author =       {G. Kanschat and R. Rannacher},
+  author =       {Kanschat, G. and Rannacher, R.},
   title =        {A posteriori error analysis for the dual-mixed discontinuous finite
         element {G}alerkin approximation of transport-dominated advection-diffusion
         problem},
@@ -4433,14 +4434,14 @@ laws involving discontinuous solutions},
 
 
 @InProceedings{KS00dgm,
-  author =       {G. Kanschat and F.-T. Suttmeier},
+  author =       {Kanschat, G. and Suttmeier, F. -T.},
   title =        {A Posteriori Error Estimates in the Case of Insufficient
                   Regularity of the Discrete Space},
   booktitle =    {Discontinuous {G}alerkin Methods:
                   Theory, Computation and Applications},
   pages =        {349--354},
   year =         2000,
-  editor =       {Cockburn and B. and Karniadakis and G. and Shu, C.-W.},
+  editor =       {Cockburn, B. and Karniadakis, G. and Shu, C. -W.},
   volume =       11,
   series =       LNCSE,
   publisher =    {Springer}
@@ -4448,7 +4449,7 @@ laws involving discontinuous solutions},
 
 
 @Unpublished{KS92,
-  author =       {G. Kanschat and F.-T. Suttmeier},
+  author =       {Kanschat, G. and Suttmeier, F. T.},
   title =        {{D}atenstrukturen f{\"u}r die {M}ethode der finiten {E}lemente},
   note =         {unpublished, Bonn-Venusberg},
   OPTkey =       {},
@@ -4458,7 +4459,7 @@ laws involving discontinuous solutions},
 }
 
 @Article{KS99c,
-  author =       {G. Kanschat and F.-T. Suttmeier},
+  author =       {Kanschat, G. and Suttmeier, F. -T.},
   title =        {A Posteriori Error Estimates for Nonconforming
                   Finite Element Schemes},
   journal =      {Calcolo},
@@ -4471,13 +4472,13 @@ laws involving discontinuous solutions},
 
 
 @InProceedings{Kan00ima,
-  author =       {G. Kanschat},
+  author =       {Kanschat, G.},
   title =        {Solution of Multi-Dimensional Radiative Transfer
                   Problems on Parallel Computers},
   booktitle =    {Parallel Solution of Partial Differential Equations},
   pages =        {85--96},
   year =         2000,
-  editor =       {Petter Bj{\o}rstad and Mitchell Luskin},
+  editor =       {Bj{\o}rstad, P. and Luskin, M.},
   volume =       120,
   series =       {IMA Volumes in Mathematics and its Applications},
   address =      {New York},
@@ -4487,13 +4488,13 @@ laws involving discontinuous solutions},
 
 
 @InProceedings{Kan95,
-  author =       {G. Kanschat},
+  author =       {Kanschat, G.},
   title =        {Parallel Adaptive Algorithms for Radiative Transfer
                   Problems},
   booktitle =    {Parallel Programming and Applications},
   organization = {ZEUS},
   year =         1995,
-  editor =       {Peter Fritzson and Leif Finmo},
+  editor =       {Fritzson, P. and Finmo, L.},
   publisher =    {{IOS} {P}ress},
   address =      {Amsterdam},
   pages =        {238--243},
@@ -4502,7 +4503,7 @@ laws involving discontinuous solutions},
 }
 
 @PhdThesis{Kan96,
-  author =       {G. Kanschat},
+  author =       {Kanschat, G.},
   title =        {Parallel and Adaptive {G}alerkin Methods for Radiative
                   Transfer Problems},
   school =       {Universit{\"a}t Heidelberg},
@@ -4513,33 +4514,33 @@ laws involving discontinuous solutions},
 
 
 @InProceedings{Kan97i,
-  author =       {G. Kanschat},
+  author =       {Kanschat G.},
   title =        {New Algorithms for Radiative Transfer in Accretion
                   Disks and Surroundings},
   booktitle =    {IAU Colloquium 163: Accretion Phenomena and Related
                   Outflows},
   year =         {1997},
-  editor =       {D. T. Wickramasinghe and G. V. Bicknell and
-                  L. Ferrario},
+  editor =       {Wickramasinghe, D. T. and Bicknell, G. V. and
+                  Ferrario, L.},
   publisher =    {Astronomical Society of the Pacific},
   address =      {San Francisco, California},
   pages =        {736-737}
 }
 
 @InProceedings{Kan97m,
-  author =       {G. Kanschat},
+  author =       {Kanschat, G.},
   title =        {Efficient and Reliable Solution of Multi-Dimensional
                   Radiative Transfer Problems},
   booktitle =    {Multiscale Phenomena and Their Simulation},
   year =         1997,
-  editor =       {Frithjof Karsch and Burkhard Monien and Helmut Satz},
+  editor =       {Karsch, F. and Monien, B. and Satz, H.},
   publisher =    {World Scientific},
   address =      {Singapore},
   pages =        {245--249}
 }
 
 @Article{Kan98e,
-  author =       {G. Kanschat},
+  author =       {Kanschat, G.},
   title =        {A robust finite element discretization for
                   radiative transfer problems with scattering},
   journal =      EastWest,
@@ -4551,14 +4552,14 @@ laws involving discontinuous solutions},
 
 
 @InProceedings{Kan99f,
-  author =       {G. Kanschat},
+  author =       {Kanschat, G.},
   title =        {Parallel Computation of Multi-dimensional Neutron
                   and Photon Transport in Inhomogeneous Media},
   booktitle =    {High Performance Scientific and Engineering
                   Computing},
   pages =        {431--440},
   year =         1999,
-  editor =       {H.-J. Bungartz and F. Durst and Chr. Zenger},
+  editor =       {Bungartz, H.-J. and Durst, F. and Zenger, Chr.},
   volume =       8,
   series =       LNCSE,
   publisher =    {Springer}
@@ -4566,7 +4567,7 @@ laws involving discontinuous solutions},
 
 
 @Article{Kan04,
-  author =       {G. Kanschat},
+  author =       {Kanschat, G.},
   title =        {Multilevel methods for discontinuous {G}alerkin {FEM} on
                   locally refined meshes},
   journal =      2004,
@@ -4575,7 +4576,7 @@ laws involving discontinuous solutions},
   pages =        {2437--2445}}
 
 @Article{LR81,
-  author =       {M. Luskin and R. Rannacher},
+  author =       {Luskin, M. and Rannacher, R.},
   title =        {On the Smoothing Property of the {G}alerkin Method for
                   Parabolic Problems},
   journal =      {SIAM J. Numer. Anal.},
@@ -4585,7 +4586,7 @@ laws involving discontinuous solutions},
 }
 
 @Article{LR82,
-  author =       {M. Luskin and R. Rannacher},
+  author =       {Luskin, M. and Rannacher, R.},
   title =        {On the Smoothing Property of the {C}rank-{N}icolson
                   Scheme},
   journal =      {Applic. Anal.},
@@ -4595,18 +4596,18 @@ laws involving discontinuous solutions},
 }
 
 @InProceedings{MPRT95,
-  author =       {S. M{\"u}ller and A. Prohl and R. Rannacher and S. Turek},
+  author =       {M{\"u}ller, S. and Prohl, A. and Rannacher, R. and Turek, S.},
   title =        {Implicit time-discretization of the nonstationary incompressible
                   {N}avier-{S}tokes equations},
   booktitle =    {Fast Solvers for Flow Problems, Proceedings of the tenth
                   GAMM-Seminar, Kiel January 14--16, 1994},
-  editor =       {W. Hackbusch and G. Wittum},
+  editor =       {Hackbusch, W. and Wittum, G.},
   year =         {1994},
   publisher = {F. Vieweg \& Sohn Verlagsgesellschaft mbH, Braunschweig/Wiesbaden}
 }
 
 @Article{MV07,
-  author =       {D. Meidner and B. Vexler},
+  author =       {Meidner, D. and Vexler. B.},
   title =        {Adaptive Space-Time Finite Element Methods for Parabolic
                   Optimization Problems},
   journal =      {SIAM J. Contr. Optim.},
@@ -4617,9 +4618,9 @@ laws involving discontinuous solutions},
 
 
 @Article{PKCKBMSW05,
-  author =       {M. Parashar and H. Klie and U. Catalyurek
-                  and T. Kurc and W. Bangerth and
-                  V. Matossian and J. Saltz and M. F. Wheeler},
+  author =       {Parashar, M. and Klie, H. and Catalyurek, U.
+                  and Kurc, T. and Bangerth, W. and
+                  Matossian, V. and Saltz, J. and Wheeler, M. F.},
   title =        {Application of Grid-enabled Technologies for Solving
                Optimization Problems in Data-Driven Reservoir Studies},
   journal =      {Future Generation Computer Systems},
@@ -4630,9 +4631,9 @@ laws involving discontinuous solutions},
 
 
 @InProceedings{PMBKRKCSW05,
-  author =       {M. Parashar and V. Matossian and W. Bangerth
-                  and H. Klie and B. Rutt and T. Kurc and
-                  U. Catalyurek and J. Saltz and M. F. Wheeler},
+  author =       {Parashar, M. and Matossian, V. and Bangerth, W.
+                  and Klie, H. and Rutt, B. and Kurc, T. and
+                  Catalyurek, U. and Saltz, J. and Wheeler, M. F.},
   title =        {Towards dynamic data-driven optimization of oil well
                   placement},
   booktitle =    {Computational Science -- ICCS 2005: 5th International
@@ -4640,13 +4641,13 @@ laws involving discontinuous solutions},
                   Part II},
   pages =        {656--663},
   year =         2005,
-  editor =       {Vaidy S. Sunderam and Geert Dick van Albada and
-                  Peter M. A. Sloot and et al.}
+  editor =       {Sunderam, V. S. and van Albada, G. D. and
+                  Sloot, P. M. A. and et al.}
 }
 
 
 @InCollection{RS02,
-  author =       {Rannacher, R. and Suttmeier, F. T.},
+  author =       {Rannacher, R. and Suttmeier, F.-T.},
   title =        {Error estimation and adaptive mesh design for FE models in elasto-plasticity},
   booktitle =    {Error-Controlled Adaptive FEMs in Solid Mechanics},
   publisher =    {John Wiley},
@@ -4656,7 +4657,7 @@ laws involving discontinuous solutions},
 
 
 @Article{RS97,
-  author =       {R. Rannacher and F.-T. Suttmeier},
+  author =       {Rannacher, R. and F.-T. Suttmeier, F.-T.},
   title =        {A Feed-Back Approach to Error Control in Finite
                   Element Methods: Application to Linear Elasticity},
   journal =      {Comp. Mech.},
@@ -4668,7 +4669,7 @@ laws involving discontinuous solutions},
 
 
 @InProceedings{RS98b,
-  author =       {R. Rannacher and F.-T. Suttmeier},
+  author =       {Rannacher, R. and Suttmeier, F.-T.},
   title =        {An adaptive finite element method for problems in perfect plasticity},
   booktitle =    {GAMM-Conference 1998, Bremen, April  6-9, 1998},
   OPTcrossref =  {},
@@ -4689,7 +4690,7 @@ laws involving discontinuous solutions},
 
 
 @Article{RS98c,
-  author =       {R. Rannacher and F.-T. Suttmeier},
+  author =       {Rannacher, R. and Suttmeier. F.-T.},
   title =        {A Posteriori Error Control in Finite Element Methods
                   Via Duality Techniques: Application to Perfect
                   Plasticity},
@@ -4701,14 +4702,14 @@ laws involving discontinuous solutions},
 }
 
 @InProceedings{RS98p,
-  author =       {R. Rannacher and F.-T. Suttmeier},
+  author =       {Rannacher, R. and Suttmeier, F.-T.},
   title =        {A Posteriori Error estimation and Mesh Adaptation in
                   Elasticity and Elasto-Plasticity},
   booktitle =    {Advances in Adaptive Computational Methods in
                   Mechanics},
   OPTcrossref =  {},
   OPTkey =       {},
-  editor =       {P. Ladev\`eze and J. T. Oden},
+  editor =       {Ladev\`eze, P. and Oden, J. T.},
   volume =       {176},
   OPTnumber =    {},
   OPTseries =    {},
@@ -4723,7 +4724,7 @@ laws involving discontinuous solutions},
 }
 
 @Article{RS99,
-  author =       {R. Rannacher and F.-T. Suttmeier},
+  author =       {Rannacher, R. and Suttmeier, F.-T.},
   title =        {A Posteriori Error Control and Mesh Adaptation
                   for Finite Element Models in
                   Elasticity and Elasto-Plasticity},
@@ -4733,8 +4734,8 @@ laws involving discontinuous solutions},
 }
 
 @Article{RSWODW96,
-  author =       {R. Rannacher and J. Segatz and J. Wichmann and
-                  C. Orlemann and T. Dreier and J. Wolfrum},
+  author =       {Rannacher, R. and Segatz, J. and Wichmann, J. and
+                  Orlemann, C. and Dreier, T. and Wolfrum, J.},
   title =        {Detailed numerical simulations in flow reactors --
                   A new approach in measuring absolute rate constants},
   journal =      {J. Phys. Chem.},
@@ -4744,7 +4745,7 @@ laws involving discontinuous solutions},
 }
 
 @Article{RT92,
-  author =       {R. Rannacher and S. Turek},
+  author =       {Rannacher, R. and Turek, S.},
   title =        {Simple nonconforming Quadrilateral {S}tokes Element},
   journal =      {Num. Meth. PDE},
   year =         1992,
@@ -4757,13 +4758,13 @@ laws involving discontinuous solutions},
 
 
 @InProceedings{RZ94,
-  author =       {R. Rannacher and G. Zhou},
+  author =       {Rannacher, R. and Zhou, G.},
   title =        {Mesh adaptation via a predictor-corrector strategy in the
 streamline diffusion method for nonstationary hyperbolic systems},
   booktitle =    {Proceedings Workshop Adaptive Methods},
   pages =        {236--250},
   year =         1994,
-  editor =       {Wolfgang Hackbusch and Gabriel Wittum},
+  editor =       {Hackbusch, W. and Wittum, G.},
   volume =       46,
   series =       {NNFM},
   publisher =    {Vieweg}
@@ -4771,7 +4772,7 @@ streamline diffusion method for nonstationary hyperbolic systems},
 
 
 @TechReport{RZ97,
-  author =       {R. Rannacher and G. Zhou},
+  author =       {Rannacher, R. and Zhou, G.},
   title =        {Local {$L^2$}-error analysis and
         superconvergence of the streamline-diffusion finite element method for stationary
         convection--diffusion problems},
@@ -4787,18 +4788,18 @@ streamline diffusion method for nonstationary hyperbolic systems},
 
 
 @InProceedings{Ran00a,
-  author =       {R. Rannacher},
+  author =       {Rannacher, R.},
   title =        {The dual-weighted-residual method for error control and
         mesh adaptation in finite element methods},
   booktitle =    {Proc. MAFELAP 1999},
   pages =        {97--116},
   year =         2000,
-  editor =       {J. R. Whiteman},
+  editor =       {Whiteman, J. R.},
   publisher = {Elsevier, Amsterdam}
 }
 
 @Article{Ran00b,
-  author =       {R. Rannacher},
+  author =       {Rannacher, R.},
   title =        {Adaptive {G}alerkin finite element methods for partial
         differential equations},
   journal =      {Special Millenium 2000 Issue of J. Comput. Appl. Math.},
@@ -4808,20 +4809,20 @@ streamline diffusion method for nonstationary hyperbolic systems},
 
 
 @InProceedings{Ran00c,
-  author =       {R. Rannacher},
+  author =       {Rannacher, R.},
   title =        {Adaptive finite element discretization of optimization problems},
   booktitle =    {Proc. Conf. Numer. Analysis 1999},
   year =         2000,
-  editor =       {D. F. Griffiths and G. A. Watson},
+  editor =       {Griffiths, D. F. and Watson, G. A.},
   publisher =    {Chapman\&Hall/ CRC, London}
 }
 
 @InCollection{Ran00d,
-  author =       {R. Rannacher},
+  author =       {Rannacher, R.},
   title =        {Numerical Methods for the Incompressible {N}avier-{S}tokes Equations},
   booktitle =    {Fundamental Directions in Mathematical Fluid Mechanics},
   pages =        {191--293},
-  publisher =    {Birkh{\"a}user, Basel},
+  publisher =    {Birkh{\"a}user, B.},
   year =         2000,
   editor =       {P. Galdi and J. Heywood and R. Rannacher}
 }
@@ -4843,13 +4844,13 @@ streamline diffusion method for nonstationary hyperbolic systems},
   booktitle =    {Applications of Mathematics in Industry and Technology},
   publisher =    {B. G. Teubner, Stuttgart},
   year =         {1989},
-  editor =       {V. C. Boffi and H. Neunzert},
+  editor =       {Boffi, V. C. and Neunzert, H.},
   pages =        {34--53}
 }
 
 
 @TechReport{Ran92,
-  author =       {R. Rannacher},
+  author =       {Rannacher, R.},
   title =        {On the numerical Solution of the Incompressible
                   {N}avier--{S}tokes Equations},
   institution =  {IWR, Univ. Heidelberg},
@@ -4859,20 +4860,20 @@ streamline diffusion method for nonstationary hyperbolic systems},
 }
 
 @InProceedings{Ran98a,
-  author =       {R. Rannacher},
+  author =       {Rannacher, R.},
   title =        {Error Control in Finite Element Computations},
   booktitle =    {Proc. {NATO} Summer School: ``Error Control and
                   Adaptivity in Scientific Computing'', Antalya, Turkey, Aug. 9-12, 1998},
   pages =        {247--278},
   year =         1999,
-  editor =       {H. Bulgak and C. Zenger},
+  editor =       {Bulgak, H. and Zenger, C.},
   series =       {NATO Science Series},
   publisher =    {Kluwer Academic Publ., Dortrecht/Boston/London}
 }
 
 
 @Article{Ran98c,
-  author =       {R. Rannacher},
+  author =       {Rannacher, R.},
   title =        {A posteriori error estimation in least-squares
         stabilized finite element schemes},
   journal =      {Comput. Meth. Appl. Mech. Engrg.},
@@ -4882,7 +4883,7 @@ streamline diffusion method for nonstationary hyperbolic systems},
 }
 
 @TechReport{Ran98d,
-  author =       {R. Rannacher},
+  author =       {Rannacher, R.},
   title =        {A Posteriori Error Estimates for Dual-Mixed Finite
                   Element Approximations},
   year =         1998,
@@ -4894,7 +4895,7 @@ streamline diffusion method for nonstationary hyperbolic systems},
 
 
 @InProceedings{Ran99a,
-  author =       {R. Rannacher},
+  author =       {Rannacher, R.},
   title =        {Adaptive finite element methods for flow problems},
   booktitle =    {Proc. 88th Int. Symp. on Comput. Fluid Dynamics, Bremen,
         Sept. 5-10, 1999},
@@ -4916,7 +4917,7 @@ streamline diffusion method for nonstationary hyperbolic systems},
 
 
 @InProceedings{Ran99b,
-  author =       {R. Rannacher},
+  author =       {Rannacher, R.},
   title =        {Adaptive {FEM}},
   booktitle =    {Proc. CISM-Course ``Adaptive Finite Elements in
 Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
@@ -4938,8 +4939,8 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @InProceedings{SPSB04,
-  author =       {R. B. Schulz and J. Peter and W. Semmler
-                  and W. Bangerth},
+  author =       {Schulz, R. B. and Peter, J. and Semmler, W.
+                  and Bangerth, W.},
   title =        {Independent modeling of fluorescence excitation and
                   emission},
   booktitle =    {Proceedings of the 2004 OSA Biomedical Topical Meetings},
@@ -4948,9 +4949,9 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @InProceedings{SSSKGBRW05,
-  author =       {P. L. Stoffa and M. K. Sen and R. Seifoullaev and
-                  H. Klie and X. Gai and W. Bangerth and
-                  J. Rungamornrat and M. F. Wheeler},
+  author =       {Stoffa, P. L. and Sen, M. K. and Seifoullaev, R. and
+                  Klie, H. and Gai, X. and Bangerth, W. and
+                  Rungamornrat, J. and Wheeler, M. F.},
   title =        {An analysis of flow-simulation scales and seismic response},
   booktitle =    {Proceedings of the SEG},
   year =         2005
@@ -4958,7 +4959,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @InProceedings{STR98,
-  author =       {M. Sch{\"a}fer and S. Turek and R. Rannacher},
+  author =       {Sch{\"a}fer, M. and Turek, S. and Rannacher, R.},
   title =        {Evaluation of a {CFD} Benchmark for Laminar Flows},
   booktitle =    {ENUMATH 97},
   crossref =     {enumath97},
@@ -4979,7 +4980,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Book{Sch88,
-  author =       {J. P. Schl{\"o}der},
+  author =       {Schl{\"o}der, J. P.},
   title =        {Numerische Methoden zur Behandlung hochdimensionaler Aufgaben der
                   Parameteridentifizierung},
   publisher =    {University of Bonn},
@@ -4991,7 +4992,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @PhdThesis{Sch96,
-  author =       {P. Schreiber},
+  author =       {Schreiber, P},
   title =        {Eine nichtkonforme Finite-Elemente-Methode zur
                   L{\"o}sung der inkompressiblen 3-D {N}avier-{S}tokes
                   Gleichungen},
@@ -5002,7 +5003,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{Sch98,
-  author =       {V. H. Schulz},
+  author =       {Schulz, V. H.},
   title =        {Solving discretized optimization
                   problems by partially reduced {SQP} methods},
   journal =      {Comput. Visual. Sci.},
@@ -5013,7 +5014,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{Sut01,
-  author =       {F.-T. Suttmeier},
+  author =       {Suttmeier, F.-T.},
   title =        {General approach for a posteriori error estimates for
                   finite element solutions of variational inequalities},
   journal =      {Comp. Mech.},
@@ -5024,7 +5025,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Book{Sut01a,
-  author =       {F.-T. Suttmeier},
+  author =       {Suttmeier. F.-T.},
   title =        {Error Analysis for Finite Element Solutions of Variational Inequalities. Professorial Dissertation},
   publisher =    {University of Dortmund},
   year =         2001
@@ -5033,7 +5034,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{Sut02,
-  author =       {F.-T. Suttmeier},
+  author =       {Suttmeier, F.-T.},
   title =        {Error bounds for finite element solutions of elliptic
                   variational inequalities of second kind},
   journal =      {East-West J. Numer. Math.},
@@ -5044,7 +5045,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @PhdThesis{Sut96,
-  author =       {F.-T. Suttmeier},
+  author =       {Suttmeier, F.-T.},
   title =        {Adaptive Finite Element Approximation of Problems in
                   Elasto-Plasticity Theory},
   school =       {Universit{\"a}t Heidelberg},
@@ -5054,7 +5055,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @TechReport{Sut97,
-  author =       {F.-T. Suttmeier},
+  author =       {Suttmeier, F.-T.},
   title =        {An Adaptive Finite Element Scheme for a Benchmark
                   Problem in Perfect Plasticity},
   institution =  {IWR, Universit{\"a}t Heidelberg},
@@ -5064,7 +5065,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @TechReport{TW94,
-  author =       {S. Turek and R. Wehrse},
+  author =       {Turek, S. and Wehrse, R.},
   title =        {Spectral Appearance of Dust Enshrouded Stars: A
                   Finite Element Approach to 2D Radiative Transfer},
   institution =  {IWR, Universit{\"a}t Heidelberg},
@@ -5078,7 +5079,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{Tur93,
-  author =       {S. Turek},
+  author =       {Turek, S.},
   title =        {An Efficient Solution Technique for the Radiative
                   Transfer Equation},
   journal =      {Imp. Comp. Sci. Eng.},
@@ -5089,7 +5090,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{Tur94,
-  author =       {S. Turek},
+  author =       {Turek, S.},
   title =        {Tools for Simulating Non-Stationary Incompressible Flow via
                   Discretely Divergence-Free Finite Element Models},
   journal =      {Int. J. Numer. Methods Fluids},
@@ -5101,7 +5102,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Book{Tur99,
-  author =       {S. Turek},
+  author =       {Turek, S.},
   title =        {Efficient Solvers for Incompressible Flow Problems},
   publisher =    {Springer},
   year =         1999,
@@ -5111,14 +5112,14 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @MastersThesis{Vex00,
-  author =       {B. Vexler},
+  author =       {Vexler, B.},
   title =        {A posteriori Fehlersch\"atzung bei Finite Element Approximation nichtlinearer elliptischer Differentialgleichungen},
   school =       {Universit\"at Heidelberg},
   year =         2000
 }
 
 @InProceedings{WK99,
-  author =       {R. Wehrse and G. Kanschat},
+  author =       {Wehrse, R. and Kanschat, G.},
   title =        {Radiative Fluxes and Forces in Non-spherical Winds},
   booktitle =    {Variable and Non-spherical Stellar Winds in Luminous Hot Stars},
   pages =        {144--150},
@@ -5131,7 +5132,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @TechReport{WMK99,
-  author =       {R. Wehrse and E. Meink{\"o}hn and G. Kanschat},
+  author =       {Wehrse, R. and Meink{\"o}hn, E. and Kanschat, G.},
   title =        {Recent Work in {H}eidelberg on the Solution of the Radiative Transfer},
   institution =  SFB,
   year =         1999,
@@ -5140,7 +5141,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 }
 
 @TechReport{ZR94,
-  author =       {G. Zhou and R. Rannacher},
+  author =       {Zhou, G. and Rannacher, R.},
   title =        {Pointwise Superconvergence of the Streamline
                   Diffusion Finite Element Method},
   institution =  {IWR, Universit{\"a}t Heidelberg},
@@ -5152,7 +5153,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{ZR96,
-  author =       {G. Zhou and R. Rannacher},
+  author =       {Zhou, G. and Rannacher, R.},
   title =        {Pointwise Superconvergence of the Streamline
                   Diffusion Finite Element Method},
   journal =      {Num. Meth. PDE},
@@ -5163,7 +5164,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 }
 
 @Article{Zho97,
-  author =       {G. Zhou},
+  author =       {Zhou, G.},
   title =        {How Accurate is the Streamline Diffusion Method?},
   journal =      {Math. Comp.},
   year =         1997,
@@ -5175,15 +5176,15 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 @Proceedings{enumath97,
   title =        {ENUMATH 97, Proceedings of the 2nd European Conference on Numerical Mathematics and Advanced Applications},
   year =         1998,
-  editor =       {H. G. Bock and F. Brezzi and R.
-                  Glowinsky and G. Kanschat and Y. A. Kuznetsov
-                  and J. Périaux and R. Rannacher},
+  editor =       {Bock, H. G. and Brezzi, F. and 
+                  Glowinsky, R. and Kanschat, G. and Kuznetsov, Y. A.
+                  and Périaux, J. and Rannacher, R.},
   address =      {Singapore},
   publisher =    {World Scientific}
 }
 
 @TechReport{fuehrer:study:93,
-  author =       {C. F{\"u}hrer},
+  author =       {F{\"u}hrer, C.},
   title =        {A comparative study of finite element solvers for
                   hyperbolic problems with applications to radiative
                   transfer},
@@ -5196,7 +5197,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{tur95,
-  author =       {S. Turek},
+  author =       {Turek, S.},
   title =        {A Generalized Mean Intensity Approach for the
                   Numerical Solution of the Radiative Transfer
                   Equation},
@@ -5208,18 +5209,18 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 }
 
 @InCollection{JBS08a,
-  author =       {A. Joshi and W. Bangerth and E. Sevick},
+  author =       {Joshi, A. and Bangerth, W. and Sevick, E.},
   title =        {Non-Contact Fluorescence Optical Tomography with
         Adaptive Finite Element Methods},
   booktitle =    {Mathematical Methods in Biomedical Imaging and
                   Intensity-Modulated Radiation Therapy (IMRT)},
   publisher = {Birkh{\"a}user},
   year =         2008,
-  editor =       {Y. Censor and M. Jiang and A. K. Louis}
+  editor =       {Censor, Y. and Jiang, M. and Louis, A. K.}
 }
 
 @Article{BJ07ip,
-  author =       {W. Bangerth and A. Joshi},
+  author =       {Bangerth, W. and Joshi, A.},
   title =        {Adaptive finite element methods for the solution of
                   inverse problems in optical tomography},
   journal =      {Inverse Problems},
@@ -5230,7 +5231,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{BAK08,
-  author =       {W. Bangerth and M. Allmaras and P. Kuchment},
+  author =       {Bangerth, W. and Allmaras, M. and Kuchment, P.},
   title =        {Ultrasound modulated optical tomography: {M}odels and approximations},
   journal =      {Inverse Problems},
   year =         {2008, in preparation},
@@ -5246,7 +5247,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{ABK08,
-  author =       {M. Allmaras and W. Bangerth and P. Kuchment},
+  author =       {Allmaras, M. and Bangerth, W. and Kuchment, P.},
   title =        {Ultrasound modulated optical tomography: Reconstruction algorithms},
   journal =      {Inverse Problems},
   year =         {2008, in preparation},
@@ -5264,7 +5265,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{AB07,
-  author =       {S. S. Adavani and G. Biros},
+  author =       {Adavani, S. S. and Biros, G.},
   title =        {Multigrid algorithms for inverse problems with linear
                   parabolic {PDE} constraints},
   journal =      {submitted},
@@ -5280,7 +5281,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{ABPR86,
-  author =       {E. Allgower and K. Bohmer and F. Potra and W. Rheinboldt},
+  author =       {Allgower, E. and Bohmer, K. and Potra, F. and Rheinboldt, W.},
   title =        {A mesh independence principle for operator equations and
                   their discretizations},
   journal =      {SIAM J. Numer. Anal.},
@@ -5291,7 +5292,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @InProceedings{ACG02,
-  author =       {S. I. Aanonsen and A. Cominelli and O. Gosselin},
+  author =       {Aanonsen, S. I. and Cominelli, A. and Gosselin, O.},
   title =        {Integration of 4d data in the history match loop by
                   investigating scale dependent correlations in the
                   acoustic impedance cube},
@@ -5304,14 +5305,14 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 }
 
 @Book{AD92,
-  author =       {A. C. Atkinson and A. N. Donev},
+  author =       {Atkinson, A. C. and Donev, A. N.},
   title =        {Optimum Experimental Design},
   publisher =    {Clarendon Press, Oxford},
   year =         1992
 }
 
 @Article{ADYF08,
-  author =       {A. H. Alhuthali and A. Datta-Gupta and B. Yuen and J. P. Fontanilla},
+  author =       {Alhuthali, A. H. and Datta-Gupta, A. and Yuen, B. and Fontanilla. J. P.},
   title =        {Optimal rate control under geologic uncertainty},
   journal =      {Society of Petroleum Engineers, article SPE 113628},
   year =         2008}
@@ -5319,8 +5320,8 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{AGBPV03,
-  author =       {N. Agarwal and S. Gupta and Bhawna and A. Pradhan and K. Vishwanathan
-                  and P. K. Panigrahi},
+  author =       {Agarwal, N. and Gupta, S. and Pradhan, A. and Vishwanathan, K.
+                  and Panigrahi, P. K.},
   title =        {Wavelet transform of breast tissue fluorescence spectra: {A} technique for
                   diagnosis of tumors},
   journal =      {IEE. J. Sel. Topics Quantum Electr.},
@@ -5329,7 +5330,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
   pages =        {154--161}}
 
 @Article{AH01,
-  author =       {U. M. Ascher and E. Haber},
+  author =       {Ascher, U. M. and Haber, E.},
   title =        {Grid refinement and scaling for distributed parameter
                   estimation problems},
   journal =      {Inverse Problems},
@@ -5339,7 +5340,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 }
 
 @Article{AH02,
-  author =       {U. M. Ascher and E. Haber},
+  author =       {Ascher, U. M. and Haber, E.},
   title =        {A multigrid method for distributed parameter
                   estimation problems},
   journal =      {ETNA},
@@ -5350,7 +5351,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{AL98,
-  author =       {S. R. Arridge and W. R. B. Lionheart},
+  author =       {Arridge, S. R. and Lionheart, W. R. B.},
   title =        {Nonuniqueness in diffusion-based optical tomography},
   journal =      {Optics Letters},
   year =         1998,
@@ -5359,7 +5360,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 }
 
 @Article{AMMMBL04,
-  author =       {A. M. Ali and Z. Melegy and M. Morsy and R. M. Megahid and T. Bucherl and E. H. Lehmann},
+  author =       {Ali, A. M. and Melegy, Z. and Morsy, M. and Megahid, R. M. and Bucherl, T. and Lehmann, E. H.},
   title =        {Image reconstruction techniques using projection data from transmission method},
   journal =      {Anals Nucl. Eng.},
   year =         2004,
@@ -5368,7 +5369,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 }
 
 @Article{AMMMBL04,
-  author =       {A. M. Ali and Z. Melegy and M. Morsy and R. M. Megahid and T. Bucherl and E. H. Lehmann},
+  author =       {Ali, A. M. and Melegy, Z. and Morsy, M. and Megahid, R. M. and Bucherl, T. and Lehmann, E. H.},
   title =        {Image reconstruction techniques using projection data from transmission method},
   journal =      {Anals Nucl. Eng.},
   year =         2004,
@@ -5380,7 +5381,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{ANS91,
-  author =       {M. Akamatsu and G. Nakamura and S. Steinberg},
+  author =       {Akamatsu, M. and Nakamura, G. and Steinberg, S.},
   title =        {Identification of {L}am{\'e} coefficients from boundary observations},
   journal =      {Inverse Problems},
   year =         1991,
@@ -5389,7 +5390,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 }
 
 @Article{AP06,
-  author =       {K. Astala and L. P{\"a}iv{\"a}rinta},
+  author =       {Astala, K. and P{\"a}iv{\"a}rinta, L.},
   title =        {Calder{\'o}n's inverse conductivity problem in the plane},
   journal =      {Annals of Mathematics},
   year =         2006,
@@ -5399,7 +5400,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{ARH05,
-  author =       {G. S. Abdoulaev and K. Ren and A. H. Hielscher},
+  author =       {Abdoulaev, G. S. and Ren, K. and Hielscher, A. H.},
   title =        {Optical tomography as a {PDE}-constrained optimization
                   problem},
   journal =      {Inverse Problems},
@@ -5412,7 +5413,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{AS95,
-  author =       {S. R. Arridge and M. Schweiger},
+  author =       {Arridge, S. R. and Schweiger, M.},
   title =        {Sensitivity to prior knowledge in optical tomographic
                   reconstruction},
   journal =      {Proc. SPIE},
@@ -5424,7 +5425,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{AV94,
-  author =       {R. Acar and C. R. Vogel},
+  author =       {Acar, R. and C. R. Vogel, C. R.},
   title =        {Analysis of bounded variation penalty methods for
                   ill-posed problems},
   journal =      {Inverse Problems},
@@ -5434,7 +5435,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 }
 
 @Article{Aca93,
-  author =       {R. Acar},
+  author =       {Acar, R.},
   title =        {Identification of coefficients in elliptic equations},
   journal =      {SIAM J. Control Optim.},
   year =         1993,
@@ -5444,7 +5445,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{Ale90,
-  author =       {G. Alessandrini},
+  author =       {Alessandrini, G.},
   title =        {Singular solutions of elliptic equations and the
                   determination of conductivity by boundary measurements},
   journal =      {J. Diff. Eq.},
@@ -5455,7 +5456,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{Amu91,
-  author =       {L. Amundsen},
+  author =       {Amundsen, L.},
   title =        {Comparison of the least-squares criterion and the {C}auchy criterion
                   in frequency-wavenumber inversion},
   journal =      {Geophysics},
@@ -5466,7 +5467,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{Arr99,
-  author =       {S. R. Arridge},
+  author =       {Arridge, S. R.},
   title =        {Optical tomography in medical imaging},
   journal =      {Inverse Problems},
   year =         1999,
@@ -5478,14 +5479,14 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Book{BA77,
-  author =       {J. V. Beck and K. J. Arnold},
+  author =       {Beck, J. V. and Arnold, K. J},
   title =        {Parameter Estimation in Engineering and Science},
   publisher =    {John Wiley \& Sons},
   year =         1977
 }
 
 @Article{BB01,
-  author =       {H. T. Banks and K. L. Bihari},
+  author =       {Banks, H. T. and Bihari, K. L.},
   title =        {Modelling and estimating uncertainty in parameter estimation},
   journal =      {Inverse Problems},
   year =         2001,
@@ -5494,8 +5495,8 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 }
 
 @Article{BBKS00,
-  author =       {I. Bauer and H. G. Bock and S. K{\"o}rkel and
-                  J. B. Schl{\"o}der},
+  author =       {Bauer, I. and Bock, H. G. and K{\"o}rkel, S. and
+                  Schl{\"o}der, J. B.},
   title =        {Numerical methods for optimum experimental design in {DAE}
                   systems},
   journal =      {J. Comput. Appl. Math.},
@@ -5507,7 +5508,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{BBP96,
-  author =       {L. Borcea and J. G. Berryman and G. C. Papanicolaou},
+  author =       {Borcea, L. and Berryman, J. G. and Papanicolaou, G. C.},
   title =        {High-contrast impedance tomography},
   journal =      {Inverse Problems},
   year =         1996,
@@ -5516,7 +5517,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 }
 
 @Article{BBR01,
-  author =       {J. A. Barcel\'o and B. Barcel\'o and A. Ruiz},
+  author =       {Barcel\'o, J. A. and Barcel\'o, B. and Ruiz, A.},
   title =        {Stability of the inverse conductivity problem in the plane
                   for less regular conductivities},
   journal =      {J. Differ. Equations},
@@ -5528,7 +5529,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{BCJ02,
-  author =       {H. {Ben Ameur} and G. Chavent and J. Jaffr{\'e}},
+  author =       {Ameur, H. B. and Chavent, G. and Jaffr{\'e}, J.},
   title =        {Refinement and coarsening indicators for adaptive
                   parametrization: application to the estimation of
                   hydraulic transmissivities},
@@ -5539,7 +5540,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 }
 
 @TechReport{BCJ99,
-  author =       {H. {Ben Ameur} and G. Chavent and J. Jaffr{\'e}},
+  author =       {Ameur, H. B. and Chavent, G. and Jaffr{\'e}, J.},
   title =        {Raffinement et d{\'e}raffinement de param{\'e}trisation pour l'{}estimation de
                   transmissivit{\'e} hydraulique},
   institution =  {INRIA},
@@ -5549,7 +5550,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 }
 
 @Article{BCT03,
-  author =       {J. van den Berg and A. Curtis and J. Trampert},
+  author =       {van den Berg, J. and Curtis, A. and Trampert, J.},
   title =        {Optimal nonlinear {B}ayesian experiment design:
                   {A}n application to amplitude versus offset experiments},
   journal =      {Geophys. J. Int.},
@@ -5558,7 +5559,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
   pages =        {411--421}}
 
 @Article{BD02,
-  author =       {L. Borcea and V. Druskin},
+  author =       {Borcea, L. and Druskin, V.},
   title =        {Optimal finite difference grids for direct and inverse
                   {S}turm {L}iouville problems},
   journal =      {Inverse Problems},
@@ -5570,7 +5571,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{BDK05,
-  author =       {L. Borcea and V. Druskin and L. Knizhnerman},
+  author =       {Borcea, L. and Druskin, V. and Knizhnerman, L.},
   title =        {On the continuum limit of a discrete inverse spectral
                   problem on optimal finite difference grids},
   journal =      {Comm. Pure. Appl. Math.},
@@ -5582,7 +5583,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{BG00,
-  author =       {G. Biros and O. Ghattas},
+  author =       {Biros, G. and Ghattas, O.},
   title =        {A {L}agrange-{N}ewton-{K}rylov-{S}chur method for
                   {PDE}-constrained optimization},
   journal =      {SIAG/OPT Views-and-News},
@@ -5593,7 +5594,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 }
 
 @Article{BG03a,
-  author =       {G. Biros and O. Ghattas},
+  author =       {Biros, G. and Ghattas, O.},
   title =        {Parallel {L}agrange-{N}ewton-{K}rylov-{S}chur methods for
                   {PDE}-constrained optimizaion.
                   {P}art {I}: {T}he {K}rylov-{S}chur solver},
@@ -5605,7 +5606,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 
 @Article{BG03b,
-  author =       {G. Biros and O. Ghattas},
+  author =       {Biros, G. and Ghattas, O},
   title =        {Parallel {L}agrange-{N}ewton-{K}rylov-{S}chur methods for
                   {PDE}-constrained optimizaion.
                   {P}art {II}: {T}he {L}agrange-{N}ewton solver and its


### PR DESCRIPTION
I altered the author names in the list of references per issue #1488. This update is part one of two and includes up to line 5620 in manual.bib. All authors (and editors if applicable) are now listed as last name followed by initials. A paper authored by Joshua Keyes, Edward Brazzelton, and Conrad Zimsky would be listed as {Keyes, J. and Brazzelton, E. and Zimsky, C.} .

