### PR TITLE
Print the commands being executed in tests/checkpoint_01.

### DIFF
--- a/tests/checkpoint_01.cc
+++ b/tests/checkpoint_01.cc
@@ -1,4 +1,5 @@
 #include <aspect/simulator.h>
+#include <iostream>
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT
@@ -10,35 +11,47 @@ int f()
 
   // call ASPECT with "--" and pipe an existing input file into it.
   int ret;
+  std::string command;
 
-  ret = system ("cd output-checkpoint_01 ; "
-                "(cat " ASPECT_SOURCE_DIR "/tests/checkpoint_01.prm "
-                " ; "
-                " echo 'set Output directory = output1.tmp' "
-                " ; "
-                " rm -rf output1.tmp ; mkdir output1.tmp "
-                ") "
-                "| ../../aspect -- >/dev/null ");
-
+  command = ("cd output-checkpoint_01 ; "
+             "(cat " ASPECT_SOURCE_DIR "/tests/checkpoint_01.prm "
+             " ; "
+             " echo 'set Output directory = output1.tmp' "
+             " ; "
+             " rm -rf output1.tmp ; mkdir output1.tmp "
+             ") "
+             "| ../../aspect -- > /dev/null");
+  std::cout << "Executing the following command:\n"
+            << command
+            << std::endl;
+  ret = system (command.c_str());
   if (ret!=0)
     std::cout << "system() returned error " << ret << std::endl;
 
-  ret = system ("cd output-checkpoint_01 ; "
-                " rm -rf output2.tmp ; mkdir output2.tmp ; "
-                " cp output1.tmp/restart* output2.tmp/");
+  command = ("cd output-checkpoint_01 ; "
+             " rm -rf output2.tmp ; mkdir output2.tmp ; "
+             " cp output1.tmp/restart* output2.tmp/");
+  std::cout << "Executing the following command:\n"
+            << command
+            << std::endl;
+  ret = system (command.c_str());
   if (ret!=0)
     std::cout << "system() returned error " << ret << std::endl;
 
 
   std::cout << "* now resuming:" << std::endl;
-  ret = system ("cd output-checkpoint_01 ; "
-                "(cat " ASPECT_SOURCE_DIR "/tests/checkpoint_01.prm "
-                " ; "
-                " echo 'set Output directory = output2.tmp' "
-                " ; "
-                " echo 'set Resume computation = true' "
-                ") "
-                "| ../../aspect -- >/dev/null");
+  command = ("cd output-checkpoint_01 ; "
+             "(cat " ASPECT_SOURCE_DIR "/tests/checkpoint_01.prm "
+             " ; "
+             " echo 'set Output directory = output2.tmp' "
+             " ; "
+             " echo 'set Resume computation = true' "
+             ") "
+             "| ../../aspect -- > /dev/null");
+  std::cout << "Executing the following command:\n"
+            << command
+            << std::endl;
+  ret = system (command.c_str());
   if (ret!=0)
     std::cout << "system() returned error " << ret << std::endl;
 

--- a/tests/checkpoint_01/screen-output
+++ b/tests/checkpoint_01/screen-output
@@ -1,12 +1,13 @@
 -----------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 1.4.pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
 -----------------------------------------------------------------------------
 
 Loading shared library <./libcheckpoint_01.so>
 * starting from beginning:
+Executing the following command:
+cd output-checkpoint_01 ; (cat ASPECT_DIR/tests/checkpoint_01.prm  ;  echo 'set Output directory = output1.tmp'  ;  rm -rf output1.tmp ; mkdir output1.tmp ) | ../../aspect -- > /dev/null
+Executing the following command:
+cd output-checkpoint_01 ;  rm -rf output2.tmp ; mkdir output2.tmp ;  cp output1.tmp/restart* output2.tmp/
 * now resuming:
+Executing the following command:
+cd output-checkpoint_01 ; (cat ASPECT_DIR/tests/checkpoint_01.prm  ;  echo 'set Output directory = output2.tmp'  ;  echo 'set Resume computation = true' ) | ../../aspect -- > /dev/null
 * now comparing:


### PR DESCRIPTION
I had to do this for debugging why this test failed with a floating
point exception in #1756. I thought it may be worth always doing.

It may fail because I'm printing a pathname, which I'm only
moderately sure the comparison script normalizes. Let's find
out what the tester has to say.