### PR TITLE
Fix the drucker_prager material model compiling warning

### DIFF
--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -622,6 +622,12 @@ namespace aspect
       get_current_constraints() const;
 
       /**
+       * Return whether or not the current object has been initialized by providing it with
+       * a pointer to a Simulator class object.
+       */
+      bool simulator_is_initialized () const;
+
+      /**
        * A convenience function that copies the values of the compositional
        * fields at the quadrature point q given as input parameter to the
        * output vector composition_values_at_q_point.

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -70,7 +70,7 @@ namespace aspect
               // The negative of the second principle invariant is equal to 0.5 e_dot_dev_ij e_dot_dev_ji,
               // where e_dot_dev is the deviatoric strain rate tensor. The square root of this quantity
               // gives the common definition of effective strain rate.
-              const double edot_ii_strict = (this->simulator_is_initialized()
+              const double edot_ii_strict = (this->simulator_is_initialized() == false
                                              ?
                                              // no simulator object available -- we are probably in a unit test
                                              std::fabs(second_invariant(strain_rate_deviator))

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -70,7 +70,7 @@ namespace aspect
               // The negative of the second principle invariant is equal to 0.5 e_dot_dev_ij e_dot_dev_ji,
               // where e_dot_dev is the deviatoric strain rate tensor. The square root of this quantity
               // gives the common definition of effective strain rate.
-              const double edot_ii_strict = (&(this->get_simulator()) == NULL
+              const double edot_ii_strict = (this->simulator_is_initialized()
                                              ?
                                              // no simulator object available -- we are probably in a unit test
                                              std::fabs(second_invariant(strain_rate_deviator))

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -578,6 +578,13 @@ namespace aspect
     return simulator->current_constraints;
   }
 
+  template <int dim>
+  bool
+  SimulatorAccess<dim>::simulator_is_initialized () const
+  {
+    return (simulator != NULL);
+  }
+
 }
 
 


### PR DESCRIPTION
This fixes the drucker_prager material model compiling warning after @bangerth 