### PR TITLE
Fix reference to an outdated grant number.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -348,7 +348,7 @@ Please acknowledge CIG as follows:
     \shadowbox{
       \begin{minipage}[c]{0.9\linewidth}
 ASPECT is hosted by the Computational Infrastructure for Geodynamics (CIG)
-which is supported by the National Science Foundation award NSF-094946.
+which is supported by the National Science Foundation award EAR-1550901.
       \end{minipage}
     }
   \end{center}


### PR DESCRIPTION
The correct grant number was already listed just a few lines above, but we must have forgotten to fix this one.