### PR TITLE
Add function to expand variable names

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -68,6 +68,22 @@ namespace aspect
                                  const unsigned int N,
                                  const std::string &id_text);
 
+    /**
+     * Given a vector @p var_declarations expand any entries of the form
+     * vector(str) or tensor(str) to sublists with component names of the form
+     * str_x, str_y, str_z or str_xx, str_xy... for the correct dimension
+     * value.
+     *
+     * This function is to be used for expanding lists of variable names where
+     * one or more such variable is actually intended to be a list of
+     * components.
+     *
+     * Returns the generated list of variable names
+     */
+    template <int dim>
+    std::vector<std::string>
+    expand_dimensional_variable_names (const std::vector<std::string> &var_declarations);
+
 
     /**
      * Split the set of DoFs (typically locally owned or relevant) in @p whole_set into blocks
@@ -409,6 +425,44 @@ namespace aspect
       // This should never happen, but return an empty vector so the compiler
       // will be happy
       return std::vector<T> ();
+    }
+
+    template <int dim>
+    std::vector<std::string>
+    expand_dimensional_variable_names (const std::vector<std::string> &var_declarations)
+    {
+      std::vector<std::string> dim_names = {"x", "y", "z"};
+      char fn_split = "(", fn_end = ")";
+      std::vector<std::string> var_name_list;
+      for (auto const var_decl : var_decls)
+        {
+
+          if (var_decl.find(fn_split) != std::string::npos&&var_decl[var_decl.length()-1]==fn_end)
+            {
+              std::string fn_name = var_decl.substr(0, var_decl.find(fn_split));
+              std::string var_name = var_decl.substr(var_decl.find(fn_split), var_decl.length()-2-var_decl.find(fn_split));
+              if (fn_name == "vector")
+                {
+                  for (int i=0; i<dim; ++i)
+                    var_name_list.push_back(var_name+"_"+dim_names[i]);
+                }
+              else if (fn_name == "tensor")
+                {
+                  for (int i=0; i<dim; ++i)
+                    for (int j=0; j< dim; ++j)
+                      var_name_list.push_back(var_name+"_"+dim_names[i]+dim_names[j]);
+                }
+              else
+                {
+                  var_name_list.push_back(var_decl);
+                }
+            }
+          else
+            {
+              var_name_list.push_back(var_decl);
+            }
+        }
+      return var_name_list;
     }
 
     /**

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -427,44 +427,6 @@ namespace aspect
       return std::vector<T> ();
     }
 
-    template <int dim>
-    std::vector<std::string>
-    expand_dimensional_variable_names (const std::vector<std::string> &var_declarations)
-    {
-      std::vector<std::string> dim_names = {"x", "y", "z"};
-      char fn_split = "(", fn_end = ")";
-      std::vector<std::string> var_name_list;
-      for (auto const var_decl : var_decls)
-        {
-
-          if (var_decl.find(fn_split) != std::string::npos&&var_decl[var_decl.length()-1]==fn_end)
-            {
-              std::string fn_name = var_decl.substr(0, var_decl.find(fn_split));
-              std::string var_name = var_decl.substr(var_decl.find(fn_split), var_decl.length()-2-var_decl.find(fn_split));
-              if (fn_name == "vector")
-                {
-                  for (int i=0; i<dim; ++i)
-                    var_name_list.push_back(var_name+"_"+dim_names[i]);
-                }
-              else if (fn_name == "tensor")
-                {
-                  for (int i=0; i<dim; ++i)
-                    for (int j=0; j< dim; ++j)
-                      var_name_list.push_back(var_name+"_"+dim_names[i]+dim_names[j]);
-                }
-              else
-                {
-                  var_name_list.push_back(var_decl);
-                }
-            }
-          else
-            {
-              var_name_list.push_back(var_decl);
-            }
-        }
-      return var_name_list;
-    }
-
     /**
      * Replace the string <tt>\$ASPECT_SOURCE_DIR</tt> in @p location by the current
      * source directory of ASPECT and return the resulting string.

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -73,6 +73,53 @@ namespace aspect
         }
     }
 
+    template <int dim>
+    std::vector<std::string>
+    expand_dimensional_variable_names (const std::vector<std::string> &var_declarations)
+    {
+      std::string dim_names[3] = {"x", "y", "z"};
+      char fn_split = '(', fn_end = ')';
+      std::vector<std::string> var_name_list;
+
+      for (std::vector<std::string>::const_iterator var_decl_iterator = var_declarations.begin();
+           var_decl_iterator != var_declarations.end();
+           ++var_decl_iterator)
+        {
+          const std::string &var_decl = *var_decl_iterator;
+          if (var_decl.find(fn_split) != std::string::npos && var_decl[var_decl.length()-1]==fn_end)
+            {
+              const std::string fn_name = var_decl.substr(0, var_decl.find(fn_split));
+
+              // Cannot be const because will be manipulated to strip whitespace
+              std::string var_name = var_decl.substr(var_decl.find(fn_split)+1, var_decl.length()-2-var_decl.find(fn_split));
+              while ((var_name.length() != 0) && (var_name[0] == ' '))
+                var_name.erase(0, 1);
+              while ((var_name.length() != 0) && (var_name[var_name.length()-1] == ' '))
+                var_name.erase(var_name.length()-1, 1);
+              if (fn_name == "vector")
+                {
+                  for (int i=0; i<dim; ++i)
+                    var_name_list.push_back(var_name+"_"+dim_names[i]);
+                }
+              else if (fn_name == "tensor")
+                {
+                  for (int i=0; i<dim; ++i)
+                    for (int j=0; j< dim; ++j)
+                      var_name_list.push_back(var_name+"_"+dim_names[i]+dim_names[j]);
+                }
+              else
+                {
+                  var_name_list.push_back(var_decl);
+                }
+            }
+          else
+            {
+              var_name_list.push_back(var_decl);
+            }
+        }
+      return var_name_list;
+    }
+
 
     /**
     * This is an internal deal.II function stolen from dof_tools.cc
@@ -2449,7 +2496,10 @@ namespace aspect
 #define INSTANTIATE(dim) \
   template \
   IndexSet extract_locally_active_dofs_with_component(const DoFHandler<dim> &, \
-                                                      const ComponentMask &);
+                                                      const ComponentMask &); \
+  template \
+  std::vector<std::string> \
+  expand_dimensional_variable_names<dim> (const std::vector<std::string> &var_declarations);
 
     ASPECT_INSTANTIATE(INSTANTIATE)
 

--- a/tests/var_declaration_expansion.cc
+++ b/tests/var_declaration_expansion.cc
@@ -1,0 +1,35 @@
+#include <aspect/utilities.h>
+
+#include <iostream>
+
+void print_string_vector(std::vector<std::string> data)
+{
+  for (std::vector<std::string>::iterator it = data.begin(); it != data.end(); ++it)
+    std::cout << "\t" << *it << std::endl;
+}
+
+int f()
+{
+  using namespace aspect::Utilities;
+
+  std::vector<std::string> base_declarations;
+  base_declarations.push_back("vector(  vec  )");
+  base_declarations.push_back("tensor(  ten )");
+
+  std::vector<std::string> var_decl_2 = expand_dimensional_variable_names<2> (base_declarations);
+  std::vector<std::string> var_decl_3 = expand_dimensional_variable_names<3> (base_declarations);
+
+  std::cout << "Dimension 2:" << std::endl;
+  print_string_vector(var_decl_2);
+
+  std::cout << "Dimension 3:" << std::endl;
+  print_string_vector(var_decl_3);
+
+  exit(0);
+
+  // dummy return for compilation warnings
+
+  return 0;
+}
+
+int ignored_variable = f();

--- a/tests/var_declaration_expansion.prm
+++ b/tests/var_declaration_expansion.prm
@@ -1,0 +1,113 @@
+# A test that simply verifies that the additional material
+# model outputs can be accessed. 
+
+
+
+
+
+set Dimension = 2
+
+set CFL number                             = 1.0
+set End time                               = 0
+set Resume computation                     = false
+
+set Start time                             = 0
+
+set Adiabatic surface temperature          = 0
+
+set Surface pressure                       = 0
+
+set Use years in output instead of seconds = false  # default: true
+
+set Nonlinear solver scheme                = IMPES
+
+subsection Boundary temperature model
+  set List of model names = box
+end
+
+
+subsection Discretization
+  set Stokes velocity polynomial degree       = 2
+
+  set Temperature polynomial degree           = 2
+
+  set Use locally conservative discretization = false
+
+  subsection Stabilization parameters
+    set alpha = 2
+
+    set beta  = 0.078
+
+    set cR    = 0.5   # default: 0.11
+  end
+
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+
+    set Y extent = 1
+
+    set Z extent = 1
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+end
+
+
+subsection Initial temperature model
+  set Model name = perturbed box
+
+end
+
+
+subsection Material model
+  set Model name = simple
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0                       # default: 2
+  set Initial global refinement          = 2                       # default: 2
+
+  set Strategy                           = density, temperature
+end
+
+
+subsection Model settings
+
+
+  set Fixed temperature boundary indicators   = 0, 1
+
+  set Prescribed velocity boundary indicators =
+
+  set Tangential velocity boundary indicators = 0,1,2,3
+
+  set Zero velocity boundary indicators       =
+end
+
+
+subsection Postprocess
+  set List of postprocessors =
+
+  subsection Depth average
+    set Time between graphical output = 1e8
+  end
+
+  subsection Visualization
+    set Number of grouped files       = 0
+
+    set Output format                 = gnuplot
+
+    set Time between graphical output = 0   # default: 1e8
+  end
+end
+

--- a/tests/var_declaration_expansion/screen-output
+++ b/tests/var_declaration_expansion/screen-output
@@ -1,0 +1,24 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libvar_declaration_expansion.so>
+Dimension 2:
+	vec_x
+	vec_y
+	ten_xx
+	ten_xy
+	ten_yx
+	ten_yy
+Dimension 3:
+	vec_x
+	vec_y
+	vec_z
+	ten_xx
+	ten_xy
+	ten_xz
+	ten_yx
+	ten_yy
+	ten_yz
+	ten_zx
+	ten_zy
+	ten_zz


### PR DESCRIPTION
Attempt to add function requested by #1240. Needs to be tested, so it would help to identify likely locations of use.

Note that this will not be sufficiently dimension agnostic in composition field names, as the count cannot be currently used as the number of fields is a provided constant. This could possibly be corrected by making a breaking change to the parameter file that would also require that composition fields always be named. As I do not know of any other good test locations, I do not yet have a test in place.