### PR TITLE
[WIP] To fix possible bug for problems with periodic boundary using DG and AMR 

### DIFF
--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -494,7 +494,7 @@ namespace aspect
               ExcInternalError());
       const bool cell_has_periodic_neighbor = cell->has_periodic_neighbor (face_no);
 
-      if ((!face->at_boundary() && !face->has_children()) 
+      if ((!face->at_boundary() && !face->has_children())
           ||
           (face->at_boundary() && cell->periodic_neighbor_is_coarser(face_no))
           ||
@@ -817,11 +817,12 @@ namespace aspect
              :
              cell->neighbor_face_no(face_no));
 
-           // TODO: need to consider subfaces on periodic neighbors of a coarsen cell
-           // as in such case, the face of current active cell is on the boundary and face->number_of_children()==1 
+          // TODO: need to consider subfaces on periodic neighbors of a coarsen cell
+          // as in such case, the face of current active cell is on the boundary and face->number_of_children()==1
 
           // loop over subfaces
-          for (unsigned int subface_no=0; subface_no<face->number_of_children(); ++subface_no)
+          typename DoFHandler<dim>::face_iterator neighbor_face=neighbor->face(neighbor2);
+          for (unsigned int subface_no=0; subface_no<neighbor_face->number_of_children(); ++subface_no)
             {
               const typename DoFHandler<dim>::active_cell_iterator neighbor_child
                 = ( cell_has_periodic_neighbor

--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -494,7 +494,11 @@ namespace aspect
               ExcInternalError());
       const bool cell_has_periodic_neighbor = cell->has_periodic_neighbor (face_no);
 
-      if (!(face->has_children()))
+      if ((!face->at_boundary() && !face->has_children()) 
+          ||
+          (face->at_boundary() && cell->periodic_neighbor_is_coarser(face_no))
+          ||
+          (face->at_boundary() && neighbor->level () == cell->level () && neighbor->active()))
         {
           if (neighbor->level () == cell->level () &&
               neighbor->active() &&
@@ -812,6 +816,9 @@ namespace aspect
              cell->periodic_neighbor_face_no(face_no)
              :
              cell->neighbor_face_no(face_no));
+
+           // TODO: need to consider subfaces on periodic neighbors of a coarsen cell
+           // as in such case, the face of current active cell is on the boundary and face->number_of_children()==1 
 
           // loop over subfaces
           for (unsigned int subface_no=0; subface_no<face->number_of_children(); ++subface_no)


### PR DESCRIPTION
Issue #1822 gives an example showing that DG method can return a wrong solution for the periodic boundary problem on an AMR grid. After further investigating the code,   it does show a potential bug in the  flux construction. For the current implementation, the flux calculation will skip the case when the periodic neighbor cell is finer. One reason is that the periodic face in a coarsen cell is always on the boundary, therefore face->has_children() always return false. So face->has_children() can not be a criterion to indicate the current cell is coarser than the periodic neighbor. 
Todo: need to carefully go over the surfaces in the periodic case. 