### PR TITLE
Fix some warnings and a bug

### DIFF
--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -310,7 +310,7 @@ namespace aspect
     BoundaryTemperatureType *
     Manager<dim>::find_boundary_temperature_model () const
     {
-      for (typename std::list<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
+      for (typename std::vector<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
            p = boundary_temperature_objects.begin();
            p != boundary_temperature_objects.end(); ++p)
         if (BoundaryTemperatureType *x = dynamic_cast<BoundaryTemperatureType *> ( (*p).get()) )

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -43,7 +43,7 @@ namespace aspect
     double
     DynamicCore<dim>::
     boundary_temperature (const types::boundary_id            boundary_indicator,
-                          const Point<dim>                    &location) const
+                          const Point<dim>                    &/*location*/) const
     {
       const GeometryModel::Interface<dim> *geometry_model = &this->get_geometry_model();
       // verify that the geometry is in fact a spherical shell since only
@@ -70,7 +70,7 @@ namespace aspect
     template <int dim>
     double
     DynamicCore<dim>::
-    minimal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids) const
+    minimal_temperature (const std::set<types::boundary_id> &/*fixed_boundary_ids*/) const
     {
       return std::min (inner_temperature, outer_temperature);
     }
@@ -80,7 +80,7 @@ namespace aspect
     template <int dim>
     double
     DynamicCore<dim>::
-    maximal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids) const
+    maximal_temperature (const std::set<types::boundary_id> &/*fixed_boundary_ids*/) const
     {
       return std::max (inner_temperature, outer_temperature);
     }
@@ -480,6 +480,8 @@ namespace aspect
                            <<"Q_CMB="<<core_data.Q<<std::endl;
           AssertThrow(false, ExcMessage("[Dynamic core] No inner core radius solution found!"));
         }
+
+      return false;
     }
 
     template <int dim>

--- a/source/postprocess/core_statistics.cc
+++ b/source/postprocess/core_statistics.cc
@@ -45,11 +45,14 @@ namespace aspect
       // now add all of the computed heat fluxes to the statistics object
       // and create a single string that can be output to the screen
       std::ostringstream screen_text;
+
       const BoundaryTemperature::DynamicCore<dim> *dynamic_core =
-        dynamic_cast<const BoundaryTemperature::DynamicCore<dim>*> (&(SimulatorAccess<dim>::get_boundary_temperature()));
-      AssertThrow (dynamic_core != NULL
-                   !=0,
-                   ExcMessage ("Core statistics has to be working with dynamic core boundary conditions."));
+        this->get_boundary_temperature_manager().template find_boundary_temperature_model<BoundaryTemperature::DynamicCore<dim> >();
+
+      AssertThrow(dynamic_core != NULL,
+                  ExcMessage("Could not find the dynamic core temperature boundary conditions. "
+                             "Perhaps you forgot to include it?"));
+
       core_data = dynamic_core->get_core_data();
 
       // now add core mantle boundary heat flux to the statistics object


### PR DESCRIPTION
This PR fixes some compiler and deprecation warnings that were introduced in #1882. These fixes reveal a bug in `BoundaryTemperature::Manager::find_boundary_temperature_model` that was introduced by me in #1771. The bug was never discovered, because it was in a template function that was not instantiated until now. Fixed now.