### PR TITLE
Add ParticleHandler

### DIFF
--- a/include/aspect/particle/particle.h
+++ b/include/aspect/particle/particle.h
@@ -319,6 +319,7 @@ namespace aspect
     void Particle<dim,spacedim>::serialize (Archive &ar, const unsigned int)
     {
       ar &location
+      & reference_location
       & id
       & properties
       ;

--- a/include/aspect/particle/particle.h
+++ b/include/aspect/particle/particle.h
@@ -277,10 +277,20 @@ namespace aspect
         get_properties () const;
 
         /**
-         * Serialize the contents of this class.
+         * Write the data of this object to a stream for the purpose of
+         * serialization.
          */
         template <class Archive>
-        void serialize (Archive &ar, const unsigned int version);
+        void save (Archive &ar, const unsigned int version) const;
+
+        /**
+         * Read the data of this object from a stream for the purpose of
+         * serialization.
+         */
+        template <class Archive>
+        void load (Archive &ar, const unsigned int version);
+
+        BOOST_SERIALIZATION_SPLIT_MEMBER()
 
       private:
         /**
@@ -316,13 +326,38 @@ namespace aspect
 
     template <int dim, int spacedim>
     template <class Archive>
-    void Particle<dim,spacedim>::serialize (Archive &ar, const unsigned int)
+    void Particle<dim,spacedim>::load (Archive &ar, const unsigned int)
     {
-      ar & location
-      & reference_location
-      & id
-      & (*properties)
-      ;
+        unsigned int n_properties = 0;
+
+        ar & location
+        & reference_location
+        & id
+        & n_properties;
+
+        if (n_properties > 0)
+          {
+            properties = new double[n_properties];
+            ar & boost::serialization::make_array(properties, n_properties);
+          }
+    }
+
+    template <int dim, int spacedim>
+    template <class Archive>
+    void Particle<dim,spacedim>::save (Archive &ar, const unsigned int) const
+    {
+        unsigned int n_properties = 0;
+        if ((property_pool != NULL) && (properties != PropertyPool::invalid_handle))
+          n_properties = get_properties().size();
+
+        ar & location
+        & reference_location
+        & id
+        & n_properties;
+
+        if (n_properties > 0)
+          ar & boost::serialization::make_array(properties, n_properties);
+
     }
   }
 }

--- a/include/aspect/particle/particle.h
+++ b/include/aspect/particle/particle.h
@@ -328,35 +328,35 @@ namespace aspect
     template <class Archive>
     void Particle<dim,spacedim>::load (Archive &ar, const unsigned int)
     {
-        unsigned int n_properties = 0;
+      unsigned int n_properties = 0;
 
-        ar & location
-        & reference_location
-        & id
-        & n_properties;
+      ar &location
+      & reference_location
+      & id
+      & n_properties;
 
-        if (n_properties > 0)
-          {
-            properties = new double[n_properties];
-            ar & boost::serialization::make_array(properties, n_properties);
-          }
+      if (n_properties > 0)
+        {
+          properties = new double[n_properties];
+          ar &boost::serialization::make_array(properties, n_properties);
+        }
     }
 
     template <int dim, int spacedim>
     template <class Archive>
     void Particle<dim,spacedim>::save (Archive &ar, const unsigned int) const
     {
-        unsigned int n_properties = 0;
-        if ((property_pool != NULL) && (properties != PropertyPool::invalid_handle))
-          n_properties = get_properties().size();
+      unsigned int n_properties = 0;
+      if ((property_pool != NULL) && (properties != PropertyPool::invalid_handle))
+        n_properties = get_properties().size();
 
-        ar & location
-        & reference_location
-        & id
-        & n_properties;
+      ar &location
+      & reference_location
+      & id
+      & n_properties;
 
-        if (n_properties > 0)
-          ar & boost::serialization::make_array(properties, n_properties);
+      if (n_properties > 0)
+        ar &boost::serialization::make_array(properties, n_properties);
 
     }
   }

--- a/include/aspect/particle/particle.h
+++ b/include/aspect/particle/particle.h
@@ -318,10 +318,10 @@ namespace aspect
     template <class Archive>
     void Particle<dim,spacedim>::serialize (Archive &ar, const unsigned int)
     {
-      ar &location
+      ar & location
       & reference_location
       & id
-      & properties
+      & (*properties)
       ;
     }
   }

--- a/include/aspect/particle/particle_accessor.h
+++ b/include/aspect/particle/particle_accessor.h
@@ -25,6 +25,7 @@
 #include <aspect/particle/particle.h>
 
 #include <deal.II/base/array_view.h>
+#include <deal.II/distributed/tria.h>
 
 namespace aspect
 {
@@ -33,6 +34,7 @@ namespace aspect
     using namespace dealii;
 
     template <int, int> class ParticleIterator;
+    template <int, int> class ParticleHandler;
 
     template<int dim, int spacedim=dim>
     class ParticleAccessor
@@ -135,6 +137,12 @@ namespace aspect
         get_properties () const;
 
         /**
+         * Get a cell iterator to the cell surrounding the current particle.
+         */
+        typename parallel::distributed::Triangulation<dim,spacedim>::cell_iterator
+        get_surrounding_cell (const parallel::distributed::Triangulation<dim,spacedim> &triangulation) const;
+
+        /**
          * Serialize the contents of this class.
          */
         template <class Archive>
@@ -144,6 +152,11 @@ namespace aspect
          * Advance the ParticleAccessor to the next particle.
          */
         void advance ();
+
+        /**
+         * Move the ParticleAccessor to the previous particle.
+         */
+        void decrease ();
 
         /**
          * Inequality operator.
@@ -181,6 +194,7 @@ namespace aspect
          * Make ParticleIterator a friend to allow it constructing ParticleAccessors.
          */
         template <int, int> friend class ParticleIterator;
+        template <int, int> friend class ParticleHandler;
     };
   }
 }

--- a/include/aspect/particle/particle_accessor.h
+++ b/include/aspect/particle/particle_accessor.h
@@ -138,6 +138,9 @@ namespace aspect
 
         /**
          * Get a cell iterator to the cell surrounding the current particle.
+         * As particles are organized in the structure of a triangulation,
+         * but the triangulation itself is not stored in the particle this
+         * operation requires a reference to the triangulation.
          */
         typename parallel::distributed::Triangulation<dim,spacedim>::cell_iterator
         get_surrounding_cell (const parallel::distributed::Triangulation<dim,spacedim> &triangulation) const;
@@ -151,12 +154,12 @@ namespace aspect
         /**
          * Advance the ParticleAccessor to the next particle.
          */
-        void advance ();
+        void next ();
 
         /**
          * Move the ParticleAccessor to the previous particle.
          */
-        void decrease ();
+        void prev ();
 
         /**
          * Inequality operator.

--- a/include/aspect/particle/particle_handler.h
+++ b/include/aspect/particle/particle_handler.h
@@ -32,6 +32,8 @@
 #include <deal.II/base/array_view.h>
 #include <deal.II/base/smartpointer.h>
 
+#include <boost/serialization/map.hpp>
+
 namespace aspect
 {
   namespace Particle

--- a/include/aspect/particle/particle_handler.h
+++ b/include/aspect/particle/particle_handler.h
@@ -1,0 +1,258 @@
+/*
+ Copyright (C) 2017 by the authors of the ASPECT code.
+
+ This file is part of ASPECT.
+
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _aspect_particle_particle_handler_h
+#define _aspect_particle_particle_handler_h
+
+#include <aspect/global.h>
+#include <aspect/particle/particle.h>
+#include <aspect/particle/particle_accessor.h>
+#include <aspect/particle/particle_iterator.h>
+
+#include <aspect/particle/property_pool.h>
+
+#include <deal.II/base/subscriptor.h>
+#include <deal.II/base/array_view.h>
+#include <deal.II/base/smartpointer.h>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    using namespace dealii;
+
+    template <int> class World;
+
+    /**
+     * This class manages the storage and handling of particles. It provides
+     * the data structures necessary to store particles efficiently, accessor
+     * functions to iterate over particles and find particles, and algorithms
+     * to distribute particles in parallel domains.
+     *
+     * @ingroup Particle
+     */
+    template <int dim, int spacedim=dim>
+    class ParticleHandler: public Subscriptor
+    {
+      public:
+        /**
+         * A type that can be used to iterate over all particles in the domain.
+         */
+        typedef ParticleIterator<dim,spacedim> particle_iterator;
+
+        /**
+         * Default constructor.
+         */
+        ParticleHandler();
+
+        /**
+         * Default constructor.
+         */
+        ParticleHandler(const parallel::distributed::Triangulation<dim,spacedim> &tria,
+                        MPI_Comm mpi_communicator);
+
+        /**
+         * Default destructor.
+         */
+        ~ParticleHandler();
+
+        /**
+         * Initialize the particle world.
+         */
+        void initialize();
+
+        /**
+         * Clear all particle related data.
+         */
+        void clear();
+
+        /**
+         * Return an iterator to the first particle.
+         */
+        ParticleHandler<dim,spacedim>::particle_iterator begin() const;
+
+        /**
+         * Return an iterator to the first particle.
+         */
+        ParticleHandler<dim,spacedim>::particle_iterator begin();
+
+        /**
+         * Return an iterator past the end of the particles.
+         */
+        ParticleHandler<dim,spacedim>::particle_iterator end() const;
+
+        /**
+         * Return an iterator past the end of the particles.
+         */
+        ParticleHandler<dim,spacedim>::particle_iterator end();
+
+        /**
+         * Return a pair of particle iterators that mark the begin and end of
+         * the particles in a particular cell. The last iterator is the first
+         * particle that is not longer in the cell.
+         */
+        std::pair<ParticleHandler<dim,spacedim>::particle_iterator,ParticleHandler<dim,spacedim>::particle_iterator>
+        particle_range_in_cell(const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const;
+
+        /**
+         * Return an iterator past the end of the particles.
+         */
+        std::pair<ParticleHandler<dim,spacedim>::particle_iterator,ParticleHandler<dim,spacedim>::particle_iterator>
+        particle_range_in_cell(const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell);
+
+        /**
+         * Remove a particle pointed to by the iterator.
+         */
+        void
+        remove_particle(const typename ParticleHandler<dim,spacedim>::particle_iterator &particle);
+
+        /**
+         * Access to particles in this handler.
+         * TODO: This function eventually needs to go, to not expose internal structure.
+         * This can only be done once World no longer uses this function.
+         */
+        std::multimap<types::LevelInd, Particle<dim,spacedim> > &
+        get_particles();
+
+        /**
+         * Const access to particles in this world.
+         * TODO: This function needs to go to not expose internal structure.
+         * This can only be done once World no longer uses this function.
+         */
+        const std::multimap<types::LevelInd, Particle<dim,spacedim> > &
+        get_particles() const;
+
+        /**
+         * Return the total number of particles in the simulation. Note that
+         * this function does
+         * not compute the number of particles, because that is an expensive
+         * global MPI operation. Instead it returns the number, which is
+         * updated internally every time it might change by a call to
+         * update_n_global_particles().
+         *
+         * @return Total number of particles in simulation.
+         */
+        types::particle_index n_global_particles() const;
+
+        /**
+         * Return the number of particles in the local part of the
+         * triangulation.
+         */
+        types::particle_index n_locally_owned_particles() const;
+
+        /**
+         * Return the number of particles in the given cell.
+         */
+        unsigned int n_particles_in_cell(const typename Triangulation<dim>::active_cell_iterator &cell) const;
+
+        /**
+         * Serialize the contents of this class.
+         */
+        template <class Archive>
+        void serialize (Archive &ar, const unsigned int version);
+
+      private:
+        /**
+         * Address of the triangulation to work on.
+         */
+        SmartPointer<const parallel::distributed::Triangulation<dim,spacedim>,ParticleHandler<dim,spacedim> > triangulation;
+
+        /**
+         * MPI communicator.
+         */
+        MPI_Comm mpi_communicator;
+
+        /**
+         * Set of particles currently in the local domain, organized by
+         * the level/index of the cell they are in.
+         */
+        std::multimap<types::LevelInd, Particle<dim,spacedim> > particles;
+
+        /**
+         * This variable stores how many particles are stored globally. It is
+         * calculated by update_n_global_particles().
+         */
+        types::particle_index global_number_of_particles;
+
+        /**
+         * The maximum number of particles per cell in the global domain. This
+         * variable is important to store and load particle data during
+         * repartition and serialization of the solution. Note that the
+         * variable is only updated when it is needed, e.g. before or after
+         * serialization (before/after mesh refinement, before creating a
+         * checkpoint and after resuming from a checkpoint).
+         */
+        unsigned int global_max_particles_per_cell;
+
+        /**
+         * This variable stores the next free particle index that is available
+         * globally in case new particles need to be generated.
+         */
+        types::particle_index next_free_particle_index;
+
+        /**
+         * Calculates the number of particles in the global model domain.
+         */
+        void
+        update_n_global_particles();
+
+        /**
+         * Calculates and stores the number of particles in the cell that
+         * contains the most particles in the global model (stored in the
+         * member variable global_max_particles_per_cell). This variable is a
+         * state variable, because it is needed to serialize and deserialize
+         * the particle data correctly in parallel (it determines the size of
+         * the data chunks per cell that are stored and read). Before accessing
+         * the variable this function has to be called, unless the state was
+         * read from another source (e.g. after resuming from a checkpoint).
+         */
+        void
+        update_global_max_particles_per_cell();
+
+        /**
+         * Calculates the next free particle index in the global model domain.
+         * This equals one plus the highest particle index currently active.
+         */
+        void
+        update_next_free_particle_index();
+
+        /**
+         * Make World a friend to access private functions while we transition
+         * functionality from World to ParticleHandler.
+         * TODO: remove when done moving functionality.
+         */
+        template <int> friend class World;
+    };
+
+    /* -------------------------- inline and template functions ---------------------- */
+
+    template <int dim, int spacedim>
+    template <class Archive>
+    void ParticleHandler<dim,spacedim>::serialize (Archive &ar, const unsigned int)
+    {
+      ar &particles
+      &global_number_of_particles
+      &global_max_particles_per_cell
+      &next_free_particle_index;
+    }
+  }
+}
+
+#endif

--- a/include/aspect/particle/particle_handler.h
+++ b/include/aspect/particle/particle_handler.h
@@ -76,9 +76,13 @@ namespace aspect
         ~ParticleHandler();
 
         /**
-         * Initialize the particle world.
+         * Initialize the particle handler. This function does not clear the
+         * internal data structures, it just sets the connections to the
+         * MPI communicator and the triangulation. This is useful after de-
+         * serialization of a particle handler.
          */
-        void initialize();
+        void initialize(const parallel::distributed::Triangulation<dim,spacedim> &tria,
+                        MPI_Comm mpi_communicator);
 
         /**
          * Clear all particle related data.

--- a/include/aspect/particle/particle_iterator.h
+++ b/include/aspect/particle/particle_iterator.h
@@ -35,7 +35,7 @@ namespace aspect
      * of the particle class and the particle container.
      */
     template<int dim, int spacedim=dim>
-    class ParticleIterator
+    class ParticleIterator: public std::iterator<std::bidirectional_iterator_tag,ParticleAccessor<dim,spacedim> >
     {
       public:
         /**
@@ -92,6 +92,20 @@ namespace aspect
          * previously pointed to.
          */
         ParticleIterator operator ++ (int);
+
+        /**
+         * Prefix <tt>--</tt> operator: <tt>--iterator</tt>. This operator moves
+         * the iterator to the previous element and returns a reference to
+         * <tt>*this</tt>.
+         */
+        ParticleIterator &operator -- ();
+
+        /**
+         * Postfix <tt>--</tt> operator: <tt>iterator--</tt>. This operator moves
+         * the iterator to the previous element, but returns an iterator to the element
+         * previously pointed to.
+         */
+        ParticleIterator operator -- (int);
 
       private:
         /**

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -508,6 +508,11 @@ namespace aspect
       ar
       &particle_handler
       ;
+
+      // Note that initialize is not necessary when saving the particle handler,
+      // but it does not harm either. When loading the triangulation we need to
+      // recreate the links to the triangulation and the MPI communicator.
+      particle_handler->initialize(this->get_triangulation(),this->get_mpi_communicator());
     }
   }
 }

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -40,6 +40,8 @@
 #include <deal.II/base/timer.h>
 #include <deal.II/base/array_view.h>
 
+#include <boost/serialization/unique_ptr.hpp>
+
 namespace aspect
 {
   namespace Particle

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1298,7 +1298,6 @@ namespace aspect
        */
       TableHandler                        statistics;
 
-      Postprocess::Manager<dim>           postprocess_manager;
       mutable TimerOutput                 computing_timer;
 
       /**
@@ -1376,6 +1375,7 @@ namespace aspect
 
       MeshRefinement::Manager<dim>                              mesh_refinement_manager;
       HeatingModel::Manager<dim>                                heating_model_manager;
+      Postprocess::Manager<dim>                                 postprocess_manager;
 
       /**
        * Pointer to the Mapping object used by the finite elements when

--- a/source/particle/particle_accessor.cc
+++ b/source/particle/particle_accessor.cc
@@ -172,7 +172,7 @@ namespace aspect
 
     template <int dim, int spacedim>
     void
-    ParticleAccessor<dim,spacedim>::advance ()
+    ParticleAccessor<dim,spacedim>::next ()
     {
       Assert (particle != map->end(),ExcInternalError());
       ++particle;
@@ -182,7 +182,7 @@ namespace aspect
 
     template <int dim, int spacedim>
     void
-    ParticleAccessor<dim,spacedim>::decrease ()
+    ParticleAccessor<dim,spacedim>::prev ()
     {
       Assert (particle != map->begin(),ExcInternalError());
       --particle;

--- a/source/particle/particle_accessor.cc
+++ b/source/particle/particle_accessor.cc
@@ -144,6 +144,21 @@ namespace aspect
 
 
     template <int dim, int spacedim>
+    typename parallel::distributed::Triangulation<dim,spacedim>::cell_iterator
+    ParticleAccessor<dim,spacedim>::get_surrounding_cell (const parallel::distributed::Triangulation<dim,spacedim> &triangulation) const
+    {
+      Assert(particle != map->end(),
+             ExcInternalError());
+
+      const typename parallel::distributed::Triangulation<dim,spacedim>::cell_iterator cell (&triangulation,
+          particle->first.first,
+          particle->first.second);
+      return cell;
+    }
+
+
+
+    template <int dim, int spacedim>
     const ArrayView<double>
     ParticleAccessor<dim,spacedim>::get_properties ()
     {
@@ -161,6 +176,16 @@ namespace aspect
     {
       Assert (particle != map->end(),ExcInternalError());
       ++particle;
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    ParticleAccessor<dim,spacedim>::decrease ()
+    {
+      Assert (particle != map->begin(),ExcInternalError());
+      --particle;
     }
 
 

--- a/source/particle/particle_handler.cc
+++ b/source/particle/particle_handler.cc
@@ -32,7 +32,9 @@ namespace aspect
       global_number_of_particles(0),
       global_max_particles_per_cell(0),
       next_free_particle_index(0)
-    {}
+    {
+      std::cout << "Default constructor";
+    }
 
     template <int dim,int spacedim>
     ParticleHandler<dim,spacedim>::ParticleHandler(const parallel::distributed::Triangulation<dim,spacedim> &triangulation,
@@ -43,11 +45,22 @@ namespace aspect
       global_number_of_particles(0),
       global_max_particles_per_cell(0),
       next_free_particle_index(0)
-    {}
+    {
+      std::cout << "Standard constructor";
+    }
 
     template <int dim,int spacedim>
     ParticleHandler<dim,spacedim>::~ParticleHandler()
     {}
+
+    template <int dim,int spacedim>
+    void
+    ParticleHandler<dim,spacedim>::initialize(const parallel::distributed::Triangulation<dim,spacedim> &tria,
+                                              MPI_Comm communicator)
+    {
+      triangulation = &tria;
+      mpi_communicator = communicator;
+    }
 
     template <int dim,int spacedim>
     void

--- a/source/particle/particle_handler.cc
+++ b/source/particle/particle_handler.cc
@@ -1,0 +1,194 @@
+/*
+  Copyright (C) 2015 - 2017 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/particle/particle_handler.h>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    template <int dim,int spacedim>
+    ParticleHandler<dim,spacedim>::ParticleHandler()
+      :
+      triangulation(),
+      mpi_communicator(),
+      global_number_of_particles(0),
+      global_max_particles_per_cell(0),
+      next_free_particle_index(0)
+    {}
+
+    template <int dim,int spacedim>
+    ParticleHandler<dim,spacedim>::ParticleHandler(const parallel::distributed::Triangulation<dim,spacedim> &triangulation,
+                                                   MPI_Comm mpi_communicator)
+      :
+      triangulation(&triangulation, typeid(*this).name()),
+      mpi_communicator(mpi_communicator),
+      global_number_of_particles(0),
+      global_max_particles_per_cell(0),
+      next_free_particle_index(0)
+    {}
+
+    template <int dim,int spacedim>
+    ParticleHandler<dim,spacedim>::~ParticleHandler()
+    {}
+
+    template <int dim,int spacedim>
+    void
+    ParticleHandler<dim,spacedim>::clear()
+    {
+      particles.clear();
+      global_number_of_particles = 0;
+      next_free_particle_index = 0;
+      global_max_particles_per_cell = 0;
+    }
+
+    template <int dim,int spacedim>
+    typename ParticleHandler<dim,spacedim>::particle_iterator
+    ParticleHandler<dim,spacedim>::begin() const
+    {
+      return particle_iterator(particles,(const_cast<ParticleHandler<dim,spacedim> *> (this))->particles.begin());
+    }
+
+    template <int dim,int spacedim>
+    typename ParticleHandler<dim,spacedim>::particle_iterator
+    ParticleHandler<dim,spacedim>::begin()
+    {
+      return ParticleHandler<dim,spacedim>::particle_iterator(particles,particles.begin());
+    }
+
+    template <int dim,int spacedim>
+    typename ParticleHandler<dim,spacedim>::particle_iterator
+    ParticleHandler<dim,spacedim>::end() const
+    {
+      return (const_cast<ParticleHandler<dim,spacedim> *> (this))->end();
+    }
+
+    template <int dim,int spacedim>
+    typename ParticleHandler<dim,spacedim>::particle_iterator
+    ParticleHandler<dim,spacedim>::end()
+    {
+      return ParticleHandler<dim,spacedim>::particle_iterator(particles,particles.end());
+    }
+
+    template <int dim,int spacedim>
+    std::pair<typename ParticleHandler<dim,spacedim>::particle_iterator,typename ParticleHandler<dim,spacedim>::particle_iterator>
+    ParticleHandler<dim,spacedim>::particle_range_in_cell(const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell)
+    {
+      const types::LevelInd level_index = std::make_pair<int, int> (cell->level(),cell->index());
+      const std::pair<typename std::multimap<types::LevelInd, Particle<dim> >::iterator,
+            typename std::multimap<types::LevelInd, Particle<dim> >::iterator> particles_in_cell
+            = particles.equal_range(level_index);
+
+      return std::make_pair(particle_iterator(particles,particles_in_cell.first),
+                            particle_iterator(particles,particles_in_cell.second));
+    }
+
+    template <int dim,int spacedim>
+    void
+    ParticleHandler<dim,spacedim>::remove_particle(const ParticleHandler<dim,spacedim>::particle_iterator &particle)
+    {
+      particles.erase(particle->particle);
+    }
+
+    template <int dim,int spacedim>
+    std::multimap<types::LevelInd, Particle<dim,spacedim> > &
+    ParticleHandler<dim,spacedim>::get_particles()
+    {
+      return particles;
+    }
+
+    template <int dim,int spacedim>
+    const std::multimap<types::LevelInd, Particle<dim,spacedim> > &
+    ParticleHandler<dim,spacedim>::get_particles() const
+    {
+      return particles;
+    }
+
+    template <int dim,int spacedim>
+    types::particle_index
+    ParticleHandler<dim,spacedim>::n_global_particles() const
+    {
+      return global_number_of_particles;
+    }
+
+    template <int dim,int spacedim>
+    types::particle_index
+    ParticleHandler<dim,spacedim>::n_locally_owned_particles() const
+    {
+      return particles.size();
+    }
+
+    template <int dim,int spacedim>
+    void
+    ParticleHandler<dim,spacedim>::update_n_global_particles()
+    {
+      global_number_of_particles = dealii::Utilities::MPI::sum (particles.size(), mpi_communicator);
+    }
+
+    template <int dim,int spacedim>
+    unsigned int
+    ParticleHandler<dim,spacedim>::n_particles_in_cell(const typename Triangulation<dim>::active_cell_iterator &cell) const
+    {
+      const types::LevelInd found_cell = std::make_pair<int, int> (cell->level(),cell->index());
+      return particles.count(found_cell);
+    }
+
+    template <int dim,int spacedim>
+    void
+    ParticleHandler<dim,spacedim>::update_next_free_particle_index()
+    {
+      types::particle_index locally_highest_index = 0;
+      for (particle_iterator particle = begin(); particle != end(); ++particle)
+        locally_highest_index = std::max(locally_highest_index,particle->get_id());
+
+      next_free_particle_index = dealii::Utilities::MPI::max (locally_highest_index, mpi_communicator) + 1;
+    }
+
+    template <int dim,int spacedim>
+    void
+    ParticleHandler<dim,spacedim>::update_global_max_particles_per_cell()
+    {
+      unsigned int local_max_particles_per_cell(0);
+      typename parallel::distributed::Triangulation<dim>::active_cell_iterator cell = triangulation->begin_active();
+      for (; cell!=triangulation->end(); ++cell)
+        if (cell->is_locally_owned())
+          {
+            const unsigned int particles_in_cell = n_particles_in_cell(cell);
+            local_max_particles_per_cell = std::max(local_max_particles_per_cell,
+                                                    particles_in_cell);
+          }
+
+      global_max_particles_per_cell = dealii::Utilities::MPI::max(local_max_particles_per_cell,mpi_communicator);
+    }
+  }
+}
+
+
+// explicit instantiation of the functions we implement in this file
+namespace aspect
+{
+  namespace Particle
+  {
+#define INSTANTIATE(dim) \
+  template class ParticleHandler<dim,dim>;
+
+    ASPECT_INSTANTIATE(INSTANTIATE)
+  }
+}

--- a/source/particle/particle_handler.cc
+++ b/source/particle/particle_handler.cc
@@ -32,35 +32,39 @@ namespace aspect
       global_number_of_particles(0),
       global_max_particles_per_cell(0),
       next_free_particle_index(0)
-    {
-      std::cout << "Default constructor";
-    }
+    {}
+
+
 
     template <int dim,int spacedim>
     ParticleHandler<dim,spacedim>::ParticleHandler(const parallel::distributed::Triangulation<dim,spacedim> &triangulation,
-                                                   MPI_Comm mpi_communicator)
+                                                   const MPI_Comm mpi_communicator)
       :
       triangulation(&triangulation, typeid(*this).name()),
       mpi_communicator(mpi_communicator),
       global_number_of_particles(0),
       global_max_particles_per_cell(0),
       next_free_particle_index(0)
-    {
-      std::cout << "Standard constructor";
-    }
+    {}
+
+
 
     template <int dim,int spacedim>
     ParticleHandler<dim,spacedim>::~ParticleHandler()
     {}
 
+
+
     template <int dim,int spacedim>
     void
     ParticleHandler<dim,spacedim>::initialize(const parallel::distributed::Triangulation<dim,spacedim> &tria,
-                                              MPI_Comm communicator)
+                                              const MPI_Comm communicator)
     {
       triangulation = &tria;
       mpi_communicator = communicator;
     }
+
+
 
     template <int dim,int spacedim>
     void
@@ -72,12 +76,16 @@ namespace aspect
       global_max_particles_per_cell = 0;
     }
 
+
+
     template <int dim,int spacedim>
     typename ParticleHandler<dim,spacedim>::particle_iterator
     ParticleHandler<dim,spacedim>::begin() const
     {
       return particle_iterator(particles,(const_cast<ParticleHandler<dim,spacedim> *> (this))->particles.begin());
     }
+
+
 
     template <int dim,int spacedim>
     typename ParticleHandler<dim,spacedim>::particle_iterator
@@ -86,12 +94,16 @@ namespace aspect
       return ParticleHandler<dim,spacedim>::particle_iterator(particles,particles.begin());
     }
 
+
+
     template <int dim,int spacedim>
     typename ParticleHandler<dim,spacedim>::particle_iterator
     ParticleHandler<dim,spacedim>::end() const
     {
       return (const_cast<ParticleHandler<dim,spacedim> *> (this))->end();
     }
+
+
 
     template <int dim,int spacedim>
     typename ParticleHandler<dim,spacedim>::particle_iterator
@@ -100,8 +112,10 @@ namespace aspect
       return ParticleHandler<dim,spacedim>::particle_iterator(particles,particles.end());
     }
 
+
+
     template <int dim,int spacedim>
-    std::pair<typename ParticleHandler<dim,spacedim>::particle_iterator,typename ParticleHandler<dim,spacedim>::particle_iterator>
+    boost::iterator_range<typename ParticleHandler<dim,spacedim>::particle_iterator>
     ParticleHandler<dim,spacedim>::particle_range_in_cell(const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell)
     {
       const types::LevelInd level_index = std::make_pair<int, int> (cell->level(),cell->index());
@@ -109,9 +123,11 @@ namespace aspect
             typename std::multimap<types::LevelInd, Particle<dim> >::iterator> particles_in_cell
             = particles.equal_range(level_index);
 
-      return std::make_pair(particle_iterator(particles,particles_in_cell.first),
-                            particle_iterator(particles,particles_in_cell.second));
+      return boost::make_iterator_range(particle_iterator(particles,particles_in_cell.first),
+                                        particle_iterator(particles,particles_in_cell.second));
     }
+
+
 
     template <int dim,int spacedim>
     void
@@ -120,12 +136,16 @@ namespace aspect
       particles.erase(particle->particle);
     }
 
+
+
     template <int dim,int spacedim>
     std::multimap<types::LevelInd, Particle<dim,spacedim> > &
     ParticleHandler<dim,spacedim>::get_particles()
     {
       return particles;
     }
+
+
 
     template <int dim,int spacedim>
     const std::multimap<types::LevelInd, Particle<dim,spacedim> > &
@@ -134,12 +154,16 @@ namespace aspect
       return particles;
     }
 
+
+
     template <int dim,int spacedim>
     types::particle_index
     ParticleHandler<dim,spacedim>::n_global_particles() const
     {
       return global_number_of_particles;
     }
+
+
 
     template <int dim,int spacedim>
     types::particle_index
@@ -148,12 +172,16 @@ namespace aspect
       return particles.size();
     }
 
+
+
     template <int dim,int spacedim>
     void
     ParticleHandler<dim,spacedim>::update_n_global_particles()
     {
       global_number_of_particles = dealii::Utilities::MPI::sum (particles.size(), mpi_communicator);
     }
+
+
 
     template <int dim,int spacedim>
     unsigned int
@@ -162,6 +190,8 @@ namespace aspect
       const types::LevelInd found_cell = std::make_pair<int, int> (cell->level(),cell->index());
       return particles.count(found_cell);
     }
+
+
 
     template <int dim,int spacedim>
     void
@@ -173,6 +203,8 @@ namespace aspect
 
       next_free_particle_index = dealii::Utilities::MPI::max (locally_highest_index, mpi_communicator) + 1;
     }
+
+
 
     template <int dim,int spacedim>
     void

--- a/source/particle/particle_iterator.cc
+++ b/source/particle/particle_iterator.cc
@@ -91,7 +91,7 @@ namespace aspect
     ParticleIterator<dim,spacedim> &
     ParticleIterator<dim,spacedim>::operator++()
     {
-      accessor.advance();
+      accessor.next();
       return *this;
     }
 
@@ -113,7 +113,7 @@ namespace aspect
     ParticleIterator<dim,spacedim> &
     ParticleIterator<dim,spacedim>::operator--()
     {
-      accessor.decrease();
+      accessor.prev();
       return *this;
     }
 

--- a/source/particle/particle_iterator.cc
+++ b/source/particle/particle_iterator.cc
@@ -106,6 +106,28 @@ namespace aspect
 
       return tmp;
     }
+
+
+
+    template <int dim, int spacedim>
+    ParticleIterator<dim,spacedim> &
+    ParticleIterator<dim,spacedim>::operator--()
+    {
+      accessor.decrease();
+      return *this;
+    }
+
+
+
+    template <int dim, int spacedim>
+    ParticleIterator<dim,spacedim>
+    ParticleIterator<dim,spacedim>::operator--(int)
+    {
+      ParticleIterator tmp(*this);
+      operator-- ();
+
+      return tmp;
+    }
   }
 }
 

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -91,8 +91,6 @@ namespace aspect
     template <int dim>
     World<dim>::World()
       :
-      global_number_of_particles(0),
-      next_free_particle_index(0),
       data_offset(numbers::invalid_unsigned_int)
     {}
 
@@ -111,34 +109,8 @@ namespace aspect
                                                                               std_cxx11::ref(*this),
                                                                               std_cxx11::_1,
                                                                               std_cxx11::_2));
-    }
 
-    template <int dim>
-    typename World<dim>::particle_iterator
-    World<dim>::begin() const
-    {
-      return particle_iterator(particles,(const_cast<World<dim> *> (this))->particles.begin());
-    }
-
-    template <int dim>
-    typename World<dim>::particle_iterator
-    World<dim>::begin()
-    {
-      return World<dim>::particle_iterator(particles,particles.begin());
-    }
-
-    template <int dim>
-    typename World<dim>::particle_iterator
-    World<dim>::end() const
-    {
-      return (const_cast<World<dim> *> (this))->end();
-    }
-
-    template <int dim>
-    typename World<dim>::particle_iterator
-    World<dim>::end()
-    {
-      return World<dim>::particle_iterator(particles,particles.end());
+      particle_handler.reset(new ParticleHandler<dim>(this->get_triangulation(),this->get_mpi_communicator()));
     }
 
     template <int dim>
@@ -146,6 +118,13 @@ namespace aspect
     World<dim>::get_property_manager() const
     {
       return *property_manager;
+    }
+
+    template <int dim>
+    const ParticleHandler<dim> &
+    World<dim>::get_particle_handler() const
+    {
+      return *particle_handler.get();
     }
 
     template <int dim>
@@ -159,14 +138,14 @@ namespace aspect
     std::multimap<types::LevelInd, Particle<dim> > &
     World<dim>::get_particles()
     {
-      return particles;
+      return particle_handler->get_particles();
     }
 
     template <int dim>
     const std::multimap<types::LevelInd, Particle<dim> > &
     World<dim>::get_particles() const
     {
-      return particles;
+      return particle_handler->get_particles();
     }
 
     template <int dim>
@@ -194,7 +173,7 @@ namespace aspect
                                   this->get_time() / year_in_seconds :
                                   this->get_time());
 
-      const std::string filename = output->output_particle_data(particles,
+      const std::string filename = output->output_particle_data(particle_handler->get_particles(),
                                                                 property_manager->get_data_info(),
                                                                 output_time);
 
@@ -205,44 +184,9 @@ namespace aspect
     types::particle_index
     World<dim>::n_global_particles() const
     {
-      return global_number_of_particles;
+      return particle_handler->n_global_particles();
     }
 
-    template <int dim>
-    void
-    World<dim>::update_n_global_particles()
-    {
-      global_number_of_particles = dealii::Utilities::MPI::sum (particles.size(), this->get_mpi_communicator());
-    }
-
-    template <int dim>
-    void
-    World<dim>::update_next_free_particle_index()
-    {
-      types::particle_index locally_highest_index = 0;
-      for (particle_iterator particle = begin(); particle != end(); ++particle)
-        locally_highest_index = std::max(locally_highest_index,particle->get_id());
-
-      next_free_particle_index = dealii::Utilities::MPI::max (locally_highest_index, this->get_mpi_communicator()) + 1;
-    }
-
-    template <int dim>
-    void
-    World<dim>::update_global_max_particles_per_cell()
-    {
-      unsigned int local_max_particles_per_cell(0);
-      typename parallel::distributed::Triangulation<dim>::active_cell_iterator cell = this->get_triangulation().begin_active();
-      for (; cell!=this->get_triangulation().end(); ++cell)
-        if (cell->is_locally_owned())
-          {
-            const types::LevelInd found_cell = std::make_pair<int, int> (cell->level(),cell->index());
-            const unsigned int particles_in_cell = particles.count(found_cell);
-            local_max_particles_per_cell = std::max(local_max_particles_per_cell,
-                                                    particles_in_cell);
-          }
-
-      global_max_particles_per_cell = dealii::Utilities::MPI::max(local_max_particles_per_cell,this->get_mpi_communicator());
-    }
 
     template <int dim>
     void
@@ -280,9 +224,9 @@ namespace aspect
       // Only save and load particles if there are any, we might get here for
       // example before the particle generation in timestep 0, or if somebody
       // selected the particle postprocessor but generated 0 particles
-      update_global_max_particles_per_cell();
+      particle_handler->update_global_max_particles_per_cell();
 
-      if (global_max_particles_per_cell > 0)
+      if (particle_handler->global_max_particles_per_cell > 0)
         {
           const std_cxx11::function<void(const typename parallel::distributed::Triangulation<dim>::cell_iterator &,
                                          const typename parallel::distributed::Triangulation<dim>::CellStatus, void *) > callback_function
@@ -298,7 +242,7 @@ namespace aspect
           // space for the data in case a cell is coarsened and all particles
           // of the children have to be stored in the parent cell.
           const std::size_t transfer_size_per_cell = sizeof (unsigned int) +
-                                                     (property_manager->get_particle_size() * global_max_particles_per_cell) *
+                                                     (property_manager->get_particle_size() * particle_handler->global_max_particles_per_cell) *
                                                      (serialization ?
                                                       1
                                                       :
@@ -317,13 +261,13 @@ namespace aspect
 
       // All particles have been stored, when we reach this point. Empty the
       // map and fill with new particles.
-      particles.clear();
+      particle_handler->clear();
 
       // If we are resuming from a checkpoint, we first have to register the
       // store function again, to set the triangulation in the same state as
       // before the serialization. Only by this it knows how to deserialize the
       // data correctly. Only do this if something was actually stored.
-      if (serialization && (global_max_particles_per_cell > 0))
+      if (serialization && (particle_handler->global_max_particles_per_cell > 0))
         {
           const std_cxx11::function<void(const typename parallel::distributed::Triangulation<dim>::cell_iterator &,
                                          const typename parallel::distributed::Triangulation<dim>::CellStatus, void *) > callback_function
@@ -337,7 +281,7 @@ namespace aspect
           // the particle data itself and we need to provide 2^dim times the
           // space for the data in case a cell is coarsened
           const std::size_t transfer_size_per_cell = sizeof (unsigned int) +
-                                                     (property_manager->get_particle_size() * global_max_particles_per_cell);
+                                                     (property_manager->get_particle_size() * particle_handler->global_max_particles_per_cell);
           data_offset = triangulation.register_data_attach(transfer_size_per_cell,callback_function);
         }
 
@@ -360,7 +304,7 @@ namespace aspect
           // Reset offset and update global number of particles. The number
           // can change because of discarded or newly generated particles
           data_offset = numbers::invalid_unsigned_int;
-          update_n_global_particles();
+          particle_handler->update_n_global_particles();
 
           if (update_ghost_particles)
             exchange_ghost_particles();
@@ -379,7 +323,7 @@ namespace aspect
           // generate so that they are globally unique.
           // Ensure this by communicating the number of particles that every
           // process is going to generate.
-          types::particle_index local_next_particle_index = next_free_particle_index;
+          types::particle_index local_next_particle_index = particle_handler->next_free_particle_index;
           if (particle_load_balancing & ParticleLoadBalancing::add_particles)
             {
               types::particle_index particles_to_add_locally = 0;
@@ -392,8 +336,7 @@ namespace aspect
               for (; cell!=endc; ++cell)
                 if (cell->is_locally_owned())
                   {
-                    const types::LevelInd found_cell(cell->level(),cell->index());
-                    const unsigned int particles_in_cell = particles.count(found_cell);
+                    const unsigned int particles_in_cell = particle_handler->n_particles_in_cell(cell);
 
                     if (particles_in_cell < min_particles_per_cell)
                       particles_to_add_locally += static_cast<types::particle_index> (min_particles_per_cell - particles_in_cell);
@@ -412,13 +355,14 @@ namespace aspect
               const types::particle_index globally_generated_particles =
                 dealii::Utilities::MPI::sum(particles_to_add_locally,this->get_mpi_communicator());
 
-              AssertThrow (next_free_particle_index <= std::numeric_limits<types::particle_index>::max() - globally_generated_particles,
+              AssertThrow (particle_handler->next_free_particle_index
+                           <= std::numeric_limits<types::particle_index>::max() - globally_generated_particles,
                            ExcMessage("There is no free particle index left to generate a new particle id. Please check if your "
                                       "model generates unusually many new particles (by repeatedly deleting and regenerating particles), or "
                                       "recompile deal.II with the DEAL_II_WITH_64BIT_INDICES option enabled, to use 64-bit integers for "
                                       "particle ids."));
 
-              next_free_particle_index += globally_generated_particles;
+              particle_handler->next_free_particle_index += globally_generated_particles;
             }
 
           boost::mt19937 random_number_generator;
@@ -432,7 +376,7 @@ namespace aspect
             if (cell->is_locally_owned())
               {
                 const types::LevelInd found_cell(cell->level(),cell->index());
-                const unsigned int n_particles_in_cell = particles.count(found_cell);
+                const unsigned int n_particles_in_cell = particle_handler->n_particles_in_cell(cell);
 
                 // Add particles if necessary
                 if ((particle_load_balancing & ParticleLoadBalancing::add_particles) &&
@@ -442,11 +386,11 @@ namespace aspect
                       {
                         std::pair<aspect::Particle::types::LevelInd,Particle<dim> > new_particle = generator->generate_particle(cell,local_next_particle_index);
                         property_manager->initialize_late_particle(new_particle.second,
-                                                                   particles,
+                                                                   particle_handler->get_particles(),
                                                                    *interpolator,
                                                                    cell);
 
-                        particles.insert(new_particle);
+                        particle_handler->get_particles().insert(new_particle);
                       }
                   }
 
@@ -454,8 +398,9 @@ namespace aspect
                 else if ((particle_load_balancing & ParticleLoadBalancing::remove_particles) &&
                          (n_particles_in_cell > max_particles_per_cell))
                   {
-                    const std::pair<typename std::multimap<types::LevelInd, Particle<dim> >::iterator, typename std::multimap<types::LevelInd, Particle<dim> >::iterator>
-                    particles_in_cell = particles.equal_range(found_cell);
+                    const std::pair<typename ParticleHandler<dim>::particle_iterator,
+                          typename ParticleHandler<dim>::particle_iterator> particles_in_cell
+                          = particle_handler->particle_range_in_cell(cell);
 
                     const unsigned int n_particles_to_remove = n_particles_in_cell - max_particles_per_cell;
 
@@ -463,21 +408,21 @@ namespace aspect
                     while (particle_ids_to_remove.size() < n_particles_to_remove)
                       particle_ids_to_remove.insert(random_number_generator() % n_particles_in_cell);
 
-                    std::list<typename std::multimap<types::LevelInd, Particle<dim> >::iterator> particles_to_remove;
+                    std::list<typename ParticleHandler<dim>::particle_iterator> particles_to_remove;
 
                     for (std::set<unsigned int>::const_iterator id = particle_ids_to_remove.begin();
                          id != particle_ids_to_remove.end(); ++id)
                       {
-                        typename std::multimap<types::LevelInd, Particle<dim> >::iterator particle_to_remove = particles_in_cell.first;
+                        typename ParticleHandler<dim>::particle_iterator particle_to_remove = particles_in_cell.first;
                         std::advance(particle_to_remove,*id);
 
                         particles_to_remove.push_back(particle_to_remove);
                       }
 
-                    for (typename std::list<typename std::multimap<types::LevelInd, Particle<dim> >::iterator>::iterator particle = particles_to_remove.begin();
+                    for (typename std::list<typename ParticleHandler<dim>::particle_iterator>::iterator particle = particles_to_remove.begin();
                          particle != particles_to_remove.end(); ++particle)
                       {
-                        particles.erase(*particle);
+                        particle_handler->remove_particle(*particle);
                       }
                   }
               }
@@ -495,8 +440,7 @@ namespace aspect
       if (status == parallel::distributed::Triangulation<dim>::CELL_PERSIST
           || status == parallel::distributed::Triangulation<dim>::CELL_REFINE)
         {
-          const types::LevelInd found_cell = std::make_pair<int, int> (cell->level(),cell->index());
-          const unsigned int n_particles_in_cell = particles.count(found_cell);
+          const unsigned int n_particles_in_cell = particle_handler->n_particles_in_cell(cell);
           return n_particles_in_cell * particle_weight;
         }
       else if (status == parallel::distributed::Triangulation<dim>::CELL_COARSEN)
@@ -504,11 +448,8 @@ namespace aspect
           unsigned int n_particles_in_cell = 0;
 
           for (unsigned int child_index = 0; child_index < GeometryInfo<dim>::max_children_per_cell; ++child_index)
-            {
-              const typename parallel::distributed::Triangulation<dim>::cell_iterator child = cell->child(child_index);
-              const types::LevelInd found_cell = std::make_pair<int, int> (child->level(),child->index());
-              n_particles_in_cell += particles.count(found_cell);
-            }
+            n_particles_in_cell += particle_handler->n_particles_in_cell(cell->child(child_index));
+
           return n_particles_in_cell * particle_weight;
         }
 
@@ -528,19 +469,19 @@ namespace aspect
       if (status == parallel::distributed::Triangulation<dim>::CELL_PERSIST
           || status == parallel::distributed::Triangulation<dim>::CELL_REFINE)
         {
-          const types::LevelInd found_cell = std::make_pair<int, int> (cell->level(),cell->index());
-          const std::pair<typename std::multimap<types::LevelInd, Particle<dim> >::iterator, typename std::multimap<types::LevelInd, Particle<dim> >::iterator> particles_in_cell
-            = particles.equal_range(found_cell);
+          const std::pair<typename ParticleHandler<dim>::particle_iterator,
+                typename ParticleHandler<dim>::particle_iterator> particles_in_cell
+                = particle_handler->particle_range_in_cell(cell);
           n_particles_in_cell = std::distance(particles_in_cell.first,particles_in_cell.second);
 
           unsigned int *ndata = static_cast<unsigned int *> (data);
           *ndata = n_particles_in_cell;
           data = static_cast<void *> (ndata + 1);
 
-          for (typename std::multimap<types::LevelInd, Particle<dim> >::iterator particle = particles_in_cell.first;
+          for (typename ParticleHandler<dim>::particle_iterator particle = particles_in_cell.first;
                particle != particles_in_cell.second; ++particle)
             {
-              particle->second.write_data(data);
+              particle->write_data(data);
             }
         }
       // If this cell is the parent of children that will be coarsened, collect
@@ -553,9 +494,9 @@ namespace aspect
           for (unsigned int child_index = 0; child_index < GeometryInfo<dim>::max_children_per_cell; ++child_index)
             {
               const typename parallel::distributed::Triangulation<dim>::cell_iterator child = cell->child(child_index);
-              const types::LevelInd found_cell = std::make_pair<int, int> (child->level(),child->index());
-              const std::pair<typename std::multimap<types::LevelInd, Particle<dim> >::iterator, typename std::multimap<types::LevelInd, Particle<dim> >::iterator> particles_in_cell
-                = particles.equal_range(found_cell);
+              const std::pair<typename ParticleHandler<dim>::particle_iterator,
+                    typename ParticleHandler<dim>::particle_iterator> particles_in_cell
+                    = particle_handler->particle_range_in_cell(cell);
               n_particles_in_cell += std::distance(particles_in_cell.first,particles_in_cell.second);
             }
 
@@ -567,14 +508,14 @@ namespace aspect
           for (unsigned int child_index = 0; child_index < GeometryInfo<dim>::max_children_per_cell; ++child_index)
             {
               const typename parallel::distributed::Triangulation<dim>::cell_iterator child = cell->child(child_index);
-              const types::LevelInd found_cell = std::make_pair<int, int> (child->level(),child->index());
-              const std::pair<typename std::multimap<types::LevelInd, Particle<dim> >::iterator, typename std::multimap<types::LevelInd, Particle<dim> >::iterator>
-              particles_in_cell = particles.equal_range(found_cell);
+              const std::pair<typename ParticleHandler<dim>::particle_iterator,
+                    typename ParticleHandler<dim>::particle_iterator> particles_in_cell
+                    = particle_handler->particle_range_in_cell(cell);
 
-              for (typename std::multimap<types::LevelInd, Particle<dim> >::iterator particle = particles_in_cell.first;
+              for (typename ParticleHandler<dim>::particle_iterator particle = particles_in_cell.first;
                    particle != particles_in_cell.second; ++particle)
                 {
-                  particle->second.write_data(data);
+                  particle->write_data(data);
                 }
             }
         }
@@ -599,7 +540,7 @@ namespace aspect
       // particle map.
       if (status == parallel::distributed::Triangulation<dim>::CELL_PERSIST)
         {
-          typename std::multimap<types::LevelInd,Particle<dim> >::iterator position_hint = particles.end();
+          typename std::multimap<types::LevelInd,Particle<dim> >::iterator position_hint = particle_handler->get_particles().end();
           for (unsigned int i = 0; i < *n_particles_in_cell_ptr; ++i)
             {
               // Use std::multimap::emplace_hint to speed up insertion of
@@ -607,13 +548,13 @@ namespace aspect
               // that report a -std=c++11 (like gcc 4.6) implement it, so
               // require C++14 instead.
 #ifdef DEAL_II_WITH_CXX14
-              position_hint = particles.emplace_hint(position_hint,
-                                                     std::make_pair(cell->level(),cell->index()),
-                                                     Particle<dim>(pdata,property_manager->get_property_pool()));
+              position_hint = particle_handler->get_particles().emplace_hint(position_hint,
+                                                                             std::make_pair(cell->level(),cell->index()),
+                                                                             Particle<dim>(pdata,property_manager->get_property_pool()));
 #else
-              position_hint = particles.insert(position_hint,
-                                               std::make_pair(std::make_pair(cell->level(),cell->index()),
-                                                              Particle<dim>(pdata,property_manager->get_property_pool())));
+              position_hint = particle_handler->get_particles().insert(position_hint,
+                                                                       std::make_pair(std::make_pair(cell->level(),cell->index()),
+                                                                                      Particle<dim>(pdata,property_manager->get_property_pool())));
 #endif
               ++position_hint;
             }
@@ -621,7 +562,7 @@ namespace aspect
 
       else if (status == parallel::distributed::Triangulation<dim>::CELL_COARSEN)
         {
-          typename std::multimap<types::LevelInd,Particle<dim> >::iterator position_hint = particles.end();
+          typename std::multimap<types::LevelInd,Particle<dim> >::iterator position_hint = this->get_particles().end();
           for (unsigned int i = 0; i < *n_particles_in_cell_ptr; ++i)
             {
               // Use std::multimap::emplace_hint to speed up insertion of
@@ -629,13 +570,13 @@ namespace aspect
               // that report a -std=c++11 (like gcc 4.6) implement it, so
               // require C++14 instead.
 #ifdef DEAL_II_WITH_CXX14
-              position_hint = particles.emplace_hint(position_hint,
-                                                     std::make_pair(cell->level(),cell->index()),
-                                                     Particle<dim>(pdata,property_manager->get_property_pool()));
+              position_hint = particle_handler->get_particles().emplace_hint(position_hint,
+                                                                             std::make_pair(cell->level(),cell->index()),
+                                                                             Particle<dim>(pdata,property_manager->get_property_pool()));
 #else
-              position_hint = particles.insert(position_hint,
-                                               std::make_pair(std::make_pair(cell->level(),cell->index()),
-                                                              Particle<dim>(pdata,property_manager->get_property_pool())));
+              position_hint = particle_handler->get_particles().insert(position_hint,
+                                                                       std::make_pair(std::make_pair(cell->level(),cell->index()),
+                                                                                      Particle<dim>(pdata,property_manager->get_property_pool())));
 #endif
               const Point<dim> p_unit = this->get_mapping().transform_real_to_unit_cell(cell, position_hint->second.get_location());
               position_hint->second.set_reference_location(p_unit);
@@ -648,7 +589,7 @@ namespace aspect
           for (unsigned int child_index=0; child_index<GeometryInfo<dim>::max_children_per_cell; ++child_index)
             {
               const typename parallel::distributed::Triangulation<dim>::cell_iterator child = cell->child(child_index);
-              position_hints[child_index] = particles.upper_bound(std::make_pair(child->level(),child->index()));
+              position_hints[child_index] = this->get_particles().upper_bound(std::make_pair(child->level(),child->index()));
             }
 
           for (unsigned int i = 0; i < *n_particles_in_cell_ptr; ++i)
@@ -671,13 +612,13 @@ namespace aspect
                           // that report a -std=c++11 (like gcc 4.6) implement it, so
                           // require C++14 instead.
 #ifdef DEAL_II_WITH_CXX14
-                          position_hints[child_index] = particles.emplace_hint(position_hints[child_index],
-                                                                               std::make_pair(child->level(),child->index()),
-                                                                               std::move(p));
+                          position_hints[child_index] = particle_handler->get_particles().emplace_hint(position_hints[child_index],
+                                                                                                       std::make_pair(child->level(),child->index()),
+                                                                                                       std::move(p));
 #else
-                          position_hints[child_index] = particles.insert(position_hints[child_index],
-                                                                         std::make_pair(std::make_pair(child->level(),child->index()),
-                                                                                        p));
+                          position_hints[child_index] = particle_handler->get_particles().insert(position_hints[child_index],
+                                                                                                 std::make_pair(std::make_pair(child->level(),child->index()),
+                                                                                                     p));
 #endif
                           ++position_hints[child_index];
                           break;
@@ -745,7 +686,7 @@ namespace aspect
                 {
                   const std::pair< const typename std::multimap<types::LevelInd,Particle <dim> >::iterator,
                         const typename std::multimap<types::LevelInd,Particle <dim> >::iterator>
-                        particle_range_in_cell = particles.equal_range(std::make_pair(cell->level(),cell->index()));
+                        particle_range_in_cell = particle_handler->get_particles().equal_range(std::make_pair(cell->level(),cell->index()));
 
                   for (std::set<types::subdomain_id>::const_iterator domain=cell_to_neighbor_subdomain.begin();
                        domain != cell_to_neighbor_subdomain.end(); ++domain)
@@ -957,7 +898,7 @@ namespace aspect
       const std::multimap<types::LevelInd,Particle <dim> > sorted_particles_map(sorted_particles.begin(),
                                                                                 sorted_particles.end());
 
-      particles.insert(sorted_particles_map.begin(),sorted_particles_map.end());
+      particle_handler->get_particles().insert(sorted_particles_map.begin(),sorted_particles_map.end());
     }
 
     template <int dim>
@@ -1335,7 +1276,7 @@ namespace aspect
                   // Also make sure we do not invalidate the iterator we are increasing.
                   const typename std::multimap<types::LevelInd, Particle<dim> >::iterator particle_to_delete = it;
                   it++;
-                  particles.erase(particle_to_delete);
+                  particle_handler->get_particles().erase(particle_to_delete);
                 }
             }
           catch (typename Mapping<dim>::ExcTransformationFailed &)
@@ -1347,7 +1288,7 @@ namespace aspect
               // Also make sure we do not invalidate the iterator we are increasing.
               const typename std::multimap<types::LevelInd, Particle<dim> >::iterator particle_to_delete = it;
               it++;
-              particles.erase(particle_to_delete);
+              particle_handler->get_particles().erase(particle_to_delete);
             }
         }
     }
@@ -1371,10 +1312,10 @@ namespace aspect
     {
       TimerOutput::Scope timer_section(this->get_computing_timer(), "Particles: Generate");
 
-      generator->generate_particles(particles);
+      generator->generate_particles(particle_handler->get_particles());
 
-      update_n_global_particles();
-      update_next_free_particle_index();
+      particle_handler->update_n_global_particles();
+      particle_handler->update_next_free_particle_index();
     }
 
     template <int dim>
@@ -1384,10 +1325,8 @@ namespace aspect
       // Initialize the particle's access to the property_pool. This is necessary
       // even if the Particle do not carry properties, because they need a
       // way to determine the number of properties they carry.
-      typename std::multimap<types::LevelInd,Particle <dim> >::iterator particle = particles.begin(),
-                                                                        end_particle = particles.end();
-      for (; particle!=end_particle; ++particle)
-        particle->second.set_property_pool(property_manager->get_property_pool());
+      for (ParticleIterator<dim> particle = particle_handler->begin(); particle!=particle_handler->end(); ++particle)
+        particle->set_property_pool(property_manager->get_property_pool());
 
 
       // TODO: Change this loop over all cells to use the WorkStream interface
@@ -1395,7 +1334,7 @@ namespace aspect
         {
           TimerOutput::Scope timer_section(this->get_computing_timer(), "Particles: Initialize properties");
 
-          property_manager->get_property_pool().reserve(2 * particles.size());
+          property_manager->get_property_pool().reserve(2 * particle_handler->n_locally_owned_particles());
 
           // Loop over all cells and initialize the particles cell-wise
           typename DoFHandler<dim>::active_cell_iterator
@@ -1407,7 +1346,7 @@ namespace aspect
               {
                 std::pair< const typename std::multimap<types::LevelInd,Particle <dim> >::iterator,
                     const typename std::multimap<types::LevelInd,Particle <dim> >::iterator>
-                    particle_range_in_cell = particles.equal_range(std::make_pair(cell->level(),cell->index()));
+                    particle_range_in_cell = particle_handler->get_particles().equal_range(std::make_pair(cell->level(),cell->index()));
 
                 // Only initialize particles, if there are any in this cell
                 if (particle_range_in_cell.first != particle_range_in_cell.second)
@@ -1439,7 +1378,7 @@ namespace aspect
               {
                 const std::pair< const typename std::multimap<types::LevelInd,Particle <dim> >::iterator,
                       const typename std::multimap<types::LevelInd,Particle <dim> >::iterator>
-                      particle_range_in_cell = particles.equal_range(std::make_pair(cell->level(),cell->index()));
+                      particle_range_in_cell = particle_handler->get_particles().equal_range(std::make_pair(cell->level(),cell->index()));
 
                 // Only update particles, if there are any in this cell
                 if (particle_range_in_cell.first != particle_range_in_cell.second)
@@ -1455,7 +1394,7 @@ namespace aspect
     World<dim>::advect_particles()
     {
       std::vector<std::pair<types::LevelInd,Particle <dim> > > particles_out_of_cell;
-      particles_out_of_cell.reserve(particles.size());
+      particles_out_of_cell.reserve(particle_handler->n_locally_owned_particles());
 
       {
         // TODO: Change this loop over all cells to use the WorkStream interface
@@ -1471,7 +1410,7 @@ namespace aspect
             {
               const std::pair< const typename std::multimap<types::LevelInd,Particle <dim> >::iterator,
                     const typename std::multimap<types::LevelInd,Particle <dim> >::iterator>
-                    particle_range_in_cell = particles.equal_range(std::make_pair(cell->level(),cell->index()));
+                    particle_range_in_cell = particle_handler->get_particles().equal_range(std::make_pair(cell->level(),cell->index()));
 
               // Only advect particles, if there are any in this cell
               if (particle_range_in_cell.first != particle_range_in_cell.second)
@@ -1504,7 +1443,7 @@ namespace aspect
         update_particles();
 
       // Update the number of global particles if some have left the domain
-      update_n_global_particles();
+      particle_handler->update_n_global_particles();
 
       // Now that all particle information was updated, exchange the new
       // ghost particles.

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -110,7 +110,16 @@ namespace aspect
                                                                               std_cxx11::_1,
                                                                               std_cxx11::_2));
 
-      particle_handler.reset(new ParticleHandler<dim>(this->get_triangulation(),this->get_mpi_communicator()));
+      // Normally create a particle handler that stores the future particles.
+      // If we restarted from a checkpoint we already have constructed a
+      // particle handler. In that case only reinitialize the connections to the
+      // triangulation and the MPI communicator.
+      if (!particle_handler)
+        particle_handler.reset(new ParticleHandler<dim>(this->get_triangulation(),this->get_mpi_communicator()));
+      else
+        {
+          particle_handler->initialize(this->get_triangulation(),this->get_mpi_communicator());
+        }
     }
 
     template <int dim>
@@ -1457,7 +1466,9 @@ namespace aspect
     {
       aspect::oarchive oa (os);
       oa << (*this);
+#if !DEAL_II_VERSION_GTE(9,0,0)
       output->save(os);
+#endif
     }
 
     template <int dim>
@@ -1466,7 +1477,9 @@ namespace aspect
     {
       aspect::iarchive ia (is);
       ia >> (*this);
+#if !DEAL_II_VERSION_GTE(9,0,0)
       output->load(is);
+#endif
     }
 
     template <int dim>


### PR DESCRIPTION
This PR takes apart the `World` class. Everything specific to ASPECT remains in `World`, everything related to particle handling goes into `ParticleHandler`. So far `ParticleHandler` only contains the data structures and some simple functions. In follow-up PRs I will move functionality from `World` into `ParticleHandler` until `World` no longer needs to be friend of `ParticleHandler`. At that point `ParticleHandler` and the iterator and accessor classes can move into deal.II.