### PR TITLE
Print 0 if solver_control returns an invalid unsigned integer for last_step

### DIFF
--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -855,8 +855,14 @@ namespace aspect
         solution.block(block_p) = distributed_stokes_solution.block(block_p);
 
         // print the number of iterations to screen
-        pcout << solver_control_cheap.last_step() << '+'
-              << solver_control_expensive.last_step() << " iterations.";
+        pcout << (solver_control_cheap.last_step() != numbers::invalid_unsigned_int ?
+                  solver_control_cheap.last_step():
+                  0)
+              << '+'
+              << (solver_control_expensive.last_step() != numbers::invalid_unsigned_int ?
+                  solver_control_expensive.last_step():
+                  0)
+              << " iterations.";
         pcout << std::endl;
       }
 


### PR DESCRIPTION
This addresses one of the issues in #1912. 

Through patch dealii/dealii/pull/4870, `SolverControl ` now initializes the number of iterations as `numbers::invalid_unsigned_int`. This broke most (all?) of the tests as the number of printed cheap or expensive iterations was incorrect.

This is fixed by printing `0` if the number of stokes iterations is `numbers::invalid_unsigned_int`.