### PR TITLE
Split cartesean natrual coordinate dimension templates

### DIFF
--- a/include/aspect/geometry_model/interface.h
+++ b/include/aspect/geometry_model/interface.h
@@ -138,7 +138,7 @@ namespace aspect
          * latitude) in 3d.
          */
         virtual
-        std_cxx11::array<double,dim> cartesian_to_natural_coordinates(const Point<dim> &position) const;
+        Tensor<1,dim> cartesian_to_natural_coordinates(const Point<dim> &position) const;
 
         /**
          * Undoes the action of cartesian_to_natural_coordinates, and turns the
@@ -146,7 +146,7 @@ namespace aspect
          * Cartesian coordinates.
          */
         virtual
-        Point<dim> natural_to_cartesian_coordinates(const std_cxx11::array<double,dim> &position) const;
+        Point<dim> natural_to_cartesian_coordinates(const Tensor<1,dim> &position) const;
 
         /**
          * Returns a representative point for a given depth. Such a point must

--- a/include/aspect/geometry_model/interface.h
+++ b/include/aspect/geometry_model/interface.h
@@ -138,7 +138,10 @@ namespace aspect
          * latitude) in 3d.
          */
         virtual
-        Tensor<1,dim> cartesian_to_natural_coordinates(const Point<dim> &position) const;
+        Tensor<1,2> cartesian_to_natural_coordinates(const Point<2> &position) const;
+
+        virtual
+        Tensor<1,3> cartesian_to_natural_coordinates(const Point<3> &position) const;
 
         /**
          * Undoes the action of cartesian_to_natural_coordinates, and turns the
@@ -146,7 +149,10 @@ namespace aspect
          * Cartesian coordinates.
          */
         virtual
-        Point<dim> natural_to_cartesian_coordinates(const Tensor<1,dim> &position) const;
+        Point<2> natural_to_cartesian_coordinates(const Tensor<1,2> &position) const;
+
+        virtual
+        Point<3> natural_to_cartesian_coordinates(const Tensor<1,3> &position) const;
 
         /**
          * Returns a representative point for a given depth. Such a point must

--- a/source/geometry_model/interface.cc
+++ b/source/geometry_model/interface.cc
@@ -71,25 +71,49 @@ namespace aspect
 
 
     template <int dim>
-    Tensor<1,dim>
-    Interface<dim>::cartesian_to_natural_coordinates(const Point<dim> &) const
+    Tensor<1,2>
+    Interface<dim>::cartesian_to_natural_coordinates(const Point<2> &) const
     {
       Assert (false,
               ExcMessage ("The cartesian_to_natural_coordinates function has "
                           "not been implemented in this geometry model."));
-      return Tensor<1,dim>();
+      return Tensor<1,2>();
     }
 
 
 
     template <int dim>
-    Point<dim>
-    Interface<dim>::natural_to_cartesian_coordinates(const Tensor<1,dim> &) const
+    Tensor<1,3>
+    Interface<dim>::cartesian_to_natural_coordinates(const Point<3> &) const
+    {
+      Assert (false,
+              ExcMessage ("The cartesian_to_natural_coordinates function has "
+                          "not been implemented in this geometry model."));
+      return Tensor<1,3>();
+    }
+
+
+
+    template <int dim>
+    Point<2>
+    Interface<dim>::natural_to_cartesian_coordinates(const Tensor<1,2> &) const
     {
       Assert (false,
               ExcMessage ("The natural_to_cartesian_coordinates function has "
                           "not been implemented in this geometry model."));
-      return Point<dim>();
+      return Point<2>();
+    }
+
+
+
+    template <int dim>
+    Point<3>
+    Interface<dim>::natural_to_cartesian_coordinates(const Tensor<1,3> &) const
+    {
+      Assert (false,
+              ExcMessage ("The natural_to_cartesian_coordinates function has "
+                          "not been implemented in this geometry model."));
+      return Point<3>();
     }
 
 

--- a/source/geometry_model/interface.cc
+++ b/source/geometry_model/interface.cc
@@ -71,20 +71,20 @@ namespace aspect
 
 
     template <int dim>
-    std_cxx11::array<double,dim>
+    Tensor<1,dim>
     Interface<dim>::cartesian_to_natural_coordinates(const Point<dim> &) const
     {
       Assert (false,
               ExcMessage ("The cartesian_to_natural_coordinates function has "
                           "not been implemented in this geometry model."));
-      return std_cxx11::array<double,dim>();
+      return Tensor<1,dim>();
     }
 
 
 
     template <int dim>
     Point<dim>
-    Interface<dim>::natural_to_cartesian_coordinates(const std_cxx11::array<double,dim> &) const
+    Interface<dim>::natural_to_cartesian_coordinates(const Tensor<1,dim> &) const
     {
       Assert (false,
               ExcMessage ("The natural_to_cartesian_coordinates function has "


### PR DESCRIPTION
This is a follow up to #1906. Like #1906, this is meant as a proposition to start a discussion. 

The problem I try to solve here is that I have functions which always require 3d points, no matter if you are in 2d or 3d). To accommodate that I have split these functions in explicit 2d and 3d input and output. Are there any objections against doing this?