### PR TITLE
Add signal to free_surface to remove manifold from boundaries

### DIFF
--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -152,7 +152,10 @@ namespace aspect
 
     /**
      * A signal that is called before the computation of tangential boundary
-     * conditions for which normal vectors are needed.
+     * conditions for which normal vectors are needed, i.e. calls to the
+     * compute_no_normal_flux_constraints function for both the
+     * velocity variable in the main simulator and the mesh velocity
+     * variable in the free surface model.
      *
      * The functions that connect to this signal must take a reference
      * to a parallel::distributed::Triangulation object as
@@ -163,7 +166,10 @@ namespace aspect
 
     /**
      * A signal that is called after the computation of tangential boundary
-     * conditions for which normal vectors are needed.
+     * conditions for which normal vectors are needed, i.e. calls to the
+     * compute_no_normal_flux_constraints function for both the
+     * velocity variable in the main simulator and the mesh velocity
+     * variable in the free surface model.
      *
      * The functions that connect to this signal must take a reference
      * to a parallel::distributed::Triangulation object as

--- a/source/simulator/free_surface.cc
+++ b/source/simulator/free_surface.cc
@@ -250,6 +250,7 @@ namespace aspect
           }
       }
 
+    sim.signals.pre_compute_no_normal_flux_constraints(sim.triangulation);
     // Make the no flux boundary constraints for boundaries with tangential mesh boundaries
     VectorTools::compute_no_normal_flux_constraints (free_surface_dof_handler,
                                                      /* first_vector_component= */
@@ -269,6 +270,7 @@ namespace aspect
                                                      0,
                                                      periodic_boundaries,
                                                      mesh_displacement_constraints, *sim.mapping);
+    sim.signals.post_compute_no_normal_flux_constraints(sim.triangulation);
 
     // For the free surface indicators we constrain the displacement to be v.n
     LinearAlgebra::Vector boundary_velocity;


### PR DESCRIPTION
Without these signals, pre deal.II 9 versions will complain, because they will only have a manifold and not a boundary object to compute normal vectors.