### PR TITLE
Improve manual description for adiabatic conditions function subsection

### DIFF
--- a/source/adiabatic_conditions/function.cc
+++ b/source/adiabatic_conditions/function.cc
@@ -92,8 +92,8 @@ namespace aspect
         Functions::ParsedFunction<1>::declare_parameters (prm, 3);
         prm.declare_entry("Function expression","0.0; 0.0; 1.0",
                           Patterns::Anything(),
-                          "Expression for the adiabatic pressure, "
-                          "temperature, and density separated by "
+                          "Expression for the adiabatic temperature, "
+                          "pressure, and density separated by "
                           "semicolons as a function of `depth'.");
         prm.declare_entry("Variable names","depth");
         prm.leave_subsection();


### PR DESCRIPTION
The order for adiabatic function input should be temperature, pressure, and density. This causes a little confusion for the user. The description for the input order at the bottom is correct.