### PR TITLE
Instantiate particles for spacedim

### DIFF
--- a/source/particle/particle.cc
+++ b/source/particle/particle.cc
@@ -24,8 +24,8 @@ namespace aspect
 {
   namespace Particle
   {
-    template <int dim>
-    Particle<dim>::Particle ()
+    template <int dim, int spacedim>
+    Particle<dim,spacedim>::Particle ()
       :
       location (),
       reference_location(),
@@ -36,10 +36,10 @@ namespace aspect
     }
 
 
-    template <int dim>
-    Particle<dim>::Particle (const Point<dim> &new_location,
-                             const Point<dim> &new_reference_location,
-                             const types::particle_index new_id)
+    template <int dim, int spacedim>
+    Particle<dim,spacedim>::Particle (const Point<spacedim> &new_location,
+                                      const Point<dim> &new_reference_location,
+                                      const types::particle_index new_id)
       :
       location (new_location),
       reference_location (new_reference_location),
@@ -49,8 +49,8 @@ namespace aspect
     {
     }
 
-    template <int dim>
-    Particle<dim>::Particle (const Particle<dim> &particle)
+    template <int dim, int spacedim>
+    Particle<dim,spacedim>::Particle (const Particle<dim,spacedim> &particle)
       :
       location (particle.get_location()),
       reference_location (particle.get_reference_location()),
@@ -72,9 +72,9 @@ namespace aspect
     }
 
 
-    template <int dim>
-    Particle<dim>::Particle (const void *&data,
-                             PropertyPool &new_property_pool)
+    template <int dim, int spacedim>
+    Particle<dim,spacedim>::Particle (const void *&data,
+                                      PropertyPool &new_property_pool)
     {
       const types::particle_index *id_data = static_cast<const types::particle_index *> (data);
       id = *id_data++;
@@ -99,8 +99,8 @@ namespace aspect
 
 #ifdef DEAL_II_WITH_CXX11
 
-    template <int dim>
-    Particle<dim>::Particle (Particle<dim> &&particle)
+    template <int dim, int spacedim>
+    Particle<dim,spacedim>::Particle (Particle<dim,spacedim> &&particle)
       :
       location (particle.location),
       reference_location(particle.reference_location),
@@ -111,9 +111,9 @@ namespace aspect
       particle.properties = PropertyPool::invalid_handle;
     }
 
-    template <int dim>
-    Particle<dim> &
-    Particle<dim>::operator=(const Particle<dim> &particle)
+    template <int dim, int spacedim>
+    Particle<dim,spacedim> &
+    Particle<dim,spacedim>::operator=(const Particle<dim,spacedim> &particle)
     {
       if (this != &particle)
         {
@@ -139,9 +139,9 @@ namespace aspect
       return *this;
     }
 
-    template <int dim>
-    Particle<dim> &
-    Particle<dim>::operator=(Particle<dim> &&particle)
+    template <int dim, int spacedim>
+    Particle<dim,spacedim> &
+    Particle<dim,spacedim>::operator=(Particle<dim,spacedim> &&particle)
     {
       if (this != &particle)
         {
@@ -156,16 +156,16 @@ namespace aspect
     }
 #endif
 
-    template <int dim>
-    Particle<dim>::~Particle ()
+    template <int dim, int spacedim>
+    Particle<dim,spacedim>::~Particle ()
     {
       if (properties != PropertyPool::invalid_handle)
         property_pool->deallocate_properties_array(properties);
     }
 
-    template <int dim>
+    template <int dim, int spacedim>
     void
-    Particle<dim>::write_data (void *&data) const
+    Particle<dim,spacedim>::write_data (void *&data) const
     {
       types::particle_index *id_data  = static_cast<types::particle_index *> (data);
       *id_data = id;
@@ -188,51 +188,51 @@ namespace aspect
       data = static_cast<void *> (pdata);
     }
 
-    template <int dim>
+    template <int dim, int spacedim>
     void
-    Particle<dim>::set_location (const Point<dim> &new_loc)
+    Particle<dim,spacedim>::set_location (const Point<spacedim> &new_loc)
     {
       location = new_loc;
     }
 
-    template <int dim>
-    const Point<dim> &
-    Particle<dim>::get_location () const
+    template <int dim, int spacedim>
+    const Point<spacedim> &
+    Particle<dim,spacedim>::get_location () const
     {
       return location;
     }
 
-    template <int dim>
+    template <int dim, int spacedim>
     void
-    Particle<dim>::set_reference_location (const Point<dim> &new_loc)
+    Particle<dim,spacedim>::set_reference_location (const Point<dim> &new_loc)
     {
       reference_location = new_loc;
     }
 
-    template <int dim>
+    template <int dim, int spacedim>
     const Point<dim> &
-    Particle<dim>::get_reference_location () const
+    Particle<dim,spacedim>::get_reference_location () const
     {
       return reference_location;
     }
 
-    template <int dim>
+    template <int dim, int spacedim>
     types::particle_index
-    Particle<dim>::get_id () const
+    Particle<dim,spacedim>::get_id () const
     {
       return id;
     }
 
-    template <int dim>
+    template <int dim, int spacedim>
     void
-    Particle<dim>::set_property_pool (PropertyPool &new_property_pool)
+    Particle<dim,spacedim>::set_property_pool (PropertyPool &new_property_pool)
     {
       property_pool = &new_property_pool;
     }
 
-    template <int dim>
+    template <int dim, int spacedim>
     void
-    Particle<dim>::set_properties (const std::vector<double> &new_properties)
+    Particle<dim,spacedim>::set_properties (const std::vector<double> &new_properties)
     {
       if (properties == PropertyPool::invalid_handle)
         properties = property_pool->allocate_properties_array();
@@ -242,9 +242,9 @@ namespace aspect
       std::copy(new_properties.begin(),new_properties.end(),&old_properties[0]);
     }
 
-    template <int dim>
+    template <int dim, int spacedim>
     const ArrayView<const double>
-    Particle<dim>::get_properties () const
+    Particle<dim,spacedim>::get_properties () const
     {
       Assert(property_pool != NULL,
              ExcInternalError());
@@ -253,9 +253,9 @@ namespace aspect
     }
 
 
-    template <int dim>
+    template <int dim, int spacedim>
     const ArrayView<double>
-    Particle<dim>::get_properties ()
+    Particle<dim,spacedim>::get_properties ()
     {
       Assert(property_pool != NULL,
              ExcInternalError());


### PR DESCRIPTION
This is the first step towards addressing the comments and discussions of dealii/dealii#4729 inside of ASPECT to then move parts of the particle implementation into deal.II

This PR allows for particles where dim != spacedim, which never happens in ASPECT. 