### PR TITLE
Be more conservative with regexes.

### DIFF
--- a/doc/aspect-gui
+++ b/doc/aspect-gui
@@ -42,7 +42,7 @@ if [ "$1" == "" ]; then
   OUTPUT_FILE=temp.xml
   echo " " |  $ASPECT_DIR/aspect --output-xml -- > $OUTPUT_FILE
 else
-  OUTPUT_FILE=`echo $1 | sed -e 's/\.prm/\.xml/g'`
+  OUTPUT_FILE=`echo $1 | sed -e 's/\.prm$/\.xml/'`
   $ASPECT_DIR/aspect --output-xml $1 > $OUTPUT_FILE
 fi
 


### PR DESCRIPTION
In particular, we only want to do one replacement (so don't use 'g') and
only want to do it at the end of the filename (use the dollar sign for end
of string).

This is an update to #1759. I'd appreciate if @gassmoeller could verify
that using the dollar sign in the regex with sed actually works as
expected. But it seems to work for me.