### PR TITLE
Clarify and elaborate point 2 of section 3.1.2 in the manual

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2467,20 +2467,28 @@ volume into the docker container\footnote{Note that it is possible to mount a
 directory as writeable into the container. However, this is often associated
 with file permission conflicts between the host system and the container.
 Therefore, we recommend this slightly more cumbersome, but also more reliable
-workflow.}. 
+workflow.}. This is accomplished by specifying the -v flag followed by
+the absolute path on the host machine, colon, absolute path within the docker
+container, colon, and specifing readonly permissions as in the example below.
+
 Make sure your parameter file specifies a model output directory \textit{other}
 than the input directory, e.g. \texttt{/home/dealii/aspect/model\_output}. When
 you have started the container run the aspect model inside the container. Note
 that there are two \aspect{} executables in the work directory of the container:
 \texttt{aspect} and \texttt{aspect-release}. For a discussion of the
 different versions see Section~\ref{sec:debug-mode}, in essence: You should run
-texttt{aspect} first to check your model for errors, then run
+\texttt{aspect} first to check your model for errors, then run
 \texttt{aspect-release} for a faster model run.
 
 To sum up, the steps you will want to execute are:
 \begin{lstlisting}[frame=single,language=ksh]
 docker run -it -v "$(pwd):/home/dealii/aspect/model_input:ro" \
   gassmoeller/aspect:latest bash
+\end{lstlisting}
+
+Within the container, simply run your model by executing:
+
+\begin{lstlisting}[frame=single,language=ksh]
 ./aspect model_input/your_input_file.prm
 \end{lstlisting}
 


### PR DESCRIPTION
Add details to the command line options of point 2, in particular, details of mounting a volume using docker. Fixed warped line issue as well.

Reference issue #1481 

