### PR TITLE
Fix which include file we include.

### DIFF
--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -32,7 +32,7 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <deal.II/lac/petsc_parallel_block_sparse_matrix.h>
 #  include <deal.II/lac/petsc_precondition.h>
 #else
-#  include <deal.II/lac/trilinos_block_vector.h>
+#  include <deal.II/lac/trilinos_parallel_block_vector.h>
 #  include <deal.II/lac/trilinos_block_sparse_matrix.h>
 #  include <deal.II/lac/trilinos_precondition.h>
 #endif

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -29,7 +29,7 @@
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 
-#include <deal.II/lac/trilinos_block_vector.h>
+#include <deal.II/lac/trilinos_parallel_block_vector.h>
 #include <deal.II/lac/trilinos_block_sparse_matrix.h>
 #include <deal.II/lac/trilinos_precondition.h>
 


### PR DESCRIPTION
We ought to be using the one that declares the *parallel* Trilinos block vectors,
not the one for the sequential version.

This may not have mattered in the past, but is currently necessary because
compilation with current deal.II otherwise fails, see
https://github.com/dealii/dealii/issues/4486 . It is also clearly the correct
thing to do regardless.