### PR TITLE
add a link to the online version of CONTRIBUTING.md in the manual

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -11818,7 +11818,7 @@ as well. The process of contributing to a new project can be daunting, but we ap
 every contribution and are happy to work with you on improving \aspect{}. To get
 you started we have collected a set of guidelines and advice on how to get involved in the
 community. To avoid duplication we store these guidelines in a separate file \url{CONTRIBUTING.md}
-in the main folder of the repository. Even if something in that file is not clear, this
+in the main folder of the repository, and you can also access them online at \url{https://github.com/geodynamics/aspect/blob/master/CONTRIBUTING.md}. Even if something in that file is not clear, this
 is an opportunity for you to ask your question on the mailing list (see 
 Section~\ref{sec:questions-and-answers}, and let us know that file needs improvement.
 


### PR DESCRIPTION
If someone only reads the online version of the manual, the link in the manual to the CONTRIBUTING.md file will not work for them, because it points to the file in the local aspect folder. This pull request adds a link to the file on the github website. 