### PR TITLE
Add safeguard for unusual file names to aspect-gui

### DIFF
--- a/doc/aspect-gui
+++ b/doc/aspect-gui
@@ -43,6 +43,13 @@ if [ "$1" == "" ]; then
   echo " " |  $ASPECT_DIR/aspect --output-xml -- > $OUTPUT_FILE
 else
   OUTPUT_FILE=`echo $1 | sed -e 's/\.prm$/\.xml/'`
+
+  if [ "$OUTPUT_FILE" == "$1" ]; then
+    # The input file has an unusual file ending. Append .xml instead of
+    # trying to replace
+    OUTPUT_FILE=${1}.xml
+  fi
+
   $ASPECT_DIR/aspect --output-xml $1 > $OUTPUT_FILE
 fi
 


### PR DESCRIPTION
While reviewing #1762 I noticed that `aspect-gui` will currently overwrite input file names, if sed does not find anything to replace. All our parameter files usually end on `.prm`, but this is not a requirement, and we should take care not to damage input files in the process.