### PR TITLE
fixes for non c++11 compilers

### DIFF
--- a/source/boundary_temperature/function.cc
+++ b/source/boundary_temperature/function.cc
@@ -42,11 +42,11 @@ namespace aspect
     boundary_temperature (const types::boundary_id /*boundary_indicator*/,
                           const Point<dim> &position) const
     {
-      if (coordinate_system == ::aspect::Utilities::Coordinates::CoordinateSystem::cartesian)
+      if (coordinate_system == ::aspect::Utilities::Coordinates::cartesian)
         {
           return boundary_temperature_function.value(position);
         }
-      else if (coordinate_system == ::aspect::Utilities::Coordinates::CoordinateSystem::spherical)
+      else if (coordinate_system == ::aspect::Utilities::Coordinates::spherical)
         {
           const std_cxx11::array<double,dim> spherical_coordinates =
             aspect::Utilities::Coordinates::cartesian_to_spherical_coordinates(position);
@@ -57,7 +57,7 @@ namespace aspect
 
           return boundary_temperature_function.value(point);
         }
-      else if (coordinate_system == ::aspect::Utilities::Coordinates::CoordinateSystem::depth)
+      else if (coordinate_system == ::aspect::Utilities::Coordinates::depth)
         {
           const double depth = this->get_geometry_model().depth(position);
           Point<dim> point;

--- a/source/boundary_traction/function.cc
+++ b/source/boundary_traction/function.cc
@@ -44,13 +44,13 @@ namespace aspect
                        const Tensor<1,dim> &) const
     {
       Tensor<1,dim> traction;
-      if (coordinate_system == ::aspect::Utilities::Coordinates::CoordinateSystem::cartesian)
+      if (coordinate_system == ::aspect::Utilities::Coordinates::cartesian)
         {
           for (unsigned int d=0; d<dim; ++d)
             traction[d] = boundary_traction_function.value(p,d);
 
         }
-      else if (coordinate_system == ::aspect::Utilities::Coordinates::CoordinateSystem::spherical)
+      else if (coordinate_system == ::aspect::Utilities::Coordinates::spherical)
         {
           const std_cxx11::array<double,dim> spherical_coordinates =
             aspect::Utilities::Coordinates::cartesian_to_spherical_coordinates(p);
@@ -63,7 +63,7 @@ namespace aspect
             traction[d] = boundary_traction_function.value(point,d);
 
         }
-      else if (coordinate_system == ::aspect::Utilities::Coordinates::CoordinateSystem::depth)
+      else if (coordinate_system == ::aspect::Utilities::Coordinates::depth)
         {
           const double depth = this->get_geometry_model().depth(p);
           Point<dim> point;
@@ -75,7 +75,7 @@ namespace aspect
       else
         {
           AssertThrow(false, ExcNotImplemented());
-          return numbers::signaling_nan<Tensor<1,dim>>();
+          return numbers::signaling_nan<Tensor<1,dim> >();
         }
 
       return traction;

--- a/source/boundary_velocity/function.cc
+++ b/source/boundary_velocity/function.cc
@@ -43,12 +43,12 @@ namespace aspect
                        const Point<dim> &position) const
     {
       Tensor<1,dim> velocity;
-      if (coordinate_system == ::aspect::Utilities::Coordinates::CoordinateSystem::cartesian)
+      if (coordinate_system == ::aspect::Utilities::Coordinates::cartesian)
         {
           for (unsigned int d=0; d<dim; ++d)
             velocity[d] = boundary_velocity_function.value(position,d);
         }
-      else if (coordinate_system == ::aspect::Utilities::Coordinates::CoordinateSystem::spherical)
+      else if (coordinate_system == ::aspect::Utilities::Coordinates::spherical)
         {
           const std_cxx11::array<double,dim> spherical_coordinates =
             aspect::Utilities::Coordinates::cartesian_to_spherical_coordinates(position);
@@ -60,7 +60,7 @@ namespace aspect
           for (unsigned int d=0; d<dim; ++d)
             velocity[d] = boundary_velocity_function.value(point,d);
         }
-      else if (coordinate_system == ::aspect::Utilities::Coordinates::CoordinateSystem::depth)
+      else if (coordinate_system == ::aspect::Utilities::Coordinates::depth)
         {
           const double depth = this->get_geometry_model().depth(position);
           Point<dim> point;
@@ -72,7 +72,7 @@ namespace aspect
       else
         {
           AssertThrow(false, ExcNotImplemented());
-          return numbers::signaling_nan<Tensor<1,dim>>();
+          return numbers::signaling_nan<Tensor<1,dim> >();
         }
 
 

--- a/source/initial_temperature/function.cc
+++ b/source/initial_temperature/function.cc
@@ -41,11 +41,11 @@ namespace aspect
     Function<dim>::
     initial_temperature (const Point<dim> &position) const
     {
-      if (coordinate_system == Utilities::Coordinates::CoordinateSystem::cartesian)
+      if (coordinate_system == Utilities::Coordinates::cartesian)
         {
           return function.value(position);
         }
-      else if (coordinate_system == Utilities::Coordinates::CoordinateSystem::spherical)
+      else if (coordinate_system == Utilities::Coordinates::spherical)
         {
           const std_cxx11::array<double,dim> spherical_coordinates =
             Utilities::Coordinates::cartesian_to_spherical_coordinates(position);
@@ -56,7 +56,7 @@ namespace aspect
 
           return function.value(point);
         }
-      else if (coordinate_system == Utilities::Coordinates::CoordinateSystem::depth)
+      else if (coordinate_system == Utilities::Coordinates::depth)
         {
           const double depth = this->get_geometry_model().depth(position);
           Point<dim> point;

--- a/source/mesh_refinement/maximum_refinement_function.cc
+++ b/source/mesh_refinement/maximum_refinement_function.cc
@@ -63,14 +63,14 @@ namespace aspect
                   const Point<dim> vertex = cell->vertex(v);
                   double maximum_refinement_level = 0;
 
-                  if (coordinate_system == ::aspect::Utilities::Coordinates::CoordinateSystem::depth)
+                  if (coordinate_system == ::aspect::Utilities::Coordinates::depth)
                     {
                       const double depth = this->get_geometry_model().depth(vertex);
                       Point<dim> point;
                       point(0) = depth;
                       maximum_refinement_level = max_refinement_level.value(point);
                     }
-                  else if (coordinate_system == ::aspect::Utilities::Coordinates::CoordinateSystem::spherical)
+                  else if (coordinate_system == ::aspect::Utilities::Coordinates::spherical)
                     {
                       const std_cxx11::array<double,dim> spherical_coordinates =
                         aspect::Utilities::Coordinates::cartesian_to_spherical_coordinates(vertex);
@@ -83,7 +83,7 @@ namespace aspect
 
                       maximum_refinement_level = max_refinement_level.value(point);
                     }
-                  else if (coordinate_system == ::aspect::Utilities::Coordinates::CoordinateSystem::cartesian)
+                  else if (coordinate_system == ::aspect::Utilities::Coordinates::cartesian)
                     {
                       maximum_refinement_level = max_refinement_level.value(vertex);
                     }
@@ -154,11 +154,11 @@ namespace aspect
         prm.enter_subsection("Maximum refinement function");
         {
           if (prm.get ("Coordinate system") == "depth")
-            coordinate_system = ::aspect::Utilities::Coordinates::CoordinateSystem::depth;
+            coordinate_system = ::aspect::Utilities::Coordinates::depth;
           else if (prm.get ("Coordinate system") == "cartesian")
-            coordinate_system = ::aspect::Utilities::Coordinates::CoordinateSystem::cartesian;
+            coordinate_system = ::aspect::Utilities::Coordinates::cartesian;
           else if (prm.get ("Coordinate system") == "spherical")
-            coordinate_system = ::aspect::Utilities::Coordinates::CoordinateSystem::spherical;
+            coordinate_system = ::aspect::Utilities::Coordinates::spherical;
           else
             AssertThrow (false, ExcNotImplemented());
 

--- a/source/mesh_refinement/minimum_refinement_function.cc
+++ b/source/mesh_refinement/minimum_refinement_function.cc
@@ -63,14 +63,14 @@ namespace aspect
                   const Point<dim> vertex = cell->vertex(v);
                   double minimum_refinement_level = 0;
 
-                  if (coordinate_system == ::aspect::Utilities::Coordinates::CoordinateSystem::depth)
+                  if (coordinate_system == ::aspect::Utilities::Coordinates::depth)
                     {
                       const double depth = this->get_geometry_model().depth(vertex);
                       Point<dim> point;
                       point(0) = depth;
                       minimum_refinement_level = min_refinement_level.value(point);
                     }
-                  else if (coordinate_system == ::aspect::Utilities::Coordinates::CoordinateSystem::spherical)
+                  else if (coordinate_system == ::aspect::Utilities::Coordinates::spherical)
                     {
                       const std_cxx11::array<double,dim> spherical_coordinates =
                         aspect::Utilities::Coordinates::cartesian_to_spherical_coordinates(vertex);
@@ -83,7 +83,7 @@ namespace aspect
 
                       minimum_refinement_level = min_refinement_level.value(point);
                     }
-                  else if (coordinate_system == ::aspect::Utilities::Coordinates::CoordinateSystem::cartesian)
+                  else if (coordinate_system == ::aspect::Utilities::Coordinates::cartesian)
                     {
                       minimum_refinement_level = min_refinement_level.value(vertex);
                     }
@@ -154,11 +154,11 @@ namespace aspect
         prm.enter_subsection("Minimum refinement function");
         {
           if (prm.get ("Coordinate system") == "depth")
-            coordinate_system = ::aspect::Utilities::Coordinates::CoordinateSystem::depth;
+            coordinate_system = ::aspect::Utilities::Coordinates::depth;
           else if (prm.get ("Coordinate system") == "cartesian")
-            coordinate_system = ::aspect::Utilities::Coordinates::CoordinateSystem::cartesian;
+            coordinate_system = ::aspect::Utilities::Coordinates::cartesian;
           else if (prm.get ("Coordinate system") == "spherical")
-            coordinate_system = ::aspect::Utilities::Coordinates::CoordinateSystem::spherical;
+            coordinate_system = ::aspect::Utilities::Coordinates::spherical;
           else
             AssertThrow (false, ExcNotImplemented());
 

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -247,7 +247,7 @@ namespace aspect
                                                        scratch.phi_p[i] * scratch.div_phi_u[j]))
                                                   * JxW;
 
-                        Assert(dealii::numbers::is_finite(data.local_matrix(i,j)),ExcMessage ("Error: Assembly matrix is not finite." + std::to_string(data.local_matrix(i,j)) + " = " + std::to_string(eta)));
+                        Assert(dealii::numbers::is_finite(data.local_matrix(i,j)),ExcMessage ("Error: Assembly matrix is not finite." + Utilities::to_string(data.local_matrix(i,j)) + " = " + Utilities::to_string(eta)));
                       }
 
                 }

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -217,15 +217,15 @@ namespace aspect
       string_to_coordinate_system(const std::string &coordinate_system)
       {
         if (coordinate_system == "cartesian")
-          return CoordinateSystem::cartesian;
+          return cartesian;
         else if (coordinate_system == "spherical")
-          return CoordinateSystem::spherical;
+          return spherical;
         else if (coordinate_system == "depth")
-          return Coordinates::CoordinateSystem::depth;
+          return Coordinates::depth;
         else
           AssertThrow(false, ExcNotImplemented());
 
-        return Coordinates::CoordinateSystem::invalid;
+        return Coordinates::invalid;
       }
 
 


### PR DESCRIPTION
This addresses incompatibilities with a pre c++11 compiler introduced by the CoordinateSystem namespace @mbweller . I also included the to_string incompatibility addressed by a pull request by @MFraters (I had to do that as well to check whether it compiles). 