### PR TITLE
Make default of Number of grouped files 16

### DIFF
--- a/doc/modules/changes/20170515_austermann
+++ b/doc/modules/changes/20170515_austermann
@@ -1,0 +1,5 @@
+Changed: The default number of grouped files has been changed from 0 (i.e. the nunmber of 
+processors) to 16 in order to keep the number of output files small if not explicitely
+stated otherwise.
+<br>
+(Jacky Austermann, 2017/05/15)

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -727,7 +727,7 @@ namespace aspect
                              Patterns::Selection (DataOutBase::get_output_format_names ()),
                              "The file format to be used for graphical output.");
 
-          prm.declare_entry ("Number of grouped files", "0",
+          prm.declare_entry ("Number of grouped files", "16",
                              Patterns::Integer(0),
                              "VTU file output supports grouping files from several CPUs "
                              "into a given number of files using MPI I/O when writing on a parallel "


### PR DESCRIPTION
I would prefer the default to be 1 ... what do others think?