### PR TITLE
Add option to use full finite strain tensor for strain weakening

### DIFF
--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -186,6 +186,7 @@ namespace aspect
                                           const YieldScheme &yield_type) const;
 
         bool use_strain_weakening;
+        bool use_finite_strain_tensor;
         std::vector<double> start_strain_weakening_intervals;
         std::vector<double> end_strain_weakening_intervals;
         std::vector<double> viscous_strain_weakening_factors;

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -843,7 +843,7 @@ namespace aspect
                                    "The finite strain invariant or full strain tensor is calculated through "
                                    "compositional fields within the material model. This implementation is "
                                    "identical to the compositional field finite strain plugin and cookbook "
-                                   "described in the manual (author: Gassmoeller). If the user selects to track "
+                                   "described in the manual (author: Gassmoeller, Dannberg). If the user selects to track "
                                    "the finite strain invariant ($e_ii$), a single compositional field tracks "
                                    "the value derived from $e_ii^t = (e_ii)^(t-1) + edot_ii*dt, where $t$ and $t-1$ "
                                    "are the current and prior time steps, $edot_ii$ is the second invariant of the "

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -20,6 +20,7 @@
 
 #include <aspect/material_model/visco_plastic.h>
 #include <aspect/utilities.h>
+#include <deal.II/fe/fe_values.h>
 using namespace dealii;
 
 namespace aspect

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -41,7 +41,17 @@ namespace aspect
 
       // assign compositional fields associated with strain a value of 0
       if (use_strain_weakening == true)
-        x_comp[0] = 0.0;
+        {
+          if (use_finite_strain_tensor == false)
+            {
+              x_comp[0] = 0.0;
+            }
+          else
+            {
+              for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
+                x_comp[i] = 0.;
+            }
+        }
 
       //sum the compositional fields for normalization purposes
       double sum_composition = 0.0;
@@ -200,11 +210,25 @@ namespace aspect
           double coh = cohesions[j];
 
           // Strain weakening
+          double strain_ii = 0.;
           if (use_strain_weakening == true)
             {
 
-              // Constrain the second strain invariant of the previous timestep
-              const double strain_ii = std::max(std::min(composition[0],end_strain_weakening_intervals[j]),start_strain_weakening_intervals[j]);
+              // Calculate and/or constrain the strain invariant of the previous timestep
+              if ( use_finite_strain_tensor == true )
+                {
+                  // Calculate second invarinat of left stretching tensor "L"
+                  Tensor<2,dim> strain;
+                  for (unsigned int q = 0; q < Tensor<2,dim>::n_independent_components ; ++q)
+                    strain[Tensor<2,dim>::unrolled_to_component_indices(q)] = composition[q];
+                  const SymmetricTensor<2,dim> L = symmetrize( strain * transpose(strain) );                  
+                  strain_ii = std::fabs(second_invariant(L)); 
+                }
+              else
+                {
+                  // Here the compositional field already contains the finite strain invariant magnitude
+                  strain_ii = std::max(std::min(composition[0],end_strain_weakening_intervals[j]),start_strain_weakening_intervals[j]);
+                }
 
               // Linear strain weakening of cohesion and internal friction angle between specified strain values
               const double strain_fraction = ( strain_ii - start_strain_weakening_intervals[j] ) /
@@ -274,6 +298,10 @@ namespace aspect
     evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
+
+
+
+      // Loop through points
       for (unsigned int i=0; i < in.temperature.size(); ++i)
         {
           const double temperature = in.temperature[i];
@@ -347,14 +375,56 @@ namespace aspect
             out.reaction_terms[i][c] = 0.0;
           // If strain weakening is used, overwrite the first reaction term,
           // which represents the second invariant of the strain tensor
-          if  (use_strain_weakening && this->get_timestep_number() > 0)
+          double edot_ii = 0.;
+          double e_ii = 0.;
+          if  (use_strain_weakening == true && use_finite_strain_tensor == false && this->get_timestep_number() > 0)
             {
-              const double edot_ii = std::max(sqrt(std::fabs(second_invariant(deviator(in.strain_rate[i])))),min_strain_rate);
-
-              // Update reaction term
-              out.reaction_terms[i][0] = edot_ii*this->get_timestep();
+               edot_ii = std::max(sqrt(std::fabs(second_invariant(deviator(in.strain_rate[i])))),min_strain_rate);
+               e_ii = edot_ii*this->get_timestep();
+               // Update reaction term
+              out.reaction_terms[i][0] = e_ii;
             }
         }
+
+      // We need the velocity gradient for the finite strain (they are not included in material model inputs),
+      // so we get them from the finite element.
+      if (in.cell && use_finite_strain_tensor == true && this->get_timestep_number() > 0)
+        {
+          const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.velocities).degree+1);
+          FEValues<dim> fe_values (this->get_mapping(),
+                                   this->get_fe(),
+                                   quadrature_formula,
+                                   update_gradients);
+
+          std::vector<Tensor<2,dim> > velocity_gradients (quadrature_formula.size(), Tensor<2,dim>());
+
+          fe_values.reinit (*in.cell);
+          fe_values[this->introspection().extractors.velocities].get_function_gradients (this->get_solution(),
+                                                                                         velocity_gradients);
+
+          // Assign the strain components to the compositional fields reaction terms.
+          // If there are too many fields, we simply fill only the first fields with the
+          // existing strain rate tensor components.
+          for (unsigned int q=0; q < in.position.size(); ++q)
+            {
+              // Convert the compositional fields into the tensor quantity they represent.
+              Tensor<2,dim> strain;
+              for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
+                {
+                  strain[Tensor<2,dim>::unrolled_to_component_indices(i)] = in.composition[q][i];
+                }
+
+              // Compute the strain accumulated in this timestep.
+              const Tensor<2,dim> strain_increment = this->get_timestep() * (velocity_gradients[q] * strain);
+              
+              // Output the strain increment component-wise to its respective compositional field's reaction terms.
+              for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
+                {
+                  out.reaction_terms[q][i] = strain_increment[Tensor<2,dim>::unrolled_to_component_indices(i)];
+                }
+            }
+
+        }        
     }
 
     template <int dim>
@@ -429,6 +499,10 @@ namespace aspect
                              Patterns::Bool (),
                              "Apply strain weakening to viscosity, cohesion and internal angle "
                              "of friction based on accumulated finite strain.  Units: None");
+          prm.declare_entry ("Use finite strain tensor", "false",
+                             Patterns::Bool (),
+                             "Track and use the full finite strain tensor for strain weakening. "
+                             "Units: None");
           prm.declare_entry ("Start strain weakening intervals", "0.",
                              Patterns::List(Patterns::Double(0)),
                              "List of strain weakening interval initial strains "
@@ -568,6 +642,9 @@ namespace aspect
       //increment by one for background:
       const unsigned int n_fields = this->n_compositional_fields() + 1;
 
+      // number of required compositional fields for full finite strain tensor
+      const unsigned int s = Tensor<2,dim>::n_independent_components;
+
       prm.enter_subsection("Material model");
       {
         prm.enter_subsection ("Visco Plastic");
@@ -603,7 +680,10 @@ namespace aspect
           if (use_strain_weakening)
             AssertThrow(this->n_compositional_fields() >= 1,
                         ExcMessage("There must be at least one compositional field. "));
-
+          use_finite_strain_tensor  = prm.get_bool ("Use finite strain tensor");
+          if (use_finite_strain_tensor)
+            AssertThrow(this->n_compositional_fields() >= s,
+                        ExcMessage("There must be enough compositional fields to track all components of the finite strain tensor (4 in 2D, 9 in 3D). "));
           start_strain_weakening_intervals = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Start strain weakening intervals"))),
                                                                                      n_fields,
                                                                                      "Start strain weakening intervals");
@@ -758,12 +838,29 @@ namespace aspect
                                    "See, for example, Thieulot, C. (2011), PEPI 188, pp. 47-68. "
                                    "\n\n"
                                    "The user has the option to linearly reduce the cohesion and "
-                                   "internal friction angle as a function of the finite strain invariant. "
-                                   "The finite strain invariant may be calculated through particles or the compositional "
-                                   "field finite strain invariant plugin (see \\cite{buiter2008dissipation} benchmark). "
-                                   "In either case, the user specifies a compositional field for the finite "
-                                   "strain invariant, which must be the first listed compositional field "
-                                   "in the parameter file."
+                                   "internal friction angle as a function of the finite strain magnitude. "
+                                   "The finite strain invariant or full strain tensor is calculated through "
+                                   "compositional fields within the material model. This implementation is "
+                                   "identical to the compositional field finite strain plugin and cookbook "
+                                   "described in the manual (author: Gassmoeller). If the user selects to track "
+                                   "the finite strain invariant ($e_ii$), a single compositional field tracks "
+                                   "the value derived from $e_ii^t = (e_ii)^(t-1) + edot_ii*dt, where $t$ and $t-1$ "
+                                   "are the current and prior time steps, $edot_ii$ is the second invariant of the "
+                                   "strain rate tensor and $dt$ is the time step size. In the case of the "
+                                   "full strain tensor $F$, the finite strain magnitude is derived from the "
+                                   "second invariant of the symmetric stretching tensor $L$, where "
+                                   "$L = F * [F]^T$. In either case, the user specifies a single compositional "
+                                   "field for the finite strain invariant or multiple fields (4 in 2D, 9 in 3D) "
+                                   "for the finite strain tensor. These field(s) must be the first lised "
+                                   "compositional fields in the paramter file. Note that one or more of the finite strain "
+                                   "tensor components must be assigned a non-zero value intially. This value can be "
+                                   "be quite small (ex: 1.e-8), but still non-zero. While the option to track and use "
+                                   "the full finite strain tensor exists, tracking the associated compositional "
+                                   "is computationally expensive in 3D. Similarly, the finite strain magnitudes "
+                                   "may in fact decrease if the orientation of the deformation field switches "
+                                   "through time. Consequently, the ideal solution is track the finite strain "
+                                   "invariant (single compositional) field within the material and track "
+                                   "the full finite strain tensor through tracers."
                                    ""
                                    "\n\n"
                                    "Viscous stress may also be limited by a non-linear stress limiter "
@@ -775,7 +872,7 @@ namespace aspect
                                    "reference strain rate, $\\varepsilon_{ii}$ is the strain rate "
                                    "and $n_y$ is the stress limiter exponent.  The yield stress, "
                                    "$\\tau_y$, is defined through the Drucker Prager yield criterion "
-                                   "formulation.  This method of limiting viscous stress has been used "
+                                   "formulation. This method of limiting viscous stress has been used "
                                    "in various forms within the geodynamic literature, including "
                                    "Christensen (1992), JGR, 97(B2), pp. 2015-2036; "
                                    "Cizkova and Bina (2013), EPSL, 379, pp. 95-103; "

--- a/tests/visco_plastic_yield_strain_weakening_full_strain_tensor.prm
+++ b/tests/visco_plastic_yield_strain_weakening_full_strain_tensor.prm
@@ -66,7 +66,7 @@ subsection Compositional fields
   set Names of fields = s11, s12, s21, s22
 end
 
-# All compositional fields have an initial value of 0
+# The compositional fields have an initial value 0 or 0.5
 subsection Initial composition model
   set Model name = function
   subsection Function

--- a/tests/visco_plastic_yield_strain_weakening_full_strain_tensor.prm
+++ b/tests/visco_plastic_yield_strain_weakening_full_strain_tensor.prm
@@ -1,0 +1,116 @@
+# Global parameters
+set Dimension                              = 2
+set Start time                             = 0
+set End time                               = 1e2
+set Use years in output instead of seconds = true
+set Nonlinear solver scheme                = iterated Stokes
+set Max nonlinear iterations               = 1
+set Number of cheap Stokes solver steps    = 0
+set Output directory                       = visco_plastic_yield_strain_weakening_full_strain_tensor
+set Timing output frequency                = 1
+
+# Model geometry (100x100 km, 10 km spacing)
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X repetitions = 10
+    set Y repetitions = 10
+    set X extent      = 100e3
+    set Y extent      = 100e3
+  end
+end
+
+# Mesh refinement specifications 
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 0
+  set Time steps between mesh refinement = 0
+end
+
+
+# Boundary classifications (fixed T boundaries, prescribed velocity) 
+subsection Model settings
+  set Fixed temperature boundary indicators   = bottom, top, left, right
+  set Prescribed velocity boundary indicators = bottom y: function, top y: function, left x: function, right x: function
+end
+
+# Velocity on boundaries characterized by functions
+subsection Boundary velocity model
+  subsection Function
+    set Variable names      = x,y
+    set Function constants  = m=0.0005, year=1
+    set Function expression = if (x<50e3 , -1*m/year, 1*m/year); if (y<50e3 , 1*m/year, -1*m/year);
+  end
+end
+
+# Temperature boundary and initial conditions
+subsection Boundary temperature model
+  set Model name = box
+  subsection Box
+    set Bottom temperature = 273
+    set Left temperature   = 273
+    set Right temperature  = 273
+    set Top temperature    = 273
+  end
+end
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 273
+  end
+end
+
+# Compositional fields used to track finite strain
+subsection Compositional fields
+  set Number of fields = 4
+  set Names of fields = s11, s12, s21, s22
+end
+
+# All compositional fields have an initial value of 0
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Variable names      = x,y
+    set Function expression = 0.5; 0; 0; 0.5;
+  end
+end
+
+# Boundary composition specification
+subsection Boundary composition model
+  set Model name = initial composition
+end
+
+# Material model (values for background material and strain fields)
+subsection Material model
+  set Model name = visco plastic
+  subsection Visco Plastic
+    set Reference strain rate = 1.e-16
+    set Viscous flow law = dislocation
+    set Prefactors for dislocation creep = 5.e-23
+    set Stress exponents for dislocation creep = 1.0
+    set Activation energies for dislocation creep = 0.
+    set Activation volumes for dislocation creep = 0.
+    set Yield mechanism = drucker
+    set Angles of internal friction = 0.
+    set Cohesions = 1.e6
+    set Use strain weakening = true
+    set Use finite strain tensor = true
+    set Start strain weakening intervals = 0.
+    set End strain weakening intervals = 1.0
+    set Cohesion strain weakening factors = 0.5
+    set Friction strain weakening factors = 0.5
+  end
+end
+
+# Gravity model
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+end
+
+# Post processing
+subsection Postprocess
+  set List of postprocessors = velocity statistics, mass flux statistics
+end

--- a/tests/visco_plastic_yield_strain_weakening_full_strain_tensor/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening_full_strain_tensor/screen-output
@@ -1,0 +1,52 @@
+
+Number of active cells: 100 (on 1 levels)
+Number of degrees of freedom: 3,208 (882+121+441+441+441+441+441)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving s11 system ... 0 iterations.
+   Skipping s12 composition solve because RHS is zero.
+   Skipping s21 composition solve because RHS is zero.
+   Solving s22 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+2 iterations.
+      Relative Stokes residual after nonlinear iteration 1: 1
+
+
+   Postprocessing:
+     RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
+     Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
+
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=100 years
+   Solving temperature system... 0 iterations.
+   Solving s11 system ... 6 iterations.
+   Solving s12 system ... 12 iterations.
+   Solving s21 system ... 12 iterations.
+   Solving s22 system ... 6 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+      Relative Stokes residual after nonlinear iteration 1: 6.62146e-15
+
+   Postprocessing:
+     RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
+     Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
+
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+


### PR DESCRIPTION
Provide an option to use the full finite strain tensor for the strain weakening component of the visco_plastic material model.  There is a warning in the material model's documentation about the pitfalls of this option.

@anne-glerum - Any and all feedback welcome!