### PR TITLE
WIP: fix bug in Newton solver which increases velocities

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -907,7 +907,7 @@ namespace aspect
                 mask[i]=introspection.component_masks.velocities[i];
             }
 
-          if (!assemble_newton_stokes_system || (assemble_newton_stokes_system && nonlinear_iteration == 0))
+          if (!assemble_newton_stokes_system || (assemble_newton_stokes_system && nonlinear_iteration == 0 && timestep_number == 0))
             {
               VectorTools::interpolate_boundary_values (*mapping,
                                                         dof_handler,


### PR DESCRIPTION
Let me start with that this is not a final fix. 

The problem I found is that when using the Newton solver for several timesteps with a velocity boundary conditions is that the boundary velocity is added every time step. This means that the boundary velocity keep increasing (went in my case from 1 cm/year to 2 meter per year in about 30 time steps). 

The fix here was my first attempt to see if I correctly asses the problem, and the model with the constant boundary condition is now fine. The problem with this fix is that if there is a time dependent boundary condition, it will just apply the boundary from the first time step. 

The conceptual solution to this problem is I think  replacing `vel` by  something like `boundary_velocity_new-boundary_velocity_old`. But subtracting Functions from each other to create a new function is currently not possible. 

Before I start out coding a lot (and for example try to add this functionality to the deal.ii function), I would like to know what the best solution for this problem is.