### PR TITLE
Improve an error message.

### DIFF
--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -46,7 +46,10 @@ namespace aspect
     SphericalShell<dim>::
     create_coarse_mesh (parallel::distributed::Triangulation<dim> &coarse_grid) const
     {
-      AssertThrow (phi == 360 || phi == 90 || dim!=3, ExcNotImplemented());
+      AssertThrow (phi == 360 || phi == 90 || ((phi == 180) && (dim == 2)),
+                   ExcMessage ("The only opening angles that are allowed for "
+                               "this geometry are 90, 180, and 360 in 2d; "
+                               "and 90 and 360 in 3d."));
 
       if (phi == 360)
         {
@@ -365,7 +368,11 @@ namespace aspect
           prm.declare_entry ("Opening angle", "360",
                              Patterns::Double (0, 360),
                              "Opening angle in degrees of the section of the shell "
-                             "that we want to build. Units: degrees.");
+                             "that we want to build. "
+                             "The only opening angles that are allowed for "
+                             "this geometry are 90, 180, and 360 in 2d; "
+                             "and 90 and 360 in 3d. "
+                             "Units: degrees.");
 
           prm.declare_entry ("Cells along circumference", "0",
                              Patterns::Integer (0),


### PR DESCRIPTION
In particular, let the assertion check exactly the cases we support. It seems
to me that at one point, we allowed arbitrary opening angles for the spherical
shell geometry in 2d, and the assertion suggests that too, but the current
code does not allow for that. Match the error message to the actual code.