### PR TITLE
Add MeltInterface and reference_darcy_coefficient

### DIFF
--- a/benchmarks/shear_bands/shear_bands.cc
+++ b/benchmarks/shear_bands/shear_bands.cc
@@ -49,7 +49,7 @@ namespace aspect
      * @ingroup MaterialModels
      */
     template <int dim>
-    class ShearBandsMaterial : public MaterialModel::Interface<dim>,
+    class ShearBandsMaterial : public MaterialModel::MeltInterface<dim>,
       public ::aspect::SimulatorAccess<dim>
     {
       public:
@@ -62,6 +62,12 @@ namespace aspect
         {
           return eta_0;
         }
+
+        virtual double reference_darcy_coefficient () const
+        {
+          return reference_permeability * pow(0.01, permeability_exponent) / eta_f;
+        }
+
 
         double
         get_background_porosity () const;

--- a/benchmarks/solitary_wave/solitary_wave.cc
+++ b/benchmarks/solitary_wave/solitary_wave.cc
@@ -298,7 +298,7 @@ namespace aspect
      * @ingroup MaterialModels
      */
     template <int dim>
-    class SolitaryWaveMaterial : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    class SolitaryWaveMaterial : public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
     {
       public:
         virtual bool is_compressible () const
@@ -309,6 +309,11 @@ namespace aspect
         virtual double reference_viscosity () const
         {
           return eta_0;
+        }
+
+        virtual double reference_darcy_coefficient () const
+        {
+          return reference_permeability * pow(0.01, 3.0) / eta_f;
         }
 
         double length_scaling (const double porosity) const

--- a/include/aspect/material_model/latent_heat_melt.h
+++ b/include/aspect/material_model/latent_heat_melt.h
@@ -78,8 +78,6 @@ namespace aspect
          */
         virtual double reference_viscosity () const;
 
-        virtual double reference_darcy_coefficient () const;
-
         /**
          * @}
          */

--- a/include/aspect/material_model/latent_heat_melt.h
+++ b/include/aspect/material_model/latent_heat_melt.h
@@ -39,7 +39,7 @@ namespace aspect
      * @ingroup MaterialModels
      */
     template <int dim>
-    class LatentHeatMelt : public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>, public MaterialModel::MeltFractionModel<dim>
+    class LatentHeatMelt : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>, public MaterialModel::MeltFractionModel<dim>
     {
       public:
         /**

--- a/include/aspect/material_model/latent_heat_melt.h
+++ b/include/aspect/material_model/latent_heat_melt.h
@@ -39,7 +39,7 @@ namespace aspect
      * @ingroup MaterialModels
      */
     template <int dim>
-    class LatentHeatMelt : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>, public MaterialModel::MeltFractionModel<dim>
+    class LatentHeatMelt : public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>, public MaterialModel::MeltFractionModel<dim>
     {
       public:
         /**
@@ -77,6 +77,9 @@ namespace aspect
          * @{
          */
         virtual double reference_viscosity () const;
+
+        virtual double reference_darcy_coefficient () const;
+
         /**
          * @}
          */

--- a/include/aspect/material_model/melt_global.h
+++ b/include/aspect/material_model/melt_global.h
@@ -44,7 +44,7 @@ namespace aspect
      * @ingroup MaterialModels
      */
     template <int dim>
-    class MeltGlobal : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>, public MaterialModel::MeltFractionModel<dim>
+    class MeltGlobal : public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>, public MaterialModel::MeltFractionModel<dim>
     {
       public:
         /**
@@ -57,17 +57,20 @@ namespace aspect
          */
         virtual bool is_compressible () const;
 
+        virtual void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
+                              typename Interface<dim>::MaterialModelOutputs &out) const;
+
+        virtual void melt_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
+                                     std::vector<double> &melt_fractions) const;
+
         /**
          * @name Reference quantities
          * @{
          */
         virtual double reference_viscosity () const;
 
-        virtual void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
-                              typename Interface<dim>::MaterialModelOutputs &out) const;
+        virtual double reference_darcy_coefficient () const;
 
-        virtual void melt_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
-                                     std::vector<double> &melt_fractions) const;
 
         /**
          * @}

--- a/include/aspect/material_model/melt_simple.h
+++ b/include/aspect/material_model/melt_simple.h
@@ -52,7 +52,7 @@ namespace aspect
      * @ingroup MaterialModels
      */
     template <int dim>
-    class MeltSimple : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>, public MaterialModel::MeltFractionModel<dim>
+    class MeltSimple : public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>, public MaterialModel::MeltFractionModel<dim>
     {
       public:
         /**
@@ -65,17 +65,21 @@ namespace aspect
          */
         virtual bool is_compressible () const;
 
-        /**
-         * @name Reference quantities
-         * @{
-         */
-        virtual double reference_viscosity () const;
 
         virtual void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
                               typename Interface<dim>::MaterialModelOutputs &out) const;
 
         virtual void melt_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
                                      std::vector<double> &melt_fractions) const;
+
+        /**
+         * @name Reference quantities
+         * @{
+         */
+        virtual double reference_viscosity () const;
+
+        virtual double reference_darcy_coefficient () const;
+
         /**
          * @}
          */

--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -107,6 +107,20 @@ namespace aspect
         {};
     };
 
+    /**
+     * Base class for material models to be used with melt transport enabled.
+     */
+    template <int dim>
+    class MeltInterface: public MaterialModel::Interface<dim>
+    {
+      public:
+        /**
+          * Reference permeability divided by fluid viscosity, also known as Darcy coeffcient, Units: m^2/Pa/s
+          */
+        virtual double reference_darcy_coefficient () const = 0;
+    };
+
+
   }
 
 

--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -115,7 +115,8 @@ namespace aspect
     {
       public:
         /**
-          * Reference permeability divided by fluid viscosity, also known as Darcy coeffcient, Units: m^2/Pa/s
+          * Reference value for the Darcy coefficient, which is defined as
+          * permeability divided by fluid viscosity. Units: m^2/Pa/s.
           */
         virtual double reference_darcy_coefficient () const = 0;
     };

--- a/source/material_model/latent_heat_melt.cc
+++ b/source/material_model/latent_heat_melt.cc
@@ -67,18 +67,9 @@ namespace aspect
                                                + composition[0] * log10 ( eta * composition_viscosity_prefactor * temperature_dependence))));
             }
           else
-            reference_darcy_coefficient() const
             {
-              return -1.0; // invalid
+              out.viscosities[i] = composition_dependence * temperature_dependence * eta;
             }
-
-
-          template <int dim>
-          double
-          LatentHeatMelt<dim>::
-          {
-            out.viscosities[i] = composition_dependence * temperature_dependence * eta;
-          }
 
           out.specific_heat[i] = reference_specific_heat;
           out.thermal_conductivities[i] = k_value;
@@ -133,6 +124,15 @@ namespace aspect
     reference_viscosity () const
     {
       return eta;
+    }
+
+
+    template <int dim>
+    double
+    LatentHeatMelt<dim>::
+    reference_darcy_coefficient() const
+    {
+      return -1.0; // invalid
     }
 
 

--- a/source/material_model/latent_heat_melt.cc
+++ b/source/material_model/latent_heat_melt.cc
@@ -67,9 +67,18 @@ namespace aspect
                                                + composition[0] * log10 ( eta * composition_viscosity_prefactor * temperature_dependence))));
             }
           else
+            reference_darcy_coefficient() const
             {
-              out.viscosities[i] = composition_dependence * temperature_dependence * eta;
+              return -1.0; // invalid
             }
+
+
+          template <int dim>
+          double
+          LatentHeatMelt<dim>::
+          {
+            out.viscosities[i] = composition_dependence * temperature_dependence * eta;
+          }
 
           out.specific_heat[i] = reference_specific_heat;
           out.thermal_conductivities[i] = k_value;

--- a/source/material_model/latent_heat_melt.cc
+++ b/source/material_model/latent_heat_melt.cc
@@ -130,15 +130,6 @@ namespace aspect
     template <int dim>
     double
     LatentHeatMelt<dim>::
-    reference_darcy_coefficient() const
-    {
-      return -1.0; // invalid
-    }
-
-
-    template <int dim>
-    double
-    LatentHeatMelt<dim>::
     entropy_derivative (const double temperature,
                         const double pressure,
                         const std::vector<double> &compositional_fields,

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -38,6 +38,14 @@ namespace aspect
       return eta_0;
     }
 
+    template <int dim>
+    double
+    MeltGlobal<dim>::
+    reference_darcy_coefficient () const
+    {
+      // 0.01 = 1% melt
+      return reference_permeability * pow(0.01,3.0) / eta_f;
+    }
 
     template <int dim>
     bool

--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -38,6 +38,14 @@ namespace aspect
       return eta_0;
     }
 
+    template <int dim>
+    double
+    MeltSimple<dim>::
+    reference_darcy_coefficient () const
+    {
+      // 0.01 = 1% melt
+      return reference_permeability * pow(0.01,3.0) / eta_f;
+    }
 
     template <int dim>
     bool

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -121,6 +121,9 @@ namespace aspect
 
       MaterialModel::MeltOutputs<dim> *melt_outputs = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
 
+      Assert(dynamic_cast<const MaterialModel::MeltInterface<dim>*>(&this->get_material_model()) !=
+             NULL, ExcMessage("Error: The current material model needs to be derived from MeltInterface to use melt transport."));
+
       const FEValuesExtractors::Scalar ex_p_f = introspection.variable("fluid pressure").extractor_scalar();
       const FEValuesExtractors::Scalar ex_p_c = introspection.variable("compaction pressure").extractor_scalar();
 
@@ -233,6 +236,9 @@ namespace aspect
       MaterialModel::MeltOutputs<dim> *melt_outputs = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
       const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>
       *force = scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >();
+
+      Assert(dynamic_cast<const MaterialModel::MeltInterface<dim>*>(&this->get_material_model()) !=
+             NULL, ExcMessage("Error: The current material model needs to be derived from MeltInterface to use melt transport."));
 
       for (unsigned int i=0, i_stokes=0; i_stokes<stokes_dofs_per_cell; /*increment at end of loop*/)
         {

--- a/tests/composition_active_with_melt.cc
+++ b/tests/composition_active_with_melt.cc
@@ -13,7 +13,7 @@ namespace aspect
 
   template <int dim>
   class SimpleWithMelt:
-    public MaterialModel::Interface<dim>
+    public MaterialModel::MeltInterface<dim>
   {
     public:
       virtual bool is_compressible () const
@@ -25,6 +25,12 @@ namespace aspect
       {
         return 0.2;
       }
+
+      virtual double reference_darcy_coefficient () const
+      {
+        return 1.0;
+      }
+
 
       /**
        * Declare the parameters this class takes through input files.

--- a/tests/melt_compressible_advection.cc
+++ b/tests/melt_compressible_advection.cc
@@ -22,7 +22,7 @@ namespace aspect
     */
   template <int dim>
   class CompressibleMeltMaterial:
-    public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
   {
     public:
       virtual bool is_compressible () const
@@ -33,6 +33,11 @@ namespace aspect
       virtual double reference_viscosity () const
       {
         return 1.5;
+      }
+
+      virtual double reference_darcy_coefficient () const
+      {
+        return 1.0;
       }
 
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,

--- a/tests/melt_force_vector.cc
+++ b/tests/melt_force_vector.cc
@@ -15,7 +15,7 @@ namespace aspect
 
   template <int dim>
   class TestMeltMaterial:
-    public MaterialModel::Melt Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
   {
     public:
 

--- a/tests/melt_force_vector.cc
+++ b/tests/melt_force_vector.cc
@@ -15,9 +15,16 @@ namespace aspect
 
   template <int dim>
   class TestMeltMaterial:
-    public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    public MaterialModel::Melt Interface<dim>, public ::aspect::SimulatorAccess<dim>
   {
     public:
+
+      virtual double reference_darcy_coefficient () const
+      {
+        return 1.0;
+      }
+
+
       virtual bool
       viscosity_depends_on (const MaterialModel::NonlinearDependence::Dependence dependence) const
       {

--- a/tests/melt_introspection.cc
+++ b/tests/melt_introspection.cc
@@ -42,7 +42,7 @@ namespace aspect
 
   template <int dim>
   class MeltMaterial:
-    public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
   {
       virtual bool is_compressible () const
       {
@@ -52,6 +52,13 @@ namespace aspect
       virtual double reference_viscosity () const
       {
         return 1.0;
+      }
+
+      virtual double reference_darcy_coefficient () const
+      {
+        const double porosity = 0.01;
+        const double permeability = 1.0 * std::pow(porosity, 3) * std::pow(1.0-porosity, 2);
+        return permeability / 0.1;
       }
 
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,

--- a/tests/melt_material_1.cc
+++ b/tests/melt_material_1.cc
@@ -16,7 +16,7 @@ namespace aspect
 {
   template <int dim>
   class MeltMaterial:
-    public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
   {
       virtual bool is_compressible () const
       {
@@ -26,6 +26,13 @@ namespace aspect
       virtual double reference_viscosity () const
       {
         return 1.0;
+      }
+
+      virtual double reference_darcy_coefficient () const
+      {
+        const double porosity = 0.01;
+        const double permeability = 1.0 * std::pow(porosity,3) * std::pow(1.0-porosity,2);
+        return permeability / 0.1;
       }
 
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,

--- a/tests/melt_material_2.cc
+++ b/tests/melt_material_2.cc
@@ -17,7 +17,7 @@ namespace aspect
 {
   template <int dim>
   class MeltMaterial:
-    public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
   {
       virtual bool is_compressible () const
       {
@@ -27,6 +27,12 @@ namespace aspect
       virtual double reference_viscosity () const
       {
         return 1.0;
+      }
+
+      virtual double reference_darcy_coefficient () const
+      {
+        const double permeability = 1.0 + std::pow(0.5, 2.0);
+        return permeability / 2.0;
       }
 
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,

--- a/tests/melt_material_3.cc
+++ b/tests/melt_material_3.cc
@@ -17,7 +17,7 @@ namespace aspect
 {
   template <int dim>
   class MeltMaterial:
-    public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
   {
       virtual bool is_compressible () const
       {
@@ -27,6 +27,12 @@ namespace aspect
       virtual double reference_viscosity () const
       {
         return 1.0;
+      }
+
+      virtual double reference_darcy_coefficient () const
+      {
+        const double permeability = 1.0 + std::pow(0.5, 2.0);
+        return permeability / 2.0;
       }
 
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,

--- a/tests/melt_material_4.cc
+++ b/tests/melt_material_4.cc
@@ -19,7 +19,7 @@ namespace aspect
 {
   template <int dim>
   class MeltMaterial:
-    public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
   {
       virtual bool is_compressible () const
       {
@@ -29,6 +29,13 @@ namespace aspect
       virtual double reference_viscosity () const
       {
         return 1.0;
+      }
+
+      virtual double reference_darcy_coefficient () const
+      {
+        const double porosity = 0.01;
+        const double permeability = 1.0 + 0.001 / (1.0 - porosity);
+        return permeability / 2.0;
       }
 
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,

--- a/tests/melt_transport_adaptive.cc
+++ b/tests/melt_transport_adaptive.cc
@@ -88,7 +88,7 @@ namespace aspect
 
   template <int dim>
   class TestMeltMaterial:
-    public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
   {
     public:
       virtual bool is_compressible () const
@@ -99,6 +99,13 @@ namespace aspect
       virtual double reference_viscosity () const
       {
         return 1.0;
+      }
+
+      virtual double reference_darcy_coefficient () const
+      {
+        const double porosity = 0.01;
+        const double permeability = porosity;
+        return permeability / 1.0;
       }
 
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,

--- a/tests/melt_transport_compressible.cc
+++ b/tests/melt_transport_compressible.cc
@@ -17,7 +17,7 @@ namespace aspect
 {
   template <int dim>
   class CompressibleMeltMaterial:
-    public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
   {
     public:
       virtual bool is_compressible () const
@@ -28,6 +28,12 @@ namespace aspect
       virtual double reference_viscosity () const
       {
         return 1.0;
+      }
+
+      virtual double reference_darcy_coefficient () const
+      {
+        const double permeability = K_D_0 + 2.0 * B / E - rho_s_0 * B * D / E * (1.0/rho_s_0 - 1.0/rho_f_0) * std::exp(0.5);
+        return permeability / 1.0;
       }
 
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,

--- a/tests/melt_transport_convergence_simple.cc
+++ b/tests/melt_transport_convergence_simple.cc
@@ -19,7 +19,7 @@ namespace aspect
 {
   template <int dim>
   class TestMeltMaterial:
-    public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
   {
     public:
       virtual bool is_compressible () const
@@ -30,6 +30,13 @@ namespace aspect
       virtual double reference_viscosity () const
       {
         return 1.0;
+      }
+
+      virtual double reference_darcy_coefficient () const
+      {
+        const double porosity = 0.01;
+        const double permeability = porosity * porosity;
+        return permeability / 1.0;
       }
 
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,

--- a/tests/melt_transport_convergence_test.cc
+++ b/tests/melt_transport_convergence_test.cc
@@ -17,12 +17,19 @@ namespace aspect
 {
   template <int dim>
   class TestMeltMaterial:
-    public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
   {
     public:
       virtual bool is_compressible () const
       {
         return false;
+      }
+
+      virtual double reference_darcy_coefficient () const
+      {
+        const double porosity = 0.01;
+        const double permeability = porosity * porosity;
+        return permeability / 1.0;
       }
 
       virtual double reference_viscosity () const

--- a/tests/melting_rate.cc
+++ b/tests/melting_rate.cc
@@ -19,7 +19,7 @@ namespace aspect
 {
   template <int dim>
   class MeltingRate:
-    public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
   {
       virtual bool is_compressible () const
       {
@@ -29,6 +29,12 @@ namespace aspect
       virtual double reference_viscosity () const
       {
         return 5e20;
+      }
+
+      virtual double reference_darcy_coefficient () const
+      {
+        return 1e-8 * std::pow(0.01,3) / 10.0;
+
       }
 
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,

--- a/tests/melting_rate.cc
+++ b/tests/melting_rate.cc
@@ -33,8 +33,7 @@ namespace aspect
 
       virtual double reference_darcy_coefficient () const
       {
-        return 1e-8 * std::pow(0.01,3) / 10.0;
-
+        return 1e-8 * std::pow(0.01, 3.0) / 10.0;
       }
 
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,


### PR DESCRIPTION
- require material models to derive from MeltInterface if you want to use them with melt transport
- add a new function ``reference_darcy_coefficient()`` (not used in computation yet)