### PR TITLE
Make default value for 'density below' consistent across postprocessors

### DIFF
--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -801,7 +801,7 @@ namespace aspect
           prm.declare_entry("Density above","0",
                             Patterns::Double (0),
                             "The density value above the surface boundary.");
-          prm.declare_entry("Density below","8000",
+          prm.declare_entry("Density below","9900",
                             Patterns::Double (0),
                             "The density value below the CMB boundary.");
           prm.declare_entry("Also output the spherical harmonic coefficients of geoid anomaly", "false",


### PR DESCRIPTION
The default value for 'density below' was different in the dynamic topography postprocessor and the  geoid postprocessor but for consistency this should probably be the same value. I adapted the default density below in the geoid postprocessor to be the same as in the dynamic topography postprocessor.