### PR TITLE
Update the style for the plugin graph.

### DIFF
--- a/doc/manual/plugin_graph.dot
+++ b/doc/manual/plugin_graph.dot
@@ -17,6 +17,7 @@ digraph Plugins
         color="black",
         fillcolor="white",
         style="filled"];
+  layout=neato;
 
   Simulator [height=1.5,width=2,shape="octagon",fillcolor="yellow"];
   SimulatorAccess [height=1.2,width=1.2,shape="rect",fillcolor="yellow"];
@@ -24,86 +25,73 @@ digraph Plugins
 N6aspect19AdiabaticConditions9InterfaceILi2EEE [label="Adiabatic conditions interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect19AdiabaticConditions9AsciiDataILi2EEE [label="ascii data", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19AdiabaticConditions9AsciiDataILi2EEE -> N6aspect19AdiabaticConditions9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19AdiabaticConditions9AsciiDataILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect19AdiabaticConditions9AsciiDataILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect19AdiabaticConditions8FunctionILi2EEE [label="function", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19AdiabaticConditions8FunctionILi2EEE -> N6aspect19AdiabaticConditions9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19AdiabaticConditions8FunctionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect19AdiabaticConditions14InitialProfileILi2EEE [label="initial
-profile", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect19AdiabaticConditions8FunctionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect19AdiabaticConditions14InitialProfileILi2EEE [label="initial\nprofile", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19AdiabaticConditions14InitialProfileILi2EEE -> N6aspect19AdiabaticConditions9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19AdiabaticConditions14InitialProfileILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect19AdiabaticConditions14InitialProfileILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect19AdiabaticConditions9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect19BoundaryComposition9InterfaceILi2EEE [label="Boundary composition interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect19BoundaryComposition9AsciiDataILi2EEE [label="ascii data", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19BoundaryComposition9AsciiDataILi2EEE -> N6aspect19BoundaryComposition9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19BoundaryComposition9AsciiDataILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect19BoundaryComposition9AsciiDataILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect19BoundaryComposition3BoxILi2EEE [label="box", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19BoundaryComposition3BoxILi2EEE -> N6aspect19BoundaryComposition9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19BoundaryComposition3BoxILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect19BoundaryComposition18InitialCompositionILi2EEE [label="initial
-composition", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect19BoundaryComposition3BoxILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect19BoundaryComposition18InitialCompositionILi2EEE [label="initial\ncomposition", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19BoundaryComposition18InitialCompositionILi2EEE -> N6aspect19BoundaryComposition9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19BoundaryComposition18InitialCompositionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect19BoundaryComposition17SphericalConstantILi2EEE [label="spherical
-constant", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect19BoundaryComposition18InitialCompositionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect19BoundaryComposition17SphericalConstantILi2EEE [label="spherical\nconstant", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19BoundaryComposition17SphericalConstantILi2EEE -> N6aspect19BoundaryComposition9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19BoundaryComposition17SphericalConstantILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect19BoundaryComposition14TwoMergedBoxesILi2EEE [label="box with
-lithosphere
-boundary
-indicators", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect19BoundaryComposition17SphericalConstantILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect19BoundaryComposition14TwoMergedBoxesILi2EEE [label="box with\nlithosphere\nboundary\nindicators", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19BoundaryComposition14TwoMergedBoxesILi2EEE -> N6aspect19BoundaryComposition9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19BoundaryComposition14TwoMergedBoxesILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect19BoundaryComposition14TwoMergedBoxesILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect19BoundaryComposition9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect21BoundaryFluidPressure9InterfaceILi2EEE [label="Boundary fluid pressure interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect21BoundaryFluidPressure7DensityILi2EEE [label="density", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect21BoundaryFluidPressure7DensityILi2EEE -> N6aspect21BoundaryFluidPressure9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect21BoundaryFluidPressure7DensityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect21BoundaryFluidPressure7DensityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect21BoundaryFluidPressure9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect19BoundaryTemperature9InterfaceILi2EEE [label="Boundary temperature interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect19BoundaryTemperature9AsciiDataILi2EEE [label="ascii data", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19BoundaryTemperature9AsciiDataILi2EEE -> N6aspect19BoundaryTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19BoundaryTemperature9AsciiDataILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect19BoundaryTemperature9AsciiDataILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect19BoundaryTemperature3BoxILi2EEE [label="box", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19BoundaryTemperature3BoxILi2EEE -> N6aspect19BoundaryTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19BoundaryTemperature3BoxILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect19BoundaryTemperature3BoxILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect19BoundaryTemperature8ConstantILi2EEE [label="constant", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19BoundaryTemperature8ConstantILi2EEE -> N6aspect19BoundaryTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19BoundaryTemperature8ConstantILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect19BoundaryTemperature8ConstantILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect19BoundaryTemperature8FunctionILi2EEE [label="function", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19BoundaryTemperature8FunctionILi2EEE -> N6aspect19BoundaryTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19BoundaryTemperature8FunctionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect19BoundaryTemperature18InitialTemperatureILi2EEE [label="initial
-temperature", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect19BoundaryTemperature8FunctionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect19BoundaryTemperature18InitialTemperatureILi2EEE [label="initial\ntemperature", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19BoundaryTemperature18InitialTemperatureILi2EEE -> N6aspect19BoundaryTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19BoundaryTemperature18InitialTemperatureILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect19BoundaryTemperature17SphericalConstantILi2EEE [label="spherical
-constant", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect19BoundaryTemperature18InitialTemperatureILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect19BoundaryTemperature17SphericalConstantILi2EEE [label="spherical\nconstant", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19BoundaryTemperature17SphericalConstantILi2EEE -> N6aspect19BoundaryTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19BoundaryTemperature17SphericalConstantILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect19BoundaryTemperature14TwoMergedBoxesILi2EEE [label="box with
-lithosphere
-boundary
-indicators", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect19BoundaryTemperature17SphericalConstantILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect19BoundaryTemperature14TwoMergedBoxesILi2EEE [label="box with\nlithosphere\nboundary\nindicators", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19BoundaryTemperature14TwoMergedBoxesILi2EEE -> N6aspect19BoundaryTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19BoundaryTemperature14TwoMergedBoxesILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect19BoundaryTemperature14TwoMergedBoxesILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect19BoundaryTemperature9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect16BoundaryTraction9InterfaceILi2EEE [label="Boundary traction interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect16BoundaryTraction9AsciiDataILi2EEE [label="ascii data", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect16BoundaryTraction9AsciiDataILi2EEE -> N6aspect16BoundaryTraction9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect16BoundaryTraction9AsciiDataILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect16BoundaryTraction9AsciiDataILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect16BoundaryTraction8FunctionILi2EEE [label="function", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect16BoundaryTraction8FunctionILi2EEE -> N6aspect16BoundaryTraction9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect16BoundaryTraction8FunctionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect16BoundaryTraction26InitialLithostaticPressureILi2EEE [label="initial
-lithostatic
-pressure", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect16BoundaryTraction8FunctionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect16BoundaryTraction26InitialLithostaticPressureILi2EEE [label="initial\nlithostatic\npressure", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect16BoundaryTraction26InitialLithostaticPressureILi2EEE -> N6aspect16BoundaryTraction9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect16BoundaryTraction26InitialLithostaticPressureILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect16BoundaryTraction26InitialLithostaticPressureILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect16BoundaryTraction12ZeroTractionILi2EEE [label="zero traction", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect16BoundaryTraction12ZeroTractionILi2EEE -> N6aspect16BoundaryTraction9InterfaceILi2EEE [len=3, weight=50];
 N6aspect16BoundaryTraction9InterfaceILi2EEE -> Simulator [len=15, weight=50];
@@ -111,13 +99,13 @@ N6aspect16BoundaryTraction9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 N6aspect16BoundaryVelocity9InterfaceILi2EEE [label="Boundary velocity interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect16BoundaryVelocity9AsciiDataILi2EEE [label="ascii data", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect16BoundaryVelocity9AsciiDataILi2EEE -> N6aspect16BoundaryVelocity9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect16BoundaryVelocity9AsciiDataILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect16BoundaryVelocity9AsciiDataILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect16BoundaryVelocity8FunctionILi2EEE [label="function", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect16BoundaryVelocity8FunctionILi2EEE -> N6aspect16BoundaryVelocity9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect16BoundaryVelocity8FunctionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect16BoundaryVelocity8FunctionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect16BoundaryVelocity7GPlatesILi2EEE [label="gplates", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect16BoundaryVelocity7GPlatesILi2EEE -> N6aspect16BoundaryVelocity9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect16BoundaryVelocity7GPlatesILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect16BoundaryVelocity7GPlatesILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect16BoundaryVelocity12ZeroVelocityILi2EEE [label="zero velocity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect16BoundaryVelocity12ZeroVelocityILi2EEE -> N6aspect16BoundaryVelocity9InterfaceILi2EEE [len=3, weight=50];
 N6aspect16BoundaryVelocity9InterfaceILi2EEE -> Simulator [len=15, weight=50];
@@ -125,325 +113,280 @@ N6aspect16BoundaryVelocity9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 N6aspect22InitialTopographyModel9InterfaceILi2EEE [label="Initial topography interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect22InitialTopographyModel9AsciiDataILi2EEE [label="ascii data", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect22InitialTopographyModel9AsciiDataILi2EEE -> N6aspect22InitialTopographyModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect22InitialTopographyModel9AsciiDataILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect22InitialTopographyModel9AsciiDataILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect22InitialTopographyModel10PrmPolygonILi2EEE [label="prm polygon", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect22InitialTopographyModel10PrmPolygonILi2EEE -> N6aspect22InitialTopographyModel9InterfaceILi2EEE [len=3, weight=50];
-N6aspect22InitialTopographyModel14ZeroTopographyILi2EEE [label="zero
-topography", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+N6aspect22InitialTopographyModel14ZeroTopographyILi2EEE [label="zero\ntopography", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect22InitialTopographyModel14ZeroTopographyILi2EEE -> N6aspect22InitialTopographyModel9InterfaceILi2EEE [len=3, weight=50];
 N6aspect22InitialTopographyModel9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect13GeometryModel9InterfaceILi2EEE [label="Geometry model interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect13GeometryModel3BoxILi2EEE [label="box", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13GeometryModel3BoxILi2EEE -> N6aspect13GeometryModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13GeometryModel3BoxILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect13GeometryModel3BoxILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect13GeometryModel5ChunkILi2EEE [label="chunk", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13GeometryModel5ChunkILi2EEE -> N6aspect13GeometryModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13GeometryModel5ChunkILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect13GeometryModel16EllipsoidalChunkILi2EEE [label="ellipsoidal
-chunk", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect13GeometryModel5ChunkILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect13GeometryModel16EllipsoidalChunkILi2EEE [label="ellipsoidal\nchunk", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13GeometryModel16EllipsoidalChunkILi2EEE -> N6aspect13GeometryModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13GeometryModel16EllipsoidalChunkILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect13GeometryModel16EllipsoidalChunkILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect13GeometryModel6SphereILi2EEE [label="sphere", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13GeometryModel6SphereILi2EEE -> N6aspect13GeometryModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13GeometryModel6SphereILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect13GeometryModel14SphericalShellILi2EEE [label="spherical
-shell", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect13GeometryModel6SphereILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect13GeometryModel14SphericalShellILi2EEE [label="spherical\nshell", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13GeometryModel14SphericalShellILi2EEE -> N6aspect13GeometryModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13GeometryModel14SphericalShellILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect13GeometryModel14TwoMergedBoxesILi2EEE [label="box with
-lithosphere
-boundary
-indicators", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect13GeometryModel14SphericalShellILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect13GeometryModel14TwoMergedBoxesILi2EEE [label="box with\nlithosphere\nboundary\nindicators", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13GeometryModel14TwoMergedBoxesILi2EEE -> N6aspect13GeometryModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13GeometryModel14TwoMergedBoxesILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect13GeometryModel14TwoMergedBoxesILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect13GeometryModel9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect12GravityModel9InterfaceILi2EEE [label="Gravity model interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect12GravityModel9AsciiDataILi2EEE [label="ascii data", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12GravityModel9AsciiDataILi2EEE -> N6aspect12GravityModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect12GravityModel9AsciiDataILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect12GravityModel9AsciiDataILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect12GravityModel8FunctionILi2EEE [label="function", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12GravityModel8FunctionILi2EEE -> N6aspect12GravityModel9InterfaceILi2EEE [len=3, weight=50];
-N6aspect12GravityModel14RadialConstantILi2EEE [label="radial
-constant", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+N6aspect12GravityModel14RadialConstantILi2EEE [label="radial\nconstant", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12GravityModel14RadialConstantILi2EEE -> N6aspect12GravityModel9InterfaceILi2EEE [len=3, weight=50];
-N6aspect12GravityModel15RadialEarthLikeILi2EEE [label="radial
-earth-like", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+N6aspect12GravityModel15RadialEarthLikeILi2EEE [label="radial\nearth-like", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12GravityModel15RadialEarthLikeILi2EEE -> N6aspect12GravityModel9InterfaceILi2EEE [len=3, weight=50];
 N6aspect12GravityModel12RadialLinearILi2EEE [label="radial linear", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12GravityModel12RadialLinearILi2EEE -> N6aspect12GravityModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect12GravityModel12RadialLinearILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect12GravityModel12RadialLinearILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect12GravityModel8VerticalILi2EEE [label="vertical", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12GravityModel8VerticalILi2EEE -> N6aspect12GravityModel9InterfaceILi2EEE [len=3, weight=50];
 N6aspect12GravityModel9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect12HeatingModel9InterfaceILi2EEE [label="Heating model interface", height=.8,width=.8,shape="rect",fillcolor="green"]
-N6aspect12HeatingModel16AdiabaticHeatingILi2EEE [label="adiabatic
-heating", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+N6aspect12HeatingModel16AdiabaticHeatingILi2EEE [label="adiabatic\nheating", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12HeatingModel16AdiabaticHeatingILi2EEE -> N6aspect12HeatingModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect12HeatingModel16AdiabaticHeatingILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect12HeatingModel20AdiabaticHeatingMeltILi2EEE [label="adiabatic
-heating of
-melt", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect12HeatingModel16AdiabaticHeatingILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect12HeatingModel20AdiabaticHeatingMeltILi2EEE [label="adiabatic\nheating of\nmelt", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12HeatingModel20AdiabaticHeatingMeltILi2EEE -> N6aspect12HeatingModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect12HeatingModel20AdiabaticHeatingMeltILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect12HeatingModel20CompositionalHeatingILi2EEE [label="compositional
-heating", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect12HeatingModel20AdiabaticHeatingMeltILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect12HeatingModel20CompositionalHeatingILi2EEE [label="compositional\nheating", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12HeatingModel20CompositionalHeatingILi2EEE -> N6aspect12HeatingModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect12HeatingModel20CompositionalHeatingILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect12HeatingModel15ConstantHeatingILi2EEE [label="constant
-heating", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect12HeatingModel20CompositionalHeatingILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect12HeatingModel15ConstantHeatingILi2EEE [label="constant\nheating", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12HeatingModel15ConstantHeatingILi2EEE -> N6aspect12HeatingModel9InterfaceILi2EEE [len=3, weight=50];
 N6aspect12HeatingModel8FunctionILi2EEE [label="function", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12HeatingModel8FunctionILi2EEE -> N6aspect12HeatingModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect12HeatingModel8FunctionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect12HeatingModel8FunctionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect12HeatingModel10LatentHeatILi2EEE [label="latent heat", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12HeatingModel10LatentHeatILi2EEE -> N6aspect12HeatingModel9InterfaceILi2EEE [len=3, weight=50];
-N6aspect12HeatingModel14LatentHeatMeltILi2EEE [label="latent heat
-melt", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+N6aspect12HeatingModel14LatentHeatMeltILi2EEE [label="latent heat\nmelt", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12HeatingModel14LatentHeatMeltILi2EEE -> N6aspect12HeatingModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect12HeatingModel14LatentHeatMeltILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect12HeatingModel16RadioactiveDecayILi2EEE [label="radioactive
-decay", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect12HeatingModel14LatentHeatMeltILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect12HeatingModel16RadioactiveDecayILi2EEE [label="radioactive\ndecay", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12HeatingModel16RadioactiveDecayILi2EEE -> N6aspect12HeatingModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect12HeatingModel16RadioactiveDecayILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect12HeatingModel16RadioactiveDecayILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect12HeatingModel12ShearHeatingILi2EEE [label="shear heating", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12HeatingModel12ShearHeatingILi2EEE -> N6aspect12HeatingModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect12HeatingModel12ShearHeatingILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect12HeatingModel16ShearHeatingMeltILi2EEE [label="shear heating
-with melt", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect12HeatingModel12ShearHeatingILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect12HeatingModel16ShearHeatingMeltILi2EEE [label="shear heating\nwith melt", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect12HeatingModel16ShearHeatingMeltILi2EEE -> N6aspect12HeatingModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect12HeatingModel16ShearHeatingMeltILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect12HeatingModel16ShearHeatingMeltILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect12HeatingModel9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect18InitialComposition9InterfaceILi2EEE [label="Initial composition interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect18InitialComposition9AsciiDataILi2EEE [label="ascii data", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialComposition9AsciiDataILi2EEE -> N6aspect18InitialComposition9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialComposition9AsciiDataILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect18InitialComposition9AsciiDataILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect18InitialComposition8FunctionILi2EEE [label="function", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialComposition8FunctionILi2EEE -> N6aspect18InitialComposition9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialComposition8FunctionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect18InitialComposition8FunctionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect18InitialComposition8PorosityILi2EEE [label="porosity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialComposition8PorosityILi2EEE -> N6aspect18InitialComposition9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialComposition8PorosityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect18InitialComposition8PorosityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect18InitialComposition9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect18InitialTemperature9InterfaceILi2EEE [label="Initial temperature interface", height=.8,width=.8,shape="rect",fillcolor="green"]
-N6aspect18InitialTemperature18S40RTSPerturbationILi2EEE [label="S40RTS
-perturbation", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+N6aspect18InitialTemperature18S40RTSPerturbationILi2EEE [label="S40RTS\nperturbation", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialTemperature18S40RTSPerturbationILi2EEE -> N6aspect18InitialTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialTemperature18S40RTSPerturbationILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect18InitialTemperature18SAVANIPerturbationILi2EEE [label="SAVANI
-perturbation", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect18InitialTemperature18S40RTSPerturbationILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect18InitialTemperature18SAVANIPerturbationILi2EEE [label="SAVANI\nperturbation", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialTemperature18SAVANIPerturbationILi2EEE -> N6aspect18InitialTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialTemperature18SAVANIPerturbationILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect18InitialTemperature18SAVANIPerturbationILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect18InitialTemperature9AdiabaticILi2EEE [label="adiabatic", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialTemperature9AdiabaticILi2EEE -> N6aspect18InitialTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialTemperature9AdiabaticILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect18InitialTemperature17AdiabaticBoundaryILi2EEE [label="adiabatic
-boundary", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect18InitialTemperature9AdiabaticILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect18InitialTemperature17AdiabaticBoundaryILi2EEE [label="adiabatic\nboundary", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialTemperature17AdiabaticBoundaryILi2EEE -> N6aspect18InitialTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialTemperature17AdiabaticBoundaryILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect18InitialTemperature17AdiabaticBoundaryILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect18InitialTemperature9AsciiDataILi2EEE [label="ascii data", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialTemperature9AsciiDataILi2EEE -> N6aspect18InitialTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialTemperature9AsciiDataILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect18InitialTemperature9AsciiDataILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect18InitialTemperature12PerturbedBoxILi2EEE [label="perturbed box", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialTemperature12PerturbedBoxILi2EEE -> N6aspect18InitialTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialTemperature12PerturbedBoxILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect18InitialTemperature12PerturbedBoxILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect18InitialTemperature8PolarBoxILi2EEE [label="polar box", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialTemperature8PolarBoxILi2EEE -> N6aspect18InitialTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialTemperature8PolarBoxILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect18InitialTemperature17InclusionShapeBoxILi2EEE [label="inclusion shape
-perturbation", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect18InitialTemperature8PolarBoxILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect18InitialTemperature17InclusionShapeBoxILi2EEE [label="inclusion shape\nperturbation", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialTemperature17InclusionShapeBoxILi2EEE -> N6aspect18InitialTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialTemperature17InclusionShapeBoxILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect18InitialTemperature17InclusionShapeBoxILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect18InitialTemperature9MandelBoxILi2EEE [label="mandelbox", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialTemperature9MandelBoxILi2EEE -> N6aspect18InitialTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialTemperature9MandelBoxILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect18InitialTemperature9MandelBoxILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect18InitialTemperature8FunctionILi2EEE [label="function", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialTemperature8FunctionILi2EEE -> N6aspect18InitialTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialTemperature8FunctionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect18InitialTemperature20HarmonicPerturbationILi2EEE [label="harmonic
-perturbation", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect18InitialTemperature8FunctionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect18InitialTemperature20HarmonicPerturbationILi2EEE [label="harmonic\nperturbation", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialTemperature20HarmonicPerturbationILi2EEE -> N6aspect18InitialTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialTemperature20HarmonicPerturbationILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect18InitialTemperature20HarmonicPerturbationILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect18InitialTemperature7SolidusILi2EEE [label="solidus", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialTemperature7SolidusILi2EEE -> N6aspect18InitialTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialTemperature7SolidusILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect18InitialTemperature30SphericalHexagonalPerturbationILi2EEE [label="spherical
-hexagonal
-perturbation", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect18InitialTemperature7SolidusILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect18InitialTemperature30SphericalHexagonalPerturbationILi2EEE [label="spherical\nhexagonal\nperturbation", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialTemperature30SphericalHexagonalPerturbationILi2EEE -> N6aspect18InitialTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialTemperature30SphericalHexagonalPerturbationILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect18InitialTemperature29SphericalGaussianPerturbationILi2EEE [label="spherical
-gaussian
-perturbation", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect18InitialTemperature30SphericalHexagonalPerturbationILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect18InitialTemperature29SphericalGaussianPerturbationILi2EEE [label="spherical\ngaussian\nperturbation", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect18InitialTemperature29SphericalGaussianPerturbationILi2EEE -> N6aspect18InitialTemperature9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect18InitialTemperature29SphericalGaussianPerturbationILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect18InitialTemperature29SphericalGaussianPerturbationILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect18InitialTemperature9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect13MaterialModel9InterfaceILi2EEE [label="Material model interface", height=.8,width=.8,shape="rect",fillcolor="green"]
-N6aspect13MaterialModel21AsciiReferenceProfileILi2EEE [label="ascii reference
-profile", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+N6aspect13MaterialModel21AsciiReferenceProfileILi2EEE [label="ascii reference\nprofile", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel21AsciiReferenceProfileILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel21AsciiReferenceProfileILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect13MaterialModel21AsciiReferenceProfileILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect13MaterialModel9AveragingILi2EEE [label="averaging", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel9AveragingILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel9AveragingILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect13MaterialModel19CompositionReactionILi2EEE [label="composition
-reaction", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect13MaterialModel9AveragingILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect13MaterialModel11CompositingILi2EEE [label="compositing", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+N6aspect13MaterialModel11CompositingILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
+SimulatorAccess -> N6aspect13MaterialModel11CompositingILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect13MaterialModel19CompositionReactionILi2EEE [label="composition\nreaction", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel19CompositionReactionILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel19CompositionReactionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect13MaterialModel14DepthDependentILi2EEE [label="depth
-dependent", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect13MaterialModel19CompositionReactionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect13MaterialModel14DepthDependentILi2EEE [label="depth\ndependent", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel14DepthDependentILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel14DepthDependentILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect13MaterialModel20DiffusionDislocationILi2EEE [label="diffusion
-dislocation", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect13MaterialModel14DepthDependentILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect13MaterialModel20DiffusionDislocationILi2EEE [label="diffusion\ndislocation", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel20DiffusionDislocationILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel20DiffusionDislocationILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect13MaterialModel20DiffusionDislocationILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect13MaterialModel13DruckerPragerILi2EEE [label="drucker prager", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel13DruckerPragerILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel13DruckerPragerILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect13MaterialModel15DynamicFrictionILi2EEE [label="dynamic
-friction", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect13MaterialModel13DruckerPragerILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect13MaterialModel15DynamicFrictionILi2EEE [label="dynamic\nfriction", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel15DynamicFrictionILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel15DynamicFrictionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect13MaterialModel15DynamicFrictionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect13MaterialModel10LatentHeatILi2EEE [label="latent heat", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel10LatentHeatILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel10LatentHeatILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect13MaterialModel14LatentHeatMeltILi2EEE [label="latent heat
-melt", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect13MaterialModel10LatentHeatILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect13MaterialModel14LatentHeatMeltILi2EEE [label="latent heat\nmelt", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel14LatentHeatMeltILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel14LatentHeatMeltILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect13MaterialModel14LatentHeatMeltILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect13MaterialModel10MeltGlobalILi2EEE [label="melt global", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel10MeltGlobalILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel10MeltGlobalILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect13MaterialModel10MeltGlobalILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect13MaterialModel10MeltSimpleILi2EEE [label="melt simple", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel10MeltSimpleILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel10MeltSimpleILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect13MaterialModel11MorencyDoinILi2EEE [label="Morency and
-Doin", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect13MaterialModel10MeltSimpleILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect13MaterialModel11MorencyDoinILi2EEE [label="Morency and\nDoin", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel11MorencyDoinILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel11MorencyDoinILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect13MaterialModel11MorencyDoinILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect13MaterialModel14MulticomponentILi2EEE [label="multicomponent", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel14MulticomponentILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel14MulticomponentILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect13MaterialModel14MulticomponentILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect13MaterialModel14NondimensionalILi2EEE [label="nondimensional", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel14NondimensionalILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel14NondimensionalILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect13MaterialModel14NondimensionalILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect13MaterialModel6SimpleILi2EEE [label="simple", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel6SimpleILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel6SimpleILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect13MaterialModel18SimpleCompressibleILi2EEE [label="simple
-compressible", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect13MaterialModel6SimpleILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect13MaterialModel18SimpleCompressibleILi2EEE [label="simple\ncompressible", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel18SimpleCompressibleILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel18SimpleCompressibleILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect13MaterialModel18SimpleCompressibleILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect13MaterialModel7SimplerILi2EEE [label="simpler", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel7SimplerILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
 N6aspect13MaterialModel11SteinbergerILi2EEE [label="Steinberger", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel11SteinbergerILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel11SteinbergerILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect13MaterialModel11SteinbergerILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect13MaterialModel12ViscoPlasticILi2EEE [label="visco plastic", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect13MaterialModel12ViscoPlasticILi2EEE -> N6aspect13MaterialModel9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect13MaterialModel12ViscoPlasticILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect13MaterialModel12ViscoPlasticILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect13MaterialModel9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect14MeshRefinement9InterfaceILi2EEE [label="Mesh refinement criteria interface", height=.8,width=.8,shape="rect",fillcolor="green"]
-N6aspect14MeshRefinement19ArtificialViscosityILi2EEE [label="artificial
-viscosity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+N6aspect14MeshRefinement19ArtificialViscosityILi2EEE [label="artificial\nviscosity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement19ArtificialViscosityILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement19ArtificialViscosityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect14MeshRefinement19ArtificialViscosityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect14MeshRefinement8BoundaryILi2EEE [label="boundary", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement8BoundaryILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement8BoundaryILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect14MeshRefinement8BoundaryILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect14MeshRefinement11CompositionILi2EEE [label="composition", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement11CompositionILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement11CompositionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect14MeshRefinement30CompositionApproximateGradientILi2EEE [label="composition
-approximate
-gradient", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect14MeshRefinement11CompositionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect14MeshRefinement30CompositionApproximateGradientILi2EEE [label="composition\napproximate\ngradient", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement30CompositionApproximateGradientILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement30CompositionApproximateGradientILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect14MeshRefinement19CompositionGradientILi2EEE [label="composition
-gradient", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect14MeshRefinement30CompositionApproximateGradientILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect14MeshRefinement19CompositionGradientILi2EEE [label="composition\ngradient", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement19CompositionGradientILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement19CompositionGradientILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect14MeshRefinement20CompositionThresholdILi2EEE [label="composition
-threshold", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect14MeshRefinement19CompositionGradientILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect14MeshRefinement20CompositionThresholdILi2EEE [label="composition\nthreshold", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement20CompositionThresholdILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement20CompositionThresholdILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect14MeshRefinement20CompositionThresholdILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect14MeshRefinement7DensityILi2EEE [label="density", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement7DensityILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement7DensityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect14MeshRefinement25MaximumRefinementFunctionILi2EEE [label="maximum
-refinement
-function", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect14MeshRefinement7DensityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect14MeshRefinement25MaximumRefinementFunctionILi2EEE [label="maximum\nrefinement\nfunction", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement25MaximumRefinementFunctionILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement25MaximumRefinementFunctionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect14MeshRefinement25MinimumRefinementFunctionILi2EEE [label="minimum
-refinement
-function", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect14MeshRefinement25MaximumRefinementFunctionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect14MeshRefinement25MinimumRefinementFunctionILi2EEE [label="minimum\nrefinement\nfunction", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement25MinimumRefinementFunctionILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement25MinimumRefinementFunctionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect14MeshRefinement23NonadiabaticTemperatureILi2EEE [label="nonadiabatic
-temperature", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect14MeshRefinement25MinimumRefinementFunctionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect14MeshRefinement23NonadiabaticTemperatureILi2EEE [label="nonadiabatic\ntemperature", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement23NonadiabaticTemperatureILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement23NonadiabaticTemperatureILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect14MeshRefinement15ParticleDensityILi2EEE [label="particle
-density", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect14MeshRefinement23NonadiabaticTemperatureILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect14MeshRefinement15ParticleDensityILi2EEE [label="particle\ndensity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement15ParticleDensityILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement15ParticleDensityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect14MeshRefinement15ParticleDensityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect14MeshRefinement5SlopeILi2EEE [label="slope", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement5SlopeILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement5SlopeILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect14MeshRefinement5SlopeILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect14MeshRefinement10StrainRateILi2EEE [label="strain rate", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement10StrainRateILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement10StrainRateILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect14MeshRefinement10StrainRateILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect14MeshRefinement11TemperatureILi2EEE [label="temperature", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement11TemperatureILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement11TemperatureILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect14MeshRefinement20ThermalEnergyDensityILi2EEE [label="thermal energy
-density", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect14MeshRefinement11TemperatureILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect14MeshRefinement20ThermalEnergyDensityILi2EEE [label="thermal energy\ndensity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement20ThermalEnergyDensityILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement20ThermalEnergyDensityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect14MeshRefinement20ThermalEnergyDensityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect14MeshRefinement10TopographyILi2EEE [label="topography", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement10TopographyILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement10TopographyILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect14MeshRefinement10TopographyILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect14MeshRefinement8VelocityILi2EEE [label="velocity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement8VelocityILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement8VelocityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect14MeshRefinement8VelocityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect14MeshRefinement9ViscosityILi2EEE [label="viscosity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect14MeshRefinement9ViscosityILi2EEE -> N6aspect14MeshRefinement9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect14MeshRefinement9ViscosityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect14MeshRefinement9ViscosityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect14MeshRefinement9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect8Particle9Generator9InterfaceILi2EEE [label="Particle generator interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect8Particle9Generator9AsciiFileILi2EEE [label="ascii file", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle9Generator9AsciiFileILi2EEE -> N6aspect8Particle9Generator9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle9Generator9AsciiFileILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect8Particle9Generator26ProbabilityDensityFunctionILi2EEE [label="probability
-density
-function", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect8Particle9Generator9AsciiFileILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect8Particle9Generator26ProbabilityDensityFunctionILi2EEE [label="probability\ndensity\nfunction", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle9Generator26ProbabilityDensityFunctionILi2EEE -> N6aspect8Particle9Generator9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle9Generator26ProbabilityDensityFunctionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect8Particle9Generator16QuadraturePointsILi2EEE [label="quadrature
-points", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect8Particle9Generator26ProbabilityDensityFunctionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect8Particle9Generator16QuadraturePointsILi2EEE [label="quadrature\npoints", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle9Generator16QuadraturePointsILi2EEE -> N6aspect8Particle9Generator9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle9Generator16QuadraturePointsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle9Generator16QuadraturePointsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle9Generator13RandomUniformILi2EEE [label="random uniform", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle9Generator13RandomUniformILi2EEE -> N6aspect8Particle9Generator9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle9Generator13RandomUniformILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle9Generator13RandomUniformILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle9Generator13ReferenceCellILi2EEE [label="reference cell", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle9Generator13ReferenceCellILi2EEE -> N6aspect8Particle9Generator9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle9Generator13ReferenceCellILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle9Generator13ReferenceCellILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle9Generator10UniformBoxILi2EEE [label="uniform box", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle9Generator10UniformBoxILi2EEE -> N6aspect8Particle9Generator9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle9Generator10UniformBoxILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle9Generator10UniformBoxILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle9Generator13UniformRadialILi2EEE [label="uniform radial", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle9Generator13UniformRadialILi2EEE -> N6aspect8Particle9Generator9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle9Generator13UniformRadialILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle9Generator13UniformRadialILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle9Generator9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect8Particle10Integrator9InterfaceILi2EEE [label="Particle integrator interface", height=.8,width=.8,shape="rect",fillcolor="green"]
@@ -451,340 +394,287 @@ N6aspect8Particle10Integrator5EulerILi2EEE [label="euler", height=.8,width=.8,sh
 N6aspect8Particle10Integrator5EulerILi2EEE -> N6aspect8Particle10Integrator9InterfaceILi2EEE [len=3, weight=50];
 N6aspect8Particle10Integrator3RK2ILi2EEE [label="rk2", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle10Integrator3RK2ILi2EEE -> N6aspect8Particle10Integrator9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle10Integrator3RK2ILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle10Integrator3RK2ILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle10Integrator3RK4ILi2EEE [label="rk4", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle10Integrator3RK4ILi2EEE -> N6aspect8Particle10Integrator9InterfaceILi2EEE [len=3, weight=50];
 N6aspect8Particle10Integrator9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect8Particle12Interpolator9InterfaceILi2EEE [label="Particle interpolator interface", height=.8,width=.8,shape="rect",fillcolor="green"]
-N6aspect8Particle12Interpolator20BilinearLeastSquaresILi2EEE [label="bilinear least
-squares", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+N6aspect8Particle12Interpolator20BilinearLeastSquaresILi2EEE [label="bilinear least\nsquares", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle12Interpolator20BilinearLeastSquaresILi2EEE -> N6aspect8Particle12Interpolator9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle12Interpolator20BilinearLeastSquaresILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle12Interpolator20BilinearLeastSquaresILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle12Interpolator11CellAverageILi2EEE [label="cell average", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle12Interpolator11CellAverageILi2EEE -> N6aspect8Particle12Interpolator9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle12Interpolator11CellAverageILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect8Particle12Interpolator15NearestNeighborILi2EEE [label="nearest
-neighbor", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect8Particle12Interpolator11CellAverageILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect8Particle12Interpolator15NearestNeighborILi2EEE [label="nearest\nneighbor", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle12Interpolator15NearestNeighborILi2EEE -> N6aspect8Particle12Interpolator9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle12Interpolator15NearestNeighborILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle12Interpolator15NearestNeighborILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle12Interpolator9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect8Particle6Output9InterfaceILi2EEE [label="Particle output interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect8Particle6Output11ASCIIOutputILi2EEE [label="ascii", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle6Output11ASCIIOutputILi2EEE -> N6aspect8Particle6Output9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle6Output11ASCIIOutputILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle6Output11ASCIIOutputILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle6Output10HDF5OutputILi2EEE [label="hdf5", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle6Output10HDF5OutputILi2EEE -> N6aspect8Particle6Output9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle6Output10HDF5OutputILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle6Output10HDF5OutputILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle6Output9VTUOutputILi2EEE [label="vtu", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle6Output9VTUOutputILi2EEE -> N6aspect8Particle6Output9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle6Output9VTUOutputILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle6Output9VTUOutputILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle6Output9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect8Particle8Property9InterfaceILi2EEE [label="Particle property interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect8Particle8Property11CompositionILi2EEE [label="composition", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle8Property11CompositionILi2EEE -> N6aspect8Particle8Property9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle8Property11CompositionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle8Property11CompositionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle8Property8FunctionILi2EEE [label="function", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle8Property8FunctionILi2EEE -> N6aspect8Particle8Property9InterfaceILi2EEE [len=3, weight=50];
-N6aspect8Particle8Property18InitialCompositionILi2EEE [label="initial
-composition", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+N6aspect8Particle8Property18InitialCompositionILi2EEE [label="initial\ncomposition", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle8Property18InitialCompositionILi2EEE -> N6aspect8Particle8Property9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle8Property18InitialCompositionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect8Particle8Property15InitialPositionILi2EEE [label="initial
-position", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect8Particle8Property18InitialCompositionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect8Particle8Property15InitialPositionILi2EEE [label="initial\nposition", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle8Property15InitialPositionILi2EEE -> N6aspect8Particle8Property9InterfaceILi2EEE [len=3, weight=50];
-N6aspect8Particle8Property16IntegratedStrainILi2EEE [label="integrated
-strain", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+N6aspect8Particle8Property16IntegratedStrainILi2EEE [label="integrated\nstrain", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle8Property16IntegratedStrainILi2EEE -> N6aspect8Particle8Property9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle8Property16IntegratedStrainILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect8Particle8Property25IntegratedStrainInvariantILi2EEE [label="integrated
-strain
-invariant", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect8Particle8Property16IntegratedStrainILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect8Particle8Property25IntegratedStrainInvariantILi2EEE [label="integrated\nstrain\ninvariant", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle8Property25IntegratedStrainInvariantILi2EEE -> N6aspect8Particle8Property9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle8Property25IntegratedStrainInvariantILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle8Property25IntegratedStrainInvariantILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle8Property12MeltParticleILi2EEE [label="melt particle", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle8Property12MeltParticleILi2EEE -> N6aspect8Particle8Property9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle8Property12MeltParticleILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle8Property12MeltParticleILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle8Property6PTPathILi2EEE [label="pT path", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle8Property6PTPathILi2EEE -> N6aspect8Particle8Property9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle8Property6PTPathILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle8Property6PTPathILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle8Property8PositionILi2EEE [label="position", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle8Property8PositionILi2EEE -> N6aspect8Particle8Property9InterfaceILi2EEE [len=3, weight=50];
 N6aspect8Particle8Property8VelocityILi2EEE [label="velocity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect8Particle8Property8VelocityILi2EEE -> N6aspect8Particle8Property9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect8Particle8Property8VelocityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect8Particle8Property8VelocityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect8Particle8Property9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect11Postprocess9InterfaceILi2EEE [label="Postprocessor interface", height=.8,width=.8,shape="rect",fillcolor="green"]
-N6aspect11Postprocess15BasicStatisticsILi2EEE [label="basic
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+N6aspect11Postprocess15BasicStatisticsILi2EEE [label="basic\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess15BasicStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess15BasicStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess17BoundaryDensitiesILi2EEE [label="boundary
-densities", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess15BasicStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess17BoundaryDensitiesILi2EEE [label="boundary\ndensities", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess17BoundaryDensitiesILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess17BoundaryDensitiesILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess17BoundaryPressuresILi2EEE [label="boundary
-pressures", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess17BoundaryDensitiesILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess17BoundaryPressuresILi2EEE [label="boundary\npressures", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess17BoundaryPressuresILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess17BoundaryPressuresILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess17BoundaryPressuresILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess7CommandILi2EEE [label="command", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess7CommandILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess7CommandILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess21CompositionStatisticsILi2EEE [label="composition
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess7CommandILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess21CompositionStatisticsILi2EEE [label="composition\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess21CompositionStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess21CompositionStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess21CompositionStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess12DepthAverageILi2EEE [label="depth average", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess12DepthAverageILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess12DepthAverageILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess17DynamicTopographyILi2EEE [label="dynamic
-topography", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess12DepthAverageILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess17DynamicTopographyILi2EEE [label="dynamic\ntopography", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess17DynamicTopographyILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess17DynamicTopographyILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess17DynamicTopographyILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess5GeoidILi2EEE [label="geoid", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess5GeoidILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess5GeoidILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess16GlobalStatisticsILi2EEE [label="global
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess5GeoidILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess16GlobalStatisticsILi2EEE [label="global\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess16GlobalStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess16GlobalStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess17HeatFluxDensitiesILi2EEE [label="heat flux
-densities", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess16GlobalStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess17HeatFluxDensitiesILi2EEE [label="heat flux\ndensities", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess17HeatFluxDensitiesILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess17HeatFluxDensitiesILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess17HeatFluxDensitiesILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess11HeatFluxMapILi2EEE [label="heat flux map", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess11HeatFluxMapILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess11HeatFluxMapILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess18HeatFluxStatisticsILi2EEE [label="heat flux
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess11HeatFluxMapILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess18HeatFluxStatisticsILi2EEE [label="heat flux\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess18HeatFluxStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess18HeatFluxStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess17HeatingStatisticsILi2EEE [label="heating
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess18HeatFluxStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess17HeatingStatisticsILi2EEE [label="heating\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess17HeatingStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess17HeatingStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess18MassFluxStatisticsILi2EEE [label="mass flux
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess17HeatingStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess18MassFluxStatisticsILi2EEE [label="mass flux\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess18MassFluxStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess18MassFluxStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess16MatrixStatisticsILi2EEE [label="matrix
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess18MassFluxStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess16MatrixStatisticsILi2EEE [label="matrix\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess16MatrixStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess16MatrixStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess14MeltStatisticsILi2EEE [label="melt
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess16MatrixStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess14MeltStatisticsILi2EEE [label="melt\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess14MeltStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess14MeltStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess16MemoryStatisticsILi2EEE [label="memory
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess14MeltStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess16MemoryStatisticsILi2EEE [label="memory\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess16MemoryStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess16MemoryStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess23ParticleCountStatisticsILi2EEE [label="particle count
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess16MemoryStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess23ParticleCountStatisticsILi2EEE [label="particle count\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess23ParticleCountStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess23ParticleCountStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess23ParticleCountStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess9ParticlesILi2EEE [label="particles", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess9ParticlesILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess9ParticlesILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess9ParticlesILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess11PointValuesILi2EEE [label="point values", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess11PointValuesILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess11PointValuesILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess18PressureStatisticsILi2EEE [label="pressure
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess11PointValuesILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess18PressureStatisticsILi2EEE [label="pressure\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess18PressureStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess18PressureStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27SphericalVelocityStatisticsILi2EEE [label="spherical
-velocity
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess18PressureStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27SphericalVelocityStatisticsILi2EEE [label="spherical\nvelocity\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27SphericalVelocityStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27SphericalVelocityStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess14StokesResidualILi2EEE [label="Stokes
-residual", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27SphericalVelocityStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess14StokesResidualILi2EEE [label="Stokes\nresidual", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess14StokesResidualILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess14StokesResidualILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess21TemperatureStatisticsILi2EEE [label="temperature
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess14StokesResidualILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess21TemperatureStatisticsILi2EEE [label="temperature\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess21TemperatureStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess21TemperatureStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess21TemperatureStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess10TopographyILi2EEE [label="topography", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess10TopographyILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess10TopographyILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess26VelocityBoundaryStatisticsILi2EEE [label="velocity
-boundary
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess10TopographyILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess26VelocityBoundaryStatisticsILi2EEE [label="velocity\nboundary\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess26VelocityBoundaryStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess26VelocityBoundaryStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess18VelocityStatisticsILi2EEE [label="velocity
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess26VelocityBoundaryStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess18VelocityStatisticsILi2EEE [label="velocity\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess18VelocityStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess18VelocityStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess28ViscousDissipationStatisticsILi2EEE [label="viscous
-dissipation
-statistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess18VelocityStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess28ViscousDissipationStatisticsILi2EEE [label="viscous\ndissipation\nstatistics", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess28ViscousDissipationStatisticsILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess28ViscousDissipationStatisticsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess28ViscousDissipationStatisticsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess13VisualizationILi2EEE [label="visualization", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess13VisualizationILi2EEE -> N6aspect11Postprocess9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess13VisualizationILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess13VisualizationILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [label="Visualization postprocessor interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect11Postprocess27VisualizationPostprocessors7AdiabatILi2EEE [label="adiabat", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors7AdiabatILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors7AdiabatILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors19ArtificialViscosityILi2EEE [label="artificial
-viscosity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors7AdiabatILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors19ArtificialViscosityILi2EEE [label="artificial\nviscosity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors19ArtificialViscosityILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors19ArtificialViscosityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors30ArtificialViscosityCompositionILi2EEE [label="artificial
-viscosity
-composition", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors19ArtificialViscosityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors30ArtificialViscosityCompositionILi2EEE [label="artificial\nviscosity\ncomposition", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors30ArtificialViscosityCompositionILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors30ArtificialViscosityCompositionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors17BoundaryIndicatorILi2EEE [label="boundary
-indicators", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors30ArtificialViscosityCompositionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors17BoundaryIndicatorILi2EEE [label="boundary\nindicators", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors17BoundaryIndicatorILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors17BoundaryIndicatorILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors19CompositionalVectorILi2EEE [label="compositional
-vector", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors17BoundaryIndicatorILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors19CompositionalVectorILi2EEE [label="compositional\nvector", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors19CompositionalVectorILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors19CompositionalVectorILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors19CompositionalVectorILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors7DensityILi2EEE [label="density", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors7DensityILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors7DensityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors7DensityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors5DepthILi2EEE [label="depth", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors5DepthILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors5DepthILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors17DynamicTopographyILi2EEE [label="dynamic
-topography", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors5DepthILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors17DynamicTopographyILi2EEE [label="dynamic\ntopography", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors17DynamicTopographyILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors17DynamicTopographyILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors14ErrorIndicatorILi2EEE [label="error
-indicator", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors17DynamicTopographyILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors14ErrorIndicatorILi2EEE [label="error\nindicator", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors14ErrorIndicatorILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors14ErrorIndicatorILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors15FrictionHeatingILi2EEE [label="friction
-heating", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors14ErrorIndicatorILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors15FrictionHeatingILi2EEE [label="friction\nheating", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors15FrictionHeatingILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors15FrictionHeatingILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors15FrictionHeatingILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors5GeoidILi2EEE [label="geoid", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors5GeoidILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors5GeoidILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors5GeoidILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors7GravityILi2EEE [label="gravity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors7GravityILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors7GravityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors7GravityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors11HeatFluxMapILi2EEE [label="heat flux map", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors11HeatFluxMapILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors11HeatFluxMapILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors11HeatFluxMapILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors7HeatingILi2EEE [label="heating", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors7HeatingILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors7HeatingILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors18MaterialPropertiesILi2EEE [label="material
-properties", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors7HeatingILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors18MaterialPropertiesILi2EEE [label="material\nproperties", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors18MaterialPropertiesILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors18MaterialPropertiesILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors34MaximumHorizontalCompressiveStressILi2EEE [label="maximum
-horizontal
-compressive
-stress", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors18MaterialPropertiesILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors34MaximumHorizontalCompressiveStressILi2EEE [label="maximum\nhorizontal\ncompressive\nstress", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors34MaximumHorizontalCompressiveStressILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors34MaximumHorizontalCompressiveStressILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors22MeltMaterialPropertiesILi2EEE [label="melt material
-properties", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors34MaximumHorizontalCompressiveStressILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors22MeltMaterialPropertiesILi2EEE [label="melt material\nproperties", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors22MeltMaterialPropertiesILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors22MeltMaterialPropertiesILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors22MeltMaterialPropertiesILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors12MeltFractionILi2EEE [label="melt fraction", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors12MeltFractionILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors12MeltFractionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors22NamedAdditionalOutputsILi2EEE [label="named
-additional
-outputs", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors12MeltFractionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors22NamedAdditionalOutputsILi2EEE [label="named\nadditional\noutputs", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors22NamedAdditionalOutputsILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors22NamedAdditionalOutputsILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors20NonadiabaticPressureILi2EEE [label="nonadiabatic
-pressure", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors22NamedAdditionalOutputsILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors20NonadiabaticPressureILi2EEE [label="nonadiabatic\npressure", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors20NonadiabaticPressureILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors20NonadiabaticPressureILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors23NonadiabaticTemperatureILi2EEE [label="nonadiabatic
-temperature", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors20NonadiabaticPressureILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors23NonadiabaticTemperatureILi2EEE [label="nonadiabatic\ntemperature", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors23NonadiabaticTemperatureILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors23NonadiabaticTemperatureILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors23NonadiabaticTemperatureILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors13ParticleCountILi2EEE [label="particle count", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors13ParticleCountILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors13ParticleCountILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors13ParticleCountILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors9PartitionILi2EEE [label="partition", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors9PartitionILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors9PartitionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors9PartitionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors16SeismicVsAnomalyILi2EEE [label="Vs anomaly", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors16SeismicVsAnomalyILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors16SeismicVsAnomalyILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors16SeismicVsAnomalyILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors16SeismicVpAnomalyILi2EEE [label="Vp anomaly", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors16SeismicVpAnomalyILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors16SeismicVpAnomalyILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors16SeismicVpAnomalyILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors11ShearStressILi2EEE [label="shear stress", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors11ShearStressILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors11ShearStressILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors11ShearStressILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors10SPD_FactorILi2EEE [label="spd factor", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors10SPD_FactorILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors10SPD_FactorILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors10SPD_FactorILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors12SpecificHeatILi2EEE [label="specific heat", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors12SpecificHeatILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors12SpecificHeatILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors12SpecificHeatILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors10StrainRateILi2EEE [label="strain rate", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors10StrainRateILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors10StrainRateILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors10StrainRateILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors6StressILi2EEE [label="stress", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors6StressILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors6StressILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors19ThermalConductivityILi2EEE [label="thermal
-conductivity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors6StressILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors19ThermalConductivityILi2EEE [label="thermal\nconductivity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors19ThermalConductivityILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors19ThermalConductivityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors18ThermalDiffusivityILi2EEE [label="thermal
-diffusivity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors19ThermalConductivityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors18ThermalDiffusivityILi2EEE [label="thermal\ndiffusivity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors18ThermalDiffusivityILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors18ThermalDiffusivityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors18ThermalExpansivityILi2EEE [label="thermal
-expansivity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors18ThermalDiffusivityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors18ThermalExpansivityILi2EEE [label="thermal\nexpansivity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors18ThermalExpansivityILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors18ThermalExpansivityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect11Postprocess27VisualizationPostprocessors16VerticalHeatFluxILi2EEE [label="vertical heat
-flux", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors18ThermalExpansivityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect11Postprocess27VisualizationPostprocessors16VerticalHeatFluxILi2EEE [label="vertical heat\nflux", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors16VerticalHeatFluxILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors16VerticalHeatFluxILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors16VerticalHeatFluxILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors9ViscosityILi2EEE [label="viscosity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect11Postprocess27VisualizationPostprocessors9ViscosityILi2EEE -> N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors9ViscosityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect11Postprocess27VisualizationPostprocessors9ViscosityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect11Postprocess27VisualizationPostprocessors9InterfaceILi2EEE -> N6aspect11Postprocess13VisualizationILi2EEE [len=15, weight=50];
 
 N6aspect24PrescribedStokesSolution9InterfaceILi2EEE [label="Prescribed Stokes solution interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect24PrescribedStokesSolution9AsciiDataILi2EEE [label="ascii data", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect24PrescribedStokesSolution9AsciiDataILi2EEE -> N6aspect24PrescribedStokesSolution9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect24PrescribedStokesSolution9AsciiDataILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect24PrescribedStokesSolution9AsciiDataILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect24PrescribedStokesSolution6CircleILi2EEE [label="circle", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect24PrescribedStokesSolution6CircleILi2EEE -> N6aspect24PrescribedStokesSolution9InterfaceILi2EEE [len=3, weight=50];
 N6aspect24PrescribedStokesSolution8FunctionILi2EEE [label="function", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect24PrescribedStokesSolution8FunctionILi2EEE -> N6aspect24PrescribedStokesSolution9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect24PrescribedStokesSolution8FunctionILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect24PrescribedStokesSolution8FunctionILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect24PrescribedStokesSolution9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 N6aspect19TerminationCriteria9InterfaceILi2EEE [label="Termination criteria interface", height=.8,width=.8,shape="rect",fillcolor="green"]
 N6aspect19TerminationCriteria7EndStepILi2EEE [label="end step", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19TerminationCriteria7EndStepILi2EEE -> N6aspect19TerminationCriteria9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19TerminationCriteria7EndStepILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect19TerminationCriteria7EndStepILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect19TerminationCriteria7EndTimeILi2EEE [label="end time", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19TerminationCriteria7EndTimeILi2EEE -> N6aspect19TerminationCriteria9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19TerminationCriteria7EndTimeILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
-N6aspect19TerminationCriteria17SteadyRMSVelocityILi2EEE [label="steady state
-velocity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
+SimulatorAccess -> N6aspect19TerminationCriteria7EndTimeILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+N6aspect19TerminationCriteria17SteadyRMSVelocityILi2EEE [label="steady state\nvelocity", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19TerminationCriteria17SteadyRMSVelocityILi2EEE -> N6aspect19TerminationCriteria9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19TerminationCriteria17SteadyRMSVelocityILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect19TerminationCriteria17SteadyRMSVelocityILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect19TerminationCriteria11UserRequestILi2EEE [label="user request", height=.8,width=.8,shape="circle",fillcolor="lightblue"];
 N6aspect19TerminationCriteria11UserRequestILi2EEE -> N6aspect19TerminationCriteria9InterfaceILi2EEE [len=3, weight=50];
-SimulatorAccess -> N6aspect19TerminationCriteria11UserRequestILi2EEE [style="dashed", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
+SimulatorAccess -> N6aspect19TerminationCriteria11UserRequestILi2EEE [style="dotted", arrowhead="empty", constraint=false, color="gray", len=20, weight=0.1];
 N6aspect19TerminationCriteria9InterfaceILi2EEE -> Simulator [len=15, weight=50];
 
 }

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -467,7 +467,7 @@ namespace aspect
             Assert (plugin_label_parts.size()>0, ExcInternalError());
             std::string plugin_name = plugin_label_parts[0];
             for (unsigned int i=1; i<plugin_label_parts.size(); ++i)
-              plugin_name += "\n" + plugin_label_parts[i];
+              plugin_name += "\\n" + plugin_label_parts[i];
 
             // next create a (symbolic) node name for this plugin. because
             // each plugin corresponds to a particular class, use the mangled
@@ -500,7 +500,7 @@ namespace aspect
               output_stream << "SimulatorAccess"
                             << " -> "
                             << node_name
-                            << " [style=\"dashed\", arrowhead=\"empty\", constraint=false, color=\"gray\", len=20, weight=0.1];"
+                            << " [style=\"dotted\", arrowhead=\"empty\", constraint=false, color=\"gray\", len=20, weight=0.1];"
                             << std::endl;
           }
 


### PR DESCRIPTION
In particular, make sure that we don't spread text across multiple
lines. This appears to work on some versions of neato, but on others
it leads to errors. Instead, use \n where necessary.

Update to #1777.