### PR TITLE
Add constructor to SphericalShell class to silence icc compiler warning

### DIFF
--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -49,6 +49,11 @@ namespace aspect
     {
       public:
         /**
+         *
+         */
+        SphericalShell();
+
+        /**
          * Generate a coarse mesh for the geometry described by this class.
          */
         virtual

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -32,6 +32,16 @@ namespace aspect
   namespace GeometryModel
   {
     template <int dim>
+    SphericalShell<dim>::SphericalShell()
+      :
+      spherical_manifold()
+#if !DEAL_II_VERSION_GTE(9,0,0)
+      , boundary_shell(),
+      straight_boundary()
+#endif
+    {}
+
+    template <int dim>
     void
     SphericalShell<dim>::
     create_coarse_mesh (parallel::distributed::Triangulation<dim> &coarse_grid) const


### PR DESCRIPTION
Reference issue #1589

@jaustermann , unfortunately I do not have intel compilers to test this fix. However, both Rene and I are confident that this will fix the issue.