### PR TITLE
Fix a mistake in the manual.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -9990,7 +9990,7 @@ do:
     and compile it into a shared library yourself. This may be as easy as
     calling
     \begin{verbatim}
- g++ -I/path/to/aspect/headers -I/path/to/deal.II/headers \backslash
+ g++ -I/path/to/aspect/headers -I/path/to/deal.II/headers \
      -fPIC -shared my_plugin.cc -o my_plugin.so
     \end{verbatim}
     on Linux, but the command may be different on other systems. Now you only


### PR DESCRIPTION
In verbatim environments, one can just use a regular backslash, without having
to escape it somehow. In contrast, writing \backslash leads to printing
exactly this in the pdf, which is not what we want.