### PR TITLE
Fix for deal 90 pre

### DIFF
--- a/source/particle/particle_accessor.cc
+++ b/source/particle/particle_accessor.cc
@@ -128,6 +128,18 @@ namespace aspect
 
 
     template <int dim, int spacedim>
+    bool
+    ParticleAccessor<dim,spacedim>::has_properties () const
+    {
+      Assert(particle != map->end(),
+             ExcInternalError());
+
+      return particle->second.has_properties();
+    }
+
+
+
+    template <int dim, int spacedim>
     void
     ParticleAccessor<dim,spacedim>::set_properties (const std::vector<double> &new_properties)
     {

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -79,7 +79,7 @@ namespace aspect
         // Third build the actual patch data
         patches.resize(particle_handler.n_locally_owned_particles());
 
-        typename ParticleHandler<dim>::particle_iterator particle = particle_handler.begin();
+        typename Particle::ParticleHandler<dim>::particle_iterator particle = particle_handler.begin();
 
         for (unsigned int i=0; particle != particle_handler.end(); ++particle, ++i)
           {


### PR DESCRIPTION
I did not test #1929 for deal.II 9.0.pre. Turns out some code that is only included for 9.0pre does not compile :worried:. This PR fixes that.

I would appreciate if somebody could soon merge this, before too many people notice :smile:.