### PR TITLE
add clever abort handling to avoid MPI deadlock

### DIFF
--- a/tests/fail/screen-output
+++ b/tests/fail/screen-output
@@ -1,7 +1,7 @@
 
 
 
-Exception on processing: 
+Exception 'ExcMessage ("ASPECT can only be run in 2d and 3d but a " "different space dimension is given in the parameter file.")' on rank 0 on processing: 
 
 An error occurred in file <main.cc> in function
 (line in output replaced by default.sh script)

--- a/tests/steinberger_lateral_fail/screen-output
+++ b/tests/steinberger_lateral_fail/screen-output
@@ -7,7 +7,7 @@ In computing depth averages, there is at least one depth band that does not have
  Consider reducing number of depth layers for  averaging
 
 
-Exception on processing: 
+Exception 'ExcMessage("In computing depth averages, there is at" " least one depth band that does not have" " any quadrature points in it." " Consider reducing number of depth layers" " for averaging specified in the parameter" " file.(Number lateral average bands)")' on rank 0 on processing: 
 
 An error occurred in file <steinberger.cc> in function
 (line in output replaced by default.sh script)

--- a/tests/visualization_unique_list/screen-output
+++ b/tests/visualization_unique_list/screen-output
@@ -1,7 +1,7 @@
 
 
 
-Exception on processing: 
+Exception 'ExcMessage("The list of strings for the parameter " "'Postprocess/Visualization/List of output variables' contains entries more than once. " "This is not allowed. Please check your parameter file.")' on rank 0 on processing: 
 
 An error occurred in file <visualization.cc> in function
 (line in output replaced by default.sh script)

--- a/tests/zero_matrix/screen-output
+++ b/tests/zero_matrix/screen-output
@@ -29,7 +29,7 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
 *** Timestep 1:  t=48350 years
 
 
-Exception on processing: 
+Exception 'ExcMessage ("The " + field_name + " equation can not be solved, because the matrix is zero, " "but the right-hand side is nonzero.")' on rank 0 on processing: 
 
 An error occurred in file <solver.cc> in function
 (line in output replaced by default.sh script)


### PR DESCRIPTION
triggering Assert() in debug mode on rank!=0 can cause a deadlock inside
std::abort. This causes the tester to hang for 10 minutes on each
failing test. Work around this by hooking into SIGABRT and terminating
the process.
Also extend the information shown when an exception is detected (MPI
rank, exception name).