### PR TITLE
Add particle iterator and accessor

### DIFF
--- a/include/aspect/particle/particle_accessor.h
+++ b/include/aspect/particle/particle_accessor.h
@@ -1,0 +1,188 @@
+/*
+ Copyright (C) 2017 by the authors of the ASPECT code.
+
+ This file is part of ASPECT.
+
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _aspect_particle_particle_accessor_h
+#define _aspect_particle_particle_accessor_h
+
+#include <aspect/global.h>
+#include <aspect/particle/particle.h>
+
+#include <deal.II/base/array_view.h>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    using namespace dealii;
+
+    template <int, int> class ParticleIterator;
+
+    template<int dim, int spacedim=dim>
+    class ParticleAccessor
+    {
+      public:
+        /**
+         * Write particle data into a data array. The array is expected
+         * to be large enough to take the data, and the void pointer should
+         * point to the first element in which the data should be written. This
+         * function is meant for serializing all particle properties and
+         * afterwards de-serializing the properties by calling the appropriate
+         * constructor Particle(void *&data, PropertyPool *property_pool = NULL);
+         *
+         * @param [in,out] data The memory location to write particle data
+         * into. This pointer points to the begin of the memory, in which the
+         * data will be written and it will be advanced by the serialized size
+         * of this particle.
+         */
+        void
+        write_data(void *&data) const;
+
+        /**
+          * Set the location of this particle. Note that this does not check
+          * whether this is a valid location in the simulation domain.
+          *
+          * @param [in] new_location The new location for this particle.
+          */
+        void
+        set_location (const Point<spacedim> &new_location);
+
+        /**
+         * Get the location of this particle.
+         *
+         * @return The location of this particle.
+         */
+        const Point<spacedim> &
+        get_location () const;
+
+        /**
+         * Set the reference location of this particle.
+         *
+         * @param [in] new_reference_location The new reference location for
+         * this particle.
+         */
+        void
+        set_reference_location (const Point<dim> &new_reference_location);
+
+        /**
+         * Return the reference location of this particle in its current cell.
+         */
+        const Point<dim> &
+        get_reference_location () const;
+
+        /**
+         * Return the ID number of this particle.
+         */
+        types::particle_index
+        get_id () const;
+
+        /**
+         * Tell the particle where to store its properties (even if it does not
+         * own properties). Usually this is only done once per particle, but
+         * since the particle generator does not know about the properties
+         * we want to do it not at construction time. Another use for this
+         * function is after particle transfer to a new process.
+         */
+        void
+        set_property_pool(PropertyPool &property_pool);
+
+        /**
+          * Returns whether this particle has a valid property pool and a valid
+          * handle to properties.
+          */
+        bool
+        has_properties () const;
+
+        /**
+         * Set the properties of this particle.
+         *
+         * @param [in] new_properties A vector containing the
+         * new properties for this particle.
+         */
+        void
+        set_properties (const std::vector<double> &new_properties);
+
+        /**
+         * Get write-access to properties of this particle.
+         *
+         * @return An ArrayView of the properties of this particle.
+         */
+        const ArrayView<double>
+        get_properties ();
+
+        /**
+         * Get read-access to properties of this particle.
+         *
+         * @return An ArrayView of the properties of this particle.
+         */
+        const ArrayView<const double>
+        get_properties () const;
+
+        /**
+         * Serialize the contents of this class.
+         */
+        template <class Archive>
+        void serialize (Archive &ar, const unsigned int version);
+
+        /**
+         * Advance the ParticleAccessor to the next particle.
+         */
+        void advance ();
+
+        /**
+         * Inequality operator.
+         */
+        bool operator != (const ParticleAccessor<dim,spacedim> &other) const;
+
+        /**
+         * Equality operator.
+         */
+        bool operator == (const ParticleAccessor<dim,spacedim> &other) const;
+
+      protected:
+        /**
+         * Construct an accessor from a reference to a map and an iterator to the map.
+         * This constructor is protected so that it can only be accessed by friend
+         * classes.
+         */
+        ParticleAccessor (const std::multimap<types::LevelInd, Particle<dim,spacedim> > &map,
+                          const typename std::multimap<types::LevelInd, Particle<dim,spacedim> >::iterator &particle);
+
+      private:
+        /**
+         * A pointer to the container that stores the particles. Obviously,
+         * this accessor is invalidated if the container changes.
+         */
+        std::multimap<types::LevelInd, Particle<dim,spacedim> >            *map;
+
+        /**
+         * An iterator into the container of particles. Obviously,
+           * this accessor is invalidated if the container changes.
+         */
+        typename std::multimap<types::LevelInd, Particle<dim,spacedim> >::iterator  particle;
+
+        /**
+         * Make ParticleIterator a friend to allow it constructing ParticleAccessors.
+         */
+        template <int, int> friend class ParticleIterator;
+    };
+  }
+}
+
+#endif

--- a/include/aspect/particle/particle_iterator.h
+++ b/include/aspect/particle/particle_iterator.h
@@ -1,0 +1,105 @@
+/*
+ Copyright (C) 2017 by the authors of the ASPECT code.
+
+ This file is part of ASPECT.
+
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _aspect_particle_particle_iterator_h
+#define _aspect_particle_particle_iterator_h
+
+#include <aspect/global.h>
+#include <aspect/particle/particle_accessor.h>
+
+
+namespace aspect
+{
+  namespace Particle
+  {
+    /**
+     * A class that is used to iterate over particles. Together with the
+     * ParticleAccessor class this is used to hide the internal implementation
+     * of the particle class and the particle container.
+     */
+    template<int dim, int spacedim=dim>
+    class ParticleIterator
+    {
+      public:
+        /**
+         * Constructor of the iterator. Takes a reference to the particle
+         * container, and an iterator the the cell-particle pair.
+         */
+        ParticleIterator (const std::multimap<types::LevelInd, Particle<dim,spacedim> > &map,
+                          const typename std::multimap<types::LevelInd, Particle<dim,spacedim> >::iterator &particle);
+
+        /**
+         * Dereferencing operator, returns a reference to an accessor. Usage is thus
+         * like <tt>(*i).get_id ();</tt>
+         */
+        const ParticleAccessor<dim,spacedim> &operator * () const;
+
+        /**
+         * Dereferencing operator, non-@p const version.
+         */
+        ParticleAccessor<dim,spacedim> &operator * ();
+
+        /**
+         * Dereferencing operator, returns a pointer of the particle pointed to. Usage
+         * is thus like <tt>i->get_id ();</tt>
+         *
+         * There is a @p const and a non-@p const version.
+         */
+        const ParticleAccessor<dim,spacedim> *operator -> () const;
+
+        /**
+         * Dereferencing operator, non-@p const version.
+         */
+        ParticleAccessor<dim,spacedim> *operator -> ();
+
+        /**
+         * Compare for equality.
+         */
+        bool operator == (const ParticleIterator<dim,spacedim> &) const;
+
+        /**
+         * Compare for inequality.
+         */
+        bool operator != (const ParticleIterator<dim,spacedim> &) const;
+
+        /**
+         * Prefix <tt>++</tt> operator: <tt>++iterator</tt>. This operator advances
+         * the iterator to the next element and returns a reference to
+         * <tt>*this</tt>.
+         */
+        ParticleIterator &operator ++ ();
+
+        /**
+         * Postfix <tt>++</tt> operator: <tt>iterator++</tt>. This operator advances
+         * the iterator to the next element, but returns an iterator to the element
+         * previously pointed to.
+         */
+        ParticleIterator operator ++ (int);
+
+      private:
+        /**
+         * The accessor to the actual particle.
+         */
+        ParticleAccessor<dim,spacedim> accessor;
+    };
+  }
+}
+
+#endif

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -23,6 +23,8 @@
 
 #include <aspect/global.h>
 #include <aspect/particle/particle.h>
+#include <aspect/particle/particle_accessor.h>
+#include <aspect/particle/particle_iterator.h>
 
 #include <aspect/particle/generator/interface.h>
 #include <aspect/particle/integrator/interface.h>
@@ -59,6 +61,11 @@ namespace aspect
     {
       public:
         /**
+         * A type that can be used to iterate over all particles in the domain.
+         */
+        typedef ParticleIterator<dim> particle_iterator;
+
+        /**
          * Default World constructor.
          */
         World();
@@ -72,6 +79,26 @@ namespace aspect
          * Initialize the particle world.
          */
         void initialize();
+
+        /**
+         * Return an iterator to the first particle.
+         */
+        particle_iterator begin() const;
+
+        /**
+         * Return an iterator to the first particle.
+         */
+        particle_iterator begin();
+
+        /**
+         * Return an iterator past the end of the particles.
+         */
+        particle_iterator end() const;
+
+        /**
+         * Return an iterator past the end of the particles.
+         */
+        particle_iterator end();
 
         /**
          * Get the particle property manager for this particle world.

--- a/source/particle/particle_accessor.cc
+++ b/source/particle/particle_accessor.cc
@@ -1,0 +1,197 @@
+/*
+  Copyright (C) 2017 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/particle/particle_accessor.h>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    template <int dim, int spacedim>
+    ParticleAccessor<dim,spacedim>::ParticleAccessor (const std::multimap<types::LevelInd, Particle<dim,spacedim> > &map,
+                                                      const typename std::multimap<types::LevelInd, Particle<dim,spacedim> >::iterator &particle)
+      :
+      map (const_cast<std::multimap<types::LevelInd, Particle<dim,spacedim> > *> (&map)),
+      particle (particle)
+    {}
+
+
+
+    template <int dim, int spacedim>
+    void
+    ParticleAccessor<dim,spacedim>::write_data (void *&data) const
+    {
+      Assert(particle != map->end(),
+             ExcInternalError());
+
+      particle->second.write_data(data);
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    ParticleAccessor<dim,spacedim>::set_location (const Point<spacedim> &new_loc)
+    {
+      Assert(particle != map->end(),
+             ExcInternalError());
+
+      particle->second.set_location(new_loc);
+    }
+
+
+
+    template <int dim, int spacedim>
+    const Point<spacedim> &
+    ParticleAccessor<dim,spacedim>::get_location () const
+    {
+      Assert(particle != map->end(),
+             ExcInternalError());
+
+      return particle->second.get_location();
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    ParticleAccessor<dim,spacedim>::set_reference_location (const Point<dim> &new_loc)
+    {
+      Assert(particle != map->end(),
+             ExcInternalError());
+
+      particle->second.set_reference_location(new_loc);
+    }
+
+
+
+    template <int dim, int spacedim>
+    const Point<dim> &
+    ParticleAccessor<dim,spacedim>::get_reference_location () const
+    {
+      Assert(particle != map->end(),
+             ExcInternalError());
+
+      return particle->second.get_reference_location();
+    }
+
+
+
+    template <int dim, int spacedim>
+    types::particle_index
+    ParticleAccessor<dim,spacedim>::get_id () const
+    {
+      Assert(particle != map->end(),
+             ExcInternalError());
+
+      return particle->second.get_id();
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    ParticleAccessor<dim,spacedim>::set_property_pool (PropertyPool &new_property_pool)
+    {
+      Assert(particle != map->end(),
+             ExcInternalError());
+
+      particle->second.set_property_pool(new_property_pool);
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    ParticleAccessor<dim,spacedim>::set_properties (const std::vector<double> &new_properties)
+    {
+      Assert(particle != map->end(),
+             ExcInternalError());
+
+      particle->second.set_properties(new_properties);
+      return;
+    }
+
+
+
+    template <int dim, int spacedim>
+    const ArrayView<const double>
+    ParticleAccessor<dim,spacedim>::get_properties () const
+    {
+      Assert(particle != map->end(),
+             ExcInternalError());
+
+      return particle->second.get_properties();
+    }
+
+
+
+    template <int dim, int spacedim>
+    const ArrayView<double>
+    ParticleAccessor<dim,spacedim>::get_properties ()
+    {
+      Assert(particle != map->end(),
+             ExcInternalError());
+
+      return particle->second.get_properties();
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    ParticleAccessor<dim,spacedim>::advance ()
+    {
+      Assert (particle != map->end(),ExcInternalError());
+      ++particle;
+    }
+
+
+
+    template <int dim, int spacedim>
+    bool
+    ParticleAccessor<dim,spacedim>::operator != (const ParticleAccessor<dim,spacedim> &other) const
+    {
+      return (map != other.map) || (particle != other.particle);
+    }
+
+
+
+    template <int dim, int spacedim>
+    bool
+    ParticleAccessor<dim,spacedim>::operator == (const ParticleAccessor<dim,spacedim> &other) const
+    {
+      return (map == other.map) && (particle == other.particle);
+    }
+  }
+}
+
+
+// explicit instantiation of the functions we implement in this file
+namespace aspect
+{
+  namespace Particle
+  {
+#define INSTANTIATE(dim) \
+  template class ParticleAccessor<dim>;
+
+    ASPECT_INSTANTIATE(INSTANTIATE)
+  }
+}

--- a/source/particle/particle_iterator.cc
+++ b/source/particle/particle_iterator.cc
@@ -1,0 +1,122 @@
+/*
+  Copyright (C) 2017 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/particle/particle_iterator.h>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    template <int dim, int spacedim>
+    ParticleIterator<dim,spacedim>::ParticleIterator (const std::multimap<types::LevelInd, Particle<dim,spacedim> > &map,
+                                                      const typename std::multimap<types::LevelInd, Particle<dim,spacedim> >::iterator &particle)
+      :
+      accessor (map, particle)
+    {}
+
+
+
+    template <int dim, int spacedim>
+    ParticleAccessor<dim,spacedim> &
+    ParticleIterator<dim,spacedim>::operator *()
+    {
+      return accessor;
+    }
+
+
+
+    template <int dim, int spacedim>
+    ParticleAccessor<dim,spacedim> *
+    ParticleIterator<dim,spacedim>::operator ->()
+    {
+      return &(this->operator* ());
+    }
+
+
+
+    template <int dim, int spacedim>
+    const ParticleAccessor<dim,spacedim> &
+    ParticleIterator<dim,spacedim>::operator *() const
+    {
+      return accessor;
+    }
+
+
+
+    template <int dim, int spacedim>
+    const ParticleAccessor<dim,spacedim> *
+    ParticleIterator<dim,spacedim>::operator ->() const
+    {
+      return &(this->operator* ());
+    }
+
+
+
+    template <int dim, int spacedim>
+    bool
+    ParticleIterator<dim,spacedim>::operator != (const ParticleIterator<dim,spacedim> &other) const
+    {
+      return accessor != other.accessor;
+    }
+
+
+
+    template <int dim, int spacedim>
+    bool
+    ParticleIterator<dim,spacedim>::operator == (const ParticleIterator<dim,spacedim> &other) const
+    {
+      return accessor == other.accessor;
+    }
+
+
+
+    template <int dim, int spacedim>
+    ParticleIterator<dim,spacedim> &
+    ParticleIterator<dim,spacedim>::operator++()
+    {
+      accessor.advance();
+      return *this;
+    }
+
+
+
+    template <int dim, int spacedim>
+    ParticleIterator<dim,spacedim>
+    ParticleIterator<dim,spacedim>::operator++(int)
+    {
+      ParticleIterator tmp(*this);
+      operator++ ();
+
+      return tmp;
+    }
+  }
+}
+
+// explicit instantiation of the functions we implement in this file
+namespace aspect
+{
+  namespace Particle
+  {
+#define INSTANTIATE(dim) \
+  template class ParticleIterator<dim>;
+
+    ASPECT_INSTANTIATE(INSTANTIATE)
+  }
+}

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -114,6 +114,34 @@ namespace aspect
     }
 
     template <int dim>
+    typename World<dim>::particle_iterator
+    World<dim>::begin() const
+    {
+      return particle_iterator(particles,(const_cast<World<dim> *> (this))->particles.begin());
+    }
+
+    template <int dim>
+    typename World<dim>::particle_iterator
+    World<dim>::begin()
+    {
+      return World<dim>::particle_iterator(particles,particles.begin());
+    }
+
+    template <int dim>
+    typename World<dim>::particle_iterator
+    World<dim>::end() const
+    {
+      return (const_cast<World<dim> *> (this))->end();
+    }
+
+    template <int dim>
+    typename World<dim>::particle_iterator
+    World<dim>::end()
+    {
+      return World<dim>::particle_iterator(particles,particles.end());
+    }
+
+    template <int dim>
     const Property::Manager<dim> &
     World<dim>::get_property_manager() const
     {
@@ -192,11 +220,8 @@ namespace aspect
     World<dim>::update_next_free_particle_index()
     {
       types::particle_index locally_highest_index = 0;
-      typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator it = particles.begin();
-      for (; it!=particles.end(); ++it)
-        {
-          locally_highest_index = std::max(locally_highest_index,it->second.get_id());
-        }
+      for (particle_iterator particle = begin(); particle != end(); ++particle)
+        locally_highest_index = std::max(locally_highest_index,particle->get_id());
 
       next_free_particle_index = dealii::Utilities::MPI::max (locally_highest_index, this->get_mpi_communicator()) + 1;
     }


### PR DESCRIPTION
This PR is not  quite complete, but I would like to ask for a review by @bangerth to see if I got the concept right. I added `ParticleIterator` and `ParticleAccessor` classes and converted one of the direct uses inside of `World` to use the iterators to test they work. The intention is to convert all direct uses of particles into using the iterator class.