### PR TITLE
simplifying the code in the other source files under the refinement folder

### DIFF
--- a/source/mesh_refinement/artificial_viscosity.cc
+++ b/source/mesh_refinement/artificial_viscosity.cc
@@ -30,6 +30,7 @@ namespace aspect
     ArtificialViscosity<dim>::execute(Vector<float> &indicators) const
     {
       indicators = 0;
+      Vector<float> this_indicator(indicators.size());
       if (temperature_scaling_factor > 0.0)
         {
           this->get_artificial_viscosity(indicators);
@@ -38,7 +39,7 @@ namespace aspect
 
       for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
         {
-          Vector<float> this_indicator (indicators.size());
+          this_indicator = 0;
           this->get_artificial_viscosity_composition(this_indicator, c);
 
           // compute indicators += c*this_indicator:

--- a/source/mesh_refinement/composition.cc
+++ b/source/mesh_refinement/composition.cc
@@ -36,13 +36,12 @@ namespace aspect
                    ExcMessage ("This refinement criterion can not be used when no "
                                "compositional fields are active!"));
       indicators = 0;
+      Vector<float> this_indicator (indicators.size());
+      QGauss<dim-1> quadrature (this->introspection().polynomial_degree.compositional_fields+1);
 
       for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
         {
-          Vector<float> this_indicator (indicators.size());
-
-          QGauss<dim-1> quadrature (this->get_fe().base_element(this->introspection().base_elements.compositional_fields).degree+1);
-
+          this_indicator = 0;
           KellyErrorEstimator<dim>::estimate (this->get_mapping(),
                                               this->get_dof_handler(),
                                               quadrature,
@@ -53,9 +52,8 @@ namespace aspect
                                               0,
                                               0,
                                               this->get_triangulation().locally_owned_subdomain());
-          for (unsigned int i=0; i<indicators.size(); ++i)
-            this_indicator[i] *= composition_scaling_factors[c];
-          indicators += this_indicator;
+          // compute indicators += c*this_indicator:
+          indicators.add(composition_scaling_factors[c], this_indicator);
         }
     }
 

--- a/source/mesh_refinement/temperature.cc
+++ b/source/mesh_refinement/temperature.cc
@@ -34,7 +34,7 @@ namespace aspect
     {
       indicators = 0;
 
-      QGauss<dim-1> quadrature (this->get_fe().base_element(this->introspection().base_elements.temperature).degree+1);
+      QGauss<dim-1> quadrature (this->introspection().polynomial_degree.temperature+1);
 
       KellyErrorEstimator<dim>::estimate (this->get_mapping(),
                                           this->get_dof_handler(),


### PR DESCRIPTION
I didn't change any functionality or logic of those code. When I wrote the new mesh refinement composition_approximate_gradient.cc, just looked around other sources files in the same folder, and I found that some of those codes can also be simplified.