### PR TITLE
Initial temperature operators

### DIFF
--- a/doc/modules/changes/20170516_myhill_2
+++ b/doc/modules/changes/20170516_myhill_2
@@ -1,0 +1,11 @@
+New: Aspect can now create initial temperature conditions by supplying 
+a list of plugins and operators determining how each plugin modifies the 
+temperature field. The operators are specified as a new input file 
+parameter 'List of model operators', which takes a comma-separated list 
+taken from the selection add, subtract, minimum and maximum. This list 
+defaults to add if it is not given in the parameter file. If it is given, 
+it may either be of length 1 (in which case all plugins modify the 
+temperature field in the same way), or of the same length as 
+'List of model names'.
+<br>
+(Bob Myhill, 2017/05/16)

--- a/doc/modules/changes/20170516_myhill_3
+++ b/doc/modules/changes/20170516_myhill_3
@@ -1,0 +1,11 @@
+New: Aspect can now initialise the compositional field by supplying 
+a list of plugins and operators determining how each plugin modifies the
+field. The operators are specified as a new input file parameter
+'List of model operators', which takes a comma-separated list 
+taken from the selection add, subtract, minimum and maximum. This list 
+defaults to add if it is not given in the parameter file. If it is given, 
+it may either be of length 1 (in which case all plugins modify the 
+compositional field in the same way), or of the same length as 
+'List of model names'.
+<br>
+(Bob Myhill, 2017/05/16)

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -208,6 +208,34 @@ namespace aspect
          * in the parameter file.
          */
         std::vector<std::string> model_names;
+
+        /**
+         * A list of names of initial temperature operator strings that have been
+         * requested in the parameter file. Either one operator is given
+         * (in which case it will be used for all models), or each name is associated
+         * with a model_name, in which case each is used to modify the temperature
+         * field with the values from the current plugin. The operators should be
+         * one of: add, subtract, minimum and maximum.
+         */
+        std::vector<std::string> model_operator_names;
+
+        /**
+         * An enum of operators which match the allowed
+         * model operator names which can be given in the parameter file.
+         */
+        enum Operator
+        {
+          add,
+          subtract,
+          minimum,
+          maximum
+        };
+
+        /**
+         * A vector of enums corresponding to the list
+         * of plugin operators given in the parameter file.
+         */
+        std::vector<Operator> model_operators;
     };
 
 

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -210,10 +210,10 @@ namespace aspect
         std::vector<std::string> model_names;
 
         /**
-         * A list of names of initial temperature operator strings that have been
+         * A list of names of initial composition operator strings that have been
          * requested in the parameter file. Either one operator is given
          * (in which case it will be used for all models), or each name is associated
-         * with a model_name, in which case each is used to modify the temperature
+         * with a model_name, in which case each is used to modify the composition
          * field with the values from the current plugin. The operators should be
          * one of: add, subtract, minimum and maximum.
          */

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -205,6 +205,16 @@ namespace aspect
          * in the parameter file.
          */
         std::vector<std::string> model_names;
+
+        /**
+         * A list of names of initial temperature operator strings that have been
+         * requested in the parameter file. Either one operator is given
+         * (in which case is will be used for all models), or each name is associated
+         * with a model_name, in which case each is used to append the new model onto
+         * the previous models. The operators should be one of:
+         * add, subtract, minimum and maximum.
+         */
+        std::vector<std::string> model_operators;
     };
 
 

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -214,7 +214,17 @@ namespace aspect
          * the previous models. The operators should be one of:
          * add, subtract, minimum and maximum.
          */
-        std::vector<std::string> model_operators;
+        std::vector<std::string> model_operator_names;
+
+        enum OperatorList
+        {
+          add,
+          subtract,
+          minimum,
+          maximum
+        };
+
+        std::vector<OperatorList> model_operators;
     };
 
 

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -209,14 +209,18 @@ namespace aspect
         /**
          * A list of names of initial temperature operator strings that have been
          * requested in the parameter file. Either one operator is given
-         * (in which case is will be used for all models), or each name is associated
-         * with a model_name, in which case each is used to append the new model onto
-         * the previous models. The operators should be one of:
-         * add, subtract, minimum and maximum.
+         * (in which case it will be used for all models), or each name is associated
+         * with a model_name, in which case each is used to modify the temperature
+         * field with the values from the current plugin. The operators should be
+         * one of: add, subtract, minimum and maximum.
          */
         std::vector<std::string> model_operator_names;
 
-        enum OperatorList
+        /**
+         * An enum of operators which match the allowed
+         * model operator names which can be given in the parameter file.
+         */
+        enum Operator
         {
           add,
           subtract,
@@ -224,7 +228,11 @@ namespace aspect
           maximum
         };
 
-        std::vector<OperatorList> model_operators;
+        /**
+         * A vector of enums corresponding to the list
+         * of plugin operators given in the parameter file.
+         */
+        std::vector<Operator> model_operators;
     };
 
 

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -110,10 +110,6 @@ namespace aspect
                                "'Initial composition model/List of model names' contains entries more than once. "
                                "This is not allowed. Please check your parameter file."));
 
-        model_operator_names = Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
-                                                                       model_names.size(),
-                                                                       "List of model operators");
-
         const std::string model_name = prm.get ("Model name");
 
         AssertThrow (model_name == "unspecified" || model_names.size() == 0,
@@ -124,6 +120,10 @@ namespace aspect
 
         if (!(model_name == "unspecified"))
           model_names.push_back(model_name);
+
+        model_operator_names = Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
+                                                                       model_names.size(),
+                                                                       "List of model operators");
 
       }
       prm.leave_subsection ();
@@ -246,18 +246,18 @@ namespace aspect
         prm.declare_entry("List of model names",
                           "",
                           Patterns::MultipleSelection(pattern_of_names),
-                          "A comma separated list of initial composition models that "
-                          "describe the initial composition field. "
-                          "The results of each of these models will affect the "
-                          "already created composition field via the operator listed"
-                          "in List of model operators.\n\n"
+                          "A comma-separated list of initial composition models that "
+                          "together describe the initial composition field. "
+                          "These plugins are loaded in the order given, and modify the "
+                          "existing composition field via the operators listed "
+                          "in 'List of model operators'.\n\n"
                           "The following composition models are available:\n\n"
                           +
                           std_cxx11::get<dim>(registered_plugins).get_description_string());
 
         prm.declare_entry("List of model operators", "add",
                           Patterns::MultipleSelection("add|subtract|minimum|maximum"),
-                          "A comma separated list of operators that "
+                          "A comma-separated list of operators that "
                           "will be used to append the listed composition models onto "
                           "the previous models. If only one operator is given, "
                           "the same operator is applied to all models.");

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -110,6 +110,10 @@ namespace aspect
                                "'Initial composition model/List of model names' contains entries more than once. "
                                "This is not allowed. Please check your parameter file."));
 
+        model_operator_names = Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
+                                                                       model_names.size(),
+                                                                       "List of model operators");
+
         const std::string model_name = prm.get ("Model name");
 
         AssertThrow (model_name == "unspecified" || model_names.size() == 0,
@@ -133,11 +137,11 @@ namespace aspect
 
       // go through the list, create objects and let them parse
       // their own parameters
-      for (unsigned int name=0; name<model_names.size(); ++name)
+      for (unsigned int i=0; i<model_names.size(); ++i)
         {
           initial_composition_objects.push_back (std_cxx11::shared_ptr<Interface<dim> >
                                                  (std_cxx11::get<dim>(registered_plugins)
-                                                  .create_plugin (model_names[name],
+                                                  .create_plugin (model_names[i],
                                                                   "Initial composition model::Model names")));
 
           if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(&*initial_composition_objects.back()))
@@ -145,9 +149,22 @@ namespace aspect
 
           initial_composition_objects.back()->parse_parameters (prm);
           initial_composition_objects.back()->initialize ();
+
+          // create operator list
+          if (model_operator_names[i] == "add")
+            model_operators.push_back(add);
+          else if (model_operator_names[i] == "subtract")
+            model_operators.push_back(subtract);
+          else if (model_operator_names[i] == "minimum")
+            model_operators.push_back(minimum);
+          else if (model_operator_names[i] == "maximum")
+            model_operators.push_back(maximum);
+          else
+            AssertThrow( false,
+                         ExcMessage ("Initial composition interface only accepts the following operators: "
+                                     "add, subtract, minimum and maximum. Please check your parameter file.") );
         }
     }
-
 
 
     template <int dim>
@@ -156,13 +173,46 @@ namespace aspect
                                        const unsigned int n_comp) const
     {
       double composition = 0.0;
+      int i = 0;
+
       for (typename std::list<std_cxx11::shared_ptr<InitialComposition::Interface<dim> > >::const_iterator
            initial_composition_object = initial_composition_objects.begin();
            initial_composition_object != initial_composition_objects.end();
            ++initial_composition_object)
         {
-          composition += (*initial_composition_object)->initial_composition(position,n_comp);
+          switch (model_operators[i])
+            {
+              case add:
+              {
+                composition += (*initial_composition_object)->initial_composition(position,  n_comp);
+                break;
+              }
+              case subtract:
+              {
+                composition -= (*initial_composition_object)->initial_composition(position, n_comp);
+                break;
+              }
+              case minimum:
+              {
+                composition = std::min (composition, (*initial_composition_object)->initial_composition(position, n_comp));
+                break;
+              }
+              case maximum:
+              {
+                composition = std::max (composition, (*initial_composition_object)->initial_composition(position, n_comp));
+                break;
+              }
+              default:
+              {
+                Assert ( false, ExcMessage ("Initial composition interface only accepts the following operators: "
+                                            "add, subtract, minimum and maximum. Please check your parameter file.") );
+                break;
+              }
+            }
+
+          i++;
         }
+
       return composition;
     }
 
@@ -197,20 +247,31 @@ namespace aspect
                           "",
                           Patterns::MultipleSelection(pattern_of_names),
                           "A comma separated list of initial composition models that "
-                          "describe the initial composition field. The results "
-                          "of each of these criteria will be added.\n\n"
-                          "The following heating models are available:\n\n"
+                          "describe the initial composition field. "
+                          "The results of each of these models will affect the "
+                          "already created composition field via the operator listed"
+                          "in List of model operators.\n\n"
+                          "The following composition models are available:\n\n"
                           +
                           std_cxx11::get<dim>(registered_plugins).get_description_string());
+
+        prm.declare_entry("List of model operators", "add",
+                          Patterns::MultipleSelection("add|subtract|minimum|maximum"),
+                          "A comma separated list of operators that "
+                          "will be used to append the listed composition models onto "
+                          "the previous models. If only one operator is given, "
+                          "the same operator is applied to all models.");
 
         prm.declare_entry ("Model name", "unspecified",
                            Patterns::Selection (pattern_of_names+"|unspecified"),
                            "Select one of the following models:\n\n"
-                           "Warning: This is the old formulation of specifying "
-                           "initial composition models and shouldn't be used. "
-                           "Please use 'List of model names' instead."
                            +
-                           std_cxx11::get<dim>(registered_plugins).get_description_string());
+                           std_cxx11::get<dim>(registered_plugins).get_description_string()
+                           + "\n\n" +
+                           "\\textbf{Warning}: This parameter provides an old and "
+                           "deprecated way of specifying "
+                           "initial composition models and shouldn't be used. "
+                           "Please use 'List of model names' instead.");
       }
       prm.leave_subsection ();
 

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -108,10 +108,6 @@ namespace aspect
                                "'Initial conditions/List of model names' contains entries more than once. "
                                "This is not allowed. Please check your parameter file."));
 
-        model_operator_names = Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
-                                                                       model_names.size(),
-                                                                       "List of model operators");
-
         const std::string model_name = prm.get ("Model name");
 
         AssertThrow (model_name == "unspecified" || model_names.size() == 0,
@@ -122,6 +118,11 @@ namespace aspect
 
         if (!(model_name == "unspecified"))
           model_names.push_back(model_name);
+
+
+        model_operator_names = Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
+                                                                       model_names.size(),
+                                                                       "List of model operators");
 
       }
       prm.leave_subsection ();
@@ -235,21 +236,21 @@ namespace aspect
         prm.declare_entry("List of model names",
                           "",
                           Patterns::MultipleSelection(pattern_of_names),
-                          "A comma separated list of initial temperature models that "
+                          "A comma-separated list of initial temperature models that "
                           "will be used to initialize the temperature. "
-                          "The results of each of these models will affect the "
-                          "already created temperature field via the operator listed"
-                          "in List of model operators.\n\n"
+                          "These plugins are loaded in the order given, and modify the "
+                          "existing temperature field via the operators listed "
+                          "in 'List of model operators'.\n\n"
                           "The following initial temperature models are available:\n\n"
                           +
                           std_cxx11::get<dim>(registered_plugins).get_description_string());
 
         prm.declare_entry("List of model operators", "add",
                           Patterns::MultipleSelection("add|subtract|minimum|maximum"),
-                          "A comma separated list of operators that "
+                          "A comma-separated list of operators that "
                           "will be used to append the listed temperature models onto "
                           "the previous models. If only one operator is given, "
-                          "the same operator is applied to all models. \n\n");
+                          "the same operator is applied to all models.");
 
         prm.declare_entry ("Model name", "unspecified",
                            Patterns::Selection (pattern_of_names+"|unspecified"),

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -103,10 +103,20 @@ namespace aspect
         model_names
           = Utilities::split_string_list(prm.get("List of model names"));
 
+        model_operators
+          = Utilities::split_string_list(prm.get("List of model operators"));
+
         AssertThrow(Utilities::has_unique_entries(model_names),
                     ExcMessage("The list of strings for the parameter "
                                "'Initial conditions/List of model names' contains entries more than once. "
                                "This is not allowed. Please check your parameter file."));
+
+        AssertThrow(model_names.size() == model_operators.size() ||
+                    model_operators.size() == 1,
+                    ExcMessage("The list of strings for the parameter "
+                               "'Initial conditions/List of model names' is not of length one or "
+                               "the same size as 'Initial conditions/List of model operators'. "
+                               "Please check your parameter file."));
 
         const std::string model_name = prm.get ("Model name");
 
@@ -188,10 +198,19 @@ namespace aspect
                           Patterns::MultipleSelection(pattern_of_names),
                           "A comma separated list of initial temperature models that "
                           "will be used to initialize the temperature. "
-                          "The results of each of these models will be added.\n\n"
+                          "The results of each of these models will affect the "
+                          "already created temperature field via the operator listed"
+                          "in List of model operators.\n\n"
                           "The following initial temperature models are available:\n\n"
                           +
                           std_cxx11::get<dim>(registered_plugins).get_description_string());
+
+        prm.declare_entry("List of model operators", "add",
+                          Patterns::MultipleSelection("add"|"subtract"|"minimum"|"maximum"),
+                          "A comma separated list of operators that "
+                          "will be used to append the listed temperature models onto "
+                          "the previous models. If only one operator is given, "
+                          "the same operator is applied to all models. \n\n");
 
         prm.declare_entry ("Model name", "unspecified",
                            Patterns::Selection (pattern_of_names+"|unspecified"),

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -108,15 +108,9 @@ namespace aspect
                                "'Initial conditions/List of model names' contains entries more than once. "
                                "This is not allowed. Please check your parameter file."));
 
-        model_operator_names
-          = Utilities::split_string_list(prm.get("List of model operators"));
-
-        AssertThrow(model_names.size() == model_operator_names.size() ||
-                    model_operator_names.size() == 1,
-                    ExcMessage("The list of strings for the parameter "
-                               "'Initial conditions/List of model names' is not of length one or "
-                               "the same size as 'Initial conditions/List of model operators'. "
-                               "Please check your parameter file."));
+        model_operator_names = Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
+                                                                       model_names.size(),
+                                                                       "List of model operators");
 
         const std::string model_name = prm.get ("Model name");
 
@@ -149,17 +143,13 @@ namespace aspect
           initial_temperature_objects.back()->initialize ();
 
           // create operator list
-          unsigned int j = 0;
-          if (model_operator_names.size() != 1)
-            j = i;
-
-          if (model_operator_names[j] == "add")
+          if (model_operator_names[i] == "add")
             model_operators.push_back(add);
-          else if (model_operator_names[j] == "subtract")
+          else if (model_operator_names[i] == "subtract")
             model_operators.push_back(subtract);
-          else if (model_operator_names[j] == "minimum")
+          else if (model_operator_names[i] == "minimum")
             model_operators.push_back(minimum);
-          else if (model_operator_names[j] == "maximum")
+          else if (model_operator_names[i] == "maximum")
             model_operators.push_back(maximum);
           else
             AssertThrow( false,
@@ -167,7 +157,6 @@ namespace aspect
                                      "add, subtract, minimum and maximum. Please check your parameter file.") );
         }
     }
-
 
 
     template <int dim>

--- a/tests/initial_composition_list_using_maximum.prm
+++ b/tests/initial_composition_list_using_maximum.prm
@@ -1,0 +1,97 @@
+##### simple test for ascii data initial composition
+
+set Dimension                              = 2
+
+set Use years in output instead of seconds = true
+set End time                               = 0
+
+set Adiabatic surface temperature          = 1613.0
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 660000
+    set Y extent = 660000
+  end
+end
+
+subsection Initial temperature model
+  set Model name = adiabatic
+  subsection Adiabatic
+    set Amplitude = 300
+    set Radius    = 250000
+  end
+end
+
+
+subsection Compositional fields
+  set Number of fields = 1
+end
+
+subsection Initial composition model
+  set List of model names = ascii data, function
+  set List of model operators = add, maximum
+
+  subsection Ascii data model
+    set Data directory       = $ASPECT_SOURCE_DIR/data/initial-composition/ascii-data/test/
+    set Data file name       = box_2d.txt
+  end
+
+  subsection Function
+    set Function expression = if ((x-330000)*(x-330000)+(y-330000)*(y-330000) < 100000*100000,0.5,0.1)
+  end
+end
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = top,bottom
+
+  set Zero velocity boundary indicators       =
+  set Prescribed velocity boundary indicators = bottom:function,left:function,right:function,top:function
+
+  set Tangential velocity boundary indicators = 
+
+end
+
+
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = 1;0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Viscosity = 1e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 4
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+  set Strategy                                 = temperature
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, composition statistics
+end
+

--- a/tests/initial_composition_list_using_maximum/screen-output
+++ b/tests/initial_composition_list_using_maximum/screen-output
@@ -1,0 +1,26 @@
+
+
+   Loading Ascii data initial file ASPECT_DIR/data/initial-composition/ascii-data/test/box_2d.txt.
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 33+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  1 m/year, 1.01 m/year
+     Temperature min/avg/max:            0 K, 1646 K, 1913 K
+     Heat fluxes through boundary parts: 4.335e-11 W, 2.242e-11 W, 4.17e+05 W, 3.639e+05 W
+     Compositions min/max/mass:          0.1/1/3.268e+11
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/initial_composition_list_using_maximum/statistics
+++ b/tests/initial_composition_list_using_maximum/statistics
@@ -1,0 +1,25 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for Stokes solver
+# 11: Velocity iterations in Stokes preconditioner
+# 12: Schur complement iterations in Stokes preconditioner
+# 13: RMS velocity (m/year)
+# 14: Max. velocity (m/year)
+# 15: Minimal temperature (K)
+# 16: Average temperature (K)
+# 17: Maximal temperature (K)
+# 18: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 19: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 20: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 21: Outward heat flux through boundary with indicator 3 ("top") (W)
+# 22: Minimal value for composition C_1
+# 23: Maximal value for composition C_1
+# 24: Global mass for composition C_1
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 1089 0 0 33 34 34 1.00000452e+00 1.00543733e+00 0.00000000e+00 1.64580208e+03 1.91300000e+03 4.33478485e-11 2.24213009e-11 4.17002800e+05 3.63892800e+05 1.00000000e-01 1.00000000e+00 3.26775625e+11 

--- a/tests/initial_composition_list_using_minimum.prm
+++ b/tests/initial_composition_list_using_minimum.prm
@@ -1,0 +1,97 @@
+##### simple test for ascii data initial composition
+
+set Dimension                              = 2
+
+set Use years in output instead of seconds = true
+set End time                               = 0
+
+set Adiabatic surface temperature          = 1613.0
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 660000
+    set Y extent = 660000
+  end
+end
+
+subsection Initial temperature model
+  set Model name = adiabatic
+  subsection Adiabatic
+    set Amplitude = 300
+    set Radius    = 250000
+  end
+end
+
+
+subsection Compositional fields
+  set Number of fields = 1
+end
+
+subsection Initial composition model
+  set List of model names = ascii data, function
+  set List of model operators = add, minimum
+
+  subsection Ascii data model
+    set Data directory       = $ASPECT_SOURCE_DIR/data/initial-composition/ascii-data/test/
+    set Data file name       = box_2d.txt
+  end
+
+  subsection Function
+    set Function expression = if ((x-330000)*(x-330000)+(y-330000)*(y-330000) < 100000*100000,0.5,0.1)
+  end
+end
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = top,bottom
+
+  set Zero velocity boundary indicators       =
+  set Prescribed velocity boundary indicators = bottom:function,left:function,right:function,top:function
+
+  set Tangential velocity boundary indicators = 
+
+end
+
+
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = 1;0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Viscosity = 1e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 4
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+  set Strategy                                 = temperature
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, composition statistics
+end
+

--- a/tests/initial_composition_list_using_minimum/screen-output
+++ b/tests/initial_composition_list_using_minimum/screen-output
@@ -1,0 +1,26 @@
+
+
+   Loading Ascii data initial file ASPECT_DIR/data/initial-composition/ascii-data/test/box_2d.txt.
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 33+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  1 m/year, 1.01 m/year
+     Temperature min/avg/max:            0 K, 1646 K, 1913 K
+     Heat fluxes through boundary parts: 4.335e-11 W, 2.242e-11 W, 4.17e+05 W, 3.639e+05 W
+     Compositions min/max/mass:          0/0.5/5.475e+10
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/initial_composition_list_using_minimum/statistics
+++ b/tests/initial_composition_list_using_minimum/statistics
@@ -1,0 +1,25 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for Stokes solver
+# 11: Velocity iterations in Stokes preconditioner
+# 12: Schur complement iterations in Stokes preconditioner
+# 13: RMS velocity (m/year)
+# 14: Max. velocity (m/year)
+# 15: Minimal temperature (K)
+# 16: Average temperature (K)
+# 17: Maximal temperature (K)
+# 18: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 19: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 20: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 21: Outward heat flux through boundary with indicator 3 ("top") (W)
+# 22: Minimal value for composition C_1
+# 23: Maximal value for composition C_1
+# 24: Global mass for composition C_1
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 1089 0 0 33 34 34 1.00000452e+00 1.00543733e+00 0.00000000e+00 1.64580208e+03 1.91300000e+03 4.33478485e-11 2.24213009e-11 4.17002800e+05 3.63892800e+05 0.00000000e+00 5.00000000e-01 5.47525000e+10 

--- a/tests/initial_composition_list_using_subtract.prm
+++ b/tests/initial_composition_list_using_subtract.prm
@@ -1,0 +1,97 @@
+##### simple test for ascii data initial composition
+
+set Dimension                              = 2
+
+set Use years in output instead of seconds = true
+set End time                               = 0
+
+set Adiabatic surface temperature          = 1613.0
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 660000
+    set Y extent = 660000
+  end
+end
+
+subsection Initial temperature model
+  set Model name = adiabatic
+  subsection Adiabatic
+    set Amplitude = 300
+    set Radius    = 250000
+  end
+end
+
+
+subsection Compositional fields
+  set Number of fields = 1
+end
+
+subsection Initial composition model
+  set List of model names = ascii data, function
+  set List of model operators = add, subtract
+
+  subsection Ascii data model
+    set Data directory       = $ASPECT_SOURCE_DIR/data/initial-composition/ascii-data/test/
+    set Data file name       = box_2d.txt
+  end
+
+  subsection Function
+    set Function expression = if ((x-330000)*(x-330000)+(y-330000)*(y-330000) < 100000*100000,0.5,-0.1)
+  end
+end
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = top,bottom
+
+  set Zero velocity boundary indicators       =
+  set Prescribed velocity boundary indicators = bottom:function,left:function,right:function,top:function
+
+  set Tangential velocity boundary indicators = 
+
+end
+
+
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = 1;0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Viscosity = 1e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 4
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+  set Strategy                                 = temperature
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, composition statistics
+end
+

--- a/tests/initial_composition_list_using_subtract/screen-output
+++ b/tests/initial_composition_list_using_subtract/screen-output
@@ -1,0 +1,26 @@
+
+
+   Loading Ascii data initial file ASPECT_DIR/data/initial-composition/ascii-data/test/box_2d.txt.
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 33+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  1 m/year, 1.01 m/year
+     Temperature min/avg/max:            0 K, 1646 K, 1913 K
+     Heat fluxes through boundary parts: 4.335e-11 W, 2.242e-11 W, 4.17e+05 W, 3.639e+05 W
+     Compositions min/max/mass:          0.1/1.1/3.534e+11
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/initial_composition_list_using_subtract/statistics
+++ b/tests/initial_composition_list_using_subtract/statistics
@@ -1,0 +1,25 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for Stokes solver
+# 11: Velocity iterations in Stokes preconditioner
+# 12: Schur complement iterations in Stokes preconditioner
+# 13: RMS velocity (m/year)
+# 14: Max. velocity (m/year)
+# 15: Minimal temperature (K)
+# 16: Average temperature (K)
+# 17: Maximal temperature (K)
+# 18: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 19: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 20: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 21: Outward heat flux through boundary with indicator 3 ("top") (W)
+# 22: Minimal value for composition C_1
+# 23: Maximal value for composition C_1
+# 24: Global mass for composition C_1
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 1089 0 0 33 34 34 1.00000452e+00 1.00543733e+00 0.00000000e+00 1.64580208e+03 1.91300000e+03 4.33478485e-11 2.24213009e-11 4.17002800e+05 3.63892800e+05 1.00000000e-01 1.10000000e+00 3.53357813e+11 

--- a/tests/initial_temperature_list_using_maximum.prm
+++ b/tests/initial_temperature_list_using_maximum.prm
@@ -1,0 +1,84 @@
+##### simple test for using multiple initial temperature plugins
+
+set Dimension                              = 2
+
+set Use years in output instead of seconds = true
+set End time                               = 0
+
+set Adiabatic surface temperature          = 1613.0
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 660000
+    set Y extent = 660000
+  end
+end
+
+subsection Initial temperature model
+  set List of model names = ascii data, function
+  set List of model operators = add, maximum
+  subsection Ascii data model
+    set Data directory       = $ASPECT_SOURCE_DIR/data/initial-temperature/ascii-data/test/
+    set Data file name       = box_2d.txt
+  end
+
+  subsection Function
+    set Function expression = if ((x-330000)*(x-330000)+(y-330000)*(y-330000) < 100000*100000,10,50)
+  end
+end
+
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   =
+
+  set Zero velocity boundary indicators       =
+  set Prescribed velocity boundary indicators = bottom:function,left:function,right:function,top:function
+
+  set Tangential velocity boundary indicators = 
+
+end
+
+
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = 1;0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Viscosity = 1e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 4
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+  set Strategy                                 = temperature
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics
+end
+

--- a/tests/initial_temperature_list_using_maximum/screen-output
+++ b/tests/initial_temperature_list_using_maximum/screen-output
@@ -1,5 +1,6 @@
 
-   Loading Ascii data initial file /home/bob/software/aspect/data/initial-temperature/ascii-data/test/box_2d.txt.
+
+   Loading Ascii data initial file ASPECT_DIR/data/initial-temperature/ascii-data/test/box_2d.txt.
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 3,556 (2,178+289+1,089)

--- a/tests/initial_temperature_list_using_maximum/screen-output
+++ b/tests/initial_temperature_list_using_maximum/screen-output
@@ -1,0 +1,23 @@
+
+   Loading Ascii data initial file /home/bob/software/aspect/data/initial-temperature/ascii-data/test/box_2d.txt.
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 3,556 (2,178+289+1,089)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 34+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  1 m/year, 1 m/year
+     Temperature min/avg/max:            50 K, 77.42 K, 100 K
+     Heat fluxes through boundary parts: 122.4 W, 122.4 W, 122.4 W, 122.4 W
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/initial_temperature_list_using_maximum/statistics
+++ b/tests/initial_temperature_list_using_maximum/statistics
@@ -1,0 +1,20 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: RMS velocity (m/year)
+# 12: Max. velocity (m/year)
+# 13: Minimal temperature (K)
+# 14: Average temperature (K)
+# 15: Maximal temperature (K)
+# 16: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 17: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 18: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 19: Outward heat flux through boundary with indicator 3 ("top") (W)
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 0 34 35 35 1.00000017e+00 1.00074255e+00 5.00000000e+01 7.74169922e+01 1.00000000e+02 1.22395833e+02 1.22395833e+02 1.22395833e+02 1.22395833e+02 

--- a/tests/initial_temperature_list_using_minimum.prm
+++ b/tests/initial_temperature_list_using_minimum.prm
@@ -1,0 +1,84 @@
+##### simple test for using multiple initial temperature plugins
+
+set Dimension                              = 2
+
+set Use years in output instead of seconds = true
+set End time                               = 0
+
+set Adiabatic surface temperature          = 1613.0
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 660000
+    set Y extent = 660000
+  end
+end
+
+subsection Initial temperature model
+  set List of model names = ascii data, function
+  set List of model operators = add, minimum
+  subsection Ascii data model
+    set Data directory       = $ASPECT_SOURCE_DIR/data/initial-temperature/ascii-data/test/
+    set Data file name       = box_2d.txt
+  end
+
+  subsection Function
+    set Function expression = if ((x-330000)*(x-330000)+(y-330000)*(y-330000) < 100000*100000,10,50)
+  end
+end
+
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   =
+
+  set Zero velocity boundary indicators       =
+  set Prescribed velocity boundary indicators = bottom:function,left:function,right:function,top:function
+
+  set Tangential velocity boundary indicators = 
+
+end
+
+
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = 1;0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Viscosity = 1e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 4
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+  set Strategy                                 = temperature
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics
+end
+

--- a/tests/initial_temperature_list_using_minimum/screen-output
+++ b/tests/initial_temperature_list_using_minimum/screen-output
@@ -1,5 +1,6 @@
 
-   Loading Ascii data initial file /home/bob/software/aspect/data/initial-temperature/ascii-data/test/box_2d.txt.
+
+   Loading Ascii data initial file ASPECT_DIR/data/initial-temperature/ascii-data/test/box_2d.txt.
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 3,556 (2,178+289+1,089)

--- a/tests/initial_temperature_list_using_minimum/screen-output
+++ b/tests/initial_temperature_list_using_minimum/screen-output
@@ -1,0 +1,23 @@
+
+   Loading Ascii data initial file /home/bob/software/aspect/data/initial-temperature/ascii-data/test/box_2d.txt.
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 3,556 (2,178+289+1,089)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 34+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  1 m/year, 1 m/year
+     Temperature min/avg/max:            0 K, 45 K, 50 K
+     Heat fluxes through boundary parts: 347.6 W, 347.6 W, 347.6 W, 347.6 W
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/initial_temperature_list_using_minimum/statistics
+++ b/tests/initial_temperature_list_using_minimum/statistics
@@ -1,0 +1,20 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: RMS velocity (m/year)
+# 12: Max. velocity (m/year)
+# 13: Minimal temperature (K)
+# 14: Average temperature (K)
+# 15: Maximal temperature (K)
+# 16: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 17: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 18: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 19: Outward heat flux through boundary with indicator 3 ("top") (W)
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 0 34 35 35 1.00000012e+00 1.00056781e+00 0.00000000e+00 4.49962023e+01 5.00000000e+01 3.47604167e+02 3.47604167e+02 3.47604167e+02 3.47604167e+02 

--- a/tests/initial_temperature_list_using_subtract.prm
+++ b/tests/initial_temperature_list_using_subtract.prm
@@ -1,0 +1,84 @@
+##### simple test for using multiple initial temperature plugins
+
+set Dimension                              = 2
+
+set Use years in output instead of seconds = true
+set End time                               = 0
+
+set Adiabatic surface temperature          = 1613.0
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 660000
+    set Y extent = 660000
+  end
+end
+
+subsection Initial temperature model
+  set List of model names = ascii data, function
+  set List of model operators = add, subtract
+  subsection Ascii data model
+    set Data directory       = $ASPECT_SOURCE_DIR/data/initial-temperature/ascii-data/test/
+    set Data file name       = box_2d.txt
+  end
+
+  subsection Function
+    set Function expression = if ((x-330000)*(x-330000)+(y-330000)*(y-330000) < 100000*100000,50,-10)
+  end
+end
+
+
+subsection Boundary temperature model
+  set Model name = box
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   =
+
+  set Zero velocity boundary indicators       =
+  set Prescribed velocity boundary indicators = bottom:function,left:function,right:function,top:function
+
+  set Tangential velocity boundary indicators = 
+
+end
+
+
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = 1;0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Viscosity = 1e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 4
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+  set Strategy                                 = temperature
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics
+end
+

--- a/tests/initial_temperature_list_using_subtract/screen-output
+++ b/tests/initial_temperature_list_using_subtract/screen-output
@@ -1,0 +1,23 @@
+
+   Loading Ascii data initial file /home/bob/software/aspect/data/initial-temperature/ascii-data/test/box_2d.txt.
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 3,556 (2,178+289+1,089)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 34+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  1 m/year, 1 m/year
+     Temperature min/avg/max:            10 K, 81.12 K, 110 K
+     Heat fluxes through boundary parts: 470 W, 470 W, 470 W, 470 W
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/initial_temperature_list_using_subtract/screen-output
+++ b/tests/initial_temperature_list_using_subtract/screen-output
@@ -1,5 +1,6 @@
 
-   Loading Ascii data initial file /home/bob/software/aspect/data/initial-temperature/ascii-data/test/box_2d.txt.
+
+   Loading Ascii data initial file ASPECT_DIR/data/initial-temperature/ascii-data/test/box_2d.txt.
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 3,556 (2,178+289+1,089)

--- a/tests/initial_temperature_list_using_subtract/statistics
+++ b/tests/initial_temperature_list_using_subtract/statistics
@@ -1,0 +1,20 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: RMS velocity (m/year)
+# 12: Max. velocity (m/year)
+# 13: Minimal temperature (K)
+# 14: Average temperature (K)
+# 15: Maximal temperature (K)
+# 16: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 17: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 18: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 19: Outward heat flux through boundary with indicator 3 ("top") (W)
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 0 34 35 35 1.00000010e+00 1.00085508e+00 1.00000000e+01 8.11197917e+01 1.10000000e+02 4.70000000e+02 4.70000000e+02 4.70000000e+02 4.70000000e+02 


### PR DESCRIPTION
This PR adds the ability to choose basic arithmetic operators to the initial temperature interface (add, subtract, minimum, maximum), which control how successive plugins modify the initial temperature field.