### PR TITLE
Change from std_cxx11::array<double,dim> to Tensor<1,dim> for cartesi…

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -974,6 +974,18 @@ namespace aspect
                               const double safety_factor);
 
     /**
+     * Converts an array of size dim to a Point of size dim.
+     */
+    template <int dim>
+    Point<dim> convert_array_to_point(const std_cxx11::array<double,dim> &array);
+
+    /**
+     * Converts a Point of size dim to an array of size dim.
+     */
+    template <int dim>
+    std_cxx11::array<double,dim> convert_point_to_array(const Point<dim> &point);
+
+    /**
      * A class that represents a binary operator between two doubles. The type of
      * operation is specified on construction time, and can be checked later
      * by using the operator ==. The operator () executes the operation on two

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2411,6 +2411,30 @@ namespace aspect
 
 
 
+    template <int dim>
+    Point<dim> convert_array_to_point(const std_cxx11::array<double,dim> &array)
+    {
+      Point<dim> point;
+      for (unsigned int i = 0; i < dim; i++)
+        point[i] = array[i];
+
+      return point;
+    }
+
+
+
+    template <int dim>
+    std_cxx11::array<double,dim> convert_point_to_array(const Point<dim> &point)
+    {
+      std_cxx11::array<double,dim> array;
+      for (unsigned int i = 0; i < dim; i++)
+        array[i] = point[i];
+
+      return array;
+    }
+
+
+
     Operator::Operator()
       :
       op(uninitialized)


### PR DESCRIPTION
Change from std_cxx11::array<double,dim> to Tensor<1,dim> for cartesian_to_natural_coordinates and natural_to_cartesian_coordinates.

If I remember correctly we made this an array instead of a Point<dim> because the point functions are designed for Cartesian coordinates. The problem I am facing is that the std::array is completely devoid of functions like adding and substracting. Is it oke to make it into a Tensor? 

This would safe me quite a bit of work in using this function. This function is quite new (last hackaton) and as far as I am aware, no one is using it yet since non of the geometry models have implemented this.