### PR TITLE
Improve advice on contributing patches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,11 @@ The ASPECT community maintains an active mailing list hosted by CIG
 mailing list is for questions about ASPECT at all levels.
 
 ## Bug reports
-It is a great help to the community if you report any bugs in the code that you
+It is a great help to the community if you report any bugs that you
 may find. We keep track of all open issues related to ASPECT
 [here](https://github.com/geodynamics/aspect/issues). 
 
-Please follow some simple instructions before opening a new bug report:
+Please follow these simple instructions before opening a new bug report:
 
 - Do a quick search in the list of open and closed issues for a duplicate of
   your issue.
@@ -40,19 +40,18 @@ problem in as much detail as possible.
     how to reproduce it.
 
 ## Making ASPECT better
-As mentioned ASPECT is a community project, and we are encouraging all kinds of
-contributions. Obvious candidates for
-such contributions are implementations of new plugins as discussed in
+ASPECT is a community project, and we are encouraging all kinds of
+contributions. Obvious candidates are implementations of new plugins as discussed in
 the manual, since they are typically self-contained and do not
 require much knowledge of the details of the remaining code. Other much
 appreciated contributions are new examples (cookbooks, tests, or benchmarks),
 extended documentation (every paragraph helps), and in particular fixing typos
-or updating outdated documentation. Obviously, however, we also encourage
+or updating outdated documentation. Obviously, we also encourage
 contributions to the core functionality in any form! If you consider making a
 larger contribution to the core functionality, please open a new
 [issue](https://github.com/geodynamics/aspect/issues/new) first, to discuss
 your idea with one of the maintainers. This allows us to give you early
-advice and prevents you from spending much time on a project that might already be
+feedback and prevents you from spending much time on a project that might already be
 planned, or that conflicts with other plans.
 
 To make a change to ASPECT you should:
@@ -62,9 +61,9 @@ the code base.
 - Create a separate
 [branch](https://guides.github.com/introduction/flow/) (sometimes called a
 feature branch) on which you do your modifications.
-- You can propose that your branch be combined with the rest of
+- You can propose that your branch be merged into the ASPECT
 code by opening a [pull request](https://guides.github.com/introduction/flow/).
-This will give a chance for others to review your code. 
+This will give others a chance to review your code. 
 
 We follow the philosophy that no pull request (independent of the author) is
 merged without a review from one other member of the community, and approval of
@@ -89,9 +88,9 @@ conventions](https://www.dealii.org/developer/doxygen/deal.II/CodingConventions.
 equal to those used by <a href="http://www.dealii.org">deal.II</a>
 upon which ASPECT is based, so as to keep the style of the source code
 consistent. This convention essentially consists of using
-[astyle](http://astyle.sourceforge.net/astyle.html) v.2.04 with the included
-[options](doc/astyle.rc) for indentation, camel case for classes and
-namespaces, and lower case letters with underscores for everything else. If you
+[astyle](http://astyle.sourceforge.net/astyle.html) v.2.04 with a
+[style file](doc/astyle.rc) for indentation, CamelCase for classes and
+namespaces, and lower_case_names_with_underscores for everything else. If you
 are new to the project then we will work with you to ensure your contributions
 are formatted with this style, so please do not think of it as a road block if
 you would like to contribute some code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,34 +19,103 @@ The ASPECT community maintains an active mailing list hosted by CIG
 mailing list is for questions about ASPECT at all levels.
 
 ## Bug reports
-It is a great help to the community if you report any bugs in the
-code that you may find. We keep track of all open issues with ASPECT
-[here](https://github.com/geodynamics/aspect/issues). If you
-can, please try to include a minimal failing example that can help us
-reproduce the problem.
+It is a great help to the community if you report any bugs in the code that you
+may find. We keep track of all open issues related to ASPECT
+[here](https://github.com/geodynamics/aspect/issues). 
 
-## Making changes to ASPECT
-To make a change to ASPECT you should create a *fork* (through GitHub)
-of the code base and a separate *branch* (sometimes called a feature
-branch). You can propose that your branch be combined with the rest of
-code by opening a *pull request*. This will give a chance for others
-to review your code. While this seems very formal, keeping all of the
-code review in one place makes it easier to coordinate changes to the
-code (and there are usually several people making changes to the code
-at once). This process is described at length in the deal.II video [lecture 32.8](http://www.math.colostate.edu/~bangerth/videos.676.32.8.html). Please do not hesitate to ask questions about the workflow on the mailing list if you are not sure what to do.
+Please follow some simple instructions before opening a new bug report:
+
+- Do a quick search in the list of open and closed issues for a duplicate of
+  your issue.
+- Do a quick search in the archived discussions on the mailing list for a
+  duplicate of your issue.
+- If you did not find an answer, open a new
+  [issue](https://github.com/geodynamics/aspect/issues/new) and explain your
+problem in as much detail as possible.
+- Attach as much as possible of the following information to your issue:
+  - a minimal parameter file that reproduces the issue,
+  - the `log.txt` file that was created during the model run,
+  - the error message you saw on your screen,
+  - any information that helps us understand why you think this is a bug, and
+    how to reproduce it.
+
+## Making ASPECT better
+As mentioned ASPECT is a community project, and we are encouraging all kinds of
+contributions. Obvious candidates for
+such contributions are implementations of new plugins as discussed in
+the manual, since they are typically self-contained and do not
+require much knowledge of the details of the remaining code. Other much
+appreciated contributions are new examples (cookbooks, tests, or benchmarks),
+extended documentation (every paragraph helps), and in particular fixing typos
+or updating outdated documentation. Obviously, however, we also encourage
+contributions to the core functionality in any form! If you consider making a
+larger contribution to the core functionality, please open a new
+[issue](https://github.com/geodynamics/aspect/issues/new) first, to discuss
+your idea with one of the maintainers. This allows us to give you early
+advice and prevents you from spending much time on a project that might already be
+planned, or that conflicts with other plans.
+
+To make a change to ASPECT you should:
+- Create a
+[fork](https://guides.github.com/activities/forking/#fork) (through GitHub) of
+the code base.
+- Create a separate
+[branch](https://guides.github.com/introduction/flow/) (sometimes called a
+feature branch) on which you do your modifications.
+- You can propose that your branch be combined with the rest of
+code by opening a [pull request](https://guides.github.com/introduction/flow/).
+This will give a chance for others to review your code. 
+
+We follow the philosophy that no pull request (independent of the author) is
+merged without a review from one other member of the community, and approval of
+one of the maintainers. This applies to maintainers as well as to first-time
+contributors. We know that a review can be a daunting process, but pledge to
+keep all comments friendly and supportive, as you can see in the list of [open
+pull requests](https://github.com/geodynamics/aspect/pulls)! We are as
+interested in making ASPECT better as you are!
+
+While this seems very
+formal, keeping all of the code review in one place makes it easier to
+coordinate changes to the code (and there are usually several people making
+changes to the code at once). This process is described at length in the
+deal.II video [lecture
+32.8](http://www.math.colostate.edu/~bangerth/videos.676.32.8.html).  Please do
+not hesitate to ask questions about the workflow on the mailing list if you are
+not sure what to do.
 
 Since ASPECT is a fairly large project with lots of contributors we
 use a set of [coding
 conventions](https://www.dealii.org/developer/doxygen/deal.II/CodingConventions.html)
 equal to those used by <a href="http://www.dealii.org">deal.II</a>
 upon which ASPECT is based, so as to keep the style of the source code
-consistent. This convention essentially consists of using `astyle` for
-indentation, camel case for classes, and lower case letters with
-underscores for everything else. If you are new to the project then we
-will work with you to ensure your contributions are formatted with
-this style, so please do not think of it as a road block if you would
-like to contribute some code.
+consistent. This convention essentially consists of using
+[astyle](http://astyle.sourceforge.net/astyle.html) v.2.04 with the included
+[options](doc/astyle.rc) for indentation, camel case for classes and
+namespaces, and lower case letters with underscores for everything else. If you
+are new to the project then we will work with you to ensure your contributions
+are formatted with this style, so please do not think of it as a road block if
+you would like to contribute some code.
 
-ASPECT is licensed under the GNU General Public License; while you
+## Acknowledgment of contributions
+While we are grateful for every contribution, there are also several official
+ways how your contribution will be acknowledged by the ASPECT community:
+- Our biweekly mailing list newsletter mentions all raised issues and proposed
+  and merged pull requests including an acknowledgment of the author of the
+  issue/pull request.
+- If you contributed significant functionality to the source code we will ask
+  you to provide an entry into our
+  [changelog](http://aspect.dealii.org/doc/doxygen/changes_current.html) by
+  placing a file into the [doc/modules/changes/](doc/modules/changes/) folder.
+  This changelog is used to generate our release notes, and remains available
+  for all previous releases of ASPECT.
+- If you contributed a significant part of the manual (such as a new cookbook,
+  benchmark, or subsection), you will be listed as one of the contributing
+  authors of the manual.
+- Every commit that was merged into the ASPECT repository will make you part of
+  the growing group of ASPECT
+  [contributors](https://github.com/geodynamics/aspect/graphs/contributors).
+
+## License
+ASPECT is published under the [GPL v2 or newer](LICENSE); while you
 will retain copyright on your contributions, all changes to the code
 must be provided under this common license.

--- a/README.md
+++ b/README.md
@@ -5,15 +5,18 @@ ASPECT - Advanced Solver for Problems in Earth's ConvecTion
 About
 -----
 
-ASPECT is a code to simulate problems in thermal convection. The project is
-supported by CIG (http://geodynamics.org).
+ASPECT is a code to simulate convection in Earth's mantle and elsewhere.
+It has grown from a pure mantle-convection code into a tool for many
+geodynamic applications including applications for inner core convection,
+lithospheric scale deformation, two-phase flow, and numerical methods development.
+The project is supported by CIG (http://geodynamics.org).
 
 
 
 Installation instructions
 -------------------------
 
-The steps to install the necessary dependencies and ASPECT itself is described in the Installation instructions section of the ASPECT [manual](http://www.math.clemson.edu/~heister/manual.pdf).
+The steps to install the necessary dependencies and ASPECT itself are described in the Installation instructions section of the ASPECT [manual](http://www.math.clemson.edu/~heister/manual.pdf).
 
 
 


### PR DESCRIPTION
After reading through most of https://opensource.guide/ I made some more changes to our readme and contributing.md. Hopefully this will lower the barrier to contribute to ASPECT. One thing I am not sure about is the advice on including a code of conduct in the repository. I am not aware that we had much trouble in this regard so far, and I dislike playing by github's rules, just to get our last checkmark at https://github.com/geodynamics/aspect/community, but on the other hand it is not much of a pain, and might become useful. What do others think?

Please wait with merging this PR, I am currently waiting for a response from UC Davis IT staff as to how to search through our mailing list (if that is at all possible).