### PR TITLE
Boundary condition map

### DIFF
--- a/benchmarks/annulus/annulus.prm
+++ b/benchmarks/annulus/annulus.prm
@@ -71,7 +71,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/benchmarks/blankenbach/base_case1a.prm
+++ b/benchmarks/blankenbach/base_case1a.prm
@@ -18,7 +18,7 @@ subsection Adiabatic conditions model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 1
     set Left temperature   = 0

--- a/benchmarks/blankenbach/base_case2a.prm
+++ b/benchmarks/blankenbach/base_case2a.prm
@@ -18,7 +18,7 @@ subsection Adiabatic conditions model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 1
     set Left temperature   = 0

--- a/benchmarks/blankenbach/base_case2b.prm
+++ b/benchmarks/blankenbach/base_case2b.prm
@@ -18,7 +18,7 @@ subsection Adiabatic conditions model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 1
     set Left temperature   = 0

--- a/benchmarks/buiter_et_al_2008_jgr/figure_6_1e20.prm
+++ b/benchmarks/buiter_et_al_2008_jgr/figure_6_1e20.prm
@@ -109,7 +109,7 @@ end
 
 # Temperature boundary conditions
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 273
     set Left temperature   = 273

--- a/benchmarks/burstedde/burstedde.prm
+++ b/benchmarks/burstedde/burstedde.prm
@@ -73,7 +73,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/benchmarks/crameri_et_al/case_1/crameri_benchmark_1.prm
+++ b/benchmarks/crameri_et_al/case_1/crameri_benchmark_1.prm
@@ -19,7 +19,7 @@ set Use years in output instead of seconds = true
 set Additional shared libraries = ./libcrameri_benchmark_1.so
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = left:0, right:0, bottom:0, top:0
   end

--- a/benchmarks/crameri_et_al/case_2/crameri_benchmark_2.prm
+++ b/benchmarks/crameri_et_al/case_2/crameri_benchmark_2.prm
@@ -13,7 +13,7 @@ set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 0.0
     set Bottom temperature = 0.0

--- a/benchmarks/davies_et_al/case-1.1.prm
+++ b/benchmarks/davies_et_al/case-1.1.prm
@@ -50,7 +50,7 @@ subsection Material model
 end
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 1
     set Outer temperature = 0

--- a/benchmarks/davies_et_al/case-2.1.prm
+++ b/benchmarks/davies_et_al/case-2.1.prm
@@ -60,7 +60,7 @@ subsection Material model
 end
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 1
     set Outer temperature = 0

--- a/benchmarks/davies_et_al/case-2.2.prm
+++ b/benchmarks/davies_et_al/case-2.2.prm
@@ -60,7 +60,7 @@ subsection Material model
 end
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 1
     set Outer temperature = 0

--- a/benchmarks/davies_et_al/case-2.3.prm
+++ b/benchmarks/davies_et_al/case-2.3.prm
@@ -64,7 +64,7 @@ subsection Material model
 end
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 1
     set Outer temperature = 0

--- a/benchmarks/finite_strain/pure_shear.prm
+++ b/benchmarks/finite_strain/pure_shear.prm
@@ -101,7 +101,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/benchmarks/finite_strain/simple_shear.prm
+++ b/benchmarks/finite_strain/simple_shear.prm
@@ -87,7 +87,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/benchmarks/hollow_sphere/hollow_sphere.prm
+++ b/benchmarks/hollow_sphere/hollow_sphere.prm
@@ -62,7 +62,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box 
+  set List of model names = box 
 end
 
 subsection Initial temperature model 

--- a/benchmarks/inclusion/adaptive.prm.base
+++ b/benchmarks/inclusion/adaptive.prm.base
@@ -51,7 +51,7 @@ end
 ############### Parameters describing the temperature field
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/benchmarks/inclusion/compositional_fields/inclusion_compositional_fields.prm
+++ b/benchmarks/inclusion/compositional_fields/inclusion_compositional_fields.prm
@@ -50,7 +50,7 @@ end
 ############### Parameters describing the temperature field
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/benchmarks/inclusion/compositional_fields/inclusion_particles.prm
+++ b/benchmarks/inclusion/compositional_fields/inclusion_particles.prm
@@ -51,7 +51,7 @@ end
 ############### Parameters describing the temperature field
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/benchmarks/inclusion/global.prm.base
+++ b/benchmarks/inclusion/global.prm.base
@@ -51,7 +51,7 @@ end
 ############### Parameters describing the temperature field
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/benchmarks/king2dcompressible/ala.prm
+++ b/benchmarks/king2dcompressible/ala.prm
@@ -170,7 +170,7 @@ end
 # and the (nondimensional) temperature change across the boundary 
 # is set to 1.
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Top temperature    = 0.091

--- a/benchmarks/shear_bands/magmatic_shear_bands.prm
+++ b/benchmarks/shear_bands/magmatic_shear_bands.prm
@@ -44,7 +44,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/benchmarks/shear_bands/shear_bands.prm
+++ b/benchmarks/shear_bands/shear_bands.prm
@@ -46,7 +46,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/benchmarks/solcx/compositional_fields/solcx_compositional_fields.prm
+++ b/benchmarks/solcx/compositional_fields/solcx_compositional_fields.prm
@@ -48,7 +48,7 @@ end
 ############### Parameters describing the temperature field
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/benchmarks/solcx/compositional_fields/solcx_particles.prm
+++ b/benchmarks/solcx/compositional_fields/solcx_particles.prm
@@ -48,7 +48,7 @@ end
 ############### Parameters describing the temperature field
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/benchmarks/solcx/solcx.prm
+++ b/benchmarks/solcx/solcx.prm
@@ -52,7 +52,7 @@ end
 ############### Parameters describing the temperature field
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/benchmarks/solitary_wave/solitary_wave.prm
+++ b/benchmarks/solitary_wave/solitary_wave.prm
@@ -47,7 +47,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/benchmarks/solkz/compositional_fields/solkz_compositional_fields.prm
+++ b/benchmarks/solkz/compositional_fields/solkz_compositional_fields.prm
@@ -43,7 +43,7 @@ end
 ############### Parameters describing the temperature field
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/benchmarks/solkz/compositional_fields/solkz_particles.prm
+++ b/benchmarks/solkz/compositional_fields/solkz_particles.prm
@@ -44,7 +44,7 @@ end
 ############### Parameters describing the temperature field
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/benchmarks/solkz/solkz.prm
+++ b/benchmarks/solkz/solkz.prm
@@ -48,7 +48,7 @@ end
 ############### Parameters describing the temperature field
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/benchmarks/tangurnis/ba/tan.prm
+++ b/benchmarks/tangurnis/ba/tan.prm
@@ -46,7 +46,7 @@ end
 # temperature according to the prescibed temperature of the Tan & Gurnis
 # benchmark. 
 subsection Boundary temperature model
-  set Model name = Tan Gurnis
+  set List of model names = Tan Gurnis
 end
 
 

--- a/benchmarks/tangurnis/tala/tan.prm
+++ b/benchmarks/tangurnis/tala/tan.prm
@@ -47,7 +47,7 @@ end
 # temperature according to the prescibed temperature of the Tan & Gurnis
 # benchmark. 
 subsection Boundary temperature model
-  set Model name = Tan Gurnis
+  set List of model names = Tan Gurnis
 end
 
 

--- a/benchmarks/tangurnis/tala_c/tan.prm
+++ b/benchmarks/tangurnis/tala_c/tan.prm
@@ -46,7 +46,7 @@ end
 # temperature according to the prescibed temperature of the Tan & Gurnis
 # benchmark. 
 subsection Boundary temperature model
-  set Model name = Tan Gurnis
+  set List of model names = Tan Gurnis
 end
 
 

--- a/benchmarks/zhong_et_al_93/zhong_case1.prm
+++ b/benchmarks/zhong_et_al_93/zhong_case1.prm
@@ -30,7 +30,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 0
     set Top temperature    = 0

--- a/cookbooks/S20RTS.prm
+++ b/cookbooks/S20RTS.prm
@@ -37,7 +37,7 @@ end
 # but different from the reference temperature to approximate
 # boundary layers.
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 2000
     set Outer temperature = 1000
@@ -118,7 +118,6 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, heat flux map, heat flux statistics, dynamic topography, visualization, basic statistics
 
   subsection Dynamic Topography
-    set Subtract mean of dynamic topography = true
   end
 
   subsection Visualization
@@ -128,7 +127,6 @@ subsection Postprocess
     set Number of grouped files       = 1 
    
     subsection Dynamic Topography
-      set Subtract mean of dynamic topography = true
     end
   end
 end

--- a/cookbooks/burnman.prm
+++ b/cookbooks/burnman.prm
@@ -85,7 +85,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 3500 
     set Outer temperature = 273

--- a/cookbooks/composition-active-particles.prm
+++ b/cookbooks/composition-active-particles.prm
@@ -34,7 +34,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/cookbooks/composition-active.prm
+++ b/cookbooks/composition-active.prm
@@ -33,7 +33,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/cookbooks/composition-passive-particles-properties.prm
+++ b/cookbooks/composition-passive-particles-properties.prm
@@ -35,7 +35,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/cookbooks/composition-passive-particles.prm
+++ b/cookbooks/composition-passive-particles.prm
@@ -35,7 +35,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/cookbooks/composition-passive.prm
+++ b/cookbooks/composition-passive.prm
@@ -33,7 +33,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/cookbooks/composition-reaction.prm
+++ b/cookbooks/composition-reaction.prm
@@ -45,7 +45,7 @@ end
 # We then set the temperature to one at the bottom and zero
 # at the top: 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   
   subsection Box
     set Bottom temperature = 1

--- a/cookbooks/continental_extension.prm
+++ b/cookbooks/continental_extension.prm
@@ -104,7 +104,7 @@ end
 # not used as the sides are not specified "Fixed temperature boundaries".  Rather,
 # these boundaries are insulating (zero net heat flux).
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 1573
     set Top temperature    =  273

--- a/cookbooks/convection-box-3d.prm
+++ b/cookbooks/convection-box-3d.prm
@@ -71,7 +71,7 @@ end
 # in the next section, the actual temperature prescribed here
 # at the left and right does not matter.)
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/cookbooks/convection-box.prm
+++ b/cookbooks/convection-box.prm
@@ -71,7 +71,7 @@ end
 # in the next section, the actual temperature prescribed here
 # at the left and right does not matter.)
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/cookbooks/crustal_model_2D.prm
+++ b/cookbooks/crustal_model_2D.prm
@@ -84,7 +84,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/cookbooks/crustal_model_3D.prm
+++ b/cookbooks/crustal_model_3D.prm
@@ -82,7 +82,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/cookbooks/finite_strain/finite_strain.prm
+++ b/cookbooks/finite_strain/finite_strain.prm
@@ -15,7 +15,7 @@ set Output directory                       = output-finite_strain
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     set Minimal temperature = 293

--- a/cookbooks/free-surface-with-crust/free-surface-with-crust.prm
+++ b/cookbooks/free-surface-with-crust/free-surface-with-crust.prm
@@ -27,7 +27,7 @@ set Use years in output instead of seconds = true
 # We let the boundaries be zero temperature, as we are just
 # modelling a single rising blob
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
   end

--- a/cookbooks/free-surface.prm
+++ b/cookbooks/free-surface.prm
@@ -23,7 +23,7 @@ set Use years in output instead of seconds = true
 # We let the boundaries be zero temperature, as we are just
 # modelling a single rising blob
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = left:0, right:0, bottom:0, top:0
   end

--- a/cookbooks/future/netrot.prm
+++ b/cookbooks/future/netrot.prm
@@ -43,7 +43,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4273
     set Outer temperature = 973

--- a/cookbooks/future/nettranslation.prm
+++ b/cookbooks/future/nettranslation.prm
@@ -12,7 +12,7 @@ set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 0.0
     set Bottom temperature = 1000.0

--- a/cookbooks/future/periodic_box.prm
+++ b/cookbooks/future/periodic_box.prm
@@ -12,7 +12,7 @@ set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 0.0
     set Bottom temperature = 1000.0

--- a/cookbooks/future/radiogenic_heating.prm
+++ b/cookbooks/future/radiogenic_heating.prm
@@ -54,7 +54,7 @@ end
 ############### Boundary conditions
 # We set the top temperature to T1=1000K. 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 1000
   end

--- a/cookbooks/future/radiogenic_heating_function.prm
+++ b/cookbooks/future/radiogenic_heating_function.prm
@@ -56,7 +56,7 @@ end
 ############### Boundary conditions
 # We set the top temperature to T1=1000K. 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 1000
   end

--- a/cookbooks/future/sphere.prm
+++ b/cookbooks/future/sphere.prm
@@ -33,7 +33,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = top: 0.0 
   end

--- a/cookbooks/future/steinberger.prm
+++ b/cookbooks/future/steinberger.prm
@@ -8,7 +8,7 @@ set Use years in output instead of seconds = true
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 4273

--- a/cookbooks/geomIO.prm
+++ b/cookbooks/geomIO.prm
@@ -47,7 +47,7 @@ subsection Initial composition model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/cookbooks/gplates-2d.prm
+++ b/cookbooks/gplates-2d.prm
@@ -51,7 +51,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 2600 
     set Outer temperature = 273 

--- a/cookbooks/gplates-3d.prm
+++ b/cookbooks/gplates-3d.prm
@@ -51,7 +51,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 2600 
     set Outer temperature = 273 

--- a/cookbooks/inner_core_convection/inner_core_traction.prm
+++ b/cookbooks/inner_core_convection/inner_core_traction.prm
@@ -83,7 +83,7 @@ end
 
 # The (potential) temperature is set to zero at the outer boundary.
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 0.8
     set Outer temperature = 0

--- a/cookbooks/latent-heat.prm
+++ b/cookbooks/latent-heat.prm
@@ -50,7 +50,7 @@ end
 ############### Boundary conditions
 # We set the top temperature to T1=1000K. 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 1000
   end

--- a/cookbooks/platelike-boundary.prm
+++ b/cookbooks/platelike-boundary.prm
@@ -40,7 +40,7 @@ end
 # We then set the temperature to one at the bottom and zero
 # at the top: 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   
   subsection Box
     set Bottom temperature = 1

--- a/cookbooks/shell_simple_2d.prm
+++ b/cookbooks/shell_simple_2d.prm
@@ -43,7 +43,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4273
     set Outer temperature = 973

--- a/cookbooks/shell_simple_2d_smoothing.prm
+++ b/cookbooks/shell_simple_2d_smoothing.prm
@@ -60,7 +60,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4273
     set Outer temperature = 973

--- a/cookbooks/shell_simple_3d.prm
+++ b/cookbooks/shell_simple_3d.prm
@@ -39,7 +39,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 1973
     set Outer temperature = 973

--- a/cookbooks/sinker-with-averaging/sinker-with-averaging.prm
+++ b/cookbooks/sinker-with-averaging/sinker-with-averaging.prm
@@ -46,7 +46,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/cookbooks/stokes.prm
+++ b/cookbooks/stokes.prm
@@ -64,7 +64,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/cookbooks/van-keken-discontinuous.prm
+++ b/cookbooks/van-keken-discontinuous.prm
@@ -43,7 +43,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/cookbooks/van-keken-smooth.prm
+++ b/cookbooks/van-keken-smooth.prm
@@ -44,7 +44,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/doc/manual/cookbooks/benchmarks/inclusion.prm
+++ b/doc/manual/cookbooks/benchmarks/inclusion.prm
@@ -52,7 +52,7 @@ end
 ############### Parameters describing the temperature field
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/doc/manual/cookbooks/benchmarks/solcx.prm
+++ b/doc/manual/cookbooks/benchmarks/solcx.prm
@@ -48,7 +48,7 @@ end
 ############### Parameters describing the temperature field
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/doc/manual/cookbooks/benchmarks/solkz.prm
+++ b/doc/manual/cookbooks/benchmarks/solkz.prm
@@ -47,7 +47,7 @@ end
 ############### Parameters describing the temperature field
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/doc/manual/cookbooks/benchmarks/stokes/stokeslaw.prm
+++ b/doc/manual/cookbooks/benchmarks/stokes/stokeslaw.prm
@@ -61,7 +61,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box 
+  set List of model names = box 
 end
 
 subsection Initial temperature model

--- a/doc/manual/cookbooks/continental_extension/continental_extension_boundary_conditions.prm
+++ b/doc/manual/cookbooks/continental_extension/continental_extension_boundary_conditions.prm
@@ -13,7 +13,7 @@ subsection Boundary velocity model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 1573
     set Top temperature    =  273

--- a/doc/manual/cookbooks/convection-box-3d/start.part.prm
+++ b/doc/manual/cookbooks/convection-box-3d/start.part.prm
@@ -11,7 +11,7 @@ subsection Geometry model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/doc/manual/cookbooks/convection-box/box.prm
+++ b/doc/manual/cookbooks/convection-box/box.prm
@@ -68,7 +68,7 @@ end
 # in the next section, the actual temperature prescribed here
 # at the left and right does not matter.)
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/doc/manual/cookbooks/morency_doin/morency_doin.prm
+++ b/doc/manual/cookbooks/morency_doin/morency_doin.prm
@@ -68,7 +68,7 @@ subsection Material model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary composition model

--- a/doc/manual/cookbooks/platelike-boundary/platelike.prm
+++ b/doc/manual/cookbooks/platelike-boundary/platelike.prm
@@ -35,7 +35,7 @@ end
 # We then set the temperature to one at the bottom and zero
 # at the top:
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/doc/manual/cookbooks/shell_simple_2d/shell.prm
+++ b/doc/manual/cookbooks/shell_simple_2d/shell.prm
@@ -34,7 +34,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant 
+  set List of model names = spherical constant 
   subsection Spherical constant
     set Inner temperature = 4273 
     set Outer temperature = 973 

--- a/doc/manual/cookbooks/shell_simple_3d/part3.part.prm
+++ b/doc/manual/cookbooks/shell_simple_3d/part3.part.prm
@@ -1,5 +1,5 @@
 subsection Boundary temperature model
-  set Model name = spherical constant 
+  set List of model names = spherical constant 
   subsection Spherical constant
     set Inner temperature = 1973 
     set Outer temperature = 973 

--- a/doc/manual/cookbooks/sinker-with-averaging/full.prm
+++ b/doc/manual/cookbooks/sinker-with-averaging/full.prm
@@ -46,7 +46,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/doc/manual/empty.prm
+++ b/doc/manual/empty.prm
@@ -17,7 +17,7 @@ subsection Gravity model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/doc/modules/changes/20170524_gassmoeller
+++ b/doc/modules/changes/20170524_gassmoeller
@@ -1,0 +1,5 @@
+New: Boundary temperatures can now be prescribed as a combination of several
+plugins in the same way it is possible for initial temperatures. Operators
+to combine the models are also available.
+<br>
+(Rene Gassmoeller, 2017/05/24)

--- a/doc/update_prm_files_to_2.0.0.sed
+++ b/doc/update_prm_files_to_2.0.0.sed
@@ -24,7 +24,7 @@ s/Initial conditions/Initial temperature model/g
 # belongs to the opening subsection (i.e. if the parameter is set
 # after a subsection nested inside the 'Boundary temperature model'
 # subsection the following will simply do nothing).
-/subsection Boundary temperature model/,/end/ {
+/subsection Boundary temperature model/,/\<end\>/ {
      s/set Model name/set List of model names/g
 }
 

--- a/doc/update_prm_files_to_2.0.0.sed
+++ b/doc/update_prm_files_to_2.0.0.sed
@@ -17,6 +17,17 @@ s/Compositional initial conditions/Initial composition model/g
 # Rename initial (temperature) conditions
 s/Initial conditions/Initial temperature model/g
 
+# Replace the 'model name' parameter by 'List of model names'
+# in all subsections that now use the new parameter.
+# Note that this command only works if the parameter is set
+# before the next 'end', which is not necessarily the one that
+# belongs to the opening subsection (i.e. if the parameter is set
+# after a subsection nested inside the 'Boundary temperature model'
+# subsection the following will simply do nothing).
+/subsection Boundary temperature model/,/end/ {
+     s/set Model name/set List of model names/g
+}
+
 # Rename tracers to particles
 s/tracer/particle/g
 s/Tracer/Particle/g

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -90,8 +90,8 @@ namespace aspect
          * Nusselt number indicating heat flux.
          */
         virtual
-        double minimal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids =
-                                      std::set<types::boundary_id>()) const = 0;
+        double minimal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids
+                                    = std::set<types::boundary_id>()) const = 0;
 
         /**
          * Return the maximal temperature on that part of the boundary on
@@ -101,8 +101,8 @@ namespace aspect
          * Nusselt number indicating heat flux.
          */
         virtual
-        double maximal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids =
-                                      std::set<types::boundary_id>()) const = 0;
+        double maximal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids
+                                    = std::set<types::boundary_id>()) const = 0;
 
         /**
          * A function that is called at the beginning of each time step. The
@@ -198,15 +198,15 @@ namespace aspect
          * Return the minimal temperature of all selected plugins on that
          * part of the boundary on which Dirichlet conditions are posed.
          */
-        double minimal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids =
-                                      std::set<types::boundary_id>()) const;
+        double minimal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids
+                                    = std::set<types::boundary_id>()) const;
 
         /**
          * Return the maximal temperature of all selected plugins on that
          * part of the boundary on which Dirichlet conditions are posed.
          */
-        double maximal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids =
-                                      std::set<types::boundary_id>()) const;
+        double maximal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids
+                                    = std::set<types::boundary_id>()) const;
 
         /**
          * A function that is used to register boundary temperature objects in such

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -24,6 +24,8 @@
 
 #include <aspect/plugins.h>
 #include <aspect/geometry_model/interface.h>
+#include <aspect/utilities.h>
+#include <aspect/simulator_access.h>
 
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/distributed/tria.h>
@@ -31,6 +33,8 @@
 
 namespace aspect
 {
+  template <int dim> class SimulatorAccess;
+
   /**
    * A namespace for the definition of things that have to do with describing
    * the boundary values for the temperature.
@@ -79,7 +83,7 @@ namespace aspect
                                      const Point<dim> &position) const;
 
         /**
-         * Return the minimal the temperature on that part of the boundary on
+         * Return the minimal temperature on that part of the boundary on
          * which Dirichlet conditions are posed.
          *
          * This value is used in computing dimensionless numbers such as the
@@ -90,7 +94,7 @@ namespace aspect
                                       std::set<types::boundary_id>()) const = 0;
 
         /**
-         * Return the maximal the temperature on that part of the boundary on
+         * Return the maximal temperature on that part of the boundary on
          * which Dirichlet conditions are posed.
          *
          * This value is used in computing dimensionless numbers such as the
@@ -138,51 +142,178 @@ namespace aspect
 
 
     /**
-     * Register a boundary temperature model so that it can be selected from
-     * the parameter file.
-     *
-     * @param name A string that identifies the boundary temperature model
-     * @param description A text description of what this model does and that
-     * will be listed in the documentation of the parameter file.
-     * @param declare_parameters_function A pointer to a function that can be
-     * used to declare the parameters that this geometry model wants to read
-     * from input files.
-     * @param factory_function A pointer to a function that can create an
-     * object of this boundary temperature model.
+     * A class that manages all boundary temperature objects.
      *
      * @ingroup BoundaryTemperatures
      */
     template <int dim>
-    void
-    register_boundary_temperature (const std::string &name,
-                                   const std::string &description,
-                                   void (*declare_parameters_function) (ParameterHandler &),
-                                   Interface<dim> *(*factory_function) ());
+    class Manager : public ::aspect::SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * Destructor. Made virtual since this class has virtual member
+         * functions.
+         */
+        virtual ~Manager ();
+
+        /**
+         * A function that is called at the beginning of each time step and
+         * calls the corresponding functions of all created plugins.
+         *
+         * The point of this function is to allow complex boundary temperature
+         * models to do an initialization step once at the beginning of each
+         * time step. An example would be a model that needs to call an
+         * external program to compute the temperature change at a boundary.
+         */
+        virtual
+        void
+        update ();
+
+        /**
+         * Declare the parameters of all known boundary temperature plugins, as
+         * well as the ones this class has itself.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         * This determines which boundary temperature objects will be created;
+         * then let these objects read their parameters as well.
+         */
+        void
+        parse_parameters (ParameterHandler &prm);
+
+        /**
+         * A function that calls the boundary_temperature functions of all the
+         * individual boundary temperature objects and uses the stored operators
+         * to combine them.
+         */
+        double
+        boundary_temperature (const types::boundary_id boundary_indicator,
+                              const Point<dim> &position) const;
+
+        /**
+         * Return the minimal temperature of all selected plugins on that
+         * part of the boundary on which Dirichlet conditions are posed.
+         */
+        double minimal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids =
+                                      std::set<types::boundary_id>()) const;
+
+        /**
+         * Return the maximal temperature of all selected plugins on that
+         * part of the boundary on which Dirichlet conditions are posed.
+         */
+        double maximal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids =
+                                      std::set<types::boundary_id>()) const;
+
+        /**
+         * A function that is used to register boundary temperature objects in such
+         * a way that the Manager can deal with all of them without having to
+         * know them by name. This allows the files in which individual
+         * plugins are implemented to register these plugins, rather than also
+         * having to modify the Manager class by adding the new boundary
+         * temperature plugin class.
+         *
+         * @param name A string that identifies the boundary temperature model
+         * @param description A text description of what this model does and that
+         * will be listed in the documentation of the parameter file.
+         * @param declare_parameters_function A pointer to a function that can be
+         * used to declare the parameters that this boundary temperature model
+         * wants to read from input files.
+         * @param factory_function A pointer to a function that can create an
+         * object of this boundary temperature model.
+         */
+        static
+        void
+        register_boundary_temperature (const std::string &name,
+                                       const std::string &description,
+                                       void (*declare_parameters_function) (ParameterHandler &),
+                                       Interface<dim> *(*factory_function) ());
+
+
+        /**
+         * Return a list of names of all boundary temperature models currently
+         * used in the computation, as specified in the input file.
+         */
+        const std::vector<std::string> &
+        get_active_boundary_temperature_names () const;
+
+        /**
+         * Return a list of pointers to all boundary temperature models
+         * currently used in the computation, as specified in the input file.
+         */
+        const std::vector<std_cxx11::shared_ptr<Interface<dim> > > &
+        get_active_boundary_temperature_conditions () const;
+
+        /**
+         * Go through the list of all boundary temperature models that have been selected in
+         * the input file (and are consequently currently active) and see if one
+         * of them has the desired type specified by the template argument. If so,
+         * return a pointer to it. If no boundary temperature model is active
+         * that matches the given type, return a NULL pointer.
+         */
+        template <typename BoundaryTemperatureType>
+        BoundaryTemperatureType *
+        find_boundary_temperature_model () const;
+
+        /**
+         * Exception.
+         */
+        DeclException1 (ExcBoundaryTemperatureNameNotFound,
+                        std::string,
+                        << "Could not find entry <"
+                        << arg1
+                        << "> among the names of registered boundary temperature objects.");
+      private:
+        /**
+         * A list of boundary temperature objects that have been requested in the
+         * parameter file.
+         */
+        std::vector<std_cxx11::shared_ptr<Interface<dim> > > boundary_temperature_objects;
+
+        /**
+         * A list of names of boundary temperature objects that have been requested
+         * in the parameter file.
+         */
+        std::vector<std::string> model_names;
+
+        /**
+         * A list of enums of boundary temperature operators that have been
+         * requested in the parameter file. Each name is associated
+         * with a model_name, and is used to modify the temperature
+         * boundary with the values from the current plugin.
+         */
+        std::vector<aspect::Utilities::Operator> model_operators;
+    };
+
+
+
+    template <int dim>
+    template <typename BoundaryTemperatureType>
+    inline
+    BoundaryTemperatureType *
+    Manager<dim>::find_boundary_temperature_model () const
+    {
+      for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
+           p = boundary_temperature_objects.begin();
+           p != boundary_temperature_objects.end(); ++p)
+        if (BoundaryTemperatureType *x = dynamic_cast<BoundaryTemperatureType *> ( (*p).get()) )
+          return x;
+      return NULL;
+    }
+
 
     /**
-     * A function that given the name of a model returns a pointer to an
-     * object that describes it. Ownership of the pointer is transferred to
-     * the caller.
-     *
-     * The model object returned is not yet initialized and has not read its
-     * runtime parameters yet.
-     *
-     * @ingroup BoundaryTemperatures
+     * Return a string that consists of the names of boundary temperature models that can
+     * be selected. These names are separated by a vertical line '|' so
+     * that the string can be an input to the deal.II classes
+     * Patterns::Selection or Patterns::MultipleSelection.
      */
     template <int dim>
-    Interface<dim> *
-    create_boundary_temperature (ParameterHandler &prm);
-
-
-    /**
-     * Declare the runtime parameters of the registered boundary temperature
-     * models.
-     *
-     * @ingroup BoundaryTemperatures
-     */
-    template <int dim>
-    void
-    declare_parameters (ParameterHandler &prm);
+    std::string
+    get_valid_model_names_pattern ();
 
 
     /**
@@ -198,10 +329,10 @@ namespace aspect
   namespace ASPECT_REGISTER_BOUNDARY_TEMPERATURE_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::BoundaryTemperature::Interface<2>,classname<2> > \
-    dummy_ ## classname ## _2d (&aspect::BoundaryTemperature::register_boundary_temperature<2>, \
+    dummy_ ## classname ## _2d (&aspect::BoundaryTemperature::Manager<2>::register_boundary_temperature, \
                                 name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::BoundaryTemperature::Interface<3>,classname<3> > \
-    dummy_ ## classname ## _3d (&aspect::BoundaryTemperature::register_boundary_temperature<3>, \
+    dummy_ ## classname ## _3d (&aspect::BoundaryTemperature::Manager<3>::register_boundary_temperature, \
                                 name, description); \
   }
   }

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1283,7 +1283,7 @@ namespace aspect
       const IntermediaryConstructorAction                                     post_geometry_model_creation_action;
       const std_cxx11::unique_ptr<MaterialModel::Interface<dim> >             material_model;
       const std_cxx11::unique_ptr<GravityModel::Interface<dim> >              gravity_model;
-      const std_cxx11::unique_ptr<BoundaryTemperature::Interface<dim> >       boundary_temperature;
+      BoundaryTemperature::Manager<dim>                                       boundary_temperature_manager;
       const std_cxx11::unique_ptr<BoundaryComposition::Interface<dim> >       boundary_composition;
       const std_cxx11::unique_ptr<PrescribedStokesSolution::Interface<dim> >  prescribed_stokes_solution;
       InitialComposition::Manager<dim>                                        initial_composition_manager;

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -68,6 +68,12 @@ namespace aspect
     template <int dim> class Interface;
   }
 
+  namespace BoundaryTemperature
+  {
+    template <int dim> class Manager;
+    template <int dim> class Interface;
+  }
+
   namespace InitialComposition
   {
     template <int dim> class Manager;
@@ -504,9 +510,20 @@ namespace aspect
       /**
        * Return a reference to the object that describes the temperature
        * boundary values.
+       *
+       * @deprecated: Use get_boundary_temperature_manager() instead.
        */
       const BoundaryTemperature::Interface<dim> &
-      get_boundary_temperature () const;
+      get_boundary_temperature () const DEAL_II_DEPRECATED;
+
+      /**
+       * Return an reference to the manager of the initial temperature models.
+       * This can then i.e. be used to get the names of the initial temperature
+       * models used in a computation, or to compute the initial temperature
+       * for a given position.
+       */
+      const BoundaryTemperature::Manager<dim> &
+      get_boundary_temperature_manager () const;
 
       /**
        * Return whether the current model has a boundary composition object
@@ -542,7 +559,7 @@ namespace aspect
       get_initial_temperature () const DEAL_II_DEPRECATED;
 
       /**
-       * Return a pointer to the manager of the initial temperature models.
+       * Return a reference to the manager of the initial temperature models.
        * This can then i.e. be used to get the names of the initial temperature
        * models used in a computation, or to compute the initial temperature
        * for a given position.

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -77,8 +77,28 @@ namespace aspect
     {}
 
 
-// -------------------------------- Deal with registering models and automating
-// -------------------------------- their setup and selection at run time
+    // ------------------------------ Manager -----------------------------
+    // -------------------------------- Deal with registering boundary_temperature models and automating
+    // -------------------------------- their setup and selection at run time
+
+    template <int dim>
+    Manager<dim>::~Manager()
+    {}
+
+
+
+    template <int dim>
+    void
+    Manager<dim>::update ()
+    {
+      for (unsigned int i=0; i<boundary_temperature_objects.size(); ++i)
+        {
+          boundary_temperature_objects[i]->update();
+        }
+      return;
+    }
+
+
 
     namespace
     {
@@ -90,13 +110,12 @@ namespace aspect
     }
 
 
-
     template <int dim>
     void
-    register_boundary_temperature (const std::string &name,
-                                   const std::string &description,
-                                   void (*declare_parameters_function) (ParameterHandler &),
-                                   Interface<dim> *(*factory_function) ())
+    Manager<dim>::register_boundary_temperature (const std::string &name,
+                                                 const std::string &description,
+                                                 void (*declare_parameters_function) (ParameterHandler &),
+                                                 Interface<dim> *(*factory_function) ())
     {
       std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
@@ -106,52 +125,168 @@ namespace aspect
 
 
     template <int dim>
-    Interface<dim> *
-    create_boundary_temperature (ParameterHandler &prm)
+    void
+    Manager<dim>::parse_parameters (ParameterHandler &prm)
     {
-      std::string model_name;
+      // find out which plugins are requested and the various other
+      // parameters we declare here
       prm.enter_subsection ("Boundary temperature model");
       {
-        model_name = prm.get ("Model name");
+        model_names
+          = Utilities::split_string_list(prm.get("List of model names"));
+
+        AssertThrow(Utilities::has_unique_entries(model_names),
+                    ExcMessage("The list of strings for the parameter "
+                               "'Boundary temperature model/List of model names' contains entries more than once. "
+                               "This is not allowed. Please check your parameter file."));
+
+        const std::string model_name = prm.get ("Model name");
+
+        AssertThrow (model_name == "unspecified" || model_names.size() == 0,
+                     ExcMessage ("The parameter 'Model name' is only used for reasons"
+                                 "of backwards compatibility and can not be used together with "
+                                 "the new functionality 'List of model names'. Please add your "
+                                 "boundary temperature model to the list instead."));
+
+        if (!(model_name == "unspecified"))
+          model_names.push_back(model_name);
+
+        // create operator list
+        std::vector<std::string> model_operator_names =
+          Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
+                                                  model_names.size(),
+                                                  "List of model operators");
+        model_operators = Utilities::create_model_operator_list(model_operator_names);
       }
       prm.leave_subsection ();
 
-      // If one sets the model name to an empty string in the input file,
-      // ParameterHandler produces an error while reading the file. However,
-      // if one omits specifying any model name at all (not even setting it to
-      // the empty string) then the value we get here is the empty string. If
-      // we don't catch this case here, we end up with awkward downstream
-      // errors because the value obviously does not conform to the Pattern.
-      AssertThrow(model_name != "unspecified",
-                  ExcMessage("You need to select a Boundary model for the temperature "
-                             "('set Model name' in 'subsection Boundary temperature model')."));
+      // go through the list, create objects and let them parse
+      // their own parameters
+      for (unsigned int i=0; i<model_names.size(); ++i)
+        {
+          // create boundary temperature objects
+          boundary_temperature_objects.push_back (std_cxx11::shared_ptr<Interface<dim> >
+                                                  (std_cxx11::get<dim>(registered_plugins)
+                                                   .create_plugin (model_names[i],
+                                                                   "Boundary temperature::Model names")));
 
-      return std_cxx11::get<dim>(registered_plugins).create_plugin (model_name,
-                                                                    "Boundary temperature model::Model name");
+          if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(boundary_temperature_objects.back().get()))
+            sim->initialize_simulator (this->get_simulator());
+
+          boundary_temperature_objects.back()->parse_parameters (prm);
+          boundary_temperature_objects.back()->initialize ();
+        }
     }
 
 
 
     template <int dim>
+    double
+    Manager<dim>::boundary_temperature (const types::boundary_id boundary_indicator,
+                                        const Point<dim> &position) const
+    {
+      double temperature = 0.0;
+
+      for (unsigned int i=0; i<boundary_temperature_objects.size(); ++i)
+        temperature = model_operators[i](temperature,
+                                         boundary_temperature_objects[i]->boundary_temperature(boundary_indicator,
+                                             position));
+
+      return temperature;
+    }
+
+
+
+    template <int dim>
+    double
+    Manager<dim>::minimal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids) const
+    {
+      double temperature = std::numeric_limits<double>::max();
+      const Utilities::Operator op(Utilities::Operator::minimum);
+
+      for (unsigned int i=0; i<boundary_temperature_objects.size(); ++i)
+        temperature = op(temperature,boundary_temperature_objects[i]->minimal_temperature(fixed_boundary_ids));
+
+      return temperature;
+    }
+
+
+
+    template <int dim>
+    double
+    Manager<dim>::maximal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids) const
+    {
+      double temperature = 0.0;
+      const Utilities::Operator op(Utilities::Operator::maximum);
+
+      for (unsigned int i=0; i<boundary_temperature_objects.size(); ++i)
+        temperature = op(temperature,boundary_temperature_objects[i]->maximal_temperature(fixed_boundary_ids));
+
+      return temperature;
+    }
+
+
+
+    template <int dim>
+    const std::vector<std::string> &
+    Manager<dim>::get_active_boundary_temperature_names () const
+    {
+      return model_names;
+    }
+
+
+    template <int dim>
+    const std::vector<std_cxx11::shared_ptr<Interface<dim> > > &
+    Manager<dim>::get_active_boundary_temperature_conditions () const
+    {
+      return boundary_temperature_objects;
+    }
+
+
+    template <int dim>
     void
-    declare_parameters (ParameterHandler &prm)
+    Manager<dim>::declare_parameters (ParameterHandler &prm)
     {
       // declare the entry in the parameter file
       prm.enter_subsection ("Boundary temperature model");
       {
         const std::string pattern_of_names
           = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
+
+        prm.declare_entry("List of model names",
+                          "",
+                          Patterns::MultipleSelection(pattern_of_names),
+                          "A comma-separated list of boundary temperature models that "
+                          "will be used to initialize the temperature. "
+                          "These plugins are loaded in the order given, and modify the "
+                          "existing temperature field via the operators listed "
+                          "in 'List of model operators'.\n\n"
+                          "The following boundary temperature models are available:\n\n"
+                          +
+                          std_cxx11::get<dim>(registered_plugins).get_description_string());
+
+        prm.declare_entry("List of model operators", "add",
+                          Patterns::MultipleSelection("add|subtract|minimum|maximum"),
+                          "A comma-separated list of operators that "
+                          "will be used to append the listed temperature models onto "
+                          "the previous models. If only one operator is given, "
+                          "the same operator is applied to all models.");
+
         prm.declare_entry ("Model name", "unspecified",
                            Patterns::Selection (pattern_of_names+"|unspecified"),
                            "Select one of the following models:\n\n"
                            +
-                           std_cxx11::get<dim>(registered_plugins).get_description_string());
+                           std_cxx11::get<dim>(registered_plugins).get_description_string()
+                           + "\n\n" +
+                           "\\textbf{Warning}: This parameter provides an old and "
+                           "deprecated way of specifying "
+                           "boundary temperature models and shouldn't be used. "
+                           "Please use 'List of model names' instead.");
       }
       prm.leave_subsection ();
 
       std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
-
   }
 }
 
@@ -175,21 +310,7 @@ namespace aspect
   {
 #define INSTANTIATE(dim) \
   template class Interface<dim>; \
-  \
-  template \
-  void \
-  register_boundary_temperature<dim> (const std::string &, \
-                                      const std::string &, \
-                                      void ( *) (ParameterHandler &), \
-                                      Interface<dim> *( *) ()); \
-  \
-  template  \
-  void \
-  declare_parameters<dim> (ParameterHandler &); \
-  \
-  template \
-  Interface<dim> * \
-  create_boundary_temperature<dim> (ParameterHandler &prm);
+  template class Manager<dim>;
 
     ASPECT_INSTANTIATE(INSTANTIATE)
   }

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -202,10 +202,10 @@ namespace aspect
     Manager<dim>::minimal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids) const
     {
       double temperature = std::numeric_limits<double>::max();
-      const Utilities::Operator op(Utilities::Operator::minimum);
 
       for (unsigned int i=0; i<boundary_temperature_objects.size(); ++i)
-        temperature = op(temperature,boundary_temperature_objects[i]->minimal_temperature(fixed_boundary_ids));
+        temperature = std::min(temperature,
+                               boundary_temperature_objects[i]->minimal_temperature(fixed_boundary_ids));
 
       return temperature;
     }
@@ -217,10 +217,10 @@ namespace aspect
     Manager<dim>::maximal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids) const
     {
       double temperature = 0.0;
-      const Utilities::Operator op(Utilities::Operator::maximum);
 
       for (unsigned int i=0; i<boundary_temperature_objects.size(); ++i)
-        temperature = op(temperature,boundary_temperature_objects[i]->maximal_temperature(fixed_boundary_ids));
+        temperature = std::max(temperature,
+                               boundary_temperature_objects[i]->maximal_temperature(fixed_boundary_ids));
 
       return temperature;
     }

--- a/source/initial_temperature/adiabatic.cc
+++ b/source/initial_temperature/adiabatic.cc
@@ -60,13 +60,13 @@ namespace aspect
       // at the surface and maximal_temperature() the value at the bottom.
       const double T_surface = (this->has_boundary_temperature()
                                 ?
-                                this->get_boundary_temperature().minimal_temperature(
+                                this->get_boundary_temperature_manager().minimal_temperature(
                                   this->get_fixed_temperature_boundary_indicators())
                                 :
                                 adiabatic_surface_temperature);
       const double T_bottom = (this->has_boundary_temperature()
                                ?
-                               this->get_boundary_temperature().maximal_temperature(
+                               this->get_boundary_temperature_manager().maximal_temperature(
                                  this->get_fixed_temperature_boundary_indicators())
                                :
                                adiabatic_bottom_temperature);

--- a/source/initial_temperature/solidus.cc
+++ b/source/initial_temperature/solidus.cc
@@ -134,7 +134,7 @@ namespace aspect
       AssertThrow(this->has_boundary_temperature(),
                   ExcMessage("This initial condition can only be used with a prescribed boundary temperature."));
 
-      T_min=(this->get_boundary_temperature()).minimal_temperature();
+      T_min=(this->get_boundary_temperature_manager()).minimal_temperature();
 
       // In case of spherical shell calculate spherical coordinates
       const Tensor<1,dim> scoord = spherical_surface_coordinates(position);

--- a/source/initial_temperature/spherical_shell.cc
+++ b/source/initial_temperature/spherical_shell.cc
@@ -113,9 +113,9 @@ namespace aspect
                            +
                            0.2 * s * (1-s) * std::sin(angular_mode*phi +(90 + 2*rotation_offset)*numbers::PI/180 ) * scale;
 
-      return (this->get_boundary_temperature().maximal_temperature()*(s_mod)
+      return (this->get_boundary_temperature_manager().maximal_temperature()*(s_mod)
               +
-              this->get_boundary_temperature().minimal_temperature()*(1-s_mod));
+              this->get_boundary_temperature_manager().minimal_temperature()*(1-s_mod));
     }
 
 
@@ -248,10 +248,10 @@ namespace aspect
           R1 = numbers::signaling_nan<double>();
         }
 
-      const double dT = this->get_boundary_temperature().maximal_temperature()
-                        - this->get_boundary_temperature().minimal_temperature();
-      const double T0 = this->get_boundary_temperature().maximal_temperature()/dT;
-      const double T1 = this->get_boundary_temperature().minimal_temperature()/dT;
+      const double dT = this->get_boundary_temperature_manager().maximal_temperature()
+                        - this->get_boundary_temperature_manager().minimal_temperature();
+      const double T0 = this->get_boundary_temperature_manager().maximal_temperature()/dT;
+      const double T1 = this->get_boundary_temperature_manager().minimal_temperature()/dT;
       const double h = R1-R0;
 
       // s = fraction of the way from

--- a/source/postprocess/basic_statistics.cc
+++ b/source/postprocess/basic_statistics.cc
@@ -47,8 +47,8 @@ namespace aspect
           // temperature contrast is only meaningful if boundary temperatures are prescribed, otherwise it is 0
           const double temperature_contrast = (this->has_boundary_temperature()
                                                ?
-                                               this->get_boundary_temperature().maximal_temperature(this->get_fixed_temperature_boundary_indicators())
-                                               - this->get_boundary_temperature().minimal_temperature(this->get_fixed_temperature_boundary_indicators())
+                                               this->get_boundary_temperature_manager().maximal_temperature(this->get_fixed_temperature_boundary_indicators())
+                                               - this->get_boundary_temperature_manager().minimal_temperature(this->get_fixed_temperature_boundary_indicators())
                                                :
                                                0);
 

--- a/source/postprocess/temperature_statistics.cc
+++ b/source/postprocess/temperature_statistics.cc
@@ -118,14 +118,14 @@ namespace aspect
                             global_max_temperature);
       if ((this->get_fixed_temperature_boundary_indicators().size() > 0)
           &&
-          (this->get_boundary_temperature().maximal_temperature(this->get_fixed_temperature_boundary_indicators())
+          (this->get_boundary_temperature_manager().maximal_temperature(this->get_fixed_temperature_boundary_indicators())
            !=
-           this->get_boundary_temperature().minimal_temperature(this->get_fixed_temperature_boundary_indicators())))
+           this->get_boundary_temperature_manager().minimal_temperature(this->get_fixed_temperature_boundary_indicators())))
         statistics.add_value ("Average nondimensional temperature (K)",
                               (global_mean_temperature - global_min_temperature) /
-                              (this->get_boundary_temperature().maximal_temperature(this->get_fixed_temperature_boundary_indicators())
+                              (this->get_boundary_temperature_manager().maximal_temperature(this->get_fixed_temperature_boundary_indicators())
                                -
-                               this->get_boundary_temperature().minimal_temperature(this->get_fixed_temperature_boundary_indicators())));
+                               this->get_boundary_temperature_manager().minimal_temperature(this->get_fixed_temperature_boundary_indicators())));
 
       // also make sure that the other columns filled by the this object
       // all show up with sufficient accuracy and in scientific notation
@@ -142,9 +142,9 @@ namespace aspect
 
         if ((this->get_fixed_temperature_boundary_indicators().size() > 0)
             &&
-            (this->get_boundary_temperature().maximal_temperature(this->get_fixed_temperature_boundary_indicators())
+            (this->get_boundary_temperature_manager().maximal_temperature(this->get_fixed_temperature_boundary_indicators())
              !=
-             this->get_boundary_temperature().minimal_temperature(this->get_fixed_temperature_boundary_indicators())))
+             this->get_boundary_temperature_manager().minimal_temperature(this->get_fixed_temperature_boundary_indicators())))
           {
             statistics.set_precision ("Average nondimensional temperature (K)", 8);
             statistics.set_scientific ("Average nondimensional temperature (K)", true);

--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -350,7 +350,7 @@ namespace aspect
 
               const double dirichlet_value = (advection_field.is_temperature()
                                               ?
-                                              this->get_boundary_temperature().boundary_temperature(
+                                              this->get_boundary_temperature_manager().boundary_temperature(
                                                 cell->face(face_no)->boundary_id(),
                                                 scratch.face_finite_element_values->quadrature_point(q))
                                               :

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1807,7 +1807,7 @@ namespace aspect
     InitialTemperature::Manager<dim>::declare_parameters (prm);
     InitialComposition::Manager<dim>::declare_parameters (prm);
     PrescribedStokesSolution::declare_parameters<dim> (prm);
-    BoundaryTemperature::declare_parameters<dim> (prm);
+    BoundaryTemperature::Manager<dim>::declare_parameters (prm);
     BoundaryComposition::declare_parameters<dim> (prm);
     AdiabaticConditions::declare_parameters<dim> (prm);
     BoundaryVelocity::declare_parameters<dim> (prm);

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -391,18 +391,29 @@ namespace aspect
   bool
   SimulatorAccess<dim>::has_boundary_temperature () const
   {
-    return (simulator->boundary_temperature.get() != 0);
+    return (get_boundary_temperature_manager().get_active_boundary_temperature_conditions().size() > 0);
   }
+
 
 
   template <int dim>
   const BoundaryTemperature::Interface<dim> &
   SimulatorAccess<dim>::get_boundary_temperature () const
   {
-    AssertThrow (simulator->boundary_temperature.get() != 0,
-                 ExcMessage("You can not call this function if no such model is actually available."));
-    return *simulator->boundary_temperature.get();
+    Assert (get_boundary_temperature_manager().get_active_boundary_temperature_conditions().size() == 1,
+            ExcMessage("You can only call this function if exactly one boundary temperature plugin is active."));
+    return *(get_boundary_temperature_manager().get_active_boundary_temperature_conditions().front());
   }
+
+
+
+  template <int dim>
+  const BoundaryTemperature::Manager<dim> &
+  SimulatorAccess<dim>::get_boundary_temperature_manager () const
+  {
+    return simulator->boundary_temperature_manager;
+  }
+
 
 
   template <int dim>

--- a/tests/additional_outputs.prm
+++ b/tests/additional_outputs.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/additional_outputs_02.prm
+++ b/tests/additional_outputs_02.prm
@@ -18,7 +18,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/additional_outputs_03.prm
+++ b/tests/additional_outputs_03.prm
@@ -18,7 +18,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/adiabatic_boundary.prm
+++ b/tests/adiabatic_boundary.prm
@@ -40,7 +40,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Spherical constant
     set Inner temperature = 4273 # default: 6000

--- a/tests/adiabatic_conditions.prm
+++ b/tests/adiabatic_conditions.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 1613.0

--- a/tests/adiabatic_conditions_composition_function.prm
+++ b/tests/adiabatic_conditions_composition_function.prm
@@ -74,7 +74,7 @@ subsection Initial composition model
 end
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Outer temperature = 1613
     set Inner temperature = 1613

--- a/tests/adiabatic_conditions_function.prm
+++ b/tests/adiabatic_conditions_function.prm
@@ -11,7 +11,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Adiabatic conditions model

--- a/tests/adiabatic_heating.prm
+++ b/tests/adiabatic_heating.prm
@@ -53,7 +53,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary velocity model

--- a/tests/adiabatic_heating_simplified.prm
+++ b/tests/adiabatic_heating_simplified.prm
@@ -55,7 +55,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary velocity model

--- a/tests/adiabatic_heating_with_melt.prm
+++ b/tests/adiabatic_heating_with_melt.prm
@@ -66,7 +66,7 @@ subsection Initial composition model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary composition model

--- a/tests/adiabatic_initial_conditions.prm
+++ b/tests/adiabatic_initial_conditions.prm
@@ -17,7 +17,7 @@ set Nonlinear solver scheme                = IMPES
 ############ These parameters are of interest for this test: #########
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 3000.0

--- a/tests/adiabatic_initial_conditions_chunk.prm
+++ b/tests/adiabatic_initial_conditions_chunk.prm
@@ -42,7 +42,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 

--- a/tests/adiabatic_initial_conditions_chunk_3d.prm
+++ b/tests/adiabatic_initial_conditions_chunk_3d.prm
@@ -46,7 +46,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 

--- a/tests/adiabatic_initial_conditions_compressible.prm
+++ b/tests/adiabatic_initial_conditions_compressible.prm
@@ -13,7 +13,7 @@ set Nonlinear solver scheme                = IMPES
 ############ These parameters are of interest for this test: #########
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 3000.0

--- a/tests/adiabatic_initial_conditions_constant.prm
+++ b/tests/adiabatic_initial_conditions_constant.prm
@@ -17,7 +17,7 @@ set Nonlinear solver scheme                = IMPES
 ############ These parameters are of interest for this test: #########
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 3000.0

--- a/tests/adiabatic_initial_conditions_subadiabaticity.prm
+++ b/tests/adiabatic_initial_conditions_subadiabaticity.prm
@@ -17,7 +17,7 @@ set Nonlinear solver scheme                = IMPES
 ############ These parameters are of interest for this test: #########
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 3000.0

--- a/tests/advect_mesh_vertically.prm
+++ b/tests/advect_mesh_vertically.prm
@@ -13,7 +13,7 @@ set Use years in output instead of seconds = true
 
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = left:0, right:0, bottom:0, top:0
   end

--- a/tests/airy_isostasy.prm
+++ b/tests/airy_isostasy.prm
@@ -33,7 +33,7 @@ end
 
 # Temperature is zero everywhere
 subsection Boundary temperature model
- set Model name = initial temperature
+ set List of model names = initial temperature
 end
 
 subsection Initial temperature model

--- a/tests/always_refine.prm
+++ b/tests/always_refine.prm
@@ -31,7 +31,7 @@ subsection Heating model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/anisotropic_viscosity.prm
+++ b/tests/anisotropic_viscosity.prm
@@ -10,7 +10,7 @@ set Nonlinear solver scheme                = Stokes only
 set Max nonlinear iterations               = 1
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Gravity model

--- a/tests/annulus.prm
+++ b/tests/annulus.prm
@@ -69,7 +69,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/artificial_postprocess.prm
+++ b/tests/artificial_postprocess.prm
@@ -37,7 +37,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/artificial_viscosity.prm
+++ b/tests/artificial_viscosity.prm
@@ -33,7 +33,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
 end
 

--- a/tests/ascii_boundary_member.prm
+++ b/tests/ascii_boundary_member.prm
@@ -27,7 +27,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/ascii_data_adiabatic_conditions.prm
+++ b/tests/ascii_data_adiabatic_conditions.prm
@@ -16,7 +16,7 @@ subsection Adiabatic conditions model
 end
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = top : 3.0, bottom : 4.0
   end

--- a/tests/ascii_data_boundary_composition_2d_box_time.prm
+++ b/tests/ascii_data_boundary_composition_2d_box_time.prm
@@ -29,7 +29,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/ascii_data_boundary_composition_3d_box.prm
+++ b/tests/ascii_data_boundary_composition_3d_box.prm
@@ -39,7 +39,7 @@ subsection Boundary composition model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/ascii_data_boundary_temperature_2d_box_time.prm
+++ b/tests/ascii_data_boundary_temperature_2d_box_time.prm
@@ -28,7 +28,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = ascii data
+  set List of model names = ascii data
 
   subsection Ascii data model
     set Data file name       = box_2d_%s.%d.txt

--- a/tests/ascii_data_boundary_temperature_3d_box.prm
+++ b/tests/ascii_data_boundary_temperature_3d_box.prm
@@ -26,7 +26,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = ascii data
+  set List of model names = ascii data
 
   subsection Ascii data model
     set Data file name       = box_3d_%s.0.txt

--- a/tests/ascii_data_boundary_velocity_2d_box.prm
+++ b/tests/ascii_data_boundary_velocity_2d_box.prm
@@ -27,7 +27,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/ascii_data_boundary_velocity_2d_box_time.prm
+++ b/tests/ascii_data_boundary_velocity_2d_box_time.prm
@@ -29,7 +29,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/ascii_data_boundary_velocity_2d_box_time_backward.prm
+++ b/tests/ascii_data_boundary_velocity_2d_box_time_backward.prm
@@ -29,7 +29,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/ascii_data_boundary_velocity_2d_chunk.prm
+++ b/tests/ascii_data_boundary_velocity_2d_chunk.prm
@@ -27,7 +27,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 3000
     set Outer temperature = 273

--- a/tests/ascii_data_boundary_velocity_2d_shell.prm
+++ b/tests/ascii_data_boundary_velocity_2d_shell.prm
@@ -27,7 +27,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 3000
     set Outer temperature = 273

--- a/tests/ascii_data_boundary_velocity_3d_box.prm
+++ b/tests/ascii_data_boundary_velocity_3d_box.prm
@@ -29,7 +29,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
   set Bottom temperature = 1613
   set Top temperature = 273

--- a/tests/ascii_data_boundary_velocity_3d_chunk.prm
+++ b/tests/ascii_data_boundary_velocity_3d_chunk.prm
@@ -29,7 +29,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 3000
     set Outer temperature = 273

--- a/tests/ascii_data_boundary_velocity_3d_shell.prm
+++ b/tests/ascii_data_boundary_velocity_3d_shell.prm
@@ -27,7 +27,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 3000
     set Outer temperature = 273

--- a/tests/ascii_data_gravity.prm
+++ b/tests/ascii_data_gravity.prm
@@ -16,7 +16,7 @@ subsection Adiabatic conditions model
 end
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = top : 3.0, bottom : 4.0
   end

--- a/tests/ascii_data_initial_composition_2d_box.prm
+++ b/tests/ascii_data_initial_composition_2d_box.prm
@@ -39,7 +39,7 @@ subsection Initial composition model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/ascii_data_initial_composition_3d_chunk.prm
+++ b/tests/ascii_data_initial_composition_3d_chunk.prm
@@ -30,7 +30,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 3000
     set Outer temperature = 273

--- a/tests/ascii_data_initial_composition_3d_shell.prm
+++ b/tests/ascii_data_initial_composition_3d_shell.prm
@@ -28,7 +28,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 3000
     set Outer temperature = 273

--- a/tests/ascii_data_initial_temperature_2d_box.prm
+++ b/tests/ascii_data_initial_temperature_2d_box.prm
@@ -26,7 +26,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/ascii_data_nonuniform_initial_composition_2d_box.prm
+++ b/tests/ascii_data_nonuniform_initial_composition_2d_box.prm
@@ -39,7 +39,7 @@ subsection Initial composition model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary composition model

--- a/tests/ascii_data_prescribed_stokes_2d_box.prm
+++ b/tests/ascii_data_prescribed_stokes_2d_box.prm
@@ -39,7 +39,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/average_arithmetic.prm
+++ b/tests/average_arithmetic.prm
@@ -48,7 +48,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/average_geometric.prm
+++ b/tests/average_geometric.prm
@@ -48,7 +48,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/average_harmonic.prm
+++ b/tests/average_harmonic.prm
@@ -48,7 +48,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/average_log.prm
+++ b/tests/average_log.prm
@@ -48,7 +48,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/average_none.prm
+++ b/tests/average_none.prm
@@ -48,7 +48,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/average_nwd_arithmetic.prm
+++ b/tests/average_nwd_arithmetic.prm
@@ -53,7 +53,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/average_nwd_geometric.prm
+++ b/tests/average_nwd_geometric.prm
@@ -52,7 +52,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/average_nwd_harmonic.prm
+++ b/tests/average_nwd_harmonic.prm
@@ -52,7 +52,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/average_pick_largest.prm
+++ b/tests/average_pick_largest.prm
@@ -48,7 +48,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/average_project_to_q1.prm
+++ b/tests/average_project_to_q1.prm
@@ -48,7 +48,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/backward_advection.prm
+++ b/tests/backward_advection.prm
@@ -11,7 +11,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 1

--- a/tests/blankenbach.prm
+++ b/tests/blankenbach.prm
@@ -15,7 +15,7 @@ set Use years in output instead of seconds = false
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 1
     set Left temperature   = 0

--- a/tests/blankenbach_approximation.prm
+++ b/tests/blankenbach_approximation.prm
@@ -17,7 +17,7 @@ subsection Adiabatic conditions model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 1
     set Left temperature   = 0

--- a/tests/blankenbach_case1a.prm
+++ b/tests/blankenbach_case1a.prm
@@ -16,7 +16,7 @@ subsection Adiabatic conditions model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 1
     set Left temperature   = 0

--- a/tests/blankenbach_case2b.prm
+++ b/tests/blankenbach_case2b.prm
@@ -16,7 +16,7 @@ subsection Adiabatic conditions model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 1
     set Left temperature   = 0

--- a/tests/boundary_temperature_function.prm
+++ b/tests/boundary_temperature_function.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = function
+  set List of model names = function
   subsection Function
     set Function expression = x * 1600
   end

--- a/tests/boundary_temperature_list.prm
+++ b/tests/boundary_temperature_list.prm
@@ -1,0 +1,83 @@
+# simple test for using multiple boundary temperature plugins
+
+set Dimension                              = 2
+
+set Use years in output instead of seconds = true
+set End time                               = 0
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 660000
+    set Y extent = 660000
+  end
+end
+
+subsection Initial temperature model
+  set List of model names = function
+
+  subsection Function
+    set Function expression = if ((x-330000)*(x-330000)+(y-330000)*(y-330000) < 100000*100000,-1,1.5)
+  end
+end
+
+
+subsection Boundary temperature model
+  set List of model names = box, constant, function, initial temperature
+  set List of model operators = maximum, add, subtract, add
+
+  subsection Box
+    set Left temperature = 15
+  end
+
+  subsection Constant
+    set Boundary indicator to temperature mappings = bottom:7, left:0, top:0, right:0
+  end
+
+  subsection Function
+    set Function expression = if (x>500000,3,0)
+  end
+end
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = top,left,bottom,right
+  set Prescribed velocity boundary indicators = bottom:function,left:function,right:function,top:function
+end
+
+
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = 1;0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Viscosity = 1e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 4
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+end
+
+
+subsection Postprocess
+  set List of postprocessors = temperature statistics
+end
+

--- a/tests/boundary_temperature_list/screen-output
+++ b/tests/boundary_temperature_list/screen-output
@@ -1,0 +1,19 @@
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 3,556 (2,178+289+1,089)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 33+0 iterations.
+
+   Postprocessing:
+     Temperature min/avg/max: -1.5 K, 1.52 K, 16.5 K
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/boundary_temperature_list/statistics
+++ b/tests/boundary_temperature_list/statistics
@@ -1,0 +1,15 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Minimal temperature (K)
+# 12: Average temperature (K)
+# 13: Maximal temperature (K)
+# 14: Average nondimensional temperature (K)
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 0 33 34 34 -1.50000000e+00 1.52039931e+00 1.65000000e+01 8.00529898e-04 

--- a/tests/box_end_time_1e7_terminate.prm
+++ b/tests/box_end_time_1e7_terminate.prm
@@ -13,7 +13,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/box_first_time_step.prm
+++ b/tests/box_first_time_step.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/box_first_time_step_alternate_bc.prm
+++ b/tests/box_first_time_step_alternate_bc.prm
@@ -15,7 +15,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/box_initial_topography_ascii_data.prm
+++ b/tests/box_initial_topography_ascii_data.prm
@@ -52,7 +52,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = function 
+  set List of model names = function 
   subsection Function
     set Function expression = 1613.0
   end

--- a/tests/box_initial_topography_prm_polygon.prm
+++ b/tests/box_initial_topography_prm_polygon.prm
@@ -54,7 +54,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = function 
+  set List of model names = function 
   subsection Function
     set Function expression = 1613.0
   end

--- a/tests/box_lithostatic_pressure_2d.prm
+++ b/tests/box_lithostatic_pressure_2d.prm
@@ -81,7 +81,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/box_lithostatic_pressure_3d.prm
+++ b/tests/box_lithostatic_pressure_3d.prm
@@ -80,7 +80,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/box_origin.prm
+++ b/tests/box_origin.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/box_repetitions.prm
+++ b/tests/box_repetitions.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/box_steady_state_terminate.prm
+++ b/tests/box_steady_state_terminate.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/burnman_seismic_test.prm
+++ b/tests/burnman_seismic_test.prm
@@ -83,7 +83,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 3500 
     set Outer temperature = 273

--- a/tests/burnman_test.prm
+++ b/tests/burnman_test.prm
@@ -83,7 +83,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 3500 
     set Outer temperature = 273

--- a/tests/burstedde.prm
+++ b/tests/burstedde.prm
@@ -68,7 +68,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/burstedde_stokes_rhs.prm
+++ b/tests/burstedde_stokes_rhs.prm
@@ -72,7 +72,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/cell_reference.prm
+++ b/tests/cell_reference.prm
@@ -14,7 +14,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/cells_in_circumference.prm
+++ b/tests/cells_in_circumference.prm
@@ -11,7 +11,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 1613.0

--- a/tests/checkpoint_01.prm
+++ b/tests/checkpoint_01.prm
@@ -20,7 +20,7 @@ set Use direct solver for Stokes system    = true
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Checkpointing

--- a/tests/checkpoint_02.prm
+++ b/tests/checkpoint_02.prm
@@ -18,7 +18,7 @@ set Use direct solver for Stokes system    = true
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Checkpointing

--- a/tests/checkpoint_02_petsc.prm
+++ b/tests/checkpoint_02_petsc.prm
@@ -15,7 +15,7 @@ set Use direct solver for Stokes system    = false
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Checkpointing

--- a/tests/chunk_ascii_initial_temperature.prm
+++ b/tests/chunk_ascii_initial_temperature.prm
@@ -46,7 +46,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 0
     set Outer temperature = 0

--- a/tests/chunk_conditions.prm
+++ b/tests/chunk_conditions.prm
@@ -45,7 +45,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 1800
     set Outer temperature = 273

--- a/tests/chunk_cross_hemisphere.prm
+++ b/tests/chunk_cross_hemisphere.prm
@@ -43,7 +43,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = function
+  set List of model names = function
   subsection Function
     set Function expression = 1613.0
   end

--- a/tests/chunk_first_time_step_2d.prm
+++ b/tests/chunk_first_time_step_2d.prm
@@ -43,7 +43,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = function
+  set List of model names = function
   subsection Function
     set Function expression = 1613.0
   end

--- a/tests/chunk_first_time_step_3d.prm
+++ b/tests/chunk_first_time_step_3d.prm
@@ -46,7 +46,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = function
+  set List of model names = function
   subsection Function
     set Function expression = 1613.0
   end

--- a/tests/chunk_lithostatic_pressure_2d.prm
+++ b/tests/chunk_lithostatic_pressure_2d.prm
@@ -26,7 +26,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 

--- a/tests/chunk_topography_postprocessor.prm
+++ b/tests/chunk_topography_postprocessor.prm
@@ -16,7 +16,7 @@ set Timing output frequency                = 5
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
   end

--- a/tests/command_postprocessor.prm
+++ b/tests/command_postprocessor.prm
@@ -5,7 +5,7 @@ set Dimension = 2
 set End time                               = 0
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Geometry model

--- a/tests/composition-passive_quarter-shell-cartesian.prm
+++ b/tests/composition-passive_quarter-shell-cartesian.prm
@@ -32,7 +32,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 1
     set Outer temperature = 0 

--- a/tests/composition-passive_quarter-shell-depth.prm
+++ b/tests/composition-passive_quarter-shell-depth.prm
@@ -32,7 +32,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 1
     set Outer temperature = 0 

--- a/tests/composition-passive_quarter-shell-spherical.prm
+++ b/tests/composition-passive_quarter-shell-spherical.prm
@@ -32,7 +32,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 1
     set Outer temperature = 0 

--- a/tests/composition_active.prm
+++ b/tests/composition_active.prm
@@ -32,7 +32,7 @@ subsection Heating model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/composition_active_with_melt.prm
+++ b/tests/composition_active_with_melt.prm
@@ -43,7 +43,7 @@ subsection Heating model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/composition_active_without_melt.prm
+++ b/tests/composition_active_without_melt.prm
@@ -39,7 +39,7 @@ subsection Heating model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/composition_names.prm
+++ b/tests/composition_names.prm
@@ -38,7 +38,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/composition_passive_particles.prm
+++ b/tests/composition_passive_particles.prm
@@ -31,7 +31,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/composition_reaction.prm
+++ b/tests/composition_reaction.prm
@@ -46,7 +46,7 @@ end
 # We then set the temperature to one at the bottom and zero
 # at the top: 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   
   subsection Box
     set Bottom temperature = 1

--- a/tests/composition_reaction_iterated_IMPES.prm
+++ b/tests/composition_reaction_iterated_IMPES.prm
@@ -58,7 +58,7 @@ end
 # We then set the temperature to one at the bottom and zero
 # at the top: 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   
   subsection Box
     set Bottom temperature = 1

--- a/tests/composition_stabilization.prm
+++ b/tests/composition_stabilization.prm
@@ -38,7 +38,7 @@ subsection Heating model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/compositional_boundary_values.prm
+++ b/tests/compositional_boundary_values.prm
@@ -16,7 +16,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/compositional_boundary_values_02.prm
+++ b/tests/compositional_boundary_values_02.prm
@@ -14,7 +14,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/compositional_boundary_values_03.prm
+++ b/tests/compositional_boundary_values_03.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/compositional_heating.prm
+++ b/tests/compositional_heating.prm
@@ -35,7 +35,7 @@ end
 
 # Temperature boundary conditions
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 1543
     set Top temperature    =  273

--- a/tests/compositional_vectors.prm
+++ b/tests/compositional_vectors.prm
@@ -10,7 +10,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Model settings

--- a/tests/compositional_vectors_3d.prm
+++ b/tests/compositional_vectors_3d.prm
@@ -10,7 +10,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Model settings

--- a/tests/compressibility.prm
+++ b/tests/compressibility.prm
@@ -46,7 +46,7 @@ set Max nonlinear iterations               = 1
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/compressibility_iterated_stokes.prm
+++ b/tests/compressibility_iterated_stokes.prm
@@ -34,7 +34,7 @@ set Max nonlinear iterations               = 5
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/compressibility_iterated_stokes_direct_solver.prm
+++ b/tests/compressibility_iterated_stokes_direct_solver.prm
@@ -15,7 +15,7 @@ set Max nonlinear iterations               = 5
 set Use direct solver for Stokes system = true
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/compression_heating.prm
+++ b/tests/compression_heating.prm
@@ -63,7 +63,7 @@ subsection Initial composition model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary composition model

--- a/tests/conservative_with_mpi.prm
+++ b/tests/conservative_with_mpi.prm
@@ -28,7 +28,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/constant_composition_convergence.prm
+++ b/tests/constant_composition_convergence.prm
@@ -27,7 +27,7 @@ subsection Model settings
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary composition model

--- a/tests/constant_temperature_boundary_conditions.prm
+++ b/tests/constant_temperature_boundary_conditions.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0 : 0.0, 1 : 1.0, 2:2.0, 3:3.0
   end

--- a/tests/coordinate_transformation.prm
+++ b/tests/coordinate_transformation.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/density_boundary.prm
+++ b/tests/density_boundary.prm
@@ -13,7 +13,7 @@ set Adiabatic surface temperature          = 1600.0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4250
     set Outer temperature = 273

--- a/tests/depth_average_01.prm
+++ b/tests/depth_average_01.prm
@@ -38,7 +38,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/depth_average_02.prm
+++ b/tests/depth_average_02.prm
@@ -36,7 +36,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/depth_average_03.prm
+++ b/tests/depth_average_03.prm
@@ -39,7 +39,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/depth_average_04.prm
+++ b/tests/depth_average_04.prm
@@ -36,7 +36,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/depth_average_05.prm
+++ b/tests/depth_average_05.prm
@@ -36,7 +36,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/depth_average_rounding_bug.prm
+++ b/tests/depth_average_rounding_bug.prm
@@ -44,7 +44,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = function
+  set List of model names = function
   subsection Function
     set Function expression = 1613.0
   end

--- a/tests/depth_average_txt_output.prm
+++ b/tests/depth_average_txt_output.prm
@@ -36,7 +36,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/depth_average_underres.prm
+++ b/tests/depth_average_underres.prm
@@ -40,7 +40,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/depth_dependent_3d_shell_list_simple.prm
+++ b/tests/depth_dependent_3d_shell_list_simple.prm
@@ -48,7 +48,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 1973
     set Outer temperature = 973

--- a/tests/depth_dependent_box_file_simple.prm
+++ b/tests/depth_dependent_box_file_simple.prm
@@ -74,7 +74,7 @@ end
 # in the next section, the actual temperature prescribed here
 # at the left and right does not matter.)
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 2773

--- a/tests/depth_dependent_box_function_simple.prm
+++ b/tests/depth_dependent_box_function_simple.prm
@@ -74,7 +74,7 @@ end
 # in the next section, the actual temperature prescribed here
 # at the left and right does not matter.)
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 2773

--- a/tests/depth_dependent_box_none_simple.prm
+++ b/tests/depth_dependent_box_none_simple.prm
@@ -74,7 +74,7 @@ end
 # in the next section, the actual temperature prescribed here
 # at the left and right does not matter.)
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 2773

--- a/tests/depth_postprocessor_box.prm
+++ b/tests/depth_postprocessor_box.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/depth_postprocessor_chunk.prm
+++ b/tests/depth_postprocessor_chunk.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 end
 
 

--- a/tests/depth_postprocessor_ellipsoidal_chunk.prm
+++ b/tests/depth_postprocessor_ellipsoidal_chunk.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = constant 
+  set List of model names = constant 
   subsection Constant
     set Boundary indicator to temperature mappings = west: 0, east: 1, south: 2, north: 3, inner: 4, outer:5
   end

--- a/tests/depth_postprocessor_sphere.prm
+++ b/tests/depth_postprocessor_sphere.prm
@@ -7,7 +7,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = surface: 0.0
   end

--- a/tests/depth_postprocessor_spherical_shell.prm
+++ b/tests/depth_postprocessor_spherical_shell.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 end
 
 

--- a/tests/depth_postprocessor_two_merged_boxes.prm
+++ b/tests/depth_postprocessor_two_merged_boxes.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 

--- a/tests/diffusion.prm
+++ b/tests/diffusion.prm
@@ -108,7 +108,7 @@ subsection Boundary temperature model
   # `spherical constant': A model in which the temperature is chosen constant
   # on the inner and outer boundaries of a spherical shell. Parameters are
   # read from subsection 'Sherical constant'.
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 0

--- a/tests/diffusion_dislocation.prm
+++ b/tests/diffusion_dislocation.prm
@@ -96,7 +96,7 @@ subsection Material model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary composition model

--- a/tests/diffusion_dislocation_fixed_strain_rate.prm
+++ b/tests/diffusion_dislocation_fixed_strain_rate.prm
@@ -74,7 +74,7 @@ subsection Material model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 

--- a/tests/diffusion_velocity.prm
+++ b/tests/diffusion_velocity.prm
@@ -108,7 +108,7 @@ subsection Boundary temperature model
   # `spherical constant': A model in which the temperature is chosen constant
   # on the inner and outer boundaries of a spherical shell. Parameters are
   # read from subsection 'Sherical constant'.
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 0

--- a/tests/direct_solver_1.prm
+++ b/tests/direct_solver_1.prm
@@ -46,7 +46,7 @@ end
 ############### Boundary conditions
 # We set the top temperature to T1=1000K. 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 1000
   end

--- a/tests/direct_solver_2.prm
+++ b/tests/direct_solver_2.prm
@@ -45,7 +45,7 @@ end
 ############### Boundary conditions
 # We set the top temperature to T1=1000K. 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 1000
   end

--- a/tests/discontinuous_composition_1.prm
+++ b/tests/discontinuous_composition_1.prm
@@ -27,7 +27,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/discontinuous_composition_bound_preserving_limiter.prm
+++ b/tests/discontinuous_composition_bound_preserving_limiter.prm
@@ -45,7 +45,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/discontinuous_composition_bound_preserving_limiter_3d.prm
+++ b/tests/discontinuous_composition_bound_preserving_limiter_3d.prm
@@ -46,7 +46,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/discontinuous_temperature.prm
+++ b/tests/discontinuous_temperature.prm
@@ -27,7 +27,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/discontinuous_temperature_spherical_shell_3d.prm
+++ b/tests/discontinuous_temperature_spherical_shell_3d.prm
@@ -26,7 +26,7 @@ end
 # the domain. Here we set the temperature to be constant.
 # Alternatively it could be set to the initial condition.
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 1600
     set Outer temperature = 1600

--- a/tests/drucker_prager_compression.prm
+++ b/tests/drucker_prager_compression.prm
@@ -84,7 +84,7 @@ end
 # We set the temperature to zero, as it is not important.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Left temperature = 0
   end

--- a/tests/drucker_prager_extension.prm
+++ b/tests/drucker_prager_extension.prm
@@ -84,7 +84,7 @@ end
 # We set the temperature to zero, as it is not important.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Left temperature = 0
   end

--- a/tests/dynamic_friction.prm
+++ b/tests/dynamic_friction.prm
@@ -93,7 +93,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/dynamic_topography.prm
+++ b/tests/dynamic_topography.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 
@@ -61,7 +61,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature  = 1600

--- a/tests/dynamic_topography2.prm
+++ b/tests/dynamic_topography2.prm
@@ -13,7 +13,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 
@@ -62,7 +62,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature  = 1600

--- a/tests/dynamic_topography3.prm
+++ b/tests/dynamic_topography3.prm
@@ -7,7 +7,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 1600
     set Outer temperature = 1600

--- a/tests/dynamic_topography_back.prm
+++ b/tests/dynamic_topography_back.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 
@@ -61,7 +61,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature  = 1600

--- a/tests/edit_parameters.prm
+++ b/tests/edit_parameters.prm
@@ -11,7 +11,7 @@ set Switch step = 5
 
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:0,1:0,2:10,3:0
   end

--- a/tests/ellipsoidal_chunk_coordinate_parallel.prm
+++ b/tests/ellipsoidal_chunk_coordinate_parallel.prm
@@ -40,7 +40,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = west: 0, east: 1, south: 2, north: 3, inner: 4, outer:5
   end

--- a/tests/ellipsoidal_chunk_noncoordinate_parallel.prm
+++ b/tests/ellipsoidal_chunk_noncoordinate_parallel.prm
@@ -42,7 +42,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = constant 
+  set List of model names = constant 
   subsection Constant
     set Boundary indicator to temperature mappings = west: 0, east: 1, south: 2, north: 3, inner: 4, outer:5
   end

--- a/tests/ellipsoidal_chunk_topography.prm
+++ b/tests/ellipsoidal_chunk_topography.prm
@@ -47,7 +47,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = west: 0, east: 1, south: 2, north: 3, inner: 4, outer:5
   end

--- a/tests/find_postprocess.prm
+++ b/tests/find_postprocess.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box2
+  set List of model names = box2
 end
 
 

--- a/tests/free_surface_adaptive_blob.prm
+++ b/tests/free_surface_adaptive_blob.prm
@@ -17,7 +17,7 @@ set Timing output frequency                = 5
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
   end

--- a/tests/free_surface_adaptive_blob_petsc.prm
+++ b/tests/free_surface_adaptive_blob_petsc.prm
@@ -17,7 +17,7 @@ set Timing output frequency                = 5
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
   end

--- a/tests/free_surface_blob.prm
+++ b/tests/free_surface_blob.prm
@@ -15,7 +15,7 @@ set Timing output frequency                = 5
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
   end

--- a/tests/free_surface_iterated_stokes.prm
+++ b/tests/free_surface_iterated_stokes.prm
@@ -16,7 +16,7 @@ set Timing output frequency                = 5
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
   end

--- a/tests/free_surface_relaxation.prm
+++ b/tests/free_surface_relaxation.prm
@@ -16,7 +16,7 @@ set Timing output frequency                = 5
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
   end

--- a/tests/free_surface_tangential_mesh_velocity.prm
+++ b/tests/free_surface_tangential_mesh_velocity.prm
@@ -26,7 +26,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = function
+  set List of model names = function
 
   # box prescribes a constant temp, function is for a function
   subsection Function

--- a/tests/geoid.prm
+++ b/tests/geoid.prm
@@ -50,7 +50,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = function
+  set List of model names = function
   subsection Function
     set Coordinate system = spherical
     set Function constants = pi=3.1415926536

--- a/tests/geoid_visualization.prm
+++ b/tests/geoid_visualization.prm
@@ -47,7 +47,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = function
+  set List of model names = function
   subsection Function
     set Coordinate system = spherical
     set Function constants = pi=3.1415926536

--- a/tests/geometric_average_crash.prm
+++ b/tests/geometric_average_crash.prm
@@ -40,7 +40,7 @@
  end
 
  subsection Boundary temperature model
-   set Model name    = initial temperature
+   set List of model names    = initial temperature
  end
 
  subsection Gravity model

--- a/tests/global_melt.prm
+++ b/tests/global_melt.prm
@@ -46,7 +46,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     set Minimal temperature = 293 # default: 6000

--- a/tests/global_refine_amr.prm
+++ b/tests/global_refine_amr.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/gplates_1_3.prm
+++ b/tests/gplates_1_3.prm
@@ -51,7 +51,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 2600 
     set Outer temperature = 273 

--- a/tests/gplates_1_4.prm
+++ b/tests/gplates_1_4.prm
@@ -54,7 +54,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 2600 
     set Outer temperature = 273 

--- a/tests/gplates_3d.prm
+++ b/tests/gplates_3d.prm
@@ -50,7 +50,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 2600 
     set Outer temperature = 273 

--- a/tests/gplates_rotation.prm
+++ b/tests/gplates_rotation.prm
@@ -50,7 +50,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 2600 
     set Outer temperature = 273 

--- a/tests/graphical_output.prm
+++ b/tests/graphical_output.prm
@@ -23,7 +23,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/graphical_output_02.prm
+++ b/tests/graphical_output_02.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/graphical_output_hdf5.prm
+++ b/tests/graphical_output_hdf5.prm
@@ -24,7 +24,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/gravity_function.prm
+++ b/tests/gravity_function.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/heat_advection_by_melt.prm
+++ b/tests/heat_advection_by_melt.prm
@@ -63,7 +63,7 @@ subsection Initial composition model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary composition model

--- a/tests/heat_flux_densities.prm
+++ b/tests/heat_flux_densities.prm
@@ -16,7 +16,7 @@ subsection Adiabatic conditions model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 1
     set Left temperature   = 0

--- a/tests/heat_flux_map.prm
+++ b/tests/heat_flux_map.prm
@@ -30,7 +30,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/heat_flux_map_vis.prm
+++ b/tests/heat_flux_map_vis.prm
@@ -30,7 +30,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/hexagonal_initial_temperature.prm
+++ b/tests/hexagonal_initial_temperature.prm
@@ -11,7 +11,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 1

--- a/tests/hollow_sphere.prm
+++ b/tests/hollow_sphere.prm
@@ -62,7 +62,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box 
+  set List of model names = box 
 end
 
 subsection Initial temperature model 

--- a/tests/inclusion_2.prm
+++ b/tests/inclusion_2.prm
@@ -27,7 +27,7 @@ set Use years in output instead of seconds = false  # default: true
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/inclusion_4.prm
+++ b/tests/inclusion_4.prm
@@ -26,7 +26,7 @@ set Use years in output instead of seconds = false  # default: true
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/inclusion_adaptive.prm
+++ b/tests/inclusion_adaptive.prm
@@ -26,7 +26,7 @@ set Use years in output instead of seconds = false  # default: true
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/initial_composition_list.prm
+++ b/tests/initial_composition_list.prm
@@ -43,7 +43,7 @@ subsection Initial composition model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/initial_composition_list_using_maximum.prm
+++ b/tests/initial_composition_list_using_maximum.prm
@@ -44,7 +44,7 @@ subsection Initial composition model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/initial_composition_list_using_minimum.prm
+++ b/tests/initial_composition_list_using_minimum.prm
@@ -44,7 +44,7 @@ subsection Initial composition model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/initial_composition_list_using_subtract.prm
+++ b/tests/initial_composition_list_using_subtract.prm
@@ -44,7 +44,7 @@ subsection Initial composition model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/initial_condition_S20RTS.prm
+++ b/tests/initial_condition_S20RTS.prm
@@ -35,7 +35,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 1600
     set Outer temperature = 1600

--- a/tests/initial_condition_S40RTS.prm
+++ b/tests/initial_condition_S40RTS.prm
@@ -36,7 +36,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 1600
     set Outer temperature = 1600

--- a/tests/initial_condition_SAVANI.prm
+++ b/tests/initial_condition_SAVANI.prm
@@ -37,7 +37,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 1600
     set Outer temperature = 1600

--- a/tests/initial_porosity.prm
+++ b/tests/initial_porosity.prm
@@ -52,7 +52,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     set Minimal temperature = 293 # default: 6000

--- a/tests/initial_temperature_list.prm
+++ b/tests/initial_temperature_list.prm
@@ -30,7 +30,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/initial_temperature_list_using_maximum.prm
+++ b/tests/initial_temperature_list_using_maximum.prm
@@ -31,7 +31,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/initial_temperature_list_using_minimum.prm
+++ b/tests/initial_temperature_list_using_minimum.prm
@@ -31,7 +31,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/initial_temperature_list_using_subtract.prm
+++ b/tests/initial_temperature_list_using_subtract.prm
@@ -31,7 +31,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/inner_core.prm
+++ b/tests/inner_core.prm
@@ -85,7 +85,7 @@ end
 
 # The (potential) temperature is set to zero at the outer boundary.
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 0.8
     set Outer temperature = 0

--- a/tests/internal_heating_statistics.prm
+++ b/tests/internal_heating_statistics.prm
@@ -51,7 +51,7 @@ end
 ############### Boundary conditions
 # We set the top temperature to T1=1000K. 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 1000
   end

--- a/tests/iterated_IMPES.prm
+++ b/tests/iterated_IMPES.prm
@@ -42,7 +42,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Top temperature = 0 # default: 6000

--- a/tests/iterated_IMPES_direct_solver.prm
+++ b/tests/iterated_IMPES_direct_solver.prm
@@ -45,7 +45,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Top temperature = 0 # default: 6000

--- a/tests/iterated_IMPES_residual.prm
+++ b/tests/iterated_IMPES_residual.prm
@@ -41,7 +41,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Top temperature = 0 # default: 6000

--- a/tests/king_ala.prm
+++ b/tests/king_ala.prm
@@ -152,7 +152,7 @@ end
 # in the next section, the actual temperature prescribed here
 # at the left and right does not matter.)
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 
   subsection Box

--- a/tests/king_ala_nondim.prm
+++ b/tests/king_ala_nondim.prm
@@ -108,7 +108,7 @@ end
 # in the next section, the actual temperature prescribed here
 # at the left and right does not matter.)
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 
   subsection Box

--- a/tests/latent_heat.prm
+++ b/tests/latent_heat.prm
@@ -42,7 +42,7 @@ end
 ############### Boundary conditions
 # We set the top temperature to T1=1000K. 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 1000
   end

--- a/tests/latent_heat_melt.prm
+++ b/tests/latent_heat_melt.prm
@@ -71,7 +71,7 @@ end
 ############### Boundary conditions
 # We set the top temperature to T1=1000K. 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 1000
     set Bottom temperature = 1000

--- a/tests/latent_heat_melt_statistics.prm
+++ b/tests/latent_heat_melt_statistics.prm
@@ -73,7 +73,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Model settings

--- a/tests/latent_heat_viscosity.prm
+++ b/tests/latent_heat_viscosity.prm
@@ -60,7 +60,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 2600 
     set Outer temperature = 273 

--- a/tests/lithosphere_boundary_indicator.prm
+++ b/tests/lithosphere_boundary_indicator.prm
@@ -16,7 +16,7 @@ set Nonlinear solver scheme                = IMPES
 # with additional boundary indicators 
 # as prescribed by the geometry model
 subsection Boundary temperature model
-  set Model name = box with lithosphere boundary indicators
+  set List of model names = box with lithosphere boundary indicators
   subsection Box with lithosphere boundary indicators
     set Left temperature = 0
   end

--- a/tests/lithosphere_boundary_indicator_3d.prm
+++ b/tests/lithosphere_boundary_indicator_3d.prm
@@ -17,7 +17,7 @@ set Nonlinear solver scheme                = IMPES
 # with additional boundary indicators 
 # as prescribed by the geometry model
 subsection Boundary temperature model
-  set Model name = box with lithosphere boundary indicators
+  set List of model names = box with lithosphere boundary indicators
   subsection Box with lithosphere boundary indicators
     set Left temperature = 0
   end

--- a/tests/mass_flux_statistics.prm
+++ b/tests/mass_flux_statistics.prm
@@ -6,7 +6,7 @@ set CFL number                             = 1.0
 set End time                               = 0
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/material_model_dependencies_burstedde.prm
+++ b/tests/material_model_dependencies_burstedde.prm
@@ -70,7 +70,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/material_model_dependencies_composition_reaction.prm
+++ b/tests/material_model_dependencies_composition_reaction.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/material_model_dependencies_cookbooks_freesurface_with_crust.prm
+++ b/tests/material_model_dependencies_cookbooks_freesurface_with_crust.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/material_model_dependencies_diffusion_dislocation.prm
+++ b/tests/material_model_dependencies_diffusion_dislocation.prm
@@ -69,7 +69,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 

--- a/tests/material_model_dependencies_inclusion_2.prm
+++ b/tests/material_model_dependencies_inclusion_2.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/material_model_dependencies_latent_heat.prm
+++ b/tests/material_model_dependencies_latent_heat.prm
@@ -61,7 +61,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/material_model_dependencies_latent_heat_melt.prm
+++ b/tests/material_model_dependencies_latent_heat_melt.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/material_model_dependencies_morency_doin.prm
+++ b/tests/material_model_dependencies_morency_doin.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/material_model_dependencies_multicomponent.prm
+++ b/tests/material_model_dependencies_multicomponent.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/material_model_dependencies_shear_thinning.prm
+++ b/tests/material_model_dependencies_shear_thinning.prm
@@ -31,7 +31,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/material_model_dependencies_simple.prm
+++ b/tests/material_model_dependencies_simple.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/material_model_dependencies_simple_compressible.prm
+++ b/tests/material_model_dependencies_simple_compressible.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/material_model_dependencies_simpler.prm
+++ b/tests/material_model_dependencies_simpler.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/material_model_dependencies_solcx.prm
+++ b/tests/material_model_dependencies_solcx.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/material_model_dependencies_solkz.prm
+++ b/tests/material_model_dependencies_solkz.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/material_model_dependencies_steinberger.prm
+++ b/tests/material_model_dependencies_steinberger.prm
@@ -34,7 +34,7 @@ set Adiabatic surface temperature          = 1600.0
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4250
     set Outer temperature = 273

--- a/tests/material_model_dependencies_tangurnis.prm
+++ b/tests/material_model_dependencies_tangurnis.prm
@@ -33,7 +33,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/matrix_nonzeros_1.prm
+++ b/tests/matrix_nonzeros_1.prm
@@ -11,7 +11,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/matrix_nonzeros_2.prm
+++ b/tests/matrix_nonzeros_2.prm
@@ -10,7 +10,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/matrix_nonzeros_3.prm
+++ b/tests/matrix_nonzeros_3.prm
@@ -11,7 +11,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/maximum_refinement_function.prm
+++ b/tests/maximum_refinement_function.prm
@@ -43,7 +43,7 @@ subsection Boundary temperature model
   # 
   # `box': A model in which the temperature is chosen constant on all the
   # sides of a box.
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/maximum_refinement_function_cartesian.prm
+++ b/tests/maximum_refinement_function_cartesian.prm
@@ -43,7 +43,7 @@ subsection Boundary temperature model
   # 
   # `box': A model in which the temperature is chosen constant on all the
   # sides of a box.
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/maximum_refinement_function_spherical.prm
+++ b/tests/maximum_refinement_function_spherical.prm
@@ -36,7 +36,7 @@ subsection Boundary temperature model
   # 
   # `box': A model in which the temperature is chosen constant on all the
   # sides of a box.
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/maxtimestep.prm
+++ b/tests/maxtimestep.prm
@@ -13,7 +13,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/melt_compressible_advection.prm
+++ b/tests/melt_compressible_advection.prm
@@ -44,7 +44,7 @@ subsection Discretization
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/melt_force_vector.prm
+++ b/tests/melt_force_vector.prm
@@ -52,7 +52,7 @@ subsection Boundary fluid pressure model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/melt_introspection.prm
+++ b/tests/melt_introspection.prm
@@ -18,7 +18,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Compositional fields

--- a/tests/melt_material_1.prm
+++ b/tests/melt_material_1.prm
@@ -27,7 +27,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/melt_material_2.prm
+++ b/tests/melt_material_2.prm
@@ -43,7 +43,7 @@ subsection Boundary fluid pressure model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/melt_material_3.prm
+++ b/tests/melt_material_3.prm
@@ -43,7 +43,7 @@ subsection Boundary fluid pressure model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/melt_material_4.prm
+++ b/tests/melt_material_4.prm
@@ -52,7 +52,7 @@ subsection Boundary fluid pressure model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/melt_postprocessor_peridotite.prm
+++ b/tests/melt_postprocessor_peridotite.prm
@@ -57,7 +57,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Model settings

--- a/tests/melt_postprocessor_pyroxenite.prm
+++ b/tests/melt_postprocessor_pyroxenite.prm
@@ -76,7 +76,7 @@ subsection Initial composition model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Boundary composition model

--- a/tests/melt_property_visualization.prm
+++ b/tests/melt_property_visualization.prm
@@ -42,7 +42,7 @@ subsection Boundary fluid pressure model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/melt_statistics.prm
+++ b/tests/melt_statistics.prm
@@ -73,7 +73,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Model settings

--- a/tests/melt_track.prm
+++ b/tests/melt_track.prm
@@ -46,7 +46,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/melt_transport.prm
+++ b/tests/melt_transport.prm
@@ -40,7 +40,7 @@ subsection Discretization
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/melt_transport_adaptive.prm
+++ b/tests/melt_transport_adaptive.prm
@@ -58,7 +58,7 @@ subsection Boundary fluid pressure model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/melt_transport_compressible.prm
+++ b/tests/melt_transport_compressible.prm
@@ -49,7 +49,7 @@ subsection Boundary fluid pressure model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/melt_transport_compressible_iterative.prm
+++ b/tests/melt_transport_compressible_iterative.prm
@@ -47,7 +47,7 @@ subsection Boundary fluid pressure model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/melt_transport_convergence_simple.prm
+++ b/tests/melt_transport_convergence_simple.prm
@@ -43,7 +43,7 @@ subsection Boundary fluid pressure model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/melt_transport_convergence_test.prm
+++ b/tests/melt_transport_convergence_test.prm
@@ -43,7 +43,7 @@ subsection Boundary fluid pressure model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/melting_rate.prm
+++ b/tests/melting_rate.prm
@@ -67,7 +67,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   
   subsection Box
     set Bottom temperature = 1600

--- a/tests/memory_statistics_1.prm
+++ b/tests/memory_statistics_1.prm
@@ -11,7 +11,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/mesh_velocity_output.prm
+++ b/tests/mesh_velocity_output.prm
@@ -15,7 +15,7 @@ set Timing output frequency                = 5
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
   end

--- a/tests/minimum_refinement_function.prm
+++ b/tests/minimum_refinement_function.prm
@@ -43,7 +43,7 @@ subsection Boundary temperature model
   # 
   # `box': A model in which the temperature is chosen constant on all the
   # sides of a box.
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/minimum_refinement_function_cartesian.prm
+++ b/tests/minimum_refinement_function_cartesian.prm
@@ -43,7 +43,7 @@ subsection Boundary temperature model
   # 
   # `box': A model in which the temperature is chosen constant on all the
   # sides of a box.
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/minimum_refinement_function_spherical.prm
+++ b/tests/minimum_refinement_function_spherical.prm
@@ -36,7 +36,7 @@ subsection Boundary temperature model
   # 
   # `box': A model in which the temperature is chosen constant on all the
   # sides of a box.
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/minimum_refinement_function_time_dependent.prm
+++ b/tests/minimum_refinement_function_time_dependent.prm
@@ -43,7 +43,7 @@ subsection Boundary temperature model
   # 
   # `box': A model in which the temperature is chosen constant on all the
   # sides of a box.
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/morency_doin.prm
+++ b/tests/morency_doin.prm
@@ -65,7 +65,7 @@ subsection Material model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary composition model

--- a/tests/multicomponent_arithmetic.prm
+++ b/tests/multicomponent_arithmetic.prm
@@ -16,7 +16,7 @@ set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 0.0
     set Bottom temperature = 0.0

--- a/tests/multicomponent_geometric.prm
+++ b/tests/multicomponent_geometric.prm
@@ -16,7 +16,7 @@ set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 0.0
     set Bottom temperature = 0.0

--- a/tests/multicomponent_harmonic.prm
+++ b/tests/multicomponent_harmonic.prm
@@ -16,7 +16,7 @@ set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 0.0
     set Bottom temperature = 0.0

--- a/tests/multicomponent_max_composition.prm
+++ b/tests/multicomponent_max_composition.prm
@@ -16,7 +16,7 @@ set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 0.0
     set Bottom temperature = 0.0

--- a/tests/n_expensive_stokes_solver_steps.prm
+++ b/tests/n_expensive_stokes_solver_steps.prm
@@ -77,7 +77,7 @@ end
 # in the next section, the actual temperature prescribed here
 # at the left and right does not matter.)
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 2773

--- a/tests/no_adiabatic_heating.prm
+++ b/tests/no_adiabatic_heating.prm
@@ -21,7 +21,7 @@ set Max nonlinear iterations               = 5
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/no_adiabatic_heating_02.prm
+++ b/tests/no_adiabatic_heating_02.prm
@@ -17,7 +17,7 @@ set Max nonlinear iterations               = 5
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/no_adiabatic_heating_03.prm
+++ b/tests/no_adiabatic_heating_03.prm
@@ -41,7 +41,7 @@ set Max nonlinear iterations               = 5
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 
@@ -108,7 +108,7 @@ subsection Model settings
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 0
   end

--- a/tests/no_conduction_timestep.prm
+++ b/tests/no_conduction_timestep.prm
@@ -30,7 +30,7 @@ subsection Model settings
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary composition model

--- a/tests/no_flow.prm
+++ b/tests/no_flow.prm
@@ -29,7 +29,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/non_conservative_with_mpi.prm
+++ b/tests/non_conservative_with_mpi.prm
@@ -25,7 +25,7 @@ set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/nonlinear_convergence_for_small_composition.prm
+++ b/tests/nonlinear_convergence_for_small_composition.prm
@@ -48,7 +48,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     set Minimal temperature = 293 # default: 6000

--- a/tests/normalize_initial_composition.prm
+++ b/tests/normalize_initial_composition.prm
@@ -5,7 +5,7 @@ set Dimension                              = 2
 set End time                               = 0
 
 subsection Boundary temperature model
-  set Model name = initial temperature 
+  set List of model names = initial temperature 
 end
 
 subsection Compositional fields

--- a/tests/normalize_pressure_volume.prm
+++ b/tests/normalize_pressure_volume.prm
@@ -14,7 +14,7 @@ set Pressure normalization                 = volume
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/octagonal_initial_temperature.prm
+++ b/tests/octagonal_initial_temperature.prm
@@ -13,7 +13,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 1

--- a/tests/octagonal_initial_temperature_ellipsoidal_chunk.prm
+++ b/tests/octagonal_initial_temperature_ellipsoidal_chunk.prm
@@ -13,7 +13,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 2

--- a/tests/octagonal_initial_temperature_rotated.prm
+++ b/tests/octagonal_initial_temperature_rotated.prm
@@ -13,7 +13,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 1

--- a/tests/own_gravity.prm
+++ b/tests/own_gravity.prm
@@ -23,7 +23,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/parallel_output_group_0.prm
+++ b/tests/parallel_output_group_0.prm
@@ -40,7 +40,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4273
     set Outer temperature = 973

--- a/tests/parallel_output_group_1.prm
+++ b/tests/parallel_output_group_1.prm
@@ -40,7 +40,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4273
     set Outer temperature = 973

--- a/tests/parallel_output_group_2.prm
+++ b/tests/parallel_output_group_2.prm
@@ -40,7 +40,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4273
     set Outer temperature = 973

--- a/tests/particle_count_statistics.prm
+++ b/tests/particle_count_statistics.prm
@@ -25,7 +25,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/particle_generator_ascii.prm
+++ b/tests/particle_generator_ascii.prm
@@ -45,7 +45,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_generator_box.prm
+++ b/tests/particle_generator_box.prm
@@ -43,7 +43,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_generator_box_3d.prm
+++ b/tests/particle_generator_box_3d.prm
@@ -45,7 +45,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_generator_quadrature_points.prm
+++ b/tests/particle_generator_quadrature_points.prm
@@ -45,7 +45,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_generator_radial.prm
+++ b/tests/particle_generator_radial.prm
@@ -43,7 +43,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_generator_reference_cell.prm
+++ b/tests/particle_generator_reference_cell.prm
@@ -45,7 +45,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_initial_adaptive_output.prm
+++ b/tests/particle_initial_adaptive_output.prm
@@ -42,7 +42,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_initial_adaptive_refinement.prm
+++ b/tests/particle_initial_adaptive_refinement.prm
@@ -43,7 +43,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_integrator_euler.prm
+++ b/tests/particle_integrator_euler.prm
@@ -43,7 +43,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_integrator_rk4.prm
+++ b/tests/particle_integrator_rk4.prm
@@ -43,7 +43,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_interpolator_bilinear_solkz.prm
+++ b/tests/particle_interpolator_bilinear_solkz.prm
@@ -43,7 +43,7 @@ end
 ############### Parameters describing the temperature field
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_interpolator_cell_average.prm
+++ b/tests/particle_interpolator_cell_average.prm
@@ -43,7 +43,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_interpolator_cell_average_2.prm
+++ b/tests/particle_interpolator_cell_average_2.prm
@@ -33,7 +33,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/particle_interpolator_empty_cells.prm
+++ b/tests/particle_interpolator_empty_cells.prm
@@ -46,7 +46,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary composition model

--- a/tests/particle_interpolator_from_ghost_cells.prm
+++ b/tests/particle_interpolator_from_ghost_cells.prm
@@ -48,7 +48,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary composition model

--- a/tests/particle_interpolator_nearest_neighbor.prm
+++ b/tests/particle_interpolator_nearest_neighbor.prm
@@ -43,7 +43,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_load_balancing_refinement.prm
+++ b/tests/particle_load_balancing_refinement.prm
@@ -41,7 +41,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_load_balancing_refinement_02.prm
+++ b/tests/particle_load_balancing_refinement_02.prm
@@ -41,7 +41,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_load_balancing_removal.prm
+++ b/tests/particle_load_balancing_removal.prm
@@ -41,7 +41,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_load_balancing_removal_addition.prm
+++ b/tests/particle_load_balancing_removal_addition.prm
@@ -43,7 +43,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_load_balancing_removal_addition_properties.prm
+++ b/tests/particle_load_balancing_removal_addition_properties.prm
@@ -42,7 +42,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_output_hdf5.prm
+++ b/tests/particle_output_hdf5.prm
@@ -40,7 +40,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_output_none.prm
+++ b/tests/particle_output_none.prm
@@ -44,7 +44,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_periodic_boundaries.prm
+++ b/tests/particle_periodic_boundaries.prm
@@ -47,7 +47,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_property_composition.prm
+++ b/tests/particle_property_composition.prm
@@ -46,7 +46,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/particle_property_function.prm
+++ b/tests/particle_property_function.prm
@@ -45,7 +45,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_property_initial_composition.prm
+++ b/tests/particle_property_initial_composition.prm
@@ -45,7 +45,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_property_integrated_strain_invariant.prm
+++ b/tests/particle_property_integrated_strain_invariant.prm
@@ -45,7 +45,7 @@ end
 
 # Temperature boundary and initial conditions
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 273
     set Left temperature   = 273

--- a/tests/particle_property_integrated_strain_pure_shear.prm
+++ b/tests/particle_property_integrated_strain_pure_shear.prm
@@ -49,7 +49,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_property_integrated_strain_simple_shear.prm
+++ b/tests/particle_property_integrated_strain_simple_shear.prm
@@ -49,7 +49,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_property_multiple_functions.prm
+++ b/tests/particle_property_multiple_functions.prm
@@ -46,7 +46,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_property_multiple_functions_with_interpolation.prm
+++ b/tests/particle_property_multiple_functions_with_interpolation.prm
@@ -46,7 +46,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_timing_information.prm
+++ b/tests/particle_timing_information.prm
@@ -44,7 +44,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particle_visualization_particle_count.prm
+++ b/tests/particle_visualization_particle_count.prm
@@ -41,7 +41,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/particles_with_AMR_on.prm
+++ b/tests/particles_with_AMR_on.prm
@@ -45,7 +45,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/passive_comp.prm
+++ b/tests/passive_comp.prm
@@ -48,7 +48,7 @@ subsection Boundary temperature model
   #
   # `box': A model in which the temperature is chosen constant on
   # the left and right sides of a box.
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
 
   subsection Spherical constant

--- a/tests/periodic_box.prm
+++ b/tests/periodic_box.prm
@@ -14,7 +14,7 @@ set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
   end

--- a/tests/periodic_box2.prm
+++ b/tests/periodic_box2.prm
@@ -15,7 +15,7 @@ set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
   end

--- a/tests/periodic_box_freesurface.prm
+++ b/tests/periodic_box_freesurface.prm
@@ -14,7 +14,7 @@ set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
   end

--- a/tests/periodic_box_mpi10.prm
+++ b/tests/periodic_box_mpi10.prm
@@ -17,7 +17,7 @@ set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
   end

--- a/tests/periodic_linear_momentum.prm
+++ b/tests/periodic_linear_momentum.prm
@@ -13,7 +13,7 @@ set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
   end

--- a/tests/petsc_composition_names.prm
+++ b/tests/petsc_composition_names.prm
@@ -38,7 +38,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/petsc_refinement.prm
+++ b/tests/petsc_refinement.prm
@@ -26,7 +26,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/petsc_use_petsc.prm
+++ b/tests/petsc_use_petsc.prm
@@ -40,7 +40,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/plugin.prm
+++ b/tests/plugin.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/plugin_dependency.prm
+++ b/tests/plugin_dependency.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/plugin_dependency_redundant.prm
+++ b/tests/plugin_dependency_redundant.prm
@@ -23,7 +23,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/plugin_dependency_redundant_02.prm
+++ b/tests/plugin_dependency_redundant_02.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/point_value_01.prm
+++ b/tests/point_value_01.prm
@@ -49,7 +49,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/point_value_02.prm
+++ b/tests/point_value_02.prm
@@ -51,7 +51,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/point_value_02_mpi.prm
+++ b/tests/point_value_02_mpi.prm
@@ -54,7 +54,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/point_value_03.prm
+++ b/tests/point_value_03.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 1613.0

--- a/tests/poiseuille_2d.prm
+++ b/tests/poiseuille_2d.prm
@@ -15,7 +15,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/poiseuille_2d_horizontal_pressure_bc.prm
+++ b/tests/poiseuille_2d_horizontal_pressure_bc.prm
@@ -14,7 +14,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Left temperature = 0
   end

--- a/tests/poiseuille_2d_pressure_bc.prm
+++ b/tests/poiseuille_2d_pressure_bc.prm
@@ -15,7 +15,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Left temperature = 0
   end

--- a/tests/poiseuille_3d_x_horizontal_pressure_bc.prm
+++ b/tests/poiseuille_3d_x_horizontal_pressure_bc.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
    set Left temperature = 0
   end

--- a/tests/postprocess_initial.prm
+++ b/tests/postprocess_initial.prm
@@ -30,7 +30,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/postprocess_iterations_Stokes_only.prm
+++ b/tests/postprocess_iterations_Stokes_only.prm
@@ -16,7 +16,7 @@ set Max nonlinear iterations               = 5
 set Use direct solver for Stokes system = true
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/postprocess_iterations_iterated_IMPES.prm
+++ b/tests/postprocess_iterations_iterated_IMPES.prm
@@ -42,7 +42,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Top temperature = 0 # default: 6000

--- a/tests/postprocess_iterations_iterated_Stokes.prm
+++ b/tests/postprocess_iterations_iterated_Stokes.prm
@@ -17,7 +17,7 @@ set Max nonlinear iterations               = 5
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 
@@ -84,7 +84,7 @@ subsection Model settings
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 0
   end

--- a/tests/prescribed_stokes_solution.prm
+++ b/tests/prescribed_stokes_solution.prm
@@ -48,7 +48,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/prescribed_stokes_solution_DG_periodic.prm
+++ b/tests/prescribed_stokes_solution_DG_periodic.prm
@@ -41,7 +41,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 0
     set Left temperature   = 0

--- a/tests/prescribed_velocity_boundary.prm
+++ b/tests/prescribed_velocity_boundary.prm
@@ -28,7 +28,7 @@ set Use years in output instead of seconds = false  # default: true
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/pressure_boundary.prm
+++ b/tests/pressure_boundary.prm
@@ -13,7 +13,7 @@ set Pressure normalization = volume
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 1613.0

--- a/tests/pressure_compatibility.prm
+++ b/tests/pressure_compatibility.prm
@@ -32,7 +32,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   
   subsection Box
     set Bottom temperature = 1

--- a/tests/pressure_compatibility_2.prm
+++ b/tests/pressure_compatibility_2.prm
@@ -15,7 +15,7 @@ set Linear solver tolerance                = 1e-7
 set Pressure normalization                 = no
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 0
     set Bottom temperature = 2

--- a/tests/pressure_compatibility_3.prm
+++ b/tests/pressure_compatibility_3.prm
@@ -14,7 +14,7 @@ set Linear solver tolerance                = 1e-7
 set Pressure normalization                 = no
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 0
     set Bottom temperature = 2

--- a/tests/pressure_compatibility_4.prm
+++ b/tests/pressure_compatibility_4.prm
@@ -15,7 +15,7 @@ set Linear solver tolerance                = 1e-15
 set Pressure normalization                 = no
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 0
     set Bottom temperature = 2

--- a/tests/prmbackslash.prm
+++ b/tests/prmbackslash.prm
@@ -15,7 +15,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 # \ test

--- a/tests/pure_shear.prm
+++ b/tests/pure_shear.prm
@@ -98,7 +98,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/quarter_shell_variable_coordinate_systems_cartesian.prm
+++ b/tests/quarter_shell_variable_coordinate_systems_cartesian.prm
@@ -43,7 +43,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4370
     set Outer temperature = 273 

--- a/tests/quarter_shell_variable_coordinate_systems_depth.prm
+++ b/tests/quarter_shell_variable_coordinate_systems_depth.prm
@@ -43,7 +43,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4370
     set Outer temperature = 273 

--- a/tests/quarter_shell_variable_coordinate_systems_spherical.prm
+++ b/tests/quarter_shell_variable_coordinate_systems_spherical.prm
@@ -43,7 +43,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4370
     set Outer temperature = 273 

--- a/tests/quick_mpi.prm
+++ b/tests/quick_mpi.prm
@@ -29,7 +29,7 @@ set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/radioactive_decay.prm
+++ b/tests/radioactive_decay.prm
@@ -65,7 +65,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4273
     set Outer temperature = 973

--- a/tests/radiogenic_heating.prm
+++ b/tests/radiogenic_heating.prm
@@ -48,7 +48,7 @@ end
 ############### Boundary conditions
 # We set the top temperature to T1=1000K. 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 1000
   end

--- a/tests/refine_vel.prm
+++ b/tests/refine_vel.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 1613.0

--- a/tests/refinement_artificial_viscosity_1.prm
+++ b/tests/refinement_artificial_viscosity_1.prm
@@ -29,7 +29,7 @@ subsection Compositional fields
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
 end
 

--- a/tests/refinement_boundary.prm
+++ b/tests/refinement_boundary.prm
@@ -25,7 +25,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/refinement_composition_gradient.prm
+++ b/tests/refinement_composition_gradient.prm
@@ -26,7 +26,7 @@ subsection Compositional fields
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
 end
 

--- a/tests/refinement_strainrate.prm
+++ b/tests/refinement_strainrate.prm
@@ -58,7 +58,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/refinement_switch.prm
+++ b/tests/refinement_switch.prm
@@ -33,7 +33,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/refinement_topography.prm
+++ b/tests/refinement_topography.prm
@@ -25,7 +25,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/remove_angular_momentum.prm
+++ b/tests/remove_angular_momentum.prm
@@ -37,7 +37,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 100
     set Outer temperature = 0

--- a/tests/remove_net_rotation.prm
+++ b/tests/remove_net_rotation.prm
@@ -37,7 +37,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 100
     set Outer temperature = 0

--- a/tests/resume_free_surface.prm
+++ b/tests/resume_free_surface.prm
@@ -10,7 +10,7 @@ set Linear solver tolerance                = 1.e-7
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:200,1:200,2:200,3:200
   end

--- a/tests/segregation_heating.prm
+++ b/tests/segregation_heating.prm
@@ -62,7 +62,7 @@ subsection Initial composition model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary composition model

--- a/tests/shear_bands.prm
+++ b/tests/shear_bands.prm
@@ -40,7 +40,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/shear_heating.prm
+++ b/tests/shear_heating.prm
@@ -18,7 +18,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/shear_heating_compressible.prm
+++ b/tests/shear_heating_compressible.prm
@@ -30,7 +30,7 @@ subsection Prescribed Stokes solution
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Top temperature = 0
     set Bottom temperature = 1

--- a/tests/shear_heating_with_melt.prm
+++ b/tests/shear_heating_with_melt.prm
@@ -44,7 +44,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = function
+  set List of model names = function
 
   subsection Initial temperature
     set Minimal temperature = 293

--- a/tests/shear_thinning.prm
+++ b/tests/shear_thinning.prm
@@ -26,7 +26,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/shell_with_variable_coordinate_systems.prm
+++ b/tests/shell_with_variable_coordinate_systems.prm
@@ -43,7 +43,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4370
     set Outer temperature = 273 
@@ -51,7 +51,7 @@ subsection Boundary temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = function
+  set List of model names = function
   subsection Function
         set Variable names = r,phi
         set Coordinate system = spherical

--- a/tests/signal_fem.prm
+++ b/tests/signal_fem.prm
@@ -18,7 +18,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Compositional fields

--- a/tests/signals.prm
+++ b/tests/signals.prm
@@ -24,7 +24,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/signals_connect.prm
+++ b/tests/signals_connect.prm
@@ -20,7 +20,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = IMPES
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/signals_post_constraints.prm
+++ b/tests/signals_post_constraints.prm
@@ -8,7 +8,7 @@ set Use years in output instead of seconds = false
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 1
     set Left temperature   = 0

--- a/tests/simple_compressibility_iterated_stokes.prm
+++ b/tests/simple_compressibility_iterated_stokes.prm
@@ -17,7 +17,7 @@ set Max nonlinear iterations               = 5
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/simple_compressible.prm
+++ b/tests/simple_compressible.prm
@@ -13,7 +13,7 @@ set Adiabatic surface temperature          = 1600.0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4250
     set Outer temperature = 273

--- a/tests/simple_incompressible.prm
+++ b/tests/simple_incompressible.prm
@@ -11,7 +11,7 @@ set Adiabatic surface temperature          = 1600.0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4250
     set Outer temperature = 273

--- a/tests/simple_shear.prm
+++ b/tests/simple_shear.prm
@@ -85,7 +85,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/simpler_box.prm
+++ b/tests/simpler_box.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/simpler_composition.prm
+++ b/tests/simpler_composition.prm
@@ -5,7 +5,7 @@ set Dimension                              = 2
 set End time                               = 0
 
 subsection Boundary temperature model
-  set Model name = initial temperature 
+  set List of model names = initial temperature 
 end
 
 subsection Compositional fields

--- a/tests/slope_refinement.prm
+++ b/tests/slope_refinement.prm
@@ -15,7 +15,7 @@ set Timing output frequency                = 5
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
   end

--- a/tests/smoothing.prm
+++ b/tests/smoothing.prm
@@ -51,7 +51,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 0

--- a/tests/smoothing_composition_passive.prm
+++ b/tests/smoothing_composition_passive.prm
@@ -39,7 +39,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/sol_cx_2.prm
+++ b/tests/sol_cx_2.prm
@@ -23,7 +23,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_cx_2_conservative.prm
+++ b/tests/sol_cx_2_conservative.prm
@@ -23,7 +23,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_cx_2_normalized_pressure.prm
+++ b/tests/sol_cx_2_normalized_pressure.prm
@@ -24,7 +24,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_cx_2_q3.prm
+++ b/tests/sol_cx_2_q3.prm
@@ -23,7 +23,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_cx_4.prm
+++ b/tests/sol_cx_4.prm
@@ -23,7 +23,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_cx_4_conservative.prm
+++ b/tests/sol_cx_4_conservative.prm
@@ -23,7 +23,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_cx_4_normalized_pressure.prm
+++ b/tests/sol_cx_4_normalized_pressure.prm
@@ -24,7 +24,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_cx_4_normalized_pressure_large_static_pressure.prm
+++ b/tests/sol_cx_4_normalized_pressure_large_static_pressure.prm
@@ -43,7 +43,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_cx_4_normalized_pressure_low_solver_tolerance.prm
+++ b/tests/sol_cx_4_normalized_pressure_low_solver_tolerance.prm
@@ -32,7 +32,7 @@ set Max nonlinear iterations               = 1
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_cx_mpi_2.prm
+++ b/tests/sol_cx_mpi_2.prm
@@ -26,7 +26,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_cx_particles.prm
+++ b/tests/sol_cx_particles.prm
@@ -23,7 +23,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_kz_2.prm
+++ b/tests/sol_kz_2.prm
@@ -23,7 +23,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_kz_2_cheaper_first_phase_solver.prm
+++ b/tests/sol_kz_2_cheaper_first_phase_solver.prm
@@ -23,7 +23,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_kz_2_conservative.prm
+++ b/tests/sol_kz_2_conservative.prm
@@ -23,7 +23,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_kz_2_no_first_phase_solver.prm
+++ b/tests/sol_kz_2_no_first_phase_solver.prm
@@ -23,7 +23,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_kz_2_q3.prm
+++ b/tests/sol_kz_2_q3.prm
@@ -23,7 +23,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_kz_4.prm
+++ b/tests/sol_kz_4.prm
@@ -23,7 +23,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/sol_kz_4_conservative.prm
+++ b/tests/sol_kz_4_conservative.prm
@@ -23,7 +23,7 @@ set Nonlinear solver scheme                = Stokes only
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/solidus_initial_conditions.prm
+++ b/tests/solidus_initial_conditions.prm
@@ -39,7 +39,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 2200
     set Outer temperature = 250

--- a/tests/solitary_wave.prm
+++ b/tests/solitary_wave.prm
@@ -44,7 +44,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     # Temperature at the inner boundary (core mantle boundary). Units: K.

--- a/tests/solver_history.prm
+++ b/tests/solver_history.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 set Number of cheap Stokes solver steps    = 30
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/spherical_constant_boundary_3d_sphere.prm
+++ b/tests/spherical_constant_boundary_3d_sphere.prm
@@ -6,7 +6,7 @@ set Dimension                              = 2
 set End time                               = 0
 
 subsection Boundary temperature model
-  set Model name = initial temperature 
+  set List of model names = initial temperature 
 end
 
 subsection Compositional fields

--- a/tests/spherical_velocity_statistics.prm
+++ b/tests/spherical_velocity_statistics.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 1613.0

--- a/tests/statistics_output.prm
+++ b/tests/statistics_output.prm
@@ -56,7 +56,7 @@ subsection Initial composition model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary composition model

--- a/tests/steinberger_background.prm
+++ b/tests/steinberger_background.prm
@@ -10,7 +10,7 @@ set Adiabatic surface temperature          = 1600.0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4250
     set Outer temperature = 273

--- a/tests/steinberger_compressible.prm
+++ b/tests/steinberger_compressible.prm
@@ -12,7 +12,7 @@ set Adiabatic surface temperature          = 1600.0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4250
     set Outer temperature = 273

--- a/tests/steinberger_lateral_fail.prm
+++ b/tests/steinberger_lateral_fail.prm
@@ -14,7 +14,7 @@ set Adiabatic surface temperature          = 1600.0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4250
     set Outer temperature = 273

--- a/tests/steinberger_seismic_velocities.prm
+++ b/tests/steinberger_seismic_velocities.prm
@@ -9,7 +9,7 @@ set Adiabatic surface temperature          = 1600.0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4250
     set Outer temperature = 273

--- a/tests/steinberger_viscosity.prm
+++ b/tests/steinberger_viscosity.prm
@@ -8,7 +8,7 @@ set Adiabatic surface temperature          = 1600.0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4250
     set Outer temperature = 273

--- a/tests/steinberger_viscosity_adiabatic.prm
+++ b/tests/steinberger_viscosity_adiabatic.prm
@@ -11,7 +11,7 @@ set Adiabatic surface temperature          = 1600.0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
   subsection Spherical constant
     set Inner temperature = 4250
     set Outer temperature = 273

--- a/tests/stokes.prm
+++ b/tests/stokes.prm
@@ -65,7 +65,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/stokes_residual.prm
+++ b/tests/stokes_residual.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = iterated IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/symbolic_boundary_names_box.prm
+++ b/tests/symbolic_boundary_names_box.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/symbolic_boundary_names_box_constant_bc.prm
+++ b/tests/symbolic_boundary_names_box_constant_bc.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = 0: 42, right: 84, bottom: 126, 3: 168
   end

--- a/tests/symbolic_boundary_names_spherical_shell_2d_180_degrees.prm
+++ b/tests/symbolic_boundary_names_spherical_shell_2d_180_degrees.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 end
 
 

--- a/tests/symbolic_boundary_names_spherical_shell_2d_90_degrees.prm
+++ b/tests/symbolic_boundary_names_spherical_shell_2d_90_degrees.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 end
 
 

--- a/tests/symbolic_boundary_names_spherical_shell_2d_full.prm
+++ b/tests/symbolic_boundary_names_spherical_shell_2d_full.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 end
 
 

--- a/tests/symbolic_boundary_names_spherical_shell_3d_90_degrees.prm
+++ b/tests/symbolic_boundary_names_spherical_shell_3d_90_degrees.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 end
 
 

--- a/tests/symbolic_boundary_names_spherical_shell_3d_full.prm
+++ b/tests/symbolic_boundary_names_spherical_shell_3d_full.prm
@@ -12,7 +12,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 end
 
 

--- a/tests/tangurnis_ba.prm
+++ b/tests/tangurnis_ba.prm
@@ -105,7 +105,7 @@ subsection Boundary temperature model
   # `spherical constant': A model in which the temperature is chosen constant
   # on the inner and outer boundaries of a spherical shell. Parameters are
   # read from subsection 'Sherical constant'.
-  set Model name = Tan Gurnis
+  set List of model names = Tan Gurnis
 
 end
 

--- a/tests/tangurnis_ba_custom.prm
+++ b/tests/tangurnis_ba_custom.prm
@@ -105,7 +105,7 @@ subsection Boundary temperature model
   # `spherical constant': A model in which the temperature is chosen constant
   # on the inner and outer boundaries of a spherical shell. Parameters are
   # read from subsection 'Sherical constant'.
-  set Model name = Tan Gurnis
+  set List of model names = Tan Gurnis
 
 end
 

--- a/tests/tangurnis_tala.prm
+++ b/tests/tangurnis_tala.prm
@@ -103,7 +103,7 @@ subsection Boundary temperature model
   # `spherical constant': A model in which the temperature is chosen constant
   # on the inner and outer boundaries of a spherical shell. Parameters are
   # read from subsection 'Sherical constant'.
-  set Model name = Tan Gurnis
+  set List of model names = Tan Gurnis
 
 end
 

--- a/tests/tangurnis_tala_c.prm
+++ b/tests/tangurnis_tala_c.prm
@@ -103,7 +103,7 @@ subsection Boundary temperature model
   # `spherical constant': A model in which the temperature is chosen constant
   # on the inner and outer boundaries of a spherical shell. Parameters are
   # read from subsection 'Sherical constant'.
-  set Model name = Tan Gurnis
+  set List of model names = Tan Gurnis
 
 end
 

--- a/tests/tangurnis_tala_implicit.prm
+++ b/tests/tangurnis_tala_implicit.prm
@@ -104,7 +104,7 @@ subsection Boundary temperature model
   # `spherical constant': A model in which the temperature is chosen constant
   # on the inner and outer boundaries of a spherical shell. Parameters are
   # read from subsection 'Sherical constant'.
-  set Model name = Tan Gurnis
+  set List of model names = Tan Gurnis
 
 end
 

--- a/tests/temperature_dependent_stokes_matrix.prm
+++ b/tests/temperature_dependent_stokes_matrix.prm
@@ -19,7 +19,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/terminate_user_request.prm
+++ b/tests/terminate_user_request.prm
@@ -14,7 +14,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/time_dependent_temperature_bc.prm
+++ b/tests/time_dependent_temperature_bc.prm
@@ -30,7 +30,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = time_dep_box
+  set List of model names = time_dep_box
 
   subsection Time_Dep_Box
     set Bottom temperature = 0

--- a/tests/time_dependent_temperature_bc_2.prm
+++ b/tests/time_dependent_temperature_bc_2.prm
@@ -27,7 +27,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = time_dep_box
+  set List of model names = time_dep_box
 
   subsection Time_Dep_Box
     set Bottom temperature = 0

--- a/tests/traction_ascii_data.prm
+++ b/tests/traction_ascii_data.prm
@@ -27,7 +27,7 @@ set Start time                             = 0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     set Minimal temperature = 293 # default: 6000

--- a/tests/upwelling_melting_peridotite.prm
+++ b/tests/upwelling_melting_peridotite.prm
@@ -56,7 +56,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary velocity model

--- a/tests/upwelling_melting_peridotite_compressible.prm
+++ b/tests/upwelling_melting_peridotite_compressible.prm
@@ -49,7 +49,7 @@ subsection Initial temperature model
 end
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 end
 
 subsection Boundary velocity model

--- a/tests/upwelling_melting_pyroxenite.prm
+++ b/tests/upwelling_melting_pyroxenite.prm
@@ -80,7 +80,7 @@ subsection Initial composition model
 end
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 1746.794  # 1350°C adiabat
   end

--- a/tests/van_keken_smooth_particle.prm
+++ b/tests/van_keken_smooth_particle.prm
@@ -43,7 +43,7 @@ end
 # Note: The temperature plays no role in this model
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/velocity_boundary_statistics.prm
+++ b/tests/velocity_boundary_statistics.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = spherical constant
+  set List of model names = spherical constant
 
   subsection Spherical constant
     set Inner temperature = 1613.0

--- a/tests/velocity_divergence.prm
+++ b/tests/velocity_divergence.prm
@@ -43,7 +43,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Box
     set Top temperature = 293 # default: 6000

--- a/tests/velocity_in_years.prm
+++ b/tests/velocity_in_years.prm
@@ -33,7 +33,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/vis_velocity_in_years.prm
+++ b/tests/vis_velocity_in_years.prm
@@ -9,7 +9,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/visco_plastic.prm
+++ b/tests/visco_plastic.prm
@@ -45,7 +45,7 @@ end
 
 # Temperature boundary and initial conditions
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 273
     set Left temperature   = 273

--- a/tests/visco_plastic_complex.prm
+++ b/tests/visco_plastic_complex.prm
@@ -45,7 +45,7 @@ end
 
 # Temperature boundary conditions
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 1573
     set Top temperature    =  273

--- a/tests/visco_plastic_yield.prm
+++ b/tests/visco_plastic_yield.prm
@@ -45,7 +45,7 @@ end
 
 # Temperature boundary and initial conditions
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 273
     set Left temperature   = 273

--- a/tests/visco_plastic_yield_strain_weakening.prm
+++ b/tests/visco_plastic_yield_strain_weakening.prm
@@ -45,7 +45,7 @@ end
 
 # Temperature boundary and initial conditions
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 273
     set Left temperature   = 273

--- a/tests/visco_plastic_yield_strain_weakening_full_strain_tensor.prm
+++ b/tests/visco_plastic_yield_strain_weakening_full_strain_tensor.prm
@@ -45,7 +45,7 @@ end
 
 # Temperature boundary and initial conditions
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
   subsection Box
     set Bottom temperature = 273
     set Left temperature   = 273

--- a/tests/viscosity_refinement.prm
+++ b/tests/viscosity_refinement.prm
@@ -5,7 +5,7 @@ set Dimension                              = 2
 set End time                               = 0
 
 subsection Boundary temperature model
-  set Model name = initial temperature
+  set List of model names = initial temperature
 
   subsection Initial temperature
     set Maximal temperature = 3773

--- a/tests/viscous_dissipation_statistics.prm
+++ b/tests/viscous_dissipation_statistics.prm
@@ -65,7 +65,7 @@ end
 # temperature boundary conditions.
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 subsection Initial temperature model

--- a/tests/visualization_conductivity_diffusivity.prm
+++ b/tests/visualization_conductivity_diffusivity.prm
@@ -26,7 +26,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/visualization_shear_stress.prm
+++ b/tests/visualization_shear_stress.prm
@@ -18,7 +18,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/visualization_strain_rate.prm
+++ b/tests/visualization_strain_rate.prm
@@ -15,7 +15,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/visualization_stress.prm
+++ b/tests/visualization_stress.prm
@@ -19,7 +19,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/visualization_unique_list.prm
+++ b/tests/visualization_unique_list.prm
@@ -15,7 +15,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 end
 
 

--- a/tests/visualization_vertical_heat_flux.prm
+++ b/tests/visualization_vertical_heat_flux.prm
@@ -35,7 +35,7 @@ end
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 1

--- a/tests/viz_plugin_dependency.prm
+++ b/tests/viz_plugin_dependency.prm
@@ -22,7 +22,7 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = Stokes only
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
 end
 

--- a/tests/zero_RHS.prm
+++ b/tests/zero_RHS.prm
@@ -19,7 +19,7 @@ subsection Compositional fields
 end
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = left:0, right:0, bottom:0, top:0
   end

--- a/tests/zero_matrix.prm
+++ b/tests/zero_matrix.prm
@@ -27,7 +27,7 @@ subsection Compositional fields
 end
 
 subsection Boundary temperature model
-  set Model name = constant
+  set List of model names = constant
   subsection Constant
     set Boundary indicator to temperature mappings = left:0, right:0, bottom:0, top:0
   end

--- a/tests/zero_temperature.prm
+++ b/tests/zero_temperature.prm
@@ -24,7 +24,7 @@ set Nonlinear solver scheme                = IMPES
 
 
 subsection Boundary temperature model
-  set Model name = box
+  set List of model names = box
 
   subsection Box
     set Bottom temperature = 0


### PR DESCRIPTION
See changelog entry. This change allows the combination of plugins for boundary temperatures that is already possible for initial temperatures (I wish I had had this functionality for several of my papers). After review, I will apply the update_prm script on all included .prm files. For now I keep it out, because it makes the same one-line change in 500 files, which would make the review very tedious.

I plan to do a similar change for boundary_velocity and boundary_composition as well, but I would like to make sure I get the format right, before having to make the same edits to all of them. Boundary_fluid_pressure and Boundary_traction do not really have enough plugins as that a combination would make sense, but in some future we can think of that as well. Luckily the change is backwards compatible, as long as we keep the old single plugin input parameter around.