### PR TITLE
Move melt assemblers out of assembly

### DIFF
--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -265,7 +265,11 @@ namespace aspect
   class MeltHandler: public SimulatorAccess<dim>
   {
     public:
-      MeltHandler(ParameterHandler &prm);
+      void
+      /**
+       * Connect all slots to signals.
+       */
+      initialize();
 
       /**
        * Declare additional parameters that are needed in models with
@@ -299,11 +303,6 @@ namespace aspect
        */
       void edit_finite_element_variables(const Parameters<dim> &parameters,
                                          std::vector<VariableDeclaration<dim> > &variables);
-
-      /**
-       * Setup SimulatorAccess for the plugins related to melt transport.
-       */
-      void initialize_simulator (const Simulator<dim> &simulator_object);
 
       /**
        * Compute fluid velocity and solid pressure in this ghosted solution vector.
@@ -349,8 +348,17 @@ namespace aspect
        * transport.
        */
       std_cxx11::unique_ptr<BoundaryFluidPressure::Interface<dim> > boundary_fluid_pressure;
-  };
 
+    private:
+
+      /**
+       * Connect all assemblers that are used for melt models.
+       */
+      void set_melt_assemblers(const SimulatorAccess<dim> &simulator_access,
+                               internal::Assembly::AssemblerLists<dim> &assemblers,
+                               std::vector<dealii::std_cxx11::shared_ptr<
+                               internal::Assembly::Assemblers::AssemblerBase<dim> > > &assembler_objects);
+  };
 }
 
 #endif

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -305,6 +305,15 @@ namespace aspect
       convert_output_to_years () const;
 
       /**
+       * Return whether or not we do the correction of
+       * the Stokes right hand side vector to ensure that the average
+       * divergence is zero. This is necessary for compressible models, but
+       * only if there are no in/outflow boundaries.
+       */
+      bool
+      do_pressure_rhs_compatibility_modification () const;
+
+      /**
        * Return the number of the current pre refinement step.
        * This can be useful for plugins that want to function differently in
        * the initial adaptive refinements and later on.

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -149,7 +149,7 @@ namespace aspect
     :
     assemblers (new internal::Assembly::AssemblerLists<dim>()),
     parameters (prm, mpi_communicator_),
-    melt_handler (parameters.include_melt_transport ? new MeltHandler<dim> (prm) : NULL),
+    melt_handler (parameters.include_melt_transport ? new MeltHandler<dim> () : NULL),
     post_signal_creation(
       std_cxx11::bind (&internals::SimulatorSignals::call_connector_functions<dim>,
                        std_cxx11::ref(signals))),
@@ -544,12 +544,9 @@ namespace aspect
     // Initialize the melt handler
     if (parameters.include_melt_transport)
       {
-        AssertThrow( !parameters.use_discontinuous_temperature_discretization &&
-                     !parameters.use_discontinuous_composition_discretization,
-                     ExcMessage("Melt transport can not be used with discontinuous elements.") );
-        AssertThrow( !parameters.free_surface_enabled,
-                     ExcMessage("Melt transport together with a free surface has not been tested.") );
         melt_handler->initialize_simulator (*this);
+        melt_handler->parse_parameters(prm);
+        melt_handler->initialize();
       }
 
     postprocess_manager.initialize_simulator (*this);

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -186,6 +186,16 @@ namespace aspect
   }
 
 
+
+  template <int dim>
+  bool
+  SimulatorAccess<dim>::do_pressure_rhs_compatibility_modification () const
+  {
+    return simulator->do_pressure_rhs_compatibility_modification;
+  }
+
+
+
   template <int dim>
   unsigned int
   SimulatorAccess<dim>::get_pre_refinement_step () const


### PR DESCRIPTION
This simplifies the `set_assemblers` function quite a bit by moving all of the melt related assemblers into a separate function inside of `MeltHandler`. For this to work I also had to adjust the initialization order of `MeltHandler` that so far did not follow our usual pattern of `Constructor; Initialize Simulator; Parse parameters; Initialize function`.
This PR probably conflicts with #1691, and #1542, but I have two busy weeks ahead of me anyway, so this can wait a bit. @MFraters what is your current schedule for #1691 and #1707? After #1691 is merged we can prepare a PR similar to this one for the Newton related assemblers.