### PR TITLE
make the cell object input argument in the constructor of material mo…

### DIFF
--- a/benchmarks/annulus/annulus.cc
+++ b/benchmarks/annulus/annulus.cc
@@ -522,7 +522,7 @@ namespace aspect
               if (cell->face(f)->at_boundary())
                 {
                   fe_face_values.reinit(cell, f);
-                  MaterialModel::MaterialModelInputs<dim> in_face(fe_face_values, &cell, this->introspection(), this->get_solution());
+                  MaterialModel::MaterialModelInputs<dim> in_face(fe_face_values, cell, this->introspection(), this->get_solution());
                   MaterialModel::MaterialModelOutputs<dim> out_face(fe_face_values.n_quadrature_points, this->n_compositional_fields());
                   fe_face_values[this->introspection().extractors.temperature].get_function_values(topo_vector, topo_values);
                   this->get_material_model().evaluate(in_face, out_face);

--- a/benchmarks/hollow_sphere/hollow_sphere.cc
+++ b/benchmarks/hollow_sphere/hollow_sphere.cc
@@ -599,7 +599,7 @@ namespace aspect
               if (cell->face(f)->at_boundary() && cell->face(f)->boundary_id() == 1 /*outer surface*/)
                 {
                   fe_face_values.reinit(cell, f);
-                  MaterialModel::MaterialModelInputs<dim> in_face(fe_face_values, &cell, this->introspection(), this->get_solution());
+                  MaterialModel::MaterialModelInputs<dim> in_face(fe_face_values, cell, this->introspection(), this->get_solution());
                   MaterialModel::MaterialModelOutputs<dim> out_face(fe_face_values.n_quadrature_points, this->n_compositional_fields());
                   fe_face_values[this->introspection().extractors.temperature].get_function_values(topo_vector, topo_values);
                   this->get_material_model().evaluate(in_face, out_face);

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -211,7 +211,7 @@ namespace aspect
          * @param use_strain_rates Whether to compute the strain rates.
          */
         MaterialModelInputs(const FEValuesBase<dim,dim> &fe_values,
-                            const typename DoFHandler<dim>::active_cell_iterator *cell,
+                            const typename DoFHandler<dim>::active_cell_iterator &cell,
                             const Introspection<dim> &introspection,
                             const LinearAlgebra::BlockVector &solution_vector,
                             const bool use_strain_rates = true);
@@ -226,7 +226,7 @@ namespace aspect
          * created by the constructor MaterialModelInputs.
          */
         void reinit(const FEValuesBase<dim,dim> &fe_values,
-                    const typename DoFHandler<dim>::active_cell_iterator *cell,
+                    const typename DoFHandler<dim>::active_cell_iterator &cell,
                     const Introspection<dim> &introspection,
                     const LinearAlgebra::BlockVector &solution_vector,
                     const bool use_strain_rates = true);

--- a/source/mesh_refinement/density.cc
+++ b/source/mesh_refinement/density.cc
@@ -77,7 +77,7 @@ namespace aspect
           {
             fe_values.reinit(cell);
             // Set use_strain_rates to false since we don't need viscosity
-            in.reinit(fe_values, &cell, this->introspection(), this->get_solution(), false);
+            in.reinit(fe_values, cell, this->introspection(), this->get_solution(), false);
 
             this->get_material_model().evaluate(in, out);
 

--- a/source/mesh_refinement/thermal_energy_density.cc
+++ b/source/mesh_refinement/thermal_energy_density.cc
@@ -71,7 +71,7 @@ namespace aspect
           {
             fe_values.reinit(cell);
             // Set use_strain_rates to false since we don't need viscosity
-            in.reinit(fe_values, &cell, this->introspection(), this->get_solution(), false);
+            in.reinit(fe_values, cell, this->introspection(), this->get_solution(), false);
             this->get_material_model().evaluate(in, out);
 
             cell->get_dof_indices (local_dof_indices);

--- a/source/mesh_refinement/viscosity.cc
+++ b/source/mesh_refinement/viscosity.cc
@@ -76,7 +76,7 @@ namespace aspect
         if (cell->is_locally_owned())
           {
             fe_values.reinit(cell);
-            in.reinit(fe_values, &cell, this->introspection(), this->get_solution());
+            in.reinit(fe_values, cell, this->introspection(), this->get_solution());
             this->get_material_model().evaluate(in, out);
 
             cell->get_dof_indices (local_dof_indices);

--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -152,12 +152,12 @@ namespace aspect
               local_mass_matrix = 0.;
 
               // Evaluate the material model in the cell volume.
-              MaterialModel::MaterialModelInputs<dim> in_volume(fe_volume_values, &cell, this->introspection(), this->get_solution());
+              MaterialModel::MaterialModelInputs<dim> in_volume(fe_volume_values, cell, this->introspection(), this->get_solution());
               MaterialModel::MaterialModelOutputs<dim> out_volume(fe_volume_values.n_quadrature_points, this->n_compositional_fields());
               this->get_material_model().evaluate(in_volume, out_volume);
 
               // Evaluate the material model on the cell face.
-              MaterialModel::MaterialModelInputs<dim> in_face(fe_face_values, &cell, this->introspection(), this->get_solution());
+              MaterialModel::MaterialModelInputs<dim> in_face(fe_face_values, cell, this->introspection(), this->get_solution());
               MaterialModel::MaterialModelOutputs<dim> out_face(fe_face_values.n_quadrature_points, this->n_compositional_fields());
               this->get_material_model().evaluate(in_face, out_face);
 
@@ -290,7 +290,7 @@ namespace aspect
               fe_support_values.reinit (cell, face_idx);
 
               // Evaluate the material model on the cell face.
-              MaterialModel::MaterialModelInputs<dim> in_support(fe_support_values, &cell, this->introspection(), this->get_solution());
+              MaterialModel::MaterialModelInputs<dim> in_support(fe_support_values, cell, this->introspection(), this->get_solution());
               MaterialModel::MaterialModelOutputs<dim> out_support(fe_support_values.n_quadrature_points, this->n_compositional_fields());
               this->get_material_model().evaluate(in_support, out_support);
 
@@ -334,7 +334,7 @@ namespace aspect
               fe_output_values.reinit(cell, face_idx);
 
               // Evaluate the material model on the cell face.
-              MaterialModel::MaterialModelInputs<dim> in_output(fe_output_values, &cell, this->introspection(), this->get_solution());
+              MaterialModel::MaterialModelInputs<dim> in_output(fe_output_values, cell, this->introspection(), this->get_solution());
               MaterialModel::MaterialModelOutputs<dim> out_output(fe_output_values.n_quadrature_points, this->n_compositional_fields());
               this->get_material_model().evaluate(in_output, out_output);
 

--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -121,7 +121,7 @@ namespace aspect
                   {
                     fe_values.reinit (cell);
                     // Set use_strain_rates to false since we don't need viscosity
-                    in.reinit(fe_values, &cell, this->introspection(), this->get_solution(), false);
+                    in.reinit(fe_values, cell, this->introspection(), this->get_solution(), false);
 
                     this->get_material_model().evaluate(in, out);
 

--- a/source/postprocess/heat_flux_densities.cc
+++ b/source/postprocess/heat_flux_densities.cc
@@ -72,7 +72,7 @@ namespace aspect
               {
                 fe_face_values.reinit (cell, f);
                 // Set use_strain_rates to false since we don't need viscosity
-                in.reinit(fe_face_values, &cell, this->introspection(), this->get_solution(), false);
+                in.reinit(fe_face_values, cell, this->introspection(), this->get_solution(), false);
 
                 this->get_material_model().evaluate(in, out);
 

--- a/source/postprocess/heat_flux_statistics.cc
+++ b/source/postprocess/heat_flux_statistics.cc
@@ -73,7 +73,7 @@ namespace aspect
               {
                 fe_face_values.reinit (cell, f);
                 // Set use_strain_rates to false since we don't need viscosity
-                in.reinit(fe_face_values, &cell, this->introspection(), this->get_solution(), false);
+                in.reinit(fe_face_values, cell, this->introspection(), this->get_solution(), false);
 
                 this->get_material_model().evaluate(in, out);
 

--- a/source/postprocess/heating_statistics.cc
+++ b/source/postprocess/heating_statistics.cc
@@ -80,7 +80,7 @@ namespace aspect
           {
 
             fe_values.reinit (cell);
-            in.reinit(fe_values, &cell, this->introspection(), this->get_solution());
+            in.reinit(fe_values, cell, this->introspection(), this->get_solution());
 
             for (typename std::list<std_cxx11::shared_ptr<HeatingModel::Interface<dim> > >::const_iterator
                  heating_model = heating_model_objects.begin();

--- a/source/postprocess/mass_flux_statistics.cc
+++ b/source/postprocess/mass_flux_statistics.cc
@@ -83,7 +83,7 @@ namespace aspect
               {
                 fe_face_values.reinit (cell, f);
                 // Set use_strain_rates to false since we don't need viscosity
-                in.reinit(fe_face_values, &cell, this->introspection(), this->get_solution(), false);
+                in.reinit(fe_face_values, cell, this->introspection(), this->get_solution(), false);
 
                 this->get_material_model().evaluate(in, out);
 

--- a/source/postprocess/melt_statistics.cc
+++ b/source/postprocess/melt_statistics.cc
@@ -71,7 +71,7 @@ namespace aspect
           {
             // fill material model inputs
             fe_values.reinit (cell);
-            in.reinit(fe_values, &cell, this->introspection(), this->get_solution());
+            in.reinit(fe_values, cell, this->introspection(), this->get_solution());
 
             // we can only postprocess melt fractions if the material model that is used
             // in the simulation has implemented them

--- a/source/postprocess/viscous_dissipation_statistics.cc
+++ b/source/postprocess/viscous_dissipation_statistics.cc
@@ -70,7 +70,7 @@ namespace aspect
         if (cell->is_locally_owned())
           {
             fe_values.reinit (cell);
-            in.reinit(fe_values, &cell, this->introspection(), this->get_solution());
+            in.reinit(fe_values, cell, this->introspection(), this->get_solution());
 
             // get the viscosity from the material model
             this->get_material_model().evaluate(in, out);

--- a/source/postprocess/visualization/heat_flux_map.cc
+++ b/source/postprocess/visualization/heat_flux_map.cc
@@ -79,7 +79,7 @@ namespace aspect
                           temperature_gradients);
 
                       // Set use_strain_rate to false since we don't need viscosity.
-                      in.reinit(fe_face_values, &cell, this->introspection(), this->get_solution(), false);
+                      in.reinit(fe_face_values, cell, this->introspection(), this->get_solution(), false);
                       this->get_material_model().evaluate(in, out);
 
 

--- a/source/postprocess/visualization/seismic_anomalies.cc
+++ b/source/postprocess/visualization/seismic_anomalies.cc
@@ -81,7 +81,7 @@ namespace aspect
                     // Get the pressure, temperature and composition in the cell
                     fe_values.reinit (cell);
 
-                    in.reinit(fe_values, &cell, this->introspection(), this->get_solution(), false);
+                    in.reinit(fe_values, cell, this->introspection(), this->get_solution(), false);
 
                     out.additional_outputs.push_back(
                       std_cxx11::shared_ptr<MaterialModel::AdditionalMaterialOutputs<dim> >
@@ -248,7 +248,7 @@ namespace aspect
                     // Get the pressure, temperature and composition in the cell
                     fe_values.reinit (cell);
 
-                    in.reinit(fe_values, &cell, this->introspection(), this->get_solution(), false);
+                    in.reinit(fe_values, cell, this->introspection(), this->get_solution(), false);
 
                     out.additional_outputs.push_back(
                       std_cxx11::shared_ptr<MaterialModel::AdditionalMaterialOutputs<dim> >

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -554,7 +554,7 @@ namespace aspect
           if (parameters.use_conduction_timestep)
             {
               in.reinit(fe_values,
-                        &cell,
+                        cell,
                         introspection,
                         solution);
 
@@ -1578,10 +1578,10 @@ namespace aspect
         {
           fe_values_C.reinit (cell);
           cell->get_dof_indices (local_dof_indices);
-          in_C.reinit(fe_values_C, &cell, introspection, solution);
+          in_C.reinit(fe_values_C, cell, introspection, solution);
 
           fe_values_T.reinit (cell);
-          in_T.reinit(fe_values_T, &cell, introspection, solution);
+          in_T.reinit(fe_values_T, cell, introspection, solution);
 
           std::vector<std::vector<double> > accumulated_reactions_C (quadrature_C.size(),std::vector<double> (introspection.n_compositional_fields));
           std::vector<double> accumulated_reactions_T (quadrature_T.size());

--- a/source/simulator/lateral_averaging.cc
+++ b/source/simulator/lateral_averaging.cc
@@ -82,7 +82,7 @@ namespace aspect
 
               // get the density at each quadrature point if necessary
               in.reinit(fe_values,
-                        &cell,
+                        cell,
                         this->introspection(),
                         this->get_solution());
 

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -974,7 +974,7 @@ namespace aspect
 
 
             in.reinit(fe_values,
-                      &cell,
+                      cell,
                       this->introspection(),
                       this->get_solution());
 

--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -393,7 +393,7 @@ namespace aspect
           if ( ! use_constant_density)
             {
               // Set use_strain_rates to false since we don't need viscosity
-              in.reinit(fe, &cell, introspection, solution, false);
+              in.reinit(fe, cell, introspection, solution, false);
               material_model->evaluate(in, out);
             }
 


### PR DESCRIPTION
…del inputs a reference instead of a pointer

This addresses #1907. 
However, it only adds the new functions. What do we do with the old versions? Keep them around and mark them as deprecated too? Otherwise postprocessors people have written might not work anymore. 