### PR TITLE
Fix particle hdf5 output compling on a machine which has no hdf5 installed

### DIFF
--- a/source/particle/output/hdf5.cc
+++ b/source/particle/output/hdf5.cc
@@ -293,7 +293,7 @@ namespace aspect
         return output_path_prefix;
 #else
         (void) property_information;
-        (void) particles;
+        (void) particle_handler;
         (void) current_time;
         return "";
 #endif


### PR DESCRIPTION
@gassmoeller I noticed that I could not longer compile my code with the newest version of aspect and deal.ii with the following error message:

```
aspect/source/particle/output/hdf5.cc: In member function ‘virtual std::__cxx11::string aspect::Particle::Output::HDF5Output<dim>::output_particle_data(const aspect::Particle::ParticleHandler<dim>&, const aspect::Particle::Property::ParticlePropertyInformation&, double)’:
aspect/source/particle/output/hdf5.cc:296:16: error: ‘particles’ was not declared in this scope
         (void) particles;
```

This patch makes it compile again. It seems like is a left over from the change in the interface, but since I am not really familiar with this code it might be not be the best fix. 