### PR TITLE
Simplify some code by not qualifying an enum fully.

### DIFF
--- a/include/aspect/boundary_temperature/function.h
+++ b/include/aspect/boundary_temperature/function.h
@@ -126,7 +126,7 @@ namespace aspect
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
          */
-        ::aspect::Utilities::Coordinates::CoordinateSystem coordinate_system;
+        Utilities::Coordinates::CoordinateSystem coordinate_system;
     };
   }
 }

--- a/include/aspect/boundary_traction/function.h
+++ b/include/aspect/boundary_traction/function.h
@@ -100,7 +100,7 @@ namespace aspect
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
          */
-        ::aspect::Utilities::Coordinates::CoordinateSystem coordinate_system;
+        Utilities::Coordinates::CoordinateSystem coordinate_system;
     };
   }
 }

--- a/include/aspect/boundary_velocity/function.h
+++ b/include/aspect/boundary_velocity/function.h
@@ -103,7 +103,7 @@ namespace aspect
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
          */
-        ::aspect::Utilities::Coordinates::CoordinateSystem coordinate_system;
+        Utilities::Coordinates::CoordinateSystem coordinate_system;
     };
   }
 }

--- a/include/aspect/initial_temperature/function.h
+++ b/include/aspect/initial_temperature/function.h
@@ -85,7 +85,7 @@ namespace aspect
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
          */
-        ::aspect::Utilities::Coordinates::CoordinateSystem coordinate_system;
+        Utilities::Coordinates::CoordinateSystem coordinate_system;
 
     };
   }

--- a/include/aspect/mesh_refinement/maximum_refinement_function.h
+++ b/include/aspect/mesh_refinement/maximum_refinement_function.h
@@ -80,7 +80,7 @@ namespace aspect
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
          */
-        ::aspect::Utilities::Coordinates::CoordinateSystem coordinate_system;
+        Utilities::Coordinates::CoordinateSystem coordinate_system;
 
         /**
          * A function object representing the maximum refinement level. The

--- a/include/aspect/mesh_refinement/minimum_refinement_function.h
+++ b/include/aspect/mesh_refinement/minimum_refinement_function.h
@@ -81,7 +81,7 @@ namespace aspect
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
          */
-        ::aspect::Utilities::Coordinates::CoordinateSystem coordinate_system;
+        Utilities::Coordinates::CoordinateSystem coordinate_system;
 
         /**
          * A function object representing the minimum refinement level. The


### PR DESCRIPTION
In reference to a discussion in #1628.