### PR TITLE
Fix source update script

### DIFF
--- a/doc/update_source_files_to_2.0.0.sed
+++ b/doc/update_source_files_to_2.0.0.sed
@@ -48,7 +48,7 @@ s/\@ingroup CompositionalInitialConditionsModels/\@ingroup InitialCompositions/g
 
 # Rename initial (temperature) conditions
 s/initial_conditions_model/initial_temperature/g
-s/initial_conditions[^\.][^c]/initial_temperature/g
+s/initial_conditions\([^\.][^c]\)/initial_temperature\1/g
 s/initial-conditions\//initial-temperature\//g
 s/initial_condition[^s]/initial_temperature/g
 s/InitialConditionsModels/InitialTemperatures/g


### PR DESCRIPTION
There was a bug in the update script introduced by myself during the hackathon. The script accidentally deletes two characters (that I need to distinguish `initial_conditions*` from `initial_conditions.cc`). Now I keep those characters.