### PR TITLE
Average stress limiter and pre yield viscosity

### DIFF
--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -235,7 +235,6 @@ namespace aspect
         std::vector<double> friction_strain_weakening_factors;
 
         std::vector<double> prefactors_diffusion;
-        std::vector<double> stress_exponents_diffusion;
         std::vector<double> grain_size_exponents_diffusion;
         std::vector<double> activation_energies_diffusion;
         std::vector<double> activation_volumes_diffusion;

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -201,9 +201,9 @@ namespace aspect
           // Note: values of A, d, m, E, V and n are distinct for diffusion & dislocation creep
 
           // Diffusion creep: viscosity is grain size dependent (m!=0) and strain-rate independent (n=1)
-          double viscosity_diffusion = 0.5 * std::pow(prefactors_diffusion[j],-1/stress_exponents_diffusion[j]) *
+          double viscosity_diffusion = 0.5 / prefactors_diffusion[j] *
                                        std::exp((activation_energies_diffusion[j] + pressure*activation_volumes_diffusion[j])/
-                                                (constants::gas_constant*temperature*stress_exponents_diffusion[j])) *
+                                                (constants::gas_constant*temperature)) *
                                        std::pow(grain_size, grain_size_exponents_diffusion[j]);
 
           // For dislocation creep, viscosity is grain size independent (m=0) and strain-rate dependent (n>1)
@@ -825,9 +825,6 @@ namespace aspect
           prefactors_diffusion = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Prefactors for diffusion creep"))),
                                                                          n_fields,
                                                                          "Prefactors for diffusion creep");
-          stress_exponents_diffusion = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Stress exponents for diffusion creep"))),
-                                                                               n_fields,
-                                                                               "Stress exponents for diffusion creep");
           grain_size_exponents_diffusion = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Grain size exponents for diffusion creep"))),
                                                                                    n_fields,
                                                                                    "Grain size exponents for diffusion creep");

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -306,8 +306,7 @@ namespace aspect
             {
               case stress_limiter:
               {
-                // viscosity_yield = std::min(viscosity_limiter, viscosity_pre_yield);
-                viscosity_yield = viscosity_limiter;
+                viscosity_yield = 1. / ( 1./viscosity_limiter + 1./viscosity_pre_yield);
                 break;
               }
               case drucker_prager:

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -713,8 +713,7 @@ namespace aspect
                              "List of stress limiter exponents, $n_\\text{lim}$, "
                              "for background material and compositional fields, "
                              "for a total of N+1 values, where N is the number of compositional fields. "
-                             "The default value of 1 ensures the entire stress limiter term is set to 1 "
-                             "and does not affect the viscosity. Units: none.");
+                             "Units: none.");
 
         }
         prm.leave_subsection();

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -647,7 +647,7 @@ namespace aspect
                              "List of viscosity prefactors, $A$, for background material and compositional fields, "
                              "for a total of N+1 values, where N is the number of compositional fields. "
                              "If only one value is given, then all use the same value. "
-                             "Units: $Pa^{-n_\\text{diffusion}} m^{n_\\text{diffusion}/m_\\text{diffusion}} s^{-1}$");
+                             "Units: $Pa^{-1} m^{1/m_{diffusion}} s^{-1}$");
           prm.declare_entry ("Stress exponents for diffusion creep", "1",
                              Patterns::List(Patterns::Double(0)),
                              "List of stress exponents, $n_\\text{diffusion}$, for background material and compositional fields, "

--- a/tests/visco_plastic_complex.prm
+++ b/tests/visco_plastic_complex.prm
@@ -138,7 +138,8 @@ subsection Material model
     set Activation volumes for dislocation creep = 18.e-6,18.e-6,0.
 
     # Yielding mechanism and values
-    set Yield mechanism = drucker
+    set Yield mechanism = limiter
+    set Stress limiter exponents = 10, 10, 10
     set Angles of internal friction = 0.,0.,0.
     set Cohesions = 1.e6,1.e6,1.e6
 

--- a/tests/visco_plastic_complex/screen-output
+++ b/tests/visco_plastic_complex/screen-output
@@ -1,3 +1,5 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
 
 Number of active cells: 100 (on 1 levels)
 Number of degrees of freedom: 2,326 (882+121+441+441+441)
@@ -12,7 +14,7 @@ Number of degrees of freedom: 2,326 (882+121+441+441+441)
 
 
    Postprocessing:
-     RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
+     RMS, max velocity:                  0.000408 m/year, 0.000692 m/year
      Mass fluxes through boundary parts: 1.57e+05 kg/yr, 1.57e+05 kg/yr, -1.65e+05 kg/yr, -1.4e+05 kg/yr
 
 


### PR DESCRIPTION
@naliboff Maybe I misunderstand, but at the moment, the stress_limiter option does not seem to take into account the pre_yield_viscosity. From the papers cited in the plugin description, I gathered, usually the viscosity_pre_yield and the viscosity_limiter are averaged, so I added that in. Or would you rather keep the min(viscosity_pre_yield, viscosity_limiter) that was commented out?
 