### PR TITLE
Adjust particle interfaces

### DIFF
--- a/include/aspect/particle/integrator/euler.h
+++ b/include/aspect/particle/integrator/euler.h
@@ -60,8 +60,8 @@ namespace aspect
            */
           virtual
           void
-          local_integrate_step(const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &begin_particle,
-                               const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &end_particle,
+          local_integrate_step(const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                               const typename ParticleHandler<dim>::particle_iterator &end_particle,
                                const std::vector<Tensor<1,dim> > &old_velocities,
                                const std::vector<Tensor<1,dim> > &velocities,
                                const double dt);

--- a/include/aspect/particle/integrator/interface.h
+++ b/include/aspect/particle/integrator/interface.h
@@ -73,8 +73,8 @@ namespace aspect
            */
           virtual
           void
-          local_integrate_step(const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &begin_particle,
-                               const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &end_particle,
+          local_integrate_step(const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                               const typename ParticleHandler<dim>::particle_iterator &end_particle,
                                const std::vector<Tensor<1,dim> > &old_velocities,
                                const std::vector<Tensor<1,dim> > &velocities,
                                const double dt) = 0;

--- a/include/aspect/particle/integrator/rk_2.h
+++ b/include/aspect/particle/integrator/rk_2.h
@@ -63,8 +63,8 @@ namespace aspect
            */
           virtual
           void
-          local_integrate_step(const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &begin_particle,
-                               const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &end_particle,
+          local_integrate_step(const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                               const typename ParticleHandler<dim>::particle_iterator &end_particle,
                                const std::vector<Tensor<1,dim> > &old_velocities,
                                const std::vector<Tensor<1,dim> > &velocities,
                                const double dt);

--- a/include/aspect/particle/integrator/rk_4.h
+++ b/include/aspect/particle/integrator/rk_4.h
@@ -63,8 +63,8 @@ namespace aspect
            */
           virtual
           void
-          local_integrate_step(const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &begin_particle,
-                               const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &end_particle,
+          local_integrate_step(const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                               const typename ParticleHandler<dim>::particle_iterator &end_particle,
                                const std::vector<Tensor<1,dim> > &old_velocities,
                                const std::vector<Tensor<1,dim> > &velocities,
                                const double dt);

--- a/include/aspect/particle/interpolator/bilinear_least_squares.h
+++ b/include/aspect/particle/interpolator/bilinear_least_squares.h
@@ -45,7 +45,7 @@ namespace aspect
            */
           virtual
           std::vector<std::vector<double> >
-          properties_at_points(const std::multimap<types::LevelInd, Particle<dim> > &particles,
+          properties_at_points(const ParticleHandler<dim> &particle_handler,
                                const std::vector<Point<dim> > &positions,
                                const ComponentMask &selected_properties,
                                const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const;

--- a/include/aspect/particle/interpolator/cell_average.h
+++ b/include/aspect/particle/interpolator/cell_average.h
@@ -45,7 +45,7 @@ namespace aspect
            */
           virtual
           std::vector<std::vector<double> >
-          properties_at_points(const std::multimap<types::LevelInd, Particle<dim> > &particles,
+          properties_at_points(const ParticleHandler<dim> &particle_handler,
                                const std::vector<Point<dim> > &positions,
                                const ComponentMask &selected_properties,
                                const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const;

--- a/include/aspect/particle/interpolator/interface.h
+++ b/include/aspect/particle/interpolator/interface.h
@@ -22,6 +22,7 @@
 #define _aspect_particle_interpolator_interface_h
 
 #include <aspect/particle/particle.h>
+#include <aspect/particle/particle_handler.h>
 #include <aspect/plugins.h>
 #include <aspect/global.h>
 
@@ -61,7 +62,8 @@ namespace aspect
            * of doubles which contains a somehow computed
            * value of all particle properties at all given positions.
            *
-           * @param [in] particles Reference to the particle map.
+           * @param [in] particle_handler Reference to the particle handler
+           * that allows accessing the particles in the domain.
            * @param [in] positions The vector of positions where the properties
            * should be evaluated.
            * @param [in] cell An optional iterator to the cell containing the
@@ -73,7 +75,7 @@ namespace aspect
            */
           virtual
           std::vector<std::vector<double> >
-          properties_at_points(const std::multimap<types::LevelInd, Particle<dim> > &particles,
+          properties_at_points(const ParticleHandler<dim> &particle_handler,
                                const std::vector<Point<dim> > &positions,
                                const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell = typename parallel::distributed::Triangulation<dim>::active_cell_iterator()) const DEAL_II_DEPRECATED;
 
@@ -88,7 +90,8 @@ namespace aspect
            * will be filled with computed properties, all other components
            * are not filled (or filled with invalid values).
            *
-           * @param [in] particles Reference to the particle map.
+           * @param [in] particle_handler Reference to the particle handler
+           * that allows accessing the particles in the domain.
            * @param [in] positions The vector of positions where the properties
            * should be evaluated.
            * @param [in] selected_properties A component mask that determines
@@ -102,7 +105,7 @@ namespace aspect
            */
           virtual
           std::vector<std::vector<double> >
-          properties_at_points(const std::multimap<types::LevelInd, Particle<dim> > &particles,
+          properties_at_points(const ParticleHandler<dim> &particle_handler,
                                const std::vector<Point<dim> > &positions,
                                const ComponentMask &selected_properties,
                                const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell = typename parallel::distributed::Triangulation<dim>::active_cell_iterator()) const = 0;

--- a/include/aspect/particle/interpolator/nearest_neighbor.h
+++ b/include/aspect/particle/interpolator/nearest_neighbor.h
@@ -46,7 +46,7 @@ namespace aspect
            */
           virtual
           std::vector<std::vector<double> >
-          properties_at_points(const std::multimap<types::LevelInd, Particle<dim> > &particles,
+          properties_at_points(const ParticleHandler<dim> &particle_handler,
                                const std::vector<Point<dim> > &positions,
                                const ComponentMask &selected_properties,
                                const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const;

--- a/include/aspect/particle/output/ascii.h
+++ b/include/aspect/particle/output/ascii.h
@@ -60,8 +60,8 @@ namespace aspect
            * to a file. If possible, encode the current simulation time
            * into this file using the data provided in the last argument.
            *
-           * @param[in] particles The set of particles to generate a graphical
-           * representation for.
+           * @param[in] particle_handler The particle handler that allows access
+           * to the collection of particles.
            *
            * @param [in] property_information Information object containing names and number
            * of components of each property.
@@ -77,7 +77,7 @@ namespace aspect
            */
           virtual
           std::string
-          output_particle_data(const std::multimap<types::LevelInd, Particle<dim> >     &particles,
+          output_particle_data(const ParticleHandler<dim> &particle_handler,
                                const Property::ParticlePropertyInformation &property_information,
                                const double current_time);
 

--- a/include/aspect/particle/output/hdf5.h
+++ b/include/aspect/particle/output/hdf5.h
@@ -62,8 +62,8 @@ namespace aspect
            * to a file. If possible, encode the current simulation time
            * into this file using the data provided in the last argument.
            *
-           * @param[in] particles The set of particles to generate a graphical
-           * representation for.
+           * @param[in] particle_handler The particle handler that allows access
+           * to the collection of particles.
            *
            * @param [in] property_information Information object containing names and number
            * of components of each property.
@@ -79,7 +79,7 @@ namespace aspect
            */
           virtual
           std::string
-          output_particle_data(const std::multimap<types::LevelInd, Particle<dim> >     &particles,
+          output_particle_data(const ParticleHandler<dim> &particle_handler,
                                const Property::ParticlePropertyInformation &property_information,
                                const double current_time);
 

--- a/include/aspect/particle/output/interface.h
+++ b/include/aspect/particle/output/interface.h
@@ -64,8 +64,8 @@ namespace aspect
            * to a file. If possible, encode the current simulation time
            * into this file using the data provided in the last argument.
            *
-           * @param[in] particles The set of particles to generate a graphical
-           * representation for.
+           * @param[in] particle_handler The particle handler that allows access
+           * to the collection of particles.
            *
            * @param [in] property_information Information object containing names and number
            * of components of each property.
@@ -81,7 +81,7 @@ namespace aspect
            */
           virtual
           std::string
-          output_particle_data(const std::multimap<types::LevelInd, Particle<dim> >     &particles,
+          output_particle_data(const ParticleHandler<dim> &particle_handler,
                                const Property::ParticlePropertyInformation &property_information,
                                const double current_time) = 0;
 

--- a/include/aspect/particle/output/vtu.h
+++ b/include/aspect/particle/output/vtu.h
@@ -59,8 +59,8 @@ namespace aspect
            * to a file. If possible, encode the current simulation time
            * into this file using the data provided in the last argument.
            *
-           * @param[in] particles The set of particles to generate a graphical
-           * representation for.
+           * @param[in] particle_handler The particle handler that allows access
+           * to the collection of particles.
            *
            * @param [in] property_information Information object containing names and number
            * of components of each property.
@@ -76,7 +76,7 @@ namespace aspect
            */
           virtual
           std::string
-          output_particle_data(const std::multimap<types::LevelInd, Particle<dim> >     &particles,
+          output_particle_data(const ParticleHandler<dim> &particle_handler,
                                const Property::ParticlePropertyInformation &property_information,
                                const double current_time);
 

--- a/include/aspect/particle/particle_accessor.h
+++ b/include/aspect/particle/particle_accessor.h
@@ -181,6 +181,11 @@ namespace aspect
 
       protected:
         /**
+         * Construct an invalid accessor. Such an object is not usable.
+         */
+        ParticleAccessor ();
+
+        /**
          * Construct an accessor from a reference to a map and an iterator to the map.
          * This constructor is protected so that it can only be accessed by friend
          * classes.

--- a/include/aspect/particle/particle_handler.h
+++ b/include/aspect/particle/particle_handler.h
@@ -106,6 +106,13 @@ namespace aspect
         void clear();
 
         /**
+         * Only clear particle data, but keep cache information about number
+         * of particles. This is useful during reorganization of particle data
+         * between processes.
+         */
+        void clear_particles();
+
+        /**
          * Return an iterator to the first particle.
          */
         ParticleHandler<dim,spacedim>::particle_iterator begin() const;
@@ -133,6 +140,15 @@ namespace aspect
         particle_iterator_range
         particle_range_in_cell(const typename parallel::distributed::Triangulation<dim,spacedim>::active_cell_iterator &cell);
 
+
+        /**
+         * Return a pair of particle iterators that mark the begin and end of
+         * the particles in a particular cell. The last iterator is the first
+         * particle that is no longer in the cell.
+         */
+        particle_iterator_range
+        particle_range_in_cell(const typename parallel::distributed::Triangulation<dim,spacedim>::active_cell_iterator &cell) const;
+
         /**
          * Remove a particle pointed to by the iterator.
          */
@@ -142,12 +158,20 @@ namespace aspect
         /**
          * Insert a particle into the collection of particles. Return an iterator
          * to the new position of the particle. This function involves a copy of
-         * the particle and its properties. Note that this function is of NlogN
+         * the particle and its properties. Note that this function is of O(NlogN)
          * complexity for N particles.
          */
         particle_iterator
         insert_particle(const Particle<dim,spacedim> &particle,
                         const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell);
+
+        /**
+         * Insert a number of particle into the collection of particles.
+         * This function involves a copy of the particles and their properties.
+         * Note that this function is of O(N) complexity.
+         */
+        void
+        insert_particles(const std::multimap<types::LevelInd, Particle<dim,spacedim> > &particles);
 
         /**
          * This function allows to register three additional functions that are
@@ -197,6 +221,11 @@ namespace aspect
          * triangulation.
          */
         types::particle_index n_locally_owned_particles() const;
+
+        /**
+         * Return the number of properties each particle has.
+         */
+        unsigned int n_properties_per_particle() const;
 
         /**
          * Return a reference to the property pool that owns all particle

--- a/include/aspect/particle/particle_handler.h
+++ b/include/aspect/particle/particle_handler.h
@@ -138,7 +138,7 @@ namespace aspect
          * particle that is no longer in the cell.
          */
         particle_iterator_range
-        particle_range_in_cell(const typename parallel::distributed::Triangulation<dim,spacedim>::active_cell_iterator &cell);
+        particles_in_cell(const typename parallel::distributed::Triangulation<dim,spacedim>::active_cell_iterator &cell);
 
 
         /**
@@ -147,7 +147,7 @@ namespace aspect
          * particle that is no longer in the cell.
          */
         particle_iterator_range
-        particle_range_in_cell(const typename parallel::distributed::Triangulation<dim,spacedim>::active_cell_iterator &cell) const;
+        particles_in_cell(const typename parallel::distributed::Triangulation<dim,spacedim>::active_cell_iterator &cell) const;
 
         /**
          * Remove a particle pointed to by the iterator.
@@ -158,7 +158,7 @@ namespace aspect
         /**
          * Insert a particle into the collection of particles. Return an iterator
          * to the new position of the particle. This function involves a copy of
-         * the particle and its properties. Note that this function is of O(NlogN)
+         * the particle and its properties. Note that this function is of O(N \log N)
          * complexity for N particles.
          */
         particle_iterator
@@ -168,7 +168,7 @@ namespace aspect
         /**
          * Insert a number of particle into the collection of particles.
          * This function involves a copy of the particles and their properties.
-         * Note that this function is of O(N) complexity.
+         * Note that this function is of O(n_existing_particles + n_particles) complexity.
          */
         void
         insert_particles(const std::multimap<types::LevelInd, Particle<dim,spacedim> > &particles);
@@ -278,31 +278,6 @@ namespace aspect
          */
         template <class Archive>
         void serialize (Archive &ar, const unsigned int version);
-
-      protected:
-        /**
-         * Access to particles in this handler.
-         * TODO: This function eventually needs to go, to not expose internal structure.
-         * This can only be done once World no longer uses this function.
-         */
-        std::multimap<types::LevelInd, Particle<dim,spacedim> > &
-        get_particles();
-
-        /**
-         * Const access to particles in this world.
-         * TODO: This function needs to go to not expose internal structure.
-         * This can only be done once World no longer uses this function.
-         */
-        const std::multimap<types::LevelInd, Particle<dim,spacedim> > &
-        get_particles() const;
-
-        /**
-         * Const access to particles in this world.
-         * TODO: This function needs to go to not expose internal structure.
-         * This can only be done once World no longer uses this function.
-         */
-        const std::multimap<types::LevelInd, Particle<dim,spacedim> > &
-        get_ghost_particles() const;
 
       private:
         /**

--- a/include/aspect/particle/particle_iterator.h
+++ b/include/aspect/particle/particle_iterator.h
@@ -39,6 +39,11 @@ namespace aspect
     {
       public:
         /**
+         * Empty constructor. Such an object is not usable!
+         */
+        ParticleIterator ();
+
+        /**
          * Constructor of the iterator. Takes a reference to the particle
          * container, and an iterator the the cell-particle pair.
          */
@@ -55,6 +60,11 @@ namespace aspect
          * Dereferencing operator, non-@p const version.
          */
         ParticleAccessor<dim,spacedim> &operator * ();
+
+        /**
+         * Assignment operator.
+         */
+        ParticleIterator &operator = (const ParticleIterator &);
 
         /**
          * Dereferencing operator, returns a pointer of the particle pointed to. Usage

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -486,7 +486,7 @@ namespace aspect
            * collection after it was created.
            */
           void
-          initialize_one_particle (Particle<dim> &particle) const;
+          initialize_one_particle (typename ParticleHandler<dim>::particle_iterator &particle) const;
 
           /**
            * Initialization function for particle properties. This function is
@@ -496,7 +496,7 @@ namespace aspect
            */
           std::vector<double>
           initialize_late_particle (const Point<dim> &particle_location,
-                                    const std::multimap<types::LevelInd, Particle<dim> > &particles,
+                                    const ParticleHandler<dim> &particle_handler,
                                     const Interpolator::Interface<dim> &interpolator,
                                     const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell = typename parallel::distributed::Triangulation<dim>::active_cell_iterator()) const;
 
@@ -505,7 +505,7 @@ namespace aspect
            * called once every time step for every particle.
            */
           void
-          update_one_particle (Particle<dim> &particle,
+          update_one_particle (typename ParticleHandler<dim>::particle_iterator &particle,
                                const Vector<double> &solution,
                                const std::vector<Tensor<1,dim> > &gradients) const;
 

--- a/include/aspect/particle/property_pool.h
+++ b/include/aspect/particle/property_pool.h
@@ -83,6 +83,11 @@ namespace aspect
          */
         void reserve(const std::size_t size);
 
+        /**
+         * Returns how many properties are stored per slot in the pool.
+         */
+        unsigned int n_properties_per_slot() const;
+
       private:
         /**
          * The number of properties that are reserved per particle.

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -122,26 +122,6 @@ namespace aspect
         void initialize_particles();
 
         /**
-         * Access to particles in this world.
-         */
-        std::multimap<types::LevelInd, Particle<dim> > &
-        get_particles();
-
-        /**
-         * Const access to particles in this world.
-         */
-        const std::multimap<types::LevelInd, Particle<dim> > &
-        get_particles() const;
-
-        /**
-         * Const access to ghost particles in this world.
-         * Ghost particles are all particles that are owned by another process
-         * and live in one of the ghost cells of the local subdomain.
-         */
-        const std::multimap<types::LevelInd, Particle<dim> > &
-        get_ghost_particles() const;
-
-        /**
          * Advance particles by the old timestep using the current
          * integration scheme. This accounts for the fact that the particles
          * are actually still at their old positions and the current timestep

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -389,16 +389,16 @@ namespace aspect
          * Initialize the particle properties of one cell.
          */
         void
-        local_initialize_particles(const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &begin_particle,
-                                   const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &end_particle);
+        local_initialize_particles(const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                                   const typename ParticleHandler<dim>::particle_iterator &end_particle);
 
         /**
          * Update the particle properties of one cell.
          */
         void
         local_update_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                               const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &begin_particle,
-                               const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &end_particle);
+                               const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                               const typename ParticleHandler<dim>::particle_iterator &end_particle);
 
         /**
          * Advect the particles of one cell. Performs only one step for
@@ -410,8 +410,8 @@ namespace aspect
          */
         void
         local_advect_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                               const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &begin_particle,
-                               const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &end_particle);
+                               const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                               const typename ParticleHandler<dim>::particle_iterator &end_particle);
     };
 
     /* -------------------------- inline and template functions ---------------------- */

--- a/include/aspect/postprocess/particles.h
+++ b/include/aspect/postprocess/particles.h
@@ -49,12 +49,12 @@ namespace aspect
       {
         public:
           /**
-           * This function prepares the data for writing. It reads the data from @p particles and their
+           * This function prepares the data for writing. It reads the data from @p particle_hander and their
            * property information from @p property_information, and builds a list of patches that is stored
            * internally until the destructor is called. This function needs to be called before one of the
            * write function of the base class can be called to write the output data.
            */
-          void build_patches(const std::multimap<aspect::Particle::types::LevelInd, aspect::Particle::Particle<dim> > &particles,
+          void build_patches(const Particle::ParticleHandler<dim> &particle_handler,
                              const aspect::Particle::Property::ParticlePropertyInformation &property_information);
 
         private:

--- a/source/mesh_refinement/particle_density.cc
+++ b/source/mesh_refinement/particle_density.cc
@@ -39,7 +39,7 @@ namespace aspect
                              "postprocessor plugin `particles' to be selected. Please activate the "
                              "particles or deactivate this mesh refinement plugin."));
 
-      const std::multimap<Particle::types::LevelInd, Particle::Particle<dim> > *particles = &particle_postprocessor->get_particle_world().get_particles();
+      const Particle::ParticleHandler<dim> &particle_handler = particle_postprocessor->get_particle_world().get_particle_handler();
 
       unsigned int i = 0;
       typename DoFHandler<dim>::active_cell_iterator
@@ -48,14 +48,11 @@ namespace aspect
       for (; cell!=endc; ++cell,++i)
         if (cell->is_locally_owned())
           {
-            const Particle::types::LevelInd cell_index (cell->level(),cell->index());
-            const unsigned int n_particles = particles->count(cell_index);
-
             // Note  that this refinement indicator will level out the number
             // of particles per cell, therefore creating fine cells in regions
             // of high particle density and coarse cells in low particle
             // density regions.
-            indicators(i) = static_cast<float>(n_particles);
+            indicators(i) = static_cast<float>(particle_handler.n_particles_in_cell(cell));
           }
       return;
     }

--- a/source/particle/integrator/euler.cc
+++ b/source/particle/integrator/euler.cc
@@ -32,8 +32,8 @@ namespace aspect
        */
       template <int dim>
       void
-      Euler<dim>::local_integrate_step(const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &begin_particle,
-                                       const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &end_particle,
+      Euler<dim>::local_integrate_step(const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                                       const typename ParticleHandler<dim>::particle_iterator &end_particle,
                                        const std::vector<Tensor<1,dim> > &old_velocities,
                                        const std::vector<Tensor<1,dim> > &,
                                        const double dt)
@@ -45,11 +45,11 @@ namespace aspect
 
         typename std::vector<Tensor<1,dim> >::const_iterator old_velocity = old_velocities.begin();
 
-        for (typename std::multimap<types::LevelInd, Particle<dim> >::iterator it = begin_particle;
+        for (typename ParticleHandler<dim>::particle_iterator it = begin_particle;
              it != end_particle; ++it, ++old_velocity)
           {
-            const Point<dim> loc = it->second.get_location();
-            it->second.set_location(loc + dt * (*old_velocity));
+            const Point<dim> loc = it->get_location();
+            it->set_location(loc + dt * (*old_velocity));
           }
       }
     }

--- a/source/particle/integrator/rk_2.cc
+++ b/source/particle/integrator/rk_2.cc
@@ -34,8 +34,8 @@ namespace aspect
 
       template <int dim>
       void
-      RK2<dim>::local_integrate_step(const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &begin_particle,
-                                     const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &end_particle,
+      RK2<dim>::local_integrate_step(const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                                     const typename ParticleHandler<dim>::particle_iterator &end_particle,
                                      const std::vector<Tensor<1,dim> > &old_velocities,
                                      const std::vector<Tensor<1,dim> > &velocities,
                                      const double dt)
@@ -53,19 +53,19 @@ namespace aspect
         typename std::vector<Tensor<1,dim> >::const_iterator old_velocity = old_velocities.begin();
         typename std::vector<Tensor<1,dim> >::const_iterator velocity = velocities.begin();
 
-        for (typename std::multimap<types::LevelInd, Particle<dim> >::iterator it = begin_particle;
+        for (typename ParticleHandler<dim>::particle_iterator it = begin_particle;
              it != end_particle; ++it, ++velocity, ++old_velocity)
           {
-            const types::particle_index particle_id = it->second.get_id();
-            const Point<dim> loc = it->second.get_location();
+            const types::particle_index particle_id = it->get_id();
+            const Point<dim> loc = it->get_location();
             if (integrator_substep == 0)
               {
                 loc0[particle_id] = loc;
-                it->second.set_location(loc + 0.5 * dt * (*old_velocity));
+                it->set_location(loc + 0.5 * dt * (*old_velocity));
               }
             else if (integrator_substep == 1)
               {
-                it->second.set_location(loc0[particle_id] + dt * (*old_velocity + *velocity) / 2.0);
+                it->set_location(loc0[particle_id] + dt * (*old_velocity + *velocity) / 2.0);
               }
             else
               {

--- a/source/particle/integrator/rk_4.cc
+++ b/source/particle/integrator/rk_4.cc
@@ -34,8 +34,8 @@ namespace aspect
 
       template <int dim>
       void
-      RK4<dim>::local_integrate_step(const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &begin_particle,
-                                     const typename std::multimap<types::LevelInd, Particle<dim> >::iterator &end_particle,
+      RK4<dim>::local_integrate_step(const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                                     const typename ParticleHandler<dim>::particle_iterator &end_particle,
                                      const std::vector<Tensor<1,dim> > &old_velocities,
                                      const std::vector<Tensor<1,dim> > &velocities,
                                      const double dt)
@@ -55,30 +55,30 @@ namespace aspect
         typename std::vector<Tensor<1,dim> >::const_iterator old_velocity = old_velocities.begin();
         typename std::vector<Tensor<1,dim> >::const_iterator velocity = velocities.begin();
 
-        for (typename std::multimap<types::LevelInd, Particle<dim> >::iterator it = begin_particle;
+        for (typename ParticleHandler<dim>::particle_iterator it = begin_particle;
              it != end_particle; ++it, ++velocity, ++old_velocity)
           {
-            const types::particle_index particle_id = it->second.get_id();
+            const types::particle_index particle_id = it->get_id();
             if (integrator_substep == 0)
               {
-                loc0[particle_id] = it->second.get_location();
+                loc0[particle_id] = it->get_location();
                 k1[particle_id] = dt * (*old_velocity);
-                it->second.set_location(it->second.get_location() + 0.5*k1[particle_id]);
+                it->set_location(it->get_location() + 0.5*k1[particle_id]);
               }
             else if (integrator_substep == 1)
               {
                 k2[particle_id] = dt * (*old_velocity + *velocity) / 2.0;
-                it->second.set_location(loc0[particle_id] + 0.5*k2[particle_id]);
+                it->set_location(loc0[particle_id] + 0.5*k2[particle_id]);
               }
             else if (integrator_substep == 2)
               {
                 k3[particle_id] = dt * (*old_velocity + *velocity) / 2.0;
-                it->second.set_location(loc0[particle_id] + k3[particle_id]);
+                it->set_location(loc0[particle_id] + k3[particle_id]);
               }
             else if (integrator_substep == 3)
               {
                 const Tensor<1,dim> k4 = dt * (*velocity);
-                it->second.set_location(loc0[particle_id] + (k1[particle_id] + 2.0*k2[particle_id] + 2.0*k3[particle_id] + k4)/6.0);
+                it->set_location(loc0[particle_id] + (k1[particle_id] + 2.0*k2[particle_id] + 2.0*k3[particle_id] + k4)/6.0);
               }
             else
               {

--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -80,7 +80,7 @@ namespace aspect
           found_cell = cell;
 
         const typename ParticleHandler<dim>::particle_iterator_range particle_range =
-          particle_handler.particle_range_in_cell(found_cell);
+          particle_handler.particles_in_cell(found_cell);
 
 
         std::vector<std::vector<double> > cell_properties(positions.size(),

--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -36,12 +36,12 @@ namespace aspect
     {
       template <int dim>
       std::vector<std::vector<double> >
-      BilinearLeastSquares<dim>::properties_at_points(const std::multimap<types::LevelInd, Particle<dim> > &particles,
+      BilinearLeastSquares<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
                                                       const std::vector<Point<dim> > &positions,
                                                       const ComponentMask &selected_properties,
                                                       const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
       {
-        const unsigned int n_particle_properties = particles.begin()->second.get_properties().size();
+        const unsigned int n_particle_properties = particle_handler.n_properties_per_particle();
 
         const unsigned int property_index = selected_properties.first_selected_component(selected_properties.size());
 
@@ -79,16 +79,15 @@ namespace aspect
         else
           found_cell = cell;
 
-        const types::LevelInd cell_index = std::make_pair<unsigned int, unsigned int> (found_cell->level(),found_cell->index());
-        const std::pair<typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator,
-              typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator> particle_range = particles.equal_range(cell_index);
+        const typename ParticleHandler<dim>::particle_iterator_range particle_range =
+          particle_handler.particle_range_in_cell(found_cell);
 
 
         std::vector<std::vector<double> > cell_properties(positions.size(),
                                                           std::vector<double>(n_particle_properties,
                                                                               numbers::signaling_nan<double>()));
 
-        const unsigned int n_particles = std::distance(particle_range.first,particle_range.second);
+        const unsigned int n_particles = std::distance(particle_range.begin(),particle_range.end());
 
         AssertThrow(n_particles != 0,
                     ExcMessage("At least one cell contained no particles. The `bilinear'"
@@ -105,13 +104,13 @@ namespace aspect
 
         unsigned int index = 0;
         const double cell_diameter = found_cell->diameter();
-        for (typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator particle = particle_range.first;
-             particle != particle_range.second; ++particle, ++index)
+        for (typename ParticleHandler<dim>::particle_iterator particle = particle_range.begin();
+             particle != particle_range.end(); ++particle, ++index)
           {
-            const double particle_property_value = particle->second.get_properties()[property_index];
+            const double particle_property_value = particle->get_properties()[property_index];
             r[index] = particle_property_value;
 
-            const Point<dim> position = particle->second.get_location();
+            const Point<dim> position = particle->get_location();
             A(index,0) = 1;
             A(index,1) = (position[0] - approximated_cell_midpoint[0])/cell_diameter;
             A(index,2) = (position[1] - approximated_cell_midpoint[1])/cell_diameter;

--- a/source/particle/interpolator/cell_average.cc
+++ b/source/particle/interpolator/cell_average.cc
@@ -61,7 +61,7 @@ namespace aspect
           found_cell = cell;
 
         const typename ParticleHandler<dim>::particle_iterator_range particle_range =
-          particle_handler.particle_range_in_cell(found_cell);
+          particle_handler.particles_in_cell(found_cell);
 
         const unsigned int n_particles = std::distance(particle_range.begin(),particle_range.end());
         const unsigned int n_particle_properties = particle_handler.n_properties_per_particle();

--- a/source/particle/interpolator/cell_average.cc
+++ b/source/particle/interpolator/cell_average.cc
@@ -33,13 +33,11 @@ namespace aspect
     {
       template <int dim>
       std::vector<std::vector<double> >
-      CellAverage<dim>::properties_at_points(const std::multimap<types::LevelInd, Particle<dim> > &particles,
+      CellAverage<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
                                              const std::vector<Point<dim> > &positions,
                                              const ComponentMask &selected_properties,
                                              const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
       {
-        const Postprocess::Particles<dim> *particle_postprocessor = this->template find_postprocessor<Postprocess::Particles<dim> >();
-
         typename parallel::distributed::Triangulation<dim>::active_cell_iterator found_cell;
 
         if (cell == typename parallel::distributed::Triangulation<dim>::active_cell_iterator())
@@ -62,18 +60,11 @@ namespace aspect
         else
           found_cell = cell;
 
-        const types::LevelInd cell_index = std::make_pair(found_cell->level(),found_cell->index());
+        const typename ParticleHandler<dim>::particle_iterator_range particle_range =
+          particle_handler.particle_range_in_cell(found_cell);
 
-        const std::pair<typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator,
-              typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator> particle_range =
-                (cell->is_locally_owned())
-                ?
-                particles.equal_range(cell_index)
-                :
-                particle_postprocessor->get_particle_world().get_ghost_particles().equal_range(cell_index);
-
-        const unsigned int n_particles = std::distance(particle_range.first,particle_range.second);
-        const unsigned int n_particle_properties = particles.begin()->second.get_properties().size();
+        const unsigned int n_particles = std::distance(particle_range.begin(),particle_range.end());
+        const unsigned int n_particle_properties = particle_handler.n_properties_per_particle();
 
         std::vector<double> cell_properties (n_particle_properties,numbers::signaling_nan<double>());
 
@@ -83,10 +74,10 @@ namespace aspect
 
         if (n_particles > 0)
           {
-            for (typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator particle = particle_range.first;
-                 particle != particle_range.second; ++particle)
+            for (typename ParticleHandler<dim>::particle_iterator particle = particle_range.begin();
+                 particle != particle_range.end(); ++particle)
               {
-                const ArrayView<const double> &particle_properties = particle->second.get_properties();
+                const ArrayView<const double> &particle_properties = particle->get_properties();
 
                 for (unsigned int i = 0; i < particle_properties.size(); ++i)
                   if (selected_properties[i])
@@ -109,15 +100,10 @@ namespace aspect
               {
                 // Only recursively call this function if the neighbor cell contains
                 // particles (else we end up in an endless recursion)
-                if ((neighbors[i]->is_locally_owned())
-                    && (particles.count(std::make_pair(neighbors[i]->level(),neighbors[i]->index())) == 0))
-                  continue;
-                else if ((!neighbors[i]->is_locally_owned())
-                         && (particle_postprocessor->get_particle_world().get_ghost_particles().count(
-                               std::make_pair(neighbors[i]->level(),neighbors[i]->index())) == 0))
+                if (particle_handler.n_particles_in_cell(neighbors[i]) == 0)
                   continue;
 
-                const std::vector<double> neighbor_properties = properties_at_points(particles,
+                const std::vector<double> neighbor_properties = properties_at_points(particle_handler,
                                                                                      std::vector<Point<dim> > (1,neighbors[i]->center(true,false)),
                                                                                      selected_properties,
                                                                                      neighbors[i])[0];

--- a/source/particle/interpolator/interface.cc
+++ b/source/particle/interpolator/interface.cc
@@ -35,11 +35,11 @@ namespace aspect
 
       template <int dim>
       std::vector<std::vector<double> >
-      Interface<dim>::properties_at_points(const std::multimap<types::LevelInd, Particle<dim> > &particles,
+      Interface<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
                                            const std::vector<Point<dim> > &positions,
                                            const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
       {
-        return properties_at_points(particles,positions,ComponentMask(), cell);
+        return properties_at_points(particle_handler,positions,ComponentMask(), cell);
       }
 
 

--- a/source/particle/interpolator/nearest_neighbor.cc
+++ b/source/particle/interpolator/nearest_neighbor.cc
@@ -59,7 +59,7 @@ namespace aspect
         else
           found_cell = cell;
 
-        const typename ParticleHandler<dim>::particle_iterator_range particle_range = particle_handler.particle_range_in_cell(found_cell);
+        const typename ParticleHandler<dim>::particle_iterator_range particle_range = particle_handler.particles_in_cell(found_cell);
 
         const unsigned int n_particles = std::distance(particle_range.begin(),particle_range.end());
         const unsigned int n_particle_properties = particle_handler.n_properties_per_particle();

--- a/source/particle/interpolator/nearest_neighbor.cc
+++ b/source/particle/interpolator/nearest_neighbor.cc
@@ -32,13 +32,11 @@ namespace aspect
     {
       template <int dim>
       std::vector<std::vector<double> >
-      NearestNeighbor<dim>::properties_at_points(const std::multimap<types::LevelInd, Particle<dim> > &particles,
+      NearestNeighbor<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
                                                  const std::vector<Point<dim> > &positions,
                                                  const ComponentMask &selected_properties,
                                                  const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
       {
-        const Postprocess::Particles<dim> *particle_postprocessor = this->template find_postprocessor<Postprocess::Particles<dim> >();
-
         typename parallel::distributed::Triangulation<dim>::active_cell_iterator found_cell;
 
         if (cell == typename parallel::distributed::Triangulation<dim>::active_cell_iterator())
@@ -61,18 +59,10 @@ namespace aspect
         else
           found_cell = cell;
 
-        const types::LevelInd cell_index = std::make_pair(found_cell->level(),found_cell->index());
+        const typename ParticleHandler<dim>::particle_iterator_range particle_range = particle_handler.particle_range_in_cell(found_cell);
 
-        const std::pair<typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator,
-              typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator> particle_range =
-                (cell->is_locally_owned())
-                ?
-                particles.equal_range(cell_index)
-                :
-                particle_postprocessor->get_particle_world().get_ghost_particles().equal_range(cell_index);
-
-        const unsigned int n_particles = std::distance(particle_range.first,particle_range.second);
-        const unsigned int n_particle_properties = particles.begin()->second.get_properties().size();
+        const unsigned int n_particles = std::distance(particle_range.begin(),particle_range.end());
+        const unsigned int n_particle_properties = particle_handler.n_properties_per_particle();
 
         std::vector<double> temp(n_particle_properties, 0.0);
         std::vector<std::vector<double> > point_properties(positions.size(), temp);
@@ -82,18 +72,18 @@ namespace aspect
             double minimum_distance = std::numeric_limits<double>::max();
             if (n_particles > 0)
               {
-                Particle<dim> nearest_neighbor;
-                for (typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator particle = particle_range.first;
-                     particle != particle_range.second; ++particle)
+                typename ParticleHandler<dim>::particle_iterator nearest_neighbor;
+                for (typename ParticleHandler<dim>::particle_iterator particle = particle_range.begin();
+                     particle != particle_range.end(); ++particle)
                   {
-                    const double dist = (positions[pos_idx] - particle->second.get_location()).norm_square();
+                    const double dist = (positions[pos_idx] - particle->get_location()).norm_square();
                     if (dist < minimum_distance)
                       {
                         minimum_distance = dist;
-                        nearest_neighbor = particle->second;
+                        nearest_neighbor = particle;
                       }
                   }
-                const dealii::ArrayView<const double> neighbor_props = nearest_neighbor.get_properties();
+                const dealii::ArrayView<const double> neighbor_props = nearest_neighbor->get_properties();
                 for (unsigned int i = 0; i < n_particle_properties; ++i)
                   if (selected_properties[i])
                     point_properties[pos_idx][i] = neighbor_props[i];
@@ -108,12 +98,7 @@ namespace aspect
                   {
                     // Only recursively call this function if the neighbor cell contains
                     // particles (else we end up in an endless recursion)
-                    if ((neighbors[i]->is_locally_owned())
-                        && (particles.count(std::make_pair(neighbors[i]->level(),neighbors[i]->index())) == 0))
-                      continue;
-                    else if ((!neighbors[i]->is_locally_owned())
-                             && (particle_postprocessor->get_particle_world().get_ghost_particles().count(
-                                   std::make_pair(neighbors[i]->level(),neighbors[i]->index())) == 0))
+                    if (particle_handler.n_particles_in_cell(neighbors[i]) == 0)
                       continue;
 
                     const double dist = (positions[pos_idx] - neighbors[i]->center()).norm_square();
@@ -124,7 +109,7 @@ namespace aspect
                       }
                   }
 
-                point_properties[pos_idx] = properties_at_points(particles,
+                point_properties[pos_idx] = properties_at_points(particle_handler,
                                                                  std::vector<Point<dim> > (1,positions[pos_idx]),
                                                                  selected_properties,
                                                                  neighbors[nearest_neighbor_cell])[0];

--- a/source/particle/output/ascii.cc
+++ b/source/particle/output/ascii.cc
@@ -44,7 +44,7 @@ namespace aspect
 
       template <int dim>
       std::string
-      ASCIIOutput<dim>::output_particle_data(const std::multimap<types::LevelInd, Particle<dim> > &particles,
+      ASCIIOutput<dim>::output_particle_data(const ParticleHandler<dim> &particle_handler,
                                              const Property::ParticlePropertyInformation &property_information,
                                              const double /*time*/)
       {
@@ -89,15 +89,15 @@ namespace aspect
         output << "\n";
 
         // And print the data for each particle
-        for (typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator it=particles.begin(); it!=particles.end(); ++it)
+        for (typename ParticleHandler<dim>::particle_iterator it=particle_handler.begin(); it!=particle_handler.end(); ++it)
           {
 
-            output << it->second.get_location();
-            output << ' ' << it->second.get_id();
+            output << it->get_location();
+            output << ' ' << it->get_id();
 
             if (property_information.n_fields() > 0)
               {
-                const ArrayView<const double> properties = it->second.get_properties();
+                const ArrayView<const double> properties = it->get_properties();
 
                 for (unsigned int i = 0; i < properties.size(); ++i)
                   output << ' ' << properties[i];

--- a/source/particle/output/hdf5.cc
+++ b/source/particle/output/hdf5.cc
@@ -74,7 +74,7 @@ namespace aspect
 
       template <int dim>
       std::string
-      HDF5Output<dim>::output_particle_data(const std::multimap<types::LevelInd, Particle<dim> > &particles,
+      HDF5Output<dim>::output_particle_data(const ParticleHandler<dim> &particle_handler,
                                             const Property::ParticlePropertyInformation &property_information,
                                             const double current_time)
       {
@@ -88,8 +88,8 @@ namespace aspect
         const std::string h5_filename = output_path_prefix+".h5";
 
         // Create the hdf5 output size information
-        types::particle_index n_local_particles = particles.size();
-        const types::particle_index n_global_particles = Utilities::MPI::sum(n_local_particles,this->get_mpi_communicator());
+        types::particle_index n_local_particles = particle_handler.n_locally_owned_particles();
+        const types::particle_index n_global_particles = particle_handler.n_global_particles();
 
         hsize_t global_dataset_size[2];
         global_dataset_size[0] = n_global_particles;
@@ -125,15 +125,15 @@ namespace aspect
           }
 
         // Write into the output vectors
-        typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator it = particles.begin();
-        for (unsigned int i = 0; it != particles.end(); ++i, ++it)
+        typename ParticleHandler<dim>::particle_iterator it = particle_handler.begin();
+        for (unsigned int i = 0; it != particle_handler.end(); ++i, ++it)
           {
             for (unsigned int d = 0; d < dim; ++d)
-              position_data[i*3+d] = it->second.get_location()(d);
+              position_data[i*3+d] = it->get_location()(d);
 
-            index_data[i] = it->second.get_id();
+            index_data[i] = it->get_id();
 
-            const ArrayView<const double> properties = it->second.get_properties();
+            const ArrayView<const double> properties = it->get_properties();
 
             unsigned int particle_property_index = 0;
 

--- a/source/particle/output/vtu.cc
+++ b/source/particle/output/vtu.cc
@@ -45,7 +45,7 @@ namespace aspect
 
       template <int dim>
       std::string
-      VTUOutput<dim>::output_particle_data(const std::multimap<types::LevelInd, Particle<dim> > &particles,
+      VTUOutput<dim>::output_particle_data(const ParticleHandler<dim> &particle_handler,
                                            const Property::ParticlePropertyInformation &property_information,
                                            const double current_time)
       {
@@ -65,7 +65,7 @@ namespace aspect
         std::ofstream output (full_filename.c_str());
         AssertThrow (output, ExcIO());
 
-        const unsigned int n_particles = particles.size();
+        const unsigned int n_particles = particle_handler.n_locally_owned_particles();
 
         // Write VTU file XML
         output << "<?xml version=\"1.0\"?>\n";
@@ -76,10 +76,10 @@ namespace aspect
         // Go through the particles on this domain and print the position of each one
         output << "      <Points>\n";
         output << "        <DataArray name=\"Position\" type=\"Float64\" NumberOfComponents=\"3\" Format=\"ascii\">\n";
-        for (typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator
-             it=particles.begin(); it!=particles.end(); ++it)
+        for (typename ParticleHandler<dim>::particle_iterator
+             it=particle_handler.begin(); it!=particle_handler.end(); ++it)
           {
-            output << "          " << it->second.get_location();
+            output << "          " << it->get_location();
 
             // pad with zeros since VTU format wants x/y/z coordinates
             for (unsigned int d=dim; d<3; ++d)
@@ -110,9 +110,9 @@ namespace aspect
         output << "      <PointData Scalars=\"scalars\">\n";
 
         output << "        <DataArray type=\"UInt64\" Name=\"id\" NumberOfComponents=\"1\" Format=\"ascii\">\n";
-        for (typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator
-             it=particles.begin(); it!=particles.end(); ++it)
-          output << "          " << it->second.get_id() << "\n" ;
+        for (typename ParticleHandler<dim>::particle_iterator
+             it=particle_handler.begin(); it!=particle_handler.end(); ++it)
+          output << "          " << it->get_id() << "\n" ;
 
         output << "        </DataArray>\n";
 
@@ -132,10 +132,10 @@ namespace aspect
                        << property_information.get_field_name_by_index(field_index)
                        << "\" NumberOfComponents=\"" << (n_components == 1 ? 1 : 3)
                        << "\" Format=\"ascii\">\n";
-                for (typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator
-                     it=particles.begin(); it!=particles.end(); ++it)
+                for (typename ParticleHandler<dim>::particle_iterator
+                     it=particle_handler.begin(); it!=particle_handler.end(); ++it)
                   {
-                    const ArrayView<const double> particle_data = it->second.get_properties();
+                    const ArrayView<const double> particle_data = it->get_properties();
 
                     output << "         ";
                     for (unsigned int d=0; d < n_components; ++d)
@@ -157,10 +157,10 @@ namespace aspect
                            << property_information.get_field_name_by_index(field_index) << '_' << d
                            << "\" NumberOfComponents=\"1"
                            << "\" Format=\"ascii\">\n";
-                    for (typename std::multimap<types::LevelInd, Particle<dim> >::const_iterator
-                         it=particles.begin(); it!=particles.end(); ++it)
+                    for (typename ParticleHandler<dim>::particle_iterator
+                         it=particle_handler.begin(); it!=particle_handler.end(); ++it)
                       {
-                        const ArrayView<const double> particle_data = it->second.get_properties();
+                        const ArrayView<const double> particle_data = it->get_properties();
 
                         output << particle_data[data_offset+d] << "\n";
                       }

--- a/source/particle/particle_accessor.cc
+++ b/source/particle/particle_accessor.cc
@@ -25,6 +25,15 @@ namespace aspect
   namespace Particle
   {
     template <int dim, int spacedim>
+    ParticleAccessor<dim,spacedim>::ParticleAccessor ()
+      :
+      map (NULL),
+      particle ()
+    {}
+
+
+
+    template <int dim, int spacedim>
     ParticleAccessor<dim,spacedim>::ParticleAccessor (const std::multimap<types::LevelInd, Particle<dim,spacedim> > &map,
                                                       const typename std::multimap<types::LevelInd, Particle<dim,spacedim> >::iterator &particle)
       :

--- a/source/particle/particle_handler.cc
+++ b/source/particle/particle_handler.cc
@@ -82,10 +82,19 @@ namespace aspect
     void
     ParticleHandler<dim,spacedim>::clear()
     {
-      particles.clear();
+      clear_particles();
       global_number_of_particles = 0;
       next_free_particle_index = 0;
       global_max_particles_per_cell = 0;
+    }
+
+
+
+    template <int dim,int spacedim>
+    void
+    ParticleHandler<dim,spacedim>::clear_particles()
+    {
+      particles.clear();
     }
 
 
@@ -128,12 +137,26 @@ namespace aspect
 
     template <int dim,int spacedim>
     typename ParticleHandler<dim,spacedim>::particle_iterator_range
+    ParticleHandler<dim,spacedim>::particle_range_in_cell(const active_cell_it &cell) const
+    {
+      return (const_cast<ParticleHandler<dim,spacedim> *> (this))->particle_range_in_cell(cell);
+    }
+
+
+
+    template <int dim,int spacedim>
+    typename ParticleHandler<dim,spacedim>::particle_iterator_range
     ParticleHandler<dim,spacedim>::particle_range_in_cell(const active_cell_it &cell)
     {
       const types::LevelInd level_index = std::make_pair<int, int> (cell->level(),cell->index());
-      const std::pair<typename std::multimap<types::LevelInd, Particle<dim,spacedim> >::iterator,
-            typename std::multimap<types::LevelInd, Particle<dim,spacedim> >::iterator> particles_in_cell
-            = particles.equal_range(level_index);
+
+      std::pair<typename std::multimap<types::LevelInd, Particle<dim,spacedim> >::iterator,
+          typename std::multimap<types::LevelInd, Particle<dim,spacedim> >::iterator> particles_in_cell;
+
+      if (!cell->is_ghost())
+        particles_in_cell = particles.equal_range(level_index);
+      else
+        particles_in_cell = ghost_particles.equal_range(level_index);
 
       return boost::make_iterator_range(particle_iterator(particles,particles_in_cell.first),
                                         particle_iterator(particles,particles_in_cell.second));
@@ -166,6 +189,15 @@ namespace aspect
           particle_it->get_properties()[n] = particle.get_properties()[n];
 
       return particle_it;
+    }
+
+
+
+    template <int dim,int spacedim>
+    void
+    ParticleHandler<dim,spacedim>::insert_particles(const std::multimap<types::LevelInd, Particle<dim,spacedim> > &new_particles)
+    {
+      particles = new_particles;
     }
 
 
@@ -216,6 +248,15 @@ namespace aspect
 
 
     template <int dim,int spacedim>
+    unsigned int
+    ParticleHandler<dim,spacedim>::n_properties_per_particle() const
+    {
+      return property_pool->n_properties_per_slot();
+    }
+
+
+
+    template <int dim,int spacedim>
     void
     ParticleHandler<dim,spacedim>::update_n_global_particles()
     {
@@ -229,7 +270,11 @@ namespace aspect
     ParticleHandler<dim,spacedim>::n_particles_in_cell(const typename Triangulation<dim,spacedim>::active_cell_iterator &cell) const
     {
       const types::LevelInd found_cell = std::make_pair<int, int> (cell->level(),cell->index());
-      return particles.count(found_cell);
+
+      if (!cell->is_ghost())
+        return particles.count(found_cell);
+      else
+        return ghost_particles.count(found_cell);
     }
 
 
@@ -901,7 +946,7 @@ namespace aspect
           for (unsigned int child_index=0; child_index<GeometryInfo<dim>::max_children_per_cell; ++child_index)
             {
               const typename parallel::distributed::Triangulation<dim,spacedim>::cell_iterator child = cell->child(child_index);
-              position_hints[child_index] = this->get_particles().upper_bound(std::make_pair(child->level(),child->index()));
+              position_hints[child_index] = particles.upper_bound(std::make_pair(child->level(),child->index()));
             }
 
           for (unsigned int i = 0; i < *n_particles_in_cell_ptr; ++i)

--- a/source/particle/particle_iterator.cc
+++ b/source/particle/particle_iterator.cc
@@ -25,6 +25,14 @@ namespace aspect
   namespace Particle
   {
     template <int dim, int spacedim>
+    ParticleIterator<dim,spacedim>::ParticleIterator ()
+      :
+      accessor ()
+    {}
+
+
+
+    template <int dim, int spacedim>
     ParticleIterator<dim,spacedim>::ParticleIterator (const std::multimap<types::LevelInd, Particle<dim,spacedim> > &map,
                                                       const typename std::multimap<types::LevelInd, Particle<dim,spacedim> >::iterator &particle)
       :
@@ -65,6 +73,15 @@ namespace aspect
     ParticleIterator<dim,spacedim>::operator ->() const
     {
       return &(this->operator* ());
+    }
+
+
+    template <int dim, int spacedim>
+    ParticleIterator<dim,spacedim> &
+    ParticleIterator<dim,spacedim>::operator =(const ParticleIterator &other)
+    {
+      accessor = other.accessor;
+      return *this;
     }
 
 

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -254,7 +254,7 @@ namespace aspect
 
       template <int dim>
       void
-      Manager<dim>::initialize_one_particle (Particle<dim> &particle) const
+      Manager<dim>::initialize_one_particle (typename ParticleHandler<dim>::particle_iterator &particle) const
       {
         if (property_information.n_components() == 0)
           return;
@@ -265,7 +265,7 @@ namespace aspect
         for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
              p = property_list.begin(); p!=property_list.end(); ++p)
           {
-            (*p)->initialize_one_particle_property(particle.get_location(),
+            (*p)->initialize_one_particle_property(particle->get_location(),
                                                    particle_properties);
           }
 
@@ -275,13 +275,13 @@ namespace aspect
                           "the property plugins. Check the selected property plugins for "
                           "consistency between reported size and actually set properties."));
 
-        particle.set_properties(particle_properties);
+        particle->set_properties(particle_properties);
       }
 
       template <int dim>
       std::vector<double>
       Manager<dim>::initialize_late_particle (const Point<dim> &particle_location,
-                                              const std::multimap<types::LevelInd, Particle<dim> > &particles,
+                                              const ParticleHandler<dim> &particle_handler,
                                               const Interpolator::Interface<dim> &interpolator,
                                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
       {
@@ -324,7 +324,7 @@ namespace aspect
                   else
                     found_cell = cell;
 
-                  const std::vector<std::vector<double> > interpolated_properties = interpolator.properties_at_points(particles,
+                  const std::vector<std::vector<double> > interpolated_properties = interpolator.properties_at_points(particle_handler,
                                                                                     std::vector<Point<dim> > (1,particle_location),
                                                                                     ComponentMask(property_information.n_components(),true),
                                                                                     found_cell);
@@ -345,7 +345,7 @@ namespace aspect
 
       template <int dim>
       void
-      Manager<dim>::update_one_particle (Particle<dim> &particle,
+      Manager<dim>::update_one_particle (typename ParticleHandler<dim>::particle_iterator &particle,
                                          const Vector<double> &solution,
                                          const std::vector<Tensor<1,dim> > &gradients) const
       {
@@ -354,10 +354,10 @@ namespace aspect
              p = property_list.begin(); p!=property_list.end(); ++p,++plugin_index)
           {
             (*p)->update_one_particle_property(property_information.get_position_by_plugin_index(plugin_index),
-                                               particle.get_location(),
+                                               particle->get_location(),
                                                solution,
                                                gradients,
-                                               particle.get_properties());
+                                               particle->get_properties());
           }
       }
 

--- a/source/particle/property_pool.cc
+++ b/source/particle/property_pool.cc
@@ -63,5 +63,11 @@ namespace aspect
     {
       (void)size;
     }
+
+    unsigned int
+    PropertyPool::n_properties_per_slot() const
+    {
+      return n_properties;
+    }
   }
 }

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -113,31 +113,6 @@ namespace aspect
     }
 
     template <int dim>
-    std::multimap<types::LevelInd, Particle<dim> > &
-    World<dim>::get_particles()
-    {
-      return particle_handler->get_particles();
-    }
-
-    template <int dim>
-    const std::multimap<types::LevelInd, Particle<dim> > &
-    World<dim>::get_particles() const
-    {
-      return particle_handler->get_particles();
-    }
-
-    template <int dim>
-    const std::multimap<types::LevelInd, Particle<dim> > &
-    World<dim>::get_ghost_particles() const
-    {
-      AssertThrow(update_ghost_particles == true,
-                  ExcMessage("A part of the model has requested access to the ghost "
-                             "particles, but the parameter 'Update ghost particles' has not "
-                             "been set, therefore no ghost particles are available."));
-      return particle_handler->get_ghost_particles();
-    }
-
-    template <int dim>
     std::string
     World<dim>::generate_output() const
     {
@@ -387,7 +362,7 @@ namespace aspect
                          (n_particles_in_cell > max_particles_per_cell))
                   {
                     const boost::iterator_range<typename ParticleHandler<dim>::particle_iterator> particles_in_cell
-                      = particle_handler->particle_range_in_cell(cell);
+                      = particle_handler->particles_in_cell(cell);
 
                     const unsigned int n_particles_to_remove = n_particles_in_cell - max_particles_per_cell;
 
@@ -718,12 +693,12 @@ namespace aspect
             if (cell->is_locally_owned())
               {
                 typename ParticleHandler<dim>::particle_iterator_range
-                particle_range_in_cell = particle_handler->particle_range_in_cell(cell);
+                particles_in_cell = particle_handler->particles_in_cell(cell);
 
                 // Only initialize particles, if there are any in this cell
-                if (particle_range_in_cell.begin() != particle_range_in_cell.end())
-                  local_initialize_particles(particle_range_in_cell.begin(),
-                                             particle_range_in_cell.end());
+                if (particles_in_cell.begin() != particles_in_cell.end())
+                  local_initialize_particles(particles_in_cell.begin(),
+                                             particles_in_cell.end());
               }
           if (update_ghost_particles &&
               dealii::Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) > 1)
@@ -753,13 +728,13 @@ namespace aspect
             if (cell->is_locally_owned())
               {
                 typename ParticleHandler<dim>::particle_iterator_range
-                particle_range_in_cell = particle_handler->particle_range_in_cell(cell);
+                particles_in_cell = particle_handler->particles_in_cell(cell);
 
                 // Only update particles, if there are any in this cell
-                if (particle_range_in_cell.begin() != particle_range_in_cell.end())
+                if (particles_in_cell.begin() != particles_in_cell.end())
                   local_update_particles(cell,
-                                         particle_range_in_cell.begin(),
-                                         particle_range_in_cell.end());
+                                         particles_in_cell.begin(),
+                                         particles_in_cell.end());
               }
         }
     }
@@ -781,13 +756,13 @@ namespace aspect
           if (cell->is_locally_owned())
             {
               const typename ParticleHandler<dim>::particle_iterator_range
-              particle_range_in_cell = particle_handler->particle_range_in_cell(cell);
+              particles_in_cell = particle_handler->particles_in_cell(cell);
 
               // Only advect particles, if there are any in this cell
-              if (particle_range_in_cell.begin() != particle_range_in_cell.end())
+              if (particles_in_cell.begin() != particles_in_cell.end())
                 local_advect_particles(cell,
-                                       particle_range_in_cell.begin(),
-                                       particle_range_in_cell.end());
+                                       particles_in_cell.begin(),
+                                       particles_in_cell.end());
             }
 
         // If particles fell out of the mesh, put them back in if they have crossed

--- a/source/postprocess/particle_count_statistics.cc
+++ b/source/postprocess/particle_count_statistics.cc
@@ -47,8 +47,8 @@ namespace aspect
                              "active postprocessors. You need to select this postprocessor to "
                              "be able to select the <particle count> visualization plugin."));
 
-      const std::multimap<aspect::Particle::types::LevelInd, aspect::Particle::Particle<dim> > &particles =
-        particle_postprocessor->get_particle_world().get_particles();
+      const Particle::ParticleHandler<dim> &particle_handler =
+        particle_postprocessor->get_particle_world().get_particle_handler();
 
       typename DoFHandler<dim>::active_cell_iterator
       cell = this->get_dof_handler().begin_active(),
@@ -62,9 +62,7 @@ namespace aspect
       for (; cell!=endc; ++cell)
         if (cell->is_locally_owned())
           {
-            const aspect::Particle::types::LevelInd current_cell (cell->level(),cell->index());
-
-            const unsigned int particles_in_cell = particles.count(current_cell);
+            const unsigned int particles_in_cell = particle_handler.n_particles_in_cell(cell);
             local_min_particles = std::min(local_min_particles,particles_in_cell);
             local_max_particles = std::max(local_max_particles,particles_in_cell);
           }

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -37,7 +37,7 @@ namespace aspect
     {
       template<int dim>
       void
-      ParticleOutput<dim>::build_patches(const std::multimap<aspect::Particle::types::LevelInd, aspect::Particle::Particle<dim> > &particles,
+      ParticleOutput<dim>::build_patches(const Particle::ParticleHandler<dim> &particle_handler,
                                          const aspect::Particle::Property::ParticlePropertyInformation &property_information)
       {
         // First store the names of the data fields
@@ -77,22 +77,22 @@ namespace aspect
 
 
         // Third build the actual patch data
-        patches.resize(particles.size());
+        patches.resize(particle_handler.n_locally_owned_particles());
 
-        typename std::multimap<aspect::Particle::types::LevelInd, aspect::Particle::Particle<dim> >::const_iterator particle = particles.begin();
+        typename ParticleHandler<dim>::particle_iterator particle = particle_handler.begin();
 
-        for (unsigned int i=0; particle != particles.end(); ++particle, ++i)
+        for (unsigned int i=0; particle != particle_handler.end(); ++particle, ++i)
           {
-            patches[i].vertices[0] = particle->second.get_location();
+            patches[i].vertices[0] = particle->get_location();
             patches[i].patch_index = i;
             patches[i].n_subdivisions = 1;
             patches[i].data.reinit(property_information.n_components()+1,1);
 
-            patches[i].data(0,0) = particle->second.get_id();
+            patches[i].data(0,0) = particle->get_id();
 
-            if (particle->second.has_properties())
+            if (particle->has_properties())
               {
-                const ArrayView<const double> properties = particle->second.get_properties();
+                const ArrayView<const double> properties = particle->get_properties();
                 for (unsigned int property_index = 0; property_index < properties.size(); ++property_index)
                   patches[i].data(property_index+1,0) = properties[property_index];
               }
@@ -346,7 +346,7 @@ namespace aspect
 
       // Create the particle output
       internal::ParticleOutput<dim> data_out;
-      data_out.build_patches(world.get_particles(),
+      data_out.build_patches(world.get_particle_handler(),
                              world.get_property_manager().get_data_info());
 
       // Now prepare everything for writing the output and choose output format

--- a/source/postprocess/visualization/particle_count.cc
+++ b/source/postprocess/visualization/particle_count.cc
@@ -43,8 +43,8 @@ namespace aspect
                                "active postprocessors. You need to select this postprocessor to "
                                "be able to select the <particle count> visualization plugin."));
 
-        const std::multimap<aspect::Particle::types::LevelInd, aspect::Particle::Particle<dim> > &particles =
-          particle_postprocessor->get_particle_world().get_particles();
+        const Particle::ParticleHandler<dim> &particle_handler =
+          particle_postprocessor->get_particle_world().get_particle_handler();
 
         std::pair<std::string, Vector<float> *>
         return_value ("particles_per_cell",
@@ -59,9 +59,7 @@ namespace aspect
         for (; cell!=endc; ++cell,++cell_index)
           if (cell->is_locally_owned())
             {
-              const aspect::Particle::types::LevelInd current_cell (cell->level(),cell->index());
-
-              (*return_value.second)(cell_index) = static_cast<float> (particles.count(current_cell));
+              (*return_value.second)(cell_index) = static_cast<float> (particle_handler.n_particles_in_cell(cell));
             }
 
         return return_value;

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -219,7 +219,6 @@ namespace aspect
     AssertThrow(particle_postprocessor != 0,
                 ExcMessage("Did not find the <particles> postprocessor when trying to interpolate particle properties."));
 
-    const std::multimap<aspect::Particle::types::LevelInd, Particle::Particle<dim> > *particles = &particle_postprocessor->get_particle_world().get_particles();
     const Particle::Interpolator::Interface<dim> *particle_interpolator = &particle_postprocessor->get_particle_world().get_interpolator();
     const Particle::Property::Manager<dim> *particle_property_manager = &particle_postprocessor->get_particle_world().get_property_manager();
 
@@ -272,7 +271,10 @@ namespace aspect
           property_mask.set(particle_property,true);
 
           const std::vector<std::vector<double> > particle_properties =
-            particle_interpolator->properties_at_points(*particles,quadrature_points,property_mask,cell);
+            particle_interpolator->properties_at_points(particle_postprocessor->get_particle_world().get_particle_handler(),
+                                                        quadrature_points,
+                                                        property_mask,
+                                                        cell);
 
           // go through the composition dofs and set their global values
           // to the particle field interpolated at these points


### PR DESCRIPTION
This is the next step towards #1897. I adjust all ASPECT interfaces to only use functionality that does not expose the internal data structure of `ParticleHandler`. After this PR the new particle classes should be ready to move to deal.II.