### PR TITLE
Add deal_II git short revision to version info

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -25,6 +25,7 @@
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/multithread_info.h>
+#include <deal.II/base/revision.h>
 
 #include <string>
 
@@ -386,6 +387,7 @@ void print_version_information(Stream &stream)
   stream << "Version information of underlying libraries:\n"
          << "   . deal.II:    "
          << DEAL_II_PACKAGE_VERSION << '\n'
+         << DEAL_II_GIT_SHORTREV    << '\n'
 #ifndef ASPECT_USE_PETSC
          << "   . Trilinos:   "
          << DEAL_II_TRILINOS_VERSION_MAJOR    << '.'


### PR DESCRIPTION
Due to the complexity of the issue #1674 , until the underlying code has been implemented, this PR will include the deal.ii git short revision id as part of `./aspect --version`