### PR TITLE
Create a graph of all plugins.

### DIFF
--- a/include/aspect/adiabatic_conditions/interface.h
+++ b/include/aspect/adiabatic_conditions/interface.h
@@ -215,6 +215,20 @@ namespace aspect
 
 
     /**
+     * For the current plugin subsystem, write a connection graph of all of the
+     * plugins we know about, in the format that the
+     * programs dot and neato understand. This allows for a visualization of
+     * how all of the plugins that ASPECT knows about are interconnected, and
+     * connect to other parts of the ASPECT code.
+     *
+     * @param output_stream The stream to write the output to.
+     */
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out);
+
+
+    /**
      * Given a class name, a name, and a description for the parameter file
      * for a adiabatic conditions model, register it with the functions that
      * can declare their parameters and create these objects.

--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -169,6 +169,20 @@ namespace aspect
 
 
     /**
+     * For the current plugin subsystem, write a connection graph of all of the
+     * plugins we know about, in the format that the
+     * programs dot and neato understand. This allows for a visualization of
+     * how all of the plugins that ASPECT knows about are interconnected, and
+     * connect to other parts of the ASPECT code.
+     *
+     * @param output_stream The stream to write the output to.
+     */
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out);
+
+
+    /**
      * Given a class name, a name, and a description for the parameter file
      * for a boundary composition model, register it with the functions that
      * can declare their parameters and create these objects.

--- a/include/aspect/boundary_fluid_pressure/interface.h
+++ b/include/aspect/boundary_fluid_pressure/interface.h
@@ -161,6 +161,20 @@ namespace aspect
 
 
     /**
+     * For the current plugin subsystem, write a connection graph of all of the
+     * plugins we know about, in the format that the
+     * programs dot and neato understand. This allows for a visualization of
+     * how all of the plugins that ASPECT knows about are interconnected, and
+     * connect to other parts of the ASPECT code.
+     *
+     * @param output_stream The stream to write the output to.
+     */
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out);
+
+
+    /**
      * Given a class name, a name, and a description for the parameter file
      * for a fluid pressure boundary model, register it with the functions that
      * can declare their parameters and create these objects.

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -259,6 +259,20 @@ namespace aspect
         find_boundary_temperature_model () const;
 
         /**
+         * For the current plugin subsystem, write a connection graph of all of the
+         * plugins we know about, in the format that the
+         * programs dot and neato understand. This allows for a visualization of
+         * how all of the plugins that ASPECT knows about are interconnected, and
+         * connect to other parts of the ASPECT code.
+         *
+         * @param output_stream The stream to write the output to.
+         */
+        static
+        void
+        write_plugin_graph (std::ostream &out);
+
+
+        /**
          * Exception.
          */
         DeclException1 (ExcBoundaryTemperatureNameNotFound,

--- a/include/aspect/boundary_traction/interface.h
+++ b/include/aspect/boundary_traction/interface.h
@@ -188,6 +188,20 @@ namespace aspect
     declare_parameters (ParameterHandler &prm);
 
 
+    /**
+     * For the current plugin subsystem, write a connection graph of all of the
+     * plugins we know about, in the format that the
+     * programs dot and neato understand. This allows for a visualization of
+     * how all of the plugins that ASPECT knows about are interconnected, and
+     * connect to other parts of the ASPECT code.
+     *
+     * @param output_stream The stream to write the output to.
+     */
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out);
+
+
 
     /**
      * Given a class name, a name, and a description for the parameter file

--- a/include/aspect/boundary_velocity/interface.h
+++ b/include/aspect/boundary_velocity/interface.h
@@ -179,6 +179,20 @@ namespace aspect
     declare_parameters (ParameterHandler &prm);
 
 
+    /**
+     * For the current plugin subsystem, write a connection graph of all of the
+     * plugins we know about, in the format that the
+     * programs dot and neato understand. This allows for a visualization of
+     * how all of the plugins that ASPECT knows about are interconnected, and
+     * connect to other parts of the ASPECT code.
+     *
+     * @param output_stream The stream to write the output to.
+     */
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out);
+
+
 
     /**
      * Given a class name, a name, and a description for the parameter file

--- a/include/aspect/geometry_model/initial_topography_model/interface.h
+++ b/include/aspect/geometry_model/initial_topography_model/interface.h
@@ -145,6 +145,20 @@ namespace aspect
 
 
     /**
+     * For the current plugin subsystem, write a connection graph of all of the
+     * plugins we know about, in the format that the
+     * programs dot and neato understand. This allows for a visualization of
+     * how all of the plugins that ASPECT knows about are interconnected, and
+     * connect to other parts of the ASPECT code.
+     *
+     * @param output_stream The stream to write the output to.
+     */
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out);
+
+
+    /**
      * Given a class name, a name, and a description for the parameter file
      * for a initial topography model, register it with the functions that
      * can declare their parameters and create these objects.

--- a/include/aspect/geometry_model/interface.h
+++ b/include/aspect/geometry_model/interface.h
@@ -357,7 +357,6 @@ namespace aspect
     Interface<dim> *
     create_geometry_model (ParameterHandler &prm);
 
-
     /**
      * Declare the runtime parameters of the registered geometry models.
      *
@@ -366,6 +365,20 @@ namespace aspect
     template <int dim>
     void
     declare_parameters (ParameterHandler &prm);
+
+    /**
+     * For the current plugin subsystem, write a connection graph of all of the
+     * plugins we know about, in the format that the
+     * programs dot and neato understand. This allows for a visualization of
+     * how all of the plugins that ASPECT knows about are interconnected, and
+     * connect to other parts of the ASPECT code.
+     *
+     * @param output_stream The stream to write the output to.
+     */
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out);
+
 
 
     /**

--- a/include/aspect/gravity_model/interface.h
+++ b/include/aspect/gravity_model/interface.h
@@ -148,6 +148,20 @@ namespace aspect
 
 
     /**
+     * For the current plugin subsystem, write a connection graph of all of the
+     * plugins we know about, in the format that the
+     * programs dot and neato understand. This allows for a visualization of
+     * how all of the plugins that ASPECT knows about are interconnected, and
+     * connect to other parts of the ASPECT code.
+     *
+     * @param output_stream The stream to write the output to.
+     */
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out);
+
+
+    /**
      * Given a class name, a name, and a description for the parameter file
      * for a gravity model, register it with the functions that can declare
      * their parameters and create these objects.

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -300,6 +300,19 @@ namespace aspect
         find_heating_model () const;
 
         /**
+         * For the current plugin subsystem, write a connection graph of all of the
+         * plugins we know about, in the format that the
+         * programs dot and neato understand. This allows for a visualization of
+         * how all of the plugins that ASPECT knows about are interconnected, and
+         * connect to other parts of the ASPECT code.
+         *
+         * @param output_stream The stream to write the output to.
+         */
+        static
+        void
+        write_plugin_graph (std::ostream &out);
+
+        /**
          * Exception.
          */
         DeclException1 (ExcHeatingModelNameNotFound,

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -190,6 +190,19 @@ namespace aspect
         find_initial_composition_model () const;
 
         /**
+         * For the current plugin subsystem, write a connection graph of all of the
+         * plugins we know about, in the format that the
+         * programs dot and neato understand. This allows for a visualization of
+         * how all of the plugins that ASPECT knows about are interconnected, and
+         * connect to other parts of the ASPECT code.
+         *
+         * @param output_stream The stream to write the output to.
+         */
+        static
+        void
+        write_plugin_graph (std::ostream &out);
+
+        /**
          * Exception.
          */
         DeclException1 (ExcInitialCompositionNameNotFound,

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -187,6 +187,19 @@ namespace aspect
         find_initial_temperature_model () const;
 
         /**
+         * For the current plugin subsystem, write a connection graph of all of the
+         * plugins we know about, in the format that the
+         * programs dot and neato understand. This allows for a visualization of
+         * how all of the plugins that ASPECT knows about are interconnected, and
+         * connect to other parts of the ASPECT code.
+         *
+         * @param output_stream The stream to write the output to.
+         */
+        static
+        void
+        write_plugin_graph (std::ostream &out);
+
+        /**
          * Exception.
          */
         DeclException1 (ExcInitialTemperatureNameNotFound,

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -964,6 +964,24 @@ namespace aspect
     declare_parameters (ParameterHandler &prm);
 
 
+
+    /**
+     * For the current plugin subsystem, write a connection graph of all of the
+     * plugins we know about, in the format that the
+     * programs dot and neato understand. This allows for a visualization of
+     * how all of the plugins that ASPECT knows about are interconnected, and
+     * connect to other parts of the ASPECT code.
+     *
+     * @param output_stream The stream to write the output to.
+     */
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out);
+
+
+
+// --------------------- template function definitions ----------------------------------
+
     template <int dim>
     template <class AdditionalOutputType>
     AdditionalOutputType *MaterialModelOutputs<dim>::get_additional_output()

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -247,6 +247,19 @@ namespace aspect
                                             Interface<dim> *(*factory_function) ());
 
         /**
+         * For the current plugin subsystem, write a connection graph of all of the
+         * plugins we know about, in the format that the
+         * programs dot and neato understand. This allows for a visualization of
+         * how all of the plugins that ASPECT knows about are interconnected, and
+         * connect to other parts of the ASPECT code.
+         *
+         * @param output_stream The stream to write the output to.
+         */
+        static
+        void
+        write_plugin_graph (std::ostream &out);
+
+        /**
          * Exception.
          */
         DeclException1 (ExcMeshRefinementNameNotFound,

--- a/include/aspect/particle/generator/interface.h
+++ b/include/aspect/particle/generator/interface.h
@@ -200,6 +200,20 @@ namespace aspect
 
 
       /**
+       * For the current plugin subsystem, write a connection graph of all of the
+       * plugins we know about, in the format that the
+       * programs dot and neato understand. This allows for a visualization of
+       * how all of the plugins that ASPECT knows about are interconnected, and
+       * connect to other parts of the ASPECT code.
+       *
+       * @param output_stream The stream to write the output to.
+       */
+      template <int dim>
+      void
+      write_plugin_graph (std::ostream &out);
+
+
+      /**
        * Given a class name, a name, and a description for the parameter file
        * for a particle generator, register it with the functions that
        * can declare their parameters and create these objects.

--- a/include/aspect/particle/integrator/interface.h
+++ b/include/aspect/particle/integrator/interface.h
@@ -215,6 +215,20 @@ namespace aspect
       void
       declare_parameters (ParameterHandler &prm);
 
+
+      /**
+       * For the current plugin subsystem, write a connection graph of all of the
+       * plugins we know about, in the format that the
+       * programs dot and neato understand. This allows for a visualization of
+       * how all of the plugins that ASPECT knows about are interconnected, and
+       * connect to other parts of the ASPECT code.
+       *
+       * @param output_stream The stream to write the output to.
+       */
+      template <int dim>
+      void
+      write_plugin_graph (std::ostream &out);
+
       /**
        * Given a class name, a name, and a description for the parameter file
        * for a particle integrator, register it with the functions that

--- a/include/aspect/particle/interpolator/interface.h
+++ b/include/aspect/particle/interpolator/interface.h
@@ -183,6 +183,20 @@ namespace aspect
       void
       declare_parameters (ParameterHandler &prm);
 
+
+      /**
+       * For the current plugin subsystem, write a connection graph of all of the
+       * plugins we know about, in the format that the
+       * programs dot and neato understand. This allows for a visualization of
+       * how all of the plugins that ASPECT knows about are interconnected, and
+       * connect to other parts of the ASPECT code.
+       *
+       * @param output_stream The stream to write the output to.
+       */
+      template <int dim>
+      void
+      write_plugin_graph (std::ostream &out);
+
       /**
        * Given a class name, a name, and a description for the parameter file
        * for a particle interpolator, register it with the functions that

--- a/include/aspect/particle/output/interface.h
+++ b/include/aspect/particle/output/interface.h
@@ -174,6 +174,20 @@ namespace aspect
       void
       declare_parameters (ParameterHandler &prm);
 
+
+      /**
+       * For the current plugin subsystem, write a connection graph of all of the
+       * plugins we know about, in the format that the
+       * programs dot and neato understand. This allows for a visualization of
+       * how all of the plugins that ASPECT knows about are interconnected, and
+       * connect to other parts of the ASPECT code.
+       *
+       * @param output_stream The stream to write the output to.
+       */
+      template <int dim>
+      void
+      write_plugin_graph (std::ostream &out);
+
       /**
        * Given a class name, a name, and a description for the parameter file
        * for a particle output, register it with the functions that

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -619,6 +619,20 @@ namespace aspect
           void
           parse_parameters (ParameterHandler &prm);
 
+
+          /**
+           * For the current plugin subsystem, write a connection graph of all of the
+           * plugins we know about, in the format that the
+           * programs dot and neato understand. This allows for a visualization of
+           * how all of the plugins that ASPECT knows about are interconnected, and
+           * connect to other parts of the ASPECT code.
+           *
+           * @param output_stream The stream to write the output to.
+           */
+          static
+          void
+          write_plugin_graph (std::ostream &out);
+
         private:
 
           /**

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -291,6 +291,19 @@ namespace aspect
                                 Interface<dim> *(*factory_function) ());
 
         /**
+         * For the current plugin subsystem, write a connection graph of all of the
+         * plugins we know about, in the format that the
+         * programs dot and neato understand. This allows for a visualization of
+         * how all of the plugins that ASPECT knows about are interconnected, and
+         * connect to other parts of the ASPECT code.
+         *
+         * @param output_stream The stream to write the output to.
+         */
+        static
+        void
+        write_plugin_graph (std::ostream &out);
+
+        /**
          * Exception.
          */
         DeclException1 (ExcPostprocessorNameNotFound,

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -347,6 +347,20 @@ namespace aspect
         template <class Archive>
         void serialize (Archive &ar, const unsigned int version);
 
+
+        /**
+         * For the current plugin subsystem, write a connection graph of all of the
+         * plugins we know about, in the format that the
+         * programs dot and neato understand. This allows for a visualization of
+         * how all of the plugins that ASPECT knows about are interconnected, and
+         * connect to other parts of the ASPECT code.
+         *
+         * @param output_stream The stream to write the output to.
+         */
+        static
+        void
+        write_plugin_graph (std::ostream &out);
+
         /**
          * Exception.
          */

--- a/include/aspect/prescribed_stokes_solution/interface.h
+++ b/include/aspect/prescribed_stokes_solution/interface.h
@@ -167,6 +167,20 @@ namespace aspect
     declare_parameters (ParameterHandler &prm);
 
 
+    /**
+     * For the current plugin subsystem, write a connection graph of all of the
+     * plugins we know about, in the format that the
+     * programs dot and neato understand. This allows for a visualization of
+     * how all of the plugins that ASPECT knows about are interconnected, and
+     * connect to other parts of the ASPECT code.
+     *
+     * @param output_stream The stream to write the output to.
+     */
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out);
+
+
 
     /**
      * Given a class name, a name, and a description for the parameter file

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -162,6 +162,19 @@ namespace aspect
        */
       void run ();
 
+      /**
+       * Write a connection graph of all of the plugins we know about, in the
+       * format that the programs dot and neato understand. This allows for a
+       * visualization of how all of the plugins that ASPECT knows about are
+       * interconnected, and connect to other parts of the ASPECT code.
+       *
+       * This function is implemented in
+       * <code>source/simulator/helper_functions.cc</code>.
+       *
+       * @param output_stream The stream to write the output to.
+       */
+      void
+      write_plugin_graph (std::ostream &out) const;
 
       /**
        * Import Nonlinear Solver type.

--- a/include/aspect/termination_criteria/interface.h
+++ b/include/aspect/termination_criteria/interface.h
@@ -231,6 +231,19 @@ namespace aspect
                                         Interface<dim> *(*factory_function) ());
 
         /**
+         * For the current plugin subsystem, write a connection graph of all of the
+         * plugins we know about, in the format that the
+         * programs dot and neato understand. This allows for a visualization of
+         * how all of the plugins that ASPECT knows about are interconnected, and
+         * connect to other parts of the ASPECT code.
+         *
+         * @param output_stream The stream to write the output to.
+         */
+        static
+        void
+        write_plugin_graph (std::ostream &out);
+
+        /**
          * Exception.
          */
         DeclException1 (ExcTerminationCriteriaNameNotFound,

--- a/source/adiabatic_conditions/interface.cc
+++ b/source/adiabatic_conditions/interface.cc
@@ -192,6 +192,15 @@ namespace aspect
       std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
+
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Adiabatic conditions interface",
+                                                                  out);
+    }
+
   }
 }
 
@@ -226,6 +235,10 @@ namespace aspect
   template  \
   void \
   declare_parameters<dim> (ParameterHandler &); \
+  \
+  template \
+  void \
+  write_plugin_graph<dim> (std::ostream &); \
   \
   template \
   Interface<dim> * \

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -23,6 +23,7 @@
 #include <aspect/boundary_composition/interface.h>
 
 #include <aspect/utilities.h>
+#include <aspect/simulator_access.h>
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/signaling_nan.h>
@@ -74,6 +75,8 @@ namespace aspect
     void
     Interface<dim>::parse_parameters (dealii::ParameterHandler &)
     {}
+
+
 
 
 // -------------------------------- Deal with registering models and automating
@@ -151,6 +154,15 @@ namespace aspect
       std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
+
+
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Boundary composition interface",
+                                                                  out);
+    }
   }
 }
 
@@ -185,6 +197,10 @@ namespace aspect
   template  \
   void \
   declare_parameters<dim> (ParameterHandler &); \
+  \
+  template \
+  void \
+  write_plugin_graph<dim> (std::ostream &); \
   \
   template \
   Interface<dim> * \

--- a/source/boundary_fluid_pressure/interface.cc
+++ b/source/boundary_fluid_pressure/interface.cc
@@ -21,6 +21,7 @@
 
 #include <aspect/global.h>
 #include <aspect/boundary_fluid_pressure/interface.h>
+#include <aspect/simulator_access.h>
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/std_cxx11/tuple.h>
@@ -116,6 +117,16 @@ namespace aspect
       std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
+
+
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Boundary fluid pressure interface",
+                                                                  out);
+    }
+
   }
 }
 
@@ -150,6 +161,10 @@ namespace aspect
   template  \
   void \
   declare_parameters<dim> (ParameterHandler &); \
+  \
+  template \
+  void \
+  write_plugin_graph<dim> (std::ostream &); \
   \
   template \
   Interface<dim> * \

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -21,6 +21,7 @@
 
 #include <aspect/global.h>
 #include <aspect/boundary_temperature/interface.h>
+#include <aspect/simulator_access.h>
 
 #include <aspect/utilities.h>
 
@@ -286,6 +287,16 @@ namespace aspect
       prm.leave_subsection ();
 
       std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
+    }
+
+
+
+    template <int dim>
+    void
+    Manager<dim>::write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Boundary temperature interface",
+                                                                  out);
     }
   }
 }

--- a/source/boundary_traction/interface.cc
+++ b/source/boundary_traction/interface.cc
@@ -21,6 +21,7 @@
 
 #include <aspect/global.h>
 #include <aspect/boundary_traction/interface.h>
+#include <aspect/simulator_access.h>
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/std_cxx1x/tuple.h>
@@ -144,11 +145,22 @@ namespace aspect
     }
 
 
+
     template <int dim>
     void
     declare_parameters (ParameterHandler &prm)
     {
       std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
+    }
+
+
+
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Boundary traction interface",
+                                                                  out);
     }
   }
 }
@@ -184,6 +196,10 @@ namespace aspect
   template  \
   void \
   declare_parameters<dim> (ParameterHandler &); \
+  \
+  template \
+  void \
+  write_plugin_graph<dim> (std::ostream &); \
   \
   template  \
   std::string \

--- a/source/boundary_velocity/interface.cc
+++ b/source/boundary_velocity/interface.cc
@@ -21,6 +21,7 @@
 
 #include <aspect/global.h>
 #include <aspect/boundary_velocity/interface.h>
+#include <aspect/simulator_access.h>
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/std_cxx11/tuple.h>
@@ -149,6 +150,16 @@ namespace aspect
     {
       std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
+
+
+
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Boundary velocity interface",
+                                                                  out);
+    }
   }
 }
 
@@ -183,6 +194,10 @@ namespace aspect
   template  \
   void \
   declare_parameters<dim> (ParameterHandler &); \
+  \
+  template \
+  void \
+  write_plugin_graph<dim> (std::ostream &); \
   \
   template  \
   std::string \

--- a/source/geometry_model/initial_topography_model/interface.cc
+++ b/source/geometry_model/initial_topography_model/interface.cc
@@ -21,6 +21,8 @@
 
 #include <aspect/global.h>
 #include <aspect/geometry_model/initial_topography_model/interface.h>
+#include <aspect/simulator_access.h>
+
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/std_cxx11/tuple.h>
 #include <list>
@@ -136,6 +138,16 @@ namespace aspect
       std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
+
+
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Initial topography interface",
+                                                                  out);
+    }
+
   }
 }
 
@@ -171,6 +183,10 @@ namespace aspect
   template  \
   void \
   declare_parameters<dim> (ParameterHandler &); \
+  \
+  template \
+  void \
+  write_plugin_graph<dim> (std::ostream &); \
   \
   template \
   Interface<dim> * \

--- a/source/geometry_model/interface.cc
+++ b/source/geometry_model/interface.cc
@@ -21,6 +21,7 @@
 
 #include <aspect/global.h>
 #include <aspect/geometry_model/interface.h>
+#include <aspect/simulator_access.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/std_cxx11/tuple.h>
 
@@ -289,6 +290,15 @@ namespace aspect
       std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
+
+
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Geometry model interface",
+                                                                  out);
+    }
   }
 }
 
@@ -324,6 +334,10 @@ namespace aspect
   template  \
   void \
   declare_parameters<dim> (ParameterHandler &); \
+  \
+  template \
+  void \
+  write_plugin_graph<dim> (std::ostream &); \
   \
   template \
   Interface<dim> * \

--- a/source/gravity_model/interface.cc
+++ b/source/gravity_model/interface.cc
@@ -21,6 +21,7 @@
 
 #include <aspect/global.h>
 #include <aspect/gravity_model/interface.h>
+#include <aspect/simulator_access.h>
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/std_cxx11/tuple.h>
@@ -134,6 +135,15 @@ namespace aspect
       std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
+
+
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Gravity model interface",
+                                                                  out);
+    }
   }
 }
 
@@ -168,6 +178,10 @@ namespace aspect
   template  \
   void \
   declare_parameters<dim> (ParameterHandler &); \
+  \
+  template \
+  void \
+  write_plugin_graph<dim> (std::ostream &); \
   \
   template \
   Interface<dim> * \

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -370,6 +370,17 @@ namespace aspect
     }
 
 
+
+    template <int dim>
+    void
+    Manager<dim>::write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Heating model interface",
+                                                                  out);
+    }
+
+
+
     HeatingModelOutputs::HeatingModelOutputs(const unsigned int n_points,
                                              const unsigned int)
       :

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -246,6 +246,16 @@ namespace aspect
     {
       return std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
     }
+
+
+
+    template <int dim>
+    void
+    Manager<dim>::write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Initial composition interface",
+                                                                  out);
+    }
   }
 }
 

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -227,11 +227,22 @@ namespace aspect
     }
 
 
+
     template <int dim>
     std::string
     get_valid_model_names_pattern ()
     {
       return std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
+    }
+
+
+
+    template <int dim>
+    void
+    Manager<dim>::write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Initial temperature interface",
+                                                                  out);
     }
   }
 }

--- a/source/main.cc
+++ b/source/main.cc
@@ -374,6 +374,8 @@ void print_help()
             << std::endl
             << "       --output-xml           (print parameters in xml format to standard output and exit)"
             << std::endl
+            << "       --output-plugin-graph  (write a representation of all plugins to standard output and exit)"
+            << std::endl
             << std::endl;
 }
 
@@ -459,7 +461,8 @@ int main (int argc, char *argv[])
       const bool i_am_proc_0 = (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0);
 
       std::string prm_name = "";
-      bool output_xml = false;
+      bool output_xml          = false;
+      bool output_plugin_graph = false;
 
       // We hook into the abort handler on ranks != 0 to avoid an MPI
       // deadlock. The deal.II library will call std::abort() when an
@@ -491,6 +494,10 @@ int main (int argc, char *argv[])
           if (arg == "--output-xml")
             {
               output_xml = true;
+            }
+          else if (arg == "--output-plugin-graph")
+            {
+              output_plugin_graph = true;
             }
           else if (arg=="-h" || arg =="--help")
             {
@@ -542,7 +549,7 @@ int main (int argc, char *argv[])
         }
 
       // Print header
-      if (i_am_proc_0 && !output_xml)
+      if (i_am_proc_0 && !output_xml && !output_plugin_graph)
         {
           print_aspect_header(std::cout);
         }
@@ -643,6 +650,12 @@ int main (int argc, char *argv[])
                 if (i_am_proc_0)
                   prm.print_parameters(std::cout, ParameterHandler::XML);
               }
+            else if (output_plugin_graph)
+              {
+                aspect::Simulator<2> flow_problem(MPI_COMM_WORLD, prm);
+                if (i_am_proc_0)
+                  flow_problem.write_plugin_graph (std::cout);
+              }
             else
               {
                 aspect::Simulator<2> flow_problem(MPI_COMM_WORLD, prm);
@@ -660,6 +673,12 @@ int main (int argc, char *argv[])
               {
                 if (i_am_proc_0)
                   prm.print_parameters(std::cout, ParameterHandler::XML);
+              }
+            else if (output_plugin_graph)
+              {
+                aspect::Simulator<3> flow_problem(MPI_COMM_WORLD, prm);
+                if (i_am_proc_0)
+                  flow_problem.write_plugin_graph (std::cout);
               }
             else
               {

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -139,6 +139,7 @@ namespace aspect
     }
 
 
+
     template <int dim>
     Interface<dim> *
     create_material_model (ParameterHandler &prm)
@@ -222,6 +223,16 @@ namespace aspect
       prm.leave_subsection ();
 
       std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
+    }
+
+
+
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Material model interface",
+                                                                  out);
     }
 
 
@@ -790,6 +801,10 @@ namespace aspect
   template \
   Interface<dim> * \
   create_material_model<dim> (const std::string &model_name); \
+  \
+  template \
+  void \
+  write_plugin_graph<dim> (std::ostream &); \
   \
   template \
   Interface<dim> * \

--- a/source/mesh_refinement/interface.cc
+++ b/source/mesh_refinement/interface.cc
@@ -512,6 +512,16 @@ namespace aspect
                                                                factory_function);
     }
 
+
+
+    template <int dim>
+    void
+    Manager<dim>::write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Mesh refinement criteria interface",
+                                                                  out);
+    }
+
   }
 }
 

--- a/source/particle/generator/interface.cc
+++ b/source/particle/generator/interface.cc
@@ -226,6 +226,16 @@ namespace aspect
 
         std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
       }
+
+
+
+      template <int dim>
+      void
+      write_plugin_graph (std::ostream &out)
+      {
+        std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Particle generator interface",
+                                                                    out);
+      }
     }
   }
 }
@@ -263,6 +273,10 @@ namespace aspect
   template  \
   void \
   declare_parameters<dim> (ParameterHandler &); \
+  \
+  template \
+  void \
+  write_plugin_graph<dim> (std::ostream &); \
   \
   template \
   Interface<dim> * \

--- a/source/particle/integrator/interface.cc
+++ b/source/particle/integrator/interface.cc
@@ -19,6 +19,7 @@
  */
 
 #include <aspect/particle/integrator/interface.h>
+#include <aspect/simulator_access.h>
 
 #include <deal.II/base/std_cxx1x/tuple.h>
 
@@ -204,6 +205,16 @@ namespace aspect
 
         std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
       }
+
+
+
+      template <int dim>
+      void
+      write_plugin_graph (std::ostream &out)
+      {
+        std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Particle integrator interface",
+                                                                    out);
+      }
     }
   }
 }
@@ -241,6 +252,10 @@ namespace aspect
   template  \
   void \
   declare_parameters<dim> (ParameterHandler &); \
+  \
+  template \
+  void \
+  write_plugin_graph<dim> (std::ostream &); \
   \
   template \
   Interface<dim> * \

--- a/source/particle/interpolator/interface.cc
+++ b/source/particle/interpolator/interface.cc
@@ -19,6 +19,7 @@
  */
 
 #include <aspect/particle/interpolator/interface.h>
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {
@@ -128,6 +129,16 @@ namespace aspect
 
         std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
       }
+
+
+
+      template <int dim>
+      void
+      write_plugin_graph (std::ostream &out)
+      {
+        std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Particle interpolator interface",
+                                                                    out);
+      }
     }
   }
 }
@@ -165,6 +176,10 @@ namespace aspect
   template  \
   void \
   declare_parameters<dim> (ParameterHandler &); \
+  \
+  template \
+  void \
+  write_plugin_graph<dim> (std::ostream &); \
   \
   template \
   Interface<dim> * \

--- a/source/particle/output/hdf5.cc
+++ b/source/particle/output/hdf5.cc
@@ -50,8 +50,13 @@ namespace aspect
       HDF5Output<dim>::HDF5Output()
         :
         file_index(0)
-      {
+      {}
 
+
+
+      template <int dim>
+      void HDF5Output<dim>::initialize ()
+      {
 #ifndef DEAL_II_WITH_HDF5
         AssertThrow (false,
                      ExcMessage ("deal.ii was not compiled with HDF5 support, "
@@ -60,15 +65,12 @@ namespace aspect
                                  "or select a different particle output format."));
 #endif
 
-      }
-
-      template <int dim>
-      void HDF5Output<dim>::initialize ()
-      {
         aspect::Utilities::create_directory (this->get_output_directory() + "particles/",
                                              this->get_mpi_communicator(),
                                              true);
       }
+
+
 
       template <int dim>
       std::string

--- a/source/particle/output/interface.cc
+++ b/source/particle/output/interface.cc
@@ -19,6 +19,7 @@
  */
 
 #include <aspect/particle/output/interface.h>
+#include <aspect/simulator_access.h>
 
 
 namespace aspect
@@ -141,6 +142,16 @@ namespace aspect
 
         std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
       }
+
+
+
+      template <int dim>
+      void
+      write_plugin_graph (std::ostream &out)
+      {
+        std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Particle output interface",
+                                                                    out);
+      }
     }
   }
 }
@@ -178,6 +189,10 @@ namespace aspect
   template  \
   void \
   declare_parameters<dim> (ParameterHandler &); \
+  \
+  template \
+  void \
+  write_plugin_graph<dim> (std::ostream &); \
   \
   template \
   Interface<dim> * \

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -538,6 +538,17 @@ namespace aspect
                                                                  declare_parameters_function,
                                                                  factory_function);
       }
+
+
+
+      template <int dim>
+      void
+      Manager<dim>::write_plugin_graph (std::ostream &out)
+      {
+        std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Particle property interface",
+                                                                    out);
+      }
+
     }
   }
 }

--- a/source/postprocess/interface.cc
+++ b/source/postprocess/interface.cc
@@ -389,6 +389,16 @@ namespace aspect
                                                                factory_function);
     }
 
+
+
+    template <int dim>
+    void
+    Manager<dim>::write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Postprocessor interface",
+                                                                  out);
+    }
+
   }
 }
 

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -22,6 +22,7 @@
 #include <aspect/postprocess/visualization.h>
 #include <aspect/global.h>
 #include <aspect/utilities.h>
+#include <aspect/simulator_access.h>
 
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/numerics/data_out.h>
@@ -1057,6 +1058,23 @@ namespace aspect
         }
 
       return requirements;
+    }
+
+
+
+    template <int dim>
+    void
+    Visualization<dim>::write_plugin_graph (std::ostream &out)
+    {
+      // in contrast to all other plugins, the visualization
+      // postprocessors do not actually connect to the central
+      // Simulator class, but they are a sub-system of
+      // the Postprocessor plugin system. indicate this
+      // through the last argument of the function call
+      std_cxx11::get<dim>(registered_visualization_plugins)
+      .write_plugin_graph ("Visualization postprocessor interface",
+                           out,
+                           typeid(Visualization<dim>).name());
     }
 
 

--- a/source/prescribed_stokes_solution/interface.cc
+++ b/source/prescribed_stokes_solution/interface.cc
@@ -21,6 +21,8 @@
 
 #include <aspect/global.h>
 #include <aspect/prescribed_stokes_solution/interface.h>
+#include <aspect/simulator_access.h>
+
 
 namespace aspect
 {
@@ -124,6 +126,16 @@ namespace aspect
 
       std_cxx1x::get<dim>(registered_plugins).declare_parameters (prm);
     }
+
+
+
+    template <int dim>
+    void
+    write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Prescribed Stokes solution interface",
+                                                                  out);
+    }
   }
 }
 
@@ -158,6 +170,10 @@ namespace aspect
   template  \
   void \
   declare_parameters<dim> (ParameterHandler &); \
+  \
+  template \
+  void \
+  write_plugin_graph<dim> (std::ostream &); \
   \
   template \
   Interface<dim> * \

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -23,7 +23,15 @@
 #include <aspect/melt.h>
 #include <aspect/global.h>
 
+#include <aspect/geometry_model/interface.h>
+#include <aspect/heating_model/interface.h>
 #include <aspect/heating_model/adiabatic_heating.h>
+#include <aspect/material_model/interface.h>
+#include <aspect/particle/generator/interface.h>
+#include <aspect/particle/integrator/interface.h>
+#include <aspect/particle/interpolator/interface.h>
+#include <aspect/particle/output/interface.h>
+#include <aspect/postprocess/visualization.h>
 
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/conditional_ostream.h>
@@ -213,6 +221,71 @@ namespace aspect
       delete copy_of_table;
     }
   }
+
+
+
+  template <int dim>
+  void Simulator<dim>::write_plugin_graph (std::ostream &out) const
+  {
+    // write the preamble
+    out << "digraph Plugins\n"
+        "{\n"
+        "  splines=line;\n"
+        "  splines=true;\n"
+        "  overlap=false;\n"
+        "  edge [fontname=\"FreeSans\",\n"
+        "        fontsize=\"10\",\n"
+        "        labelfontname=\"FreeSans\",\n"
+        "        labelfontsize=\"10\",\n"
+        "        color=\"black\",\n"
+        "        style=\"solid\"];\n"
+        "  node [fontname=\"FreeSans\",\n"
+        "        fontsize=\"10\",\n"
+        "        shape=\"rectangle\",\n"
+        "        height=0.2,\n"
+        "        width=0.4,\n"
+        "        color=\"black\",\n"
+        "        fillcolor=\"white\",\n"
+        "        style=\"filled\"];\n"
+        "\n";
+
+    // then also write nodes for the Simulator and SimulatorAccess classes,
+    // and an arrow from the former to the latter to indicate flow of
+    // information
+    out << "  Simulator [height=1.5,width=2,shape=\"octagon\",fillcolor=\"yellow\"];\n";
+    out << "  SimulatorAccess [height=1.2,width=1.2,shape=\"rect\",fillcolor=\"yellow\"];\n";
+    out << "  Simulator -> SimulatorAccess [len=1, weight=100];\n";
+
+    // then go through all plugin systems and output everything we have
+    AdiabaticConditions::write_plugin_graph<dim>(out);
+    BoundaryComposition::write_plugin_graph<dim>(out);
+    BoundaryFluidPressure::write_plugin_graph<dim>(out);
+    BoundaryTemperature::Manager<dim>::write_plugin_graph(out);
+    BoundaryTraction::write_plugin_graph<dim>(out);
+    BoundaryVelocity::write_plugin_graph<dim>(out);
+    InitialTopographyModel::write_plugin_graph<dim>(out);
+    GeometryModel::write_plugin_graph<dim>(out);
+    GravityModel::write_plugin_graph<dim>(out);
+    HeatingModel::Manager<dim>::write_plugin_graph(out);
+    InitialComposition::Manager<dim>::write_plugin_graph(out);
+    InitialTemperature::Manager<dim>::write_plugin_graph(out);
+    MaterialModel::write_plugin_graph<dim>(out);
+    MeshRefinement::Manager<dim>::write_plugin_graph(out);
+    Particle::Generator::write_plugin_graph<dim>(out);
+    Particle::Integrator::write_plugin_graph<dim>(out);
+    Particle::Interpolator::write_plugin_graph<dim>(out);
+    Particle::Output::write_plugin_graph<dim>(out);
+    Particle::Property::Manager<dim>::write_plugin_graph(out);
+    Postprocess::Manager<dim>::write_plugin_graph(out);
+    Postprocess::Visualization<dim>::write_plugin_graph(out);
+    PrescribedStokesSolution::write_plugin_graph<dim>(out);
+    TerminationCriteria::Manager<dim>::write_plugin_graph(out);
+
+    // end the graph
+    out << "}"
+        << std::endl;
+  }
+
 
 
   template <int dim>
@@ -1519,6 +1592,7 @@ namespace aspect
   template double Simulator<dim>::compute_time_step () const; \
   template void Simulator<dim>::make_pressure_rhs_compatible(LinearAlgebra::BlockVector &vector); \
   template void Simulator<dim>::output_statistics(); \
+  template void Simulator<dim>::write_plugin_graph(std::ostream &) const; \
   template double Simulator<dim>::compute_initial_stokes_residual(); \
   template bool Simulator<dim>::stokes_matrix_depends_on_solution() const; \
   template void Simulator<dim>::interpolate_onto_velocity_system(const TensorFunction<1,dim> &func, LinearAlgebra::Vector &vec);\

--- a/source/termination_criteria/interface.cc
+++ b/source/termination_criteria/interface.cc
@@ -270,6 +270,16 @@ namespace aspect
                                                                factory_function);
     }
 
+
+
+    template <int dim>
+    void
+    Manager<dim>::write_plugin_graph (std::ostream &out)
+    {
+      std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Termination criteria interface",
+                                                                  out);
+    }
+
   }
 }
 


### PR DESCRIPTION
Here is an attempt at addressing #1667. It adds a command line option that, when
given, initializes a Simulator object and then systematically goes through all
plugin systems and asks them to write out their part of the connection graph
for all plugins.

I haven't gone through all systems yet, just seven of them, to see whether
this is the right direction to go. It's a bit of work to convert it all,
so I thought I'd put it out there already and get a bit of feedback.