### PR TITLE
Create a base class for plugins.

### DIFF
--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -119,39 +119,9 @@ namespace aspect
      * @ingroup HeatingModels
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         */
-        virtual
-        void
-        initialize ();
-
-        /**
-         * A function that is called at the beginning of each time step. The
-         * default implementation of the function does nothing, but derived
-         * classes that need more elaborate setups for a given time step may
-         * overload the function.
-         *
-         * The point of this function is to allow complex heating models to do
-         * an initialization step once at the beginning of each time step. An
-         * example would be a model that take into account the decay of heat
-         * generating elements.
-         */
-        virtual
-        void
-        update ();
-
         /**
          * Function to compute the heating terms in @p heating_model_outputs
          * given the inputs in @p material_model_inputs and the outputs of the
@@ -169,27 +139,6 @@ namespace aspect
         evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
                   const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const = 0;
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
-
 
         /**
          * Allow the heating model to attach additional material model outputs.

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -112,6 +112,74 @@ namespace aspect
     }
   }
 
+  namespace Plugins
+  {
+    using namespace dealii;
+
+
+    class InterfaceBase
+    {
+      public:
+        /**
+         * Destructor. Made virtual to enforce that derived classes also have
+         * virtual destructors.
+         */
+        virtual ~InterfaceBase();
+
+        /**
+         * Initialization function. This function is called once at the
+         * beginning of the program after parse_parameters is run and after
+         * the SimulatorAccess (if applicable) is initialized.
+         *
+         * The default implementation of this function does nothing, but
+         * plugins that derive from this class (via the <code>Interface</code>
+         * classes of their respective plugin systems) may overload it
+         * if they want something to happen upon startup of the
+         * Simulator object to which the plugin contributes.
+         */
+        virtual
+        void
+        initialize ();
+
+        /**
+         * A function that is called at the beginning of each time step.
+         *
+         * The default implementation of this function does nothing, but
+         * plugins that derive from this class (via the <code>Interface</code>
+         * classes of their respective plugin systems) may overload it
+         * if they want something to happen upon startup of the
+         * Simulator object to which the plugin contributes.
+         */
+        virtual
+        void
+        update ();
+
+        /**
+         * Declare the parameters the plugin takes through input files. The
+         * default implementation of this function does not describe any
+         * parameters. Consequently, derived classes do not have to overload
+         * this function if they do not take any runtime parameters. On
+         * the other hand, most plugins do have run-time parameters, and
+         * they may then overload this function.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         * The default implementation of this function does not read any
+         * parameters. Consequently, derived classes do not have to overload
+         * this function if they do not take any runtime parameters. On
+         * the other hand, most plugins do have run-time parameters, and
+         * they may then overload this function.
+         */
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
+    };
+  }
+
   namespace internal
   {
     /**
@@ -121,6 +189,8 @@ namespace aspect
     namespace Plugins
     {
       using namespace dealii;
+
+
 
       /**
        * An internal class that is used in the definition of the

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -38,35 +38,6 @@ namespace aspect
   {
     template <int dim>
     void
-    Interface<dim>::initialize ()
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::update ()
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (dealii::ParameterHandler &)
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (dealii::ParameterHandler &)
-    {}
-
-
-
-    template <int dim>
-    void
     Interface<dim>::
     create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> & /*outputs*/) const
     {}

--- a/source/plugins.cc
+++ b/source/plugins.cc
@@ -1,0 +1,55 @@
+/*
+  Copyright (C) 2024 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/plugins.h>
+
+namespace aspect
+{
+  namespace Plugins
+  {
+    InterfaceBase::~InterfaceBase ()
+    {}
+
+
+
+    void
+    InterfaceBase::initialize ()
+    {}
+
+
+
+    void
+    InterfaceBase::update ()
+    {}
+
+
+
+    void
+    InterfaceBase::
+    declare_parameters (dealii::ParameterHandler &)
+    {}
+
+
+
+    void
+    InterfaceBase::parse_parameters (dealii::ParameterHandler &)
+    {}
+  }
+}


### PR DESCRIPTION
This would take away some of the repetitiveness of the Interface classes that come
with every single one of our 23 plugin systems.

This PR is only meant as a discussion starter. Does this go in the right direction?
If I carried this through all 23 plugin systems, it would remove a whole bunch
of code where all we do is declare empty functions to define an interface. This
repetitiveness can be avoided.

I'm mindful that having class hierarchies makes it more difficult for newcomers
to really understand an interface because things are no longer spelled out in
one place, but now in the Interface and the InterfaceBase class. It's a debatable
question which consideration (readability vs code size reduction) is the more
important one. Any input would be welcome.

In reference to #1775 as a first little step.