### PR TITLE
optimalisation of compute current constraints in the Newton solver.

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -2308,7 +2308,8 @@ namespace aspect
                                     linearized_stokes_initial_guess,
                                     current_linearization_point);
 
-              compute_current_constraints ();
+              if (nonlinear_iteration <= 1)
+                compute_current_constraints ();
 
               // the Stokes matrix depends on the viscosity. if the viscosity
               // depends on other solution variables, then after we need to


### PR DESCRIPTION
I noticed that I forgot to put this optimalisation into the newton solver. This saves a lot of runtime on bigger models on many mpi processes.

In contrast with the Picard type solver, which only needs to compute the constraints once, in the Newton solver, the first iteration and second iteration have different values because of the velocity boundary conditions. After the second iteration they stay the same, so we don't need to recompute.