### PR TITLE
allow visualization postprocessors to use the current cell

### DIFF
--- a/doc/modules/changes/20170821_jdannberg
+++ b/doc/modules/changes/20170821_jdannberg
@@ -1,0 +1,5 @@
+Fixed: Visualization postprocessors now get the current cell, and output
+material properties that the material model computes using information 
+related to the current cell correctly.
+<br>
+(Juliane Dannberg, 2017/08/21)

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -172,124 +172,153 @@ namespace aspect
     template <int dim>
     struct MaterialModelInputs
     {
-      /**
-       * Constructor. Initialize the various arrays of this structure with the
-       * given number of quadrature points and (finite element) components.
-       *
-       * @param n_points The number of quadrature points for which input
-       * quantities will be provided.
-       * @param n_comp The number of vector quantities (in the order in which
-       * the Introspection class reports them) for which input will be
-       * provided.
-       */
-      MaterialModelInputs(const unsigned int n_points,
-                          const unsigned int n_comp);
+        /**
+         * Constructor. Initialize the various arrays of this structure with the
+         * given number of quadrature points and (finite element) components.
+         *
+         * @param n_points The number of quadrature points for which input
+         * quantities will be provided.
+         * @param n_comp The number of vector quantities (in the order in which
+         * the Introspection class reports them) for which input will be
+         * provided.
+         */
+        MaterialModelInputs(const unsigned int n_points,
+                            const unsigned int n_comp);
 
-      /**
-       * Constructor. Initialize the arrays of the structure with the number
-       * of points in the `input_data` structure, and fills them appropriately.
-       *
-       * @param input_data The data used to populate the material model input quantities.
-       * @param introspection A reference to the simulator introspection object.
-       * @param use_strain_rate Whether to compute the strain rates.
-       */
-      MaterialModelInputs(const DataPostprocessorInputs::Vector<dim> &input_data,
-                          const Introspection<dim> &introspection,
-                          const bool use_strain_rate = true);
-
-
-      /**
-       * Constructor. Initializes the various arrays of this
-       * structure with the FEValues and introspection objects and
-       * the solution_vector. This constructor calls the function
-       * reinit to populate the newly created arrays.
-       *
-       * @param fe_values An FEValuesBase object used to evaluate the finite elements.
-       * @param cell The currently active cell for the fe_values object.
-       * @param introspection A reference to the simulator introspection object.
-       * @param solution_vector The finite element vector from which to construct the inputs.
-       * @param use_strain_rates Whether to compute the strain rates.
-       */
-      MaterialModelInputs(const FEValuesBase<dim,dim> &fe_values,
-                          const typename DoFHandler<dim>::active_cell_iterator *cell,
-                          const Introspection<dim> &introspection,
-                          const LinearAlgebra::BlockVector &solution_vector,
-                          const bool use_strain_rates = true);
-
-      /**
-       * Function to re-initialize and populate the pre-existing arrays
-       * created by the constructor MaterialModelInputs.
-       */
-      void reinit(const FEValuesBase<dim,dim> &fe_values,
-                  const typename DoFHandler<dim>::active_cell_iterator *cell,
-                  const Introspection<dim> &introspection,
-                  const LinearAlgebra::BlockVector &solution_vector,
-                  const bool use_strain_rates = true);
+        /**
+         * Constructor. Initialize the arrays of the structure with the number
+         * of points in the `input_data` structure, and fills them appropriately.
+         *
+         * @param input_data The data used to populate the material model input quantities.
+         * @param introspection A reference to the simulator introspection object.
+         * @param use_strain_rate Whether to compute the strain rates.
+         */
+        MaterialModelInputs(const DataPostprocessorInputs::Vector<dim> &input_data,
+                            const Introspection<dim> &introspection,
+                            const bool use_strain_rate = true);
 
 
-      /**
-       * Vector with global positions where the material has to be evaluated
-       * in evaluate().
-       */
-      std::vector<Point<dim> > position;
+        /**
+         * Constructor. Initializes the various arrays of this
+         * structure with the FEValues and introspection objects and
+         * the solution_vector. This constructor calls the function
+         * reinit to populate the newly created arrays.
+         *
+         * @param fe_values An FEValuesBase object used to evaluate the finite elements.
+         * @param cell The currently active cell for the fe_values object.
+         * @param introspection A reference to the simulator introspection object.
+         * @param solution_vector The finite element vector from which to construct the inputs.
+         * @param use_strain_rates Whether to compute the strain rates.
+         */
+        MaterialModelInputs(const FEValuesBase<dim,dim> &fe_values,
+                            const typename DoFHandler<dim>::active_cell_iterator *cell,
+                            const Introspection<dim> &introspection,
+                            const LinearAlgebra::BlockVector &solution_vector,
+                            const bool use_strain_rates = true);
 
-      /**
-       * Temperature values at the points given in the #position vector.
-       */
-      std::vector<double> temperature;
+        /**
+         * Copy Constructor.
+         */
+        MaterialModelInputs(const MaterialModelInputs<dim> &material);
 
-      /**
-       * Pressure values at the points given in the #position vector.
-       */
-      std::vector<double> pressure;
+        /**
+         * Function to re-initialize and populate the pre-existing arrays
+         * created by the constructor MaterialModelInputs.
+         */
+        void reinit(const FEValuesBase<dim,dim> &fe_values,
+                    const typename DoFHandler<dim>::active_cell_iterator *cell,
+                    const Introspection<dim> &introspection,
+                    const LinearAlgebra::BlockVector &solution_vector,
+                    const bool use_strain_rates = true);
 
-      /**
-       * Pressure gradients at the points given in the #position vector.
-       * This is important for the heating models.
-       */
-      std::vector<Tensor<1,dim> > pressure_gradient;
 
-      /**
-       * Velocity values at the points given in the #position vector.
-       * This value is mostly important in the case of determining
-       * whether material crossed a certain region (e.g. a phase boundary).
-       * The timestep that is needed for this check can be requested from
-       * SimulatorAccess.
-       */
-      std::vector<Tensor<1,dim> > velocity;
+        /**
+         * Vector with global positions where the material has to be evaluated
+         * in evaluate().
+         */
+        std::vector<Point<dim> > position;
 
-      /**
-       * Values of the compositional fields at the points given in the
-       * #position vector: composition[i][c] is the compositional field c at
-       * point i.
-       */
-      std::vector<std::vector<double> > composition;
+        /**
+         * Temperature values at the points given in the #position vector.
+         */
+        std::vector<double> temperature;
 
-      /**
-       * Strain rate at the points given in the #position vector. Only the
-       * viscosity may depend on these values. This std::vector can be set to
-       * size 0 if the viscosity is not needed.
-       *
-       * @note The strain rate is computed as $\varepsilon(\mathbf u)=\frac 12
-       * (\nabla \mathbf u + \nabla \mathbf u^T)$, regardless of whether the
-       * model is compressible or not. This is relevant since in some other
-       * contexts, the strain rate in the compressible case is computed as
-       * $\varepsilon(\mathbf u)=\frac 12 (\nabla \mathbf u + \nabla \mathbf
-       * u^T) - \frac 13 \nabla \cdot \mathbf u \mathbf 1$.
-       */
-      std::vector<SymmetricTensor<2,dim> > strain_rate;
+        /**
+         * Pressure values at the points given in the #position vector.
+         */
+        std::vector<double> pressure;
 
-      /**
-       * Optional reference to the cell that contains these quadrature
-       * points. This allows for evaluating properties at the cell vertices
-       * and interpolating to the quadrature points, or to query the cell for
-       * material ids, neighbors, or other information that is not available
-       * solely from the locations. Note that not all calling functions can set
-       * this reference. In these cases it will be a NULL pointer, so make sure
-       * that your material model either fails with a proper error message
-       * or provide an alternative calculation for these cases.
-       */
-      const typename DoFHandler<dim>::active_cell_iterator *cell;
+        /**
+         * Pressure gradients at the points given in the #position vector.
+         * This is important for the heating models.
+         */
+        std::vector<Tensor<1,dim> > pressure_gradient;
+
+        /**
+         * Velocity values at the points given in the #position vector.
+         * This value is mostly important in the case of determining
+         * whether material crossed a certain region (e.g. a phase boundary).
+         * The timestep that is needed for this check can be requested from
+         * SimulatorAccess.
+         */
+        std::vector<Tensor<1,dim> > velocity;
+
+        /**
+         * Values of the compositional fields at the points given in the
+         * #position vector: composition[i][c] is the compositional field c at
+         * point i.
+         */
+        std::vector<std::vector<double> > composition;
+
+        /**
+         * Strain rate at the points given in the #position vector. Only the
+         * viscosity may depend on these values. This std::vector can be set to
+         * size 0 if the viscosity is not needed.
+         *
+         * @note The strain rate is computed as $\varepsilon(\mathbf u)=\frac 12
+         * (\nabla \mathbf u + \nabla \mathbf u^T)$, regardless of whether the
+         * model is compressible or not. This is relevant since in some other
+         * contexts, the strain rate in the compressible case is computed as
+         * $\varepsilon(\mathbf u)=\frac 12 (\nabla \mathbf u + \nabla \mathbf
+         * u^T) - \frac 13 \nabla \cdot \mathbf u \mathbf 1$.
+         */
+        std::vector<SymmetricTensor<2,dim> > strain_rate;
+
+        /**
+         * Optional reference to the cell that contains these quadrature
+         * points. This allows for evaluating properties at the cell vertices
+         * and interpolating to the quadrature points, or to query the cell for
+         * material ids, neighbors, or other information that is not available
+         * solely from the locations. Note that not all calling functions can set
+         * this reference. In these cases it will be a NULL pointer, so make sure
+         * that your material model either fails with a proper error message
+         * or provide an alternative calculation for these cases.
+         *
+         * @deprecated Use DoFHandler<dim>::active_cell_iterator current_cell instead.
+         */
+        const typename DoFHandler<dim>::active_cell_iterator *cell DEAL_II_DEPRECATED;
+
+        /**
+         * Optional cell object that contains these quadrature
+         * points. This allows for evaluating properties at the cell vertices
+         * and interpolating to the quadrature points, or to query the cell for
+         * material ids, neighbors, or other information that is not available
+         * solely from the locations. Note that not all calling functions can set
+         * this reference. In these cases it will be a cell constructed with a
+         * default constructor, so make sure that your material model either fails
+         * with a proper error message or provide an alternative calculation for
+         * these cases.
+         */
+        typename DoFHandler<dim>::active_cell_iterator current_cell;
+
+      private:
+        /**
+         * Assignment operator. It is forbidden to copy this object, because this
+         * would be too expensive. Hence, this function is private and no
+         * implementation is provided, so that trying to use it will throw an
+         * error indicating where the problem is.
+         */
+        MaterialModelInputs &operator=(const MaterialModelInputs &material);
     };
 
 

--- a/source/heating_model/adiabatic_heating_of_melt.cc
+++ b/source/heating_model/adiabatic_heating_of_melt.cc
@@ -44,7 +44,8 @@ namespace aspect
       // get the melt velocity from the solution vector
       std::vector<Tensor<1,dim> > melt_velocity (material_model_inputs.position.size());
 
-      if (material_model_inputs.cell && this->get_timestep_number() > 0)
+      if (material_model_inputs.current_cell.state() == IteratorState::valid
+          && this->get_timestep_number() > 0)
         {
           // we have to create a long vector, because that is the only way to extract the velocities
           // from the solution vector
@@ -53,7 +54,7 @@ namespace aspect
           Functions::FEFieldFunction<dim, DoFHandler<dim>, LinearAlgebra::BlockVector>
           fe_value(this->get_dof_handler(), this->get_solution(), this->get_mapping());
 
-          fe_value.set_active_cell(*material_model_inputs.cell);
+          fe_value.set_active_cell(material_model_inputs.current_cell);
 
           for (unsigned int d=0; d<dim; ++d)
             fe_value.value_list(material_model_inputs.position,

--- a/source/heating_model/shear_heating_with_melt.cc
+++ b/source/heating_model/shear_heating_with_melt.cc
@@ -49,7 +49,8 @@ namespace aspect
       // get the melt velocity from the solution vector
       std::vector<Tensor<1,dim> > melt_velocity (material_model_inputs.position.size());
 
-      if (material_model_inputs.cell && this->get_timestep_number() > 0)
+      if (material_model_inputs.current_cell.state() == IteratorState::valid
+          && this->get_timestep_number() > 0)
         {
           // we have to create a long vector, because that is the only way to extract the velocities
           // from the solution vector
@@ -58,7 +59,7 @@ namespace aspect
           Functions::FEFieldFunction<dim, DoFHandler<dim>, LinearAlgebra::BlockVector>
           fe_value(this->get_dof_handler(), this->get_solution(), this->get_mapping());
 
-          fe_value.set_active_cell(*material_model_inputs.cell);
+          fe_value.set_active_cell(material_model_inputs.current_cell);
 
           for (unsigned int d=0; d<dim; ++d)
             fe_value.value_list(material_model_inputs.position,

--- a/source/initial_composition/porosity.cc
+++ b/source/initial_composition/porosity.cc
@@ -69,7 +69,6 @@ namespace aspect
               in.composition[0][i] = 0.0;
 
           in.strain_rate[0] = SymmetricTensor<2,dim>();
-          in.cell = NULL;
 
           std::vector<double> melt_fraction(1);
           material_model->melt_fractions(in,melt_fraction);

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -114,7 +114,7 @@ namespace aspect
 
       // we want to get the porosity field from the old solution here,
       // because we need a field that is not updated in the nonlinear iterations
-      if (this->include_melt_transport() && in.cell
+      if (this->include_melt_transport() && in.current_cell.state() == IteratorState::valid
           && this->get_timestep_number() > 0 && !this->get_parameters().use_operator_splitting)
         {
           // Prepare the field function
@@ -126,7 +126,7 @@ namespace aspect
                                  "works if there is a compositional field called porosity."));
           const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
-          fe_value.set_active_cell(*in.cell);
+          fe_value.set_active_cell(in.current_cell);
           fe_value.value_list(in.position,
                               old_porosity,
                               this->introspection().component_indices.compositional_fields[porosity_idx]);

--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -199,7 +199,7 @@ namespace aspect
 
       // we want to get the peridotite field from the old solution here,
       // because it tells us how much of the material was already molten
-      if (this->include_melt_transport() && in.cell
+      if (this->include_melt_transport() && in.current_cell.state() == IteratorState::valid
           && this->get_timestep_number() > 0 && !this->get_parameters().use_operator_splitting)
         {
           // Prepare the field function
@@ -216,7 +216,7 @@ namespace aspect
           const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
           const unsigned int peridotite_idx = this->introspection().compositional_index_for_name("peridotite");
 
-          fe_value.set_active_cell(*in.cell);
+          fe_value.set_active_cell(in.current_cell);
           fe_value.value_list(in.position,
                               maximum_melt_fractions,
                               this->introspection().component_indices.compositional_fields[peridotite_idx]);

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -477,7 +477,8 @@ namespace aspect
 
       // We need the velocity gradient for the finite strain (they are not included in material model inputs),
       // so we get them from the finite element.
-      if (in.cell && use_strain_weakening == true && use_finite_strain_tensor == true && this->get_timestep_number() > 0)
+      if (in.current_cell.state() == IteratorState::valid && use_strain_weakening == true
+          && use_finite_strain_tensor == true && this->get_timestep_number() > 0)
         {
           const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.velocities).degree+1);
           FEValues<dim> fe_values (this->get_mapping(),
@@ -487,7 +488,7 @@ namespace aspect
 
           std::vector<Tensor<2,dim> > velocity_gradients (quadrature_formula.size(), Tensor<2,dim>());
 
-          fe_values.reinit (*in.cell);
+          fe_values.reinit (in.current_cell);
           fe_values[this->introspection().extractors.velocities].get_function_gradients (this->get_solution(),
                                                                                          velocity_gradients);
 

--- a/source/postprocess/visualization/heating.cc
+++ b/source/postprocess/visualization/heating.cc
@@ -110,7 +110,7 @@ namespace aspect
 
         typename DoFHandler<dim>::active_cell_iterator cell;
         cell = (GridTools::find_active_cell_around_point<> (this->get_mapping(), this->get_dof_handler(), mid_point)).first;
-        in.cell = &cell;
+        in.current_cell = cell;
 
         for (typename std::list<std_cxx11::shared_ptr<HeatingModel::Interface<dim> > >::const_iterator
              heating_model = heating_model_objects.begin();

--- a/source/postprocess/visualization/seismic_anomalies.cc
+++ b/source/postprocess/visualization/seismic_anomalies.cc
@@ -167,7 +167,7 @@ namespace aspect
                         for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
                           in.composition[i][c] = composition_values[c][i];
                       }
-                    in.cell = &cell;
+                    in.current_cell = cell;
 
                     out.additional_outputs.push_back(
                       std_cxx11::shared_ptr<MaterialModel::AdditionalMaterialOutputs<dim> >
@@ -332,7 +332,7 @@ namespace aspect
                         for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
                           in.composition[i][c] = composition_values[c][i];
                       }
-                    in.cell = &cell;
+                    in.current_cell = cell;
 
                     out.additional_outputs.push_back(
                       std_cxx11::shared_ptr<MaterialModel::AdditionalMaterialOutputs<dim> >

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -514,7 +514,11 @@ namespace aspect
       for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
         material_model_inputs.composition[q][c] = composition_values[c][q];
 
+    DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
     material_model_inputs.cell = &cell;
+    DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
+    material_model_inputs.current_cell = cell;
   }
 
 

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -128,7 +128,7 @@ namespace aspect
     if (advection_field.is_discontinuous(introspection))
       return 0.;
 
-    std::vector<double> residual = assemblers->compute_advection_system_residual(*scratch.material_model_inputs.cell,
+    std::vector<double> residual = assemblers->compute_advection_system_residual(scratch.material_model_inputs.current_cell,
                                                                                  advection_field,
                                                                                  scratch);
 
@@ -386,7 +386,7 @@ namespace aspect
               scratch.material_model_inputs.composition[q][c] = (scratch.old_composition_values[c][q] + scratch.old_old_composition_values[c][q]) / 2;
             scratch.material_model_inputs.strain_rate[q] = (scratch.old_strain_rates[q] + scratch.old_old_strain_rates[q]) / 2;
           }
-        scratch.material_model_inputs.cell = &cell;
+        scratch.material_model_inputs.current_cell = cell;
         create_additional_material_model_outputs(scratch.material_model_outputs);
 
         material_model->evaluate(scratch.material_model_inputs,scratch.material_model_outputs);

--- a/tests/cell_reference.cc
+++ b/tests/cell_reference.cc
@@ -20,9 +20,9 @@ namespace aspect
         {
           Simpler<dim>::evaluate(in,out);
 
-          if (in.cell)
+          if (in.current_cell.state() == IteratorState::valid)
             {
-              std::cout << "Level: " << (*in.cell)->level() << " Index: " << (*in.cell)->index() << std::endl;
+              std::cout << "Level: " << in.current_cell->level() << " Index: " << in.current_cell->index() << std::endl;
             }
         }
     };

--- a/tests/cell_reference/screen-output
+++ b/tests/cell_reference/screen-output
@@ -34,6 +34,14 @@ Level: 1 Index: 2
 Level: 1 Index: 2
 Level: 1 Index: 3
 Level: 1 Index: 3
+Level: 1 Index: 0
+Level: 1 Index: 0
+Level: 1 Index: 1
+Level: 1 Index: 1
+Level: 1 Index: 2
+Level: 1 Index: 2
+Level: 1 Index: 3
+Level: 1 Index: 3
      Writing graphical output:           output-cell_reference/solution/solution-00000
      RMS, max velocity:                  5.88e-08 m/s, 1.41e-07 m/s
      Temperature min/avg/max:            0 K, 0.9574 K, 1.1 K

--- a/tests/drucker_prager_derivatives.cc
+++ b/tests/drucker_prager_derivatives.cc
@@ -82,21 +82,17 @@ int f(double parameter)
 
   bool Error = false;
 
-  MaterialModelInputs<dim> in_dviscositydpressure(5,3);
-  in_dviscositydpressure = in_base;
+  MaterialModelInputs<dim> in_dviscositydpressure(in_base);
   in_dviscositydpressure.pressure[0] *= finite_difference_factor;
   in_dviscositydpressure.pressure[1] *= finite_difference_factor;
   in_dviscositydpressure.pressure[2] *= finite_difference_factor;
   in_dviscositydpressure.pressure[3] *= finite_difference_factor;
   in_dviscositydpressure.pressure[4] *= finite_difference_factor;
 
-  MaterialModelInputs<dim> in_dviscositydstrainrate_zerozero(5,3);
-  MaterialModelInputs<dim> in_dviscositydstrainrate_onezero(5,3);
-  MaterialModelInputs<dim> in_dviscositydstrainrate_oneone(5,3);
+  MaterialModelInputs<dim> in_dviscositydstrainrate_zerozero(in_base);
+  MaterialModelInputs<dim> in_dviscositydstrainrate_onezero(in_base);
+  MaterialModelInputs<dim> in_dviscositydstrainrate_oneone(in_base);
 
-  in_dviscositydstrainrate_zerozero = in_base;
-  in_dviscositydstrainrate_onezero = in_base;
-  in_dviscositydstrainrate_oneone = in_base;
   in_dviscositydstrainrate_zerozero.strain_rate[0] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[0][0][0]) * finite_difference_accuracy * zerozero;
   in_dviscositydstrainrate_zerozero.strain_rate[1] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[1][0][0]) * finite_difference_accuracy * zerozero;
   in_dviscositydstrainrate_zerozero.strain_rate[2] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[2][0][0]) * finite_difference_accuracy * zerozero;
@@ -113,8 +109,7 @@ int f(double parameter)
   in_dviscositydstrainrate_oneone.strain_rate[3]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[3][1][1]) * finite_difference_accuracy * oneone;
   in_dviscositydstrainrate_oneone.strain_rate[4]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[4][1][1]) * finite_difference_accuracy * oneone;
 
-  MaterialModelInputs<dim> in_dviscositydtemperature(5,3);
-  in_dviscositydtemperature = in_base;
+  MaterialModelInputs<dim> in_dviscositydtemperature(in_base);
   in_dviscositydtemperature.temperature[0] *= 1.0000000001;
   in_dviscositydtemperature.temperature[1] *= 1.0000000001;
   in_dviscositydtemperature.temperature[2] *= 1.0000000001;

--- a/tests/simple_nonlinear.cc
+++ b/tests/simple_nonlinear.cc
@@ -498,21 +498,17 @@ int f(double parameter)
 
   bool Error = false;
 
-  MaterialModelInputs<dim> in_dviscositydpressure(5,3);
-  in_dviscositydpressure = in_base;
+  MaterialModelInputs<dim> in_dviscositydpressure(in_base);
   in_dviscositydpressure.pressure[0] *= finite_difference_factor;
   in_dviscositydpressure.pressure[1] *= finite_difference_factor;
   in_dviscositydpressure.pressure[2] *= finite_difference_factor;
   in_dviscositydpressure.pressure[3] *= finite_difference_factor;
   in_dviscositydpressure.pressure[4] *= finite_difference_factor;
 
-  MaterialModelInputs<dim> in_dviscositydstrainrate_zerozero(5,3);
-  MaterialModelInputs<dim> in_dviscositydstrainrate_onezero(5,3);
-  MaterialModelInputs<dim> in_dviscositydstrainrate_oneone(5,3);
+  MaterialModelInputs<dim> in_dviscositydstrainrate_zerozero(in_base);
+  MaterialModelInputs<dim> in_dviscositydstrainrate_onezero(in_base);
+  MaterialModelInputs<dim> in_dviscositydstrainrate_oneone(in_base);
 
-  in_dviscositydstrainrate_zerozero = in_base;
-  in_dviscositydstrainrate_onezero = in_base;
-  in_dviscositydstrainrate_oneone = in_base;
   in_dviscositydstrainrate_zerozero.strain_rate[0] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[0][0][0]) * finite_difference_accuracy * zerozero;
   in_dviscositydstrainrate_zerozero.strain_rate[1] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[1][0][0]) * finite_difference_accuracy * zerozero;
   in_dviscositydstrainrate_zerozero.strain_rate[2] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[2][0][0]) * finite_difference_accuracy * zerozero;
@@ -529,8 +525,7 @@ int f(double parameter)
   in_dviscositydstrainrate_oneone.strain_rate[3]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[3][1][1]) * finite_difference_accuracy * oneone;
   in_dviscositydstrainrate_oneone.strain_rate[4]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[4][1][1]) * finite_difference_accuracy * oneone;
 
-  MaterialModelInputs<dim> in_dviscositydtemperature(5,3);
-  in_dviscositydtemperature = in_base;
+  MaterialModelInputs<dim> in_dviscositydtemperature(in_base);
   in_dviscositydtemperature.temperature[0] *= 1.0000000001;
   in_dviscositydtemperature.temperature[1] *= 1.0000000001;
   in_dviscositydtemperature.temperature[2] *= 1.0000000001;

--- a/tests/simple_shear.cc
+++ b/tests/simple_shear.cc
@@ -40,7 +40,7 @@ namespace aspect
 
       // We need the velocity gradient for the finite strain (they are not included in material model inputs),
       // so we get them from the finite element.
-      if (in.cell && this->get_timestep_number() > 0)
+      if (in.current_cell.state() == IteratorState::valid && this->get_timestep_number() > 0)
         {
           const QGauss<dim> quadrature_formula (this->introspection().polynomial_degree.velocities +1);
           FEValues<dim> fe_values (this->get_mapping(),
@@ -50,7 +50,7 @@ namespace aspect
 
           std::vector<Tensor<2,dim> > velocity_gradients (quadrature_formula.size(), Tensor<2,dim>());
 
-          fe_values.reinit (*in.cell);
+          fe_values.reinit (in.current_cell);
           fe_values[this->introspection().extractors.velocities].get_function_gradients (this->get_solution(),
                                                                                          velocity_gradients);
 


### PR DESCRIPTION
This pull request adds an active cell iterator (instead of a reference to the active cell iterator, which was used before, and is now marked as deprecated) to the material model inputs structure, which allows the cell to be filled in the constructor of material model inputs that is used for the visualization postprocessors (using `get_cell<DoFHandler<dim>`). 

This is useful in cases where the material model uses the cell information to extract, for example, the old solution, or some additional solution variables that are not in the material model inputs, like in the case of melt transport, and the computes the material model outputs using this information. With this new version, visualization postprocessors will now also be able to output these quantities from material model outputs correctly, which was not possible before. 