### PR TITLE
Only filter hdf5 output for continuous elements

### DIFF
--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -481,8 +481,13 @@ namespace aspect
           const std::string h5_solution_file_name = "solution/" + solution_file_prefix + ".h5";
           const std::string xdmf_filename = "solution.xdmf";
 
-          // Filter redundant values
-          DataOutBase::DataOutFilter data_filter(DataOutBase::DataOutFilterFlags(true, true));
+          // Filter redundant values if all elements are continuous, for discontinuous
+          // elements the averaging at cell vertices distorts the solution
+          const bool filter_duplicate_vertices = ! (this->get_parameters().use_locally_conservative_discretization
+                                                    || this->get_parameters().use_discontinuous_temperature_discretization
+                                                    || this->get_parameters().use_discontinuous_composition_discretization);
+
+          DataOutBase::DataOutFilter data_filter(DataOutBase::DataOutFilterFlags(filter_duplicate_vertices, true));
 
           // If the mesh changed since the last output, make a new mesh file
           const std::string mesh_file_prefix = "mesh-" + Utilities::int_to_string (output_file_number, 5);


### PR DESCRIPTION
Something I noticed while working on #1864. 
The hdf5 filter tries to merge duplicate vertices at the same location to reduce the necessary disk space. However, for discontinuous elements this means averaging the values at the element boundary, something that is often not intended. Even worse: The merge does not always work, because the check in deal II does not take into account floating point imprecision in the vertex position, I am opening a separate issue for that. The consequence is that during mesh refinement, even if the mesh does not change and the solution stays the same, the internal position of the vertices can be changed slighty, and the filter will create a different output field, suggesting a change that does not exist. This behavior is not a problem for continuous elements (whether we average the constant values at adjacent vertices or not does not matter), but it is a problem for discontinuous solutions. Thus, this PR disables the filtering for discontinuous solutions.