### PR TITLE
Allow plugins to modify sparsity pattern

### DIFF
--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -101,7 +101,8 @@ namespace aspect
 
     /**
      * A signal that is called at the end of setting up the
-     * constraints for the current time step. This allows to add
+     * constraints for the current time step and prior to the initialization
+     * of the linear system. This allows to add
      * more constraints on degrees of freedom, for example to fix
      * the velocity at certain points.
      *

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1395,6 +1395,8 @@ namespace aspect
                                                        constraints,
                                                        *mapping);
     }
+    // allow user constraints that will potentially modify sparsity pattern
+    signals.post_constraints_creation(*this, constraints);
     constraints.close();
     signals.post_compute_no_normal_flux_constraints(triangulation);
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1115,7 +1115,7 @@ namespace aspect
 
         DoFTools::make_flux_sparsity_pattern (dof_handler,
                                               sp,
-                                              constraints, false,
+                                              current_constraints, false,
                                               coupling,
                                               face_coupling,
                                               Utilities::MPI::
@@ -1124,7 +1124,7 @@ namespace aspect
     else
       DoFTools::make_sparsity_pattern (dof_handler,
                                        coupling, sp,
-                                       constraints, false,
+                                       current_constraints, false,
                                        Utilities::MPI::
                                        this_mpi_process(mpi_communicator));
 
@@ -1246,7 +1246,7 @@ namespace aspect
 
         DoFTools::make_flux_sparsity_pattern (dof_handler,
                                               sp,
-                                              constraints, false,
+                                              current_constraints, false,
                                               coupling,
                                               face_coupling,
                                               Utilities::MPI::
@@ -1255,7 +1255,7 @@ namespace aspect
     else
       DoFTools::make_sparsity_pattern (dof_handler,
                                        coupling, sp,
-                                       constraints, false,
+                                       current_constraints, false,
                                        Utilities::MPI::
                                        this_mpi_process(mpi_communicator));
 
@@ -1395,9 +1395,9 @@ namespace aspect
                                                        constraints,
                                                        *mapping);
     }
-    // allow user constraints that will potentially modify sparsity pattern
-    signals.post_constraints_creation(*this, constraints);
+
     constraints.close();
+    compute_current_constraints();
     signals.post_compute_no_normal_flux_constraints(triangulation);
 
     // finally initialize vectors, matrices, etc.


### PR DESCRIPTION
This allows for constraints that can potentially modify the sparsity pattern to be evaluated prior to the creation of the system matrices. This allows for prescribed pressure, for instance, as required for Pull Request #1864 .