### PR TITLE
Use the hammer.

### DIFF
--- a/source/boundary_temperature/constant.cc
+++ b/source/boundary_temperature/constant.cc
@@ -20,7 +20,10 @@
 
 
 #include <aspect/boundary_temperature/constant.h>
+
 #include <deal.II/base/utilities.h>
+#include <deal.II/base/signaling_nan.h>
+
 #include <limits>
 
 
@@ -45,7 +48,7 @@ namespace aspect
                   ExcMessage ("Unknown boundary indicator with number <" + Utilities::int_to_string(boundary_indicator) + ">. "
                               "You may not have specified the temperature for this boundary indicator "
                               "in the input file."));
-          return std::numeric_limits<double>::quiet_NaN();
+          return numbers::signaling_nan<double>();
         }
     }
 

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -22,6 +22,7 @@
 #include <aspect/utilities.h>
 #include <aspect/assembly.h>
 #include <aspect/simulator_access.h>
+
 #include <deal.II/base/signaling_nan.h>
 
 namespace aspect
@@ -161,7 +162,7 @@ namespace aspect
                               ?
                               scratch.material_model_outputs.viscosities[q]
                               :
-                              std::numeric_limits<double>::quiet_NaN());
+                              numbers::signaling_nan<double>());
 
           const SymmetricTensor<4,dim> &stress_strain_director =
             scratch.material_model_outputs.stress_strain_directors[q];

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -188,7 +188,7 @@ namespace aspect
     prescribed_stokes_solution (PrescribedStokesSolution::create_prescribed_stokes_solution<dim>(prm)),
     adiabatic_conditions (AdiabaticConditions::create_adiabatic_conditions<dim>(prm)),
 
-    time (std::numeric_limits<double>::quiet_NaN()),
+    time (numbers::signaling_nan<double>()),
     time_step (0),
     old_time_step (0),
     timestep_number (0),

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -22,7 +22,9 @@
 #include <aspect/assembly.h>
 #include <aspect/melt.h>
 
+#include <deal.II/base/signaling_nan.h>
 #include <deal.II/fe/fe_values.h>
+
 
 namespace aspect
 {
@@ -39,7 +41,7 @@ namespace aspect
     // variation. otherwise return something that's obviously
     // nonsensical
     if (parameters.stabilization_alpha != 2)
-      return std::numeric_limits<double>::quiet_NaN();
+      return numbers::signaling_nan<double>();
 
     // record maximal entropy on Gauss quadrature
     // points

--- a/source/simulator/lateral_averaging.cc
+++ b/source/simulator/lateral_averaging.cc
@@ -18,12 +18,13 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <deal.II/fe/fe_values.h>
-#include <deal.II/base/quadrature_lib.h>
-
 #include <aspect/lateral_averaging.h>
 #include <aspect/material_model/interface.h>
 #include <aspect/gravity_model/interface.h>
+
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/base/quadrature_lib.h>
+
 
 
 namespace aspect

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -21,6 +21,7 @@
 
 #include <aspect/melt.h>
 #include <aspect/simulator.h>
+
 #include <deal.II/base/signaling_nan.h>
 
 #include <deal.II/dofs/dof_tools.h>
@@ -280,12 +281,12 @@ namespace aspect
                               ?
                               scratch.material_model_outputs.viscosities[q]
                               :
-                              std::numeric_limits<double>::quiet_NaN());
+                              numbers::signaling_nan<double>());
           const double eta_two_thirds = (rebuild_stokes_matrix
                                          ?
                                          scratch.material_model_outputs.viscosities[q] * 2.0 / 3.0
                                          :
-                                         std::numeric_limits<double>::quiet_NaN());
+                                         numbers::signaling_nan<double>());
           const Tensor<1,dim>
           gravity = this->get_gravity_model().gravity_vector (scratch.finite_element_values.quadrature_point(q));
           const SymmetricTensor<4,dim> &stress_strain_director =
@@ -297,7 +298,7 @@ namespace aspect
                ?
                scratch.material_model_outputs.compressibilities[q]
                :
-               std::numeric_limits<double>::quiet_NaN() );
+               numbers::signaling_nan<double>() );
 
           const double density_s = scratch.material_model_outputs.densities[q]; // density of the solid
 


### PR DESCRIPTION
More specifically, replace quiet NaNs by signaling NaNs since they are a faster
way of figuring out what may be going wrong.