### PR TITLE
use 2 eta in Schur complement

### DIFF
--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -92,7 +92,7 @@ namespace aspect
             }
 
           const double eta = scratch.material_model_outputs.viscosities[q];
-          const double one_over_eta = 1. / eta;
+          const double one_over_eta = 1. / (2.0 * eta);
 
           const SymmetricTensor<4, dim> &stress_strain_director = scratch
                                                                   .material_model_outputs.stress_strain_directors[q];


### PR DESCRIPTION
We currently assemble the Schur complement approximation as
```
B^T A^{-1} B  \approx  \int 1/\eta  phi_i phi_j
```
which comes from the fact that
```
A \approx \eta \triangle
```
But this is not correct, as our velocity system contains 2 eta. Let's
see what happens if we do this change.