### PR TITLE
Remove some includes from simulator_access.h.

### DIFF
--- a/benchmarks/burstedde/burstedde.cc
+++ b/benchmarks/burstedde/burstedde.cc
@@ -3,6 +3,7 @@
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/gravity_model/interface.h>
+#include <aspect/postprocess/interface.h>
 
 
 #include <deal.II/dofs/dof_tools.h>

--- a/benchmarks/inclusion/inclusion.h
+++ b/benchmarks/inclusion/inclusion.h
@@ -3,6 +3,7 @@
 
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_velocity/interface.h>
+#include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 

--- a/benchmarks/shear_bands/shear_bands.cc
+++ b/benchmarks/shear_bands/shear_bands.cc
@@ -1,5 +1,7 @@
 #include <aspect/initial_composition/interface.h>
 #include <aspect/geometry_model/box.h>
+#include <aspect/postprocess/interface.h>
+#include <aspect/boundary_velocity/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/melt.h>

--- a/benchmarks/solcx/solcx.h
+++ b/benchmarks/solcx/solcx.h
@@ -3,6 +3,7 @@
 
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_velocity/interface.h>
+#include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 

--- a/benchmarks/solitary_wave/solitary_wave.cc
+++ b/benchmarks/solitary_wave/solitary_wave.cc
@@ -1,5 +1,7 @@
 #include <aspect/melt.h>
 #include <aspect/initial_composition/interface.h>
+#include <aspect/postprocess/interface.h>
+#include <aspect/gravity_model/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 

--- a/benchmarks/solkz/solkz.h
+++ b/benchmarks/solkz/solkz.h
@@ -3,6 +3,7 @@
 
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_velocity/interface.h>
+#include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 

--- a/include/aspect/assembly.h
+++ b/include/aspect/assembly.h
@@ -24,6 +24,7 @@
 
 #include <aspect/global.h>
 #include <aspect/simulator_access.h>
+#include <aspect/heating_model/interface.h>
 
 #include <deal.II/fe/fe_values.h>
 

--- a/include/aspect/initial_temperature/S40RTS_perturbation.h
+++ b/include/aspect/initial_temperature/S40RTS_perturbation.h
@@ -22,8 +22,8 @@
 #ifndef _aspect_initial_temperature_S40RTS_perturbation_h
 #define _aspect_initial_temperature_S40RTS_perturbation_h
 
-#include <aspect/simulator_access.h>
-#include <deal.II/base/std_cxx11/array.h>
+#include <aspect/initial_temperature/interface.h>
+
 
 namespace aspect
 {

--- a/include/aspect/initial_temperature/SAVANI_perturbation.h
+++ b/include/aspect/initial_temperature/SAVANI_perturbation.h
@@ -22,8 +22,8 @@
 #ifndef _aspect_initial_temperature_SAVANI_perturbation_h
 #define _aspect_initial_temperature_SAVANI_perturbation_h
 
-#include <aspect/simulator_access.h>
-#include <deal.II/base/std_cxx11/array.h>
+#include <aspect/initial_temperature/interface.h>
+
 
 namespace aspect
 {

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -22,6 +22,11 @@
 #ifndef _aspect_simulator_access_h
 #define _aspect_simulator_access_h
 
+#include <aspect/global.h>
+#include <aspect/parameters.h>
+#include <aspect/introspection.h>
+
+#include <deal.II/base/table_handler.h>
 #include <deal.II/base/timer.h>
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/distributed/tria.h>
@@ -29,23 +34,6 @@
 #include <deal.II/fe/fe.h>
 #include <deal.II/fe/mapping_q.h>
 
-#include <aspect/global.h>
-#include <aspect/parameters.h>
-#include <aspect/introspection.h>
-#include <aspect/material_model/interface.h>
-#include <aspect/geometry_model/initial_topography_model/interface.h>
-#include <aspect/geometry_model/interface.h>
-#include <aspect/gravity_model/interface.h>
-#include <aspect/boundary_temperature/interface.h>
-#include <aspect/boundary_composition/interface.h>
-#include <aspect/initial_temperature/interface.h>
-#include <aspect/initial_composition/interface.h>
-#include <aspect/boundary_velocity/interface.h>
-#include <aspect/boundary_traction/interface.h>
-#include <aspect/mesh_refinement/interface.h>
-#include <aspect/postprocess/interface.h>
-#include <aspect/heating_model/interface.h>
-#include <aspect/adiabatic_conditions/interface.h>
 
 
 namespace aspect
@@ -56,6 +44,11 @@ namespace aspect
   template <int dim> class Simulator;
   template <int dim> struct SimulatorSignals;
   template <int dim> class LateralAveraging;
+
+  namespace GravityModel
+  {
+    template <int dim> class Interface;
+  }
 
   namespace HeatingModel
   {
@@ -74,9 +67,29 @@ namespace aspect
     template <int dim> class Interface;
   }
 
+  namespace BoundaryComposition
+  {
+    template <int dim> class Interface;
+  }
+
+  namespace BoundaryTraction
+  {
+    template <int dim> class Interface;
+  }
+
+  namespace BoundaryVelocity
+  {
+    template <int dim> class Interface;
+  }
+
   namespace InitialComposition
   {
     template <int dim> class Manager;
+    template <int dim> class Interface;
+  }
+
+  namespace InitialTopographyModel
+  {
     template <int dim> class Interface;
   }
 
@@ -88,7 +101,7 @@ namespace aspect
   template <int dim> class MeltHandler;
 
   /**
-   * SimulatorAccess is base class for different plugins like postprocessors.
+   * SimulatorAccess is a base class for different plugins like postprocessors.
    * It provides access to the various variables of the main class that
    * plugins may want to use in their evaluations, such as solution vectors,
    * the current time, time step sizes, material models, or the triangulations

--- a/source/adiabatic_conditions/initial_profile.cc
+++ b/source/adiabatic_conditions/initial_profile.cc
@@ -21,6 +21,8 @@
 
 #include <aspect/global.h>
 #include <aspect/adiabatic_conditions/initial_profile.h>
+#include <aspect/gravity_model/interface.h>
+#include <aspect/initial_composition/interface.h>
 
 #include <deal.II/base/signaling_nan.h>
 

--- a/source/boundary_composition/initial_composition.cc
+++ b/source/boundary_composition/initial_composition.cc
@@ -20,6 +20,8 @@
 
 
 #include <aspect/boundary_composition/initial_composition.h>
+#include <aspect/initial_composition/interface.h>
+
 
 namespace aspect
 {

--- a/source/boundary_fluid_pressure/density.cc
+++ b/source/boundary_fluid_pressure/density.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/boundary_fluid_pressure/density.h>
+#include <aspect/gravity_model/interface.h>
 #include <aspect/melt.h>
 #include <utility>
 #include <limits>

--- a/source/boundary_temperature/initial_temperature.cc
+++ b/source/boundary_temperature/initial_temperature.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/boundary_temperature/initial_temperature.h>
+#include <aspect/initial_temperature/interface.h>
 
 
 namespace aspect

--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -20,6 +20,9 @@
 
 
 #include <aspect/boundary_traction/initial_lithostatic_pressure.h>
+#include <aspect/initial_temperature/interface.h>
+#include <aspect/initial_composition/interface.h>
+#include <aspect/gravity_model/interface.h>
 #include <aspect/global.h>
 #include <aspect/utilities.h>
 #include <deal.II/base/std_cxx11/array.h>

--- a/source/gravity_model/radial.cc
+++ b/source/gravity_model/radial.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/gravity_model/radial.h>
+#include <aspect/geometry_model/interface.h>
 
 #include <deal.II/base/tensor.h>
 

--- a/source/heating_model/adiabatic_heating.cc
+++ b/source/heating_model/adiabatic_heating.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/heating_model/adiabatic_heating.h>
+#include <aspect/gravity_model/interface.h>
 
 
 namespace aspect

--- a/source/initial_composition/porosity.cc
+++ b/source/initial_composition/porosity.cc
@@ -20,6 +20,8 @@
 
 
 #include <aspect/initial_composition/porosity.h>
+#include <aspect/initial_temperature/interface.h>
+#include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/material_model/interface.h>
 #include <aspect/melt.h>
 

--- a/source/initial_temperature/S40RTS_perturbation.cc
+++ b/source/initial_temperature/S40RTS_perturbation.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/initial_temperature/S40RTS_perturbation.h>
+#include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/utilities.h>
 #include <fstream>
 #include <iostream>

--- a/source/initial_temperature/SAVANI_perturbation.cc
+++ b/source/initial_temperature/SAVANI_perturbation.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/initial_temperature/SAVANI_perturbation.h>
+#include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/utilities.h>
 #include <fstream>
 #include <iostream>

--- a/source/initial_temperature/adiabatic.cc
+++ b/source/initial_temperature/adiabatic.cc
@@ -20,6 +20,8 @@
 
 
 #include <aspect/initial_temperature/adiabatic.h>
+#include <aspect/adiabatic_conditions/interface.h>
+#include <aspect/boundary_temperature/interface.h>
 #include <aspect/geometry_model/box.h>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/chunk.h>

--- a/source/initial_temperature/harmonic_perturbation.cc
+++ b/source/initial_temperature/harmonic_perturbation.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/initial_temperature/harmonic_perturbation.h>
+#include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/geometry_model/box.h>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/chunk.h>

--- a/source/initial_temperature/spherical_shell.cc
+++ b/source/initial_temperature/spherical_shell.cc
@@ -20,6 +20,7 @@
 
 #include <deal.II/base/signaling_nan.h>
 #include <aspect/initial_temperature/spherical_shell.h>
+#include <aspect/boundary_temperature/interface.h>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/sphere.h>
 #include <aspect/geometry_model/chunk.h>

--- a/source/material_model/ascii_reference_profile.cc
+++ b/source/material_model/ascii_reference_profile.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/material_model/ascii_reference_profile.h>
+#include <aspect/adiabatic_conditions/interface.h>
 
 
 namespace aspect

--- a/source/material_model/composition_reaction.cc
+++ b/source/material_model/composition_reaction.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/material_model/composition_reaction.h>
+#include <aspect/geometry_model/interface.h>
 
 
 namespace aspect

--- a/source/material_model/latent_heat.cc
+++ b/source/material_model/latent_heat.cc
@@ -20,6 +20,8 @@
 
 
 #include <aspect/material_model/latent_heat.h>
+#include <aspect/adiabatic_conditions/interface.h>
+#include <aspect/gravity_model/interface.h>
 
 
 namespace aspect

--- a/source/material_model/latent_heat_melt.cc
+++ b/source/material_model/latent_heat_melt.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/material_model/latent_heat_melt.h>
+#include <aspect/adiabatic_conditions/interface.h>
 
 
 namespace aspect

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/material_model/melt_global.h>
+#include <aspect/adiabatic_conditions/interface.h>
 
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/numerics/fe_field_function.h>

--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -20,6 +20,8 @@
 
 
 #include <aspect/material_model/melt_simple.h>
+#include <aspect/adiabatic_conditions/interface.h>
+#include <aspect/gravity_model/interface.h>
 
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/numerics/fe_field_function.h>

--- a/source/material_model/morency_doin.cc
+++ b/source/material_model/morency_doin.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/material_model/morency_doin.h>
+#include <aspect/geometry_model/interface.h>
 
 
 namespace aspect

--- a/source/material_model/nondimensional.cc
+++ b/source/material_model/nondimensional.cc
@@ -20,6 +20,8 @@
 
 
 #include <aspect/material_model/nondimensional.h>
+#include <aspect/geometry_model/interface.h>
+#include <aspect/adiabatic_conditions/interface.h>
 
 
 namespace aspect

--- a/source/material_model/simple_compressible.cc
+++ b/source/material_model/simple_compressible.cc
@@ -19,6 +19,7 @@
 */
 
 #include <aspect/material_model/simple_compressible.h>
+#include <aspect/adiabatic_conditions/interface.h>
 
 
 namespace aspect

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/material_model/steinberger.h>
+#include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/utilities.h>
 #include <aspect/lateral_averaging.h>
 

--- a/source/mesh_refinement/boundary.cc
+++ b/source/mesh_refinement/boundary.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/mesh_refinement/boundary.h>
+#include <aspect/geometry_model/interface.h>
 
 namespace aspect
 {

--- a/source/mesh_refinement/nonadiabatic_temperature.cc
+++ b/source/mesh_refinement/nonadiabatic_temperature.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/mesh_refinement/nonadiabatic_temperature.h>
+#include <aspect/adiabatic_conditions/interface.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/dofs/dof_tools.h>

--- a/source/mesh_refinement/slope.cc
+++ b/source/mesh_refinement/slope.cc
@@ -19,10 +19,12 @@
 */
 
 
+#include <aspect/mesh_refinement/slope.h>
+#include <aspect/gravity_model/interface.h>
+
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>
 
-#include <aspect/mesh_refinement/slope.h>
 
 namespace aspect
 {

--- a/source/mesh_refinement/topography.cc
+++ b/source/mesh_refinement/topography.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/mesh_refinement/topography.h>
+#include <aspect/geometry_model/interface.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/numerics/error_estimator.h>

--- a/source/particle/property/composition.cc
+++ b/source/particle/property/composition.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/particle/property/composition.h>
+#include <aspect/initial_composition/interface.h>
 
 namespace aspect
 {

--- a/source/particle/property/initial_composition.cc
+++ b/source/particle/property/initial_composition.cc
@@ -19,6 +19,7 @@
  */
 
 #include <aspect/particle/property/initial_composition.h>
+#include <aspect/initial_composition/interface.h>
 
 namespace aspect
 {

--- a/source/particle/property/pT_path.cc
+++ b/source/particle/property/pT_path.cc
@@ -19,6 +19,8 @@
  */
 
 #include <aspect/particle/property/pT_path.h>
+#include <aspect/adiabatic_conditions/interface.h>
+#include <aspect/initial_temperature/interface.h>
 
 namespace aspect
 {

--- a/source/postprocess/basic_statistics.cc
+++ b/source/postprocess/basic_statistics.cc
@@ -21,6 +21,10 @@
 
 #include <aspect/postprocess/basic_statistics.h>
 #include <aspect/material_model/simple.h>
+#include <aspect/geometry_model/interface.h>
+#include <aspect/gravity_model/interface.h>
+#include <aspect/boundary_temperature/interface.h>
+#include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/global.h>
 
 

--- a/source/postprocess/boundary_densities.cc
+++ b/source/postprocess/boundary_densities.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/postprocess/boundary_densities.h>
+#include <aspect/geometry_model/interface.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/boundary_pressures.cc
+++ b/source/postprocess/boundary_pressures.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/postprocess/boundary_pressures.h>
+#include <aspect/geometry_model/interface.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/depth_average.cc
+++ b/source/postprocess/depth_average.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/postprocess/depth_average.h>
+#include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/lateral_averaging.h>
 #include <aspect/global.h>
 #include <aspect/utilities.h>

--- a/source/postprocess/heating_statistics.cc
+++ b/source/postprocess/heating_statistics.cc
@@ -21,6 +21,8 @@
 
 
 #include <aspect/postprocess/heating_statistics.h>
+#include <aspect/heating_model/interface.h>
+#include <aspect/adiabatic_conditions/interface.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/temperature_statistics.cc
+++ b/source/postprocess/temperature_statistics.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/postprocess/temperature_statistics.h>
+#include <aspect/boundary_temperature/interface.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/postprocess/visualization/adiabat.cc
+++ b/source/postprocess/visualization/adiabat.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/postprocess/visualization/adiabat.h>
+#include <aspect/adiabatic_conditions/interface.h>
 
 
 namespace aspect

--- a/source/postprocess/visualization/boundary_indicator.cc
+++ b/source/postprocess/visualization/boundary_indicator.cc
@@ -20,7 +20,7 @@
 
 
 #include <aspect/postprocess/visualization/boundary_indicator.h>
-
+#include <aspect/geometry_model/interface.h>
 
 
 

--- a/source/postprocess/visualization/depth.cc
+++ b/source/postprocess/visualization/depth.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/postprocess/visualization/depth.h>
+#include <aspect/geometry_model/interface.h>
 
 
 

--- a/source/postprocess/visualization/gravity.cc
+++ b/source/postprocess/visualization/gravity.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/postprocess/visualization/gravity.h>
+#include <aspect/gravity_model/interface.h>
 
 
 

--- a/source/postprocess/visualization/heating.cc
+++ b/source/postprocess/visualization/heating.cc
@@ -20,6 +20,8 @@
 
 
 #include <aspect/postprocess/visualization/heating.h>
+#include <aspect/heating_model/interface.h>
+#include <aspect/adiabatic_conditions/interface.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/grid/grid_tools.h>
 

--- a/source/postprocess/visualization/maximum_horizontal_compressive_stress.cc
+++ b/source/postprocess/visualization/maximum_horizontal_compressive_stress.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/postprocess/visualization/maximum_horizontal_compressive_stress.h>
+#include <aspect/gravity_model/interface.h>
 #include <aspect/utilities.h>
 
 

--- a/source/postprocess/visualization/nonadiabatic_pressure.cc
+++ b/source/postprocess/visualization/nonadiabatic_pressure.cc
@@ -20,7 +20,7 @@
 
 
 #include <aspect/postprocess/visualization/nonadiabatic_pressure.h>
-
+#include <aspect/adiabatic_conditions/interface.h>
 
 
 namespace aspect

--- a/source/postprocess/visualization/nonadiabatic_temperature.cc
+++ b/source/postprocess/visualization/nonadiabatic_temperature.cc
@@ -20,7 +20,7 @@
 
 
 #include <aspect/postprocess/visualization/nonadiabatic_temperature.h>
-
+#include <aspect/adiabatic_conditions/interface.h>
 
 
 namespace aspect

--- a/source/postprocess/visualization/seismic_anomalies.cc
+++ b/source/postprocess/visualization/seismic_anomalies.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/postprocess/visualization/seismic_anomalies.h>
+#include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/lateral_averaging.h>
 #include <aspect/utilities.h>
 

--- a/source/postprocess/visualization/vertical_heat_flux.cc
+++ b/source/postprocess/visualization/vertical_heat_flux.cc
@@ -20,7 +20,7 @@
 
 
 #include <aspect/postprocess/visualization/vertical_heat_flux.h>
-
+#include <aspect/gravity_model/interface.h>
 
 
 namespace aspect

--- a/source/simulator/lateral_averaging.cc
+++ b/source/simulator/lateral_averaging.cc
@@ -21,6 +21,10 @@
 #include <aspect/lateral_averaging.h>
 #include <aspect/material_model/interface.h>
 #include <aspect/gravity_model/interface.h>
+#include <aspect/geometry_model/interface.h>
+
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/base/quadrature_lib.h>

--- a/tests/artificial_postprocess.cc
+++ b/tests/artificial_postprocess.cc
@@ -1,5 +1,6 @@
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_velocity/interface.h>
+#include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 

--- a/tests/burstedde_stokes_rhs.cc
+++ b/tests/burstedde_stokes_rhs.cc
@@ -1,5 +1,6 @@
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_velocity/interface.h>
+#include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <deal.II/dofs/dof_tools.h>

--- a/tests/composition_reaction_iterated_IMPES.cc
+++ b/tests/composition_reaction_iterated_IMPES.cc
@@ -1,4 +1,5 @@
 #include <aspect/material_model/composition_reaction.h>
+#include <aspect/geometry_model/interface.h>
 
 /**
  * This material model assumes three compositional fields

--- a/tests/heat_advection_by_melt.cc
+++ b/tests/heat_advection_by_melt.cc
@@ -1,4 +1,5 @@
 #include <aspect/boundary_fluid_pressure/interface.h>
+#include <aspect/gravity_model/interface.h>
 #include <aspect/material_model/melt_global.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>

--- a/tests/king_ala.cc
+++ b/tests/king_ala.cc
@@ -3,6 +3,7 @@
 #include <aspect/postprocess/interface.h>
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_temperature/interface.h>
+#include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/geometry_model/box.h>

--- a/tests/melt_compressible_advection.cc
+++ b/tests/melt_compressible_advection.cc
@@ -1,6 +1,8 @@
 #include <aspect/material_model/interface.h>
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/boundary_fluid_pressure/interface.h>
+#include <aspect/gravity_model/interface.h>
+#include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/melt.h>

--- a/tests/melt_force_vector.cc
+++ b/tests/melt_force_vector.cc
@@ -1,6 +1,8 @@
 #include <aspect/melt.h>
 #include <aspect/boundary_fluid_pressure/interface.h>
 #include <aspect/boundary_velocity/interface.h>
+#include <aspect/postprocess/interface.h>
+#include <aspect/gravity_model/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <deal.II/dofs/dof_tools.h>

--- a/tests/melt_material_4.cc
+++ b/tests/melt_material_4.cc
@@ -1,5 +1,6 @@
 #include <aspect/material_model/interface.h>
 #include <aspect/boundary_velocity/interface.h>
+#include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/melt.h>

--- a/tests/melt_transport_adaptive.cc
+++ b/tests/melt_transport_adaptive.cc
@@ -1,6 +1,8 @@
 #include <aspect/material_model/interface.h>
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/boundary_fluid_pressure/interface.h>
+#include <aspect/postprocess/interface.h>
+#include <aspect/gravity_model/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/mesh_refinement/interface.h>

--- a/tests/melt_transport_compressible.cc
+++ b/tests/melt_transport_compressible.cc
@@ -1,6 +1,8 @@
 #include <aspect/material_model/interface.h>
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/boundary_fluid_pressure/interface.h>
+#include <aspect/gravity_model/interface.h>
+#include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/melt.h>

--- a/tests/melt_transport_convergence_simple.cc
+++ b/tests/melt_transport_convergence_simple.cc
@@ -1,6 +1,7 @@
 #include <aspect/material_model/interface.h>
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/boundary_fluid_pressure/interface.h>
+#include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/melt.h>

--- a/tests/melt_transport_convergence_test.cc
+++ b/tests/melt_transport_convergence_test.cc
@@ -1,6 +1,7 @@
 #include <aspect/material_model/interface.h>
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/boundary_fluid_pressure/interface.h>
+#include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/melt.h>

--- a/tests/prescribed_velocity_boundary.cc
+++ b/tests/prescribed_velocity_boundary.cc
@@ -1,5 +1,6 @@
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_velocity/interface.h>
+#include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 

--- a/tests/segregation_heating.cc
+++ b/tests/segregation_heating.cc
@@ -1,4 +1,5 @@
 #include <aspect/boundary_fluid_pressure/interface.h>
+#include <aspect/gravity_model/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/melt.h>

--- a/tests/tangurnis.cc
+++ b/tests/tangurnis.cc
@@ -3,6 +3,8 @@
 #include <aspect/postprocess/interface.h>
 #include <aspect/material_model/simple.h>
 #include <aspect/boundary_temperature/interface.h>
+#include <aspect/heating_model/interface.h>
+#include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 #include <aspect/geometry_model/box.h>


### PR DESCRIPTION
Put them where they are needed instead, i.e., in .cc files individually.

This fixes #1776. Getting there was a bit painful given the number of files involved, but I think it is nonetheless the right thing to do.