### PR TITLE
fix for porosity initial composition plugin

### DIFF
--- a/source/initial_temperature/adiabatic.cc
+++ b/source/initial_temperature/adiabatic.cc
@@ -97,7 +97,7 @@ namespace aspect
                                                  erfc(this->get_geometry_model().depth(position) /
                                                       (2 * sqrt(kappa * age_top)))
                                                  : 0.0;
-      const double bottom_heating_temperature = age_bottom > 0.0 ?
+      const double bottom_heating_temperature = (age_bottom > 0.0 && this->get_adiabatic_conditions().is_initialized()) ?
                                                 (T_bottom - adiabatic_bottom_temperature + subadiabaticity)
                                                 * erfc((this->get_geometry_model().maximal_depth()
                                                         - this->get_geometry_model().depth(position)) /


### PR DESCRIPTION
This pull request fixes a problem that shows up if the `porosity` initial composition, the `adiabatic` initial temperature, and the `initial profile` adiabatic conditions are used together. They all need data from each other, so they called each other in a loop, which lead to a crash of ASPECT with an error message that was difficult to understand. This pull request fixes this particular problem in the way that the reference composition profile that is used to compute the adiabatic initial profile does not take into account boundary layers that might exist in the adiabatic initial temperature (so this is a very specific case, and it is only a problem if the initial composition depends on the initial temperature). 