### PR TITLE
move plugin_graph files

### DIFF
--- a/doc/update_parameters.sh
+++ b/doc/update_parameters.sh
@@ -67,8 +67,7 @@ $ASPECT --output-plugin-graph doc/manual/empty.prm >plugin_graph.dot 2>/dev/null
     || (echo "Running ASPECT for the plugin graph failed" ; exit 1)
 neato plugin_graph.dot -Tpdf -o plugin_graph.pdf \
     || (echo "Can't run neato" ; exit 1)
-cp plugin_graph.* doc/manual || echo "ERROR: could not copy plugin_graph.*"
-
+mv plugin_graph.pdf plugin_graph.dot doc/manual/ || echo "ERROR: could not copy plugin_graph.*"
 
 popd
 echo done


### PR DESCRIPTION
move the temporary plugin_graph files instead of copying them so we
don't have them sit there in the main directory.