### PR TITLE
Move operators to utilities

### DIFF
--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -211,11 +211,10 @@ namespace aspect
         std::vector<std::string> model_names;
 
         /**
-         * A list of enums of initial composition operator strings that have been
-         * requested in the parameter file. Each name is associated
-         * with a model_name, and is used to modify the compositional
-         * field with the values from the current plugin. The operators should be
-         * one of: add, subtract, minimum and maximum.
+         * A list of enums of initial composition operators that have been
+         * requested in the parameter file. Each entry is used to modify the
+         * initial compositional field with the values from the associated plugin
+         * in model_names.
          */
         std::vector<aspect::Utilities::Operator> model_operators;
     };

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -217,7 +217,7 @@ namespace aspect
          * field with the values from the current plugin. The operators should be
          * one of: add, subtract, minimum and maximum.
          */
-        std::vector<aspect::Utilities::Operator::operation> model_operators;
+        std::vector<aspect::Utilities::Operator> model_operators;
     };
 
 

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -23,6 +23,7 @@
 #define _aspect_initial_composition_interface_h
 
 #include <aspect/plugins.h>
+#include <aspect/utilities.h>
 #include <aspect/simulator_access.h>
 
 #include <deal.II/base/point.h>
@@ -210,32 +211,13 @@ namespace aspect
         std::vector<std::string> model_names;
 
         /**
-         * A list of names of initial composition operator strings that have been
-         * requested in the parameter file. Either one operator is given
-         * (in which case it will be used for all models), or each name is associated
-         * with a model_name, in which case each is used to modify the composition
+         * A list of enums of initial composition operator strings that have been
+         * requested in the parameter file. Each name is associated
+         * with a model_name, and is used to modify the compositional
          * field with the values from the current plugin. The operators should be
          * one of: add, subtract, minimum and maximum.
          */
-        std::vector<std::string> model_operator_names;
-
-        /**
-         * An enum of operators which match the allowed
-         * model operator names which can be given in the parameter file.
-         */
-        enum Operator
-        {
-          add,
-          subtract,
-          minimum,
-          maximum
-        };
-
-        /**
-         * A vector of enums corresponding to the list
-         * of plugin operators given in the parameter file.
-         */
-        std::vector<Operator> model_operators;
+        std::vector<aspect::Utilities::Operator::operation> model_operators;
     };
 
 

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -214,7 +214,7 @@ namespace aspect
          * field with the values from the current plugin. The operators should be
          * one of: add, subtract, minimum and maximum.
          */
-        std::vector<aspect::Utilities::Operator::operation> model_operators;
+        std::vector<aspect::Utilities::Operator> model_operators;
     };
 
 

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -208,11 +208,10 @@ namespace aspect
         std::vector<std::string> model_names;
 
         /**
-         * A list of enums of initial temperature operator strings that have been
-         * requested in the parameter file. Each name is associated
-         * with a model_name, and is used to modify the temperature
-         * field with the values from the current plugin. The operators should be
-         * one of: add, subtract, minimum and maximum.
+         * A list of enums of initial temperature operators that have been
+         * requested in the parameter file. Each entry is used to modify the
+         * initial temperature field with the values from the associated plugin
+         * in model_names.
          */
         std::vector<aspect::Utilities::Operator> model_operators;
     };

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -23,6 +23,7 @@
 #define _aspect_initial_temperature_interface_h
 
 #include <aspect/plugins.h>
+#include <aspect/utilities.h>
 #include <aspect/simulator_access.h>
 
 #include <deal.II/base/point.h>
@@ -207,32 +208,13 @@ namespace aspect
         std::vector<std::string> model_names;
 
         /**
-         * A list of names of initial temperature operator strings that have been
-         * requested in the parameter file. Either one operator is given
-         * (in which case it will be used for all models), or each name is associated
-         * with a model_name, in which case each is used to modify the temperature
+         * A list of enums of initial temperature operator strings that have been
+         * requested in the parameter file. Each name is associated
+         * with a model_name, and is used to modify the temperature
          * field with the values from the current plugin. The operators should be
          * one of: add, subtract, minimum and maximum.
          */
-        std::vector<std::string> model_operator_names;
-
-        /**
-         * An enum of operators which match the allowed
-         * model operator names which can be given in the parameter file.
-         */
-        enum Operator
-        {
-          add,
-          subtract,
-          minimum,
-          maximum
-        };
-
-        /**
-         * A vector of enums corresponding to the list
-         * of plugin operators given in the parameter file.
-         */
-        std::vector<Operator> model_operators;
+        std::vector<aspect::Utilities::Operator::operation> model_operators;
     };
 
 

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -956,22 +956,64 @@ namespace aspect
                               const SymmetricTensor<2,dim> &dviscosities_dstrain_rate,
                               const double safety_factor);
 
-    namespace Operator
+    /**
+     * A class that represents a binary operator between two doubles. The type of
+     * operation is specified on construction time, and can be checked later
+     * by using the operator ==. The operator () executes the operation on two
+     * double parameters and returns the result. This class is helpful for
+     * user specified operations that are not know at compile time.
+     */
+    class Operator
     {
-      /**
-       * An enum of operators which match the allowed
-       * model operator names which can be given in the parameter file.
-       */
-      enum operation
-      {
-        add,
-        subtract,
-        minimum,
-        maximum
-      };
+      public:
+        /**
+         * An enum of operators which match the allowed
+         * model operator names which can be given in the parameter file.
+         */
+        enum operation
+        {
+          add,
+          subtract,
+          minimum,
+          maximum,
+          uninitialized
+        };
 
-      std::vector<operation> create_model_operator_list(const std::vector<std::string> &operator_names);
-    }
+        /**
+         * The default constructor creates an invalid operation that will fail
+         * if ever executed.
+         */
+        Operator();
+
+        /**
+         * Construct the selected operator.
+         */
+        Operator(const operation op);
+
+        /**
+         * Execute the selected operation with the given parameters and
+         * return the result.
+         */
+        double operator() (double x, double y) const;
+
+        /**
+         * Return the comparison result between the current operation and
+         * the one provided as argument.
+         */
+        bool operator== (const operation op) const;
+
+      private:
+        /**
+         * The selected operation of this object.
+         */
+        const operation op;
+    };
+
+    /**
+     * Create a vector of operator objects out of a list of strings. Each
+     * entry in the list must match one of the allowed operations.
+     */
+    std::vector<Operator> create_model_operator_list(const std::vector<std::string> &operator_names);
 
     /**
      * This function computes a factor which can be used to make sure that the

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -27,9 +27,10 @@
 #include <deal.II/base/std_cxx11/array.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/conditional_ostream.h>
-
 #include <deal.II/base/table_indices.h>
 #include <deal.II/base/function_lib.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/fe/component_mask.h>
 
 #include <aspect/geometry_model/interface.h>
 
@@ -961,22 +962,21 @@ namespace aspect
      * operation is specified on construction time, and can be checked later
      * by using the operator ==. The operator () executes the operation on two
      * double parameters and returns the result. This class is helpful for
-     * user specified operations that are not know at compile time.
+     * user specified operations that are not known at compile time.
      */
     class Operator
     {
       public:
         /**
-         * An enum of operators which match the allowed
-         * model operator names which can be given in the parameter file.
+         * An enum of supported operations.
          */
         enum operation
         {
+          uninitialized,
           add,
           subtract,
           minimum,
-          maximum,
-          uninitialized
+          maximum
         };
 
         /**
@@ -994,7 +994,7 @@ namespace aspect
          * Execute the selected operation with the given parameters and
          * return the result.
          */
-        double operator() (double x, double y) const;
+        double operator() (const double x, const double y) const;
 
         /**
          * Return the comparison result between the current operation and
@@ -1006,7 +1006,7 @@ namespace aspect
         /**
          * The selected operation of this object.
          */
-        const operation op;
+        operation op;
     };
 
     /**
@@ -1014,31 +1014,6 @@ namespace aspect
      * entry in the list must match one of the allowed operations.
      */
     std::vector<Operator> create_model_operator_list(const std::vector<std::string> &operator_names);
-
-    /**
-     * This function computes a factor which can be used to make sure that the
-     * Jacobian remains positive definite.
-     *
-     * The goal of this function is to find a factor $\alpha$ so that
-     * $2\eta(\varepsilon(\bm u)) I \otimes I +  \alpha\left[a \otimes b + b \otimes a\right]$ remains a
-     * positive definite matrix. Here, $a=\varepsilon(\bm u)$ is the @p strain_rate
-     * and $b=\frac{\partial\eta(\varepsilon(\bm u),p)}{\partial \varepsilon}$ is the derivative of the viscosity
-     * with respect to the strain rate and is given by @p dviscosities_dstrain_rate. Since the viscosity $\eta$
-     * must be positive, there is always a value of $\alpha$ (possibly small) so that the result is a positive
-     * definite matrix. In the best case, we want to choose $\alpha=1$ because that corresponds to the full Newton step,
-     * and so the function never returns anything larger than one.
-     *
-     * The factor is defined by:
-     * $\frac{2\eta(\varepsilon(\bm u))}{\left[1-\frac{b:a}{\|a\| \|b\|} \right]^2\|a\|\|b\|}$. Alpha is
-     * reset to a maximum of one, and if it is smaller then one, a safety_factor scales the alpha to make
-     * sure that the 1-alpha won't get to close to zero.
-     */
-    template<int dim>
-    double compute_spd_factor(const double eta,
-                              const SymmetricTensor<2,dim> &strain_rate,
-                              const SymmetricTensor<2,dim> &dviscosities_dstrain_rate,
-                              const double safety_factor);
-
   }
 }
 

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -126,7 +126,7 @@ namespace aspect
           Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
                                                   model_names.size(),
                                                   "List of model operators");
-        model_operators = Utilities::Operator::create_model_operator_list(model_operator_names);
+        model_operators = Utilities::create_model_operator_list(model_operator_names);
 
       }
       prm.leave_subsection ();
@@ -169,36 +169,7 @@ namespace aspect
            initial_composition_object != initial_composition_objects.end();
            ++initial_composition_object)
         {
-          switch (model_operators[i])
-            {
-              case Utilities::Operator::add:
-              {
-                composition += (*initial_composition_object)->initial_composition(position,  n_comp);
-                break;
-              }
-              case Utilities::Operator::subtract:
-              {
-                composition -= (*initial_composition_object)->initial_composition(position, n_comp);
-                break;
-              }
-              case Utilities::Operator::minimum:
-              {
-                composition = std::min (composition, (*initial_composition_object)->initial_composition(position, n_comp));
-                break;
-              }
-              case Utilities::Operator::maximum:
-              {
-                composition = std::max (composition, (*initial_composition_object)->initial_composition(position, n_comp));
-                break;
-              }
-              default:
-              {
-                Assert ( false, ExcMessage ("Initial composition interface only accepts the following operators: "
-                                            "add, subtract, minimum and maximum. Please check your parameter file.") );
-                break;
-              }
-            }
-
+          composition = model_operators[i](composition,(*initial_composition_object)->initial_composition(position,  n_comp));
           i++;
         }
 

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -121,9 +121,12 @@ namespace aspect
         if (!(model_name == "unspecified"))
           model_names.push_back(model_name);
 
-        model_operator_names = Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
-                                                                       model_names.size(),
-                                                                       "List of model operators");
+        // create operator list
+        std::vector<std::string> model_operator_names =
+          Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
+                                                  model_names.size(),
+                                                  "List of model operators");
+        model_operators = Utilities::Operator::create_model_operator_list(model_operator_names);
 
       }
       prm.leave_subsection ();
@@ -149,20 +152,6 @@ namespace aspect
 
           initial_composition_objects.back()->parse_parameters (prm);
           initial_composition_objects.back()->initialize ();
-
-          // create operator list
-          if (model_operator_names[i] == "add")
-            model_operators.push_back(add);
-          else if (model_operator_names[i] == "subtract")
-            model_operators.push_back(subtract);
-          else if (model_operator_names[i] == "minimum")
-            model_operators.push_back(minimum);
-          else if (model_operator_names[i] == "maximum")
-            model_operators.push_back(maximum);
-          else
-            AssertThrow( false,
-                         ExcMessage ("Initial composition interface only accepts the following operators: "
-                                     "add, subtract, minimum and maximum. Please check your parameter file.") );
         }
     }
 
@@ -182,22 +171,22 @@ namespace aspect
         {
           switch (model_operators[i])
             {
-              case add:
+              case Utilities::Operator::add:
               {
                 composition += (*initial_composition_object)->initial_composition(position,  n_comp);
                 break;
               }
-              case subtract:
+              case Utilities::Operator::subtract:
               {
                 composition -= (*initial_composition_object)->initial_composition(position, n_comp);
                 break;
               }
-              case minimum:
+              case Utilities::Operator::minimum:
               {
                 composition = std::min (composition, (*initial_composition_object)->initial_composition(position, n_comp));
                 break;
               }
-              case maximum:
+              case Utilities::Operator::maximum:
               {
                 composition = std::max (composition, (*initial_composition_object)->initial_composition(position, n_comp));
                 break;

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -122,7 +122,7 @@ namespace aspect
           model_names.push_back(model_name);
 
         // create operator list
-        std::vector<std::string> model_operator_names =
+        const std::vector<std::string> model_operator_names =
           Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
                                                   model_names.size(),
                                                   "List of model operators");
@@ -169,7 +169,8 @@ namespace aspect
            initial_composition_object != initial_composition_objects.end();
            ++initial_composition_object)
         {
-          composition = model_operators[i](composition,(*initial_composition_object)->initial_composition(position,  n_comp));
+          composition = model_operators[i](composition,
+                                           (*initial_composition_object)->initial_composition(position,n_comp));
           i++;
         }
 

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -119,7 +119,7 @@ namespace aspect
           model_names.push_back(model_name);
 
         // create operator list
-        std::vector<std::string> model_operator_names =
+        const std::vector<std::string> model_operator_names =
           Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
                                                   model_names.size(),
                                                   "List of model operators");
@@ -157,7 +157,8 @@ namespace aspect
            initial_temperature_object != initial_temperature_objects.end();
            ++initial_temperature_object)
         {
-          temperature = model_operators[i](temperature,(*initial_temperature_object)->initial_temperature(position));
+          temperature = model_operators[i](temperature,
+                                           (*initial_temperature_object)->initial_temperature(position));
           i++;
         }
       return temperature;

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/global.h>
-#include <aspect/utilities.h>
 #include <aspect/initial_temperature/interface.h>
 
 #include <deal.II/base/exceptions.h>
@@ -119,11 +118,12 @@ namespace aspect
         if (!(model_name == "unspecified"))
           model_names.push_back(model_name);
 
-
-        model_operator_names = Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
-                                                                       model_names.size(),
-                                                                       "List of model operators");
-
+        // create operator list
+        std::vector<std::string> model_operator_names =
+          Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
+                                                  model_names.size(),
+                                                  "List of model operators");
+        model_operators = Utilities::Operator::create_model_operator_list(model_operator_names);
       }
       prm.leave_subsection ();
 
@@ -142,20 +142,6 @@ namespace aspect
 
           initial_temperature_objects.back()->parse_parameters (prm);
           initial_temperature_objects.back()->initialize ();
-
-          // create operator list
-          if (model_operator_names[i] == "add")
-            model_operators.push_back(add);
-          else if (model_operator_names[i] == "subtract")
-            model_operators.push_back(subtract);
-          else if (model_operator_names[i] == "minimum")
-            model_operators.push_back(minimum);
-          else if (model_operator_names[i] == "maximum")
-            model_operators.push_back(maximum);
-          else
-            AssertThrow( false,
-                         ExcMessage ("Initial temperature interface only accepts the following operators: "
-                                     "add, subtract, minimum and maximum. Please check your parameter file.") );
         }
     }
 
@@ -173,22 +159,22 @@ namespace aspect
         {
           switch (model_operators[i])
             {
-              case add:
+              case Utilities::Operator::add:
               {
                 temperature += (*initial_temperature_object)->initial_temperature(position);
                 break;
               }
-              case subtract:
+              case Utilities::Operator::subtract:
               {
                 temperature -= (*initial_temperature_object)->initial_temperature(position);
                 break;
               }
-              case minimum:
+              case Utilities::Operator::minimum:
               {
                 temperature = std::min (temperature, (*initial_temperature_object)->initial_temperature(position));
                 break;
               }
-              case maximum:
+              case Utilities::Operator::maximum:
               {
                 temperature = std::max (temperature, (*initial_temperature_object)->initial_temperature(position));
                 break;

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -123,7 +123,7 @@ namespace aspect
           Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
                                                   model_names.size(),
                                                   "List of model operators");
-        model_operators = Utilities::Operator::create_model_operator_list(model_operator_names);
+        model_operators = Utilities::create_model_operator_list(model_operator_names);
       }
       prm.leave_subsection ();
 
@@ -157,36 +157,7 @@ namespace aspect
            initial_temperature_object != initial_temperature_objects.end();
            ++initial_temperature_object)
         {
-          switch (model_operators[i])
-            {
-              case Utilities::Operator::add:
-              {
-                temperature += (*initial_temperature_object)->initial_temperature(position);
-                break;
-              }
-              case Utilities::Operator::subtract:
-              {
-                temperature -= (*initial_temperature_object)->initial_temperature(position);
-                break;
-              }
-              case Utilities::Operator::minimum:
-              {
-                temperature = std::min (temperature, (*initial_temperature_object)->initial_temperature(position));
-                break;
-              }
-              case Utilities::Operator::maximum:
-              {
-                temperature = std::max (temperature, (*initial_temperature_object)->initial_temperature(position));
-                break;
-              }
-              default:
-              {
-                Assert ( false, ExcMessage ("Initial temperature interface only accepts the following operators: "
-                                            "add, subtract, minimum and maximum. Please check your parameter file.") );
-                break;
-              }
-            }
-
+          temperature = model_operators[i](temperature,(*initial_temperature_object)->initial_temperature(position));
           i++;
         }
       return temperature;

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2364,31 +2364,81 @@ namespace aspect
         }
     }
 
-    namespace Operator
-    {
-      std::vector<Operator::operation> create_model_operator_list(const std::vector<std::string> &operator_names)
-      {
-        std::vector<Operator::operation> operator_list(operator_names.size());
-        for (unsigned int i=0; i<operator_names.size(); ++i)
-          {
-            // create operator list
-            if (operator_names[i] == "add")
-              operator_list[i] = Operator::add;
-            else if (operator_names[i] == "subtract")
-              operator_list[i] = Operator::subtract;
-            else if (operator_names[i] == "minimum")
-              operator_list[i] = Operator::minimum;
-            else if (operator_names[i] == "maximum")
-              operator_list[i] = Operator::maximum;
-            else
-              AssertThrow(false,
-                          ExcMessage ("ASPECT only accepts the following operators: "
-                                      "add, subtract, minimum and maximum. But your parameter file "
-                                      "contains: " + operator_names[i] + ". Please check your parameter file.") );
-          }
+    Operator::Operator()
+    :
+        op(uninitialized)
+    {}
 
-        return operator_list;
+
+      Operator::Operator(const operation _op)
+      :
+          op(_op)
+      {}
+
+
+      double
+      Operator::operator() (double x, double y) const
+      {
+        switch (op)
+          {
+            case Utilities::Operator::add:
+            {
+              return x + y;
+              break;
+            }
+            case Utilities::Operator::subtract:
+            {
+              return x - y;
+              break;
+            }
+            case Utilities::Operator::minimum:
+            {
+              return std::min(x,y);
+              break;
+            }
+            case Utilities::Operator::maximum:
+            {
+              return std::max(x,y);
+              break;
+            }
+            default:
+            {
+              Assert ( false, ExcMessage ("ASPECT's operator class only supports the following operators: "
+                                          "add, subtract, minimum and maximum. Please check your parameter file.") );
+              break;
+            }
+          }
+        return numbers::signaling_nan<double>();
       }
+
+      bool
+      Operator::operator== (const operation other_op) const
+    {
+        return other_op == op;
+    }
+
+    std::vector<Operator> create_model_operator_list(const std::vector<std::string> &operator_names)
+    {
+      std::vector<Operator> operator_list(operator_names.size());
+      for (unsigned int i=0; i<operator_names.size(); ++i)
+        {
+          // create operator list
+          if (operator_names[i] == "add")
+            operator_list[i] = Operator(Operator::add);
+          else if (operator_names[i] == "subtract")
+            operator_list[i] = Operator(Operator::subtract);
+          else if (operator_names[i] == "minimum")
+            operator_list[i] = Operator(Operator::minimum);
+          else if (operator_names[i] == "maximum")
+            operator_list[i] = Operator(Operator::maximum);
+          else
+            AssertThrow(false,
+                        ExcMessage ("ASPECT only accepts the following operators: "
+                                    "add, subtract, minimum and maximum. But your parameter file "
+                                    "contains: " + operator_names[i] + ". Please check your parameter file.") );
+        }
+
+      return operator_list;
     }
 
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2364,58 +2364,60 @@ namespace aspect
         }
     }
 
+
+
     Operator::Operator()
-    :
-        op(uninitialized)
+      :
+      op(uninitialized)
     {}
 
 
-      Operator::Operator(const operation _op)
+
+    Operator::Operator(const operation _op)
       :
-          op(_op)
-      {}
+      op(_op)
+    {}
 
 
-      double
-      Operator::operator() (double x, double y) const
-      {
-        switch (op)
-          {
-            case Utilities::Operator::add:
-            {
-              return x + y;
-              break;
-            }
-            case Utilities::Operator::subtract:
-            {
-              return x - y;
-              break;
-            }
-            case Utilities::Operator::minimum:
-            {
-              return std::min(x,y);
-              break;
-            }
-            case Utilities::Operator::maximum:
-            {
-              return std::max(x,y);
-              break;
-            }
-            default:
-            {
-              Assert ( false, ExcMessage ("ASPECT's operator class only supports the following operators: "
-                                          "add, subtract, minimum and maximum. Please check your parameter file.") );
-              break;
-            }
-          }
-        return numbers::signaling_nan<double>();
-      }
 
-      bool
-      Operator::operator== (const operation other_op) const
+    double
+    Operator::operator() (const double x, const double y) const
     {
-        return other_op == op;
+      switch (op)
+        {
+          case Utilities::Operator::add:
+          {
+            return x + y;
+          }
+          case Utilities::Operator::subtract:
+          {
+            return x - y;
+          }
+          case Utilities::Operator::minimum:
+          {
+            return std::min(x,y);
+          }
+          case Utilities::Operator::maximum:
+          {
+            return std::max(x,y);
+          }
+          default:
+          {
+            Assert (false, ExcInternalError());
+          }
+        }
+      return numbers::signaling_nan<double>();
     }
+
+
+
+    bool
+    Operator::operator== (const operation other_op) const
+    {
+      return other_op == op;
+    }
+
+
 
     std::vector<Operator> create_model_operator_list(const std::vector<std::string> &operator_names)
     {

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -19,6 +19,7 @@
 */
 #include <aspect/global.h>
 #include <aspect/utilities.h>
+#include <aspect/simulator_access.h>
 
 #include <deal.II/base/std_cxx11/array.h>
 #include <deal.II/base/point.h>
@@ -2362,6 +2363,34 @@ namespace aspect
             return std::max(0.0,safety_factor*alpha);
         }
     }
+
+    namespace Operator
+    {
+      std::vector<Operator::operation> create_model_operator_list(const std::vector<std::string> &operator_names)
+      {
+        std::vector<Operator::operation> operator_list(operator_names.size());
+        for (unsigned int i=0; i<operator_names.size(); ++i)
+          {
+            // create operator list
+            if (operator_names[i] == "add")
+              operator_list[i] = Operator::add;
+            else if (operator_names[i] == "subtract")
+              operator_list[i] = Operator::subtract;
+            else if (operator_names[i] == "minimum")
+              operator_list[i] = Operator::minimum;
+            else if (operator_names[i] == "maximum")
+              operator_list[i] = Operator::maximum;
+            else
+              AssertThrow(false,
+                          ExcMessage ("ASPECT only accepts the following operators: "
+                                      "add, subtract, minimum and maximum. But your parameter file "
+                                      "contains: " + operator_names[i] + ". Please check your parameter file.") );
+          }
+
+        return operator_list;
+      }
+    }
+
 
 
 

--- a/tests/ascii_boundary_member.cc
+++ b/tests/ascii_boundary_member.cc
@@ -1,4 +1,5 @@
 #include <aspect/boundary_velocity/interface.h>
+#include <aspect/simulator_access.h>
 #include <aspect/utilities.h>
 #include <aspect/global.h>
 


### PR DESCRIPTION
#1720 introduced some duplication by copying operators into both interfaces for initial composition and initial temperature. As I plan to extend this functionality to boundary conditions as well, it makes sense to move the code into utilities instead, and make it available for other parts of the program as well.