### PR TITLE
Fix and apply update source script

### DIFF
--- a/doc/update_source_files_to_2.0.0.sed
+++ b/doc/update_source_files_to_2.0.0.sed
@@ -22,7 +22,7 @@ s/\<\@ingroup BoundaryFluidPressure\>/\@ingroup BoundaryFluidPressures/g
 # Rename traction boundary conditions
 s/traction_boundary_conditions_model/boundary_traction/g
 s/traction_boundary_conditions/boundary_traction/g
-s/traction_boundary/boundary_traction/g
+s/(?<!prescribed_)traction_boundary/boundary_traction/g
 s/TractionBoundaryConditions/BoundaryTraction/g
 s/Traction boundary/Boundary traction/g
 s/TRACTION_BOUNDARY_CONDITIONS/BOUNDARY_TRACTION_MODEL/g

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -966,7 +966,7 @@ namespace aspect
                                    "may in fact decrease if the orientation of the deformation field switches "
                                    "through time. Consequently, the ideal solution is track the finite strain "
                                    "invariant (single compositional) field within the material and track "
-                                   "the full finite strain tensor through tracers."
+                                   "the full finite strain tensor through particles."
                                    ""
                                    "\n\n"
                                    "Viscous stress may also be limited by a non-linear stress limiter "


### PR DESCRIPTION
The current source update script renames `prescribed_traction_boundary_indicators` into `prescribed_boundary_traction_indicators`, which is inconsistent with our writing of `prescribed_velocity_boundary_indicators`. Fix that by excluding those cases from the replacement. Not sure why I did not notice this earlier.
Also there is one occurrence of `tracers` that was not properly replaced, because it was an open pull request at the time I applied the script to the repository.