### PR TITLE
Clear initial FPE flags

### DIFF
--- a/cmake/fpe_check.cmake
+++ b/cmake/fpe_check.cmake
@@ -30,7 +30,13 @@ CHECK_CXX_SOURCE_RUNS("
 
 int main()
 {
+  // Some implementations seem to not initialize the FPE bits to zero.
+  // Make sure we start from a clean state
+  feclearexcept(FE_DIVBYZERO|FE_INVALID);
+
+  // Enable floating point exceptions
   feenableexcept(FE_DIVBYZERO|FE_INVALID);
+
   std::ostringstream description;
   const double lower_bound = -std::numeric_limits<double>::max();
 

--- a/source/main.cc
+++ b/source/main.cc
@@ -448,6 +448,10 @@ int main (int argc, char *argv[])
 
 #ifdef DEBUG
 #ifdef ASPECT_USE_FP_EXCEPTIONS
+  // Some implementations seem to not initialize the floating point exception
+  // bits to zero. Make sure we start from a clean state.
+  feclearexcept(FE_DIVBYZERO|FE_INVALID);
+
   // enable floating point exceptions
   feenableexcept(FE_DIVBYZERO|FE_INVALID);
 #endif


### PR DESCRIPTION
I found some systems do not initialize the FPE flags correctly (or inherit them in an unclean state). This means their state can be different for the cmake test than for the main program, passing our cmake test, but failing at runtime. 
Additionally, there is no exception that is raised (it was supposedly raised some time before program execution, but ignored). This means the FPE is raised at some random time, whenever the first function checks the state of these flags. This can for example happen in an innocent line like `ostream << 0.0`. Not to mention any names, but this change fixes crashes on Lonestar 5 :smile:, where we so far had to explicitly disable FPE_Exceptions (although cmake wants to enable them).