### PR TITLE
Newton merge 3: To the spd factor visualisation and (a bit too far) beyond

### DIFF
--- a/include/aspect/material_model/drucker_prager.h
+++ b/include/aspect/material_model/drucker_prager.h
@@ -87,6 +87,34 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const;
 
+
+        /**
+         * @}
+         */
+
+        /**
+         * @name Qualitative properties one can ask a material model
+         * @{
+         */
+
+        /**
+         * Return whether the model is compressible or not.  Incompressibility
+         * does not necessarily imply that the density is constant; rather, it
+         * may still depend on temperature or pressure. In the current
+         * context, compressibility means whether we should solve the continuity
+         * equation as $\nabla \cdot (\rho \mathbf u)=0$ (compressible Stokes)
+         * or as $\nabla \cdot \mathbf{u}=0$ (incompressible Stokes).
+         */
+        virtual bool is_compressible () const;
+        /**
+         * @}
+         */
+
+        /**
+         * @name Reference quantities
+         * @{
+         */
+        virtual double reference_viscosity () const;
         /**
          * @}
          */

--- a/include/aspect/material_model/drucker_prager.h
+++ b/include/aspect/material_model/drucker_prager.h
@@ -79,7 +79,6 @@ namespace aspect
     class DruckerPrager : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {
       public:
-        std::vector<double> compute_volume_fractions( const std::vector<double> &compositional_fields) const;
         /**
          * @name Physical parameters used in the basic equations
          * @{
@@ -141,6 +140,12 @@ namespace aspect
          */
 
       private:
+        /**
+         * computes the volume fractions of the compositional fields, and returns it so that the sum
+         * of the volume fractions is one.
+         */
+        std::vector<double> compute_volume_fractions( const std::vector<double> &compositional_fields) const;
+
         double reference_rho;
         double reference_T;
         double reference_eta;

--- a/include/aspect/material_model/drucker_prager.h
+++ b/include/aspect/material_model/drucker_prager.h
@@ -87,63 +87,6 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const;
 
-        virtual double viscosity (const double                  temperature,
-                                  const double                  pressure,
-                                  const std::vector<double>    &compositional_fields,
-                                  const SymmetricTensor<2,dim> &strain_rate,
-                                  const Point<dim>             &position) const;
-
-        virtual double density (const double temperature,
-                                const double pressure,
-                                const std::vector<double> &compositional_fields,
-                                const Point<dim> &position) const;
-
-        virtual double compressibility (const double temperature,
-                                        const double pressure,
-                                        const std::vector<double> &compositional_fields,
-                                        const Point<dim> &position) const;
-
-        virtual double specific_heat (const double temperature,
-                                      const double pressure,
-                                      const std::vector<double> &compositional_fields,
-                                      const Point<dim> &position) const;
-
-        virtual double thermal_expansion_coefficient (const double      temperature,
-                                                      const double      pressure,
-                                                      const std::vector<double> &compositional_fields,
-                                                      const Point<dim> &position) const;
-
-        virtual double thermal_conductivity (const double temperature,
-                                             const double pressure,
-                                             const std::vector<double> &compositional_fields,
-                                             const Point<dim> &position) const;
-        /**
-         * @}
-         */
-
-        /**
-         * @name Qualitative properties one can ask a material model
-         * @{
-         */
-
-        /**
-         * Return whether the model is compressible or not.  Incompressibility
-         * does not necessarily imply that the density is constant; rather, it
-         * may still depend on temperature or pressure. In the current
-         * context, compressibility means whether we should solve the continuity
-         * equation as $\nabla \cdot (\rho \mathbf u)=0$ (compressible Stokes)
-         * or as $\nabla \cdot \mathbf{u}=0$ (incompressible Stokes).
-         */
-        virtual bool is_compressible () const;
-        /**
-         * @}
-         */
-
-        /**
-         * @name Reference quantities
-         * @{
-         */
-        virtual double reference_viscosity () const;
         /**
          * @}
          */

--- a/include/aspect/material_model/drucker_prager.h
+++ b/include/aspect/material_model/drucker_prager.h
@@ -76,13 +76,17 @@ namespace aspect
      * @ingroup MaterialModels
      */
     template <int dim>
-    class DruckerPrager : public MaterialModel::InterfaceCompatibility<dim>, public ::aspect::SimulatorAccess<dim>
+    class DruckerPrager : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {
       public:
+    	std::vector<double> compute_volume_fractions( const std::vector<double> &compositional_fields) const;
         /**
          * @name Physical parameters used in the basic equations
          * @{
          */
+        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                              MaterialModel::MaterialModelOutputs<dim> &out) const;
+
         virtual double viscosity (const double                  temperature,
                                   const double                  pressure,
                                   const std::vector<double>    &compositional_fields,
@@ -169,14 +173,14 @@ namespace aspect
         double reference_rho;
         double reference_T;
         double reference_eta;
-        double thermal_alpha;
+        double thermal_expansivity;
         double reference_specific_heat;
-        double thermal_k;
+        double thermal_conductivities;
 
         /**
          * The angle of internal friction
          */
-        double phi;
+        double angle_of_internal_friction;
 
         /**
          * The cohesion

--- a/include/aspect/material_model/drucker_prager.h
+++ b/include/aspect/material_model/drucker_prager.h
@@ -79,7 +79,7 @@ namespace aspect
     class DruckerPrager : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {
       public:
-    	std::vector<double> compute_volume_fractions( const std::vector<double> &compositional_fields) const;
+        std::vector<double> compute_volume_fractions( const std::vector<double> &compositional_fields) const;
         /**
          * @name Physical parameters used in the basic equations
          * @{

--- a/include/aspect/material_model/simple_nonlinear.h
+++ b/include/aspect/material_model/simple_nonlinear.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
+  Copyright (C) 2017 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -79,8 +79,8 @@ namespace aspect
          * which involves a division by the strain rate. Units: $1/s$.
          */
         std::vector<double> min_strain_rate;
-        std::vector<double> min_visc;
-        std::vector<double> max_visc;
+        std::vector<double> min_viscosity;
+        std::vector<double> max_viscosity;
         std::vector<double> veff_coefficient;
         double ref_visc;
 
@@ -98,10 +98,7 @@ namespace aspect
         unsigned int n_fields;
         // averaging parameters
         double viscosity_averaging_p;
-
-
     };
-
   }
 }
 

--- a/include/aspect/material_model/simple_nonlinear.h
+++ b/include/aspect/material_model/simple_nonlinear.h
@@ -33,7 +33,17 @@ namespace aspect
     /**
      * A material model based on a simple powerlaw rheology and
      * Implements the derivatives needed for the Newton method.
-     * TODO: more documentation.
+     *
+     * Power law equation to compute the viscosity $\eta$ per composition:
+     * $\eta = A * \dot\varepsilon_{II}^{\frac{1}{n}-1}$ where  $A$ is the
+     * prefactor, $\dot\varepsion$ is the strain-rate, II indicates
+     * the square root of the second invariant defined as
+     * $\frac{1}{2} \dot\varepsilon_{ij} \dot\varepsilon_{ij}$, and
+     * $n$ is the stress exponent.
+     *
+     * Afther this the viscosities per composition are averaged using the
+     * utilities weightd p-norm function, where the volume fractions are
+     * the weights.
      *
      * @ingroup MaterialModels
      */

--- a/include/aspect/material_model/simple_nonlinear.h
+++ b/include/aspect/material_model/simple_nonlinear.h
@@ -1,0 +1,146 @@
+/*
+  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __aspect__model_simple_nonlinear_h
+#define __aspect__model_simple_nonlinear_h
+
+#include <aspect/material_model/interface.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    using namespace dealii;
+
+    /**
+     * A material model based on a viscous rheology including diffusion and
+     * dislocation creep.
+     *
+     * The effective viscosity is defined as the harmonic mean of the two
+     * effective viscosity functions describing diffusion and dislocation creep:
+     * @f[
+     *   v_\text{eff} = \left( \frac{1}{v_\text{eff}^\text{diff}} + \frac{1}{v_\text{eff}^\text{dis}} \right)^{-1}
+     * @f]
+     * where
+     * @f[
+     *   v_\text{eff}^\text{diff} = A_\text{diff}^{-1} \exp\left(\frac{E_\text{diff} + PV_\text{diff}}{RT}\right),
+     * @f]
+     * and
+     * @f[
+     *   v_\text{eff}^\text{dis} =  A_\text{dis}^{\frac{-1}{n_\text{dis}}} \dot{\varepsilon}^{\frac{1-n}{n}}
+     *                        \exp\left(\frac{E_\text{diff} + PV_\text{diff}}{n_\text{dis}RT}\right)
+     * @f]
+     * where $\dot{\varepsilon}$ is the second invariant of the strain rate tensor,
+     * $A_i$ are prefactors where $i$ corresponds to diffusion or dislocation creep,
+     * $E_i$ are the activation energies, $V_i$ are the activation volumes,
+     * $\rho_m$ is the mantle density, $R$ is the gas constant,
+     * $T$ is temperature, and $P$ is pressure.
+     *
+     * Several model parameters (reference densities, thermal expansivities
+     * and rheology parameters) can be defined per-compositional field.
+     * For each material parameter the user supplies a comma delimited list of
+     * length N+1, where N is the number of compositional fields.  The
+     * additional field corresponds to the value for background mantle.  They
+     * should be ordered ``background, composition1, composition2...''
+     *
+     * If a list of values is given for the density and thermal expansivity,
+     * the volume weighted sum of the values of each of the compositional fields
+     * is used in their place, for example
+     * $\rho = \sum \left( \rho_i V_i \right)$
+     *
+     * The individual output viscosities for each compositional field are
+     * also averaged. The user can choose from a range of options for this
+     * viscosity averaging. If only one value is given for any of these parameters,
+     * all compositions are assigned the same value.
+     * The first value in the list is the value assigned to "background mantle"
+     * (regions where the sum of the compositional fields is < 1.0).
+     *
+     * @ingroup MaterialModels
+     */
+    template <int dim>
+    class SimpleNonlinear : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    {
+      public:
+        std::vector<double> compute_volume_fractions( const std::vector<double> &compositional_fields) const;
+
+        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                              MaterialModel::MaterialModelOutputs<dim> &out) const;
+
+        /**
+         * Return whether the model is compressible or not.  Incompressibility
+         * does not necessarily imply that the density is constant; rather, it
+         * may still depend on temperature or pressure. In the current
+         * context, compressibility means whether we should solve the continuity
+         * equation as $\nabla \cdot (\rho \mathbf u)=0$ (compressible Stokes)
+         * or as $\nabla \cdot \mathbf{u}=0$ (incompressible Stokes).
+        *
+        * This material model is incompressible.
+         */
+        virtual bool is_compressible () const;
+
+        virtual double reference_viscosity () const;
+
+        virtual double reference_density () const;
+
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
+
+      private:
+
+        double reference_T;
+
+        /**
+         * Defining a minimum strain rate stabilizes the viscosity calculation,
+         * which involves a division by the strain rate. Units: $1/s$.
+         */
+        std::vector<double> min_strain_rate;
+        std::vector<double> min_visc;
+        std::vector<double> max_visc;
+        std::vector<double> veff_coefficient;
+        double ref_visc;
+
+        std::vector<double> thermal_diffusivity;
+        std::vector<double> heat_capacity;
+
+
+        std::vector<double> densities;
+        std::vector<double> thermal_expansivities;
+
+
+        std::vector<double> prefactor;
+        std::vector<double> stress_exponent;
+
+        unsigned int n_fields;
+        // averaging parameters
+        double viscosity_averaging_p;
+
+
+    };
+
+  }
+}
+
+#endif

--- a/include/aspect/material_model/simple_nonlinear.h
+++ b/include/aspect/material_model/simple_nonlinear.h
@@ -31,47 +31,9 @@ namespace aspect
     using namespace dealii;
 
     /**
-     * A material model based on a viscous rheology including diffusion and
-     * dislocation creep.
-     *
-     * The effective viscosity is defined as the harmonic mean of the two
-     * effective viscosity functions describing diffusion and dislocation creep:
-     * @f[
-     *   v_\text{eff} = \left( \frac{1}{v_\text{eff}^\text{diff}} + \frac{1}{v_\text{eff}^\text{dis}} \right)^{-1}
-     * @f]
-     * where
-     * @f[
-     *   v_\text{eff}^\text{diff} = A_\text{diff}^{-1} \exp\left(\frac{E_\text{diff} + PV_\text{diff}}{RT}\right),
-     * @f]
-     * and
-     * @f[
-     *   v_\text{eff}^\text{dis} =  A_\text{dis}^{\frac{-1}{n_\text{dis}}} \dot{\varepsilon}^{\frac{1-n}{n}}
-     *                        \exp\left(\frac{E_\text{diff} + PV_\text{diff}}{n_\text{dis}RT}\right)
-     * @f]
-     * where $\dot{\varepsilon}$ is the second invariant of the strain rate tensor,
-     * $A_i$ are prefactors where $i$ corresponds to diffusion or dislocation creep,
-     * $E_i$ are the activation energies, $V_i$ are the activation volumes,
-     * $\rho_m$ is the mantle density, $R$ is the gas constant,
-     * $T$ is temperature, and $P$ is pressure.
-     *
-     * Several model parameters (reference densities, thermal expansivities
-     * and rheology parameters) can be defined per-compositional field.
-     * For each material parameter the user supplies a comma delimited list of
-     * length N+1, where N is the number of compositional fields.  The
-     * additional field corresponds to the value for background mantle.  They
-     * should be ordered ``background, composition1, composition2...''
-     *
-     * If a list of values is given for the density and thermal expansivity,
-     * the volume weighted sum of the values of each of the compositional fields
-     * is used in their place, for example
-     * $\rho = \sum \left( \rho_i V_i \right)$
-     *
-     * The individual output viscosities for each compositional field are
-     * also averaged. The user can choose from a range of options for this
-     * viscosity averaging. If only one value is given for any of these parameters,
-     * all compositions are assigned the same value.
-     * The first value in the list is the value assigned to "background mantle"
-     * (regions where the sum of the compositional fields is < 1.0).
+     * A material model based on a simple powerlaw rheology and
+     * Implements the derivatives needed for the Newton method.
+     * TODO: more documentation.
      *
      * @ingroup MaterialModels
      */

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011 - 2016 by the authors of the ASPECT code.
+  Copyright (C) 2011 - 2017 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 

--- a/include/aspect/postprocess/visualization/spd_factor.h
+++ b/include/aspect/postprocess/visualization/spd_factor.h
@@ -42,22 +42,18 @@ namespace aspect
        * base class. See there for their meaning.
        */
       template <int dim>
-      class SPDFactor
+      class SPDfactor
         : public DataPostprocessorScalar<dim>,
           public SimulatorAccess<dim>,
           public Interface<dim>
       {
         public:
-    	  SPDFactor ();
+          SPDfactor ();
 
           virtual
           void
-          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
-                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
-                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
-                                             const std::vector<Point<dim> >                  &normals,
-                                             const std::vector<Point<dim> >                  &evaluation_points,
-                                             std::vector<Vector<double> >                    &computed_quantities) const;
+          evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
+                                std::vector<Vector<double> > &computed_quantities) const;
       };
     }
   }

--- a/include/aspect/postprocess/visualization/spd_factor.h
+++ b/include/aspect/postprocess/visualization/spd_factor.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011 - 2016 by the authors of the ASPECT code.
+  Copyright (C) 2017 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -42,13 +42,13 @@ namespace aspect
        * base class. See there for their meaning.
        */
       template <int dim>
-      class SPDfactor
+      class SPD_Factor
         : public DataPostprocessorScalar<dim>,
           public SimulatorAccess<dim>,
           public Interface<dim>
       {
         public:
-          SPDfactor ();
+          SPD_Factor ();
 
           virtual
           void

--- a/include/aspect/postprocess/visualization/spd_factor.h
+++ b/include/aspect/postprocess/visualization/spd_factor.h
@@ -1,0 +1,66 @@
+/*
+  Copyright (C) 2011 - 2016 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef _aspect_postprocess_visualization_spd_factor_h
+#define _aspect_postprocess_visualization_spd_factor_h
+
+#include <aspect/postprocess/visualization.h>
+#include <aspect/simulator_access.h>
+
+#include <deal.II/numerics/data_postprocessor.h>
+
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    namespace VisualizationPostprocessors
+    {
+      /**
+       * A class derived from DataPostprocessor that takes an output vector
+       * and computes a variable that represents the viscosity at every point.
+       *
+       * The member functions are all implementations of those declared in the
+       * base class. See there for their meaning.
+       */
+      template <int dim>
+      class SPDFactor
+        : public DataPostprocessorScalar<dim>,
+          public SimulatorAccess<dim>,
+          public Interface<dim>
+      {
+        public:
+    	  SPDFactor ();
+
+          virtual
+          void
+          compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                             const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                             const std::vector<std::vector<Tensor<2,dim> > > &solution_hessians,
+                                             const std::vector<Point<dim> >                  &normals,
+                                             const std::vector<Point<dim> >                  &evaluation_points,
+                                             std::vector<Vector<double> >                    &computed_quantities) const;
+      };
+    }
+  }
+}
+
+#endif

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -30,14 +30,14 @@ namespace aspect
   namespace MaterialModel
   {
 
-  template <int dim>
+    template <int dim>
     void
-	DruckerPrager<dim>::
+    DruckerPrager<dim>::
     evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       //set up additional output for the derivatives
-	  MaterialModel::MaterialModelDerivatives<dim> *derivatives;
+      MaterialModel::MaterialModelDerivatives<dim> *derivatives;
       derivatives = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim> >();
 
       /*if (derivatives == NULL)
@@ -70,115 +70,116 @@ namespace aspect
               double composition_viscosity_pressure_derivatives = 0;//(volume_fractions.size());
 
               const SymmetricTensor<2,dim> strain_rate_deviator = deviator(in.strain_rate[i]);
-        	  const double edot_ii_strict = std::sqrt(0.5*strain_rate_deviator*strain_rate_deviator);
+              const double edot_ii_strict = std::sqrt(0.5*strain_rate_deviator*strain_rate_deviator);
 
               const double sqrt3 = std::sqrt(3.0);
               const double degree_to_rad = numbers::PI/180;
               //const int ct = -1;
 
               //for (unsigned int c=0; c < volume_fractions.size(); ++c)
-                //{
-                  // If strain rate is zero (like during the first time step) set it to some very small number
-                  // to prevent a division-by-zero, and a floating point exception.
-                  // Otherwise, calculate the square-root of the norm of the second invariant of the deviatoric-
-                  // strain rate (often simplified as epsilondot_ii)
-                  //const double edot_ii = 2.0 * std::max(edot_ii_strict, min_strain_rate[c] * min_strain_rate[c]);
+              //{
+              // If strain rate is zero (like during the first time step) set it to some very small number
+              // to prevent a division-by-zero, and a floating point exception.
+              // Otherwise, calculate the square-root of the norm of the second invariant of the deviatoric-
+              // strain rate (often simplified as epsilondot_ii)
+              //const double edot_ii = 2.0 * std::max(edot_ii_strict, min_strain_rate[c] * min_strain_rate[c]);
 
-                  // Find effective viscosities for each of the individual phases
-                  // Viscosities should have same number of entries as compositional fields
+              // Find effective viscosities for each of the individual phases
+              // Viscosities should have same number of entries as compositional fields
 
-                  // Power law equation
-                  // edot_ii_i = A_i * stress_ii_i^{n_i} * d^{-m} \exp\left(-\frac{E_i^* + PV_i^*}{n_iRT}\right)
-                  // where ii indicates the square root of the second invariant and
-                  // i corresponds to diffusion or dislocation creep
+              // Power law equation
+              // edot_ii_i = A_i * stress_ii_i^{n_i} * d^{-m} \exp\left(-\frac{E_i^* + PV_i^*}{n_iRT}\right)
+              // where ii indicates the square root of the second invariant and
+              // i corresponds to diffusion or dislocation creep
 
-                  // The isostrain condition implies that the viscosity averaging should be arithmetic (see above).
-                  // We have given the user freedom to apply alternative bounds, because in diffusion-dominated
-                  // creep (where n_diff=1) viscosities are stress and strain-rate independent, so the calculation
-                  // of compositional field viscosities is consistent with any averaging scheme.
-                  // TODO: Mailed Bob and asked why the averaging should be arithmetic. Bob replyed that this has to
-                  //       do with effective medium theory. Have to look into this a bit more.
-                  //const double stress_exponent_inv = 1/stress_exponent[c];
+              // The isostrain condition implies that the viscosity averaging should be arithmetic (see above).
+              // We have given the user freedom to apply alternative bounds, because in diffusion-dominated
+              // creep (where n_diff=1) viscosities are stress and strain-rate independent, so the calculation
+              // of compositional field viscosities is consistent with any averaging scheme.
+              // TODO: Mailed Bob and asked why the averaging should be arithmetic. Bob replyed that this has to
+              //       do with effective medium theory. Have to look into this a bit more.
+              //const double stress_exponent_inv = 1/stress_exponent[c];
 
-                  bool bool_min_strain_rate = false;
-                  double strain_rate_effective = edot_ii_strict;
-                  if(edot_ii_strict < reference_strain_rate * reference_strain_rate)
-                  {
-                	  strain_rate_effective = 2.0 * reference_strain_rate * reference_strain_rate;
-                	  bool_min_strain_rate = true;
-                  }
+              bool bool_min_strain_rate = false;
+              double strain_rate_effective = edot_ii_strict;
+              if (edot_ii_strict < reference_strain_rate * reference_strain_rate)
+                {
+                  strain_rate_effective = 2.0 * reference_strain_rate * reference_strain_rate;
+                  bool_min_strain_rate = true;
+                }
 
 //std::cout << "i = " << i << "sr = " << strain_rate_effective << " -> " << in.strain_rate[0] << ", eta = " << eta_dislocation << ", A sei c = " << A_sei_c << ", exp_disloc = " << exp_dislocation << ", inner exp = " << (activation_energies_dislocation[c] + activation_volumes_dislocation[c] * in.pressure[i])*RT_inv*stress_exponent_inv << ", aed = " << activation_energies_dislocation[c] << ", avd = " << activation_volumes_dislocation[c] << ", p = " << in.pressure[i] << ", RT_inv = " << RT_inv <<  std::endl;
-                  // plasticity
-                  const double sin_phi = std::sin(angle_of_internal_friction * degree_to_rad);
-                  const double cos_phi = std::cos(angle_of_internal_friction * degree_to_rad);
-                  const double strain_rate_effective_inv = 1/strain_rate_effective;
-                  const double strength_inv_part = 6.0/(sqrt3*(3.0-sin_phi));
-                  const double strength = (dim == 2 ?
-                		                           pressure * sin_phi + cohesion * cos_phi
-                                                   :
-												   (cohesion*cos_phi*strength_inv_part)
-												   + (sin_phi * strength_inv_part) * pressure);
-                  const double eta_plastic     = 0.5 * strength * strain_rate_effective_inv;
-                  //std::cout << "eta plastic = " << eta_plastic << " = 0.5 * " << strength << " * " << strain_rate_effective_inv << std::endl;
-                  //std::cout << "strenght  = " << strength << " = (" << cohesions[c] << "*" << cos_phi << "*" << strength_inv_part << ") + " << (sin_phi * strength_inv_part) * pressure << std::endl;
+              // plasticity
+              const double sin_phi = std::sin(angle_of_internal_friction * degree_to_rad);
+              const double cos_phi = std::cos(angle_of_internal_friction * degree_to_rad);
+              const double strain_rate_effective_inv = 1/strain_rate_effective;
+              const double strength_inv_part = 6.0/(sqrt3*(3.0-sin_phi));
+              const double strength = (dim == 2 ?
+                                       pressure * sin_phi + cohesion * cos_phi
+                                       :
+                                       (cohesion*cos_phi*strength_inv_part)
+                                       + (sin_phi * strength_inv_part) * pressure);
+              const double eta_plastic     = 0.5 * strength * strain_rate_effective_inv;
+              //std::cout << "eta plastic = " << eta_plastic << " = 0.5 * " << strength << " * " << strain_rate_effective_inv << std::endl;
+              //std::cout << "strenght  = " << strength << " = (" << cohesions[c] << "*" << cos_phi << "*" << strength_inv_part << ") + " << (sin_phi * strength_inv_part) * pressure << std::endl;
 
 
-                  /*
-        if (dim==3)
-        {
-          const int ct = -1;
-          strength = ((6.0*cohesion*std::cos(phi))/(std::sqrt(3.0)*(3.0+ct*std::sin(phi)))) +
-                     ((6.0*std::sin(phi))/(std::sqrt(3.0)*(3.0+ct*std::sin(phi)))) * std::max(pressure,0.0);
-        }
-      else strength = std::max(pressure,0.0) * std::sin(phi) + cohesion * std::cos(phi);
-      return strength / (2.0*strain_rate_norm);
-                   */
+              /*
+              if (dim==3)
+              {
+              const int ct = -1;
+              strength = ((6.0*cohesion*std::cos(phi))/(std::sqrt(3.0)*(3.0+ct*std::sin(phi)))) +
+                 ((6.0*std::sin(phi))/(std::sqrt(3.0)*(3.0+ct*std::sin(phi)))) * std::max(pressure,0.0);
+              }
+              else strength = std::max(pressure,0.0) * std::sin(phi) + cohesion * std::cos(phi);
+              return strength / (2.0*strain_rate_norm);
+               */
 
 
-                  const double composition_viscosity = std::max(std::min(eta_plastic, maximum_viscosity), minimum_viscosity);
+              const double composition_viscosity = std::max(std::min(eta_plastic, maximum_viscosity), minimum_viscosity);
 
-                  Assert(dealii::numbers::is_finite(composition_viscosity),ExcMessage ("Error: Viscosity is not finite."));
-                  if (/*this->get_parameters().newton_theta != 0 &&*/ derivatives != NULL)
+              Assert(dealii::numbers::is_finite(composition_viscosity),ExcMessage ("Error: Viscosity is not finite."));
+              if (/*this->get_parameters().newton_theta != 0 &&*/ derivatives != NULL)
+                {
+                  //std::cout << "viscosity = " << composition_viscosities[c] << ", min_visc = " << min_visc[c] << ", viscoplast = " << std::min(eta_viscous,eta_plastic) << ", visco = " << eta_viscous << ", plastic = " << eta_plastic << ", eta_diffusion = " << eta_diffusion << ", eta_dislocation = " << eta_dislocation << std::endl;
+                  //std::cout << "viscosity = " << composition_viscosities[c] << ", min_visc = " << min_visc[c]  << ", max_visc = " << max_visc[c] << ", bool = " << bool_min_strain_rate << std::endl;
+                  if (!bool_min_strain_rate && composition_viscosity < maximum_viscosity && composition_viscosity > minimum_viscosity)
                     {
-                	  //std::cout << "viscosity = " << composition_viscosities[c] << ", min_visc = " << min_visc[c] << ", viscoplast = " << std::min(eta_viscous,eta_plastic) << ", visco = " << eta_viscous << ", plastic = " << eta_plastic << ", eta_diffusion = " << eta_diffusion << ", eta_dislocation = " << eta_dislocation << std::endl;
-                	  //std::cout << "viscosity = " << composition_viscosities[c] << ", min_visc = " << min_visc[c]  << ", max_visc = " << max_visc[c] << ", bool = " << bool_min_strain_rate << std::endl;
-                      if (!bool_min_strain_rate && composition_viscosity < maximum_viscosity && composition_viscosity > minimum_viscosity)
-                        { //std::cout << "viscous = " << eta_viscous << ", eta_plastic = " << eta_plastic << std::endl;
+                      //std::cout << "viscous = " << eta_viscous << ", eta_plastic = " << eta_plastic << std::endl;
 
-                    		  //std::cout << "I am fully plastic! " << strain_rate_deviator  << ", " << in.strain_rate[i] << std::endl;
-                    		  composition_viscosity_strain_rate_derivatives = 0.5 * (eta_plastic * (-1/(edot_ii_strict * edot_ii_strict))) * strain_rate_deviator;
-                    		  composition_viscosity_pressure_derivatives = (dim == 2 ?
-                    				                                                      0.5 * sin_phi * strain_rate_effective_inv
-																						  :
-																						  (sin_phi*strength_inv_part));
-                    		  /*std::cout << "B " << eta_viscous << ":" << eta_plastic << ", eIIstict = " << edot_ii_strict << "; "
-                    		  << -1/(edot_ii_strict * edot_ii_strict) << ", " << 0.5 * (eta_plastic * (-1/(edot_ii_strict * edot_ii_strict))) *
-                    		   strain_rate_deviator  << " ; " << sin_phi << "*" << strength_inv_part << ", sr = "
-                    		   << composition_viscosities_strain_rate_derivatives[c] << std::endl;*/
-                        }
-                      else
-                        {
-                          composition_viscosity_strain_rate_derivatives = 0;
-                          //std::cout << "Set " << i << " to 0, becasue of bool_min_strain_rate = " << bool_min_strain_rate << " = " << edot_ii_strict << "<" << min_strain_rate[c] * min_strain_rate[c] << ", max:" << max_visc[c] << ", min:" << min_visc[c]  << std::endl;
-                        }
-                      //std::cout << std::setprecision (15) << "B " << composition_viscosities[c] << " = " << eta_viscous << ":" << eta_plastic << ", " << composition_viscosities_strain_rate_derivatives[c] << " = " << sin_phi << "*" << strength_inv_part << std::endl;
+                      //std::cout << "I am fully plastic! " << strain_rate_deviator  << ", " << in.strain_rate[i] << std::endl;
+                      composition_viscosity_strain_rate_derivatives = 0.5 * (eta_plastic * (-1/(edot_ii_strict * edot_ii_strict))) * strain_rate_deviator;
+                      composition_viscosity_pressure_derivatives = (dim == 2 ?
+                                                                    0.5 * sin_phi * strain_rate_effective_inv
+                                                                    :
+                                                                    (sin_phi*strength_inv_part));
+                      /*std::cout << "B " << eta_viscous << ":" << eta_plastic << ", eIIstict = " << edot_ii_strict << "; "
+                      << -1/(edot_ii_strict * edot_ii_strict) << ", " << 0.5 * (eta_plastic * (-1/(edot_ii_strict * edot_ii_strict))) *
+                       strain_rate_deviator  << " ; " << sin_phi << "*" << strength_inv_part << ", sr = "
+                       << composition_viscosities_strain_rate_derivatives[c] << std::endl;*/
                     }
+                  else
+                    {
+                      composition_viscosity_strain_rate_derivatives = 0;
+                      //std::cout << "Set " << i << " to 0, becasue of bool_min_strain_rate = " << bool_min_strain_rate << " = " << edot_ii_strict << "<" << min_strain_rate[c] * min_strain_rate[c] << ", max:" << max_visc[c] << ", min:" << min_visc[c]  << std::endl;
+                    }
+                  //std::cout << std::setprecision (15) << "B " << composition_viscosities[c] << " = " << eta_viscous << ":" << eta_plastic << ", " << composition_viscosities_strain_rate_derivatives[c] << " = " << sin_phi << "*" << strength_inv_part << std::endl;
+                }
 
-                //}
+              //}
 
               out.viscosities[i] = composition_viscosity;//Utilities::weighted_p_norm_average(volume_fractions, composition_viscosities, viscosity_averaging_p);
               /*std::cout << "C " << out.viscosities[i] << " = ";
               for(unsigned int c=0; c < volume_fractions.size(); ++c)
-            	  std::cout << ", " << composition_viscosities[c];
+                std::cout << ", " << composition_viscosities[c];
               std::cout << std::endl;*/
               Assert(dealii::numbers::is_finite(out.viscosities[i]),ExcMessage ("Error: Averaged viscosity is not finite."));
 
               if (/*this->get_parameters().newton_theta != 0 &&*/ derivatives != NULL)
                 {
-            	  //std::cout << "A derivatives->dviscosities_dpressure[i] = " << derivatives->dviscosities_dpressure[i] ;
+                  //std::cout << "A derivatives->dviscosities_dpressure[i] = " << derivatives->dviscosities_dpressure[i] ;
                   /*for(unsigned int c=0; c < volume_fractions.size(); ++c)
-                	  std::cout << ", " << composition_viscosities_pressure_derivatives[c];
+                    std::cout << ", " << composition_viscosities_pressure_derivatives[c];
                   std::cout << std::endl;*/
                   derivatives->viscosity_derivative_wrt_strain_rate[i] = composition_viscosity_strain_rate_derivatives;//Utilities::derivatives_weighed_p_norm_average(out.viscosities[i],volume_fractions, composition_viscosities, composition_viscosities_strain_rate_derivatives, viscosity_averaging_p);
 
@@ -186,26 +187,26 @@ namespace aspect
 //p_norm_average(volume_fractions, composition_viscosities_pressure_derivatives, viscosity_averaging_p);
                   //std::cout << "B derivatives->dviscosities_dpressure[i] = " << derivatives->dviscosities_dpressure[i] << ", " << composition_viscosities_pressure_derivatives[0] << ":" << composition_viscosities_pressure_derivatives[1] << ":" << composition_viscosities_pressure_derivatives[2] << ":" << composition_viscosities_pressure_derivatives[3] << ":" << composition_viscosities_pressure_derivatives[4] << std::endl;
                   //std::cout << derivatives->dviscosities_dpressure[i] << ":" << composition_viscosities_pressure_derivatives[0] << ":" << std::endl;
-/*#ifdef DEBUG
-                  for (int x = 0; x < dim; x++)
-                    for (int y = 0; y < dim; y++)
-                      if (!dealii::numbers::is_finite(derivatives->dviscosities_dstrain_rate[i][x][y]))
-                        std::cout << "Error: Averaged viscosity to strain-rate devrivative is not finite." << std::endl;
+                  /*#ifdef DEBUG
+                                    for (int x = 0; x < dim; x++)
+                                      for (int y = 0; y < dim; y++)
+                                        if (!dealii::numbers::is_finite(derivatives->dviscosities_dstrain_rate[i][x][y]))
+                                          std::cout << "Error: Averaged viscosity to strain-rate devrivative is not finite." << std::endl;
 
-                  //derivatives->dviscosities_dpressure[i]    = 0;* /
-                  if (!dealii::numbers::is_finite(derivatives->dviscosities_dpressure[i]))
-                    {
-                      std::cout << "Error: Averaged viscosity to pressure devrivative is not finite. " << std::endl;
-                      for (unsigned int c=0; c < volume_fractions.size(); ++c)
-                        std::cout << composition_viscosities_pressure_derivatives[c] << ",";
-                      std::cout << std::endl;
-                    }
-                  Assert(dealii::numbers::is_finite(derivatives->dviscosities_dpressure[i]),ExcMessage ("Error: Averaged dviscosities_dpressure is not finite."));
-                  for (int x = 0; x < dim; x++)
-                    for (int y = 0; y < dim; y++)
-                      Assert(dealii::numbers::is_finite(derivatives->dviscosities_dstrain_rate[i][x][y]),ExcMessage ("Error: Averaged dviscosities_dstrain_rate is not finite."));
-                  //Assert(dealii::numbers::is_nan(out.viscosities[i]),ExcMessage ("Error: Averaged viscosity is not finite."));
-#endif*/
+                                    //derivatives->dviscosities_dpressure[i]    = 0;* /
+                                    if (!dealii::numbers::is_finite(derivatives->dviscosities_dpressure[i]))
+                                      {
+                                        std::cout << "Error: Averaged viscosity to pressure devrivative is not finite. " << std::endl;
+                                        for (unsigned int c=0; c < volume_fractions.size(); ++c)
+                                          std::cout << composition_viscosities_pressure_derivatives[c] << ",";
+                                        std::cout << std::endl;
+                                      }
+                                    Assert(dealii::numbers::is_finite(derivatives->dviscosities_dpressure[i]),ExcMessage ("Error: Averaged dviscosities_dpressure is not finite."));
+                                    for (int x = 0; x < dim; x++)
+                                      for (int y = 0; y < dim; y++)
+                                        Assert(dealii::numbers::is_finite(derivatives->dviscosities_dstrain_rate[i][x][y]),ExcMessage ("Error: Averaged dviscosities_dstrain_rate is not finite."));
+                                    //Assert(dealii::numbers::is_nan(out.viscosities[i]),ExcMessage ("Error: Averaged viscosity is not finite."));
+                  #endif*/
                   /*if (isnan(derivatives->dviscosities_dpressure[i]))
                   {
                                       std::cout << "Error: Averaged viscosity to pressure devrivative is nam: " << derivatives->dviscosities_dpressure[i] << ":" << composition_viscosities_pressure_derivatives[0]  << ":" << composition_viscosities_pressure_derivatives[1] << ":" << composition_viscosities_pressure_derivatives[2] << ":" << composition_viscosities_pressure_derivatives[3] << ":" << composition_viscosities_pressure_derivatives[4]  << ":" << composition_viscosities_pressure_derivatives[5] << ":" << composition_viscosities_pressure_derivatives[6]  << ":" << composition_viscosities_pressure_derivatives[7] << ":" << composition_viscosities_pressure_derivatives[8]  << ":" << composition_viscosities_pressure_derivatives[9] << std::endl;
@@ -216,17 +217,17 @@ namespace aspect
                                       std::cout << "Error: Averaged viscosity to pressure devrivative is not finite: " << derivatives->dviscosities_dpressure[i] << ":" << composition_viscosities_pressure_derivatives[0] << std::endl;
                                     AssertThrow(false,ExcMessage ("Error: Averaged viscosity is not finite."));
                   }*/
-/*#ifdef DEBUG
-                  for (int x = 0; x < dim; x++)
-                    for (int y = 0; y < dim; y++)
-                      if (!dealii::numbers::is_finite(derivatives->dviscosities_dstrain_rate[i][x][y]))
-                        std::cout << "Error: Averaged viscosity to strain-rate devrivative is not finite." << std::endl;
+                  /*#ifdef DEBUG
+                                    for (int x = 0; x < dim; x++)
+                                      for (int y = 0; y < dim; y++)
+                                        if (!dealii::numbers::is_finite(derivatives->dviscosities_dstrain_rate[i][x][y]))
+                                          std::cout << "Error: Averaged viscosity to strain-rate devrivative is not finite." << std::endl;
 
-                  //derivatives->dviscosities_dpressure[i]    = 0;
-                  / *if (isnan(derivatives->dviscosities_dpressure[i]))
-                    std::cout << "Error: Averaged viscosity to pressure devrivative is not finite: " << derivatives->dviscosities_dpressure[i] << ":" << composition_viscosities_pressure_derivatives[0] << std::endl;
-                  AssertThrow(false,ExcMessage ("Error: Averaged viscosity is not finite."))* /
-#endif*/
+                                    //derivatives->dviscosities_dpressure[i]    = 0;
+                                    / *if (isnan(derivatives->dviscosities_dpressure[i]))
+                                      std::cout << "Error: Averaged viscosity to pressure devrivative is not finite: " << derivatives->dviscosities_dpressure[i] << ":" << composition_viscosities_pressure_derivatives[0] << std::endl;
+                                    AssertThrow(false,ExcMessage ("Error: Averaged viscosity is not finite."))* /
+                  #endif*/
                 }
             }
           out.densities[i] = reference_rho * (1 - thermal_expansivity * (temperature - reference_T));

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -58,7 +58,7 @@ namespace aspect
                                               ?
                                               reference_strain_rate * reference_strain_rate
                                               :
-											  0.5*strain_rate_deviator*strain_rate_deviator);//std::fabs(second_invariant(strain_rate_deviator)));
+                                              0.5*strain_rate_deviator*strain_rate_deviator);//std::fabs(second_invariant(strain_rate_deviator)));
               const double sqrt3 = std::sqrt(3.0);
               //const double degree_to_rad = numbers::PI/180;
 
@@ -132,14 +132,12 @@ namespace aspect
 
                   derivatives->viscosity_derivative_wrt_pressure[i] = effective_viscosity_pressure_derivatives;//Utilities::derivatives_weighed_p_norm_average(out.viscosities[i],volume_fractions, composition_viscosities, composition_viscosities_pressure_derivatives, viscosity_averaging_p);
 
-#ifdef DEBUG
                   Assert(dealii::numbers::is_finite(derivatives->viscosity_derivative_wrt_pressure[i]),
                          ExcMessage ("Error: Averaged dviscosities_dpressure is not finite."));
                   for (int x = 0; x < dim; x++)
                     for (int y = 0; y < dim; y++)
                       Assert(dealii::numbers::is_finite(derivatives->viscosity_derivative_wrt_strain_rate[i][x][y]),
                              ExcMessage ("Error: Averaged dviscosities_dstrain_rate is not finite."));
-#endif
 
                 }
             }
@@ -165,6 +163,8 @@ namespace aspect
         }
     }
 
+
+
     template <int dim>
     double
     DruckerPrager<dim>::
@@ -173,6 +173,8 @@ namespace aspect
       return reference_eta;
     }
 
+
+
     template <int dim>
     bool
     DruckerPrager<dim>::
@@ -180,6 +182,8 @@ namespace aspect
     {
       return false;
     }
+
+
 
     template <int dim>
     void
@@ -286,6 +290,7 @@ namespace aspect
     }
   }
 }
+
 
 // explicit instantiations
 namespace aspect

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -40,65 +40,23 @@ namespace aspect
       MaterialModel::MaterialModelDerivatives<dim> *derivatives;
       derivatives = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim> >();
 
-      /*if (derivatives == NULL)
-      {
-
-      const unsigned int n_points = out.viscosities.size();
-      const unsigned int n_comp = out.reaction_terms[0].size();
-      out.additional_outputs.push_back(
-        std_cxx11::shared_ptr<MaterialModel::AdditionalMaterialOutputs<dim> >
-        (new MaterialModel::MaterialModelDerivatives<dim> (n_points)));
-      }
-
-      derivatives = out.template get_additional_output<MaterialModelDerivatives<dim> >();*/
-
       for (unsigned int i=0; i < in.temperature.size(); ++i)
         {
-          // const Point<dim> position = in.position[i];
           const double temperature = in.temperature[i];
           const double pressure=std::max(in.pressure[i],0.0);
 
           // calculate effective viscosity
           if (in.strain_rate.size())
             {
-              // This function calculates viscosities assuming that all the compositional fields
-              // experience the same strain rate (isostrain). Since there is only one process in
-              // this material model (a general powerlaw) we do not need to worry about how to
-              // distribute the strain-rate and stress over the processes.
-              //double composition_viscosities;
-              SymmetricTensor<2,dim> composition_viscosity_strain_rate_derivatives;//(volume_fractions.size());
-              double composition_viscosity_pressure_derivatives = 0;//(volume_fractions.size());
+              SymmetricTensor<2,dim> composition_viscosity_strain_rate_derivatives;
+              double composition_viscosity_pressure_derivatives = 0;
 
               const SymmetricTensor<2,dim> strain_rate_deviator = deviator(in.strain_rate[i]);
               const double edot_ii_strict = std::sqrt(0.5*strain_rate_deviator*strain_rate_deviator);
 
               const double sqrt3 = std::sqrt(3.0);
               const double degree_to_rad = numbers::PI/180;
-              //const int ct = -1;
 
-              //for (unsigned int c=0; c < volume_fractions.size(); ++c)
-              //{
-              // If strain rate is zero (like during the first time step) set it to some very small number
-              // to prevent a division-by-zero, and a floating point exception.
-              // Otherwise, calculate the square-root of the norm of the second invariant of the deviatoric-
-              // strain rate (often simplified as epsilondot_ii)
-              //const double edot_ii = 2.0 * std::max(edot_ii_strict, min_strain_rate[c] * min_strain_rate[c]);
-
-              // Find effective viscosities for each of the individual phases
-              // Viscosities should have same number of entries as compositional fields
-
-              // Power law equation
-              // edot_ii_i = A_i * stress_ii_i^{n_i} * d^{-m} \exp\left(-\frac{E_i^* + PV_i^*}{n_iRT}\right)
-              // where ii indicates the square root of the second invariant and
-              // i corresponds to diffusion or dislocation creep
-
-              // The isostrain condition implies that the viscosity averaging should be arithmetic (see above).
-              // We have given the user freedom to apply alternative bounds, because in diffusion-dominated
-              // creep (where n_diff=1) viscosities are stress and strain-rate independent, so the calculation
-              // of compositional field viscosities is consistent with any averaging scheme.
-              // TODO: Mailed Bob and asked why the averaging should be arithmetic. Bob replyed that this has to
-              //       do with effective medium theory. Have to look into this a bit more.
-              //const double stress_exponent_inv = 1/stress_exponent[c];
 
               bool bool_min_strain_rate = false;
               double strain_rate_effective = edot_ii_strict;
@@ -108,7 +66,6 @@ namespace aspect
                   bool_min_strain_rate = true;
                 }
 
-//std::cout << "i = " << i << "sr = " << strain_rate_effective << " -> " << in.strain_rate[0] << ", eta = " << eta_dislocation << ", A sei c = " << A_sei_c << ", exp_disloc = " << exp_dislocation << ", inner exp = " << (activation_energies_dislocation[c] + activation_volumes_dislocation[c] * in.pressure[i])*RT_inv*stress_exponent_inv << ", aed = " << activation_energies_dislocation[c] << ", avd = " << activation_volumes_dislocation[c] << ", p = " << in.pressure[i] << ", RT_inv = " << RT_inv <<  std::endl;
               // plasticity
               const double sin_phi = std::sin(angle_of_internal_friction * degree_to_rad);
               const double cos_phi = std::cos(angle_of_internal_friction * degree_to_rad);
@@ -120,20 +77,6 @@ namespace aspect
                                        (cohesion*cos_phi*strength_inv_part)
                                        + (sin_phi * strength_inv_part) * pressure);
               const double eta_plastic     = 0.5 * strength * strain_rate_effective_inv;
-              //std::cout << "eta plastic = " << eta_plastic << " = 0.5 * " << strength << " * " << strain_rate_effective_inv << std::endl;
-              //std::cout << "strenght  = " << strength << " = (" << cohesions[c] << "*" << cos_phi << "*" << strength_inv_part << ") + " << (sin_phi * strength_inv_part) * pressure << std::endl;
-
-
-              /*
-              if (dim==3)
-              {
-              const int ct = -1;
-              strength = ((6.0*cohesion*std::cos(phi))/(std::sqrt(3.0)*(3.0+ct*std::sin(phi)))) +
-                 ((6.0*std::sin(phi))/(std::sqrt(3.0)*(3.0+ct*std::sin(phi)))) * std::max(pressure,0.0);
-              }
-              else strength = std::max(pressure,0.0) * std::sin(phi) + cohesion * std::cos(phi);
-              return strength / (2.0*strain_rate_norm);
-               */
 
 
               const double composition_viscosity = std::max(std::min(eta_plastic, maximum_viscosity), minimum_viscosity);
@@ -141,93 +84,39 @@ namespace aspect
               Assert(dealii::numbers::is_finite(composition_viscosity),ExcMessage ("Error: Viscosity is not finite."));
               if (/*this->get_parameters().newton_theta != 0 &&*/ derivatives != NULL)
                 {
-                  //std::cout << "viscosity = " << composition_viscosities[c] << ", min_visc = " << min_visc[c] << ", viscoplast = " << std::min(eta_viscous,eta_plastic) << ", visco = " << eta_viscous << ", plastic = " << eta_plastic << ", eta_diffusion = " << eta_diffusion << ", eta_dislocation = " << eta_dislocation << std::endl;
-                  //std::cout << "viscosity = " << composition_viscosities[c] << ", min_visc = " << min_visc[c]  << ", max_visc = " << max_visc[c] << ", bool = " << bool_min_strain_rate << std::endl;
                   if (!bool_min_strain_rate && composition_viscosity < maximum_viscosity && composition_viscosity > minimum_viscosity)
                     {
-                      //std::cout << "viscous = " << eta_viscous << ", eta_plastic = " << eta_plastic << std::endl;
-
-                      //std::cout << "I am fully plastic! " << strain_rate_deviator  << ", " << in.strain_rate[i] << std::endl;
                       composition_viscosity_strain_rate_derivatives = 0.5 * (eta_plastic * (-1/(edot_ii_strict * edot_ii_strict))) * strain_rate_deviator;
                       composition_viscosity_pressure_derivatives = (dim == 2 ?
                                                                     0.5 * sin_phi * strain_rate_effective_inv
                                                                     :
                                                                     (sin_phi*strength_inv_part));
-                      /*std::cout << "B " << eta_viscous << ":" << eta_plastic << ", eIIstict = " << edot_ii_strict << "; "
-                      << -1/(edot_ii_strict * edot_ii_strict) << ", " << 0.5 * (eta_plastic * (-1/(edot_ii_strict * edot_ii_strict))) *
-                       strain_rate_deviator  << " ; " << sin_phi << "*" << strength_inv_part << ", sr = "
-                       << composition_viscosities_strain_rate_derivatives[c] << std::endl;*/
                     }
                   else
                     {
                       composition_viscosity_strain_rate_derivatives = 0;
-                      //std::cout << "Set " << i << " to 0, becasue of bool_min_strain_rate = " << bool_min_strain_rate << " = " << edot_ii_strict << "<" << min_strain_rate[c] * min_strain_rate[c] << ", max:" << max_visc[c] << ", min:" << min_visc[c]  << std::endl;
                     }
-                  //std::cout << std::setprecision (15) << "B " << composition_viscosities[c] << " = " << eta_viscous << ":" << eta_plastic << ", " << composition_viscosities_strain_rate_derivatives[c] << " = " << sin_phi << "*" << strength_inv_part << std::endl;
                 }
 
-              //}
-
-              out.viscosities[i] = composition_viscosity;//Utilities::weighted_p_norm_average(volume_fractions, composition_viscosities, viscosity_averaging_p);
-              /*std::cout << "C " << out.viscosities[i] << " = ";
-              for(unsigned int c=0; c < volume_fractions.size(); ++c)
-                std::cout << ", " << composition_viscosities[c];
-              std::cout << std::endl;*/
+              out.viscosities[i] = composition_viscosity;
               Assert(dealii::numbers::is_finite(out.viscosities[i]),ExcMessage ("Error: Averaged viscosity is not finite."));
 
               if (/*this->get_parameters().newton_theta != 0 &&*/ derivatives != NULL)
                 {
-                  //std::cout << "A derivatives->dviscosities_dpressure[i] = " << derivatives->dviscosities_dpressure[i] ;
-                  /*for(unsigned int c=0; c < volume_fractions.size(); ++c)
-                    std::cout << ", " << composition_viscosities_pressure_derivatives[c];
-                  std::cout << std::endl;*/
+
                   derivatives->viscosity_derivative_wrt_strain_rate[i] = composition_viscosity_strain_rate_derivatives;//Utilities::derivatives_weighed_p_norm_average(out.viscosities[i],volume_fractions, composition_viscosities, composition_viscosities_strain_rate_derivatives, viscosity_averaging_p);
 
                   derivatives->viscosity_derivative_wrt_pressure[i] = composition_viscosity_pressure_derivatives;//Utilities::derivatives_weighed_p_norm_average(out.viscosities[i],volume_fractions, composition_viscosities, composition_viscosities_pressure_derivatives, viscosity_averaging_p);
-//p_norm_average(volume_fractions, composition_viscosities_pressure_derivatives, viscosity_averaging_p);
-                  //std::cout << "B derivatives->dviscosities_dpressure[i] = " << derivatives->dviscosities_dpressure[i] << ", " << composition_viscosities_pressure_derivatives[0] << ":" << composition_viscosities_pressure_derivatives[1] << ":" << composition_viscosities_pressure_derivatives[2] << ":" << composition_viscosities_pressure_derivatives[3] << ":" << composition_viscosities_pressure_derivatives[4] << std::endl;
-                  //std::cout << derivatives->dviscosities_dpressure[i] << ":" << composition_viscosities_pressure_derivatives[0] << ":" << std::endl;
-                  /*#ifdef DEBUG
-                                    for (int x = 0; x < dim; x++)
-                                      for (int y = 0; y < dim; y++)
-                                        if (!dealii::numbers::is_finite(derivatives->dviscosities_dstrain_rate[i][x][y]))
-                                          std::cout << "Error: Averaged viscosity to strain-rate devrivative is not finite." << std::endl;
 
-                                    //derivatives->dviscosities_dpressure[i]    = 0;* /
-                                    if (!dealii::numbers::is_finite(derivatives->dviscosities_dpressure[i]))
-                                      {
-                                        std::cout << "Error: Averaged viscosity to pressure devrivative is not finite. " << std::endl;
-                                        for (unsigned int c=0; c < volume_fractions.size(); ++c)
-                                          std::cout << composition_viscosities_pressure_derivatives[c] << ",";
-                                        std::cout << std::endl;
-                                      }
-                                    Assert(dealii::numbers::is_finite(derivatives->dviscosities_dpressure[i]),ExcMessage ("Error: Averaged dviscosities_dpressure is not finite."));
-                                    for (int x = 0; x < dim; x++)
-                                      for (int y = 0; y < dim; y++)
-                                        Assert(dealii::numbers::is_finite(derivatives->dviscosities_dstrain_rate[i][x][y]),ExcMessage ("Error: Averaged dviscosities_dstrain_rate is not finite."));
-                                    //Assert(dealii::numbers::is_nan(out.viscosities[i]),ExcMessage ("Error: Averaged viscosity is not finite."));
-                  #endif*/
-                  /*if (isnan(derivatives->dviscosities_dpressure[i]))
-                  {
-                                      std::cout << "Error: Averaged viscosity to pressure devrivative is nam: " << derivatives->dviscosities_dpressure[i] << ":" << composition_viscosities_pressure_derivatives[0]  << ":" << composition_viscosities_pressure_derivatives[1] << ":" << composition_viscosities_pressure_derivatives[2] << ":" << composition_viscosities_pressure_derivatives[3] << ":" << composition_viscosities_pressure_derivatives[4]  << ":" << composition_viscosities_pressure_derivatives[5] << ":" << composition_viscosities_pressure_derivatives[6]  << ":" << composition_viscosities_pressure_derivatives[7] << ":" << composition_viscosities_pressure_derivatives[8]  << ":" << composition_viscosities_pressure_derivatives[9] << std::endl;
-                                    AssertThrow(false,ExcMessage ("Error: Averaged viscosity is nan."));
-                  }
-                  if (!dealii::numbers::is_finite(derivatives->dviscosities_dpressure[i]))
-                  {
-                                      std::cout << "Error: Averaged viscosity to pressure devrivative is not finite: " << derivatives->dviscosities_dpressure[i] << ":" << composition_viscosities_pressure_derivatives[0] << std::endl;
-                                    AssertThrow(false,ExcMessage ("Error: Averaged viscosity is not finite."));
-                  }*/
-                  /*#ifdef DEBUG
-                                    for (int x = 0; x < dim; x++)
-                                      for (int y = 0; y < dim; y++)
-                                        if (!dealii::numbers::is_finite(derivatives->dviscosities_dstrain_rate[i][x][y]))
-                                          std::cout << "Error: Averaged viscosity to strain-rate devrivative is not finite." << std::endl;
+#ifdef DEBUG
+                  Assert(dealii::numbers::is_finite(derivatives->viscosity_derivative_wrt_pressure[i]),
+                         ExcMessage ("Error: Averaged dviscosities_dpressure is not finite."));
+                  for (int x = 0; x < dim; x++)
+                    for (int y = 0; y < dim; y++)
+                      Assert(dealii::numbers::is_finite(derivatives->viscosity_derivative_wrt_strain_rate[i][x][y]),
+                             ExcMessage ("Error: Averaged dviscosities_dstrain_rate is not finite."));
+#endif
 
-                                    //derivatives->dviscosities_dpressure[i]    = 0;
-                                    / *if (isnan(derivatives->dviscosities_dpressure[i]))
-                                      std::cout << "Error: Averaged viscosity to pressure devrivative is not finite: " << derivatives->dviscosities_dpressure[i] << ":" << composition_viscosities_pressure_derivatives[0] << std::endl;
-                                    AssertThrow(false,ExcMessage ("Error: Averaged viscosity is not finite."))* /
-                  #endif*/
                 }
             }
           out.densities[i] = reference_rho * (1 - thermal_expansivity * (temperature - reference_T));
@@ -251,136 +140,6 @@ namespace aspect
             out.reaction_terms[i][c] = 0.0;
         }
     }
-
-    template <int dim>
-    double
-    DruckerPrager<dim>::
-    viscosity (const double /*temperature*/,
-               const double pressure,
-               const std::vector<double> &/*composition*/,
-               const SymmetricTensor<2,dim> &strain_rate,
-               const Point<dim> &/*position*/) const
-    {
-      // For the very first time this function is called
-      // (the first iteration of the first timestep), this function is called
-      // with a zero input strain rate. We provide a representative reference
-      // strain rate for this case, which avoids division by zero and produces
-      // a representative first guess of the viscosities.
-      // In later iterations and timesteps we calculate the second moment
-      // invariant of the deviatoric strain rate tensor.
-      // This is equal to the negative of the second principle
-      // invariant calculated with the function second_invariant.
-      const double strain_rate_dev_inv2 = ( (this->get_timestep_number() == 0 && strain_rate.norm() <= std::numeric_limits<double>::min())
-                                            ?
-                                            reference_strain_rate * reference_strain_rate
-                                            :
-                                            std::fabs(second_invariant(deviator(strain_rate))));
-
-      // In later timesteps, we still need to care about cases of very small
-      // strain rates. We expect the viscosity to approach the maximum_viscosity
-      // in these cases. This check prevents a division-by-zero.
-      if (std::sqrt(strain_rate_dev_inv2) <= std::numeric_limits<double>::min())
-        return maximum_viscosity;
-
-      // To avoid negative yield strengths and eventually viscosities,
-      // we make sure the pressure is not negative
-      const double strength = ( (dim==3)
-                                ?
-                                ( 6.0 * cohesion * std::cos(angle_of_internal_friction) + 2.0 * std::max(pressure,0.0) * std::sin(angle_of_internal_friction) )
-                                / ( std::sqrt(3.0) * ( 3.0 + std::sin(angle_of_internal_friction) ) )
-                                :
-                                cohesion * std::cos(angle_of_internal_friction) + std::max(pressure,0.0) * std::sin(angle_of_internal_friction) );
-
-      // Rescale the viscosity back onto the yield surface
-      const double viscosity = strength / ( 2.0 * std::sqrt(strain_rate_dev_inv2) );
-
-      // Cut off the viscosity between a minimum and maximum value to avoid
-      // a numerically unfavourable large viscosity range.
-      const double effective_viscosity = 1.0 / ( ( 1.0 / ( viscosity + minimum_viscosity ) ) + ( 1.0 / maximum_viscosity ) );
-
-      return effective_viscosity;
-
-    }
-
-
-    template <int dim>
-    double
-    DruckerPrager<dim>::
-    reference_viscosity () const
-    {
-      return reference_eta;
-    }
-
-
-    template <int dim>
-    double
-    DruckerPrager<dim>::
-    specific_heat (const double,
-                   const double,
-                   const std::vector<double> &, /*composition*/
-                   const Point<dim> &) const
-    {
-      return reference_specific_heat;
-    }
-
-
-    template <int dim>
-    double
-    DruckerPrager<dim>::
-    thermal_conductivity (const double,
-                          const double,
-                          const std::vector<double> &, /*composition*/
-                          const Point<dim> &) const
-    {
-      return thermal_conductivities;
-    }
-
-
-    template <int dim>
-    double
-    DruckerPrager<dim>::
-    density (const double temperature,
-             const double,
-             const std::vector<double> &, /*composition*/
-             const Point<dim> &) const
-    {
-      return reference_rho * (1 - thermal_expansivity * (temperature - reference_T));
-    }
-
-
-    template <int dim>
-    double
-    DruckerPrager<dim>::
-    thermal_expansion_coefficient (const double,
-                                   const double,
-                                   const std::vector<double> &, /*composition*/
-                                   const Point<dim> &) const
-    {
-      return thermal_expansivity;
-    }
-
-
-    template <int dim>
-    double
-    DruckerPrager<dim>::
-    compressibility (const double,
-                     const double,
-                     const std::vector<double> &, /*composition*/
-                     const Point<dim> &) const
-    {
-      return 0.0;
-    }
-
-
-
-    template <int dim>
-    bool
-    DruckerPrager<dim>::
-    is_compressible () const
-    {
-      return false;
-    }
-
 
 
     template <int dim>

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -141,6 +141,21 @@ namespace aspect
         }
     }
 
+    template <int dim>
+    double
+    DruckerPrager<dim>::
+    reference_viscosity () const
+    {
+      return reference_eta;
+    }
+
+    template <int dim>
+    bool
+    DruckerPrager<dim>::
+    is_compressible () const
+    {
+      return false;
+    }
 
     template <int dim>
     void

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -55,19 +55,19 @@ namespace aspect
               //const double edot_ii_strict = std::fabs(second_invariant(strain_rate_deviator));//std::sqrt(0.5*strain_rate_deviator*strain_rate_deviator);//
 
               const double edot_ii_strict = (&(this->get_simulator()) == NULL
-            		  ?
-            				  // no simulator object available -- we are probably in a unit test
-            				  std::fabs(second_invariant(strain_rate_deviator))
-            		  :
-							  // simulator object is available, but we need to treat the
-							  // first time step separately
-					  ((this->get_timestep_number() == 0)
-            		   &&
-					   (in.strain_rate[i].norm() <= std::numeric_limits<double>::min())
-					   ?
-							   reference_strain_rate * reference_strain_rate
-							   :
-							   std::fabs(second_invariant(strain_rate_deviator))));//0.5*strain_rate_deviator*strain_rate_deviator);
+                                             ?
+                                             // no simulator object available -- we are probably in a unit test
+                                             std::fabs(second_invariant(strain_rate_deviator))
+                                             :
+                                             // simulator object is available, but we need to treat the
+                                             // first time step separately
+                                             ((this->get_timestep_number() == 0)
+                                              &&
+                                              (in.strain_rate[i].norm() <= std::numeric_limits<double>::min())
+                                              ?
+                                              reference_strain_rate * reference_strain_rate
+                                              :
+                                              std::fabs(second_invariant(strain_rate_deviator))));//0.5*strain_rate_deviator*strain_rate_deviator);
 
               const double sqrt3 = std::sqrt(3.0);
 

--- a/source/material_model/simple_nonlinear.cc
+++ b/source/material_model/simple_nonlinear.cc
@@ -125,20 +125,6 @@ namespace aspect
                   const double edot_ii_strict = std::sqrt(0.5*deviator(in.strain_rate[i])*deviator(in.strain_rate[i]));
                   const double edot_ii = 2.0 * std::max(edot_ii_strict, min_strain_rate[c] * min_strain_rate[c]);
 
-                  // Find effective viscosities for each of the individual phases
-                  // Viscosities should have same number of entries as compositional fields
-
-                  // Power law equation
-                  // edot_ii_i = A_i * stress_ii_i^{n_i} * d^{-m} \exp\left(-\frac{E_i^* + PV_i^*}{n_iRT}\right)
-                  // where ii indicates the square root of the second invariant and
-                  // i corresponds to diffusion or dislocation creep
-
-                  // The isostrain condition implies that the viscosity averaging should be arithmetic (see above).
-                  // We have given the user freedom to apply alternative bounds, because in diffusion-dominated
-                  // creep (where n_diff=1) viscosities are stress and strain-rate independent, so the calculation
-                  // of compositional field viscosities is consistent with any averaging scheme.
-                  // TODO: Mailed Bob and asked why the averaging should be arithmetic. Bob replyed that this has to
-                  //       do with effective medium theory. Have to look into this a bit more.
                   const double stress_exponent_inv = 1/stress_exponent[c];
                   composition_viscosities[c] = std::max(std::min(std::pow(prefactor[c],-stress_exponent_inv) * std::pow(edot_ii,stress_exponent_inv-1), max_viscosity[c]), min_viscosity[c]);
                   Assert(dealii::numbers::is_finite(composition_viscosities[c]),ExcMessage ("Error: Viscosity is not finite."));
@@ -165,12 +151,12 @@ namespace aspect
 
                   for (int x = 0; x < dim; x++)
                     for (int y = 0; y < dim; y++)
-                    	Assert (dealii::numbers::is_finite(derivatives->viscosity_derivative_wrt_strain_rate[i][x][y]),
-                    			ExcMessage ("Averaged viscosity to strain-rate devrivative is not finite."));
+                      Assert (dealii::numbers::is_finite(derivatives->viscosity_derivative_wrt_strain_rate[i][x][y]),
+                              ExcMessage ("Averaged viscosity to strain-rate devrivative is not finite."));
 
                   derivatives->viscosity_derivative_wrt_pressure[i]    = 0;
-              	Assert (dealii::numbers::is_finite(derivatives->viscosity_derivative_wrt_strain_rate[i][x][y]),
-              			ExcMessage ("Averaged viscosity to pressure devrivative is not finite."));
+                  Assert (dealii::numbers::is_finite(derivatives->viscosity_derivative_wrt_strain_rate[i][x][y]),
+                          ExcMessage ("Averaged viscosity to pressure devrivative is not finite."));
 
                 }
             }

--- a/source/material_model/simple_nonlinear.cc
+++ b/source/material_model/simple_nonlinear.cc
@@ -155,7 +155,7 @@ namespace aspect
                               ExcMessage ("Averaged viscosity to strain-rate devrivative is not finite."));
 
                   derivatives->viscosity_derivative_wrt_pressure[i]    = 0;
-                  Assert (dealii::numbers::is_finite(derivatives->viscosity_derivative_wrt_strain_rate[i][x][y]),
+                  Assert (dealii::numbers::is_finite(derivatives->viscosity_derivative_wrt_pressure[i]),
                           ExcMessage ("Averaged viscosity to pressure devrivative is not finite."));
 
                 }

--- a/source/material_model/simple_nonlinear.cc
+++ b/source/material_model/simple_nonlinear.cc
@@ -51,31 +51,6 @@ namespace aspect
     SimpleNonlinear<dim>::
     compute_volume_fractions( const std::vector<double> &compositional_fields) const
     {
-      /*std::cout << "vfFlag 1 " << std::endl;
-         std::vector<double> volume_fractions(compositional_fields.size());
-         std::cout << "vfFlag 2 " << std::endl;
-         //clip the compositional fields so they are between zero and one
-         std::vector<double> x_comp = compositional_fields;
-         for ( unsigned int i=0; i < x_comp.size(); ++i)
-           x_comp[i] = std::min(std::max(x_comp[i], 0.0), 1.0);
-         std::cout << "vfFlag 5 " << std::endl;
-         //sum the compositional fields for normalization purposes
-         double sum_composition = 0.0;
-         for ( unsigned int i=0; i < x_comp.size(); ++i)
-           sum_composition += x_comp[i];
-         std::cout << "vfFlag 8 " << std::endl;
-         // If the sum of the compositions is smaller
-         // than 0.1 something is going really wrong
-         // and we abort.
-         AssertThrow(sum_composition >= 0.1,
-             ExcMessage("The sum of the compositions is smaller than 0.1. There are " + std::to_string(x_comp.size()) + " compositions. It is " +  std::to_string(sum_composition) + ", xcomp 0: "  +  std::to_string(x_comp[0]) + ", comp 0: "  +  std::to_string(compositional_fields[0]) ))
-         std::cout << "vfFlag 10 " << std::endl;
-         //volume_fractions[0] = 0.0;  //background mantle
-         for ( unsigned int i=0; i < x_comp.size(); ++i)
-           volume_fractions[i] = x_comp[i]/sum_composition;std::cout << "vfFlag 15 " << std::endl;
-         //std::cout << "Multiple compositions, return them." << std::endl;
-         return volume_fractions;*/
-
       std::vector<double> volume_fractions( compositional_fields.size()+1);
 
       //clip the compositional fields so they are between zero and one
@@ -99,7 +74,7 @@ namespace aspect
           volume_fractions[0] = 1.0 - sum_composition; //background mantle
           for ( unsigned int i=1; i <= x_comp.size(); ++i)
             volume_fractions[i] = x_comp[i-1];
-        } //std::cout << "Background mantle = " << volume_fractions[0] << std::endl;
+        }
       return volume_fractions;
     }
 
@@ -115,9 +90,7 @@ namespace aspect
 
       for (unsigned int i=0; i < in.temperature.size(); ++i)
         {
-          // const Point<dim> position = in.position[i];
           const double temperature = in.temperature[i];
-          const double pressure= in.pressure[i];
 
           // Averaging composition-field dependent properties
           // Compositions
@@ -192,12 +165,10 @@ namespace aspect
                         {
                           //strictly speaking the derivative is this: 0.5 * ((1/stress_exponent)-1) * std::pow(2,2) * out.viscosities[i] * (1/(edot_ii*edot_ii)) * deviator(in.strain_rate[i])
                           composition_viscosities_derivatives[c] = 2 * (stress_exponent_inv-1) * composition_viscosities[c] * (1/(edot_ii*edot_ii)) * deviator(in.strain_rate[i]);
-                          //std::cout << composition_viscosities_derivatives[i] << ", dev strt:" << deviator(in.strain_rate[i]) << std::endl;
                         }
                       else
                         {
                           composition_viscosities_derivatives[c] = 0;
-                          //std::cout << "Set " << i << " to 0" << std::endl;
                         }
                     }
                 }
@@ -205,8 +176,6 @@ namespace aspect
               out.viscosities[i] = Utilities::weighted_p_norm_average(volume_fractions, composition_viscosities, viscosity_averaging_p);
               Assert(dealii::numbers::is_finite(out.viscosities[i]),ExcMessage ("Error: Averaged viscosity is not finite."));
 
-              //for(int ccc = 0; ccc < in.composition[i].size(); ccc++)
-              //  std::cout << " comp " << ccc << " = " << in.composition[i][ccc] << std::endl;
               if (derivatives != NULL)
                 {
                   derivatives->viscosity_derivative_wrt_strain_rate[i] = Utilities::derivative_of_weighted_p_norm_average(out.viscosities[i],volume_fractions, composition_viscosities, composition_viscosities_derivatives, viscosity_averaging_p);
@@ -405,7 +374,7 @@ namespace aspect
   {
     ASPECT_REGISTER_MATERIAL_MODEL(SimpleNonlinear,
                                    "simple nonlinear",
-                                   " An implementation of a viscous rheology including diffusion"
+                                   " TODO: rewrite... An implementation of a viscous rheology including diffusion"
                                    " and dislocation creep."
                                    " Compositional fields can each be assigned individual"
                                    " activation energies, reference densities, thermal expansivities,"

--- a/source/material_model/simple_nonlinear.cc
+++ b/source/material_model/simple_nonlinear.cc
@@ -191,7 +191,7 @@ namespace aspect
                       if (edot_ii_strict > min_strain_rate[c] * min_strain_rate[c] && composition_viscosities[c] < max_visc[c] && composition_viscosities[c] > min_visc[c])
                         {
                           //strictly speaking the derivative is this: 0.5 * ((1/stress_exponent)-1) * std::pow(2,2) * out.viscosities[i] * (1/(edot_ii*edot_ii)) * deviator(in.strain_rate[i])
-                          composition_viscosities_derivatives[c] = 0;//2 * (stress_exponent_inv-1) * composition_viscosities[c] * (1/(edot_ii*edot_ii)) * deviator(in.strain_rate[i]);
+                          composition_viscosities_derivatives[c] = 2 * (stress_exponent_inv-1) * composition_viscosities[c] * (1/(edot_ii*edot_ii)) * deviator(in.strain_rate[i]);
                           //std::cout << composition_viscosities_derivatives[i] << ", dev strt:" << deviator(in.strain_rate[i]) << std::endl;
                         }
                       else
@@ -201,6 +201,7 @@ namespace aspect
                         }
                     }
                 }
+
               out.viscosities[i] = Utilities::weighted_p_norm_average(volume_fractions, composition_viscosities, viscosity_averaging_p);
               Assert(dealii::numbers::is_finite(out.viscosities[i]),ExcMessage ("Error: Averaged viscosity is not finite."));
 

--- a/source/material_model/simple_nonlinear.cc
+++ b/source/material_model/simple_nonlinear.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
+  Copyright (C) 2017 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -157,11 +157,11 @@ namespace aspect
                   // TODO: Mailed Bob and asked why the averaging should be arithmetic. Bob replyed that this has to
                   //       do with effective medium theory. Have to look into this a bit more.
                   const double stress_exponent_inv = 1/stress_exponent[c];
-                  composition_viscosities[c] = std::max(std::min(std::pow(prefactor[c],-stress_exponent_inv) * std::pow(edot_ii,stress_exponent_inv-1), max_visc[c]), min_visc[c]);
+                  composition_viscosities[c] = std::max(std::min(std::pow(prefactor[c],-stress_exponent_inv) * std::pow(edot_ii,stress_exponent_inv-1), max_viscosity[c]), min_viscosity[c]);
                   Assert(dealii::numbers::is_finite(composition_viscosities[c]),ExcMessage ("Error: Viscosity is not finite."));
                   if (derivatives != NULL)
                     {
-                      if (edot_ii_strict > min_strain_rate[c] * min_strain_rate[c] && composition_viscosities[c] < max_visc[c] && composition_viscosities[c] > min_visc[c])
+                      if (edot_ii_strict > min_strain_rate[c] * min_strain_rate[c] && composition_viscosities[c] < max_viscosity[c] && composition_viscosities[c] > min_viscosity[c])
                         {
                           //strictly speaking the derivative is this: 0.5 * ((1/stress_exponent)-1) * std::pow(2,2) * out.viscosities[i] * (1/(edot_ii*edot_ii)) * deviator(in.strain_rate[i])
                           composition_viscosities_derivatives[c] = 2 * (stress_exponent_inv-1) * composition_viscosities[c] * (1/(edot_ii*edot_ii)) * deviator(in.strain_rate[i]);
@@ -332,8 +332,8 @@ namespace aspect
           reference_T = prm.get_double("Reference temperature");
           ref_visc = prm.get_double ("Reference viscosity");
           min_strain_rate = get_vector_double("Minimum strain rate",n_fields,prm);
-          min_visc = get_vector_double ("Minimum viscosity",n_fields,prm);
-          max_visc = get_vector_double ("Maximum viscosity",n_fields,prm);
+          min_viscosity = get_vector_double ("Minimum viscosity",n_fields,prm);
+          max_viscosity = get_vector_double ("Maximum viscosity",n_fields,prm);
           veff_coefficient = get_vector_double ("Effective viscosity coefficient",n_fields,prm);
 
           // Equation of state parameters

--- a/source/material_model/simple_nonlinear.cc
+++ b/source/material_model/simple_nonlinear.cc
@@ -1,0 +1,434 @@
+/*
+  Copyright (C) 2011 - 2015 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+ */
+
+#include <aspect/material_model/simple_nonlinear.h>
+#include <aspect/utilities.h>
+#include <aspect/newton.h>
+
+using namespace dealii;
+
+namespace aspect
+{
+  namespace
+  {
+    std::vector<double>
+    get_vector_double (const std::string &parameter, const unsigned int n_fields, ParameterHandler &prm)
+    {
+      std::vector<double> parameter_list;
+      parameter_list = Utilities::string_to_double(Utilities::split_string_list(prm.get (parameter)));
+      if (parameter_list.size() == 1)
+        parameter_list.resize(n_fields, parameter_list[0]);
+
+      AssertThrow(parameter_list.size() == n_fields,
+                  ExcMessage("Length of " + parameter + " list (size "+ std::to_string(parameter_list.size()) +") must be either one,"
+                             " or n_compositional_fields+1 (= " + std::to_string(n_fields) + ")."));
+
+      return parameter_list;
+    }
+  }
+
+  namespace MaterialModel
+  {
+    template <int dim>
+    std::vector<double>
+    SimpleNonlinear<dim>::
+    compute_volume_fractions( const std::vector<double> &compositional_fields) const
+    {
+      /*std::cout << "vfFlag 1 " << std::endl;
+         std::vector<double> volume_fractions(compositional_fields.size());
+         std::cout << "vfFlag 2 " << std::endl;
+         //clip the compositional fields so they are between zero and one
+         std::vector<double> x_comp = compositional_fields;
+         for ( unsigned int i=0; i < x_comp.size(); ++i)
+           x_comp[i] = std::min(std::max(x_comp[i], 0.0), 1.0);
+         std::cout << "vfFlag 5 " << std::endl;
+         //sum the compositional fields for normalization purposes
+         double sum_composition = 0.0;
+         for ( unsigned int i=0; i < x_comp.size(); ++i)
+           sum_composition += x_comp[i];
+         std::cout << "vfFlag 8 " << std::endl;
+         // If the sum of the compositions is smaller
+         // than 0.1 something is going really wrong
+         // and we abort.
+         AssertThrow(sum_composition >= 0.1,
+             ExcMessage("The sum of the compositions is smaller than 0.1. There are " + std::to_string(x_comp.size()) + " compositions. It is " +  std::to_string(sum_composition) + ", xcomp 0: "  +  std::to_string(x_comp[0]) + ", comp 0: "  +  std::to_string(compositional_fields[0]) ))
+         std::cout << "vfFlag 10 " << std::endl;
+         //volume_fractions[0] = 0.0;  //background mantle
+         for ( unsigned int i=0; i < x_comp.size(); ++i)
+           volume_fractions[i] = x_comp[i]/sum_composition;std::cout << "vfFlag 15 " << std::endl;
+         //std::cout << "Multiple compositions, return them." << std::endl;
+         return volume_fractions;*/
+
+      std::vector<double> volume_fractions( compositional_fields.size()+1);
+
+      //clip the compositional fields so they are between zero and one
+      std::vector<double> x_comp = compositional_fields;
+      for ( unsigned int i=0; i < x_comp.size(); ++i)
+        x_comp[i] = std::min(std::max(x_comp[i], 0.0), 1.0);
+
+      //sum the compositional fields for normalization purposes
+      double sum_composition = 0.0;
+      for ( unsigned int i=0; i < x_comp.size(); ++i)
+        sum_composition += x_comp[i];
+
+      if (sum_composition >= 1.0)
+        {
+          volume_fractions[0] = 0.0;  //background mantle
+          for ( unsigned int i=1; i <= x_comp.size(); ++i)
+            volume_fractions[i] = x_comp[i-1]/sum_composition;
+        }
+      else
+        {
+          volume_fractions[0] = 1.0 - sum_composition; //background mantle
+          for ( unsigned int i=1; i <= x_comp.size(); ++i)
+            volume_fractions[i] = x_comp[i-1];
+        } //std::cout << "Background mantle = " << volume_fractions[0] << std::endl;
+      return volume_fractions;
+    }
+
+    template <int dim>
+    void
+    SimpleNonlinear<dim>::
+    evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+             MaterialModel::MaterialModelOutputs<dim> &out) const
+    {
+      //set up additional output for the derivatives
+      MaterialModelDerivatives<dim> *derivatives;
+      derivatives = out.template get_additional_output<MaterialModelDerivatives<dim> >();
+
+      for (unsigned int i=0; i < in.temperature.size(); ++i)
+        {
+          // const Point<dim> position = in.position[i];
+          const double temperature = in.temperature[i];
+          const double pressure= in.pressure[i];
+
+          // Averaging composition-field dependent properties
+          // Compositions
+          //This assert may be help when designing tests for this material model
+          AssertThrow(in.composition[i].size()+1 == n_fields,
+                      ExcMessage("Number of compositional fields + 1 not equal to number of fields given in input file."));
+
+          const std::vector<double> volume_fractions = compute_volume_fractions(in.composition[i]);
+          double density = 0.0;
+          for (unsigned int c=0; c < volume_fractions.size(); ++c)
+            {
+              //not strictly correct if thermal expansivities are different, since we are interpreting
+              //these compositions as volume fractions, but the error introduced should not be too bad.
+              const double temperature_factor = (1.0 - thermal_expansivities[c] * (temperature - reference_T));
+              density += volume_fractions[c] * densities[c] * temperature_factor;
+            }
+
+          // thermal expansivities
+          double thermal_expansivity = 0.0;
+          for (unsigned int c=0; c < volume_fractions.size(); ++c)
+            thermal_expansivity += volume_fractions[c] * thermal_expansivities[c];
+
+          // Specific heat at the given positions.
+          double specific_heat = 0.0;
+          for (unsigned int c=0; c < volume_fractions.size(); ++c)
+            specific_heat += volume_fractions[c] * heat_capacity[c];
+
+          // Thermal conductivity at the given positions.
+          double thermal_conductivities = 0.0;
+          for (unsigned int c=0; c < volume_fractions.size(); ++c)
+            thermal_conductivities += volume_fractions[c] * thermal_diffusivity[c] * heat_capacity[c] * densities[c];
+
+          // calculate effective viscosity
+          if (in.strain_rate.size())
+            {
+              // This function calculates viscosities assuming that all the compositional fields
+              // experience the same strain rate (isostrain). Since there is only one process in
+              // this material model (a general powerlaw) we do not need to worry about how to
+              // distribute the strain-rate and stress over the processes.
+              std::vector<double> composition_viscosities(volume_fractions.size());
+              std::vector<SymmetricTensor<2,dim> > composition_viscosities_derivatives(volume_fractions.size());
+
+              for (unsigned int c=0; c < volume_fractions.size(); ++c)
+                {
+                  // If strain rate is zero (like during the first time step) set it to some very small number
+                  // to prevent a division-by-zero, and a floating point exception.
+                  // Otherwise, calculate the square-root of the norm of the second invariant of the deviatoric-
+                  // strain rate (often simplified as epsilondot_ii)
+                  const double edot_ii_strict = std::sqrt(0.5*deviator(in.strain_rate[i])*deviator(in.strain_rate[i]));
+                  const double edot_ii = 2.0 * std::max(edot_ii_strict, min_strain_rate[c] * min_strain_rate[c]);
+
+                  // Find effective viscosities for each of the individual phases
+                  // Viscosities should have same number of entries as compositional fields
+
+                  // Power law equation
+                  // edot_ii_i = A_i * stress_ii_i^{n_i} * d^{-m} \exp\left(-\frac{E_i^* + PV_i^*}{n_iRT}\right)
+                  // where ii indicates the square root of the second invariant and
+                  // i corresponds to diffusion or dislocation creep
+
+                  // The isostrain condition implies that the viscosity averaging should be arithmetic (see above).
+                  // We have given the user freedom to apply alternative bounds, because in diffusion-dominated
+                  // creep (where n_diff=1) viscosities are stress and strain-rate independent, so the calculation
+                  // of compositional field viscosities is consistent with any averaging scheme.
+                  // TODO: Mailed Bob and asked why the averaging should be arithmetic. Bob replyed that this has to
+                  //       do with effective medium theory. Have to look into this a bit more.
+                  const double stress_exponent_inv = 1/stress_exponent[c];
+                  composition_viscosities[c] = std::max(std::min(std::pow(prefactor[c],-stress_exponent_inv) * std::pow(edot_ii,stress_exponent_inv-1), max_visc[c]), min_visc[c]);
+                  Assert(dealii::numbers::is_finite(composition_viscosities[c]),ExcMessage ("Error: Viscosity is not finite."));
+                  if (derivatives != NULL)
+                    {
+                      if (edot_ii_strict > min_strain_rate[c] * min_strain_rate[c] && composition_viscosities[c] < max_visc[c] && composition_viscosities[c] > min_visc[c])
+                        {
+                          //strictly speaking the derivative is this: 0.5 * ((1/stress_exponent)-1) * std::pow(2,2) * out.viscosities[i] * (1/(edot_ii*edot_ii)) * deviator(in.strain_rate[i])
+                          composition_viscosities_derivatives[c] = 0;//2 * (stress_exponent_inv-1) * composition_viscosities[c] * (1/(edot_ii*edot_ii)) * deviator(in.strain_rate[i]);
+                          //std::cout << composition_viscosities_derivatives[i] << ", dev strt:" << deviator(in.strain_rate[i]) << std::endl;
+                        }
+                      else
+                        {
+                          composition_viscosities_derivatives[c] = 0;
+                          //std::cout << "Set " << i << " to 0" << std::endl;
+                        }
+                    }
+                }
+              out.viscosities[i] = Utilities::weighted_p_norm_average(volume_fractions, composition_viscosities, viscosity_averaging_p);
+              Assert(dealii::numbers::is_finite(out.viscosities[i]),ExcMessage ("Error: Averaged viscosity is not finite."));
+
+              //for(int ccc = 0; ccc < in.composition[i].size(); ccc++)
+              //  std::cout << " comp " << ccc << " = " << in.composition[i][ccc] << std::endl;
+              if (derivatives != NULL)
+                {
+                  derivatives->viscosity_derivative_wrt_strain_rate[i] = Utilities::derivative_of_weighted_p_norm_average(out.viscosities[i],volume_fractions, composition_viscosities, composition_viscosities_derivatives, viscosity_averaging_p);
+
+#ifdef DEBUG
+                  for (int x = 0; x < dim; x++)
+                    for (int y = 0; y < dim; y++)
+                      if (!dealii::numbers::is_finite(derivatives->viscosity_derivative_wrt_strain_rate[i][x][y]))
+                        std::cout << "Error: Averaged viscosity to strain-rate devrivative is not finite." << std::endl;
+
+                  derivatives->viscosity_derivative_wrt_pressure[i]    = 0;
+                  if (!dealii::numbers::is_finite(derivatives->viscosity_derivative_wrt_pressure[i]))
+                    std::cout << "Error: Averaged viscosity to pressure devrivative is not finite." << std::endl;
+#endif
+                }
+            }
+          out.densities[i] = density;
+          out.thermal_expansion_coefficients[i] = thermal_expansivity;
+          // Specific heat at the given positions.
+          out.specific_heat[i] = specific_heat;
+          // Thermal conductivity at the given positions.
+          out.thermal_conductivities[i] = thermal_conductivities;
+          // Compressibility at the given positions.
+          // The compressibility is given as
+          // $\frac 1\rho \frac{\partial\rho}{\partial p}$.
+          out.compressibilities[i] = 0.0;
+          // Pressure derivative of entropy at the given positions.
+          out.entropy_derivative_pressure[i] = 0.0;
+          // Temperature derivative of entropy at the given positions.
+          out.entropy_derivative_temperature[i] = 0.0;
+          // Change in composition due to chemical reactions at the
+          // given positions. The term reaction_terms[i][c] is the
+          // change in compositional field c at point i.
+          for (unsigned int c=0; c < in.composition[i].size(); ++c)
+            out.reaction_terms[i][c] = 0.0;
+        }
+    }
+    template <int dim>
+    double
+    SimpleNonlinear<dim>::
+    reference_viscosity () const
+    {
+      return ref_visc;
+    }
+
+    template <int dim>
+    double
+    SimpleNonlinear<dim>::
+    reference_density () const
+    {
+      return densities[0];
+    }
+
+    template <int dim>
+    bool
+    SimpleNonlinear<dim>::
+    is_compressible () const
+    {
+      return false;
+    }
+
+    template <int dim>
+    void
+    SimpleNonlinear<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection ("Compositional fields");
+      {
+        prm.declare_entry ("Number of fields", "0",
+                           Patterns::Integer (0),
+                           "The number of fields that will be advected along with the flow field, excluding "
+                           "velocity, pressure and temperature.");
+      }
+      prm.leave_subsection();
+      prm.enter_subsection("Material model");
+      {
+        prm.enter_subsection ("Simple nonlinear");
+        {
+          // Reference and minimum/maximum values
+          prm.declare_entry ("Reference temperature", "293", Patterns::Double(0),
+                             "For calculating density by thermal expansivity. Units: $K$");
+          prm.declare_entry ("Minimum strain rate", "1.4e-20", Patterns::List(Patterns::Double(0)),
+                             "Stabilizes strain dependent viscosity. Units: $1 / s$");
+          prm.declare_entry ("Minimum viscosity", "1e10", Patterns::List(Patterns::Double(0)),
+                             "Lower cutoff for effective viscosity. Units: $Pa s$");
+          prm.declare_entry ("Maximum viscosity", "1e28", Patterns::List(Patterns::Double(0)),
+                             "Upper cutoff for effective viscosity. Units: $Pa s$");
+          prm.declare_entry ("Effective viscosity coefficient", "1.0", Patterns::List(Patterns::Double(0)),
+                             "Scaling coefficient for effective viscosity.");
+          prm.declare_entry ("Reference viscosity", "1e22", Patterns::List(Patterns::Double(0)),
+                             "Reference viscosity for nondimensionalization. Units $Pa s$");
+
+          // Equation of state parameters
+          prm.declare_entry ("Thermal diffusivity", "0.8e-6", Patterns::List(Patterns::Double(0)), "Units: $m^2/s$");
+          prm.declare_entry ("Heat capacity", "1.25e3", Patterns::List(Patterns::Double(0)), "Units: $J / (K * kg)$");
+          prm.declare_entry ("Densities", "3300.",
+                             Patterns::List(Patterns::Double(0)),
+                             "List of densities, $\\rho$, for background mantle and compositional fields, "
+                             "for a total of N+1 values, where N is the number of compositional fields. "
+                             "If only one values is given, then all use the same value.  Units: $kg / m^3$");
+          prm.declare_entry ("Thermal expansivities", "3.5e-5",
+                             Patterns::List(Patterns::Double(0)),
+                             "List of thermal expansivities for background mantle and compositional fields, "
+                             "for a total of N+1 values, where N is the number of compositional fields. "
+                             "If only one values is given, then all use the same value.  Units: $1 / K$");
+
+
+          // SimpleNonlinear creep parameters
+          prm.declare_entry ("Prefactor", "1e-37",
+                             Patterns::List(Patterns::Double(0)),
+                             "List of viscosity prefactors, $A$, for background mantle and compositional fields, "
+                             "for a total of N+1 values, where N is the number of compositional fields. "
+                             "If only one values is given, then all use the same value. "
+                             "Units: $Pa^{-n_{dislocation}} m^{n_{dislocation}/m_{dislocation}} s^{-1}$");
+          prm.declare_entry ("Stress exponent", "3",
+                             Patterns::List(Patterns::Double(0)),
+                             "List of stress exponents, $n_dislocation$, for background mantle and compositional fields, "
+                             "for a total of N+1 values, where N is the number of compositional fields. "
+                             "If only one values is given, then all use the same value.  Units: None");
+
+          // averaging parameters
+          prm.declare_entry ("Viscosity averaging p", "-1",
+                             Patterns::Double(),
+                             "This is the p value in the generalized weighed average eqation: "
+                             " mean = \\frac{1}{k}(\\sum_{i=1}^k \\big(c_i \\eta_{\\text{eff}_i}^p)\\big)^{\\frac{1}{p}}. "
+                             " Units: $Pa s$");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+
+
+    template <int dim>
+    void
+    SimpleNonlinear<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      // can't use this->n_compositional_fields(), because some
+      // tests never initiate the simulator, but uses the material
+      // model directly.
+      prm.enter_subsection ("Compositional fields");
+      {
+        n_fields = prm.get_integer ("Number of fields")+1;
+        //AssertThrow(n_fields > 0, ExcMessage("This material model needs at least one compositional field."))
+      }
+      prm.leave_subsection();
+
+      prm.enter_subsection("Material model");
+      {
+        prm.enter_subsection ("Simple nonlinear");
+        {
+
+          // Reference and minimum/maximum values
+          reference_T = prm.get_double("Reference temperature");
+          ref_visc = prm.get_double ("Reference viscosity");
+          min_strain_rate = get_vector_double("Minimum strain rate",n_fields,prm);
+          min_visc = get_vector_double ("Minimum viscosity",n_fields,prm);
+          max_visc = get_vector_double ("Maximum viscosity",n_fields,prm);
+          veff_coefficient = get_vector_double ("Effective viscosity coefficient",n_fields,prm);
+
+          // Equation of state parameters
+          thermal_diffusivity = get_vector_double("Thermal diffusivity",n_fields,prm);
+          heat_capacity = get_vector_double("Heat capacity",n_fields,prm);
+
+          // ---- Compositional parameters
+          densities = get_vector_double("Densities",n_fields,prm);
+          thermal_expansivities = get_vector_double("Thermal expansivities",n_fields,prm);
+
+          // Rheological parameters
+          prefactor = get_vector_double("Prefactor",n_fields,prm);
+          stress_exponent = get_vector_double("Stress exponent",n_fields,prm);
+
+          // averaging parameters
+          viscosity_averaging_p = prm.get_double("Viscosity averaging p");
+
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+
+
+      // Declare dependencies on solution variables
+      this->model_dependence.viscosity = NonlinearDependence::temperature | NonlinearDependence::pressure | NonlinearDependence::strain_rate | NonlinearDependence::compositional_fields;
+      this->model_dependence.density = NonlinearDependence::temperature | NonlinearDependence::pressure | NonlinearDependence::compositional_fields;
+      this->model_dependence.compressibility = NonlinearDependence::none;
+      this->model_dependence.specific_heat = NonlinearDependence::none;
+      this->model_dependence.thermal_conductivity = NonlinearDependence::temperature | NonlinearDependence::pressure | NonlinearDependence::compositional_fields;
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    ASPECT_REGISTER_MATERIAL_MODEL(SimpleNonlinear,
+                                   "simple nonlinear",
+                                   " An implementation of a viscous rheology including diffusion"
+                                   " and dislocation creep."
+                                   " Compositional fields can each be assigned individual"
+                                   " activation energies, reference densities, thermal expansivities,"
+                                   " and stress exponents. The effective viscosity is defined as"
+                                   " \n\n"
+                                   " \\[v_\\text{eff} = \\left(\\frac{1}{v_\\text{eff}^\\text{diff}}+"
+                                   " \\frac{1}{v_\\text{eff}^\\text{dis}}\\right)^{-1}\\]"
+                                   " where"
+                                   " \\[v_\\text{i} = 0.5 * A^{-\\frac{1}{n_i}} d^\\frac{m_i}{n_i}"
+                                   " \\dot{\\varepsilon_i}^{\\frac{1-n_i}{n_i}}"
+                                   " \\exp\\left(\\frac{E_i^* + PV_i^*}{n_iRT}\\right)\\]"
+                                   " \n\n"
+                                   " where $d$ is grain size, $i$ corresponds to diffusion or dislocation creep,"
+                                   " $\\dot{\\varepsilon}$ is the square root of the second invariant of the"
+                                   " strain rate tensor, $R$ is the gas constant, $T$ is temperature, "
+                                   " and $P$ is pressure."
+                                   " $A_i$ are prefactors, $n_i$ and $m_i$ are stress and grain size exponents"
+                                   " $E_i$ are the activation energies and $V_i$ are the activation volumes."
+                                   " \n\n"
+                                   " The ratio of diffusion to dislocation strain rate is found by Newton's"
+                                   " method, iterating to find the stress which satisfies the above equations."
+                                   " The value for the components of this formula and additional"
+                                   " parameters are read from the parameter file in subsection"
+                                   " 'Material model/SimpleNonlinear'.")
+  }
+}
+

--- a/source/postprocess/visualization/spd_factor.cc
+++ b/source/postprocess/visualization/spd_factor.cc
@@ -93,7 +93,7 @@ namespace aspect
         	const SymmetricTensor<2,dim> viscosity_derivative_wrt_strain_rate = derivatives->viscosity_derivative_wrt_strain_rate[q];
         	const SymmetricTensor<2,dim> strain_rate = in.strain_rate[q];
 
-          computed_quantities[q](0) = Utilities::compute_spd_factor<dim>(strain_rate, viscosity_derivative_wrt_strain_rate, eta);
+          computed_quantities[q](0) = Utilities::compute_spd_factor<dim>(eta, strain_rate, viscosity_derivative_wrt_strain_rate, 0.9);
         }
       }
     }

--- a/source/postprocess/visualization/spd_factor.cc
+++ b/source/postprocess/visualization/spd_factor.cc
@@ -1,0 +1,117 @@
+/*
+  Copyright (C) 2011 - 2017 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/postprocess/visualization/spd_factor.h>
+
+#include <aspect/newton.h>
+#include <aspect/utilities.h>
+
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    namespace VisualizationPostprocessors
+    {
+      template <int dim>
+      SPDFactor<dim>::
+	  SPDFactor ()
+        :
+        DataPostprocessorScalar<dim> ("spd_factor",
+                                      update_values | update_gradients | update_q_points)
+      {}
+
+
+
+      template <int dim>
+      void
+	  SPDFactor<dim>::
+      compute_derived_quantities_vector (const std::vector<Vector<double> >              &solution_values,
+                                         const std::vector<std::vector<Tensor<1,dim> > > &solution_gradients,
+                                         const std::vector<std::vector<Tensor<2,dim> > > &,
+                                         const std::vector<Point<dim> > &,
+                                         const std::vector<Point<dim> >                  &evaluation_points,
+                                         std::vector<Vector<double> >                    &computed_quantities) const
+      {
+        const unsigned int n_quadrature_points = solution_values.size();
+        Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
+        Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
+        Assert (solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
+        Assert (solution_gradients[0].size() == this->introspection().n_components,          ExcInternalError());
+
+        MaterialModel::MaterialModelInputs<dim> in(n_quadrature_points,
+                                                   this->n_compositional_fields());
+        MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points,
+                                                     this->n_compositional_fields());
+
+        in.position = evaluation_points;
+        for (unsigned int q=0; q<n_quadrature_points; ++q)
+          {
+            Tensor<2,dim> grad_u;
+            for (unsigned int d=0; d<dim; ++d)
+              grad_u[d] = solution_gradients[q][d];
+            in.strain_rate[q] = symmetrize (grad_u);
+
+            in.pressure[q]=solution_values[q][this->introspection().component_indices.pressure];
+            in.temperature[q]=solution_values[q][this->introspection().component_indices.temperature];
+            for (unsigned int d = 0; d < dim; ++d)
+              {
+                in.velocity[q][d]=solution_values[q][this->introspection().component_indices.velocities[d]];
+                in.pressure_gradient[q][d] = solution_gradients[q][this->introspection().component_indices.pressure][d];
+              }
+
+            for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
+              in.composition[q][c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
+          }
+
+        this->get_material_model().evaluate(in, out);
+
+        for (unsigned int q=0; q<n_quadrature_points; ++q)
+        {
+        	const double eta = out.viscosities[q];
+        	const MaterialModel::MaterialModelDerivatives<dim> *derivatives = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim> >();;
+        	AssertThrow(derivatives != NULL, ExcMessage ("Error: The newton method requires the derivatives"));
+
+        	const SymmetricTensor<2,dim> viscosity_derivative_wrt_strain_rate = derivatives->viscosity_derivative_wrt_strain_rate[q];
+        	const SymmetricTensor<2,dim> strain_rate = in.strain_rate[q];
+
+          computed_quantities[q](0) = Utilities::compute_spd_factor<dim>(strain_rate, viscosity_derivative_wrt_strain_rate, eta);
+        }
+      }
+    }
+  }
+}
+
+
+// explicit instantiations
+namespace aspect
+{
+  namespace Postprocess
+  {
+    namespace VisualizationPostprocessors
+    {
+      ASPECT_REGISTER_VISUALIZATION_POSTPROCESSOR(SPDFactor,
+                                                  "spd factor",
+                                                  "A visualization output object that generates output "
+                                                  "for the viscosity.")
+    }
+  }
+}

--- a/source/postprocess/visualization/spd_factor.cc
+++ b/source/postprocess/visualization/spd_factor.cc
@@ -81,13 +81,20 @@ namespace aspect
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
               in.composition[q][c] = solution_values[q][this->introspection().component_indices.compositional_fields[c]];
           }
+        //const MaterialModel::MaterialModelDerivatives<dim> *derivatives = out.template create_additional_output<MaterialModel::MaterialModelDerivatives<dim> >();
+        std_cxx11::shared_ptr<MaterialModel::AdditionalMaterialOutputs<dim> > mmd(new MaterialModel::MaterialModelDerivatives<dim> (n_quadrature_points));
+
+        out.additional_outputs.push_back(mmd);
 
         this->get_material_model().evaluate(in, out);
+
+        const MaterialModel::MaterialModelDerivatives<dim> *derivatives = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim> >();
+
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)
         {
         	const double eta = out.viscosities[q];
-        	const MaterialModel::MaterialModelDerivatives<dim> *derivatives = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim> >();;
+        	//const MaterialModel::MaterialModelDerivatives<dim> *derivatives = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim> >();;
         	AssertThrow(derivatives != NULL, ExcMessage ("Error: The newton method requires the derivatives"));
 
         	const SymmetricTensor<2,dim> viscosity_derivative_wrt_strain_rate = derivatives->viscosity_derivative_wrt_strain_rate[q];

--- a/source/postprocess/visualization/spd_factor.cc
+++ b/source/postprocess/visualization/spd_factor.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011 - 2016 by the authors of the ASPECT code.
+  Copyright (C) 2017 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -32,8 +32,8 @@ namespace aspect
     namespace VisualizationPostprocessors
     {
       template <int dim>
-      SPDfactor<dim>::
-      SPDfactor ()
+      SPD_Factor<dim>::
+      SPD_Factor ()
         :
         DataPostprocessorScalar<dim> ("spd_factor",
                                       update_values | update_gradients | update_q_points)
@@ -43,7 +43,7 @@ namespace aspect
 
       template <int dim>
       void
-      SPDfactor<dim>::
+      SPD_Factor<dim>::
       evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
                             std::vector<Vector<double> > &computed_quantities) const
       {
@@ -104,7 +104,7 @@ namespace aspect
   {
     namespace VisualizationPostprocessors
     {
-      ASPECT_REGISTER_VISUALIZATION_POSTPROCESSOR(SPDfactor,
+      ASPECT_REGISTER_VISUALIZATION_POSTPROCESSOR(SPD_Factor,
                                                   "spd factor",
                                                   "A visualization output object that generates output "
                                                   "for the spd factor.")

--- a/source/postprocess/visualization/spd_factor.cc
+++ b/source/postprocess/visualization/spd_factor.cc
@@ -85,12 +85,12 @@ namespace aspect
         AssertThrow(derivatives != NULL, ExcMessage ("Error: The newton method requires the derivatives"));
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)
-        {
-        	const double eta = out.viscosities[q];
-        	const SymmetricTensor<2,dim> viscosity_derivative_wrt_strain_rate = derivatives->viscosity_derivative_wrt_strain_rate[q];
-        	const SymmetricTensor<2,dim> strain_rate = in.strain_rate[q];
-        	computed_quantities[q](0) = Utilities::compute_spd_factor<dim>(eta, strain_rate, viscosity_derivative_wrt_strain_rate, 0.9);
-        }
+          {
+            const double eta = out.viscosities[q];
+            const SymmetricTensor<2,dim> viscosity_derivative_wrt_strain_rate = derivatives->viscosity_derivative_wrt_strain_rate[q];
+            const SymmetricTensor<2,dim> strain_rate = in.strain_rate[q];
+            computed_quantities[q](0) = Utilities::compute_spd_factor<dim>(eta, strain_rate, viscosity_derivative_wrt_strain_rate, 0.9);
+          }
       }
     }
   }

--- a/tests/drucker_prager_derivatives.cc
+++ b/tests/drucker_prager_derivatives.cc
@@ -1,0 +1,279 @@
+#include <aspect/simulator.h>
+#include <deal.II/grid/tria.h>
+#include <aspect/material_model/interface.h>
+#include <aspect/material_model/drucker_prager.h>
+#include <aspect/simulator_access.h>
+#include <aspect/newton.h>
+
+#include <iostream>
+#include <typeinfo>
+
+int f(double parameter)
+{
+
+  std::cout << std::endl << "Test for p = " << parameter << std::endl;
+
+  const int dim=2;
+  using namespace aspect::MaterialModel;
+  MaterialModelInputs<dim> in_base(5,3);
+  in_base.composition[0][0] = 0;
+  in_base.composition[0][1] = 0;
+  in_base.composition[0][2] = 0;
+  in_base.composition[1][0] = 0.75;
+  in_base.composition[1][1] = 0.15;
+  in_base.composition[1][2] = 0.10;
+  in_base.composition[2][0] = 0;
+  in_base.composition[2][1] = 0.2;
+  in_base.composition[2][2] = 0.4;
+  in_base.composition[3][0] = 0;
+  in_base.composition[3][1] = 0.2;
+  in_base.composition[3][2] = 0.4;
+  in_base.composition[4][0] = 1;
+  in_base.composition[4][1] = 0;
+  in_base.composition[4][2] = 0;
+
+  in_base.pressure[0] = 1e9;
+  in_base.pressure[1] = 5e9;
+  in_base.pressure[2] = 2e10;
+  in_base.pressure[3] = 2e11;
+  in_base.pressure[4] = 2e12;
+
+  /**
+   * We cant take to slow values, because then the difference in the
+   * visocisty will be too small for the double accuracy which stores
+   * the visocity solutions and the finite diference solution.
+   */
+  in_base.strain_rate[0] = SymmetricTensor<2,dim>();
+  in_base.strain_rate[0][0][0] = 1e-12;
+  in_base.strain_rate[0][0][1] = 1e-12;
+  in_base.strain_rate[0][1][1] = 1e-11;
+  in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+  in_base.strain_rate[1][0][0] = -1.71266e-13;
+  in_base.strain_rate[1][0][1] = -5.82647e-12;
+  in_base.strain_rate[1][1][1] = 4.21668e-14;
+  in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+  in_base.strain_rate[2][1][1] = 1e-13;
+  in_base.strain_rate[2][0][1] = 1e-11;
+  in_base.strain_rate[2][0][0] = -1e-12;
+  in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+  in_base.strain_rate[3][1][1] = 4.9e-21;
+  in_base.strain_rate[3][0][1] = 4.9e-21;
+  in_base.strain_rate[3][0][0] = 4.9e-21;
+  in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+  in_base.strain_rate[4][1][1] = 1e-11;
+  in_base.strain_rate[4][0][1] = 1e-11;
+  in_base.strain_rate[4][0][0] = 1e-11;
+
+  in_base.temperature[0] = 293;
+  in_base.temperature[1] = 1600;
+  in_base.temperature[2] = 2000;
+  in_base.temperature[3] = 2100;
+  in_base.temperature[4] = 2200;
+
+  SymmetricTensor<2,dim> zerozero = SymmetricTensor<2,dim>();
+  SymmetricTensor<2,dim> onezero = SymmetricTensor<2,dim>();
+  SymmetricTensor<2,dim> oneone = SymmetricTensor<2,dim>();
+
+  zerozero[0][0] = 1;
+  onezero[1][0]  = 0.5; // because symmetry doubles this entry
+  oneone[1][1]   = 1;
+
+  double finite_difference_accuracy = 1e-7;
+  double finite_difference_factor = 1+finite_difference_accuracy;
+
+  bool Error = false;
+
+  MaterialModelInputs<dim> in_dviscositydpressure(5,3);
+  in_dviscositydpressure = in_base;
+  in_dviscositydpressure.pressure[0] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[1] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[2] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[3] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[4] *= finite_difference_factor;
+
+  MaterialModelInputs<dim> in_dviscositydstrainrate_zerozero(5,3);
+  MaterialModelInputs<dim> in_dviscositydstrainrate_onezero(5,3);
+  MaterialModelInputs<dim> in_dviscositydstrainrate_oneone(5,3);
+
+  in_dviscositydstrainrate_zerozero = in_base;
+  in_dviscositydstrainrate_onezero = in_base;
+  in_dviscositydstrainrate_oneone = in_base;
+  in_dviscositydstrainrate_zerozero.strain_rate[0] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[0][0][0]) * finite_difference_accuracy * zerozero;
+  in_dviscositydstrainrate_zerozero.strain_rate[1] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[1][0][0]) * finite_difference_accuracy * zerozero;
+  in_dviscositydstrainrate_zerozero.strain_rate[2] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[2][0][0]) * finite_difference_accuracy * zerozero;
+  in_dviscositydstrainrate_zerozero.strain_rate[3] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[3][0][0]) * finite_difference_accuracy * zerozero;
+  in_dviscositydstrainrate_zerozero.strain_rate[4] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[4][0][0]) * finite_difference_accuracy * zerozero;
+  in_dviscositydstrainrate_onezero.strain_rate[0]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[0][1][0]) * finite_difference_accuracy * onezero;
+  in_dviscositydstrainrate_onezero.strain_rate[1]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[1][1][0]) * finite_difference_accuracy * onezero;
+  in_dviscositydstrainrate_onezero.strain_rate[2]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[2][1][0]) * finite_difference_accuracy * onezero;
+  in_dviscositydstrainrate_onezero.strain_rate[3]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[3][1][0]) * finite_difference_accuracy * onezero;
+  in_dviscositydstrainrate_onezero.strain_rate[4]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[4][1][0]) * finite_difference_accuracy * onezero;
+  in_dviscositydstrainrate_oneone.strain_rate[0]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[0][1][1]) * finite_difference_accuracy * oneone;
+  in_dviscositydstrainrate_oneone.strain_rate[1]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[1][1][1]) * finite_difference_accuracy * oneone;
+  in_dviscositydstrainrate_oneone.strain_rate[2]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[2][1][1]) * finite_difference_accuracy * oneone;
+  in_dviscositydstrainrate_oneone.strain_rate[3]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[3][1][1]) * finite_difference_accuracy * oneone;
+  in_dviscositydstrainrate_oneone.strain_rate[4]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[4][1][1]) * finite_difference_accuracy * oneone;
+
+  MaterialModelInputs<dim> in_dviscositydtemperature(5,3);
+  in_dviscositydtemperature = in_base;
+  in_dviscositydtemperature.temperature[0] *= 1.0000000001;
+  in_dviscositydtemperature.temperature[1] *= 1.0000000001;
+  in_dviscositydtemperature.temperature[2] *= 1.0000000001;
+  in_dviscositydtemperature.temperature[3] *= 1.0000000001;
+  in_dviscositydtemperature.temperature[4] *= 1.0000000001;
+
+
+  MaterialModelOutputs<dim> out_base(5,3);
+
+  MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
+  MaterialModelOutputs<dim> out_dviscositydstrainrate_zerozero(5,3);
+  MaterialModelOutputs<dim> out_dviscositydstrainrate_onezero(5,3);
+  MaterialModelOutputs<dim> out_dviscositydstrainrate_oneone(5,3);
+  MaterialModelOutputs<dim> out_dviscositydtemperature(5,3);
+
+  if (out_base.get_additional_output<MaterialModelDerivatives<dim> >() != NULL)
+    throw "error";
+
+  out_base.additional_outputs.push_back(std::make_shared<MaterialModelDerivatives<dim> > (5));
+
+  DruckerPrager<dim> mat;
+  ParameterHandler prm;
+  mat.declare_parameters(prm);
+
+  prm.enter_subsection("Material model");
+  {
+    prm.enter_subsection ("Drucker Prager");
+    {
+      prm.enter_subsection ("Viscosity");
+      {
+        prm.set ("Reference strain rate", "1e-20");
+        prm.set ("Angle of internal friction", "30");
+      }
+      prm.leave_subsection();
+    }
+    prm.leave_subsection();
+  }
+  prm.leave_subsection();
+
+  mat.parse_parameters(prm);
+
+  mat.evaluate(in_base, out_base);
+  mat.evaluate(in_dviscositydpressure, out_dviscositydpressure);
+  mat.evaluate(in_dviscositydstrainrate_zerozero, out_dviscositydstrainrate_zerozero);
+  mat.evaluate(in_dviscositydstrainrate_onezero, out_dviscositydstrainrate_onezero);
+  mat.evaluate(in_dviscositydstrainrate_oneone, out_dviscositydstrainrate_oneone);
+  mat.evaluate(in_dviscositydtemperature, out_dviscositydtemperature);
+
+  //set up additional output for the derivatives
+  MaterialModelDerivatives<dim> *derivatives;
+  derivatives = out_base.get_additional_output<MaterialModelDerivatives<dim> >();
+
+  double temp;
+  SymmetricTensor<2,dim> temp_tensor = SymmetricTensor<2,dim> ();
+  for (unsigned int i = 0; i < 5; i++)
+    {
+      // prevent division by zero. If it is zero, the test has passed, because or
+      // the finite difference and the analytical result match perfectly, or (more
+      // likely) the material model in independent of this variable.
+      temp = (out_dviscositydpressure.viscosities[i] - out_base.viscosities[i]);
+      if (in_base.pressure[i] != 0)
+        {
+          temp /= (in_base.pressure[i] * finite_difference_accuracy);
+        }
+
+      if (temp > derivatives->viscosity_derivative_wrt_pressure[i] * finite_difference_factor || temp < derivatives->viscosity_derivative_wrt_pressure[i] * (2-finite_difference_factor))
+        {
+          std::cout << "Error: The derivative of the viscosity to the pressure is too different from the analitical value." << std::endl;
+          Error = true;
+        }
+
+    }
+
+  for (unsigned int i = 0; i < 5; i++)
+    {
+      // prevent division by zero. If it is zero, the test has passed, because or
+      // the finite difference and the analytical result match perfectly, or (more
+      // likely) the material model in independent of this variable.
+      temp = out_dviscositydstrainrate_zerozero.viscosities[i] - out_base.viscosities[i];
+      if (temp != 0)
+        {
+          temp /= std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[i][0][0]) * finite_difference_accuracy;
+        }
+      std::cout << "zerozero " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][0][0]  << std::endl;
+      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][0][0]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][0][0])))
+        {
+          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analitical value." << std::endl;
+          Error = true;
+        }
+
+
+
+    }
+
+  for (unsigned int i = 0; i < 5; i++)
+    {
+      // prevent division by zero. If it is zero, the test has passed, because or
+      // the finite difference and the analytical result match perfectly, or (more
+      // likely) the material model in independent of this variable.
+      temp = out_dviscositydstrainrate_onezero.viscosities[i] - out_base.viscosities[i];
+      if (temp != 0)
+        {
+          temp /= std::fabs(in_dviscositydstrainrate_onezero.strain_rate[i][1][0]) * finite_difference_accuracy;
+        }
+      std::cout << "onezero " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]   << std::endl;
+      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][0])) )
+        {
+          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analitical value." << std::endl;
+          Error = true;
+        }
+    }
+
+  for (unsigned int i = 0; i < 5; i++)
+    {
+      // prevent division by zero. If it is zero, the test has passed, because or
+      // the finite difference and the analytical result match perfectly, or (more
+      // likely) the material model in independent of this variable.
+      temp = out_dviscositydstrainrate_oneone.viscosities[i] - out_base.viscosities[i];
+      if (temp != 0)
+        {
+          temp /= std::fabs(in_dviscositydstrainrate_oneone.strain_rate[i][1][1]) * finite_difference_accuracy;
+        }
+      std::cout << "oneone " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]  << std::endl;
+      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][1])) )
+        {
+          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analitical value." << std::endl;
+          Error = true;
+        }
+
+    }
+
+  if (Error)
+    {
+      std::cout << "Some parts of the test where not succesfull." << std::endl;
+    }
+  else
+    {
+      std::cout << "OK" << std::endl;
+    }
+
+  return 42;
+}
+
+int exit_function()
+{
+  exit(0);
+  return 42;
+}
+// run this function by initializing a global variable by it
+int ii = f(-1000); // Testing min function
+int iz = f(-2); // Testing min function
+int ij = f(-1.5); // Testing generalized p norm mean with negative p
+int ik = f(-1); // Testing harmonic mean
+int ji = f(0); // Testing geometric mean
+int jj = f(1); // Testing arithmetic mean
+int jk = f(2); // Testing generalized p norm mean with positive p
+//int ki = f(10); // Testing generalized p norm mean with large positive p
+int kj = f(1000); // Testing max function
+int kl = exit_function();
+
+

--- a/tests/drucker_prager_derivatives.cc
+++ b/tests/drucker_prager_derivatives.cc
@@ -169,7 +169,6 @@ int f(double parameter)
   derivatives = out_base.get_additional_output<MaterialModelDerivatives<dim> >();
 
   double temp;
-  SymmetricTensor<2,dim> temp_tensor = SymmetricTensor<2,dim> ();
   for (unsigned int i = 0; i < 5; i++)
     {
       // prevent division by zero. If it is zero, the test has passed, because or
@@ -180,10 +179,11 @@ int f(double parameter)
         {
           temp /= (in_base.pressure[i] * finite_difference_accuracy);
         }
-
-      if (temp > derivatives->viscosity_derivative_wrt_pressure[i] * finite_difference_factor || temp < derivatives->viscosity_derivative_wrt_pressure[i] * (2-finite_difference_factor))
+      std::cout << "pressure " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i]  << std::endl;
+      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_pressure[i]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_pressure[i])))
+        //if (temp > derivatives->viscosity_derivative_wrt_pressure[i] * finite_difference_factor || temp < derivatives->viscosity_derivative_wrt_pressure[i] * (2-finite_difference_factor))
         {
-          std::cout << "Error: The derivative of the viscosity to the pressure is too different from the analitical value." << std::endl;
+          std::cout << "   Error: The derivative of the viscosity to the pressure is too different from the analitical value." << std::endl;
           Error = true;
         }
 

--- a/tests/drucker_prager_derivatives.prm
+++ b/tests/drucker_prager_derivatives.prm
@@ -1,0 +1,1 @@
+set Additional shared libraries = tests/libdrucker_prager_derivatives.so

--- a/tests/drucker_prager_derivatives/screen-output
+++ b/tests/drucker_prager_derivatives/screen-output
@@ -1,0 +1,164 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libdrucker_prager_derivatives.so>
+
+Test for p = -1000
+zerozero 0: Finite difference = 0. Analytical derivative = 0
+zerozero 1: Finite difference = 0. Analytical derivative = 0
+zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 0: Finite difference = 0. Analytical derivative = 0
+onezero 1: Finite difference = 0. Analytical derivative = 0
+onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
+onezero 3: Finite difference = 0. Analytical derivative = 0
+onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
+oneone 0: Finite difference = 0. Analytical derivative = 0
+oneone 1: Finite difference = 0. Analytical derivative = 0
+oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesfull.
+
+Test for p = -2
+zerozero 0: Finite difference = 0. Analytical derivative = 0
+zerozero 1: Finite difference = 0. Analytical derivative = 0
+zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 0: Finite difference = 0. Analytical derivative = 0
+onezero 1: Finite difference = 0. Analytical derivative = 0
+onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
+onezero 3: Finite difference = 0. Analytical derivative = 0
+onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
+oneone 0: Finite difference = 0. Analytical derivative = 0
+oneone 1: Finite difference = 0. Analytical derivative = 0
+oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesfull.
+
+Test for p = -1.5
+zerozero 0: Finite difference = 0. Analytical derivative = 0
+zerozero 1: Finite difference = 0. Analytical derivative = 0
+zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 0: Finite difference = 0. Analytical derivative = 0
+onezero 1: Finite difference = 0. Analytical derivative = 0
+onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
+onezero 3: Finite difference = 0. Analytical derivative = 0
+onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
+oneone 0: Finite difference = 0. Analytical derivative = 0
+oneone 1: Finite difference = 0. Analytical derivative = 0
+oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesfull.
+
+Test for p = -1
+zerozero 0: Finite difference = 0. Analytical derivative = 0
+zerozero 1: Finite difference = 0. Analytical derivative = 0
+zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 0: Finite difference = 0. Analytical derivative = 0
+onezero 1: Finite difference = 0. Analytical derivative = 0
+onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
+onezero 3: Finite difference = 0. Analytical derivative = 0
+onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
+oneone 0: Finite difference = 0. Analytical derivative = 0
+oneone 1: Finite difference = 0. Analytical derivative = 0
+oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesfull.
+
+Test for p = 0
+zerozero 0: Finite difference = 0. Analytical derivative = 0
+zerozero 1: Finite difference = 0. Analytical derivative = 0
+zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 0: Finite difference = 0. Analytical derivative = 0
+onezero 1: Finite difference = 0. Analytical derivative = 0
+onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
+onezero 3: Finite difference = 0. Analytical derivative = 0
+onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
+oneone 0: Finite difference = 0. Analytical derivative = 0
+oneone 1: Finite difference = 0. Analytical derivative = 0
+oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesfull.
+
+Test for p = 1
+zerozero 0: Finite difference = 0. Analytical derivative = 0
+zerozero 1: Finite difference = 0. Analytical derivative = 0
+zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 0: Finite difference = 0. Analytical derivative = 0
+onezero 1: Finite difference = 0. Analytical derivative = 0
+onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
+onezero 3: Finite difference = 0. Analytical derivative = 0
+onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
+oneone 0: Finite difference = 0. Analytical derivative = 0
+oneone 1: Finite difference = 0. Analytical derivative = 0
+oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesfull.
+
+Test for p = 2
+zerozero 0: Finite difference = 0. Analytical derivative = 0
+zerozero 1: Finite difference = 0. Analytical derivative = 0
+zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 0: Finite difference = 0. Analytical derivative = 0
+onezero 1: Finite difference = 0. Analytical derivative = 0
+onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
+onezero 3: Finite difference = 0. Analytical derivative = 0
+onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
+oneone 0: Finite difference = 0. Analytical derivative = 0
+oneone 1: Finite difference = 0. Analytical derivative = 0
+oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesfull.
+
+Test for p = 1000
+zerozero 0: Finite difference = 0. Analytical derivative = 0
+zerozero 1: Finite difference = 0. Analytical derivative = 0
+zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 0: Finite difference = 0. Analytical derivative = 0
+onezero 1: Finite difference = 0. Analytical derivative = 0
+onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
+onezero 3: Finite difference = 0. Analytical derivative = 0
+onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
+oneone 0: Finite difference = 0. Analytical derivative = 0
+oneone 1: Finite difference = 0. Analytical derivative = 0
+oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesfull.

--- a/tests/drucker_prager_derivatives/screen-output
+++ b/tests/drucker_prager_derivatives/screen-output
@@ -4,161 +4,201 @@
 Loading shared library <./libdrucker_prager_derivatives.so>
 
 Test for p = -1000
-zerozero 0: Finite difference = 0. Analytical derivative = 0
-zerozero 1: Finite difference = 0. Analytical derivative = 0
-zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
+pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
+pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
+pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
+pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
+zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
+zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
+zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+zerozero 3: Finite difference = 0. Analytical derivative = -0
+zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = 0. Analytical derivative = 0
-onezero 1: Finite difference = 0. Analytical derivative = 0
-onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
-oneone 0: Finite difference = 0. Analytical derivative = 0
-oneone 1: Finite difference = 0. Analytical derivative = 0
-oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
+onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
+onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
+onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
+onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
+oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
+oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
+oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+oneone 3: Finite difference = 0. Analytical derivative = -0
+oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.
 
 Test for p = -2
-zerozero 0: Finite difference = 0. Analytical derivative = 0
-zerozero 1: Finite difference = 0. Analytical derivative = 0
-zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
+pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
+pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
+pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
+pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
+zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
+zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
+zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+zerozero 3: Finite difference = 0. Analytical derivative = -0
+zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = 0. Analytical derivative = 0
-onezero 1: Finite difference = 0. Analytical derivative = 0
-onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
-oneone 0: Finite difference = 0. Analytical derivative = 0
-oneone 1: Finite difference = 0. Analytical derivative = 0
-oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
+onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
+onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
+onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
+onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
+oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
+oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
+oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+oneone 3: Finite difference = 0. Analytical derivative = -0
+oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.
 
 Test for p = -1.5
-zerozero 0: Finite difference = 0. Analytical derivative = 0
-zerozero 1: Finite difference = 0. Analytical derivative = 0
-zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
+pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
+pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
+pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
+pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
+zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
+zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
+zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+zerozero 3: Finite difference = 0. Analytical derivative = -0
+zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = 0. Analytical derivative = 0
-onezero 1: Finite difference = 0. Analytical derivative = 0
-onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
-oneone 0: Finite difference = 0. Analytical derivative = 0
-oneone 1: Finite difference = 0. Analytical derivative = 0
-oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
+onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
+onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
+onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
+onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
+oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
+oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
+oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+oneone 3: Finite difference = 0. Analytical derivative = -0
+oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.
 
 Test for p = -1
-zerozero 0: Finite difference = 0. Analytical derivative = 0
-zerozero 1: Finite difference = 0. Analytical derivative = 0
-zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
+pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
+pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
+pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
+pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
+zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
+zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
+zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+zerozero 3: Finite difference = 0. Analytical derivative = -0
+zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = 0. Analytical derivative = 0
-onezero 1: Finite difference = 0. Analytical derivative = 0
-onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
-oneone 0: Finite difference = 0. Analytical derivative = 0
-oneone 1: Finite difference = 0. Analytical derivative = 0
-oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
+onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
+onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
+onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
+onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
+oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
+oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
+oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+oneone 3: Finite difference = 0. Analytical derivative = -0
+oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.
 
 Test for p = 0
-zerozero 0: Finite difference = 0. Analytical derivative = 0
-zerozero 1: Finite difference = 0. Analytical derivative = 0
-zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
+pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
+pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
+pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
+pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
+zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
+zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
+zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+zerozero 3: Finite difference = 0. Analytical derivative = -0
+zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = 0. Analytical derivative = 0
-onezero 1: Finite difference = 0. Analytical derivative = 0
-onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
-oneone 0: Finite difference = 0. Analytical derivative = 0
-oneone 1: Finite difference = 0. Analytical derivative = 0
-oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
+onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
+onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
+onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
+onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
+oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
+oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
+oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+oneone 3: Finite difference = 0. Analytical derivative = -0
+oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.
 
 Test for p = 1
-zerozero 0: Finite difference = 0. Analytical derivative = 0
-zerozero 1: Finite difference = 0. Analytical derivative = 0
-zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
+pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
+pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
+pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
+pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
+zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
+zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
+zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+zerozero 3: Finite difference = 0. Analytical derivative = -0
+zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = 0. Analytical derivative = 0
-onezero 1: Finite difference = 0. Analytical derivative = 0
-onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
-oneone 0: Finite difference = 0. Analytical derivative = 0
-oneone 1: Finite difference = 0. Analytical derivative = 0
-oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
+onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
+onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
+onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
+onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
+oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
+oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
+oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+oneone 3: Finite difference = 0. Analytical derivative = -0
+oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.
 
 Test for p = 2
-zerozero 0: Finite difference = 0. Analytical derivative = 0
-zerozero 1: Finite difference = 0. Analytical derivative = 0
-zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
+pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
+pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
+pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
+pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
+zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
+zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
+zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+zerozero 3: Finite difference = 0. Analytical derivative = -0
+zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = 0. Analytical derivative = 0
-onezero 1: Finite difference = 0. Analytical derivative = 0
-onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
-oneone 0: Finite difference = 0. Analytical derivative = 0
-oneone 1: Finite difference = 0. Analytical derivative = 0
-oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
+onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
+onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
+onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
+onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
+oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
+oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
+oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+oneone 3: Finite difference = 0. Analytical derivative = -0
+oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.
 
 Test for p = 1000
-zerozero 0: Finite difference = 0. Analytical derivative = 0
-zerozero 1: Finite difference = 0. Analytical derivative = 0
-zerozero 2: Finite difference = 2.77544e+28. Analytical derivative = 2.77544e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
+pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
+pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
+pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
+pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
+zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
+zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
+zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+zerozero 3: Finite difference = 0. Analytical derivative = -0
+zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = 0. Analytical derivative = 0
-onezero 1: Finite difference = 0. Analytical derivative = 0
-onezero 2: Finite difference = -5.04626e+29. Analytical derivative = -5.04626e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.5742e+31. Analytical derivative = -4.5742e+31
-oneone 0: Finite difference = 0. Analytical derivative = 0
-oneone 1: Finite difference = 0. Analytical derivative = 0
-oneone 2: Finite difference = -2.77545e+28. Analytical derivative = -2.77544e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.04858e+24. Analytical derivative = -0
+onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
+onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
+onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
+onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
+onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
+oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
+oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
+oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+oneone 3: Finite difference = 0. Analytical derivative = -0
+oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.

--- a/tests/drucker_prager_derivatives/screen-output
+++ b/tests/drucker_prager_derivatives/screen-output
@@ -4,201 +4,217 @@
 Loading shared library <./libdrucker_prager_derivatives.so>
 
 Test for p = -1000
-pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
-pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
-pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
-pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
-pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
-zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
-zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
-zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
+pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
+pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
+pressure 3: Finite difference = 496606. Analytical derivative = 489830
+   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
+pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
+zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
+zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
+zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
 zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
-onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
-onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
-onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
-onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
-oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
-oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
-oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
+onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
+onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
+onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
+oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
+oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
+oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
 oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.
 
 Test for p = -2
-pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
-pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
-pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
-pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
-pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
-zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
-zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
-zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
+pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
+pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
+pressure 3: Finite difference = 496606. Analytical derivative = 489830
+   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
+pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
+zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
+zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
+zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
 zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
-onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
-onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
-onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
-onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
-oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
-oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
-oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
+onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
+onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
+onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
+oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
+oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
+oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
 oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.
 
 Test for p = -1.5
-pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
-pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
-pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
-pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
-pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
-zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
-zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
-zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
+pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
+pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
+pressure 3: Finite difference = 496606. Analytical derivative = 489830
+   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
+pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
+zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
+zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
+zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
 zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
-onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
-onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
-onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
-onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
-oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
-oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
-oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
+onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
+onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
+onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
+oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
+oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
+oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
 oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.
 
 Test for p = -1
-pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
-pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
-pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
-pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
-pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
-zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
-zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
-zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
+pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
+pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
+pressure 3: Finite difference = 496606. Analytical derivative = 489830
+   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
+pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
+zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
+zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
+zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
 zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
-onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
-onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
-onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
-onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
-oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
-oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
-oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
+onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
+onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
+onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
+oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
+oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
+oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
 oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.
 
 Test for p = 0
-pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
-pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
-pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
-pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
-pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
-zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
-zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
-zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
+pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
+pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
+pressure 3: Finite difference = 496606. Analytical derivative = 489830
+   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
+pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
+zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
+zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
+zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
 zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
-onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
-onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
-onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
-onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
-oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
-oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
-oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
+onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
+onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
+onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
+oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
+oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
+oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
 oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.
 
 Test for p = 1
-pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
-pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
-pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
-pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
-pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
-zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
-zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
-zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
+pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
+pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
+pressure 3: Finite difference = 496606. Analytical derivative = 489830
+   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
+pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
+zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
+zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
+zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
 zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
-onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
-onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
-onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
-onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
-oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
-oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
-oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
+onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
+onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
+onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
+oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
+oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
+oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
 oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.
 
 Test for p = 2
-pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
-pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
-pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
-pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
-pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
-zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
-zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
-zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
+pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
+pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
+pressure 3: Finite difference = 496606. Analytical derivative = 489830
+   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
+pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
+zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
+zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
+zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
 zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
-onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
-onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
-onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
-onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
-oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
-oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
-oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
+onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
+onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
+onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
+oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
+oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
+oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
 oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.
 
 Test for p = 1000
-pressure 0: Finite difference = 9.91172e+08. Analytical derivative = 9.91172e+08
-pressure 1: Finite difference = 7.84058e+08. Analytical derivative = 7.84058e+08
-pressure 2: Finite difference = 4.56212e+08. Analytical derivative = 4.56212e+08
-pressure 3: Finite difference = 2.62329e+07. Analytical derivative = 2.62324e+07
-pressure 4: Finite difference = 4.56076e+08. Analytical derivative = 4.56076e+08
-zerozero 0: Finite difference = 3.34623e+29. Analytical derivative = 3.34623e+29
-zerozero 1: Finite difference = 8.85574e+27. Analytical derivative = 8.85583e+27
-zerozero 2: Finite difference = 2.77533e+28. Analytical derivative = 2.77533e+28
+pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
+pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
+pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
+pressure 3: Finite difference = 496606. Analytical derivative = 489830
+   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
+pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
+zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
+zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
+zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
 zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -7.43607e+28. Analytical derivative = -7.43607e+28
-onezero 1: Finite difference = 4.83508e+29. Analytical derivative = 4.83508e+29
-onezero 2: Finite difference = -5.04606e+29. Analytical derivative = -5.04606e+29
-onezero 3: Finite difference = -5.41254e+38. Analytical derivative = -5.41214e+38
-onezero 4: Finite difference = -4.56575e+31. Analytical derivative = -4.56575e+31
-oneone 0: Finite difference = -3.34623e+29. Analytical derivative = -3.34623e+29
-oneone 1: Finite difference = -8.85607e+27. Analytical derivative = -8.85583e+27
-oneone 2: Finite difference = -2.77537e+28. Analytical derivative = -2.77533e+28
+onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
+onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
+onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
+onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
+oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
+oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
+oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
 oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -9.17504e+23. Analytical derivative = -0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesfull.

--- a/tests/simple_nonlinear.cc
+++ b/tests/simple_nonlinear.cc
@@ -171,7 +171,6 @@ int f(double parameter)
   derivatives = out_base.get_additional_output<MaterialModelDerivatives<dim> >();
 
   double temp;
-  SymmetricTensor<2,dim> temp_tensor = SymmetricTensor<2,dim> ();
   for (unsigned int i = 0; i < 5; i++)
     {
       // prevent division by zero. If it is zero, the test has passed, because or

--- a/tests/simple_nonlinear.cc
+++ b/tests/simple_nonlinear.cc
@@ -1,0 +1,281 @@
+#include <aspect/simulator.h>
+#include <deal.II/grid/tria.h>
+#include <aspect/material_model/interface.h>
+#include <aspect/material_model/simple_nonlinear.h>
+#include <aspect/simulator_access.h>
+#include <aspect/newton.h>
+
+#include <iostream>
+#include <typeinfo>
+
+int f(double parameter)
+{
+
+  std::cout << std::endl << "Test for p = " << parameter << std::endl;
+
+  const int dim=2;
+  using namespace aspect::MaterialModel;
+  MaterialModelInputs<dim> in_base(5,3);
+  in_base.composition[0][0] = 0;
+  in_base.composition[0][1] = 0;
+  in_base.composition[0][2] = 0;
+  in_base.composition[1][0] = 0.75;
+  in_base.composition[1][1] = 0.15;
+  in_base.composition[1][2] = 0.10;
+  in_base.composition[2][0] = 0;
+  in_base.composition[2][1] = 0.2;
+  in_base.composition[2][2] = 0.4;
+  in_base.composition[3][0] = 0;
+  in_base.composition[3][1] = 0.2;
+  in_base.composition[3][2] = 0.4;
+  in_base.composition[4][0] = 1;
+  in_base.composition[4][1] = 0;
+  in_base.composition[4][2] = 0;
+
+  in_base.pressure[0] = 1e9;
+  in_base.pressure[1] = 5e9;
+  in_base.pressure[2] = 2e10;
+  in_base.pressure[3] = 2e11;
+  in_base.pressure[4] = 2e12;
+
+  /**
+   * We cant take to slow values, because then the difference in the
+   * visocisty will be too small for the double accuracy which stores
+   * the visocity solutions and the finite diference solution.
+   */
+  in_base.strain_rate[0] = SymmetricTensor<2,dim>();
+  in_base.strain_rate[0][0][0] = 1e-12;
+  in_base.strain_rate[0][0][1] = 1e-12;
+  in_base.strain_rate[0][1][1] = 1e-11;
+  in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+  in_base.strain_rate[1][0][0] = -1.71266e-13;
+  in_base.strain_rate[1][0][1] = -5.82647e-12;
+  in_base.strain_rate[1][1][1] = 4.21668e-14;
+  in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+  in_base.strain_rate[2][1][1] = 1e-13;
+  in_base.strain_rate[2][0][1] = 1e-11;
+  in_base.strain_rate[2][0][0] = -1e-12;
+  in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+  in_base.strain_rate[3][1][1] = 4.9e-21;
+  in_base.strain_rate[3][0][1] = 4.9e-21;
+  in_base.strain_rate[3][0][0] = 4.9e-21;
+  in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+  in_base.strain_rate[4][1][1] = 1e-11;
+  in_base.strain_rate[4][0][1] = 1e-11;
+  in_base.strain_rate[4][0][0] = 1e-11;
+
+  in_base.temperature[0] = 293;
+  in_base.temperature[1] = 1600;
+  in_base.temperature[2] = 2000;
+  in_base.temperature[3] = 2100;
+  in_base.temperature[4] = 2200;
+
+  SymmetricTensor<2,dim> zerozero = SymmetricTensor<2,dim>();
+  SymmetricTensor<2,dim> onezero = SymmetricTensor<2,dim>();
+  SymmetricTensor<2,dim> oneone = SymmetricTensor<2,dim>();
+
+  zerozero[0][0] = 1;
+  onezero[1][0]  = 0.5; // because symmetry doubles this entry
+  oneone[1][1]   = 1;
+
+  double finite_difference_accuracy = 1e-7;
+  double finite_difference_factor = 1+finite_difference_accuracy;
+
+  bool Error = false;
+
+  MaterialModelInputs<dim> in_dviscositydpressure(5,3);
+  in_dviscositydpressure = in_base;
+  in_dviscositydpressure.pressure[0] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[1] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[2] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[3] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[4] *= finite_difference_factor;
+
+  MaterialModelInputs<dim> in_dviscositydstrainrate_zerozero(5,3);
+  MaterialModelInputs<dim> in_dviscositydstrainrate_onezero(5,3);
+  MaterialModelInputs<dim> in_dviscositydstrainrate_oneone(5,3);
+
+  in_dviscositydstrainrate_zerozero = in_base;
+  in_dviscositydstrainrate_onezero = in_base;
+  in_dviscositydstrainrate_oneone = in_base;
+  in_dviscositydstrainrate_zerozero.strain_rate[0] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[0][0][0]) * finite_difference_accuracy * zerozero;
+  in_dviscositydstrainrate_zerozero.strain_rate[1] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[1][0][0]) * finite_difference_accuracy * zerozero;
+  in_dviscositydstrainrate_zerozero.strain_rate[2] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[2][0][0]) * finite_difference_accuracy * zerozero;
+  in_dviscositydstrainrate_zerozero.strain_rate[3] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[3][0][0]) * finite_difference_accuracy * zerozero;
+  in_dviscositydstrainrate_zerozero.strain_rate[4] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[4][0][0]) * finite_difference_accuracy * zerozero;
+  in_dviscositydstrainrate_onezero.strain_rate[0]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[0][1][0]) * finite_difference_accuracy * onezero;
+  in_dviscositydstrainrate_onezero.strain_rate[1]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[1][1][0]) * finite_difference_accuracy * onezero;
+  in_dviscositydstrainrate_onezero.strain_rate[2]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[2][1][0]) * finite_difference_accuracy * onezero;
+  in_dviscositydstrainrate_onezero.strain_rate[3]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[3][1][0]) * finite_difference_accuracy * onezero;
+  in_dviscositydstrainrate_onezero.strain_rate[4]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[4][1][0]) * finite_difference_accuracy * onezero;
+  in_dviscositydstrainrate_oneone.strain_rate[0]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[0][1][1]) * finite_difference_accuracy * oneone;
+  in_dviscositydstrainrate_oneone.strain_rate[1]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[1][1][1]) * finite_difference_accuracy * oneone;
+  in_dviscositydstrainrate_oneone.strain_rate[2]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[2][1][1]) * finite_difference_accuracy * oneone;
+  in_dviscositydstrainrate_oneone.strain_rate[3]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[3][1][1]) * finite_difference_accuracy * oneone;
+  in_dviscositydstrainrate_oneone.strain_rate[4]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[4][1][1]) * finite_difference_accuracy * oneone;
+
+  MaterialModelInputs<dim> in_dviscositydtemperature(5,3);
+  in_dviscositydtemperature = in_base;
+  in_dviscositydtemperature.temperature[0] *= 1.0000000001;
+  in_dviscositydtemperature.temperature[1] *= 1.0000000001;
+  in_dviscositydtemperature.temperature[2] *= 1.0000000001;
+  in_dviscositydtemperature.temperature[3] *= 1.0000000001;
+  in_dviscositydtemperature.temperature[4] *= 1.0000000001;
+
+
+  MaterialModelOutputs<dim> out_base(5,3);
+
+  MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
+  MaterialModelOutputs<dim> out_dviscositydstrainrate_zerozero(5,3);
+  MaterialModelOutputs<dim> out_dviscositydstrainrate_onezero(5,3);
+  MaterialModelOutputs<dim> out_dviscositydstrainrate_oneone(5,3);
+  MaterialModelOutputs<dim> out_dviscositydtemperature(5,3);
+
+  if (out_base.get_additional_output<MaterialModelDerivatives<dim> >() != NULL)
+    throw "error";
+
+  out_base.additional_outputs.push_back(std::make_shared<MaterialModelDerivatives<dim> > (5));
+
+  SimpleNonlinear<dim> mat;
+  ParameterHandler prm;
+  mat.declare_parameters(prm);
+
+  prm.enter_subsection("Compositional fields");
+  {
+    prm.set("Number of fields","3");
+  }
+  prm.leave_subsection();
+  prm.enter_subsection("Material model");
+  {
+    prm.enter_subsection ("Simple nonlinear");
+    {
+      prm.set ("Prefactor", "1e-37,1e-36,1e-35,5e-36");
+      prm.set ("Viscosity averaging p", std::to_string(parameter));
+      prm.set ("Minimum strain rate", 1.4e-20);
+    }
+    prm.leave_subsection();
+  }
+  prm.leave_subsection();
+
+  mat.parse_parameters(prm);
+
+  mat.evaluate(in_base, out_base);
+  mat.evaluate(in_dviscositydpressure, out_dviscositydpressure);
+  mat.evaluate(in_dviscositydstrainrate_zerozero, out_dviscositydstrainrate_zerozero);
+  mat.evaluate(in_dviscositydstrainrate_onezero, out_dviscositydstrainrate_onezero);
+  mat.evaluate(in_dviscositydstrainrate_oneone, out_dviscositydstrainrate_oneone);
+  mat.evaluate(in_dviscositydtemperature, out_dviscositydtemperature);
+
+  //set up additional output for the derivatives
+  MaterialModelDerivatives<dim> *derivatives;
+  derivatives = out_base.get_additional_output<MaterialModelDerivatives<dim> >();
+
+  double temp;
+  SymmetricTensor<2,dim> temp_tensor = SymmetricTensor<2,dim> ();
+  for (unsigned int i = 0; i < 5; i++)
+    {
+      // prevent division by zero. If it is zero, the test has passed, because or
+      // the finite difference and the analytical result match perfectly, or (more
+      // likely) the material model in independent of this variable.
+      temp = (out_dviscositydpressure.viscosities[i] - out_base.viscosities[i]);
+      if (in_base.pressure[i] != 0)
+        {
+          temp /= (in_base.pressure[i] * finite_difference_accuracy);
+        }
+
+      if (temp > derivatives->viscosity_derivative_wrt_pressure[i] * finite_difference_factor || temp < derivatives->viscosity_derivative_wrt_pressure[i] * (2-finite_difference_factor))
+        {
+          std::cout << "Error: The derivative of the viscosity to the pressure is too different from the analitical value." << std::endl;
+          Error = true;
+        }
+
+    }
+
+  for (unsigned int i = 0; i < 5; i++)
+    {
+      // prevent division by zero. If it is zero, the test has passed, because or
+      // the finite difference and the analytical result match perfectly, or (more
+      // likely) the material model in independent of this variable.
+      temp = out_dviscositydstrainrate_zerozero.viscosities[i] - out_base.viscosities[i];
+      if (temp != 0)
+        {
+          temp /= std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[i][0][0]) * finite_difference_accuracy;
+        }
+      std::cout << "zerozero " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][0][0]  << std::endl;
+      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][0][0]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][0][0])))
+        {
+          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analitical value." << std::endl;
+          Error = true;
+        }
+
+
+
+    }
+
+  for (unsigned int i = 0; i < 5; i++)
+    {
+      // prevent division by zero. If it is zero, the test has passed, because or
+      // the finite difference and the analytical result match perfectly, or (more
+      // likely) the material model in independent of this variable.
+      temp = out_dviscositydstrainrate_onezero.viscosities[i] - out_base.viscosities[i];
+      if (temp != 0)
+        {
+          temp /= std::fabs(in_dviscositydstrainrate_onezero.strain_rate[i][1][0]) * finite_difference_accuracy;
+        }
+      std::cout << "onezero " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]   << std::endl;
+      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][0])) )
+        {
+          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analitical value." << std::endl;
+          Error = true;
+        }
+    }
+
+  for (unsigned int i = 0; i < 5; i++)
+    {
+      // prevent division by zero. If it is zero, the test has passed, because or
+      // the finite difference and the analytical result match perfectly, or (more
+      // likely) the material model in independent of this variable.
+      temp = out_dviscositydstrainrate_oneone.viscosities[i] - out_base.viscosities[i];
+      if (temp != 0)
+        {
+          temp /= std::fabs(in_dviscositydstrainrate_oneone.strain_rate[i][1][1]) * finite_difference_accuracy;
+        }
+      std::cout << "oneone " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]  << std::endl;
+      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][1])) )
+        {
+          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analitical value." << std::endl;
+          Error = true;
+        }
+
+    }
+
+  if (Error)
+    {
+      std::cout << "Some parts of the test where not succesfull." << std::endl;
+    }
+  else
+    {
+      std::cout << "OK" << std::endl;
+    }
+
+  return 42;
+}
+
+int exit_function()
+{
+  exit(0);
+  return 42;
+}
+// run this function by initializing a global variable by it
+int ii = f(-1000); // Testing min function
+int iz = f(-2); // Testing min function
+int ij = f(-1.5); // Testing generalized p norm mean with negative p
+int ik = f(-1); // Testing harmonic mean
+int ji = f(0); // Testing geometric mean
+int jj = f(1); // Testing arithmetic mean
+int jk = f(2); // Testing generalized p norm mean with positive p
+//int ki = f(10); // Testing generalized p norm mean with large positive p
+int kj = f(1000); // Testing max function
+int kl = exit_function();
+
+

--- a/tests/simple_nonlinear.prm
+++ b/tests/simple_nonlinear.prm
@@ -1,0 +1,1 @@
+set Additional shared libraries = tests/libsimple_nonlinear.so

--- a/tests/simple_nonlinear/screen-output
+++ b/tests/simple_nonlinear/screen-output
@@ -1,106 +1,176 @@
 -----------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.0-pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
 -----------------------------------------------------------------------------
 
 Loading shared library <./libsimple_nonlinear.so>
 
 Test for p = -1000
-zerozero 0: Finite difference = 1.60543e+30. Analytical derivative = 1.60543e+30
-zerozero 1: Finite difference = 4.39022e+28. Analytical derivative = 4.39017e+28
-zerozero 2: Finite difference = 2.47822e+28. Analytical derivative = 2.47822e+28
-onezero 0: Finite difference = -3.56763e+29. Analytical derivative = -3.56763e+29
-onezero 1: Finite difference = 2.39693e+30. Analytical derivative = 2.39693e+30
-onezero 2: Finite difference = -4.50585e+29. Analytical derivative = -4.50585e+29
-oneone 0: Finite difference = -1.60543e+30. Analytical derivative = -1.60543e+30
-oneone 1: Finite difference = -4.39006e+28. Analytical derivative = -4.39017e+28
-oneone 2: Finite difference = -2.47822e+28. Analytical derivative = -2.47822e+28
-OK
+zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
+zerozero 1: Finite difference = 9.45819e+27. Analytical derivative = 9.45833e+27
+zerozero 2: Finite difference = 1.15028e+28. Analytical derivative = 1.15029e+28
+zerozero 3: Finite difference = -1.31479e+37. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+zerozero 4: Finite difference = -1.4336e+22. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
+onezero 1: Finite difference = 5.16403e+29. Analytical derivative = 5.16403e+29
+onezero 2: Finite difference = -2.09143e+29. Analytical derivative = -2.09143e+29
+onezero 3: Finite difference = -6.89496e+44. Analytical derivative = -6.89496e+44
+onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
+oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
+oneone 1: Finite difference = -9.45857e+27. Analytical derivative = -9.45833e+27
+oneone 2: Finite difference = -1.1503e+28. Analytical derivative = -1.15029e+28
+oneone 3: Finite difference = -1.31479e+37. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+oneone 4: Finite difference = -1.4336e+22. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesfull.
+
+Test for p = -2
+zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
+zerozero 1: Finite difference = 1.54539e+28. Analytical derivative = 1.54541e+28
+zerozero 2: Finite difference = 1.67688e+28. Analytical derivative = 1.67688e+28
+zerozero 3: Finite difference = -1.75305e+37. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+zerozero 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
+onezero 1: Finite difference = 8.43757e+29. Analytical derivative = 8.43757e+29
+onezero 2: Finite difference = -3.04888e+29. Analytical derivative = -3.04888e+29
+onezero 3: Finite difference = -1.00515e+45. Analytical derivative = -1.00515e+45
+onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
+oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
+oneone 1: Finite difference = -1.54542e+28. Analytical derivative = -1.54541e+28
+oneone 2: Finite difference = -1.6769e+28. Analytical derivative = -1.67688e+28
+oneone 3: Finite difference = -1.75305e+37. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+oneone 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesfull.
 
 Test for p = -1.5
 zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
-zerozero 1: Finite difference = 1.59215e+28. Analytical derivative = 1.59213e+28
+zerozero 1: Finite difference = 1.59213e+28. Analytical derivative = 1.59213e+28
 zerozero 2: Finite difference = 1.77238e+28. Analytical derivative = 1.77239e+28
+zerozero 3: Finite difference = -2.19131e+37. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+zerozero 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
 onezero 1: Finite difference = 8.69267e+29. Analytical derivative = 8.69267e+29
 onezero 2: Finite difference = -3.22252e+29. Analytical derivative = -3.22252e+29
+onezero 3: Finite difference = -1.06239e+45. Analytical derivative = -1.06239e+45
+onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
 oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
-oneone 1: Finite difference = -1.59204e+28. Analytical derivative = -1.59213e+28
-oneone 2: Finite difference = -1.77242e+28. Analytical derivative = -1.77239e+28
-OK
+oneone 1: Finite difference = -1.59209e+28. Analytical derivative = -1.59213e+28
+oneone 2: Finite difference = -1.7724e+28. Analytical derivative = -1.77239e+28
+oneone 3: Finite difference = -2.19131e+37. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+oneone 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesfull.
 
 Test for p = -1
 zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
-zerozero 1: Finite difference = 1.63784e+28. Analytical derivative = 1.63784e+28
+zerozero 1: Finite difference = 1.63782e+28. Analytical derivative = 1.63784e+28
 zerozero 2: Finite difference = 1.90553e+28. Analytical derivative = 1.90553e+28
+zerozero 3: Finite difference = -1.31479e+37. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+zerozero 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
 onezero 1: Finite difference = 8.94221e+29. Analytical derivative = 8.94221e+29
 onezero 2: Finite difference = -3.46459e+29. Analytical derivative = -3.46459e+29
+onezero 3: Finite difference = -1.1422e+45. Analytical derivative = -1.1422e+45
+onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
 oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
-oneone 1: Finite difference = -1.6378e+28. Analytical derivative = -1.63784e+28
+oneone 1: Finite difference = -1.63784e+28. Analytical derivative = -1.63784e+28
 oneone 2: Finite difference = -1.90554e+28. Analytical derivative = -1.90553e+28
-OK
+oneone 3: Finite difference = -1.31479e+37. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+oneone 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesfull.
 
 Test for p = 0
 zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
 zerozero 1: Finite difference = 1.72138e+28. Analytical derivative = 1.72127e+28
 zerozero 2: Finite difference = 2.33127e+28. Analytical derivative = 2.33136e+28
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = 0. Analytical derivative = 0
 onezero 0: Finite difference = -7.68624e+29. Analytical derivative = -7.68623e+29
 onezero 1: Finite difference = 9.39773e+29. Analytical derivative = 9.39773e+29
 onezero 2: Finite difference = -4.23884e+29. Analytical derivative = -4.23884e+29
+onezero 3: Finite difference = -1.39745e+45. Analytical derivative = -1.39745e+45
+onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
 oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
 oneone 1: Finite difference = -1.72231e+28. Analytical derivative = -1.72127e+28
 oneone 2: Finite difference = -2.33099e+28. Analytical derivative = -2.33136e+28
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = 0. Analytical derivative = 0
 OK
 
 Test for p = 1
 zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
-zerozero 1: Finite difference = 1.78935e+28. Analytical derivative = 1.78934e+28
+zerozero 1: Finite difference = 1.78932e+28. Analytical derivative = 1.78934e+28
 zerozero 2: Finite difference = 2.94542e+28. Analytical derivative = 2.94543e+28
+zerozero 3: Finite difference = -4.38262e+37. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+zerozero 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
 onezero 1: Finite difference = 9.7694e+29. Analytical derivative = 9.7694e+29
 onezero 2: Finite difference = -5.35532e+29. Analytical derivative = -5.35532e+29
+onezero 3: Finite difference = -1.76553e+45. Analytical derivative = -1.76553e+45
+onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
 oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
-oneone 1: Finite difference = -1.78928e+28. Analytical derivative = -1.78934e+28
+oneone 1: Finite difference = -1.78938e+28. Analytical derivative = -1.78934e+28
 oneone 2: Finite difference = -2.94545e+28. Analytical derivative = -2.94543e+28
-OK
+oneone 3: Finite difference = -4.38262e+37. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+oneone 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesfull.
 
 Test for p = 2
 zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
-zerozero 1: Finite difference = 1.84132e+28. Analytical derivative = 1.84132e+28
+zerozero 1: Finite difference = 1.84129e+28. Analytical derivative = 1.84132e+28
 zerozero 2: Finite difference = 3.53658e+28. Analytical derivative = 3.53658e+28
+zerozero 3: Finite difference = -4.38262e+37. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+zerozero 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
 onezero 1: Finite difference = 1.00532e+30. Analytical derivative = 1.00532e+30
 onezero 2: Finite difference = -6.43015e+29. Analytical derivative = -6.43015e+29
+onezero 3: Finite difference = -2.11987e+45. Analytical derivative = -2.11987e+45
+onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
 oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
-oneone 1: Finite difference = -1.8413e+28. Analytical derivative = -1.84132e+28
+oneone 1: Finite difference = -1.8414e+28. Analytical derivative = -1.84132e+28
 oneone 2: Finite difference = -3.53661e+28. Analytical derivative = -3.53658e+28
-OK
-
-Test for p = 10
-zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
-zerozero 1: Finite difference = 1.98008e+28. Analytical derivative = 1.98009e+28
-zerozero 2: Finite difference = 4.87168e+28. Analytical derivative = 4.87168e+28
-onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
-onezero 1: Finite difference = 1.08108e+30. Analytical derivative = 1.08108e+30
-onezero 2: Finite difference = -8.85759e+29. Analytical derivative = -8.8576e+29
-oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
-oneone 1: Finite difference = -1.98006e+28. Analytical derivative = -1.98009e+28
-oneone 2: Finite difference = -4.87174e+28. Analytical derivative = -4.87168e+28
-OK
+oneone 3: Finite difference = -4.38262e+37. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+oneone 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesfull.
 
 Test for p = 1000
 zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
-zerozero 1: Finite difference = 2.03774e+28. Analytical derivative = 2.03773e+28
-zerozero 2: Finite difference = 1.44927e+28. Analytical derivative = 1.44927e+28
+zerozero 1: Finite difference = 2.03772e+28. Analytical derivative = 2.03773e+28
+zerozero 2: Finite difference = 5.33915e+28. Analytical derivative = 5.33915e+28
+zerozero 3: Finite difference = -7.01219e+37. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+zerozero 4: Finite difference = -1.4336e+22. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
 onezero 1: Finite difference = 1.11256e+30. Analytical derivative = 1.11256e+30
-onezero 2: Finite difference = -2.63503e+29. Analytical derivative = -2.63504e+29
+onezero 2: Finite difference = -9.70755e+29. Analytical derivative = -9.70755e+29
+onezero 3: Finite difference = -3.20036e+45. Analytical derivative = -3.20036e+45
+onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
 oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
-oneone 1: Finite difference = -2.03766e+28. Analytical derivative = -2.03773e+28
-oneone 2: Finite difference = -1.44928e+28. Analytical derivative = -1.44927e+28
-OK
-
+oneone 1: Finite difference = -2.03776e+28. Analytical derivative = -2.03773e+28
+oneone 2: Finite difference = -5.33922e+28. Analytical derivative = -5.33915e+28
+oneone 3: Finite difference = -7.01219e+37. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+oneone 4: Finite difference = -1.4336e+22. Analytical derivative = -0
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesfull.

--- a/tests/simple_nonlinear/screen-output
+++ b/tests/simple_nonlinear/screen-output
@@ -1,0 +1,106 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 1.4.0-pre
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+--     . using Trilinos
+-----------------------------------------------------------------------------
+
+Loading shared library <./libsimple_nonlinear.so>
+
+Test for p = -1000
+zerozero 0: Finite difference = 1.60543e+30. Analytical derivative = 1.60543e+30
+zerozero 1: Finite difference = 4.39022e+28. Analytical derivative = 4.39017e+28
+zerozero 2: Finite difference = 2.47822e+28. Analytical derivative = 2.47822e+28
+onezero 0: Finite difference = -3.56763e+29. Analytical derivative = -3.56763e+29
+onezero 1: Finite difference = 2.39693e+30. Analytical derivative = 2.39693e+30
+onezero 2: Finite difference = -4.50585e+29. Analytical derivative = -4.50585e+29
+oneone 0: Finite difference = -1.60543e+30. Analytical derivative = -1.60543e+30
+oneone 1: Finite difference = -4.39006e+28. Analytical derivative = -4.39017e+28
+oneone 2: Finite difference = -2.47822e+28. Analytical derivative = -2.47822e+28
+OK
+
+Test for p = -1.5
+zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
+zerozero 1: Finite difference = 1.59215e+28. Analytical derivative = 1.59213e+28
+zerozero 2: Finite difference = 1.77238e+28. Analytical derivative = 1.77239e+28
+onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
+onezero 1: Finite difference = 8.69267e+29. Analytical derivative = 8.69267e+29
+onezero 2: Finite difference = -3.22252e+29. Analytical derivative = -3.22252e+29
+oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
+oneone 1: Finite difference = -1.59204e+28. Analytical derivative = -1.59213e+28
+oneone 2: Finite difference = -1.77242e+28. Analytical derivative = -1.77239e+28
+OK
+
+Test for p = -1
+zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
+zerozero 1: Finite difference = 1.63784e+28. Analytical derivative = 1.63784e+28
+zerozero 2: Finite difference = 1.90553e+28. Analytical derivative = 1.90553e+28
+onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
+onezero 1: Finite difference = 8.94221e+29. Analytical derivative = 8.94221e+29
+onezero 2: Finite difference = -3.46459e+29. Analytical derivative = -3.46459e+29
+oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
+oneone 1: Finite difference = -1.6378e+28. Analytical derivative = -1.63784e+28
+oneone 2: Finite difference = -1.90554e+28. Analytical derivative = -1.90553e+28
+OK
+
+Test for p = 0
+zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
+zerozero 1: Finite difference = 1.72138e+28. Analytical derivative = 1.72127e+28
+zerozero 2: Finite difference = 2.33127e+28. Analytical derivative = 2.33136e+28
+onezero 0: Finite difference = -7.68624e+29. Analytical derivative = -7.68623e+29
+onezero 1: Finite difference = 9.39773e+29. Analytical derivative = 9.39773e+29
+onezero 2: Finite difference = -4.23884e+29. Analytical derivative = -4.23884e+29
+oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
+oneone 1: Finite difference = -1.72231e+28. Analytical derivative = -1.72127e+28
+oneone 2: Finite difference = -2.33099e+28. Analytical derivative = -2.33136e+28
+OK
+
+Test for p = 1
+zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
+zerozero 1: Finite difference = 1.78935e+28. Analytical derivative = 1.78934e+28
+zerozero 2: Finite difference = 2.94542e+28. Analytical derivative = 2.94543e+28
+onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
+onezero 1: Finite difference = 9.7694e+29. Analytical derivative = 9.7694e+29
+onezero 2: Finite difference = -5.35532e+29. Analytical derivative = -5.35532e+29
+oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
+oneone 1: Finite difference = -1.78928e+28. Analytical derivative = -1.78934e+28
+oneone 2: Finite difference = -2.94545e+28. Analytical derivative = -2.94543e+28
+OK
+
+Test for p = 2
+zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
+zerozero 1: Finite difference = 1.84132e+28. Analytical derivative = 1.84132e+28
+zerozero 2: Finite difference = 3.53658e+28. Analytical derivative = 3.53658e+28
+onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
+onezero 1: Finite difference = 1.00532e+30. Analytical derivative = 1.00532e+30
+onezero 2: Finite difference = -6.43015e+29. Analytical derivative = -6.43015e+29
+oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
+oneone 1: Finite difference = -1.8413e+28. Analytical derivative = -1.84132e+28
+oneone 2: Finite difference = -3.53661e+28. Analytical derivative = -3.53658e+28
+OK
+
+Test for p = 10
+zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
+zerozero 1: Finite difference = 1.98008e+28. Analytical derivative = 1.98009e+28
+zerozero 2: Finite difference = 4.87168e+28. Analytical derivative = 4.87168e+28
+onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
+onezero 1: Finite difference = 1.08108e+30. Analytical derivative = 1.08108e+30
+onezero 2: Finite difference = -8.85759e+29. Analytical derivative = -8.8576e+29
+oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
+oneone 1: Finite difference = -1.98006e+28. Analytical derivative = -1.98009e+28
+oneone 2: Finite difference = -4.87174e+28. Analytical derivative = -4.87168e+28
+OK
+
+Test for p = 1000
+zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
+zerozero 1: Finite difference = 2.03774e+28. Analytical derivative = 2.03773e+28
+zerozero 2: Finite difference = 1.44927e+28. Analytical derivative = 1.44927e+28
+onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
+onezero 1: Finite difference = 1.11256e+30. Analytical derivative = 1.11256e+30
+onezero 2: Finite difference = -2.63503e+29. Analytical derivative = -2.63504e+29
+oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
+oneone 1: Finite difference = -2.03766e+28. Analytical derivative = -2.03773e+28
+oneone 2: Finite difference = -1.44928e+28. Analytical derivative = -1.44927e+28
+OK
+


### PR DESCRIPTION
This pull request was intended to only add a visualisation post processor for the spd factor computations. But to make that work I also needed material models to play with. 

So I have rewritten drucker prager (@anne-glerum, are you oke with this?) to be able to compute the derivatives (analytically) and have written tests for them. The tests test the derivative of the material model (which are analytical) with a finite difference derivative. There are some cases where there are differences between these, which I can derive from both sides, but don't know which is actually better. 