### PR TITLE
Do not access uninitialized part of adiabatic conditions

### DIFF
--- a/source/initial_temperature/adiabatic.cc
+++ b/source/initial_temperature/adiabatic.cc
@@ -47,7 +47,7 @@ namespace aspect
       const Point<dim> surface_point = this->get_geometry_model().representative_point(0.0);
       const Point<dim> bottom_point = this->get_geometry_model().representative_point(this->get_geometry_model().maximal_depth());
       const double adiabatic_surface_temperature = this->get_adiabatic_conditions().temperature(surface_point);
-      const double adiabatic_bottom_temperature = (this->include_adiabatic_heating())
+      const double adiabatic_bottom_temperature = (this->include_adiabatic_heating() && this->get_adiabatic_conditions().is_initialized())
                                                   ?
                                                   this->get_adiabatic_conditions().temperature(bottom_point)
                                                   :


### PR DESCRIPTION
A while ago we removed all `adiabatic_conditions.is_initialized()` statement, because the profile is now available for every position, except the (lower) uninitialized part. However, in some places plugins access this part before it is computed, see the attached case. Currently, there is no plugin that will cause this (because the adiabatic conditions do not access the initial conditions), but I am currently working on a plugin that will do this. Reinsert the check.