### PR TITLE
give the strain rate to the melt properties visualization postprocessor

### DIFF
--- a/source/postprocess/visualization/melt.cc
+++ b/source/postprocess/visualization/melt.cc
@@ -104,9 +104,9 @@ namespace aspect
         Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
         Assert (input_data.solution_values[0].size() == this->introspection().n_components,   ExcInternalError());
 
-        // Set use_strain_rates to false since we have no need for viscosity.
+        // Set use_strain_rates to true since the compaction viscosity might also depend on the strain rate.
         MaterialModel::MaterialModelInputs<dim> in(input_data,
-                                                   this->introspection(), false);
+                                                   this->introspection(), true);
         MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points, this->n_compositional_fields());
         MeltHandler<dim>::create_material_model_outputs(out);
 


### PR DESCRIPTION
In the beginning, we thought that the additional material model outputs used in models with melt transport (which are visualized by the Melt material properties visualization postprocessor) would not depend on the strain rate. However, it turned out that in more complex models, for example the compaction viscosity might depend on the strain rate. Because of that, we need the strain rate in the material model inputs that is used by the postprocessor. This issue is fixed in this pull request. 