### PR TITLE
New mesh refinement criterion for discontinuous composition field using approximated gradient

### DIFF
--- a/include/aspect/mesh_refinement/composition_approximate_gradient.h
+++ b/include/aspect/mesh_refinement/composition_approximate_gradient.h
@@ -1,0 +1,80 @@
+/*
+  Copyright (C) 2011 - 2016 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef _aspect_mesh_refinement_composition_approximate_gradient_h
+#define _aspect_mesh_refinement_composition_approximate_gradient_h
+
+#include <aspect/mesh_refinement/interface.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+  namespace MeshRefinement
+  {
+
+    /**
+     * A class that implements a mesh refinement criterion based on
+     * the approximated gradient of the compositional fields (if available).
+     *
+     * @ingroup MeshRefinement
+     */
+    template <int dim>
+    class CompositionApproximateGradient : public Interface<dim>,
+      public SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * Execute this mesh refinement criterion.
+         *
+         * @param[out] error_indicators A vector that for every active cell of
+         * the current mesh (which may be a partition of a distributed mesh)
+         * provides an error indicator. This vector will already have the
+         * correct size when the function is called.
+         */
+        virtual
+        void
+        execute (Vector<float> &error_indicators) const;
+
+        /**
+        * Declare the parameters this class takes through input files.
+        */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         */
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
+
+      private:
+        /**
+         * The scaling factors that should be applied to the individual
+         * refinement indicators before merging.
+         */
+        std::vector<double> composition_scaling_factors;
+    };
+  }
+}
+
+#endif

--- a/source/mesh_refinement/composition_approximate_gradient.cc
+++ b/source/mesh_refinement/composition_approximate_gradient.cc
@@ -1,0 +1,156 @@
+/*
+  Copyright (C) 2015 - 2016 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/mesh_refinement/composition_approximate_gradient.h>
+
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/numerics/derivative_approximation.h>
+
+namespace aspect
+{
+  namespace MeshRefinement
+  {
+    template <int dim>
+    void
+    CompositionApproximateGradient<dim>::execute(Vector<float> &indicators) const
+    {
+      AssertThrow (this->n_compositional_fields() >= 1,
+                   ExcMessage ("This refinement criterion can not be used when no "
+                               "compositional fields are active!"));
+      indicators = 0;
+      // create a vector with the requisite ghost elements
+      // and use it for estimating the gradients of compositional field
+      LinearAlgebra::BlockVector vec(this->introspection().index_sets.system_partitioning,
+                                     this->introspection().index_sets.system_relevant_partitioning,
+                                     this->get_mpi_communicator());
+      Vector<float> indicators_tmp(this->get_triangulation().n_active_cells());
+      for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
+        {
+          const unsigned int block_idx = this->introspection().block_indices.compositional_fields[c];
+          vec.block(block_idx) = this->get_solution().block(block_idx);
+          vec.compress(VectorOperation::insert);
+          indicators_tmp = 0;
+          DerivativeApproximation::approximate_gradient(this->get_mapping(),
+                                                        this->get_dof_handler(),
+                                                        vec,
+                                                        indicators_tmp,
+                                                        this->introspection().component_indices.compositional_fields[c]);
+
+          indicators_tmp *= composition_scaling_factors[c];
+
+          // Scale approximated gradient in each cell with the correct power of h. Otherwise,
+          // error indicators do not reduce when refined if there is a density
+          // jump. We need at least order 1 for the error not to grow when
+          // refining, so anything >1 should work. (note that the gradient
+          // itself scales like 1/h, so multiplying it with any factor h^s, s>1
+          // will yield convergence of the error indicators to zero as h->0)
+          const double power = 1.0 + dim / 2.0;
+          typename DoFHandler<dim>::active_cell_iterator
+          cell = this->get_dof_handler().begin_active(),
+          endc = this->get_dof_handler().end();
+          for (unsigned int i=0; cell != endc; ++cell, ++i)
+            if (cell->is_locally_owned())
+              indicators_tmp(i) *= std::pow(cell->diameter(), power);
+          indicators += indicators_tmp;
+        }
+    }
+
+
+    template <int dim>
+    void
+    CompositionApproximateGradient<dim>::
+    declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Mesh refinement");
+      {
+        prm.enter_subsection("Composition approximate gradient");
+        {
+          prm.declare_entry("Compositional field scaling factors",
+                            "",
+                            Patterns::List (Patterns::Double(0)),
+                            "A list of scaling factors by which every individual compositional "
+                            "field gradient will be multiplied. If only a single compositional "
+                            "field exists, then this parameter has no particular meaning. "
+                            "On the other hand, if multiple criteria are chosen, then these "
+                            "factors are used to weigh the various indicators relative to "
+                            "each other. "
+                            "\n\n"
+                            "If the list of scaling factors given in this parameter is empty, then this "
+                            "indicates that they should all be chosen equal to one. If the list "
+                            "is not empty then it needs to have as many entries as there are "
+                            "compositional fields.");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+    template <int dim>
+    void
+    CompositionApproximateGradient<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Mesh refinement");
+      {
+        prm.enter_subsection("Composition approximate gradient");
+        {
+          composition_scaling_factors
+            = Utilities::string_to_double(
+                Utilities::split_string_list(prm.get("Compositional field scaling factors")));
+
+          AssertThrow (composition_scaling_factors.size() == this->n_compositional_fields()
+                       ||
+                       composition_scaling_factors.size() == 0,
+                       ExcMessage ("The number of scaling factors given here must either be "
+                                   "zero or equal to the number of chosen refinement criteria."));
+
+          if (composition_scaling_factors.size() == 0)
+            composition_scaling_factors.resize (this->n_compositional_fields(), 1.0);
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace MeshRefinement
+  {
+    ASPECT_REGISTER_MESH_REFINEMENT_CRITERION(CompositionApproximateGradient,
+                                              "composition approximate gradient",
+                                              "A mesh refinement criterion that computes refinement "
+                                              "indicators from the gradients of compositional fields. "
+                                              "If there is more than one compositional field, then "
+                                              "it simply takes the sum of the indicators times "
+                                              "a user-specified weight for each field."
+                                              "\n\n"
+                                              "In contrast to the `composition gradient' refinement "
+                                              "criterion, the current criterion does not "
+                                              "compute the gradient at quadrature points on each cell, "
+                                              "but by a finite difference approximation between the "
+                                              "centers of cells. Consequently, it also works if "
+                                              "the compositional fields are computed using discontinuous "
+                                              "finite elements.")
+  }
+}
+

--- a/tests/particles_with_AMR_on.prm
+++ b/tests/particles_with_AMR_on.prm
@@ -1,0 +1,132 @@
+# A description of the falling box benchmark see the reference:
+# Gerya, T. V., Yuen, D. A., 2003a. Characteristics-based marker-in-cell method
+# with conservative finite-differences schemes for modeling geological flows with
+# strongly variable transport properties
+
+set Dimension                              = 2
+set Start time                             = 0
+set End time                               = 5e5
+set Use years in output instead of seconds = true
+set CFL number                             = 1
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent  = 500e3
+    set Y extent  = 500e3
+  end
+end
+
+subsection Model settings
+  set Include adiabatic heating               = false
+  set Include shear heating                   = false
+  set Tangential velocity boundary indicators = left, right, bottom, top
+end
+
+# Thermal expansion coeff = 0 --> no temperature depedence
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Reference density             = 3200
+    set Viscosity                     = 1e21
+    set Thermal expansion coefficient = 0
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 9.81
+  end
+end
+
+
+############### Parameters describing the temperature field
+# Note: The temperature plays no role in this model
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+
+############### Parameters describing the compositional field
+# Note: The compositional field is what drives the flow
+# in this example
+
+subsection Compositional fields
+  set Number of fields = 1
+  set Names of fields = composition
+  set Compositional field methods = particles
+  set Mapped particle properties = composition:function
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if(((x>187.5e3)&&(x<312.5e3)&&(z>312.5e3)&&(z<437.5e3)), 1, 0)  
+ end
+end
+
+subsection Material model
+  subsection Simple model
+    set Density differential for compositional field 1 = 100  # 3300 kg/m^3
+    set Composition viscosity prefactor = 1  # ONLY PARAMETER THAT CHANGES IN THESE TESTS
+  end
+end
+
+
+############### Parameters describing the discretization
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 2
+  set Strategy                           = composition approximate gradient 
+  set Initial global refinement          = 4
+  set Time steps between mesh refinement = 1
+  set Coarsening fraction                = 0.05
+  set Refinement fraction                = 0.3
+  set Normalize individual refinement criteria = true
+end
+
+
+
+############### Parameters describing what to do with the solution
+
+subsection Discretization
+  set Use discontinuous composition discretization = true
+end
+
+subsection Postprocess
+  set List of postprocessors = particles, velocity statistics, composition statistics
+  subsection Particles
+    set Number of particles = 120000
+    set Load balancing strategy = remove and add particles
+    set Minimum particles per cell = 9
+    set Maximum particles per cell = 36
+    set Data output format = none
+    set List of particle properties = function
+    set Integration scheme = rk2
+    set Interpolation scheme = cell average
+    set Update ghost particles = true
+
+    subsection Function
+       set Variable names      = x,z
+       set Function expression = if(((x>187.5e3)&&(x<312.5e3)&&(z>312.5e3)&&(z<437.5e3)), 1, 0)  
+    end
+
+    set Particle generator name = reference cell
+
+    subsection Generator
+      subsection Reference cell
+         set Number of particles per cell per direction = 8
+      end
+    end
+  end
+end

--- a/tests/particles_with_AMR_on/screen-output
+++ b/tests/particles_with_AMR_on/screen-output
@@ -1,0 +1,105 @@
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 5,860 (2,178+289+1,089+2,304)
+
+*** Timestep 0:  t=0 years
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+0 iterations.
+
+Number of active cells: 196 (on 6 levels)
+Number of degrees of freedom: 4,728 (1,818+237+909+1,764)
+
+*** Timestep 0:  t=0 years
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 18+0 iterations.
+
+Number of active cells: 352 (on 7 levels)
+Number of degrees of freedom: 8,581 (3,326+424+1,663+3,168)
+
+*** Timestep 0:  t=0 years
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 32+0 iterations.
+
+   Postprocessing:
+     Number of advected particles: 5433
+     RMS, max velocity:            0.0137 m/year, 0.0369 m/year
+     Compositions min/max/mass:    0/1/1.563e+10
+
+Number of active cells: 376 (on 7 levels)
+Number of degrees of freedom: 9,109 (3,518+448+1,759+3,384)
+
+*** Timestep 1:  t=113316 years
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 19+0 iterations.
+
+   Postprocessing:
+     Number of advected particles: 5774
+     RMS, max velocity:            0.0137 m/year, 0.0369 m/year
+     Compositions min/max/mass:    0/1/1.563e+10
+
+Number of active cells: 376 (on 7 levels)
+Number of degrees of freedom: 9,109 (3,518+448+1,759+3,384)
+
+*** Timestep 2:  t=226632 years
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 28+0 iterations.
+
+   Postprocessing:
+     Number of advected particles: 5867
+     RMS, max velocity:            0.0138 m/year, 0.0374 m/year
+     Compositions min/max/mass:    0/1/1.566e+10
+
+Number of active cells: 376 (on 7 levels)
+Number of degrees of freedom: 9,109 (3,518+448+1,759+3,384)
+
+*** Timestep 3:  t=337599 years
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 25+0 iterations.
+
+   Postprocessing:
+     Number of advected particles: 5977
+     RMS, max velocity:            0.014 m/year, 0.0379 m/year
+     Compositions min/max/mass:    0/1/1.566e+10
+
+Number of active cells: 364 (on 7 levels)
+Number of degrees of freedom: 8,858 (3,430+437+1,715+3,276)
+
+*** Timestep 4:  t=445884 years
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 26+0 iterations.
+
+   Postprocessing:
+     Number of advected particles: 6034
+     RMS, max velocity:            0.0141 m/year, 0.0381 m/year
+     Compositions min/max/mass:    0/1/1.561e+10
+
+Number of active cells: 364 (on 7 levels)
+Number of degrees of freedom: 8,897 (3,454+440+1,727+3,276)
+
+*** Timestep 5:  t=500000 years
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 26+0 iterations.
+
+   Postprocessing:
+     Number of advected particles: 6033
+     RMS, max velocity:            0.0142 m/year, 0.0383 m/year
+     Compositions min/max/mass:    0/1/1.557e+10
+
+Number of active cells: 394 (on 7 levels)
+Number of degrees of freedom: 9,492 (3,654+465+1,827+3,546)
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/particles_with_AMR_on/statistics
+++ b/tests/particles_with_AMR_on/statistics
@@ -1,0 +1,23 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Number of advected particles
+# 13: RMS velocity (m/year)
+# 14: Max. velocity (m/year)
+# 15: Minimal value for composition composition
+# 16: Maximal value for composition composition
+# 17: Global mass for composition composition
+0 0.000000000000e+00 0.000000000000e+00 352 3750 1663 3168 0 32 33 137 5433 1.36629812e-02 3.69482906e-02 0.00000000e+00 1.00000000e+00 1.56250000e+10 
+1 1.133159370251e+05 1.133159370251e+05 376 3966 1759 3384 0 19 20  98 5774 1.36629793e-02 3.69483030e-02 0.00000000e+00 1.00000000e+00 1.56250000e+10 
+2 2.266316069952e+05 1.133156699701e+05 376 3966 1759 3384 0 28 29 139 5867 1.38258622e-02 3.73666729e-02 0.00000000e+00 1.00000000e+00 1.56618066e+10 
+3 3.375987195511e+05 1.109671125560e+05 376 3966 1759 3384 0 25 26 127 5977 1.39961813e-02 3.79068462e-02 0.00000000e+00 1.00000000e+00 1.56554266e+10 
+4 4.458839204941e+05 1.082852009429e+05 364 3867 1715 3276 0 26 27 132 6034 1.41068001e-02 3.81019220e-02 0.00000000e+00 1.00000000e+00 1.56126914e+10 
+5 5.000000000000e+05 5.411607950592e+04 364 3894 1727 3276 0 26 27 122 6033 1.42085779e-02 3.83361691e-02 0.00000000e+00 1.00000000e+00 1.55688190e+10 


### PR DESCRIPTION
This new patch added a new mesh refinement criterion for compositional field using approximated gradient, which can be also used for passive particles, where the properties are  interpolated to the discontinuous composition field. Below are the three simple tests with provided test example prm file but with three different mesh refinement strategies: 

set Strategy    = composition approximate gradient
![composition_approximate_gradient_amr](https://cloud.githubusercontent.com/assets/12536604/26029041/2127fede-37fa-11e7-9861-d512526e4f39.png)

set Strategy    = composition gradient
![composition_gradient_amr](https://cloud.githubusercontent.com/assets/12536604/26029040/212726d0-37fa-11e7-803f-54db64200f3a.png)

set Strategy    = composition 
![composition](https://cloud.githubusercontent.com/assets/12536604/26029042/212966fc-37fa-11e7-9c13-f18a6110c434.png)
