### PR TITLE
Fix deprecation warning

### DIFF
--- a/include/aspect/geometry_model/sphere.h
+++ b/include/aspect/geometry_model/sphere.h
@@ -129,6 +129,12 @@ namespace aspect
          */
         double R;
 
+#if DEAL_II_VERSION_GTE(9,0,0)
+        /**
+         * The manifold that describes the geometry.
+         */
+        const SphericalManifold<dim> spherical_manifold;
+#endif
     };
   }
 }

--- a/source/geometry_model/sphere.cc
+++ b/source/geometry_model/sphere.cc
@@ -38,8 +38,14 @@ namespace aspect
       GridGenerator::hyper_ball (coarse_grid,
                                  Point<dim>(),
                                  R);
+
+#if DEAL_II_VERSION_GTE(9,0,0)
+      coarse_grid.set_manifold(0,spherical_manifold);
+      coarse_grid.set_all_manifold_ids_on_boundary(0);
+#else
       static const HyperBallBoundary<dim> boundary_ball(Point<dim>(), R);
       coarse_grid.set_boundary (0, boundary_ball);
+#endif
     }
 
 


### PR DESCRIPTION
This primarily fixes a deprecation warning with deal.II 9.0.pre.

Note that I do not set the manifold ids for all cells yet. The reason is that the resulting mesh looks strange, and I wanted an opinion on that. The figure below shows from left to right the mesh with 8.5.0, the mesh with 9.0.pre with this PR (no difference), and the mesh with 9.0.pre with the spherical manifold attached to all cells. The mesh on the right has some pretty distorted cells. Is there some best practice for how to prescribe manifolds to this case?

![mesh](https://user-images.githubusercontent.com/7582930/32239314-cf5a6b52-be2f-11e7-94f2-4aef57e80df8.png)
