### PR TITLE
Move particle serialization into ParticleHandler

### DIFF
--- a/include/aspect/particle/particle_handler.h
+++ b/include/aspect/particle/particle_handler.h
@@ -92,8 +92,7 @@ namespace aspect
         /**
          * Initialize the particle handler. This function does not clear the
          * internal data structures, it just sets the connections to the
-         * MPI communicator and the triangulation. This is useful after de-
-         * serialization of a particle handler.
+         * MPI communicator and the triangulation.
          */
         void initialize(const parallel::distributed::Triangulation<dim,spacedim> &tria,
                         const Mapping<dim,spacedim> &mapping,
@@ -382,6 +381,13 @@ namespace aspect
                                          const void *)> load_callback;
 
         /**
+         * This variable is set by the register_store_callback_function()
+         * function and used by the register_load_callback_function() function
+         * to check where the particle data was stored.
+         */
+        unsigned int data_offset;
+
+        /**
          * Calculates the number of particles in the global model domain.
          */
         void
@@ -433,6 +439,23 @@ namespace aspect
                             std::multimap<types::LevelInd,Particle <dim> >     &received_particles,
                             const std::vector<std::vector<active_cell_it> >    &new_cells_for_particles = std::vector<std::vector<active_cell_it> > ());
 
+
+
+        /**
+         * Callback function that should be called before every
+         * refinement and when writing checkpoints.
+         * Allows registering store_particles() in the triangulation.
+         */
+        void
+        register_store_callback_function(const bool serialization);
+
+        /**
+         * Callback function that should be called after every
+         * refinement and after resuming from a checkpoint.
+         * Allows registering load_particles() in the triangulation.
+         */
+        void
+        register_load_callback_function(const bool serialization);
 
         /**
          * Called by listener functions from Triangulation for every cell

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -152,24 +152,6 @@ namespace aspect
         connect_to_signals(aspect::SimulatorSignals<dim> &signals);
 
         /**
-         * Callback function that is called from Simulator before every
-         * refinement and when writing checkpoints.
-         * Allows registering store_particles() in the triangulation.
-         */
-        void
-        register_store_callback_function(const bool serialization,
-                                         typename parallel::distributed::Triangulation<dim> &triangulation);
-
-        /**
-         * Callback function that is called from Simulator after every
-         * refinement and after resuming from a checkpoint.
-         * Allows registering load_particles() in the triangulation.
-         */
-        void
-        register_load_callback_function(const bool serialization,
-                                        typename parallel::distributed::Triangulation<dim> &triangulation);
-
-        /**
          * Called by listener functions from Triangulation for every cell
          * before a refinement step. A weight is attached to every cell
          * depending on the number of contained particles.
@@ -268,13 +250,6 @@ namespace aspect
          * managing the internal particle structures.
          */
         std_cxx11::unique_ptr<ParticleHandler<dim> > particle_handler;
-
-        /**
-         * This variable is set by the register_store_callback_function()
-         * function and used by the register_load_callback_function() function
-         * to check where the particle data was stored.
-         */
-        unsigned int data_offset;
 
         /**
          * Strategy for particle load balancing.
@@ -395,8 +370,11 @@ namespace aspect
     template <class Archive>
     void World<dim>::serialize (Archive &ar, const unsigned int)
     {
+      // Note that although Boost claims to handle serialization of pointers
+      // correctly, at least for the case of unique_ptr it seems to not work.
+      // It works correctly when archiving the content of the pointer instead.
       ar
-      &particle_handler
+      &(*particle_handler)
       ;
     }
   }


### PR DESCRIPTION
This moves most of the particle serialization functionality into the ParticleHandler class. Some parts remain in World for now, I will address them in a follow-up PR.