### PR TITLE
Fixed bug preventing particles from working in Solcx benchmark

### DIFF
--- a/benchmarks/solcx/compositional_fields/solcx_compositional_fields.h
+++ b/benchmarks/solcx/compositional_fields/solcx_compositional_fields.h
@@ -15,21 +15,19 @@ namespace aspect
     class SolCxCompositionalMaterial : public SolCxMaterial<dim>
     {
       public:
-        double density(const double temperature,
-                       const double pressure,
-                       const std::vector<double> &composition,
-                       const Point <dim> &position) const
+        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                              MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          return composition[0];
-        }
-
-        double viscosity(const double temperature,
-                         const double pressure,
-                         const std::vector<double> &composition,
-                         const SymmetricTensor<2, dim> &strain_rate,
-                         const Point <dim> &position) const
-        {
-          return composition[1];
+          for (unsigned int i=0; i < in.position.size(); ++i)
+            {
+              const Point<dim> &pos = in.position[i];
+              out.densities[i] = in.composition[i][0];
+              out.viscosities[i] = in.composition[i][1];
+              out.compressibilities[i] = 0;
+              out.specific_heat[i] = 0;
+              out.thermal_expansion_coefficients[i] = 0;
+              out.thermal_conductivities[i] = 0.0;
+            }
         }
     };
   }

--- a/benchmarks/solcx/compositional_fields/solcx_particles.prm
+++ b/benchmarks/solcx/compositional_fields/solcx_particles.prm
@@ -76,6 +76,12 @@ subsection Compositional fields
   set Number of fields = 2
   set Names of fields = density_comp, viscosity_comp
   set Compositional field methods = particles, particles
+  
+  # In the source code, we assumed that density is being carried
+  # on compositional field 1 (at index 0) and viscosity is being
+  # carried on compositional field 2 (at index 1).  If this order
+  # is changed, then the evaluate() function in solcx_compositional_fields.h
+  # must also be changed.
   set Mapped particle properties = density_comp:function[0], viscosity_comp:function[1]
 end
 


### PR DESCRIPTION
The density and viscosity values at each point were not being set to the values on their respective compositional fields in solcx_compositional_fields.h.  This is because SolCxCompostionalMaterial was outdated and needed to be updated.  As a result, we would always obtain the convergence results for the direct method regardless of the method being used in the Solcx parameter file.  

Currently, if a compositional field carries viscosity, then the convergence results are less accurate then that of the direct methods.  However, the convergence results for Solcx are exactly the same as the direct method if only density is carried on a compositional field.