### PR TITLE
Add support for natural coordinates to geometry models

### DIFF
--- a/include/aspect/coordinate_systems.h
+++ b/include/aspect/coordinate_systems.h
@@ -1,0 +1,53 @@
+/*
+  Copyright (C) 2018 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _aspect_coordinate_sytems_h
+#define _aspect_coordinate_sytems_h
+
+namespace aspect
+{
+  namespace Utilities
+  {
+    namespace Coordinates
+    {
+      /**
+       * This enum lists available coordinate systems that can be used for
+       * the function variables. Allowed values are 'cartesian',
+       * 'spherical', and 'depth'. 'spherical' coordinates follow: r, phi
+       * (2D) or r, phi, theta (3D); where r is radius, phi is longitude,
+       * and theta is the polar angle (colatitude). The 'depth' is a
+       * one-dimensional coordinate system in which only the distance
+       * below the 'top' surface (depth) as defined by each geometry model,
+       * is used.
+       */
+      enum CoordinateSystem
+      {
+        depth,
+        cartesian,
+        spherical,
+        ellipsoidal,
+        invalid
+      };
+    }
+  }
+}
+
+#endif
+

--- a/include/aspect/geometry_model/box.h
+++ b/include/aspect/geometry_model/box.h
@@ -176,6 +176,29 @@ namespace aspect
         bool
         point_is_in_domain(const Point<dim> &p) const;
 
+        /*
+         * Returns what the natural coordinate system for this geometry model is,
+         * which for a box is Cartesian.
+         */
+        virtual
+        aspect::Utilities::Coordinates::CoordinateSystem natural_coordinate_system() const;
+
+        /**
+         * Takes the Cartesian points (x,z or x,y,z) and returns standardized
+         * coordinates which are most 'natural' to the geometry model. For a box
+         * the results is unchanged and is (x,z) in 2d or (x,y,z) in 3d.
+         */
+        virtual
+        std_cxx11::array<double,dim> cartesian_to_natural_coordinates(const Point<dim> &position) const;
+
+        /**
+         * Undoes the action of cartesian_to_natural_coordinates, and turns the
+         * coordinate system which is most 'natural' to the geometry model into
+         * Cartesian coordinates.
+         */
+        virtual
+        Point<dim> natural_to_cartesian_coordinates(const std_cxx11::array<double,dim> &position) const;
+
         /**
          * Declare the parameters this class takes through input files.
          */

--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -225,6 +225,29 @@ namespace aspect
         bool
         point_is_in_domain(const Point<dim> &p) const;
 
+        /*
+         * Returns what the natural coordinate system for this geometry model is,
+         * which for a chunk is Spherical.
+         */
+        virtual
+        aspect::Utilities::Coordinates::CoordinateSystem natural_coordinate_system() const;
+
+        /**
+         * Takes the Cartesian points (x,z or x,y,z) and returns standardized
+         * coordinates which are most 'natural' to the geometry model. For a chunk
+         * this is (radius, longitude) in 2d and (radius, longitude, latitude) in 3d.
+         */
+        virtual
+        std_cxx11::array<double,dim> cartesian_to_natural_coordinates(const Point<dim> &position) const;
+
+        /**
+         * Undoes the action of cartesian_to_natural_coordinates, and turns the
+         * coordinate system which is most 'natural' to the geometry model into
+         * Cartesian coordinates.
+         */
+        virtual
+        Point<dim> natural_to_cartesian_coordinates(const std_cxx11::array<double,dim> &position) const;
+
         /**
          * Declare the parameters this class takes through input files.
          */

--- a/include/aspect/geometry_model/ellipsoidal_chunk.h
+++ b/include/aspect/geometry_model/ellipsoidal_chunk.h
@@ -239,6 +239,31 @@ namespace aspect
         virtual std::map<std::string,types::boundary_id>
         get_symbolic_boundary_names_map() const;
 
+        /*
+         * Returns what the natural coordinate system for this geometry model is,
+         * which for a Ellipsoidal chunk is Ellisoidal.
+         */
+        virtual
+        aspect::Utilities::Coordinates::CoordinateSystem natural_coordinate_system() const;
+
+        /**
+         * Takes the Cartesian points (x,z or x,y,z) and returns standardized
+         * coordinates which are most 'natural' to the geometry model. For a
+         * ellispoidal chunk this is (radius, longitude) in 2d and (radius,
+         * longitude, latitude) in 3d. Note that internally the coordinates are
+         * stored in longitude, latitude, depth.
+         */
+        virtual
+        std_cxx11::array<double,dim> cartesian_to_natural_coordinates(const Point<dim> &position) const;
+
+        /**
+         * Undoes the action of cartesian_to_natural_coordinates, and turns the
+         * coordinate system which is most 'natural' to the geometry model into
+         * Cartesian coordinates.
+         */
+        virtual
+        Point<dim> natural_to_cartesian_coordinates(const std_cxx11::array<double,dim> &position) const;
+
         /**
          * Declare the parameters this class takes through input files.
          */

--- a/include/aspect/geometry_model/interface.h
+++ b/include/aspect/geometry_model/interface.h
@@ -26,6 +26,8 @@
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/distributed/tria.h>
 #include <deal.II/base/std_cxx11/array.h>
+#include <aspect/utilities.h>
+#include <aspect/coordinate_systems.h>
 
 #include <set>
 
@@ -141,6 +143,13 @@ namespace aspect
         */
         virtual
         double height_above_reference_surface(const Point<dim> &position) const = 0;
+
+
+        /**
+         * Returns what the natural coordinate system for this geometry model is.
+         */
+        virtual
+        aspect::Utilities::Coordinates::CoordinateSystem natural_coordinate_system() const = 0;
 
         /**
          * Takes the Cartesian points (x,z or x,y,z) and returns standardized

--- a/include/aspect/geometry_model/sphere.h
+++ b/include/aspect/geometry_model/sphere.h
@@ -108,6 +108,13 @@ namespace aspect
         bool
         has_curved_elements() const;
 
+        /*
+         * Returns what the natural coordinate system for this geometry model is,
+         * which for a sphere is Spherical.
+         */
+        virtual
+        aspect::Utilities::Coordinates::CoordinateSystem natural_coordinate_system() const;
+
         /**
          * Return whether the given point lies within the domain specified
          * by the geometry. This function does not take into account

--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -140,6 +140,13 @@ namespace aspect
         bool
         point_is_in_domain(const Point<dim> &p) const;
 
+        /*
+         * Returns what the natural coordinate system for this geometry model is,
+         * which for a spherical shell is Spherical.
+         */
+        virtual
+        aspect::Utilities::Coordinates::CoordinateSystem natural_coordinate_system() const;
+
         /**
          * Declare the parameters this class takes through input files. The
          * default implementation of this function does not describe any

--- a/include/aspect/geometry_model/two_merged_boxes.h
+++ b/include/aspect/geometry_model/two_merged_boxes.h
@@ -149,6 +149,29 @@ namespace aspect
         bool
         point_is_in_domain(const Point<dim> &p) const;
 
+        /*
+         * Returns what the natural coordinate system for this geometry model is,
+         * which for two merged boxex is Cartesian.
+         */
+        virtual
+        aspect::Utilities::Coordinates::CoordinateSystem natural_coordinate_system() const;
+
+        /**
+         * Takes the Cartesian points (x,z or x,y,z) and returns standardized
+         * coordinates which are most 'natural' to the geometry model. For a box
+         * the results is unchanged and is (x,z) in 2d or (x,y,z) in 3d.
+         */
+        virtual
+        std_cxx11::array<double,dim> cartesian_to_natural_coordinates(const Point<dim> &position) const;
+
+        /**
+         * Undoes the action of cartesian_to_natural_coordinates, and turns the
+         * coordinate system which is most 'natural' to the geometry model into
+         * Cartesian coordinates.
+         */
+        virtual
+        Point<dim> natural_to_cartesian_coordinates(const std_cxx11::array<double,dim> &position) const;
+
         /**
          * Declare the parameters this class takes through input files.
          */

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -33,12 +33,18 @@
 #include <deal.II/fe/component_mask.h>
 
 #include <aspect/geometry_model/interface.h>
+#include <aspect/coordinate_systems.h>
 
 
 
 namespace aspect
 {
   template <int dim> class SimulatorAccess;
+
+  namespace GeometryModel
+  {
+    template <int dim> class Interface;
+  }
 
   /**
    * A namespace for utility functions that might be used in many different
@@ -160,24 +166,6 @@ namespace aspect
       ellipsoidal_to_cartesian_coordinates(const std_cxx11::array<double,3> &phi_theta_d,
                                            const double semi_major_axis_a,
                                            const double eccentricity);
-
-      /**
-       * This enum lists available coordinate systems that can be used for
-       * the function variables. Allowed values are 'cartesian',
-       * 'spherical', and 'depth'. 'spherical' coordinates follow: r, phi
-       * (2D) or r, phi, theta (3D); where r is radius, phi is longitude,
-       * and theta is the polar angle (colatitude). The 'depth' is a
-       * one-dimensional coordinate system in which only the distance
-       * below the 'top' surface (depth) as defined by each geometry model,
-       * is used.
-       */
-      enum CoordinateSystem
-      {
-        depth,
-        cartesian,
-        spherical,
-        invalid
-      };
 
 
       /**
@@ -1069,6 +1057,45 @@ namespace aspect
     template <int dim>
     SymmetricTensor<2,dim> nth_basis_for_symmetric_tensors (const unsigned int k);
 
+    /*
+    * A class that represents a point in a chosen coordinate system.
+    */
+    template <int dim>
+    class NaturalCoordinate
+    {
+      public:
+        /**
+         * Constructor based on providing the geometry model as a pointer
+         */
+        NaturalCoordinate(Point<dim> &position,
+                          const GeometryModel::Interface<dim> &geometry_model);
+
+        /**
+        * Returns the coordinates in the given coordinate system, which may not be Cartesian.
+        */
+        std_cxx11::array<double,dim> &get_coordinates();
+
+        /**
+        * The coordinate that represents the 'surface' directions in the chosen coordinate system.
+        **/
+        std_cxx11::array<double,dim-1> get_surface_coordinates() const;
+
+        /**
+        * The coordinate that represents the 'depth' direction in the chosen coordinate system.
+        **/
+        double get_depth_coordinate() const;
+
+      private:
+        /**
+         * An enum which stores the the coordinate system of this natural point
+         */
+        Utilities::Coordinates::CoordinateSystem coordinate_system;
+
+        /**
+         * An array which stores the coordinates in the coordinates system
+         */
+        std::array<double,dim> coordinates;
+    };
   }
 }
 

--- a/source/geometry_model/box.cc
+++ b/source/geometry_model/box.cc
@@ -279,6 +279,37 @@ namespace aspect
     }
 
     template <int dim>
+    std_cxx11::array<double,dim>
+    Box<dim>::cartesian_to_natural_coordinates(const Point<dim> &position_point) const
+    {
+      std::array<double,dim> position_array;
+      for (unsigned int i = 0; i < dim; i++)
+        position_array[i] = position_point(i);
+
+      return position_array;
+    }
+
+
+    template <int dim>
+    aspect::Utilities::Coordinates::CoordinateSystem
+    Box<dim>::natural_coordinate_system() const
+    {
+      return aspect::Utilities::Coordinates::CoordinateSystem::cartesian;
+    }
+
+
+    template <int dim>
+    Point<dim>
+    Box<dim>::natural_to_cartesian_coordinates(const std_cxx11::array<double,dim> &position_tensor) const
+    {
+      Point<dim> position_point;
+      for (unsigned int i = 0; i < dim; i++)
+        position_point[i] = position_tensor[i];
+
+      return position_point;
+    }
+
+    template <int dim>
     void
     Box<dim>::
     declare_parameters (ParameterHandler &prm)

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -559,6 +559,43 @@ namespace aspect
     }
 
     template <int dim>
+    std_cxx11::array<double,dim>
+    Chunk<dim>::cartesian_to_natural_coordinates(const Point<dim> &position_point) const
+    {
+      // the chunk manifold has a order of radius, longitude, latitude.
+      // This is exactly what we need.
+      const Point<dim> transformed_point = manifold.pull_back(position_point);
+      std::array<double,dim> position_array;
+      for (unsigned int i = 0; i < dim; i++)
+        position_array[i] = transformed_point(i);
+
+      return position_array;
+    }
+
+
+    template <int dim>
+    aspect::Utilities::Coordinates::CoordinateSystem
+    Chunk<dim>::natural_coordinate_system() const
+    {
+      return aspect::Utilities::Coordinates::CoordinateSystem::spherical;
+    }
+
+
+
+    template <int dim>
+    Point<dim>
+    Chunk<dim>::natural_to_cartesian_coordinates(const std_cxx11::array<double,dim> &position_tensor) const
+    {
+      Point<dim> position_point;
+      for (unsigned int i = 0; i < dim; i++)
+        position_point[i] = position_tensor[i];
+      const Point<dim> transformed_point = manifold.push_forward(position_point);
+
+      return transformed_point;
+    }
+
+
+    template <int dim>
     void
     Chunk<dim>::
     declare_parameters (ParameterHandler &prm)

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -50,7 +50,8 @@ namespace aspect
       semi_major_axis_a (-1),
       eccentricity (-1),
       semi_minor_axis_b (-1),
-      bottom_depth (-1)
+      bottom_depth (-1),
+      topography(NULL)
     {}
 
     // Copy constructor
@@ -103,7 +104,6 @@ namespace aspect
     EllipsoidalChunk<dim>::EllipsoidalChunkGeometry::pull_back_ellipsoid(const Point<3> &x, const double semi_major_axis_a, const double eccentricity) const
     {
       AssertThrow (dim == 3,ExcMessage ("This can currently only be used in 3d."));
-
       const double R    = semi_major_axis_a;
       const double b      = std::sqrt(R * R * (1 - eccentricity * eccentricity));
       const double ep     = std::sqrt((R * R - b * b) / (b * b));
@@ -128,13 +128,12 @@ namespace aspect
     EllipsoidalChunk<dim>::EllipsoidalChunkGeometry::push_forward_topography(const Point<3> &phi_theta_d_hat) const
     {
       AssertThrow (dim == 3,ExcMessage ("This can currently only be used in 3d."));
-
       const double d_hat = phi_theta_d_hat[2]; // long, lat, depth
       Point<dim-1> phi_theta;
       const double rad_to_degree = 180/numbers::PI;
       if (dim == 3)
         phi_theta = Point<dim-1>(phi_theta_d_hat[0] * rad_to_degree,phi_theta_d_hat[1] * rad_to_degree);
-      const double h = topography->value(phi_theta);
+      const double h = topography != NULL ? topography->value(phi_theta) : 0;
       const double d = d_hat + (d_hat + bottom_depth)/bottom_depth*h;
       const Point<3> phi_theta_d (phi_theta_d_hat[0],
                                   phi_theta_d_hat[1],
@@ -147,13 +146,12 @@ namespace aspect
     EllipsoidalChunk<dim>::EllipsoidalChunkGeometry::pull_back_topography(const Point<3> &phi_theta_d) const
     {
       AssertThrow (dim == 3,ExcMessage ("This can currently only be used in 3d."));
-
       const double d = phi_theta_d[2];
       const double rad_to_degree = 180/numbers::PI;
       Point<dim-1> phi_theta;
       if (dim == 3)
         phi_theta = Point<dim-1>(phi_theta_d[0] * rad_to_degree,phi_theta_d[1] * rad_to_degree);
-      const double h = topography->value(phi_theta);
+      const double h = topography != NULL ? topography->value(phi_theta) : 0;
       const double d_hat = bottom_depth * (d-h)/(bottom_depth+h);
       const Point<3> phi_theta_d_hat (phi_theta_d[0],
                                       phi_theta_d[1],
@@ -733,6 +731,57 @@ namespace aspect
 
       return true;
     }
+
+    template <int dim>
+    std_cxx11::array<double,dim>
+    EllipsoidalChunk<dim>::cartesian_to_natural_coordinates(const Point<dim> &position_point) const
+    {
+      Assert(dim == 3,ExcMessage("This geometry model doesn't support 2d."));
+      // the chunk manifold works internally with a vector with longitude, latitude, depth.
+      // We need to output radius, longitude, latitude to be consistent.
+
+      Point<dim> transformed_point = manifold.pull_back(position_point);
+
+      const double radius = get_radius(position_point);
+      std::array<double,dim> position_array;
+      position_array[0] = radius + transformed_point(2);
+      position_array[1] = transformed_point(1);
+      position_array[2] = transformed_point(0);
+
+      return position_array;
+    }
+
+
+    template <int dim>
+    aspect::Utilities::Coordinates::CoordinateSystem
+    EllipsoidalChunk<dim>::natural_coordinate_system() const
+    {
+      return aspect::Utilities::Coordinates::CoordinateSystem::ellipsoidal;
+    }
+
+
+
+    template <int dim>
+    Point<dim>
+    EllipsoidalChunk<dim>::natural_to_cartesian_coordinates(const std_cxx11::array<double,dim> &position_tensor) const
+    {
+      Assert(dim == 3,ExcMessage("This geometry model doesn't support 2d."));
+
+      // We receive radius, longitude, latitude and we need to turn it first back into
+      // longitude, latitude, depth for internal use, and push_forward to cartesian coordiantes.
+      Point<3> position_point;
+      position_point(0) = position_tensor[2];
+      position_point(1) = position_tensor[1];
+
+      const double radius = semi_major_axis_a / (std::sqrt(1 - eccentricity * eccentricity * std::sin(position_point(1)) * std::sin(position_point(1))));
+      position_point(2) = position_tensor[0] - radius;
+
+      Point<3> transformed_point = manifold.push_forward(position_point);
+      Point<3> double_transformed_point = manifold.pull_back(transformed_point);
+
+      return reinterpret_cast<Point<dim>&>(transformed_point);
+    }
+
   }
 }
 

--- a/source/geometry_model/sphere.cc
+++ b/source/geometry_model/sphere.cc
@@ -154,6 +154,14 @@ namespace aspect
     }
 
 
+    template <int dim>
+    aspect::Utilities::Coordinates::CoordinateSystem
+    Sphere<dim>::natural_coordinate_system() const
+    {
+      return aspect::Utilities::Coordinates::CoordinateSystem::spherical;
+    }
+
+
 
     template <int dim>
     void

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -357,6 +357,15 @@ namespace aspect
       return true;
     }
 
+
+    template <int dim>
+    aspect::Utilities::Coordinates::CoordinateSystem
+    SphericalShell<dim>::natural_coordinate_system() const
+    {
+      return aspect::Utilities::Coordinates::CoordinateSystem::spherical;
+    }
+
+
     template <int dim>
     void
     SphericalShell<dim>::declare_parameters (ParameterHandler &prm)

--- a/source/geometry_model/two_merged_boxes.cc
+++ b/source/geometry_model/two_merged_boxes.cc
@@ -292,6 +292,39 @@ namespace aspect
     }
 
 
+    template <int dim>
+    aspect::Utilities::Coordinates::CoordinateSystem
+    TwoMergedBoxes<dim>::natural_coordinate_system() const
+    {
+      return aspect::Utilities::Coordinates::CoordinateSystem::cartesian;
+    }
+
+
+    template <int dim>
+    std_cxx11::array<double,dim>
+    TwoMergedBoxes<dim>::cartesian_to_natural_coordinates(const Point<dim> &position_point) const
+    {
+      std::array<double,dim> position_array;
+      for (unsigned int i = 0; i < dim; i++)
+        position_array[i] = position_point(i);
+
+      return position_array;
+    }
+
+
+
+    template <int dim>
+    Point<dim>
+    TwoMergedBoxes<dim>::natural_to_cartesian_coordinates(const std_cxx11::array<double,dim> &position_tensor) const
+    {
+      Point<dim> position_point;
+      for (unsigned int i = 0; i < dim; i++)
+        position_point[i] = position_tensor[i];
+
+      return position_point;
+    }
+
+
 
     template <int dim>
     void

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2532,6 +2532,7 @@ namespace aspect
     }
 
 
+
     template <int dim>
     SymmetricTensor<2,dim>
     nth_basis_for_symmetric_tensors (const unsigned int k)
@@ -2545,6 +2546,98 @@ namespace aspect
       result[indices_ij] = 1;
 
       return symmetrize(result);
+    }
+
+    template <int dim>
+    NaturalCoordinate<dim>::NaturalCoordinate(Point<dim> &position,
+                                              const GeometryModel::Interface<dim> &geometry_model)
+    {
+      coordinate_system = geometry_model.natural_coordinate_system();
+      coordinates = geometry_model.cartesian_to_natural_coordinates(position);
+    }
+
+    template <int dim>
+    std_cxx11::array<double,dim> &NaturalCoordinate<dim>::get_coordinates()
+    {
+      return coordinates;
+    }
+
+    template <>
+    std_cxx11::array<double,1> NaturalCoordinate<2>::get_surface_coordinates() const
+    {
+      std_cxx11::array<double,1> coordinate;
+
+      switch (coordinate_system)
+        {
+          case Coordinates::CoordinateSystem::cartesian:
+            coordinate[0] = coordinates[0];
+            break;
+
+          case Coordinates::CoordinateSystem::spherical:
+            coordinate[0] = coordinates[1];
+            break;
+
+          case Coordinates::CoordinateSystem::ellipsoidal:
+            coordinate[0] = coordinates[1];
+            break;
+
+          default:
+            coordinate[0] = 0;
+            Assert (false, ExcNotImplemented());
+            break;
+        }
+
+      return coordinate;
+    }
+
+    template <>
+    std_cxx11::array<double,2> NaturalCoordinate<3>::get_surface_coordinates() const
+    {
+      std_cxx11::array<double,2> coordinate;
+
+      switch (coordinate_system)
+        {
+          case Coordinates::CoordinateSystem::cartesian:
+            coordinate[0] = coordinates[0];
+            coordinate[1] = coordinates[1];
+            break;
+
+          case Coordinates::CoordinateSystem::spherical:
+            coordinate[0] = coordinates[1];
+            coordinate[1] = coordinates[2];
+            break;
+
+          case Coordinates::CoordinateSystem::ellipsoidal:
+            coordinate[0] = coordinates[1];
+            coordinate[1] = coordinates[2];
+            break;
+
+          default:
+            Assert (false, ExcNotImplemented());
+        }
+
+      return coordinate;
+    }
+
+    template <int dim>
+    double NaturalCoordinate<dim>::get_depth_coordinate() const
+    {
+      switch (coordinate_system)
+        {
+          case Coordinates::CoordinateSystem::cartesian:
+            return coordinates[dim-1];
+
+          case Coordinates::CoordinateSystem::spherical:
+            return coordinates[0];
+
+          case Coordinates::CoordinateSystem::ellipsoidal:
+            return coordinates[0];
+
+          default:
+            Assert (false, ExcNotImplemented());
+        }
+
+      return 0;
     }
 
 
@@ -2635,5 +2728,7 @@ namespace aspect
     template SymmetricTensor<2,2> nth_basis_for_symmetric_tensors (const unsigned int k);
     template SymmetricTensor<2,3> nth_basis_for_symmetric_tensors (const unsigned int k);
 
+    template class NaturalCoordinate<2>;
+    template class NaturalCoordinate<3>;
   }
 }

--- a/tests/natural_coordinates_conversion.cc
+++ b/tests/natural_coordinates_conversion.cc
@@ -1,0 +1,197 @@
+#include <aspect/geometry_model/interface.h>
+#include <aspect/geometry_model/box.h>
+#include <aspect/geometry_model/chunk.h>
+#include <aspect/geometry_model/ellipsoidal_chunk.h>
+#include <aspect/geometry_model/two_merged_boxes.h>
+#include <aspect/geometry_model/initial_topography_model/interface.h>
+#include <aspect/geometry_model/initial_topography_model/zero_topography.h>
+#include <aspect/simulator_access.h>
+#include <limits>
+
+int f()
+{
+  using namespace aspect;
+  // test whether the functions return the inverse of each other.
+
+  // test point
+  Point<2> point_2d(25000,50000);
+  Point<3> point_3d(25000,25000,50000);
+
+  std::array<double,2> inter_point_2d;
+  std::array<double,3> inter_point_3d;
+  Point<2> new_point_2d = Point<2>();
+  Point<3> new_point_3d= Point<3>();
+  // get the supported geometries
+  std::cout << std::endl << "2D:" << std::endl;
+  // Box 2D
+  {
+    GeometryModel::Box<2> box;
+    ParameterHandler prm_box;
+    box.declare_parameters(prm_box);
+    prm_box.enter_subsection("Geometry model");
+    prm_box.enter_subsection("Box");
+    prm_box.set("X extent", "100e3");
+    prm_box.set("Y extent", "100e3");
+    prm_box.leave_subsection();
+    prm_box.leave_subsection();
+    box.parse_parameters(prm_box);
+
+    inter_point_2d = box.cartesian_to_natural_coordinates(point_2d);
+    new_point_2d = box.natural_to_cartesian_coordinates(inter_point_2d);
+
+    if (std::fabs(new_point_2d(0) - point_2d(0)) < 1e-8 &&
+        std::fabs(new_point_2d(1) - point_2d(1)) < 1e-8)
+      std::cout << "Box 2D ok:                   point = " << point_2d << ", inter point = " << inter_point_2d[0] << ", " << inter_point_2d[1] << ", new_point = " << new_point_2d << std::endl;
+    else
+      std::cout << "Box 2D failed:               point = " << point_2d << ", inter point = " << inter_point_2d[0] << ", " << inter_point_2d[1] << ", new_point = " << new_point_2d << std::endl;
+  }
+
+  // Two merged boxes 2d
+  {
+    GeometryModel::TwoMergedBoxes<2> two_merged_boxes;
+    ParameterHandler prm_two_merged_boxes;
+    two_merged_boxes.declare_parameters(prm_two_merged_boxes);
+    prm_two_merged_boxes.enter_subsection("Geometry model");
+    prm_two_merged_boxes.enter_subsection("Box with lithosphere boundary indicators");
+    prm_two_merged_boxes.set("X extent", "100e3");
+    prm_two_merged_boxes.set("Y extent", "100e3");
+    prm_two_merged_boxes.leave_subsection();
+    prm_two_merged_boxes.leave_subsection();
+    two_merged_boxes.parse_parameters(prm_two_merged_boxes);
+    inter_point_2d = two_merged_boxes.cartesian_to_natural_coordinates(point_2d);
+    new_point_2d = two_merged_boxes.natural_to_cartesian_coordinates(inter_point_2d);
+
+    if (std::fabs(new_point_2d(0) - point_2d(0)) < 1e-8 &&
+        std::fabs(new_point_2d(1) - point_2d(1)) < 1e-8)
+      std::cout << "Two merged boxes 2d ok:      point = " << point_2d << ", inter point = " << inter_point_2d[0] << ", " << inter_point_2d[1] << ", new_point = " << new_point_2d << std::endl;
+    else
+      std::cout << "Two merged boxes 2d failed:  point = " << point_2d << ", inter point = " << inter_point_2d[0] << ", " << inter_point_2d[1] << ", new_point = " << new_point_2d << std::endl;
+  }
+
+  // Chunk 2d
+  {
+    GeometryModel::Chunk<2> chunk;
+    ParameterHandler prm_chunk;
+    chunk.declare_parameters(prm_chunk);
+    prm_chunk.enter_subsection("Geometry model");
+    prm_chunk.enter_subsection("Chunk");
+    prm_chunk.set("Chunk inner radius", "6128137.0");
+    prm_chunk.set("Chunk outer radius", "6378137.0");
+    prm_chunk.leave_subsection();
+    prm_chunk.leave_subsection();
+    chunk.parse_parameters(prm_chunk);
+
+    inter_point_2d = chunk.cartesian_to_natural_coordinates(point_2d);
+    new_point_2d = chunk.natural_to_cartesian_coordinates(inter_point_2d);
+
+    if (std::fabs(new_point_2d(0) - point_2d(0)) < 1e-8 &&
+        std::fabs(new_point_2d(1) - point_2d(1)) < 1e-8)
+      std::cout << "Chunk 2D ok:                 point = " << point_2d << ", inter point = " << inter_point_2d[0] << ", " << inter_point_2d[1] << ", new_point = " << new_point_2d << std::endl;
+    else
+      std::cout << "Chunk 2D failed:             point = " << point_2d << ", inter point = " << inter_point_2d[0] << ", " << inter_point_2d[1] << ", new_point = " << new_point_2d << std::endl;
+
+  }
+  std::cout << std::endl << "3D:" << std::endl;
+  // Box 3D
+  {
+    GeometryModel::Box<3> box;
+    //box.initialize(topo);
+    ParameterHandler prm_box;
+    box.declare_parameters(prm_box);
+    prm_box.enter_subsection("Geometry model");
+    prm_box.enter_subsection("Box");
+    prm_box.set("X extent", "100e3");
+    prm_box.set("Y extent", "100e3");
+    prm_box.set("Z extent", "200e3");
+    prm_box.leave_subsection();
+    prm_box.leave_subsection();
+    box.parse_parameters(prm_box);
+
+    inter_point_3d = box.cartesian_to_natural_coordinates(point_3d);
+    new_point_3d = box.natural_to_cartesian_coordinates(inter_point_3d);
+
+    if (std::fabs(new_point_3d(0) - point_3d(0)) < 1e-8 &&
+        std::fabs(new_point_3d(1) - point_3d(1)) < 1e-8 &&
+        std::fabs(new_point_3d(2) - point_3d(2)) < 1e-8)
+      std::cout << "Box 3D ok:                   point = " << point_3d << ", inter point = " << inter_point_3d[0] << ", " << inter_point_3d[1] << ", " << inter_point_3d[2]<< ", new_point = " << new_point_3d << std::endl;
+    else
+      std::cout << "Box 3D failed:               point = " << point_3d << ", inter point = " << inter_point_3d[0] << ", " << inter_point_3d[1] << ", " << inter_point_3d[2]<< ", new_point = " << new_point_3d << std::endl;
+  }
+
+  // Two merged boxes 3d
+  {
+    GeometryModel::TwoMergedBoxes<3> two_merged_boxes;
+    ParameterHandler prm_two_merged_boxes;
+    two_merged_boxes.declare_parameters(prm_two_merged_boxes);
+    prm_two_merged_boxes.enter_subsection("Geometry model");
+    prm_two_merged_boxes.enter_subsection("Box with lithosphere boundary indicators");
+    prm_two_merged_boxes.set("X extent", "100e3");
+    prm_two_merged_boxes.set("Y extent", "100e3");
+    prm_two_merged_boxes.set("Z extent", "200e3");
+    prm_two_merged_boxes.leave_subsection();
+    prm_two_merged_boxes.leave_subsection();
+    two_merged_boxes.parse_parameters(prm_two_merged_boxes);
+    inter_point_3d = two_merged_boxes.cartesian_to_natural_coordinates(point_3d);
+    new_point_3d = two_merged_boxes.natural_to_cartesian_coordinates(inter_point_3d);
+
+    if (std::fabs(new_point_3d(0) - point_3d(0)) < 1e-8 &&
+        std::fabs(new_point_3d(1) - point_3d(1)) < 1e-8 &&
+        std::fabs(new_point_3d(2) - point_3d(2)) < 1e-8)
+      std::cout << "Two merged boxes 3d ok:      point = " << point_3d << ", inter point = " << inter_point_3d[0] << ", " << inter_point_3d[1] << ", " << inter_point_3d[2]<< ", new_point = " << new_point_3d << std::endl;
+    else
+      std::cout << "Two merged boxes 3d failed:  point = " << point_3d << ", inter point = " << inter_point_3d[0] << ", " << inter_point_3d[1] << ", " << inter_point_3d[2]<< ", new_point = " << new_point_3d << std::endl;
+  }
+
+  // Chunk 3d
+  {
+    GeometryModel::Chunk<3> chunk;
+    ParameterHandler prm_chunk;
+    chunk.declare_parameters(prm_chunk);
+    prm_chunk.enter_subsection("Geometry model");
+    prm_chunk.enter_subsection("Chunk");
+    prm_chunk.set("Chunk inner radius", "6128137.0");
+    prm_chunk.set("Chunk outer radius", "6378137.0");
+    prm_chunk.leave_subsection();
+    prm_chunk.leave_subsection();
+    chunk.parse_parameters(prm_chunk);
+
+    inter_point_3d = chunk.cartesian_to_natural_coordinates(point_3d);
+    new_point_3d = chunk.natural_to_cartesian_coordinates(inter_point_3d);
+
+    if (std::fabs(new_point_3d(0) - point_3d(0)) < 1e-8 &&
+        std::fabs(new_point_3d(1) - point_3d(1)) < 1e-8 &&
+        std::fabs(new_point_3d(2) - point_3d(2)) < 1e-8)
+      std::cout << "Chunk 3D ok:                 point = " << point_3d << ", inter point = " << inter_point_3d[0] << ", " << inter_point_3d[1] << ", new_point = " << new_point_3d << std::endl;
+    else
+      std::cout << "Chunk 3D failed:             point = " << point_3d << ", inter point = " << inter_point_3d[0] << ", " << inter_point_3d[1] << ", new_point = " << new_point_3d << std::endl;
+  }
+
+  // Ellipsoidal chunk 3d
+  {
+    GeometryModel::EllipsoidalChunk<3> ellipsoidal_chunk;
+    ParameterHandler prm_ellispoidal_chunk;
+    ellipsoidal_chunk.declare_parameters(prm_ellispoidal_chunk);
+    prm_ellispoidal_chunk.enter_subsection("Geometry model");
+    prm_ellispoidal_chunk.enter_subsection("Ellipsoidal chunk");
+    prm_ellispoidal_chunk.set("NE corner", "10:10");
+    prm_ellispoidal_chunk.set("SW corner", "0:0");
+    prm_ellispoidal_chunk.leave_subsection();
+    prm_ellispoidal_chunk.leave_subsection();
+    ellipsoidal_chunk.parse_parameters(prm_ellispoidal_chunk);
+    inter_point_3d = ellipsoidal_chunk.cartesian_to_natural_coordinates(point_3d);
+    new_point_3d = ellipsoidal_chunk.natural_to_cartesian_coordinates(inter_point_3d);
+
+    if (std::fabs(new_point_3d(0) - point_3d(0)) < 1e-8 &&
+        std::fabs(new_point_3d(1) - point_3d(1)) < 1e-8 &&
+        std::fabs(new_point_3d(2) - point_3d(2)) < 1e-8)
+      std::cout << "Ellipsoidal 3d chunk ok:     point = " << point_3d << ", inter point = " << inter_point_3d[0] << ", " << inter_point_3d[1] << ", " << inter_point_3d[2]<< ", new_point = " << new_point_3d << std::endl;
+    else
+      std::cout << "Ellipsoidal 3d chunk failed: point = " << point_3d << ", inter point = " << inter_point_3d[0] << ", " << inter_point_3d[1] << ", " << inter_point_3d[2]<< ", new_point = " << new_point_3d << std::endl;
+  }
+
+
+  exit(0);
+  return 42;
+}
+// run this function by initializing a global variable by it
+int i = f();

--- a/tests/natural_coordinates_conversion.prm
+++ b/tests/natural_coordinates_conversion.prm
@@ -1,0 +1,1 @@
+set Additional shared libraries = tests/libnatural_coordinates_conversion.so

--- a/tests/natural_coordinates_conversion/screen-output
+++ b/tests/natural_coordinates_conversion/screen-output
@@ -1,0 +1,15 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libnatural_coordinates_conversion.so>
+
+2D:
+Box 2D ok:                   point = 25000 50000, inter point = 25000, 50000, new_point = 25000 50000
+Two merged boxes 2d ok:      point = 25000 50000, inter point = 25000, 50000, new_point = 25000 50000
+Chunk 2D ok:                 point = 25000 50000, inter point = 55901.7, 1.10715, new_point = 25000 50000
+
+3D:
+Box 3D ok:                   point = 25000 25000 50000, inter point = 25000, 25000, 50000, new_point = 25000 25000 50000
+Two merged boxes 3d ok:      point = 25000 25000 50000, inter point = 25000, 25000, 50000, new_point = 25000 25000 50000
+Chunk 3D ok:                 point = 25000 25000 50000, inter point = 61237.2, 0.785398, new_point = 25000 25000 50000
+Ellipsoidal 3d chunk failed: point = 25000 25000 50000, inter point = 101768, 1.21599, 0.785398, new_point = 25000 25000 55272.2


### PR DESCRIPTION
This implements the cartesian_to_natural_coordinates and natural_to_cartesian_coordinates functions for the box, two_merged_boxes, chunk and ellipsoidal chunk geometry models. These where the easy ones since they where or just the original input, or I could use their manifold of the geometry model itself. 

I will add a test for these functions later.