### PR TITLE
Ensure that the base class also gets to serialize its data.

### DIFF
--- a/include/aspect/particle/output/interface.h
+++ b/include/aspect/particle/output/interface.h
@@ -129,6 +129,14 @@ namespace aspect
       };
 
 
+      // template function
+      template <int dim>
+      template <class Archive>
+      void Interface<dim>::serialize (Archive &, const unsigned int)
+      {}
+
+
+
       /**
        * Register a particle output so that it can be selected from
        * the parameter file.

--- a/source/particle/output/ascii.cc
+++ b/source/particle/output/ascii.cc
@@ -116,6 +116,8 @@ namespace aspect
       void ASCIIOutput<dim>::serialize (Archive &ar, const unsigned int)
       {
         // invoke serialization of the base class
+        ar &static_cast<Interface<dim> &>(*this);
+
         ar &file_index
         ;
       }

--- a/source/particle/output/hdf5.cc
+++ b/source/particle/output/hdf5.cc
@@ -305,6 +305,8 @@ namespace aspect
       void HDF5Output<dim>::serialize (Archive &ar, const unsigned int)
       {
         // invoke serialization of the base class
+        ar &static_cast<Interface<dim> &>(*this);
+
         ar &file_index
         &xdmf_entries
         ;

--- a/source/particle/output/interface.cc
+++ b/source/particle/output/interface.cc
@@ -48,11 +48,6 @@ namespace aspect
       {}
 
       template <int dim>
-      template <class Archive>
-      void Interface<dim>::serialize (Archive &ar, const unsigned int)
-      {}
-
-      template <int dim>
       void
       Interface<dim>::save (std::ostringstream &) const
       {}

--- a/source/particle/output/vtu.cc
+++ b/source/particle/output/vtu.cc
@@ -253,6 +253,8 @@ namespace aspect
       void VTUOutput<dim>::serialize (Archive &ar, const unsigned int)
       {
         // invoke serialization of the base class
+        ar &static_cast<Interface<dim> &>(*this);
+
         ar &file_index
         & times_and_pvtu_file_names
         & times_and_vtu_file_names


### PR DESCRIPTION
The current implementation of the various serialization functions of particle output
classes have a comment that says that we ought to call the serialization function
of the base class -- but then they all do not actually do so. Fix this.

It doesn't current make any difference since the base class has nothing to serialize.
But it may acquire some data at some point in the future, and this patch prevents
the bug that would then become apparent.