### PR TITLE
Unify the screen output of the different solver schemes

### DIFF
--- a/doc/modules/changes/20171101_jdannberg
+++ b/doc/modules/changes/20171101_jdannberg
@@ -1,0 +1,6 @@
+Changed: The screen output of the different solver schemes now has
+the same style. All lines that output the total nonlinear residual 
+of the system iterated over begin with 'Nonlinear residual' and 
+then specify the system being solved. 
+<br>
+(Juliane Dannberg, 2017/11/01)

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -291,8 +291,9 @@ namespace aspect
         const double relative_stokes_residual =
           assemble_and_solve_stokes(nonlinear_iteration == 0, &initial_stokes_residual);
 
-        pcout << "      Relative Stokes residual after nonlinear iteration " << nonlinear_iteration+1
+        pcout << "      Relative nonlinear residual (Stokes system) after nonlinear iteration " << nonlinear_iteration+1
               << ": " << relative_stokes_residual
+              << std::endl
               << std::endl;
 
         if (parameters.run_postprocessors_on_nonlinear_iterations)
@@ -337,7 +338,7 @@ namespace aspect
           assemble_and_solve_stokes(nonlinear_iteration == 0, &initial_stokes_residual);
 
         // write the residual output in the same order as the solutions
-        pcout << "      Relative nonlinear residuals: " << relative_temperature_residual;
+        pcout << "      Relative nonlinear residuals (temperature, compositional fields, Stokes system): " << relative_temperature_residual;
         for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
           pcout << ", " << relative_composition_residual[c];
         pcout << ", " << relative_stokes_residual;
@@ -361,8 +362,9 @@ namespace aspect
 
         max = std::max(relative_stokes_residual, max);
         max = std::max(relative_temperature_residual, max);
-        pcout << "      Total relative residual after nonlinear iteration " << nonlinear_iteration+1 << ": " << max << std::endl;
-        pcout << std::endl
+        pcout << "      Relative nonlinear residual (total system) after nonlinear iteration " << nonlinear_iteration+1
+              << ": " << max
+              << std::endl
               << std::endl;
 
         if (parameters.run_postprocessors_on_nonlinear_iterations)
@@ -404,8 +406,9 @@ namespace aspect
         const double relative_stokes_residual =
           assemble_and_solve_stokes(nonlinear_iteration == 0, &initial_stokes_residual);
 
-        pcout << "      Relative Stokes residual after nonlinear iteration " << nonlinear_iteration+1
+        pcout << "      Relative nonlinear residual (Stokes system) after nonlinear iteration " << nonlinear_iteration+1
               << ": " << relative_stokes_residual
+              << std::endl
               << std::endl;
 
         if (parameters.run_postprocessors_on_nonlinear_iterations)
@@ -414,8 +417,6 @@ namespace aspect
         // if reached convergence, exit nonlinear iterations.
         if (relative_stokes_residual < parameters.nonlinear_tolerance)
           break;
-
-        pcout << std::endl;
 
         ++nonlinear_iteration;
       }
@@ -612,7 +613,7 @@ namespace aspect
                 ||
                 use_picard)
               {
-                pcout << "      Total relative residual after nonlinear iteration " << nonlinear_iteration+1
+                pcout << "      Relative nonlinear residual (total Newton system) after nonlinear iteration " << nonlinear_iteration+1
                       << ": " << residual/initial_residual << ", norm of the rhs: " << test_residual
                       << ", newton_derivative_scaling_factor: " << newton_handler->get_newton_derivative_scaling_factor() << std::endl;
                 break;

--- a/tests/adiabatic_boundary/screen-output
+++ b/tests/adiabatic_boundary/screen-output
@@ -6,10 +6,11 @@ Number of degrees of freedom: 527 (375+27+125)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 4.14038e-06
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 4.14038e-06
+
 
    Postprocessing:
      RMS, max velocity: 0.00495 m/year, 0.00881 m/year

--- a/tests/adiabatic_heating_with_melt/screen-output
+++ b/tests/adiabatic_heating_with_melt/screen-output
@@ -9,9 +9,8 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 54+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.85418e-16, 9.58741e-17, 0, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.85418e-16, 9.58741e-17, 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -19,9 +18,8 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.85418e-16, 9.58741e-17, 0, 9.29021e-13
-      Total relative residual after nonlinear iteration 2: 9.29021e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.85418e-16, 9.58741e-17, 0, 9.29021e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 9.29021e-13
 
 
    Postprocessing:
@@ -35,9 +33,8 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.0391e-06, 1.53408e-16, 0, 4.87025e-09
-      Total relative residual after nonlinear iteration 1: 2.0391e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.0391e-06, 1.53408e-16, 0, 4.87025e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.0391e-06
 
 
    Postprocessing:
@@ -51,9 +48,8 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.21934e-06, 1.21242e-16, 0, 4.20135e-09
-      Total relative residual after nonlinear iteration 1: 2.21934e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.21934e-06, 1.21242e-16, 0, 4.20135e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.21934e-06
 
 
    Postprocessing:
@@ -67,9 +63,8 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 4.7975e-08, 1.56341e-16, 0, 8.51551e-10
-      Total relative residual after nonlinear iteration 1: 4.7975e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.7975e-08, 1.56341e-16, 0, 8.51551e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 4.7975e-08
 
 
    Postprocessing:

--- a/tests/anisotropic_viscosity/screen-output
+++ b/tests/anisotropic_viscosity/screen-output
@@ -7,7 +7,8 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 200+9 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
 
    Postprocessing:
      Heating rate (average/total):  4.71 W/kg, 6.193 W

--- a/tests/annulus/screen-output
+++ b/tests/annulus/screen-output
@@ -7,10 +7,12 @@ Number of degrees of freedom: 2,832 (1,728+240+864)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+23 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 2.41488e-13
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 2.41488e-13
+
 
    Postprocessing:
      Writing graphical output:               output-annulus/solution/solution-00000

--- a/tests/burstedde/screen-output
+++ b/tests/burstedde/screen-output
@@ -7,10 +7,12 @@ Number of degrees of freedom: 3,041 (2,187+125+729)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+XYZ iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+XYZ iterations.
-      Relative Stokes residual after nonlinear iteration 2: 4.81093e-13
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 4.81093e-13
+
 
    Postprocessing:
      RMS, max velocity:             4.3 m/s, 13.2 m/s

--- a/tests/burstedde_stokes_rhs/screen-output
+++ b/tests/burstedde_stokes_rhs/screen-output
@@ -7,10 +7,12 @@ Number of degrees of freedom: 3,041 (2,187+125+729)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+XYZ iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+XYZ iterations.
-      Relative Stokes residual after nonlinear iteration 2: 6.95385e-13
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 6.95385e-13
+
 
    Postprocessing:
      RMS, max velocity:             4.3 m/s, 13.2 m/s

--- a/tests/composition_reaction_iterated_IMPES/screen-output
+++ b/tests/composition_reaction_iterated_IMPES/screen-output
@@ -11,9 +11,8 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Skipping C_3 composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 61+0 iterations.
-      Relative nonlinear residuals: 1.73321e-16, 0, 1, 0, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73321e-16, 0, 1, 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving C_1 system ... 11 iterations.
@@ -21,9 +20,8 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_3 system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 40+0 iterations.
-      Relative nonlinear residuals: 1.72329e-16, 0, 5.7186e-13, 0, 0.00772709
-      Total relative residual after nonlinear iteration 2: 0.00772709
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.72329e-16, 0, 5.7186e-13, 0, 0.00772709
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00772709
 
    Solving temperature system... 0 iterations.
    Solving C_1 system ... 0 iterations.
@@ -31,9 +29,8 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_3 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 1.82797e-16, 0, 5.7186e-13, 0, 8.29714e-08
-      Total relative residual after nonlinear iteration 3: 8.29714e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.82797e-16, 0, 5.7186e-13, 0, 8.29714e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 8.29714e-08
 
 
    Postprocessing:
@@ -47,9 +44,8 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_3 system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residuals: 0.003938, 0.5, 0.5, 0.5, 1.17264e-06
-      Total relative residual after nonlinear iteration 1: 0.5
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.003938, 0.5, 0.5, 0.5, 1.17264e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.5
 
    Solving temperature system... 5 iterations.
    Solving C_1 system ... 11 iterations.
@@ -57,9 +53,8 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_3 system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 40+0 iterations.
-      Relative nonlinear residuals: 1.89051e-07, 0.5, 9.41726e-13, 0.5, 0.00783271
-      Total relative residual after nonlinear iteration 2: 0.5
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.89051e-07, 0.5, 9.41726e-13, 0.5, 0.00783271
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.5
 
    Solving temperature system... 5 iterations.
    Solving C_1 system ... 0 iterations.
@@ -67,9 +62,8 @@ Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
    Solving C_3 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 1.40557e-07, 9.41813e-13, 9.41721e-13, 9.41813e-13, 8.42599e-08
-      Total relative residual after nonlinear iteration 3: 1.40557e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.40557e-07, 9.41813e-13, 9.41721e-13, 9.41813e-13, 8.42599e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 1.40557e-07
 
 
    Postprocessing:

--- a/tests/compressibility/screen-output
+++ b/tests/compressibility/screen-output
@@ -7,7 +7,8 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
 
    Postprocessing:
      Top/bottom flux:          1/2.718

--- a/tests/compressibility_iterated_stokes/screen-output
+++ b/tests/compressibility_iterated_stokes/screen-output
@@ -7,19 +7,24 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 0.0138303
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0138303
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 0.000750092
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 3: 0.000750092
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 2.71246e-05
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 4: 2.71246e-05
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-      Relative Stokes residual after nonlinear iteration 5: 6.81727e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 5: 6.81727e-07
+
 
    Postprocessing:
      Top/bottom flux: 1/1

--- a/tests/compressibility_iterated_stokes_direct_solver/screen-output
+++ b/tests/compressibility_iterated_stokes_direct_solver/screen-output
@@ -6,15 +6,20 @@ Number of degrees of freedom: 13,764 (9,539+4,225)
 
 *** Timestep 0:  t=0 seconds
    Solving Stokes system... done.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... done.
-      Relative Stokes residual after nonlinear iteration 2: 0.0138303
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0138303
+
    Solving Stokes system... done.
-      Relative Stokes residual after nonlinear iteration 3: 0.000750098
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 3: 0.000750098
+
    Solving Stokes system... done.
-      Relative Stokes residual after nonlinear iteration 4: 2.7127e-05
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 4: 2.7127e-05
+
    Solving Stokes system... done.
-      Relative Stokes residual after nonlinear iteration 5: 6.74287e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 5: 6.74287e-07
+
 
    Postprocessing:
      Top/bottom flux: 1/1

--- a/tests/compression_heating/screen-output
+++ b/tests/compression_heating/screen-output
@@ -11,9 +11,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 114+0 iterations.
    Solving for u_f in 10 iterations.
-      Relative nonlinear residuals: 1.1272e-16, 2.22016e-16, 0, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.1272e-16, 2.22016e-16, 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -21,9 +20,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 10 iterations.
-      Relative nonlinear residuals: 1.1272e-16, 2.22016e-16, 0, 9.37726e-13
-      Total relative residual after nonlinear iteration 2: 9.37726e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.1272e-16, 2.22016e-16, 0, 9.37726e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 9.37726e-13
 
 
    Postprocessing:
@@ -38,9 +36,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 93+0 iterations.
    Solving for u_f in 10 iterations.
-      Relative nonlinear residuals: 0.000132795, 0.0833335, 0, 0.0258351
-      Total relative residual after nonlinear iteration 1: 0.0833335
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000132795, 0.0833335, 0, 0.0258351
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0833335
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 2 iterations.
@@ -48,9 +45,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 38+0 iterations.
    Solving for u_f in 10 iterations.
-      Relative nonlinear residuals: 4.02577e-06, 1.14705e-07, 0, 1.96846e-07
-      Total relative residual after nonlinear iteration 2: 4.02577e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.02577e-06, 1.14705e-07, 0, 1.96846e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.02577e-06
 
 
    Postprocessing:
@@ -65,9 +61,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 72+0 iterations.
    Solving for u_f in 10 iterations.
-      Relative nonlinear residuals: 1.14229e-06, 0.00064094, 0, 0.000209255
-      Total relative residual after nonlinear iteration 1: 0.00064094
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.14229e-06, 0.00064094, 0, 0.000209255
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00064094
 
    Solving temperature system... 3 iterations.
    Solving porosity system ... 1 iterations.
@@ -75,9 +70,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
    Solving for u_f in 10 iterations.
-      Relative nonlinear residuals: 1.56452e-08, 3.55915e-10, 0, 5.78472e-10
-      Total relative residual after nonlinear iteration 2: 1.56452e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.56452e-08, 3.55915e-10, 0, 5.78472e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 1.56452e-08
 
 
    Postprocessing:

--- a/tests/conservative_with_mpi/screen-output
+++ b/tests/conservative_with_mpi/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 291 (162+48+81)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 4.99721e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 4.99721e-08
+
 
    Postprocessing:
 

--- a/tests/diffusion_dislocation/screen-output
+++ b/tests/diffusion_dislocation/screen-output
@@ -7,25 +7,22 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
    Solving depleted_lithosphere system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residuals: 2.04449e-16, 1.05609e-16, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.04449e-16, 1.05609e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving depleted_lithosphere system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residuals: 2.04449e-16, 1.05609e-16, 0.000712092
-      Total relative residual after nonlinear iteration 2: 0.000712092
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.04449e-16, 1.05609e-16, 0.000712092
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000712092
 
    Solving temperature system... 0 iterations.
    Solving depleted_lithosphere system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residuals: 2.04449e-16, 1.05609e-16, 1.47593e-07
-      Total relative residual after nonlinear iteration 3: 1.47593e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.04449e-16, 1.05609e-16, 1.47593e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 1.47593e-07
 
 
    Postprocessing:

--- a/tests/drucker_prager_compression/screen-output
+++ b/tests/drucker_prager_compression/screen-output
@@ -6,43 +6,43 @@ Number of degrees of freedom: 2,804 (2,210+297+297)
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+14 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+20 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 0.00977024
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.00977024
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+17 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 0.00232696
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.00232696
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+13 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 0.00102811
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.00102811
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-      Relative Stokes residual after nonlinear iteration 5: 0.000883826
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 0.000883826
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+10 iterations.
-      Relative Stokes residual after nonlinear iteration 6: 0.000797158
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 0.000797158
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
-      Relative Stokes residual after nonlinear iteration 7: 0.000729936
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 0.000729936
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
-      Relative Stokes residual after nonlinear iteration 8: 0.000677241
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 8: 0.000677241
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
-      Relative Stokes residual after nonlinear iteration 9: 0.000633529
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 9: 0.000633529
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
-      Relative Stokes residual after nonlinear iteration 10: 0.000597175
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 0.000597175
 
 
    Postprocessing:

--- a/tests/drucker_prager_extension/screen-output
+++ b/tests/drucker_prager_extension/screen-output
@@ -6,43 +6,43 @@ Number of degrees of freedom: 2,804 (2,210+297+297)
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+14 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+19 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 0.0114772
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0114772
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+15 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 0.001441
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.001441
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+13 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 0.0011851
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.0011851
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-      Relative Stokes residual after nonlinear iteration 5: 0.00119301
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 0.00119301
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+12 iterations.
-      Relative Stokes residual after nonlinear iteration 6: 0.0015339
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 0.0015339
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-      Relative Stokes residual after nonlinear iteration 7: 0.00116625
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 0.00116625
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-      Relative Stokes residual after nonlinear iteration 8: 0.00101503
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 8: 0.00101504
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-      Relative Stokes residual after nonlinear iteration 9: 0.000933709
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 9: 0.000933711
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-      Relative Stokes residual after nonlinear iteration 10: 0.000859857
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 0.00085983
 
 
    Postprocessing:

--- a/tests/dynamic_friction/screen-output
+++ b/tests/dynamic_friction/screen-output
@@ -1,10 +1,3 @@
------------------------------------------------------------------------------
--- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 2.0.0-pre
---     . running in DEBUG mode
---     . running with 1 MPI process
---     . using Trilinos
------------------------------------------------------------------------------
 
 Number of active cells: 256 (on 4 levels)
 Number of degrees of freedom: 4,717 (2,210+297+1,105+1,105)
@@ -16,7 +9,7 @@ Number of free surface degrees of freedom: 594
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+17 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
    Postprocessing:
@@ -32,7 +25,7 @@ Number of free surface degrees of freedom: 2090
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+18 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
    Postprocessing:
@@ -45,47 +38,13 @@ Number of free surface degrees of freedom: 2058
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      5.84s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |     0.226s |       3.9% |
-| Assemble composition system     |         2 |     0.219s |       3.8% |
-| Assemble temperature system     |         2 |     0.493s |       8.4% |
-| Build Stokes preconditioner     |         2 |     0.439s |       7.5% |
-| Build composition preconditioner|         2 |    0.0255s |      0.44% |
-| Solve Stokes system             |         2 |     0.562s |       9.6% |
-| Solve composition system        |         2 |   0.00133s |         0% |
-| Free surface                    |         2 |       1.1s |        19% |
-| Initialization                  |         1 |     0.692s |        12% |
-| Postprocessing                  |         2 |      0.02s |      0.34% |
-| Refine mesh structure, part 1   |         2 |     0.107s |       1.8% |
-| Refine mesh structure, part 2   |         2 |    0.0344s |      0.59% |
-| Setup dof systems               |         3 |      1.23s |        21% |
-| Setup initial conditions        |         2 |     0.218s |       3.7% |
 +---------------------------------+-----------+------------+------------+
 
 Termination requested by criterion: end time
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |      5.84s |            |
-|                                             |            |            |
-| Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| Assemble Stokes system          |         2 |     0.226s |       3.9% |
-| Assemble composition system     |         2 |     0.219s |       3.8% |
-| Assemble temperature system     |         2 |     0.493s |       8.4% |
-| Build Stokes preconditioner     |         2 |     0.439s |       7.5% |
-| Build composition preconditioner|         2 |    0.0255s |      0.44% |
-| Solve Stokes system             |         2 |     0.562s |       9.6% |
-| Solve composition system        |         2 |   0.00133s |         0% |
-| Free surface                    |         2 |       1.1s |        19% |
-| Initialization                  |         1 |     0.692s |        12% |
-| Postprocessing                  |         2 |      0.02s |      0.34% |
-| Refine mesh structure, part 1   |         2 |     0.107s |       1.8% |
-| Refine mesh structure, part 2   |         2 |    0.0344s |      0.59% |
-| Setup dof systems               |         3 |      1.23s |        21% |
-| Setup initial conditions        |         2 |     0.218s |       3.7% |
 +---------------------------------+-----------+------------+------------+
 

--- a/tests/free_surface_iterated_stokes/screen-output
+++ b/tests/free_surface_iterated_stokes/screen-output
@@ -8,10 +8,11 @@ Number of free surface degrees of freedom: 1394
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+12 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 4.3798e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 4.3798e-08
+
 
 Number of active cells: 664 (on 5 levels)
 Number of degrees of freedom: 9,184 (5,634+733+2,817)
@@ -22,10 +23,11 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+12 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 5.97035e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 5.97035e-08
+
 
    Postprocessing:
 
@@ -51,10 +53,11 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+14 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1.49063
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1.49063
 
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 8.78595e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 8.78595e-08
+
 
    Postprocessing:
      Topography min/max: -78.72 m, 175.3 m
@@ -65,10 +68,11 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+14 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1.60276
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1.60276
 
    Solving Stokes system... 0+1 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 8.04425e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 8.04424e-08
+
 
    Postprocessing:
      Topography min/max: -106.6 m, 83.69 m
@@ -79,10 +83,11 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+14 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 0.470828
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.470828
 
    Solving Stokes system... 0+1 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 4.82789e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 4.82788e-08
+
 
    Postprocessing:
      Topography min/max: -12.79 m, 41.33 m
@@ -93,10 +98,11 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+13 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 0.364006
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.364006
 
    Solving Stokes system... 0+2 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 7.54723e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 7.54723e-08
+
 
    Postprocessing:
      Topography min/max: -18.67 m, 58.42 m
@@ -107,10 +113,11 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+14 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 0.159617
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.159617
 
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 3.05077e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 3.05077e-08
+
 
    Postprocessing:
      Topography min/max: -14.4 m, 48.93 m
@@ -127,10 +134,11 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+13 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 0.10418
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.10418
 
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 6.62821e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 6.62821e-08
+
 
    Postprocessing:
      Topography min/max: -16.56 m, 53.6 m
@@ -141,10 +149,11 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+12 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 0.0473456
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0473456
 
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 8.8979e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 8.8979e-08
+
 
    Postprocessing:
      Topography min/max: -15.59 m, 51.61 m
@@ -155,10 +164,11 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+12 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 0.0267511
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0267511
 
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 3.89629e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 3.89629e-08
+
 
    Postprocessing:
      Topography min/max: -16.14 m, 52.83 m
@@ -169,10 +179,11 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+12 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 0.0142383
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0142383
 
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 2.29327e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 2.29327e-08
+
 
    Postprocessing:
      Topography min/max: -15.92 m, 52.4 m
@@ -183,10 +194,11 @@ Number of free surface degrees of freedom: 1466
    Solving temperature system... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 0.00867112
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.00867112
 
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 6.26255e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 6.26255e-08
+
 
    Postprocessing:
      Topography min/max: -16.1 m, 52.83 m

--- a/tests/geoid/screen-output
+++ b/tests/geoid/screen-output
@@ -5,9 +5,11 @@ Number of degrees of freedom: 28,690 (20,790+970+6,930)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 131+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 11+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 5.22911e-06
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 5.22911e-06
+
 
    Postprocessing:
 

--- a/tests/geoid_visualization/log.txt
+++ b/tests/geoid_visualization/log.txt
@@ -5,11 +5,14 @@ Number of degrees of freedom: 4,030 (2,910+150+970)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 168+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 10+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.00849e-05
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.00849e-05
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 3.53216e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 3: 3.53216e-08
+
 
    Postprocessing:
      Density at top/bottom of domain:  1 kg/m^3, 1 kg/m^3

--- a/tests/global_melt/screen-output
+++ b/tests/global_melt/screen-output
@@ -9,19 +9,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 1.93774e-16, 0, 0, 1
-      Total relative residual after nonlinear iteration 1: 1
-
-
-   Solving temperature system... 0 iterations.
-   Skipping porosity composition solve because RHS is zero.
-   Skipping peridotite composition solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+8 iterations.
-   Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 2.04275e-16, 0, 0, 0.799766
-      Total relative residual after nonlinear iteration 2: 0.799766
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.93774e-16, 0, 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -29,19 +18,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 2.57791e-16, 0, 0, 0.173272
-      Total relative residual after nonlinear iteration 3: 0.173272
-
-
-   Solving temperature system... 0 iterations.
-   Skipping porosity composition solve because RHS is zero.
-   Skipping peridotite composition solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+8 iterations.
-   Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 2.43416e-16, 0, 0, 0.0272016
-      Total relative residual after nonlinear iteration 4: 0.0272016
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.04275e-16, 0, 0, 0.799766
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.799766
 
    Solving temperature system... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -49,9 +27,26 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 2.30853e-16, 0, 0, 0.0032544
-      Total relative residual after nonlinear iteration 5: 0.0032544
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.57791e-16, 0, 0, 0.173272
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.173272
 
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+8 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.43416e-16, 0, 0, 0.0272016
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0272016
+
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+8 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.30853e-16, 0, 0, 0.0032544
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.0032544
 
    Solving temperature system... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -59,9 +54,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 2.49451e-16, 0, 0, 0.000312907
-      Total relative residual after nonlinear iteration 6: 0.000312907
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.49451e-16, 0, 0, 0.000312907
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000312907
 
    Solving temperature system... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -69,9 +63,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 2.62223e-16, 0, 0, 2.51035e-05
-      Total relative residual after nonlinear iteration 7: 2.51035e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.62223e-16, 0, 0, 2.51035e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 2.51035e-05
 
    Solving temperature system... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -79,9 +72,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 2.42614e-16, 0, 0, 1.72283e-06
-      Total relative residual after nonlinear iteration 8: 1.72283e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.42614e-16, 0, 0, 1.72283e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.72283e-06
 
 
    Postprocessing:
@@ -98,9 +90,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 0.000991159, 0, 0, 0.0240528
-      Total relative residual after nonlinear iteration 1: 0.0240528
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000991159, 0, 0, 0.0240528
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0240528
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -108,9 +99,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 1.3476e-05, 0, 0, 0.000984558
-      Total relative residual after nonlinear iteration 2: 0.000984558
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.3476e-05, 0, 0, 0.000984558
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000984558
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -118,9 +108,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 7.32672e-07, 0, 0, 0.000187049
-      Total relative residual after nonlinear iteration 3: 0.000187049
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.32672e-07, 0, 0, 0.000187049
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000187049
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -128,9 +117,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 3.4116e-08, 0, 0, 3.96409e-05
-      Total relative residual after nonlinear iteration 4: 3.96409e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.4116e-08, 0, 0, 3.96409e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 3.96409e-05
 
    Solving temperature system... 5 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -138,9 +126,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 9.16557e-10, 0, 0, 5.74474e-06
-      Total relative residual after nonlinear iteration 5: 5.74474e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.16557e-10, 0, 0, 5.74474e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 5.74474e-06
 
 
    Postprocessing:
@@ -157,9 +144,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 0.000138201, 0, 0, 0.0033994
-      Total relative residual after nonlinear iteration 1: 0.0033994
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000138201, 0, 0, 0.0033994
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0033994
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -167,9 +153,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 3.14812e-07, 0, 0, 0.000241801
-      Total relative residual after nonlinear iteration 2: 0.000241801
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.14812e-07, 0, 0, 0.000241801
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000241801
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -177,9 +162,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 3.74306e-08, 0, 0, 7.72142e-05
-      Total relative residual after nonlinear iteration 3: 7.72142e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.74306e-08, 0, 0, 7.72142e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 7.72142e-05
 
    Solving temperature system... 5 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -187,9 +171,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 2.0005e-09, 0, 0, 1.52198e-05
-      Total relative residual after nonlinear iteration 4: 1.52198e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.0005e-09, 0, 0, 1.52198e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.52198e-05
 
    Solving temperature system... 4 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -197,9 +180,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 7.48012e-11, 0, 0, 2.14798e-06
-      Total relative residual after nonlinear iteration 5: 2.14798e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.48012e-11, 0, 0, 2.14798e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 2.14798e-06
 
 
    Postprocessing:
@@ -216,9 +198,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 1.2938e-05, 0, 0, 0.000284218
-      Total relative residual after nonlinear iteration 1: 0.000284218
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.2938e-05, 0, 0, 0.000284218
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000284218
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -226,9 +207,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 1.97026e-07, 0, 0, 5.37861e-05
-      Total relative residual after nonlinear iteration 2: 5.37861e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.97026e-07, 0, 0, 5.37861e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.37861e-05
 
    Solving temperature system... 4 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -236,9 +216,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 3.96568e-10, 0, 0, 1.59852e-05
-      Total relative residual after nonlinear iteration 3: 1.59852e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.96568e-10, 0, 0, 1.59852e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 1.59852e-05
 
    Solving temperature system... 3 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -246,9 +225,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 3.30779e-11, 0, 0, 3.03751e-06
-      Total relative residual after nonlinear iteration 4: 3.03751e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.30779e-11, 0, 0, 3.03751e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 3.03751e-06
 
 
    Postprocessing:

--- a/tests/graphical_output/screen-output
+++ b/tests/graphical_output/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.87792e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.87792e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174944e-01, 1.069688e-04, 1.192654e-01

--- a/tests/graphical_output_hdf5/screen-output
+++ b/tests/graphical_output_hdf5/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.87792e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.87792e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174944e-01, 1.069688e-04, 1.192654e-01

--- a/tests/heat_advection_by_melt/screen-output
+++ b/tests/heat_advection_by_melt/screen-output
@@ -11,9 +11,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.80371e-16, 2.44479e-16, 0, 0.0526341
-      Total relative residual after nonlinear iteration 1: 0.0526341
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.80371e-16, 2.44479e-16, 0, 0.0526341
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0526341
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -21,9 +20,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.80371e-16, 2.44479e-16, 0, 6.93218e-13
-      Total relative residual after nonlinear iteration 2: 6.93218e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.80371e-16, 2.44479e-16, 0, 6.93218e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 6.93218e-13
 
 
    Postprocessing:
@@ -38,9 +36,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000399056, 1.08876e-13, 0, 6.93183e-13
-      Total relative residual after nonlinear iteration 1: 0.000399056
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000399056, 1.08876e-13, 0, 6.93183e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000399056
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -48,9 +45,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.52837e-13, 1.08876e-13, 0, 6.93183e-13
-      Total relative residual after nonlinear iteration 2: 6.93183e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.52837e-13, 1.08876e-13, 0, 6.93183e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 6.93183e-13
 
 
    Postprocessing:
@@ -65,9 +61,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000179105, 7.25484e-14, 0, 6.93183e-13
-      Total relative residual after nonlinear iteration 1: 0.000179105
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000179105, 7.25484e-14, 0, 6.93183e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000179105
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -75,9 +70,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 4.13911e-13, 7.25484e-14, 0, 6.93183e-13
-      Total relative residual after nonlinear iteration 2: 6.93183e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.13911e-13, 7.25484e-14, 0, 6.93183e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 6.93183e-13
 
 
    Postprocessing:
@@ -92,9 +86,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000100345, 7.25484e-14, 0, 6.93183e-13
-      Total relative residual after nonlinear iteration 1: 0.000100345
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000100345, 7.25484e-14, 0, 6.93183e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000100345
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -102,9 +95,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.39945e-13, 7.25484e-14, 0, 6.93183e-13
-      Total relative residual after nonlinear iteration 2: 6.93183e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.39945e-13, 7.25484e-14, 0, 6.93183e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 6.93183e-13
 
 
    Postprocessing:
@@ -119,9 +111,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.70704e-05, 1.86717e-14, 0, 6.93289e-13
-      Total relative residual after nonlinear iteration 1: 1.70704e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.70704e-05, 1.86717e-14, 0, 6.93289e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1.70704e-05
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -129,9 +120,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 3.30007e-13, 1.86717e-14, 0, 6.93299e-13
-      Total relative residual after nonlinear iteration 2: 6.93299e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.30007e-13, 1.86717e-14, 0, 6.93299e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 6.93299e-13
 
 
    Postprocessing:

--- a/tests/hollow_sphere/screen-output
+++ b/tests/hollow_sphere/screen-output
@@ -7,10 +7,12 @@ Number of degrees of freedom: 28,690 (20,790+970+6,930)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+46 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 4.28149e-13
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 4.28149e-13
+
 
    Postprocessing:
      Writing graphical output:              output-hollow_sphere/solution/solution-00000

--- a/tests/inclusion_2/screen-output
+++ b/tests/inclusion_2/screen-output
@@ -7,7 +7,8 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
 
    Postprocessing:
      Writing graphical output:            output-inclusion_2/solution/solution-00000

--- a/tests/inclusion_4/screen-output
+++ b/tests/inclusion_4/screen-output
@@ -7,7 +7,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 86+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
 
    Postprocessing:
      Writing graphical output:            output-inclusion_4/solution/solution-00000

--- a/tests/inclusion_adaptive/screen-output
+++ b/tests/inclusion_adaptive/screen-output
@@ -7,7 +7,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
 
    Postprocessing:
      Writing graphical output:            output-inclusion_adaptive/solution/solution-00000
@@ -19,7 +20,8 @@ Number of degrees of freedom: 1,520 (930+125+465)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
 
    Postprocessing:
      Writing graphical output:            output-inclusion_adaptive/solution/solution-00001
@@ -31,7 +33,8 @@ Number of degrees of freedom: 2,664 (1,634+213+817)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
 
    Postprocessing:
      Writing graphical output:            output-inclusion_adaptive/solution/solution-00002
@@ -43,7 +46,8 @@ Number of degrees of freedom: 4,172 (2,562+329+1,281)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 143+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
 
    Postprocessing:
      Writing graphical output:            output-inclusion_adaptive/solution/solution-00003
@@ -55,7 +59,8 @@ Number of degrees of freedom: 6,824 (4,194+533+2,097)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 144+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
 
    Postprocessing:
      Writing graphical output:            output-inclusion_adaptive/solution/solution-00004
@@ -67,7 +72,8 @@ Number of degrees of freedom: 11,153 (6,858+866+3,429)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 131+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
 
    Postprocessing:
      Writing graphical output:            output-inclusion_adaptive/solution/solution-00005

--- a/tests/initial_porosity/screen-output
+++ b/tests/initial_porosity/screen-output
@@ -1,5 +1,3 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 
 Number of active cells: 192 (on 4 levels)
 Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
@@ -11,9 +9,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+36 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.87476e-16, 1.20111e-16, 0, 0.956793
-      Total relative residual after nonlinear iteration 1: 0.956793
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.87476e-16, 1.20111e-16, 0, 0.956793
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.956793
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -21,9 +18,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+36 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.06779e-16, 1.20111e-16, 0, 0.752886
-      Total relative residual after nonlinear iteration 2: 0.752886
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.13013e-16, 1.20111e-16, 0, 0.752886
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.752886
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -31,9 +27,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+35 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.27332e-16, 1.20111e-16, 0, 0.16311
-      Total relative residual after nonlinear iteration 3: 0.16311
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.3936e-16, 1.20111e-16, 0, 0.16311
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.16311
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -41,9 +36,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+32 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.11339e-16, 1.20111e-16, 0, 0.025768
-      Total relative residual after nonlinear iteration 4: 0.025768
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.21222e-16, 1.20111e-16, 0, 0.025768
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.025768
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -51,9 +45,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+28 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.18051e-16, 1.20111e-16, 0, 0.00311419
-      Total relative residual after nonlinear iteration 5: 0.00311419
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.24729e-16, 1.20111e-16, 0, 0.00311419
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.00311419
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -61,9 +54,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+25 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.12606e-16, 1.20111e-16, 0, 0.000303303
-      Total relative residual after nonlinear iteration 6: 0.000303303
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.12646e-16, 1.20111e-16, 0, 0.000303303
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000303303
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -71,9 +63,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+21 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.18238e-16, 1.20111e-16, 0, 2.46785e-05
-      Total relative residual after nonlinear iteration 7: 2.46785e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.2184e-16, 1.20111e-16, 0, 2.46785e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 2.46785e-05
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -81,9 +72,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+17 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.06733e-16, 1.20111e-16, 0, 1.71537e-06
-      Total relative residual after nonlinear iteration 8: 1.71537e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.16234e-16, 1.20111e-16, 0, 1.71537e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.71537e-06
 
 
    Postprocessing:

--- a/tests/iterated_IMPES/screen-output
+++ b/tests/iterated_IMPES/screen-output
@@ -7,16 +7,14 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 58+0 iterations.
-      Relative nonlinear residuals: 1.89643e-16, 1.57797e-16, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.89643e-16, 1.57797e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residuals: 1.89643e-16, 1.57797e-16, 5.20807e-13
-      Total relative residual after nonlinear iteration 2: 5.20807e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.89643e-16, 1.57797e-16, 5.20807e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.20807e-13
 
 
    Postprocessing:
@@ -25,58 +23,50 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 10 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residuals: 0.821377, 0.0571457, 0.75783
-      Total relative residual after nonlinear iteration 1: 0.821377
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.821377, 0.0571457, 0.75783
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.821377
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 53+0 iterations.
-      Relative nonlinear residuals: 0.0977331, 0.00375789, 0.113623
-      Total relative residual after nonlinear iteration 2: 0.113623
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0977331, 0.00375789, 0.113623
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.113623
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 49+0 iterations.
-      Relative nonlinear residuals: 0.0168861, 0.000513186, 0.0205037
-      Total relative residual after nonlinear iteration 3: 0.0205037
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0168861, 0.000513186, 0.0205037
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0205037
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 46+0 iterations.
-      Relative nonlinear residuals: 0.00320707, 0.00010333, 0.00392882
-      Total relative residual after nonlinear iteration 4: 0.00392882
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00320707, 0.00010333, 0.00392882
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00392882
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 0.000633249, 2.34421e-05, 0.000777886
-      Total relative residual after nonlinear iteration 5: 0.000777886
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000633249, 2.34421e-05, 0.000777886
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000777886
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 40+0 iterations.
-      Relative nonlinear residuals: 0.000127909, 5.42261e-06, 0.000157509
-      Total relative residual after nonlinear iteration 6: 0.000157509
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000127909, 5.42261e-06, 0.000157509
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000157509
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residuals: 2.62433e-05, 1.24498e-06, 3.24128e-05
-      Total relative residual after nonlinear iteration 7: 3.24128e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.62433e-05, 1.24498e-06, 3.24128e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 3.24128e-05
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residuals: 5.44567e-06, 2.82028e-07, 6.74805e-06
-      Total relative residual after nonlinear iteration 8: 6.74805e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.44567e-06, 2.82028e-07, 6.74805e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 6.74805e-06
 
 
    Postprocessing:
@@ -85,58 +75,50 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residuals: 0.247282, 0.00789326, 0.455259
-      Total relative residual after nonlinear iteration 1: 0.455259
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.247282, 0.00789326, 0.455259
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.455259
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 52+0 iterations.
-      Relative nonlinear residuals: 0.015113, 0.000446344, 0.055206
-      Total relative residual after nonlinear iteration 2: 0.055206
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.015113, 0.000446344, 0.055206
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.055206
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 47+0 iterations.
-      Relative nonlinear residuals: 0.00209268, 7.85134e-05, 0.00922176
-      Total relative residual after nonlinear iteration 3: 0.00922176
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00209268, 7.85134e-05, 0.00922176
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00922176
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 0.000380649, 2.13856e-05, 0.00168053
-      Total relative residual after nonlinear iteration 4: 0.00168053
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000380649, 2.13856e-05, 0.00168053
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00168053
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 40+0 iterations.
-      Relative nonlinear residuals: 7.22582e-05, 5.57131e-06, 0.000317032
-      Total relative residual after nonlinear iteration 5: 0.000317032
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.22582e-05, 5.57131e-06, 0.000317032
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000317032
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residuals: 1.39971e-05, 1.351e-06, 6.12444e-05
-      Total relative residual after nonlinear iteration 6: 6.12444e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.39971e-05, 1.351e-06, 6.12444e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 6.12444e-05
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residuals: 2.7557e-06, 3.12297e-07, 1.2047e-05
-      Total relative residual after nonlinear iteration 7: 1.2047e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.7557e-06, 3.12297e-07, 1.2047e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 1.2047e-05
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals: 5.4958e-07, 6.99312e-08, 2.40272e-06
-      Total relative residual after nonlinear iteration 8: 2.40272e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.4958e-07, 6.99312e-08, 2.40272e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 2.40272e-06
 
 
    Postprocessing:
@@ -145,44 +127,38 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residuals: 0.254258, 0.00608319, 0.647102
-      Total relative residual after nonlinear iteration 1: 0.647102
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.254258, 0.00608319, 0.647102
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.647102
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 48+0 iterations.
-      Relative nonlinear residuals: 0.00864642, 0.000460019, 0.0271297
-      Total relative residual after nonlinear iteration 2: 0.0271297
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00864642, 0.000460019, 0.0271297
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0271297
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residuals: 0.000401659, 2.14864e-05, 0.00147209
-      Total relative residual after nonlinear iteration 3: 0.00147209
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000401659, 2.14864e-05, 0.00147209
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00147209
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 40+0 iterations.
-      Relative nonlinear residuals: 3.45653e-05, 2.90915e-06, 0.000143673
-      Total relative residual after nonlinear iteration 4: 0.000143673
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.45653e-05, 2.90915e-06, 0.000143673
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000143673
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 36+0 iterations.
-      Relative nonlinear residuals: 4.35868e-06, 3.40281e-07, 1.83012e-05
-      Total relative residual after nonlinear iteration 5: 1.83012e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.35868e-06, 3.40281e-07, 1.83012e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.83012e-05
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals: 5.86969e-07, 3.66392e-08, 2.45329e-06
-      Total relative residual after nonlinear iteration 6: 2.45329e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.86969e-07, 3.66392e-08, 2.45329e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 2.45329e-06
 
 
    Postprocessing:
@@ -191,44 +167,38 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residuals: 0.120332, 0.00649854, 0.594093
-      Total relative residual after nonlinear iteration 1: 0.594093
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.120332, 0.00649854, 0.594093
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.594093
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 49+0 iterations.
-      Relative nonlinear residuals: 0.00420756, 0.000824451, 0.0150718
-      Total relative residual after nonlinear iteration 2: 0.0150718
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00420756, 0.000824451, 0.0150718
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0150718
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residuals: 0.000244847, 6.41437e-05, 0.00104033
-      Total relative residual after nonlinear iteration 3: 0.00104033
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000244847, 6.41437e-05, 0.00104033
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00104033
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 39+0 iterations.
-      Relative nonlinear residuals: 2.29483e-05, 6.59889e-06, 9.98032e-05
-      Total relative residual after nonlinear iteration 4: 9.98032e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.29483e-05, 6.59889e-06, 9.98032e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 9.98032e-05
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 35+0 iterations.
-      Relative nonlinear residuals: 2.3895e-06, 7.20227e-07, 1.05543e-05
-      Total relative residual after nonlinear iteration 5: 1.05543e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.3895e-06, 7.20227e-07, 1.05543e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.05543e-05
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals: 2.54344e-07, 7.39165e-08, 1.12433e-06
-      Total relative residual after nonlinear iteration 6: 1.12433e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.54344e-07, 7.39165e-08, 1.12433e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 1.12433e-06
 
 
    Postprocessing:
@@ -237,37 +207,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residuals: 0.0801971, 0.00650811, 0.383226
-      Total relative residual after nonlinear iteration 1: 0.383226
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0801971, 0.00650811, 0.383226
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.383226
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 48+0 iterations.
-      Relative nonlinear residuals: 0.00260234, 0.000921972, 0.0120047
-      Total relative residual after nonlinear iteration 2: 0.0120047
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00260234, 0.000921972, 0.0120047
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0120047
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 0.000185779, 0.000117988, 0.000929408
-      Total relative residual after nonlinear iteration 3: 0.000929408
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000185779, 0.000117988, 0.000929408
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000929408
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 39+0 iterations.
-      Relative nonlinear residuals: 1.754e-05, 1.23398e-05, 9.01498e-05
-      Total relative residual after nonlinear iteration 4: 9.01498e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.754e-05, 1.23398e-05, 9.01498e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 9.01498e-05
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residuals: 1.74434e-06, 1.25013e-06, 9.03192e-06
-      Total relative residual after nonlinear iteration 5: 9.03192e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.74434e-06, 1.25013e-06, 9.03192e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 9.03192e-06
 
 
    Postprocessing:
@@ -276,37 +241,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residuals: 0.0572412, 0.00689934, 0.258279
-      Total relative residual after nonlinear iteration 1: 0.258279
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0572412, 0.00689934, 0.258279
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.258279
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 48+0 iterations.
-      Relative nonlinear residuals: 0.00175675, 0.00107406, 0.00805902
-      Total relative residual after nonlinear iteration 2: 0.00805902
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00175675, 0.00107406, 0.00805902
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00805902
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 0.000127417, 0.000112878, 0.000630225
-      Total relative residual after nonlinear iteration 3: 0.000630225
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000127417, 0.000112878, 0.000630225
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000630225
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 38+0 iterations.
-      Relative nonlinear residuals: 1.18384e-05, 1.12086e-05, 6.03151e-05
-      Total relative residual after nonlinear iteration 4: 6.03151e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.18384e-05, 1.12086e-05, 6.03151e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 6.03151e-05
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residuals: 1.14789e-06, 1.10076e-06, 5.95712e-06
-      Total relative residual after nonlinear iteration 5: 5.95712e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.14789e-06, 1.10076e-06, 5.95712e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 5.95712e-06
 
 
    Postprocessing:
@@ -315,37 +275,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residuals: 0.038188, 0.00732507, 0.159808
-      Total relative residual after nonlinear iteration 1: 0.159808
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.038188, 0.00732507, 0.159808
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.159808
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 48+0 iterations.
-      Relative nonlinear residuals: 0.00121057, 0.000995593, 0.00550759
-      Total relative residual after nonlinear iteration 2: 0.00550759
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00121057, 0.000995593, 0.00550759
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00550759
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 9.03844e-05, 9.45603e-05, 0.000439483
-      Total relative residual after nonlinear iteration 3: 0.000439483
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.03844e-05, 9.45603e-05, 0.000439483
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000439483
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 38+0 iterations.
-      Relative nonlinear residuals: 8.20473e-06, 8.8462e-06, 4.12574e-05
-      Total relative residual after nonlinear iteration 4: 4.12574e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.20473e-06, 8.8462e-06, 4.12574e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 4.12574e-05
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residuals: 7.72319e-07, 8.30891e-07, 3.96441e-06
-      Total relative residual after nonlinear iteration 5: 3.96441e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.72319e-07, 8.30891e-07, 3.96441e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 3.96441e-06
 
 
    Postprocessing:
@@ -354,37 +309,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 53+0 iterations.
-      Relative nonlinear residuals: 0.0247562, 0.00760225, 0.0961601
-      Total relative residual after nonlinear iteration 1: 0.0961601
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0247562, 0.00760225, 0.0961601
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0961601
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 47+0 iterations.
-      Relative nonlinear residuals: 0.000898388, 0.000855813, 0.00400586
-      Total relative residual after nonlinear iteration 2: 0.00400586
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000898388, 0.000855813, 0.00400586
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00400586
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 42+0 iterations.
-      Relative nonlinear residuals: 7.01468e-05, 7.60177e-05, 0.000325253
-      Total relative residual after nonlinear iteration 3: 0.000325253
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.01468e-05, 7.60177e-05, 0.000325253
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000325253
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residuals: 6.16673e-06, 6.72049e-06, 2.93572e-05
-      Total relative residual after nonlinear iteration 4: 2.93572e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.16673e-06, 6.72049e-06, 2.93572e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 2.93572e-05
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals: 5.54728e-07, 5.98863e-07, 2.67649e-06
-      Total relative residual after nonlinear iteration 5: 2.67649e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.54728e-07, 5.98863e-07, 2.67649e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 2.67649e-06
 
 
    Postprocessing:
@@ -393,37 +343,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 52+0 iterations.
-      Relative nonlinear residuals: 0.0164665, 0.00766179, 0.0590716
-      Total relative residual after nonlinear iteration 1: 0.0590716
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0164665, 0.00766179, 0.0590716
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0590716
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 46+0 iterations.
-      Relative nonlinear residuals: 0.00068657, 0.000710171, 0.00294368
-      Total relative residual after nonlinear iteration 2: 0.00294368
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00068657, 0.000710171, 0.00294368
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00294368
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 41+0 iterations.
-      Relative nonlinear residuals: 5.36425e-05, 5.79232e-05, 0.000236209
-      Total relative residual after nonlinear iteration 3: 0.000236209
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.36425e-05, 5.79232e-05, 0.000236209
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000236209
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 36+0 iterations.
-      Relative nonlinear residuals: 4.45823e-06, 4.77118e-06, 2.00694e-05
-      Total relative residual after nonlinear iteration 4: 2.00694e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.45823e-06, 4.77118e-06, 2.00694e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 2.00694e-05
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals: 3.76583e-07, 3.98543e-07, 1.70762e-06
-      Total relative residual after nonlinear iteration 5: 1.70762e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.76583e-07, 3.98543e-07, 1.70762e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.70762e-06
 
 
    Postprocessing:
@@ -432,37 +377,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 52+0 iterations.
-      Relative nonlinear residuals: 0.0123146, 0.00762178, 0.0416316
-      Total relative residual after nonlinear iteration 1: 0.0416316
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0123146, 0.00762178, 0.0416316
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0416316
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residuals: 0.00056907, 0.000605296, 0.00224469
-      Total relative residual after nonlinear iteration 2: 0.00224469
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00056907, 0.000605296, 0.00224469
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00224469
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 41+0 iterations.
-      Relative nonlinear residuals: 4.14175e-05, 4.41337e-05, 0.000170268
-      Total relative residual after nonlinear iteration 3: 0.000170268
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.14175e-05, 4.41337e-05, 0.000170268
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000170268
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 36+0 iterations.
-      Relative nonlinear residuals: 3.17896e-06, 3.34472e-06, 1.33117e-05
-      Total relative residual after nonlinear iteration 4: 1.33117e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.17896e-06, 3.34472e-06, 1.33117e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.33117e-05
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals: 2.47978e-07, 2.58616e-07, 1.04354e-06
-      Total relative residual after nonlinear iteration 5: 1.04354e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.47978e-07, 2.58616e-07, 1.04354e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.04354e-06
 
 
    Postprocessing:
@@ -471,30 +411,26 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 52+0 iterations.
-      Relative nonlinear residuals: 0.00785454, 0.00556257, 0.0254169
-      Total relative residual after nonlinear iteration 1: 0.0254169
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00785454, 0.00556257, 0.0254169
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0254169
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residuals: 0.000300093, 0.000322736, 0.00111551
-      Total relative residual after nonlinear iteration 2: 0.00111551
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000300093, 0.000322736, 0.00111551
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00111551
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 39+0 iterations.
-      Relative nonlinear residuals: 1.66866e-05, 1.763e-05, 6.51037e-05
-      Total relative residual after nonlinear iteration 3: 6.51037e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.66866e-05, 1.763e-05, 6.51037e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 6.51037e-05
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residuals: 9.88274e-07, 1.02788e-06, 3.9168e-06
-      Total relative residual after nonlinear iteration 4: 3.9168e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.88274e-07, 1.02788e-06, 3.9168e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 3.9168e-06
 
 
    Postprocessing:

--- a/tests/iterated_IMPES_direct_solver/screen-output
+++ b/tests/iterated_IMPES_direct_solver/screen-output
@@ -6,16 +6,14 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 2.00269e-16, 1.56192e-16, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.89643e-16, 1.57797e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 2.00269e-16, 1.56192e-16, 2.08736e-12
-      Total relative residual after nonlinear iteration 2: 2.08736e-12
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.89643e-16, 1.57797e-16, 4.37568e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.37568e-12
 
 
    Postprocessing:
@@ -24,58 +22,50 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 10 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.821377, 0.0571457, 0.75783
-      Total relative residual after nonlinear iteration 1: 0.821377
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.821377, 0.0571457, 0.75783
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.821377
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.0977331, 0.00375789, 0.113623
-      Total relative residual after nonlinear iteration 2: 0.113623
-
-
-   Solving temperature system... 9 iterations.
-   Solving porosity system ... 8 iterations.
-   Solving Stokes system... done.
-      Relative nonlinear residuals: 0.0168861, 0.000513186, 0.0205037
-      Total relative residual after nonlinear iteration 3: 0.0205037
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0977331, 0.00375789, 0.113623
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.113623
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.00320707, 0.00010333, 0.00392882
-      Total relative residual after nonlinear iteration 4: 0.00392882
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0168861, 0.000513186, 0.0205037
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0205037
 
+   Solving temperature system... 9 iterations.
+   Solving porosity system ... 8 iterations.
+   Solving Stokes system... done.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00320707, 0.00010333, 0.00392882
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00392882
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.000633249, 2.34421e-05, 0.000777886
-      Total relative residual after nonlinear iteration 5: 0.000777886
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000633249, 2.34421e-05, 0.000777886
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000777886
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.000127909, 5.42261e-06, 0.000157509
-      Total relative residual after nonlinear iteration 6: 0.000157509
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000127909, 5.42261e-06, 0.000157509
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000157509
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 2.62433e-05, 1.24498e-06, 3.24128e-05
-      Total relative residual after nonlinear iteration 7: 3.24128e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.62433e-05, 1.24498e-06, 3.24128e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 3.24128e-05
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 5.44567e-06, 2.82028e-07, 6.74805e-06
-      Total relative residual after nonlinear iteration 8: 6.74805e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.44567e-06, 2.82028e-07, 6.74805e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 6.74805e-06
 
 
    Postprocessing:
@@ -84,58 +74,50 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.247282, 0.00789326, 0.455259
-      Total relative residual after nonlinear iteration 1: 0.455259
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.247282, 0.00789326, 0.455259
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.455259
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.015113, 0.000446344, 0.055206
-      Total relative residual after nonlinear iteration 2: 0.055206
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.015113, 0.000446344, 0.055206
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.055206
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.00209268, 7.85134e-05, 0.00922176
-      Total relative residual after nonlinear iteration 3: 0.00922176
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00209268, 7.85134e-05, 0.00922176
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00922176
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.000380649, 2.13856e-05, 0.00168053
-      Total relative residual after nonlinear iteration 4: 0.00168053
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000380649, 2.13856e-05, 0.00168053
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00168053
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 7.22582e-05, 5.57131e-06, 0.000317032
-      Total relative residual after nonlinear iteration 5: 0.000317032
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.22582e-05, 5.57131e-06, 0.000317032
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000317032
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 1.39971e-05, 1.351e-06, 6.12444e-05
-      Total relative residual after nonlinear iteration 6: 6.12444e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.39971e-05, 1.351e-06, 6.12444e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 6.12444e-05
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 2.7557e-06, 3.12297e-07, 1.2047e-05
-      Total relative residual after nonlinear iteration 7: 1.2047e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.7557e-06, 3.12297e-07, 1.2047e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 1.2047e-05
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 5.4958e-07, 6.99312e-08, 2.40272e-06
-      Total relative residual after nonlinear iteration 8: 2.40272e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.4958e-07, 6.99312e-08, 2.40272e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 2.40272e-06
 
 
    Postprocessing:
@@ -144,44 +126,38 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.254258, 0.00608319, 0.647102
-      Total relative residual after nonlinear iteration 1: 0.647102
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.254258, 0.00608319, 0.647102
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.647102
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.00864642, 0.000460019, 0.0271297
-      Total relative residual after nonlinear iteration 2: 0.0271297
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00864642, 0.000460019, 0.0271297
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0271297
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.000401659, 2.14864e-05, 0.00147209
-      Total relative residual after nonlinear iteration 3: 0.00147209
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000401659, 2.14864e-05, 0.00147209
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00147209
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 3.45653e-05, 2.90915e-06, 0.000143673
-      Total relative residual after nonlinear iteration 4: 0.000143673
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.45653e-05, 2.90915e-06, 0.000143673
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000143673
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 4.35868e-06, 3.40281e-07, 1.83012e-05
-      Total relative residual after nonlinear iteration 5: 1.83012e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.35868e-06, 3.40281e-07, 1.83012e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.83012e-05
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 5.86969e-07, 3.66392e-08, 2.45329e-06
-      Total relative residual after nonlinear iteration 6: 2.45329e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.86969e-07, 3.66392e-08, 2.45329e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 2.45329e-06
 
 
    Postprocessing:
@@ -190,44 +166,38 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.120332, 0.00649854, 0.594093
-      Total relative residual after nonlinear iteration 1: 0.594093
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.120332, 0.00649854, 0.594093
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.594093
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.00420756, 0.000824451, 0.0150718
-      Total relative residual after nonlinear iteration 2: 0.0150718
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00420756, 0.000824451, 0.0150718
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0150718
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.000244847, 6.41437e-05, 0.00104033
-      Total relative residual after nonlinear iteration 3: 0.00104033
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000244847, 6.41437e-05, 0.00104033
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00104033
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 2.29483e-05, 6.59889e-06, 9.98032e-05
-      Total relative residual after nonlinear iteration 4: 9.98032e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.29483e-05, 6.59889e-06, 9.98032e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 9.98032e-05
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 2.3895e-06, 7.20227e-07, 1.05543e-05
-      Total relative residual after nonlinear iteration 5: 1.05543e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.3895e-06, 7.20227e-07, 1.05543e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.05543e-05
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 2.54344e-07, 7.39165e-08, 1.12433e-06
-      Total relative residual after nonlinear iteration 6: 1.12433e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.54344e-07, 7.39165e-08, 1.12433e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 1.12433e-06
 
 
    Postprocessing:
@@ -236,37 +206,32 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.0801971, 0.00650811, 0.383226
-      Total relative residual after nonlinear iteration 1: 0.383226
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0801971, 0.00650811, 0.383226
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.383226
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.00260234, 0.000921972, 0.0120047
-      Total relative residual after nonlinear iteration 2: 0.0120047
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00260234, 0.000921972, 0.0120047
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0120047
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.000185779, 0.000117988, 0.000929408
-      Total relative residual after nonlinear iteration 3: 0.000929408
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000185779, 0.000117988, 0.000929408
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000929408
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 1.754e-05, 1.23398e-05, 9.01498e-05
-      Total relative residual after nonlinear iteration 4: 9.01498e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.754e-05, 1.23398e-05, 9.01498e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 9.01498e-05
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 1.74434e-06, 1.25013e-06, 9.03192e-06
-      Total relative residual after nonlinear iteration 5: 9.03192e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.74434e-06, 1.25013e-06, 9.03192e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 9.03192e-06
 
 
    Postprocessing:
@@ -275,37 +240,32 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.0572412, 0.00689934, 0.258279
-      Total relative residual after nonlinear iteration 1: 0.258279
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0572412, 0.00689934, 0.258279
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.258279
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.00175675, 0.00107406, 0.00805902
-      Total relative residual after nonlinear iteration 2: 0.00805902
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00175675, 0.00107406, 0.00805902
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00805902
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.000127417, 0.000112878, 0.000630225
-      Total relative residual after nonlinear iteration 3: 0.000630225
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000127417, 0.000112878, 0.000630225
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000630225
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 1.18384e-05, 1.12086e-05, 6.03151e-05
-      Total relative residual after nonlinear iteration 4: 6.03151e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.18384e-05, 1.12086e-05, 6.03151e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 6.03151e-05
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 1.14789e-06, 1.10076e-06, 5.95712e-06
-      Total relative residual after nonlinear iteration 5: 5.95712e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.14789e-06, 1.10076e-06, 5.95712e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 5.95712e-06
 
 
    Postprocessing:
@@ -314,37 +274,32 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.038188, 0.00732507, 0.159808
-      Total relative residual after nonlinear iteration 1: 0.159808
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.038188, 0.00732507, 0.159808
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.159808
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.00121057, 0.000995593, 0.00550759
-      Total relative residual after nonlinear iteration 2: 0.00550759
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00121057, 0.000995593, 0.00550759
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00550759
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 9.03844e-05, 9.45603e-05, 0.000439483
-      Total relative residual after nonlinear iteration 3: 0.000439483
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.03844e-05, 9.45603e-05, 0.000439483
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000439483
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 8.20473e-06, 8.8462e-06, 4.12574e-05
-      Total relative residual after nonlinear iteration 4: 4.12574e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.20473e-06, 8.8462e-06, 4.12574e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 4.12574e-05
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 7.72319e-07, 8.30891e-07, 3.96441e-06
-      Total relative residual after nonlinear iteration 5: 3.96441e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.72319e-07, 8.30891e-07, 3.96441e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 3.96441e-06
 
 
    Postprocessing:
@@ -353,37 +308,32 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.0247562, 0.00760225, 0.0961601
-      Total relative residual after nonlinear iteration 1: 0.0961601
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0247562, 0.00760225, 0.0961601
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0961601
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.000898388, 0.000855813, 0.00400586
-      Total relative residual after nonlinear iteration 2: 0.00400586
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000898388, 0.000855813, 0.00400586
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00400586
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 7.01468e-05, 7.60177e-05, 0.000325253
-      Total relative residual after nonlinear iteration 3: 0.000325253
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.01468e-05, 7.60177e-05, 0.000325253
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000325253
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 6.16673e-06, 6.72049e-06, 2.93572e-05
-      Total relative residual after nonlinear iteration 4: 2.93572e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.16673e-06, 6.72049e-06, 2.93572e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 2.93572e-05
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 5.54728e-07, 5.98863e-07, 2.67649e-06
-      Total relative residual after nonlinear iteration 5: 2.67649e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.54728e-07, 5.98863e-07, 2.67649e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 2.67649e-06
 
 
    Postprocessing:
@@ -392,37 +342,32 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.0164665, 0.00766179, 0.0590716
-      Total relative residual after nonlinear iteration 1: 0.0590716
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0164665, 0.00766179, 0.0590716
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0590716
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.00068657, 0.000710171, 0.00294368
-      Total relative residual after nonlinear iteration 2: 0.00294368
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00068657, 0.000710171, 0.00294368
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00294368
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 5.36425e-05, 5.79232e-05, 0.000236209
-      Total relative residual after nonlinear iteration 3: 0.000236209
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.36425e-05, 5.79232e-05, 0.000236209
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000236209
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 4.45823e-06, 4.77118e-06, 2.00694e-05
-      Total relative residual after nonlinear iteration 4: 2.00694e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.45823e-06, 4.77118e-06, 2.00694e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 2.00694e-05
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 3.76583e-07, 3.98543e-07, 1.70762e-06
-      Total relative residual after nonlinear iteration 5: 1.70762e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.76583e-07, 3.98543e-07, 1.70762e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.70762e-06
 
 
    Postprocessing:
@@ -431,37 +376,32 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.0123146, 0.00762178, 0.0416316
-      Total relative residual after nonlinear iteration 1: 0.0416316
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0123146, 0.00762178, 0.0416316
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0416316
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.00056907, 0.000605296, 0.00224469
-      Total relative residual after nonlinear iteration 2: 0.00224469
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00056907, 0.000605296, 0.00224469
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00224469
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 4.14175e-05, 4.41337e-05, 0.000170268
-      Total relative residual after nonlinear iteration 3: 0.000170268
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.14175e-05, 4.41337e-05, 0.000170268
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000170268
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 3.17896e-06, 3.34472e-06, 1.33117e-05
-      Total relative residual after nonlinear iteration 4: 1.33117e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.17896e-06, 3.34472e-06, 1.33117e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.33117e-05
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 2.47978e-07, 2.58616e-07, 1.04355e-06
-      Total relative residual after nonlinear iteration 5: 1.04355e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.47978e-07, 2.58616e-07, 1.04355e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.04355e-06
 
 
    Postprocessing:
@@ -470,30 +410,26 @@ Number of degrees of freedom: 9,141 (4,851+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.00785454, 0.00556257, 0.0254169
-      Total relative residual after nonlinear iteration 1: 0.0254169
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00785454, 0.00556257, 0.0254169
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0254169
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 0.000300093, 0.000322736, 0.00111551
-      Total relative residual after nonlinear iteration 2: 0.00111551
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000300093, 0.000322736, 0.00111551
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00111551
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 1.66866e-05, 1.763e-05, 6.51037e-05
-      Total relative residual after nonlinear iteration 3: 6.51037e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.66866e-05, 1.763e-05, 6.51037e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 6.51037e-05
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-      Relative nonlinear residuals: 9.88274e-07, 1.02788e-06, 3.9168e-06
-      Total relative residual after nonlinear iteration 4: 3.9168e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.88274e-07, 1.02788e-06, 3.9168e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 3.9168e-06
 
 
    Postprocessing:

--- a/tests/iterated_IMPES_residual/screen-output
+++ b/tests/iterated_IMPES_residual/screen-output
@@ -7,16 +7,14 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 58+0 iterations.
-      Relative nonlinear residuals: 1.89643e-16, 0, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.89643e-16, 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residuals: 1.89643e-16, 0, 5.20807e-13
-      Total relative residual after nonlinear iteration 2: 5.20807e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.89643e-16, 0, 5.20807e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.20807e-13
 
 
    Postprocessing:
@@ -25,58 +23,50 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 10 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residuals: 0.821377, 0, 0.75783
-      Total relative residual after nonlinear iteration 1: 0.821377
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.821377, 0, 0.75783
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.821377
 
    Solving temperature system... 10 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 53+0 iterations.
-      Relative nonlinear residuals: 0.0977331, 0, 0.113623
-      Total relative residual after nonlinear iteration 2: 0.113623
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0977331, 0, 0.113623
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.113623
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 49+0 iterations.
-      Relative nonlinear residuals: 0.0168861, 0, 0.0205037
-      Total relative residual after nonlinear iteration 3: 0.0205037
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0168861, 0, 0.0205037
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0205037
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 46+0 iterations.
-      Relative nonlinear residuals: 0.00320707, 0, 0.00392882
-      Total relative residual after nonlinear iteration 4: 0.00392882
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00320707, 0, 0.00392882
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00392882
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 0.000633249, 0, 0.000777886
-      Total relative residual after nonlinear iteration 5: 0.000777886
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000633249, 0, 0.000777886
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000777886
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 40+0 iterations.
-      Relative nonlinear residuals: 0.000127909, 0, 0.000157509
-      Total relative residual after nonlinear iteration 6: 0.000157509
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000127909, 0, 0.000157509
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000157509
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residuals: 2.62433e-05, 0, 3.24128e-05
-      Total relative residual after nonlinear iteration 7: 3.24128e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.62433e-05, 0, 3.24128e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 3.24128e-05
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residuals: 5.44567e-06, 0, 6.74805e-06
-      Total relative residual after nonlinear iteration 8: 6.74805e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.44567e-06, 0, 6.74805e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 6.74805e-06
 
 
    Postprocessing:
@@ -85,58 +75,50 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residuals: 0.247282, 0, 0.455259
-      Total relative residual after nonlinear iteration 1: 0.455259
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.247282, 0, 0.455259
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.455259
 
    Solving temperature system... 10 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 52+0 iterations.
-      Relative nonlinear residuals: 0.015113, 0, 0.055206
-      Total relative residual after nonlinear iteration 2: 0.055206
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.015113, 0, 0.055206
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.055206
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 47+0 iterations.
-      Relative nonlinear residuals: 0.00209268, 0, 0.00922176
-      Total relative residual after nonlinear iteration 3: 0.00922176
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00209268, 0, 0.00922176
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00922176
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 0.000380649, 0, 0.00168053
-      Total relative residual after nonlinear iteration 4: 0.00168053
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000380649, 0, 0.00168053
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00168053
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 40+0 iterations.
-      Relative nonlinear residuals: 7.22582e-05, 0, 0.000317032
-      Total relative residual after nonlinear iteration 5: 0.000317032
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.22582e-05, 0, 0.000317032
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000317032
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residuals: 1.39971e-05, 0, 6.12444e-05
-      Total relative residual after nonlinear iteration 6: 6.12444e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.39971e-05, 0, 6.12444e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 6.12444e-05
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residuals: 2.7557e-06, 0, 1.2047e-05
-      Total relative residual after nonlinear iteration 7: 1.2047e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.7557e-06, 0, 1.2047e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 1.2047e-05
 
    Solving temperature system... 5 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals: 5.4958e-07, 0, 2.40272e-06
-      Total relative residual after nonlinear iteration 8: 2.40272e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.4958e-07, 0, 2.40272e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 2.40272e-06
 
 
    Postprocessing:
@@ -145,44 +127,38 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residuals: 0.254258, 0, 0.647102
-      Total relative residual after nonlinear iteration 1: 0.647102
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.254258, 0, 0.647102
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.647102
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 48+0 iterations.
-      Relative nonlinear residuals: 0.00864642, 0, 0.0271297
-      Total relative residual after nonlinear iteration 2: 0.0271297
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00864642, 0, 0.0271297
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0271297
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residuals: 0.000401659, 0, 0.00147209
-      Total relative residual after nonlinear iteration 3: 0.00147209
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000401659, 0, 0.00147209
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00147209
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 40+0 iterations.
-      Relative nonlinear residuals: 3.45653e-05, 0, 0.000143673
-      Total relative residual after nonlinear iteration 4: 0.000143673
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.45653e-05, 0, 0.000143673
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000143673
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 36+0 iterations.
-      Relative nonlinear residuals: 4.35868e-06, 0, 1.83012e-05
-      Total relative residual after nonlinear iteration 5: 1.83012e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.35868e-06, 0, 1.83012e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.83012e-05
 
    Solving temperature system... 5 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals: 5.86969e-07, 0, 2.45329e-06
-      Total relative residual after nonlinear iteration 6: 2.45329e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.86969e-07, 0, 2.45329e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 2.45329e-06
 
 
    Postprocessing:
@@ -191,44 +167,38 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residuals: 0.120332, 0, 0.594093
-      Total relative residual after nonlinear iteration 1: 0.594093
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.120332, 0, 0.594093
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.594093
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 49+0 iterations.
-      Relative nonlinear residuals: 0.00420756, 0, 0.0150718
-      Total relative residual after nonlinear iteration 2: 0.0150718
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00420756, 0, 0.0150718
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0150718
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residuals: 0.000244847, 0, 0.00104033
-      Total relative residual after nonlinear iteration 3: 0.00104033
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000244847, 0, 0.00104033
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00104033
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 39+0 iterations.
-      Relative nonlinear residuals: 2.29483e-05, 0, 9.98032e-05
-      Total relative residual after nonlinear iteration 4: 9.98032e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.29483e-05, 0, 9.98032e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 9.98032e-05
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 35+0 iterations.
-      Relative nonlinear residuals: 2.3895e-06, 0, 1.05543e-05
-      Total relative residual after nonlinear iteration 5: 1.05543e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.3895e-06, 0, 1.05543e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.05543e-05
 
    Solving temperature system... 5 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals: 2.54344e-07, 0, 1.12433e-06
-      Total relative residual after nonlinear iteration 6: 1.12433e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.54344e-07, 0, 1.12433e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 1.12433e-06
 
 
    Postprocessing:
@@ -237,37 +207,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residuals: 0.0801971, 0, 0.383226
-      Total relative residual after nonlinear iteration 1: 0.383226
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0801971, 0, 0.383226
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.383226
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 48+0 iterations.
-      Relative nonlinear residuals: 0.00260234, 0, 0.0120047
-      Total relative residual after nonlinear iteration 2: 0.0120047
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00260234, 0, 0.0120047
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0120047
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 0.000185779, 0, 0.000929408
-      Total relative residual after nonlinear iteration 3: 0.000929408
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000185779, 0, 0.000929408
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000929408
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 39+0 iterations.
-      Relative nonlinear residuals: 1.754e-05, 0, 9.01498e-05
-      Total relative residual after nonlinear iteration 4: 9.01498e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.754e-05, 0, 9.01498e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 9.01498e-05
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residuals: 1.74434e-06, 0, 9.03192e-06
-      Total relative residual after nonlinear iteration 5: 9.03192e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.74434e-06, 0, 9.03192e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 9.03192e-06
 
 
    Postprocessing:
@@ -276,37 +241,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residuals: 0.0572412, 0, 0.258279
-      Total relative residual after nonlinear iteration 1: 0.258279
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0572412, 0, 0.258279
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.258279
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 48+0 iterations.
-      Relative nonlinear residuals: 0.00175675, 0, 0.00805902
-      Total relative residual after nonlinear iteration 2: 0.00805902
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00175675, 0, 0.00805902
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00805902
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 0.000127417, 0, 0.000630225
-      Total relative residual after nonlinear iteration 3: 0.000630225
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000127417, 0, 0.000630225
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000630225
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 38+0 iterations.
-      Relative nonlinear residuals: 1.18384e-05, 0, 6.03151e-05
-      Total relative residual after nonlinear iteration 4: 6.03151e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.18384e-05, 0, 6.03151e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 6.03151e-05
 
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residuals: 1.14789e-06, 0, 5.95712e-06
-      Total relative residual after nonlinear iteration 5: 5.95712e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.14789e-06, 0, 5.95712e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 5.95712e-06
 
 
    Postprocessing:
@@ -315,37 +275,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residuals: 0.038188, 0, 0.159808
-      Total relative residual after nonlinear iteration 1: 0.159808
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.038188, 0, 0.159808
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.159808
 
    Solving temperature system... 10 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 48+0 iterations.
-      Relative nonlinear residuals: 0.00121057, 0, 0.00550759
-      Total relative residual after nonlinear iteration 2: 0.00550759
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00121057, 0, 0.00550759
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00550759
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 9.03844e-05, 0, 0.000439483
-      Total relative residual after nonlinear iteration 3: 0.000439483
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.03844e-05, 0, 0.000439483
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000439483
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 38+0 iterations.
-      Relative nonlinear residuals: 8.20473e-06, 0, 4.12574e-05
-      Total relative residual after nonlinear iteration 4: 4.12574e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.20473e-06, 0, 4.12574e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 4.12574e-05
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residuals: 7.72319e-07, 0, 3.96441e-06
-      Total relative residual after nonlinear iteration 5: 3.96441e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.72319e-07, 0, 3.96441e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 3.96441e-06
 
 
    Postprocessing:
@@ -354,37 +309,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 12 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 53+0 iterations.
-      Relative nonlinear residuals: 0.0247562, 0, 0.0961601
-      Total relative residual after nonlinear iteration 1: 0.0961601
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0247562, 0, 0.0961601
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0961601
 
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 47+0 iterations.
-      Relative nonlinear residuals: 0.000898388, 0, 0.00400586
-      Total relative residual after nonlinear iteration 2: 0.00400586
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000898388, 0, 0.00400586
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00400586
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 42+0 iterations.
-      Relative nonlinear residuals: 7.01468e-05, 0, 0.000325253
-      Total relative residual after nonlinear iteration 3: 0.000325253
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.01468e-05, 0, 0.000325253
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000325253
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residuals: 6.16673e-06, 0, 2.93572e-05
-      Total relative residual after nonlinear iteration 4: 2.93572e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.16673e-06, 0, 2.93572e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 2.93572e-05
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals: 5.54728e-07, 0, 2.67649e-06
-      Total relative residual after nonlinear iteration 5: 2.67649e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.54728e-07, 0, 2.67649e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 2.67649e-06
 
 
    Postprocessing:
@@ -393,37 +343,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 12 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 52+0 iterations.
-      Relative nonlinear residuals: 0.0164665, 0, 0.0590716
-      Total relative residual after nonlinear iteration 1: 0.0590716
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0164665, 0, 0.0590716
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0590716
 
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 46+0 iterations.
-      Relative nonlinear residuals: 0.00068657, 0, 0.00294368
-      Total relative residual after nonlinear iteration 2: 0.00294368
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00068657, 0, 0.00294368
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00294368
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 41+0 iterations.
-      Relative nonlinear residuals: 5.36425e-05, 0, 0.000236209
-      Total relative residual after nonlinear iteration 3: 0.000236209
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.36425e-05, 0, 0.000236209
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000236209
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 36+0 iterations.
-      Relative nonlinear residuals: 4.45823e-06, 0, 2.00694e-05
-      Total relative residual after nonlinear iteration 4: 2.00694e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.45823e-06, 0, 2.00694e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 2.00694e-05
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals: 3.76583e-07, 0, 1.70762e-06
-      Total relative residual after nonlinear iteration 5: 1.70762e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.76583e-07, 0, 1.70762e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.70762e-06
 
 
    Postprocessing:
@@ -432,37 +377,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 12 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 52+0 iterations.
-      Relative nonlinear residuals: 0.0123146, 0, 0.0416316
-      Total relative residual after nonlinear iteration 1: 0.0416316
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0123146, 0, 0.0416316
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0416316
 
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residuals: 0.00056907, 0, 0.00224469
-      Total relative residual after nonlinear iteration 2: 0.00224469
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00056907, 0, 0.00224469
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00224469
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 41+0 iterations.
-      Relative nonlinear residuals: 4.14175e-05, 0, 0.000170268
-      Total relative residual after nonlinear iteration 3: 0.000170268
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.14175e-05, 0, 0.000170268
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000170268
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 36+0 iterations.
-      Relative nonlinear residuals: 3.17896e-06, 0, 1.33117e-05
-      Total relative residual after nonlinear iteration 4: 1.33117e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.17896e-06, 0, 1.33117e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.33117e-05
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals: 2.47978e-07, 0, 1.04354e-06
-      Total relative residual after nonlinear iteration 5: 1.04354e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.47978e-07, 0, 1.04354e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.04354e-06
 
 
    Postprocessing:
@@ -471,30 +411,26 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 52+0 iterations.
-      Relative nonlinear residuals: 0.00785454, 0, 0.0254169
-      Total relative residual after nonlinear iteration 1: 0.0254169
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00785454, 0, 0.0254169
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0254169
 
    Solving temperature system... 10 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residuals: 0.000300093, 0, 0.00111551
-      Total relative residual after nonlinear iteration 2: 0.00111551
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000300093, 0, 0.00111551
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00111551
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 39+0 iterations.
-      Relative nonlinear residuals: 1.66866e-05, 0, 6.51037e-05
-      Total relative residual after nonlinear iteration 3: 6.51037e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.66866e-05, 0, 6.51037e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 6.51037e-05
 
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residuals: 9.88274e-07, 0, 3.9168e-06
-      Total relative residual after nonlinear iteration 4: 3.9168e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.88274e-07, 0, 3.9168e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 3.9168e-06
 
 
    Postprocessing:

--- a/tests/latent_heat_melt_transport/screen-output
+++ b/tests/latent_heat_melt_transport/screen-output
@@ -9,9 +9,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.83933e-16, 1.60089e-16, 1.50592e-16, 0.00012165
-      Total relative residual after nonlinear iteration 1: 0.00012165
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.83933e-16, 1.60089e-16, 1.50592e-16, 0.00012165
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00012165
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -19,9 +18,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.83933e-16, 1.60089e-16, 1.50592e-16, 8.25373e-08
-      Total relative residual after nonlinear iteration 2: 8.25373e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.83933e-16, 1.60089e-16, 1.50592e-16, 8.25373e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 8.25373e-08
 
 
    Postprocessing:
@@ -36,9 +34,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0150594, 0.203757, 0.259564, 4.07818e-05
-      Total relative residual after nonlinear iteration 1: 0.259564
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0150594, 0.203757, 0.259564, 4.07818e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.259564
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 13 iterations.
@@ -46,9 +43,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 5.49004e-05, 0.00333518, 0.00286354, 6.51165e-08
-      Total relative residual after nonlinear iteration 2: 0.00333518
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.49004e-05, 0.00333518, 0.00286354, 6.51165e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00333518
 
    Solving temperature system... 4 iterations.
    Solving porosity system ... 0 iterations.
@@ -56,9 +52,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.08607e-10, 2.20879e-13, 2.26445e-13, 6.51165e-08
-      Total relative residual after nonlinear iteration 3: 6.51165e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.08607e-10, 2.20879e-13, 2.26445e-13, 6.51165e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 6.51165e-08
 
 
    Postprocessing:
@@ -73,9 +68,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0105744, 0.154238, 0.167567, 5.51298e-07
-      Total relative residual after nonlinear iteration 1: 0.167567
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0105744, 0.154238, 0.167567, 5.51298e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.167567
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 10 iterations.
@@ -83,9 +77,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.12669e-05, 0.00117165, 0.000389695, 4.86123e-08
-      Total relative residual after nonlinear iteration 2: 0.00117165
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.12669e-05, 0.00117165, 0.000389695, 4.86123e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00117165
 
    Solving temperature system... 2 iterations.
    Solving porosity system ... 9 iterations.
@@ -93,19 +86,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.85983e-11, 0.000148815, 7.41024e-13, 4.86174e-08
-      Total relative residual after nonlinear iteration 3: 0.000148815
-
-
-   Solving temperature system... 0 iterations.
-   Solving porosity system ... 9 iterations.
-   Solving peridotite system ... 0 iterations.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.59393e-13, 0.000148815, 7.41024e-13, 4.86123e-08
-      Total relative residual after nonlinear iteration 4: 0.000148815
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.85983e-11, 0.000148815, 7.41024e-13, 4.86174e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000148815
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 9 iterations.
@@ -113,19 +95,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.26918e-13, 0.000148815, 7.41024e-13, 4.86174e-08
-      Total relative residual after nonlinear iteration 5: 0.000148815
-
-
-   Solving temperature system... 0 iterations.
-   Solving porosity system ... 9 iterations.
-   Solving peridotite system ... 0 iterations.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.59393e-13, 0.000148815, 7.41024e-13, 4.86123e-08
-      Total relative residual after nonlinear iteration 6: 0.000148815
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.59393e-13, 0.000148815, 7.41024e-13, 4.86123e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000148815
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 9 iterations.
@@ -133,19 +104,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.26918e-13, 0.000148815, 7.41024e-13, 4.86174e-08
-      Total relative residual after nonlinear iteration 7: 0.000148815
-
-
-   Solving temperature system... 0 iterations.
-   Solving porosity system ... 9 iterations.
-   Solving peridotite system ... 0 iterations.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.59393e-13, 0.000148815, 7.41024e-13, 4.86123e-08
-      Total relative residual after nonlinear iteration 8: 0.000148815
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.26918e-13, 0.000148815, 7.41024e-13, 4.86174e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000148815
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 9 iterations.
@@ -153,9 +113,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.26916e-13, 0.000148815, 7.41024e-13, 4.86174e-08
-      Total relative residual after nonlinear iteration 9: 0.000148815
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.59393e-13, 0.000148815, 7.41024e-13, 4.86123e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000148815
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 9 iterations.
@@ -163,9 +122,35 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.59395e-13, 0.000148815, 7.41024e-13, 4.86123e-08
-      Total relative residual after nonlinear iteration 10: 0.000148815
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.26918e-13, 0.000148815, 7.41024e-13, 4.86174e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.000148815
 
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 9 iterations.
+   Solving peridotite system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.59393e-13, 0.000148815, 7.41024e-13, 4.86123e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.000148815
+
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 9 iterations.
+   Solving peridotite system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.26916e-13, 0.000148815, 7.41024e-13, 4.86174e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.000148815
+
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 9 iterations.
+   Solving peridotite system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.59395e-13, 0.000148815, 7.41024e-13, 4.86123e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 0.000148815
 
 
    Postprocessing:
@@ -180,9 +165,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0158185, 0.146794, 0.124944, 5.70469e-07
-      Total relative residual after nonlinear iteration 1: 0.146794
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0158185, 0.146794, 0.124944, 5.70469e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.146794
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 10 iterations.
@@ -190,9 +174,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.85531e-05, 0.000699156, 0.000238916, 3.16831e-08
-      Total relative residual after nonlinear iteration 2: 0.000699156
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.85531e-05, 0.000699156, 0.000238916, 3.16831e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000699156
 
    Solving temperature system... 2 iterations.
    Solving porosity system ... 0 iterations.
@@ -200,9 +183,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 3.5252e-11, 1.71746e-13, 1.91736e-13, 3.16831e-08
-      Total relative residual after nonlinear iteration 3: 3.16831e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.5252e-11, 1.71746e-13, 1.91736e-13, 3.16831e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 3.16831e-08
 
 
    Postprocessing:
@@ -217,9 +199,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.021462, 0.14055, 0.111032, 5.50671e-07
-      Total relative residual after nonlinear iteration 1: 0.14055
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.021462, 0.14055, 0.111032, 5.50671e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.14055
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 9 iterations.
@@ -227,9 +208,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.17211e-05, 0.00044463, 0.000115323, 8.10133e-08
-      Total relative residual after nonlinear iteration 2: 0.00044463
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.17211e-05, 0.00044463, 0.000115323, 8.10133e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00044463
 
    Solving temperature system... 2 iterations.
    Solving porosity system ... 0 iterations.
@@ -237,9 +217,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 3.02717e-11, 8.36798e-13, 8.72412e-14, 8.10133e-08
-      Total relative residual after nonlinear iteration 3: 8.10133e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.02717e-11, 8.36798e-13, 8.72412e-14, 8.10133e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 8.10133e-08
 
 
    Postprocessing:
@@ -254,9 +233,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0264644, 0.131136, 0.104996, 2.9482e-07
-      Total relative residual after nonlinear iteration 1: 0.131136
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0264644, 0.131136, 0.104996, 2.9482e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.131136
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 10 iterations.
@@ -264,9 +242,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.9962e-05, 0.000448412, 0.000107037, 8.25724e-08
-      Total relative residual after nonlinear iteration 2: 0.000448412
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.9962e-05, 0.000448412, 0.000107037, 8.25724e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000448412
 
    Solving temperature system... 2 iterations.
    Solving porosity system ... 0 iterations.
@@ -274,9 +251,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.67759e-11, 1.37331e-13, 1.1967e-13, 8.25724e-08
-      Total relative residual after nonlinear iteration 3: 8.25724e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.67759e-11, 1.37331e-13, 1.1967e-13, 8.25724e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 8.25724e-08
 
 
    Postprocessing:
@@ -291,9 +267,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0308942, 0.127509, 0.107849, 1.29482e-07
-      Total relative residual after nonlinear iteration 1: 0.127509
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0308942, 0.127509, 0.107849, 1.29482e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.127509
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 10 iterations.
@@ -301,9 +276,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 5.38432e-05, 0.000672806, 0.000154405, 6.00908e-08
-      Total relative residual after nonlinear iteration 2: 0.000672806
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.38432e-05, 0.000672806, 0.000154405, 6.00908e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000672806
 
    Solving temperature system... 2 iterations.
    Solving porosity system ... 0 iterations.
@@ -311,9 +285,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 6.10969e-11, 6.12537e-13, 1.43974e-13, 6.00908e-08
-      Total relative residual after nonlinear iteration 3: 6.00908e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.10969e-11, 6.12537e-13, 1.43974e-13, 6.00908e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 6.00908e-08
 
 
    Postprocessing:
@@ -328,9 +301,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0328401, 0.1246, 0.112742, 1.57815e-07
-      Total relative residual after nonlinear iteration 1: 0.1246
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0328401, 0.1246, 0.112742, 1.57815e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.1246
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 10 iterations.
@@ -338,9 +310,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.12398e-05, 0.000151324, 4.82231e-05, 5.11078e-08
-      Total relative residual after nonlinear iteration 2: 0.000151324
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.12398e-05, 0.000151324, 4.82231e-05, 5.11078e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000151324
 
    Solving temperature system... 1 iterations.
    Solving porosity system ... 0 iterations.
@@ -348,9 +319,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 6.71597e-12, 3.41592e-13, 5.36169e-13, 5.11078e-08
-      Total relative residual after nonlinear iteration 3: 5.11078e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.71597e-12, 3.41592e-13, 5.36169e-13, 5.11078e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 5.11078e-08
 
 
    Postprocessing:
@@ -365,9 +335,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0339234, 0.121681, 0.115215, 7.37796e-08
-      Total relative residual after nonlinear iteration 1: 0.121681
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0339234, 0.121681, 0.115215, 7.37796e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.121681
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 0 iterations.
@@ -375,9 +344,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 9.62654e-09, 4.04142e-13, 4.66009e-13, 7.37796e-08
-      Total relative residual after nonlinear iteration 2: 7.37796e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.62654e-09, 4.04142e-13, 4.66009e-13, 7.37796e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 7.37796e-08
 
 
    Postprocessing:
@@ -392,9 +360,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0337888, 0.120189, 0.114098, 8.15124e-08
-      Total relative residual after nonlinear iteration 1: 0.120189
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0337888, 0.120189, 0.114098, 8.15124e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.120189
 
    Solving temperature system... 4 iterations.
    Solving porosity system ... 0 iterations.
@@ -402,9 +369,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 7.78622e-09, 5.71682e-13, 7.8228e-13, 8.15124e-08
-      Total relative residual after nonlinear iteration 2: 8.15124e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.78622e-09, 5.71682e-13, 7.8228e-13, 8.15124e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 8.15124e-08
 
 
    Postprocessing:
@@ -419,9 +385,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0329769, 0.119843, 0.114976, 8.43178e-08
-      Total relative residual after nonlinear iteration 1: 0.119843
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0329769, 0.119843, 0.114976, 8.43178e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.119843
 
    Solving temperature system... 4 iterations.
    Solving porosity system ... 0 iterations.
@@ -429,9 +394,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 5.43156e-09, 4.90299e-13, 2.06152e-13, 8.43178e-08
-      Total relative residual after nonlinear iteration 2: 8.43178e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.43156e-09, 4.90299e-13, 2.06152e-13, 8.43178e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 8.43178e-08
 
 
    Postprocessing:
@@ -446,9 +410,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0316927, 0.120157, 0.116813, 8.41751e-08
-      Total relative residual after nonlinear iteration 1: 0.120157
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0316927, 0.120157, 0.116813, 8.41751e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.120157
 
    Solving temperature system... 4 iterations.
    Solving porosity system ... 0 iterations.
@@ -456,9 +419,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 4.40566e-09, 6.57999e-13, 2.9013e-13, 8.41751e-08
-      Total relative residual after nonlinear iteration 2: 8.41751e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.40566e-09, 6.57999e-13, 2.9013e-13, 8.41751e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 8.41751e-08
 
 
    Postprocessing:
@@ -473,9 +435,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0300061, 0.12079, 0.118311, 8.9351e-08
-      Total relative residual after nonlinear iteration 1: 0.12079
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0300061, 0.12079, 0.118311, 8.9351e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.12079
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 0 iterations.
@@ -483,9 +444,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 5.07565e-09, 9.83068e-13, 4.13064e-13, 8.9351e-08
-      Total relative residual after nonlinear iteration 2: 8.9351e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.07565e-09, 9.83068e-13, 4.13064e-13, 8.9351e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 8.9351e-08
 
 
    Postprocessing:
@@ -500,9 +460,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0286491, 0.1217, 0.119684, 1.05713e-07
-      Total relative residual after nonlinear iteration 1: 0.1217
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0286491, 0.1217, 0.119684, 1.05713e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.1217
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 10 iterations.
@@ -510,9 +469,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 8.60041e-06, 0.000285958, 3.54737e-05, 4.50705e-08
-      Total relative residual after nonlinear iteration 2: 0.000285958
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.60041e-06, 0.000285958, 3.54737e-05, 4.50705e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000285958
 
    Solving temperature system... 1 iterations.
    Solving porosity system ... 0 iterations.
@@ -520,9 +478,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.40022e-11, 5.52793e-13, 7.36531e-13, 4.50705e-08
-      Total relative residual after nonlinear iteration 3: 4.50705e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.40022e-11, 5.52793e-13, 7.36531e-13, 4.50705e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 4.50705e-08
 
 
    Postprocessing:
@@ -537,9 +494,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0280877, 0.123633, 0.1219, 4.50963e-08
-      Total relative residual after nonlinear iteration 1: 0.123633
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0280877, 0.123633, 0.1219, 4.50963e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.123633
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 0 iterations.
@@ -547,9 +503,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 7.81997e-09, 2.21162e-13, 1.65415e-13, 4.50963e-08
-      Total relative residual after nonlinear iteration 2: 4.50963e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.81997e-09, 2.21162e-13, 1.65415e-13, 4.50963e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.50963e-08
 
 
    Postprocessing:
@@ -564,9 +519,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0276304, 0.123819, 0.122267, 4.39449e-08
-      Total relative residual after nonlinear iteration 1: 0.123819
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0276304, 0.123819, 0.122267, 4.39449e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.123819
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 0 iterations.
@@ -574,9 +528,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 7.65069e-09, 2.21849e-13, 1.99435e-13, 4.39449e-08
-      Total relative residual after nonlinear iteration 2: 4.39449e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.65069e-09, 2.21849e-13, 1.99435e-13, 4.39449e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.39449e-08
 
 
    Postprocessing:
@@ -591,9 +544,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0274124, 0.124034, 0.122377, 4.38016e-08
-      Total relative residual after nonlinear iteration 1: 0.124034
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0274124, 0.124034, 0.122377, 4.38016e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.124034
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 0 iterations.
@@ -601,9 +553,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 6.65409e-09, 2.39067e-13, 1.9749e-13, 4.38016e-08
-      Total relative residual after nonlinear iteration 2: 4.38016e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.65409e-09, 2.39067e-13, 1.9749e-13, 4.38016e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.38016e-08
 
 
    Postprocessing:
@@ -618,9 +569,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.00475285, 0.0239615, 0.0235776, 1.32739e-06
-      Total relative residual after nonlinear iteration 1: 0.0239615
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00475285, 0.0239615, 0.0235776, 1.32739e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0239615
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
@@ -628,9 +578,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 4.52595e-05, 0.000705658, 0.000203359, 2.32535e-09
-      Total relative residual after nonlinear iteration 2: 0.000705658
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.52595e-05, 0.000705658, 0.000203359, 2.32535e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000705658
 
    Solving temperature system... 1 iterations.
    Solving porosity system ... 0 iterations.
@@ -638,9 +587,8 @@ Number of degrees of freedom: 2,266 (578+162+578+81+289+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.46144e-11, 5.72576e-13, 1.71332e-13, 2.32535e-09
-      Total relative residual after nonlinear iteration 3: 2.32535e-09
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.46144e-11, 5.72576e-13, 1.71332e-13, 2.32535e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 2.32535e-09
 
 
    Postprocessing:

--- a/tests/material_model_dependencies_burstedde/screen-output
+++ b/tests/material_model_dependencies_burstedde/screen-output
@@ -7,10 +7,12 @@ Number of degrees of freedom: 3,041 (2,187+125+729)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+54 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 4.81093e-13
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 4.81093e-13
+
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_composition_reaction/screen-output
+++ b/tests/material_model_dependencies_composition_reaction/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 4+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 7.08454e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 7.08454e-08
+
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_cookbooks_freesurface_with_crust/screen-output
+++ b/tests/material_model_dependencies_cookbooks_freesurface_with_crust/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 4+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 7.08454e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 7.08454e-08
+
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_diffusion_dislocation/screen-output
+++ b/tests/material_model_dependencies_diffusion_dislocation/screen-output
@@ -7,10 +7,12 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.14426e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.14426e-08
+
 
    Postprocessing:
 viscosity depends on pressure temperature strainrate composition

--- a/tests/material_model_dependencies_inclusion_2/screen-output
+++ b/tests/material_model_dependencies_inclusion_2/screen-output
@@ -7,7 +7,8 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 0
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 0
+
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_latent_heat/screen-output
+++ b/tests/material_model_dependencies_latent_heat/screen-output
@@ -7,34 +7,44 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 0.0294233
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0294233
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 0.0379145
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 3: 0.0379145
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 0.0422029
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 4: 0.0422029
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative Stokes residual after nonlinear iteration 5: 0.0271934
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 5: 0.0271934
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 6: 0.025862
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 6: 0.025862
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 7: 0.0253227
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 7: 0.0253227
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 8: 0.0287235
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 8: 0.0287235
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative Stokes residual after nonlinear iteration 9: 0.0265349
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 9: 0.0265349
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative Stokes residual after nonlinear iteration 10: 0.0294574
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 10: 0.0294574
+
 
    Postprocessing:
 viscosity depends on temperature composition

--- a/tests/material_model_dependencies_latent_heat_melt/screen-output
+++ b/tests/material_model_dependencies_latent_heat_melt/screen-output
@@ -7,10 +7,12 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 6.07177e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 6.07177e-08
+
 
    Postprocessing:
 viscosity depends on temperature composition

--- a/tests/material_model_dependencies_morency_doin/screen-output
+++ b/tests/material_model_dependencies_morency_doin/screen-output
@@ -7,10 +7,12 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 7.02044e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 7.02044e-08
+
 
    Postprocessing:
 viscosity depends on temperature strainrate composition

--- a/tests/material_model_dependencies_multicomponent/screen-output
+++ b/tests/material_model_dependencies_multicomponent/screen-output
@@ -7,10 +7,12 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 7.08461e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 7.08461e-08
+
 
    Postprocessing:
 viscosity depends on composition

--- a/tests/material_model_dependencies_shear_thinning/screen-output
+++ b/tests/material_model_dependencies_shear_thinning/screen-output
@@ -7,10 +7,12 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.0136e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.0136e-07
+
 
    Postprocessing:
 viscosity depends on strainrate

--- a/tests/material_model_dependencies_simple/screen-output
+++ b/tests/material_model_dependencies_simple/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 4+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 7.08454e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 7.08454e-08
+
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_simple_compressible/screen-output
+++ b/tests/material_model_dependencies_simple_compressible/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 3+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 6.04956e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 6.04956e-08
+
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_simpler/screen-output
+++ b/tests/material_model_dependencies_simpler/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 4+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 7.08454e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 7.08454e-08
+
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_solcx/screen-output
+++ b/tests/material_model_dependencies_solcx/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.87792e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.87792e-08
+
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_solkz/screen-output
+++ b/tests/material_model_dependencies_solkz/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 7.96927e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 7.96927e-08
+
 
    Postprocessing:
 viscosity depends on

--- a/tests/material_model_dependencies_steinberger/screen-output
+++ b/tests/material_model_dependencies_steinberger/screen-output
@@ -7,25 +7,32 @@ Number of degrees of freedom: 740 (450+65+225)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.35577
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.35577
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 0.0195071
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 3: 0.0195071
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 0.00606259
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 4: 0.00606259
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative Stokes residual after nonlinear iteration 5: 0.000110896
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 5: 0.000110896
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Relative Stokes residual after nonlinear iteration 6: 2.76625e-05
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 6: 2.76625e-05
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Relative Stokes residual after nonlinear iteration 7: 6.19593e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 7: 6.19593e-07
+
 
    Postprocessing:
 viscosity depends on temperature

--- a/tests/material_model_dependencies_tangurnis/screen-output
+++ b/tests/material_model_dependencies_tangurnis/screen-output
@@ -7,25 +7,35 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 7+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 20.4416
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 20.4416
+
    Solving Stokes system... 7+0 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 10.31
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 3: 10.31
+
    Solving Stokes system... 7+0 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 5.34104
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 4: 5.34104
+
    Solving Stokes system... 7+0 iterations.
-      Relative Stokes residual after nonlinear iteration 5: 2.84276
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 5: 2.84276
+
    Solving Stokes system... 6+0 iterations.
-      Relative Stokes residual after nonlinear iteration 6: 1.55029
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 6: 1.55029
+
    Solving Stokes system... 6+0 iterations.
-      Relative Stokes residual after nonlinear iteration 7: 0.862476
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 7: 0.862476
+
    Solving Stokes system... 6+0 iterations.
-      Relative Stokes residual after nonlinear iteration 8: 0.487235
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 8: 0.487235
+
    Solving Stokes system... 6+0 iterations.
-      Relative Stokes residual after nonlinear iteration 9: 0.278377
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 9: 0.278377
+
    Solving Stokes system... 6+0 iterations.
-      Relative Stokes residual after nonlinear iteration 10: 0.160346
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 10: 0.160346
+
 
    Postprocessing:
 viscosity depends on

--- a/tests/melt_and_traction/screen-output
+++ b/tests/melt_and_traction/screen-output
@@ -9,9 +9,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 1.49526e-16, 2.30078e-16, 0, 0.000973208
-      Total relative residual after nonlinear iteration 1: 0.000973208
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.49526e-16, 2.30078e-16, 0, 0.000973208
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000973208
 
    Postprocessing:
      Writing graphical output:           output-melt_and_traction/solution/solution-00000.0000
@@ -26,9 +25,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 1.49526e-16, 2.30078e-16, 0, 9.27108e-09
-      Total relative residual after nonlinear iteration 2: 9.27108e-09
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.49526e-16, 2.30078e-16, 0, 9.27108e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 9.27108e-09
 
    Postprocessing:
      Writing graphical output:           output-melt_and_traction/solution/solution-00000.0001
@@ -46,9 +44,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 0.000274912, 0.00595397, 0, 8.47115e-06
-      Total relative residual after nonlinear iteration 1: 0.00595397
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000274912, 0.00595397, 0, 8.47115e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00595397
 
    Postprocessing:
      Writing graphical output:           output-melt_and_traction/solution/solution-00001.0000
@@ -63,9 +60,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 3.21996e-08, 5.53571e-05, 0, 2.65971e-08
-      Total relative residual after nonlinear iteration 2: 5.53571e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.21996e-08, 5.53571e-05, 0, 2.65971e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.53571e-05
 
    Postprocessing:
      Writing graphical output:           output-melt_and_traction/solution/solution-00001.0001
@@ -80,9 +76,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 1.05011e-09, 8.14583e-07, 0, 5.61319e-09
-      Total relative residual after nonlinear iteration 3: 8.14583e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.05011e-09, 8.14583e-07, 0, 5.61319e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 8.14583e-07
 
    Postprocessing:
      Writing graphical output:           output-melt_and_traction/solution/solution-00001.0002
@@ -97,9 +92,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 2.57816e-13, 6.51048e-14, 0, 5.61319e-09
-      Total relative residual after nonlinear iteration 4: 5.61319e-09
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.57816e-13, 6.51048e-14, 0, 5.61319e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 5.61319e-09
 
    Postprocessing:
      Writing graphical output:           output-melt_and_traction/solution/solution-00001.0003

--- a/tests/melt_compressible_advection/screen-output
+++ b/tests/melt_compressible_advection/screen-output
@@ -9,33 +9,29 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
-      Relative nonlinear residuals: 0, 2.11707e-16, 1
-      Total relative residual after nonlinear iteration 1: 1
-
-
-   Skipping temperature solve because RHS is zero.
-   Solving porosity system ... 0 iterations.
-   Solving Stokes system... done.
-   Solving for u_f in 13 iterations.
-      Relative nonlinear residuals: 0, 2.11707e-16, 0.141048
-      Total relative residual after nonlinear iteration 2: 0.141048
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.11707e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
-      Relative nonlinear residuals: 0, 2.11707e-16, 0.000754542
-      Total relative residual after nonlinear iteration 3: 0.000754542
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.11707e-16, 0.141048
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.141048
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
-      Relative nonlinear residuals: 0, 2.11707e-16, 2.13141e-05
-      Total relative residual after nonlinear iteration 4: 2.13141e-05
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.11707e-16, 0.000754542
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000754542
 
+   Skipping temperature solve because RHS is zero.
+   Solving porosity system ... 0 iterations.
+   Solving Stokes system... done.
+   Solving for u_f in 13 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.11707e-16, 2.13141e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 2.13141e-05
 
 
    Postprocessing:
@@ -49,9 +45,8 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
-      Relative nonlinear residuals: 0, 2.4356e-05, 1.64247e-05
-      Total relative residual after nonlinear iteration 1: 2.4356e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.4356e-05, 1.64247e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.4356e-05
 
 
    Postprocessing:
@@ -65,9 +60,8 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
    Solving for u_f in 13 iterations.
-      Relative nonlinear residuals: 0, 1.26889e-06, 1.71145e-05
-      Total relative residual after nonlinear iteration 1: 1.71145e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.26889e-06, 1.71145e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1.71145e-05
 
 
    Postprocessing:

--- a/tests/melt_material_4/screen-output
+++ b/tests/melt_material_4/screen-output
@@ -9,24 +9,22 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving porosity system ... 3 iterations.
    Solving Stokes system... done.
    Solving for u_f in 8 iterations.
-      Relative nonlinear residuals: 1.9817e-16, 1.92266e-16, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.9277e-16, 1.87568e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 3 iterations.
    Solving porosity system ... 3 iterations.
    Solving Stokes system... done.
    Solving for u_f in 8 iterations.
-      Relative nonlinear residuals: 2.40604e-16, 1.30411e-16, 5.41055e-16
-      Total relative residual after nonlinear iteration 2: 5.41055e-16
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.51232e-16, 1.37441e-16, 5.2096e-16
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.2096e-16
 
 
    Postprocessing:
      RMS, max velocity:                         0.236 m/s, 0.497 m/s
      Pressure min/avg/max:                      -1000 Pa, -277.5 Pa, -0.1001 Pa
      Max and min velocity along boundary parts: 0.4968 m/s, 0.005322 m/s, 0.4968 m/s, 0.005322 m/s, 0.005 m/s, 0.005 m/s, 0.5 m/s, 0.5 m/s
-     Errors u_L2, p_f_L2, porosity_L2:          2.773584e-07, 7.711115e-08, 2.928076e-05
+     Errors u_L2, p_f_L2, porosity_L2:          2.773584e-07, 7.711114e-08, 2.928076e-05
 
 Termination requested by criterion: end time
 

--- a/tests/melt_property_visualization/screen-output
+++ b/tests/melt_property_visualization/screen-output
@@ -9,9 +9,8 @@ Number of degrees of freedom: 28,617 (10,628+8,450+1,089+4,225+4,225)
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 2.06347e-16, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.06347e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
 
    Postprocessing:

--- a/tests/melt_transport_adaptive/screen-output
+++ b/tests/melt_transport_adaptive/screen-output
@@ -10,18 +10,16 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+23 iterations.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 0, 2.19049e-16, 0.997001
-      Total relative residual after nonlinear iteration 1: 0.997001
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.0324e-16, 0.997001
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.997001
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 0, 2.19049e-16, 6.5074e-13
-      Total relative residual after nonlinear iteration 2: 6.5074e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.0324e-16, 7.172e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 7.172e-13
 
 
    Postprocessing:
@@ -39,18 +37,16 @@ Number of degrees of freedom: 9,414 (2,774+728+2,774+364+1,387+1,387)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+23 iterations.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 0, 1.91625e-16, 0.996549
-      Total relative residual after nonlinear iteration 1: 0.996549
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.85486e-16, 0.996549
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.996549
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 0, 1.91625e-16, 9.97179e-13
-      Total relative residual after nonlinear iteration 2: 9.97179e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.85486e-16, 6.3218e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 6.3218e-13
 
 
    Postprocessing:
@@ -68,18 +64,16 @@ Number of degrees of freedom: 13,239 (3,906+1,014+3,906+507+1,953+1,953)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+23 iterations.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 0, 2.0644e-16, 0.994442
-      Total relative residual after nonlinear iteration 1: 0.994442
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.07228e-16, 0.994442
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.994442
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 0, 2.0644e-16, 8.47912e-13
-      Total relative residual after nonlinear iteration 2: 8.47912e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.07228e-16, 6.19869e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 6.19869e-13
 
 
    Postprocessing:

--- a/tests/melt_transport_compressible/screen-output
+++ b/tests/melt_transport_compressible/screen-output
@@ -9,25 +9,22 @@ Number of degrees of freedom: 112,521 (41,732+33,282+4,225+16,641+16,641)
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 1.93561e-16, 1
-      Total relative residual after nonlinear iteration 1: 1
-
-
-   Skipping temperature solve because RHS is zero.
-   Solving porosity system ... 0 iterations.
-   Solving Stokes system... done.
-   Solving for u_f in 10 iterations.
-      Relative nonlinear residuals: 0, 1.93561e-16, 0.074198
-      Total relative residual after nonlinear iteration 2: 0.074198
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.93561e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 10 iterations.
-      Relative nonlinear residuals: 0, 1.93561e-16, 4.55798e-06
-      Total relative residual after nonlinear iteration 3: 4.55798e-06
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.93561e-16, 0.074198
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.074198
 
+   Skipping temperature solve because RHS is zero.
+   Solving porosity system ... 0 iterations.
+   Solving Stokes system... done.
+   Solving for u_f in 10 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.93561e-16, 4.55798e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 4.55798e-06
 
 
    Postprocessing:

--- a/tests/melt_transport_compressible_iterative/screen-output
+++ b/tests/melt_transport_compressible_iterative/screen-output
@@ -10,54 +10,48 @@ Number of degrees of freedom: 7,401 (2,178+578+2,178+289+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+130 iterations.
    Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 2.12953e-16, 0.123457
-      Total relative residual after nonlinear iteration 1: 0.123457
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.12953e-16, 0.123457
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.123457
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+176 iterations.
    Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 2.12953e-16, 0.0651889
-      Total relative residual after nonlinear iteration 2: 0.0651889
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.12953e-16, 0.0651889
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0651889
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+28 iterations.
    Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 2.12953e-16, 0.000123058
-      Total relative residual after nonlinear iteration 3: 0.000123058
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.12953e-16, 0.000123058
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000123058
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+27 iterations.
    Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 2.12953e-16, 0.000126027
-      Total relative residual after nonlinear iteration 4: 0.000126027
-
-
-   Skipping temperature solve because RHS is zero.
-   Solving porosity system ... 0 iterations.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+2 iterations.
-   Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 2.12953e-16, 0.000228996
-      Total relative residual after nonlinear iteration 5: 0.000228996
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.12953e-16, 0.000126027
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000126027
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
    Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 2.12953e-16, 8.24759e-05
-      Total relative residual after nonlinear iteration 6: 8.24759e-05
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.12953e-16, 0.000228996
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000228996
 
+   Skipping temperature solve because RHS is zero.
+   Solving porosity system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+2 iterations.
+   Solving for u_f in 11 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.12953e-16, 8.24759e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 8.24759e-05
 
 
    Postprocessing:

--- a/tests/melt_transport_convergence_simple/screen-output
+++ b/tests/melt_transport_convergence_simple/screen-output
@@ -10,25 +10,23 @@ Number of degrees of freedom: 28,617 (8,450+2,178+8,450+1,089+4,225+4,225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+30 iterations.
    Solving for u_f in 7 iterations.
-      Relative nonlinear residuals: 0, 1.40805e-16, 1.00154
-      Total relative residual after nonlinear iteration 1: 1.00154
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.42904e-16, 1.00154
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1.00154
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 7 iterations.
-      Relative nonlinear residuals: 0, 1.40805e-16, 8.56233e-11
-      Total relative residual after nonlinear iteration 2: 8.56233e-11
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.42904e-16, 8.44953e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 8.44953e-11
 
 
    Postprocessing:
      RMS, max velocity:                                      1.41 m/s, 1.41 m/s
      Pressure min/avg/max:                                   0.3686 Pa, 1.176 Pa, 2.718 Pa
      Max and min velocity along boundary parts:              1.414 m/s, 1.414 m/s, 1.414 m/s, 1.414 m/s, 1.414 m/s, 1.414 m/s, 1.414 m/s, 1.414 m/s
-     Errors u_L2, p_L2, p_f_L2, p_c_L2, porosity_L2, u_f_L2: 1.028077e-04, 1.709337e-02, 1.709899e-02, 6.920575e-05, 2.402420e-03, 4.334907e-03
+     Errors u_L2, p_L2, p_f_L2, p_c_L2, porosity_L2, u_f_L2: 1.028076e-04, 1.709337e-02, 1.709899e-02, 6.920573e-05, 2.402420e-03, 4.334907e-03
 
 Termination requested by criterion: end time
 

--- a/tests/melt_transport_convergence_test/screen-output
+++ b/tests/melt_transport_convergence_test/screen-output
@@ -10,18 +10,16 @@ Number of degrees of freedom: 28,617 (8,450+2,178+8,450+1,089+4,225+4,225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+19 iterations.
    Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 1.6773e-16, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.6773e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 1.6773e-16, 4.65294e-07
-      Total relative residual after nonlinear iteration 2: 4.65294e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.6773e-16, 4.65294e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.65294e-07
 
 
    Postprocessing:

--- a/tests/melting_rate/screen-output
+++ b/tests/melting_rate/screen-output
@@ -10,18 +10,16 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 1.64801e-16, 1.20288e-16, 1.20288e-16, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.64801e-16, 1.20288e-16, 1.20288e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 1.64801e-16, 1.20288e-16, 1.20288e-16, 2.1144e-14
-      Total relative residual after nonlinear iteration 2: 2.1144e-14
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.64801e-16, 1.20288e-16, 1.20288e-16, 2.1144e-14
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 2.1144e-14
 
 
    Postprocessing:
@@ -34,27 +32,24 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 8 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 8.22092e-06, 0.00118027, 0.00043042, 0.0644232
-      Total relative residual after nonlinear iteration 1: 0.0644232
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.22092e-06, 0.00118027, 0.00043042, 0.0644232
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0644232
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 6 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 1.11749e-07, 5.91335e-05, 3.91962e-06, 0.000199814
-      Total relative residual after nonlinear iteration 2: 0.000199814
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.11749e-07, 5.91335e-05, 3.91962e-06, 0.000199814
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000199814
 
    Solving temperature system... 2 iterations.
    Solving porosity system ... 5 iterations.
    Solving peridotite system ... 3 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 1.23925e-10, 1.31332e-07, 4.80308e-09, 4.6855e-07
-      Total relative residual after nonlinear iteration 3: 4.6855e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.23925e-10, 1.31332e-07, 4.80308e-09, 4.6855e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 4.6855e-07
 
 
    Postprocessing:
@@ -67,27 +62,24 @@ Number of degrees of freedom: 16,698 (5,412+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 8 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 2.7119e-07, 0.000139096, 0.000130185, 0.0201433
-      Total relative residual after nonlinear iteration 1: 0.0201433
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.7119e-07, 0.000139096, 0.000130185, 0.0201433
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0201433
 
    Solving temperature system... 4 iterations.
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 5 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 1.63895e-08, 9.09717e-06, 6.07305e-07, 3.50701e-05
-      Total relative residual after nonlinear iteration 2: 3.50701e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.63895e-08, 9.09717e-06, 6.07305e-07, 3.50701e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 3.50701e-05
 
    Solving temperature system... 1 iterations.
    Solving porosity system ... 4 iterations.
    Solving peridotite system ... 2 iterations.
    Solving Stokes system... done.
    Solving for u_f in 12 iterations.
-      Relative nonlinear residuals: 9.92437e-12, 1.06588e-08, 4.12437e-10, 5.51056e-08
-      Total relative residual after nonlinear iteration 3: 5.51056e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.92437e-12, 1.06588e-08, 4.12437e-10, 5.51056e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 5.51056e-08
 
 
    Postprocessing:

--- a/tests/no_adiabatic_heating/screen-output
+++ b/tests/no_adiabatic_heating/screen-output
@@ -7,19 +7,24 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 0.0245986
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0245986
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 0.0013297
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 3: 0.0013297
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 4.77178e-05
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 4: 4.77178e-05
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-      Relative Stokes residual after nonlinear iteration 5: 1.17398e-06
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 5: 1.17398e-06
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -27,7 +32,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 1:  t=0.0284091 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -35,7 +41,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 2:  t=0.0568182 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -43,7 +50,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 3:  t=0.0852272 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -51,7 +59,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 4:  t=0.113636 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -59,7 +68,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 5:  t=0.142045 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -67,7 +77,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 6:  t=0.170454 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -75,7 +86,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 7:  t=0.198864 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -83,7 +95,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 8:  t=0.227273 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -91,7 +104,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 9:  t=0.255682 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -99,7 +113,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 10:  t=0.284091 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -110,7 +125,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 11:  t=0.3125 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 7.06825e-06
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 7.06825e-06
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -118,7 +134,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 12:  t=0.369318 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1.26368e-06
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1.26368e-06
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -126,7 +143,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 13:  t=0.426136 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1.50858e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1.50858e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -134,7 +152,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 14:  t=0.482954 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 9.17819e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 9.17819e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -142,7 +161,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 15:  t=0.539772 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1.53702e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1.53702e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -150,7 +170,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 16:  t=0.59659 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 9.00269e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 9.00269e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -158,7 +179,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 17:  t=0.653409 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1.7734e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1.7734e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -166,7 +188,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 18:  t=0.710227 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 9.36361e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 9.36361e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -174,7 +197,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 19:  t=0.767045 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1.83033e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1.83033e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -182,7 +206,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 20:  t=0.823863 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1.0864e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1.0864e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -193,10 +218,12 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 21:  t=0.880681 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 2.9854e-05
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 2.9854e-05
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.24753e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.24753e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -204,7 +231,8 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 22:  t=0.994317 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 7.10509e-06
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 7.10509e-06
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -212,7 +240,8 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 23:  t=1 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 2.16829e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 2.16829e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K

--- a/tests/no_adiabatic_heating_02/screen-output
+++ b/tests/no_adiabatic_heating_02/screen-output
@@ -7,19 +7,24 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 0.0245986
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0245986
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 0.0013297
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 3: 0.0013297
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 4.77178e-05
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 4: 4.77178e-05
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-      Relative Stokes residual after nonlinear iteration 5: 1.17398e-06
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 5: 1.17398e-06
+
 
    Postprocessing:
 
@@ -43,7 +48,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 1:  t=0.0284091 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -52,7 +58,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 2:  t=0.0568182 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -61,7 +68,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 3:  t=0.0852272 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -70,7 +78,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 4:  t=0.113636 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -79,7 +88,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 5:  t=0.142045 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -88,7 +98,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 6:  t=0.170454 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -97,7 +108,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 7:  t=0.198864 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -106,7 +118,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 8:  t=0.227273 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -115,7 +128,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 9:  t=0.255682 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -124,7 +138,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 10:  t=0.284091 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.83713e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.83713e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -136,7 +151,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 11:  t=0.3125 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 7.06825e-06
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 7.06825e-06
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -145,7 +161,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 12:  t=0.369318 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1.26368e-06
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1.26368e-06
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -154,7 +171,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 13:  t=0.426136 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1.50858e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1.50858e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -163,7 +181,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 14:  t=0.482954 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 9.17819e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 9.17819e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -172,7 +191,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 15:  t=0.539772 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1.53702e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1.53702e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -181,7 +201,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 16:  t=0.59659 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 9.00269e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 9.00269e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -190,7 +211,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 17:  t=0.653409 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1.7734e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1.7734e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -199,7 +221,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 18:  t=0.710227 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 9.36361e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 9.36361e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -208,7 +231,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 19:  t=0.767045 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1.83033e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1.83033e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -217,7 +241,8 @@ Number of degrees of freedom: 948 (578+81+289)
 *** Timestep 20:  t=0.823863 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1.0864e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1.0864e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -229,10 +254,12 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 21:  t=0.880681 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 2.9854e-05
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 2.9854e-05
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.24753e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.24753e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -241,7 +268,8 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 22:  t=0.994317 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 7.10509e-06
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 7.10509e-06
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K
@@ -250,7 +278,8 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 23:  t=1 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 2.16829e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 2.16829e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0 K, 0 K

--- a/tests/no_adiabatic_heating_03/screen-output
+++ b/tests/no_adiabatic_heating_03/screen-output
@@ -8,23 +8,24 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 0.0245986
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0245986
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 0.00133812
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.00133812
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 4.59661e-05
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 4.59661e-05
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-      Relative Stokes residual after nonlinear iteration 5: 2.11124e-06
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 2.11124e-06
+
 
    Postprocessing:
 
@@ -50,7 +51,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 17 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 2.14941e-07
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 2.14941e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0.003202 K, 0.003462 K
@@ -60,7 +62,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 2.01605e-07
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 2.01605e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0.006333 K, 0.006918 K
@@ -70,7 +73,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 2.27322e-07
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 2.27322e-07
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0.009376 K, 0.01037 K
@@ -80,7 +84,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 13 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 8.39909e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 8.39909e-08
+
 
    Postprocessing:
      Temperature min/avg/max: 0 K, 0.01093 K, 0.01215 K

--- a/tests/non_conservative_with_mpi/screen-output
+++ b/tests/non_conservative_with_mpi/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.87792e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.87792e-08
+
 
    Postprocessing:
 

--- a/tests/nonlinear_channel_flow_tractions_Newton_Stokes/screen-output
+++ b/tests/nonlinear_channel_flow_tractions_Newton_Stokes/screen-output
@@ -1,5 +1,3 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 
 Loading shared library <./libnonlinear_channel_flow_tractions_Newton_Stokes.so>
 
@@ -12,77 +10,77 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 41+0 iterations.
-      Total relative residual after nonlinear iteration 1: 1, norm of the rhs: 3.34887e+11, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 3.34887e+11, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 53+0 iterations.
-      Total relative residual after nonlinear iteration 2: 0.180853, norm of the rhs: 3.1208e+11, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.180853, norm of the rhs: 3.1208e+11, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 98+0 iterations.
-      Total relative residual after nonlinear iteration 3: 0.168536, norm of the rhs: 2.72888e+11, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.168536, norm of the rhs: 2.72888e+11, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 189+0 iterations.
-      Total relative residual after nonlinear iteration 4: 0.147371, norm of the rhs: 2.23862e+11, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.147371, norm of the rhs: 2.23862e+11, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 200+2 iterations.
-      Total relative residual after nonlinear iteration 5: 0.120895, norm of the rhs: 1.73575e+11, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.120895, norm of the rhs: 1.73575e+11, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
-      Total relative residual after nonlinear iteration 6: 0.0937377, norm of the rhs: 1.03442e+11, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.0937377, norm of the rhs: 1.03442e+11, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
-      Total relative residual after nonlinear iteration 7: 0.0558632, norm of the rhs: 5.43354e+10, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.0558632, norm of the rhs: 5.43354e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
-      Total relative residual after nonlinear iteration 8: 0.0293433, norm of the rhs: 2.75453e+10, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.0293433, norm of the rhs: 2.75453e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-      Total relative residual after nonlinear iteration 9: 0.0148756, norm of the rhs: 1.59028e+10, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.0148756, norm of the rhs: 1.59028e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-      Total relative residual after nonlinear iteration 10: 0.00858824, norm of the rhs: 1.12497e+10, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 0.00858824, norm of the rhs: 1.12497e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 41+0 iterations.
-      Total relative residual after nonlinear iteration 11: 0.00607532, norm of the rhs: 9.92198e+09, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 0.00607532, norm of the rhs: 9.92198e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-      Total relative residual after nonlinear iteration 12: 0.0053583, norm of the rhs: 5.94163e+09, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 0.0053583, norm of the rhs: 5.94163e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 42+0 iterations.
    Line search iteration 0, with norm of the rhs 6.7968e+09 and going to 5.94134e+09, relative residual: 0.00320889
-      Total relative residual after nonlinear iteration 13: 0.00320889, norm of the rhs: 4.34714e+09, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 0.00320889, norm of the rhs: 4.34714e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
@@ -90,19 +88,19 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 45+0 iterations.
    Line search iteration 0, with norm of the rhs 6.28398e+09 and going to 4.34671e+09, relative residual: 0.00234764
    Line search iteration 1, with norm of the rhs 4.69929e+09 and going to 4.34685e+09, relative residual: 0.00234764
-      Total relative residual after nonlinear iteration 14: 0.00234764, norm of the rhs: 3.84086e+09, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 0.00234764, norm of the rhs: 3.84086e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 40+0 iterations.
-      Total relative residual after nonlinear iteration 15: 0.00207423, norm of the rhs: 2.76824e+09, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 0.00207423, norm of the rhs: 2.76824e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 36+0 iterations.
-      Total relative residual after nonlinear iteration 16: 0.00149497, norm of the rhs: 1.29774e+09, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 0.00149497, norm of the rhs: 1.29774e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
@@ -113,7 +111,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Line search iteration 2, with norm of the rhs 1.50406e+09 and going to 1.29769e+09, relative residual: 0.000700836
    Line search iteration 3, with norm of the rhs 1.369e+09 and going to 1.29771e+09, relative residual: 0.000700836
    Line search iteration 4, with norm of the rhs 1.30926e+09 and going to 1.29772e+09, relative residual: 0.000700836
-      Total relative residual after nonlinear iteration 17: 0.000700836, norm of the rhs: 1.28578e+09, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 0.000700836, norm of the rhs: 1.28578e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.00922199
@@ -124,7 +122,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Line search iteration 2, with norm of the rhs 1.73175e+09 and going to 1.28572e+09, relative residual: 0.000694373
    Line search iteration 3, with norm of the rhs 1.54582e+09 and going to 1.28574e+09, relative residual: 0.000694373
    Line search iteration 4, with norm of the rhs 1.45279e+09 and going to 1.28575e+09, relative residual: 0.000694373
-      Total relative residual after nonlinear iteration 18: 0.000694373, norm of the rhs: 1.37856e+09, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 0.000694373, norm of the rhs: 1.37856e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.0721613
@@ -132,73 +130,73 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 42+0 iterations.
    Line search iteration 0, with norm of the rhs 1.73198e+09 and going to 1.37842e+09, relative residual: 0.00074448
    Line search iteration 1, with norm of the rhs 1.3846e+09 and going to 1.37847e+09, relative residual: 0.00074448
-      Total relative residual after nonlinear iteration 19: 0.00074448, norm of the rhs: 1.27372e+09, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 0.00074448, norm of the rhs: 1.27372e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.0760525
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 36+0 iterations.
-      Total relative residual after nonlinear iteration 20: 0.000687861, norm of the rhs: 9.77133e+07, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 0.000687861, norm of the rhs: 9.77133e+07, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 142+0 iterations.
-      Total relative residual after nonlinear iteration 21: 5.27864e-05, norm of the rhs: 1.85405e+07, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 5.27864e-05, norm of the rhs: 1.85405e+07, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 177+0 iterations.
-      Total relative residual after nonlinear iteration 22: 1.00166e-05, norm of the rhs: 6.25064e+06, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 1.00166e-05, norm of the rhs: 6.25064e+06, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 94+0 iterations.
-      Total relative residual after nonlinear iteration 23: 3.37596e-06, norm of the rhs: 2.25473e+06, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 3.37596e-06, norm of the rhs: 2.25473e+06, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 122+0 iterations.
-      Total relative residual after nonlinear iteration 24: 1.21764e-06, norm of the rhs: 826302, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 1.21764e-06, norm of the rhs: 826302, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 109+0 iterations.
-      Total relative residual after nonlinear iteration 25: 4.46251e-07, norm of the rhs: 320755, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 4.46251e-07, norm of the rhs: 320755, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 104+0 iterations.
-      Total relative residual after nonlinear iteration 26: 1.73221e-07, norm of the rhs: 121767, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 1.73221e-07, norm of the rhs: 121767, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 98+0 iterations.
-      Total relative residual after nonlinear iteration 27: 6.57586e-08, norm of the rhs: 48741.3, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 6.57586e-08, norm of the rhs: 48741.3, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 102+0 iterations.
-      Total relative residual after nonlinear iteration 28: 2.63229e-08, norm of the rhs: 19246.6, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 2.63229e-08, norm of the rhs: 19246.6, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 103+0 iterations.
-      Total relative residual after nonlinear iteration 29: 1.0394e-08, norm of the rhs: 7697.06, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 1.0394e-08, norm of the rhs: 7697.06, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 98+0 iterations.
-      Total relative residual after nonlinear iteration 30: 4.1567e-09, norm of the rhs: 3104.07, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 4.1567e-09, norm of the rhs: 3104.07, newton_derivative_scaling_factor: 1
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_tractions_iterated_IMPES/screen-output
+++ b/tests/nonlinear_channel_flow_tractions_iterated_IMPES/screen-output
@@ -8,331 +8,284 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 41+0 iterations.
-      Relative nonlinear residuals: 0, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 53+0 iterations.
-      Relative nonlinear residuals: 0, 0.180853
-      Total relative residual after nonlinear iteration 2: 0.180853
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.180853
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.180853
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 98+0 iterations.
-      Relative nonlinear residuals: 0, 0.168536
-      Total relative residual after nonlinear iteration 3: 0.168536
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 187+0 iterations.
-      Relative nonlinear residuals: 0, 0.147371
-      Total relative residual after nonlinear iteration 4: 0.147371
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+1 iterations.
-      Relative nonlinear residuals: 0, 0.120895
-      Total relative residual after nonlinear iteration 5: 0.120895
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+2 iterations.
-      Relative nonlinear residuals: 0, 0.0937377
-      Total relative residual after nonlinear iteration 6: 0.0937377
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+4 iterations.
-      Relative nonlinear residuals: 0, 0.0695116
-      Total relative residual after nonlinear iteration 7: 0.0695116
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+4 iterations.
-      Relative nonlinear residuals: 0, 0.0498794
-      Total relative residual after nonlinear iteration 8: 0.0498794
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+4 iterations.
-      Relative nonlinear residuals: 0, 0.0349657
-      Total relative residual after nonlinear iteration 9: 0.0349657
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+4 iterations.
-      Relative nonlinear residuals: 0, 0.0241168
-      Total relative residual after nonlinear iteration 10: 0.0241168
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+3 iterations.
-      Relative nonlinear residuals: 0, 0.0164504
-      Total relative residual after nonlinear iteration 11: 0.0164504
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+3 iterations.
-      Relative nonlinear residuals: 0, 0.0111368
-      Total relative residual after nonlinear iteration 12: 0.0111368
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+3 iterations.
-      Relative nonlinear residuals: 0, 0.00750136
-      Total relative residual after nonlinear iteration 13: 0.00750136
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+2 iterations.
-      Relative nonlinear residuals: 0, 0.00503545
-      Total relative residual after nonlinear iteration 14: 0.00503545
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+2 iterations.
-      Relative nonlinear residuals: 0, 0.00337244
-      Total relative residual after nonlinear iteration 15: 0.00337244
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+2 iterations.
-      Relative nonlinear residuals: 0, 0.0022552
-      Total relative residual after nonlinear iteration 16: 0.0022552
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+1 iterations.
-      Relative nonlinear residuals: 0, 0.00150655
-      Total relative residual after nonlinear iteration 17: 0.00150655
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+1 iterations.
-      Relative nonlinear residuals: 0, 0.00100574
-      Total relative residual after nonlinear iteration 18: 0.00100574
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+1 iterations.
-      Relative nonlinear residuals: 0, 0.000671105
-      Total relative residual after nonlinear iteration 19: 0.000671105
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+1 iterations.
-      Relative nonlinear residuals: 0, 0.000447675
-      Total relative residual after nonlinear iteration 20: 0.000447675
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+1 iterations.
-      Relative nonlinear residuals: 0, 0.000298571
-      Total relative residual after nonlinear iteration 21: 0.000298571
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+1 iterations.
-      Relative nonlinear residuals: 0, 0.000199101
-      Total relative residual after nonlinear iteration 22: 0.000199101
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+1 iterations.
-      Relative nonlinear residuals: 0, 0.000132758
-      Total relative residual after nonlinear iteration 23: 0.000132758
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+1 iterations.
-      Relative nonlinear residuals: 0, 8.85159e-05
-      Total relative residual after nonlinear iteration 24: 8.85159e-05
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+1 iterations.
-      Relative nonlinear residuals: 0, 5.90153e-05
-      Total relative residual after nonlinear iteration 25: 5.90153e-05
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+1 iterations.
-      Relative nonlinear residuals: 0, 3.93457e-05
-      Total relative residual after nonlinear iteration 26: 3.93457e-05
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+1 iterations.
-      Relative nonlinear residuals: 0, 2.62314e-05
-      Total relative residual after nonlinear iteration 27: 2.62314e-05
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 200+1 iterations.
-      Relative nonlinear residuals: 0, 1.7488e-05
-      Total relative residual after nonlinear iteration 28: 1.7488e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.168536
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.168536
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 187+0 iterations.
-      Relative nonlinear residuals: 0, 1.16588e-05
-      Total relative residual after nonlinear iteration 29: 1.16588e-05
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.147371
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.147371
 
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.120895
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.120895
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+2 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0937377
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.0937377
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+4 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0695116
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.0695116
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+4 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0498794
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.0498794
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+4 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0349657
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.0349657
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+4 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0241168
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 0.0241168
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+3 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0164504
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 0.0164504
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+3 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0111368
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 0.0111368
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+3 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00750136
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 0.00750136
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+2 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00503545
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 0.00503545
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+2 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00337244
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 0.00337244
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+2 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0022552
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 0.0022552
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00150655
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 0.00150655
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00100574
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 0.00100574
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000671105
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 0.000671105
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000447675
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 0.000447675
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000298571
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 0.000298571
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000199101
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 0.000199101
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000132758
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 0.000132758
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 8.85159e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 8.85159e-05
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.90153e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 5.90153e-05
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 3.93457e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 3.93457e-05
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.62314e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 2.62314e-05
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.7488e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 1.7488e-05
+
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 187+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.16588e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 29: 1.16588e-05
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 181+0 iterations.
-      Relative nonlinear residuals: 0, 7.77265e-06
-      Total relative residual after nonlinear iteration 30: 7.77265e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.77265e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 30: 7.77265e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 158+0 iterations.
-      Relative nonlinear residuals: 0, 5.18181e-06
-      Total relative residual after nonlinear iteration 31: 5.18181e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.18181e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 31: 5.18181e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 141+0 iterations.
-      Relative nonlinear residuals: 0, 3.45455e-06
-      Total relative residual after nonlinear iteration 32: 3.45455e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 3.45455e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 32: 3.45455e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 136+0 iterations.
-      Relative nonlinear residuals: 0, 2.30304e-06
-      Total relative residual after nonlinear iteration 33: 2.30304e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.30304e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 33: 2.30304e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 123+0 iterations.
-      Relative nonlinear residuals: 0, 1.53536e-06
-      Total relative residual after nonlinear iteration 34: 1.53536e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.53536e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 34: 1.53536e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 106+0 iterations.
-      Relative nonlinear residuals: 0, 1.02358e-06
-      Total relative residual after nonlinear iteration 35: 1.02358e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.02358e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 35: 1.02358e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 92+0 iterations.
-      Relative nonlinear residuals: 0, 6.8238e-07
-      Total relative residual after nonlinear iteration 36: 6.8238e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.8238e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 36: 6.8238e-07
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals: 0, 4.54919e-07
-      Total relative residual after nonlinear iteration 37: 4.54919e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.54919e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 37: 4.54919e-07
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals: 0, 3.03284e-07
-      Total relative residual after nonlinear iteration 38: 3.03284e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 3.03284e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 38: 3.03284e-07
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals: 0, 2.02183e-07
-      Total relative residual after nonlinear iteration 39: 2.02183e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.02183e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 39: 2.02183e-07
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals: 0, 1.34796e-07
-      Total relative residual after nonlinear iteration 40: 1.34796e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.34796e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 40: 1.34796e-07
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 58+0 iterations.
-      Relative nonlinear residuals: 0, 8.987e-08
-      Total relative residual after nonlinear iteration 41: 8.987e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 8.987e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 41: 8.987e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 46+0 iterations.
-      Relative nonlinear residuals: 0, 5.99453e-08
-      Total relative residual after nonlinear iteration 42: 5.99453e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.99453e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 42: 5.99453e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 41+0 iterations.
-      Relative nonlinear residuals: 0, 3.99962e-08
-      Total relative residual after nonlinear iteration 43: 3.99962e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 3.99962e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 43: 3.99962e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 36+0 iterations.
-      Relative nonlinear residuals: 0, 2.67055e-08
-      Total relative residual after nonlinear iteration 44: 2.67055e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.67055e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 44: 2.67055e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals: 0, 1.78555e-08
-      Total relative residual after nonlinear iteration 45: 1.78555e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.78555e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 45: 1.78555e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals: 0, 1.19793e-08
-      Total relative residual after nonlinear iteration 46: 1.19793e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.19793e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 46: 1.19793e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residuals: 0, 8.09585e-09
-      Total relative residual after nonlinear iteration 47: 8.09585e-09
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 8.09585e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 47: 8.09585e-09
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_velocities_Newton_Stokes/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_Newton_Stokes/screen-output
@@ -1,5 +1,3 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 
 Loading shared library <./libnonlinear_channel_flow_velocities_Newton_Stokes.so>
 
@@ -12,138 +10,138 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 36+0 iterations.
-      Total relative residual after nonlinear iteration 1: 1, norm of the rhs: 1.92843e+17, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 1.92843e+17, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 78+0 iterations.
-      Total relative residual after nonlinear iteration 2: 0.11328, norm of the rhs: 9.09366e+13, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.11328, norm of the rhs: 9.09366e+13, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 45+0 iterations.
-      Total relative residual after nonlinear iteration 3: 5.3418e-05, norm of the rhs: 1.58931e+12, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 5.3418e-05, norm of the rhs: 1.58931e+12, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Total relative residual after nonlinear iteration 4: 9.33593e-07, norm of the rhs: 1.42455e+12, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 9.33593e-07, norm of the rhs: 1.42455e+12, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-      Total relative residual after nonlinear iteration 5: 8.36808e-07, norm of the rhs: 9.00059e+11, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 8.36808e-07, norm of the rhs: 9.00059e+11, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-      Total relative residual after nonlinear iteration 6: 5.28713e-07, norm of the rhs: 6.53168e+11, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 5.28713e-07, norm of the rhs: 6.53168e+11, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Total relative residual after nonlinear iteration 7: 3.83684e-07, norm of the rhs: 3.76935e+11, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 3.83684e-07, norm of the rhs: 3.76935e+11, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Total relative residual after nonlinear iteration 8: 2.21419e-07, norm of the rhs: 2.1922e+11, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 2.21419e-07, norm of the rhs: 2.1922e+11, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Total relative residual after nonlinear iteration 9: 1.28774e-07, norm of the rhs: 8.22743e+10, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 1.28774e-07, norm of the rhs: 8.22743e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-      Total relative residual after nonlinear iteration 10: 4.83296e-08, norm of the rhs: 3.4855e+10, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 4.83296e-08, norm of the rhs: 3.4855e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Total relative residual after nonlinear iteration 11: 2.04745e-08, norm of the rhs: 9.59477e+09, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 2.04745e-08, norm of the rhs: 9.59477e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Total relative residual after nonlinear iteration 12: 5.63616e-09, norm of the rhs: 2.53136e+09, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 5.63616e-09, norm of the rhs: 2.53136e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Total relative residual after nonlinear iteration 13: 1.48697e-09, norm of the rhs: 8.66919e+08, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 1.48697e-09, norm of the rhs: 8.66919e+08, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Total relative residual after nonlinear iteration 14: 5.09246e-10, norm of the rhs: 3.3151e+08, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 5.09246e-10, norm of the rhs: 3.3151e+08, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Total relative residual after nonlinear iteration 15: 1.94736e-10, norm of the rhs: 1.27111e+08, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 1.94736e-10, norm of the rhs: 1.27111e+08, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Total relative residual after nonlinear iteration 16: 7.46677e-11, norm of the rhs: 4.86158e+07, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 7.46677e-11, norm of the rhs: 4.86158e+07, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Total relative residual after nonlinear iteration 17: 2.85579e-11, norm of the rhs: 1.72178e+07, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 2.85579e-11, norm of the rhs: 1.72178e+07, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Total relative residual after nonlinear iteration 18: 1.01141e-11, norm of the rhs: 6.83718e+06, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 1.01141e-11, norm of the rhs: 6.83718e+06, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Total relative residual after nonlinear iteration 19: 4.01629e-12, norm of the rhs: 2.4847e+06, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 4.01629e-12, norm of the rhs: 2.4847e+06, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Total relative residual after nonlinear iteration 20: 1.45956e-12, norm of the rhs: 1.039e+06, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 1.45956e-12, norm of the rhs: 1.039e+06, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Total relative residual after nonlinear iteration 21: 6.10331e-13, norm of the rhs: 374020, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 6.10331e-13, norm of the rhs: 374020, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Total relative residual after nonlinear iteration 22: 2.19707e-13, norm of the rhs: 159847, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 2.19707e-13, norm of the rhs: 159847, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Total relative residual after nonlinear iteration 23: 9.38973e-14, norm of the rhs: 57773.3, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 9.38973e-14, norm of the rhs: 57773.3, newton_derivative_scaling_factor: 1
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_velocities_iterated_IMPES/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_iterated_IMPES/screen-output
@@ -8,261 +8,224 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 46+0 iterations.
-      Relative nonlinear residuals: 0, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 92+0 iterations.
-      Relative nonlinear residuals: 0, 0.11328
-      Total relative residual after nonlinear iteration 2: 0.11328
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.11328
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.11328
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residuals: 0, 4.14784e-07
-      Total relative residual after nonlinear iteration 3: 4.14784e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.14784e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 4.14784e-07
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 60+0 iterations.
-      Relative nonlinear residuals: 0, 4.81049e-07
-      Total relative residual after nonlinear iteration 4: 4.81049e-07
-
-
-   Skipping temperature solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 59+0 iterations.
-      Relative nonlinear residuals: 0, 1.78985e-07
-      Total relative residual after nonlinear iteration 5: 1.78985e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.81049e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 4.81049e-07
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 59+0 iterations.
-      Relative nonlinear residuals: 0, 8.81842e-08
-      Total relative residual after nonlinear iteration 6: 8.81842e-08
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.78985e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.78985e-07
 
+   Skipping temperature solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 59+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 8.81842e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 8.81842e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 57+0 iterations.
-      Relative nonlinear residuals: 0, 4.97151e-08
-      Total relative residual after nonlinear iteration 7: 4.97151e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.97151e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 4.97151e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residuals: 0, 2.93807e-08
-      Total relative residual after nonlinear iteration 8: 2.93807e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.93807e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 2.93807e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 52+0 iterations.
-      Relative nonlinear residuals: 0, 1.78057e-08
-      Total relative residual after nonlinear iteration 9: 1.78057e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.78057e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 1.78057e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 49+0 iterations.
-      Relative nonlinear residuals: 0, 1.09606e-08
-      Total relative residual after nonlinear iteration 10: 1.09606e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.09606e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 1.09606e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 47+0 iterations.
-      Relative nonlinear residuals: 0, 6.81561e-09
-      Total relative residual after nonlinear iteration 11: 6.81561e-09
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.81561e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 6.81561e-09
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 45+0 iterations.
-      Relative nonlinear residuals: 0, 4.26771e-09
-      Total relative residual after nonlinear iteration 12: 4.26771e-09
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.26771e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 4.26771e-09
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 0, 2.68603e-09
-      Total relative residual after nonlinear iteration 13: 2.68603e-09
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.68603e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 2.68603e-09
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 41+0 iterations.
-      Relative nonlinear residuals: 0, 1.69741e-09
-      Total relative residual after nonlinear iteration 14: 1.69741e-09
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.69741e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 1.69741e-09
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 39+0 iterations.
-      Relative nonlinear residuals: 0, 1.07631e-09
-      Total relative residual after nonlinear iteration 15: 1.07631e-09
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.07631e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 1.07631e-09
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residuals: 0, 6.84503e-10
-      Total relative residual after nonlinear iteration 16: 6.84503e-10
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.84503e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 6.84503e-10
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 35+0 iterations.
-      Relative nonlinear residuals: 0, 4.36485e-10
-      Total relative residual after nonlinear iteration 17: 4.36485e-10
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.36485e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 4.36485e-10
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residuals: 0, 2.79006e-10
-      Total relative residual after nonlinear iteration 18: 2.79006e-10
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.79006e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 2.79006e-10
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals: 0, 1.78741e-10
-      Total relative residual after nonlinear iteration 19: 1.78741e-10
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.78741e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 1.78741e-10
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals: 0, 1.14743e-10
-      Total relative residual after nonlinear iteration 20: 1.14743e-10
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.14743e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 1.14743e-10
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals: 0, 7.37987e-11
-      Total relative residual after nonlinear iteration 21: 7.37987e-11
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.37987e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 7.37987e-11
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residuals: 0, 4.75455e-11
-      Total relative residual after nonlinear iteration 22: 4.75455e-11
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.75455e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 4.75455e-11
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residuals: 0, 3.0679e-11
-      Total relative residual after nonlinear iteration 23: 3.0679e-11
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 3.0679e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 3.0679e-11
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residuals: 0, 1.98254e-11
-      Total relative residual after nonlinear iteration 24: 1.98254e-11
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.98254e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 1.98254e-11
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residuals: 0, 1.28284e-11
-      Total relative residual after nonlinear iteration 25: 1.28284e-11
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.28284e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 1.28284e-11
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residuals: 0, 8.31006e-12
-      Total relative residual after nonlinear iteration 26: 8.31006e-12
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 8.31006e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 8.31006e-12
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residuals: 0, 5.38819e-12
-      Total relative residual after nonlinear iteration 27: 5.38819e-12
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.38819e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 5.38819e-12
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residuals: 0, 3.49697e-12
-      Total relative residual after nonlinear iteration 28: 3.49697e-12
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 3.49697e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 3.49697e-12
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residuals: 0, 2.27002e-12
-      Total relative residual after nonlinear iteration 29: 2.27002e-12
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.27002e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 29: 2.27002e-12
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residuals: 0, 1.47448e-12
-      Total relative residual after nonlinear iteration 30: 1.47448e-12
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.47448e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 30: 1.47448e-12
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residuals: 0, 9.60028e-13
-      Total relative residual after nonlinear iteration 31: 9.60028e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 9.60028e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 31: 9.60028e-13
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residuals: 0, 6.25908e-13
-      Total relative residual after nonlinear iteration 32: 6.25908e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.25908e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 32: 6.25908e-13
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residuals: 0, 4.07482e-13
-      Total relative residual after nonlinear iteration 33: 4.07482e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.07482e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 33: 4.07482e-13
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-      Relative nonlinear residuals: 0, 2.64737e-13
-      Total relative residual after nonlinear iteration 34: 2.64737e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.64737e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 34: 2.64737e-13
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residuals: 0, 1.72179e-13
-      Total relative residual after nonlinear iteration 35: 1.72179e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.72179e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 35: 1.72179e-13
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residuals: 0, 1.12207e-13
-      Total relative residual after nonlinear iteration 36: 1.12207e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.12207e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 36: 1.12207e-13
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residuals: 0, 7.42098e-14
-      Total relative residual after nonlinear iteration 37: 7.42098e-14
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.42098e-14
+      Relative nonlinear residual (total system) after nonlinear iteration 37: 7.42098e-14
 
 
    Postprocessing:

--- a/tests/nonlinear_convergence_for_small_composition/screen-output
+++ b/tests/nonlinear_convergence_for_small_composition/screen-output
@@ -10,18 +10,16 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
-      Relative nonlinear residuals: 1.91012e-16, 0, 0, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.91012e-16, 0, 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 1.91012e-16, 0, 0, 3.63294e-10
-      Total relative residual after nonlinear iteration 2: 3.63294e-10
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.91012e-16, 0, 0, 3.63294e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 3.63294e-10
 
 
    Postprocessing:
@@ -33,180 +31,160 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
-      Relative nonlinear residuals: 0.0181737, 1, 1, 0.552867
-      Total relative residual after nonlinear iteration 1: 1
-
-
-   Solving temperature system... 14 iterations.
-   Solving porosity system ... 7 iterations.
-   Solving peridotite system ... 7 iterations.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+7 iterations.
-      Relative nonlinear residuals: 0.00111716, 9.83214, 9.83214, 0.0384851
-      Total relative residual after nonlinear iteration 2: 9.83214
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0181737, 1, 1, 0.552867
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 14 iterations.
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
-      Relative nonlinear residuals: 0.000270712, 9.68581, 9.68581, 0.00896525
-      Total relative residual after nonlinear iteration 3: 9.68581
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00111716, 9.83214, 9.83214, 0.0384851
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 9.83214
 
+   Solving temperature system... 14 iterations.
+   Solving porosity system ... 7 iterations.
+   Solving peridotite system ... 7 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+7 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000270712, 9.68581, 9.68581, 0.00896525
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 9.68581
 
    Solving temperature system... 13 iterations.
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
-      Relative nonlinear residuals: 8.71897e-05, 2.69109, 2.69109, 0.0028078
-      Total relative residual after nonlinear iteration 4: 2.69109
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.71897e-05, 2.69109, 2.69109, 0.0028078
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 2.69109
 
    Solving temperature system... 12 iterations.
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
-      Relative nonlinear residuals: 2.93263e-05, 2.41042, 2.41042, 0.000935051
-      Total relative residual after nonlinear iteration 5: 2.41042
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.93263e-05, 2.41042, 2.41042, 0.000935051
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 2.41042
 
    Solving temperature system... 12 iterations.
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
-      Relative nonlinear residuals: 9.73916e-06, 1.86628, 1.86628, 0.000309697
-      Total relative residual after nonlinear iteration 6: 1.86628
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.73916e-06, 1.86628, 1.86628, 0.000309697
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 1.86628
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
-      Relative nonlinear residuals: 3.18218e-06, 8.21147, 8.21147, 0.000101405
-      Total relative residual after nonlinear iteration 7: 8.21147
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.18218e-06, 8.21147, 8.21147, 0.000101405
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 8.21147
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-      Relative nonlinear residuals: 1.028e-06, 6.8821, 6.8821, 3.29883e-05
-      Total relative residual after nonlinear iteration 8: 6.8821
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.028e-06, 6.8821, 6.8821, 3.29883e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 6.8821
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-      Relative nonlinear residuals: 3.30522e-07, 7.57411, 7.57411, 1.07267e-05
-      Total relative residual after nonlinear iteration 9: 7.57411
-
-
-   Solving temperature system... 9 iterations.
-   Solving porosity system ... 7 iterations.
-   Solving peridotite system ... 7 iterations.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+3 iterations.
-      Relative nonlinear residuals: 1.06372e-07, 5.53379, 5.53379, 3.49776e-06
-      Total relative residual after nonlinear iteration 10: 5.53379
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.30522e-07, 7.57411, 7.57411, 1.07267e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 7.57411
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+3 iterations.
-      Relative nonlinear residuals: 3.43875e-08, 8.87672, 8.87672, 1.14333e-06
-      Total relative residual after nonlinear iteration 11: 8.87672
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.06372e-07, 5.53379, 5.53379, 3.49776e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 5.53379
 
+   Solving temperature system... 9 iterations.
+   Solving porosity system ... 7 iterations.
+   Solving peridotite system ... 7 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+3 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.43875e-08, 8.87672, 8.87672, 1.14333e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 8.87672
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-      Relative nonlinear residuals: 1.10843e-08, 6.81852, 6.81852, 3.70921e-07
-      Total relative residual after nonlinear iteration 12: 6.81852
-
-
-   Solving temperature system... 7 iterations.
-   Solving porosity system ... 7 iterations.
-   Solving peridotite system ... 7 iterations.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+2 iterations.
-      Relative nonlinear residuals: 3.57457e-09, 5.75288, 5.75288, 1.19552e-07
-      Total relative residual after nonlinear iteration 13: 5.75288
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10843e-08, 6.81852, 6.81852, 3.70921e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 6.81852
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-      Relative nonlinear residuals: 1.12223e-09, 4.56325, 4.56325, 3.73322e-08
-      Total relative residual after nonlinear iteration 14: 4.56325
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.57457e-09, 5.75288, 5.75288, 1.19552e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 5.75288
 
+   Solving temperature system... 7 iterations.
+   Solving porosity system ... 7 iterations.
+   Solving peridotite system ... 7 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+2 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.12223e-09, 4.56325, 4.56325, 3.73322e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 4.56325
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
-      Relative nonlinear residuals: 3.47377e-10, 1.39087, 1.39087, 1.14448e-08
-      Total relative residual after nonlinear iteration 15: 1.39087
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.47377e-10, 1.39087, 1.39087, 1.14448e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 1.39087
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
-      Relative nonlinear residuals: 1.48484e-10, 7.95484, 7.95484, 8.01828e-09
-      Total relative residual after nonlinear iteration 16: 7.95484
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.48484e-10, 7.95484, 7.95484, 8.01828e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 7.95484
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 6 iterations.
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 6.72313e-11, 2.27028, 2.27028, 6.22935e-09
-      Total relative residual after nonlinear iteration 17: 2.27028
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.72313e-11, 2.27028, 2.27028, 6.22935e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 2.27028
 
    Solving temperature system... 1 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 2.692e-14, 3.71264e-14, 3.71264e-14, 6.22946e-09
-      Total relative residual after nonlinear iteration 18: 6.22946e-09
-
-
-   Solving temperature system... 0 iterations.
-   Solving porosity system ... 0 iterations.
-   Solving peridotite system ... 0 iterations.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 4.32016e-15, 3.71264e-14, 3.71264e-14, 6.22946e-09
-      Total relative residual after nonlinear iteration 19: 6.22946e-09
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.692e-14, 3.71264e-14, 3.71264e-14, 6.22946e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 6.22946e-09
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 4.32016e-15, 3.71264e-14, 3.71264e-14, 6.22946e-09
-      Total relative residual after nonlinear iteration 20: 6.22946e-09
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.32016e-15, 3.71264e-14, 3.71264e-14, 6.22946e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 6.22946e-09
 
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Solving peridotite system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.32016e-15, 3.71264e-14, 3.71264e-14, 6.22946e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 6.22946e-09
 
 
    Postprocessing:
@@ -218,180 +196,160 @@ Number of degrees of freedom: 15,942 (8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
-      Relative nonlinear residuals: 0.00283237, 0.0998435, 0.0998435, 0.151867
-      Total relative residual after nonlinear iteration 1: 0.151867
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00283237, 0.0998435, 0.0998435, 0.151867
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.151867
 
    Solving temperature system... 15 iterations.
    Solving porosity system ... 6 iterations.
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
-      Relative nonlinear residuals: 0.000198899, 0.501366, 0.501366, 0.0113202
-      Total relative residual after nonlinear iteration 2: 0.501366
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000198899, 0.501366, 0.501366, 0.0113202
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.501366
 
    Solving temperature system... 14 iterations.
    Solving porosity system ... 6 iterations.
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
-      Relative nonlinear residuals: 3.38864e-05, 0.227494, 0.227494, 0.00193229
-      Total relative residual after nonlinear iteration 3: 0.227494
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.38864e-05, 0.227494, 0.227494, 0.00193229
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.227494
 
    Solving temperature system... 12 iterations.
    Solving porosity system ... 6 iterations.
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
-      Relative nonlinear residuals: 6.18224e-06, 0.0958431, 0.0958431, 0.000351195
-      Total relative residual after nonlinear iteration 4: 0.0958431
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.18224e-06, 0.0958431, 0.0958431, 0.000351195
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0958431
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 6 iterations.
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-      Relative nonlinear residuals: 1.14052e-06, 0.109288, 0.109288, 6.45768e-05
-      Total relative residual after nonlinear iteration 5: 0.109288
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.14052e-06, 0.109288, 0.109288, 6.45768e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.109288
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 6 iterations.
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-      Relative nonlinear residuals: 2.09753e-07, 0.267597, 0.267597, 1.1848e-05
-      Total relative residual after nonlinear iteration 6: 0.267597
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.09753e-07, 0.267597, 0.267597, 1.1848e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.267597
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 6 iterations.
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+3 iterations.
-      Relative nonlinear residuals: 3.8326e-08, 0.200401, 0.200401, 2.16133e-06
-      Total relative residual after nonlinear iteration 7: 0.200401
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.8326e-08, 0.200401, 0.200401, 2.16133e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.200401
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 6 iterations.
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-      Relative nonlinear residuals: 6.96628e-09, 0.123702, 0.123702, 3.92437e-07
-      Total relative residual after nonlinear iteration 8: 0.123702
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.96628e-09, 0.123702, 0.123702, 3.92437e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.123702
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-      Relative nonlinear residuals: 1.2529e-09, 0.111747, 0.111747, 7.07245e-08
-      Total relative residual after nonlinear iteration 9: 0.111747
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.2529e-09, 0.111747, 0.111747, 7.07245e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.111747
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
-      Relative nonlinear residuals: 2.19519e-10, 0.110481, 0.110481, 1.23542e-08
-      Total relative residual after nonlinear iteration 10: 0.110481
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.19519e-10, 0.110481, 0.110481, 1.23542e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 0.110481
 
    Solving temperature system... 5 iterations.
    Solving porosity system ... 6 iterations.
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 5.28001e-11, 0.18963, 0.18963, 8.65993e-09
-      Total relative residual after nonlinear iteration 11: 0.18963
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.28001e-11, 0.18963, 0.18963, 8.65993e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 0.18963
 
    Solving temperature system... 1 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 1.1439e-14, 1.05083e-15, 1.05083e-15, 8.65963e-09
-      Total relative residual after nonlinear iteration 12: 8.65963e-09
-
-
-   Solving temperature system... 0 iterations.
-   Solving porosity system ... 0 iterations.
-   Solving peridotite system ... 0 iterations.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
-      Total relative residual after nonlinear iteration 13: 8.65963e-09
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.1439e-14, 1.05083e-15, 1.05083e-15, 8.65963e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 8.65963e-09
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
-      Total relative residual after nonlinear iteration 14: 8.65963e-09
-
-
-   Solving temperature system... 0 iterations.
-   Solving porosity system ... 0 iterations.
-   Solving peridotite system ... 0 iterations.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
-      Total relative residual after nonlinear iteration 15: 8.65963e-09
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 8.65963e-09
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
-      Total relative residual after nonlinear iteration 16: 8.65963e-09
-
-
-   Solving temperature system... 0 iterations.
-   Solving porosity system ... 0 iterations.
-   Solving peridotite system ... 0 iterations.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
-      Total relative residual after nonlinear iteration 17: 8.65963e-09
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 8.65963e-09
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
-      Total relative residual after nonlinear iteration 18: 8.65963e-09
-
-
-   Solving temperature system... 0 iterations.
-   Solving porosity system ... 0 iterations.
-   Solving peridotite system ... 0 iterations.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
-      Total relative residual after nonlinear iteration 19: 8.65963e-09
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 8.65963e-09
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
-      Total relative residual after nonlinear iteration 20: 8.65963e-09
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 8.65963e-09
 
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Solving peridotite system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 8.65963e-09
+
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Solving peridotite system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 8.65963e-09
+
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Solving peridotite system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 8.65963e-09
+
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Solving peridotite system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.33666e-15, 1.05083e-15, 1.05083e-15, 8.65963e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 8.65963e-09
 
 
    Postprocessing:

--- a/tests/particle_count_statistics/screen-output
+++ b/tests/particle_count_statistics/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 41+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 8.01426e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 8.01426e-08
+
 
    Postprocessing:
      Number of advected particles:        1000
@@ -17,7 +19,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 1:  t=8.80814 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Number of advected particles:        1000
@@ -25,7 +28,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 2:  t=17.6163 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Number of advected particles:        1000
@@ -33,7 +37,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 3:  t=26.4244 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Number of advected particles:        1000
@@ -41,7 +46,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 4:  t=35.2326 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Number of advected particles:        1000
@@ -49,7 +55,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 5:  t=44.0407 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Number of advected particles:        1000
@@ -57,7 +64,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 6:  t=52.8489 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Number of advected particles:        1000
@@ -65,7 +73,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 7:  t=61.657 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Number of advected particles:        1000
@@ -73,7 +82,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 8:  t=70.4652 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Number of advected particles:        1000
@@ -81,7 +91,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 9:  t=79.2733 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Number of advected particles:        1000
@@ -89,7 +100,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 10:  t=88.0814 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Number of advected particles:        1000
@@ -101,9 +113,11 @@ Number of degrees of freedom: 3,379 (2,070+274+1,035)
 *** Timestep 11:  t=96.8896 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 0.337215
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 0.337215
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 7.99688e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 7.99688e-08
+
 
    Postprocessing:
      Number of advected particles:        1000
@@ -111,9 +125,11 @@ Number of degrees of freedom: 3,379 (2,070+274+1,035)
 
 *** Timestep 12:  t=100 seconds
    Solving Stokes system... 26+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 0.101315
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 0.101315
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 9.14226e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 9.14226e-08
+
 
    Postprocessing:
      Number of advected particles:        1000

--- a/tests/particle_melt_advection/screen-output
+++ b/tests/particle_melt_advection/screen-output
@@ -9,9 +9,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+36 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.87476e-16, 1.20111e-16, 0, 0.956793
-      Total relative residual after nonlinear iteration 1: 0.956793
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.87476e-16, 1.20111e-16, 0, 0.956793
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.956793
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -19,9 +18,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+36 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.13013e-16, 1.20111e-16, 0, 0.752886
-      Total relative residual after nonlinear iteration 2: 0.752886
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.13013e-16, 1.20111e-16, 0, 0.752886
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.752886
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -29,9 +27,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+35 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.3936e-16, 1.20111e-16, 0, 0.16311
-      Total relative residual after nonlinear iteration 3: 0.16311
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.3936e-16, 1.20111e-16, 0, 0.16311
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.16311
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -39,9 +36,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+32 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.21222e-16, 1.20111e-16, 0, 0.025768
-      Total relative residual after nonlinear iteration 4: 0.025768
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.21222e-16, 1.20111e-16, 0, 0.025768
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.025768
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -49,9 +45,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+28 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.24729e-16, 1.20111e-16, 0, 0.00311419
-      Total relative residual after nonlinear iteration 5: 0.00311419
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.24729e-16, 1.20111e-16, 0, 0.00311419
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.00311419
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -59,9 +54,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+25 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.12646e-16, 1.20111e-16, 0, 0.000303303
-      Total relative residual after nonlinear iteration 6: 0.000303303
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.12646e-16, 1.20111e-16, 0, 0.000303303
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000303303
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -69,9 +63,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+21 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.2184e-16, 1.20111e-16, 0, 2.46785e-05
-      Total relative residual after nonlinear iteration 7: 2.46785e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.2184e-16, 1.20111e-16, 0, 2.46785e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 2.46785e-05
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -79,9 +72,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+17 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.16234e-16, 1.20111e-16, 0, 1.71537e-06
-      Total relative residual after nonlinear iteration 8: 1.71537e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.16234e-16, 1.20111e-16, 0, 1.71537e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.71537e-06
 
 
    Postprocessing:
@@ -99,19 +91,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+26 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0118326, 0.159783, 0, 0.0223922
-      Total relative residual after nonlinear iteration 1: 0.159783
-
-
-   Solving temperature system... 9 iterations.
-   Solving porosity system ... 6 iterations.
-   Skipping peridotite composition solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+26 iterations.
-   Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000795903, 0.07248, 0, 0.00747608
-      Total relative residual after nonlinear iteration 2: 0.07248
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0118326, 0.159783, 0, 0.0223922
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.159783
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 6 iterations.
@@ -119,19 +100,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+26 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000419264, 0.0563518, 0, 0.00436835
-      Total relative residual after nonlinear iteration 3: 0.0563518
-
-
-   Solving temperature system... 9 iterations.
-   Solving porosity system ... 6 iterations.
-   Skipping peridotite composition solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+26 iterations.
-   Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000161779, 0.0612867, 0, 0.00438236
-      Total relative residual after nonlinear iteration 4: 0.0612867
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000795903, 0.07248, 0, 0.00747608
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.07248
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 6 iterations.
@@ -139,9 +109,26 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+26 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000374396, 0.0488634, 0, 0.00396823
-      Total relative residual after nonlinear iteration 5: 0.0488634
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000419264, 0.0563518, 0, 0.00436835
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0563518
 
+   Solving temperature system... 9 iterations.
+   Solving porosity system ... 6 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000161779, 0.0612867, 0, 0.00438236
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0612867
+
+   Solving temperature system... 9 iterations.
+   Solving porosity system ... 6 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000374396, 0.0488634, 0, 0.00396823
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.0488634
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 6 iterations.
@@ -149,9 +136,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+24 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000675745, 0.0554164, 0, 0.00313225
-      Total relative residual after nonlinear iteration 6: 0.0554164
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000675745, 0.0554164, 0, 0.00313225
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.0554164
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 6 iterations.
@@ -159,19 +145,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+27 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000286676, 0.0604252, 0, 0.00703041
-      Total relative residual after nonlinear iteration 7: 0.0604252
-
-
-   Solving temperature system... 9 iterations.
-   Solving porosity system ... 6 iterations.
-   Skipping peridotite composition solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+26 iterations.
-   Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000658048, 0.055261, 0, 0.00753673
-      Total relative residual after nonlinear iteration 8: 0.055261
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000286676, 0.0604252, 0, 0.00703041
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.0604252
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 6 iterations.
@@ -179,9 +154,17 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+26 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000983284, 0.0559084, 0, 0.00615684
-      Total relative residual after nonlinear iteration 9: 0.0559084
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000658048, 0.055261, 0, 0.00753673
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.055261
 
+   Solving temperature system... 9 iterations.
+   Solving porosity system ... 6 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000983284, 0.0559084, 0, 0.00615684
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.0559084
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 5 iterations.
@@ -189,19 +172,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+27 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000612971, 0.0515675, 0, 0.0061324
-      Total relative residual after nonlinear iteration 10: 0.0515675
-
-
-   Solving temperature system... 9 iterations.
-   Solving porosity system ... 6 iterations.
-   Skipping peridotite composition solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+27 iterations.
-   Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.00086677, 0.0609365, 0, 0.00701854
-      Total relative residual after nonlinear iteration 11: 0.0609365
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000612971, 0.0515675, 0, 0.0061324
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 0.0515675
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 6 iterations.
@@ -209,69 +181,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+27 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000693629, 0.0580434, 0, 0.00589117
-      Total relative residual after nonlinear iteration 12: 0.0580434
-
-
-   Solving temperature system... 9 iterations.
-   Solving porosity system ... 6 iterations.
-   Skipping peridotite composition solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+26 iterations.
-   Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.00139261, 0.0437996, 0, 0.00434155
-      Total relative residual after nonlinear iteration 13: 0.0437996
-
-
-   Solving temperature system... 9 iterations.
-   Solving porosity system ... 6 iterations.
-   Skipping peridotite composition solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+26 iterations.
-   Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000526079, 0.0538683, 0, 0.00574833
-      Total relative residual after nonlinear iteration 14: 0.0538683
-
-
-   Solving temperature system... 9 iterations.
-   Solving porosity system ... 6 iterations.
-   Skipping peridotite composition solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+26 iterations.
-   Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000754795, 0.057319, 0, 0.00619204
-      Total relative residual after nonlinear iteration 15: 0.057319
-
-
-   Solving temperature system... 9 iterations.
-   Solving porosity system ... 6 iterations.
-   Skipping peridotite composition solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+26 iterations.
-   Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.00065743, 0.0501851, 0, 0.00478976
-      Total relative residual after nonlinear iteration 16: 0.0501851
-
-
-   Solving temperature system... 9 iterations.
-   Solving porosity system ... 6 iterations.
-   Skipping peridotite composition solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+26 iterations.
-   Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000366453, 0.046624, 0, 0.0046039
-      Total relative residual after nonlinear iteration 17: 0.046624
-
-
-   Solving temperature system... 9 iterations.
-   Solving porosity system ... 6 iterations.
-   Skipping peridotite composition solve because RHS is zero.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+26 iterations.
-   Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000336761, 0.0488559, 0, 0.00592128
-      Total relative residual after nonlinear iteration 18: 0.0488559
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00086677, 0.0609365, 0, 0.00701854
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 0.0609365
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 6 iterations.
@@ -279,9 +190,8 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+27 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000748895, 0.0527689, 0, 0.00613236
-      Total relative residual after nonlinear iteration 19: 0.0527689
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000693629, 0.0580434, 0, 0.00589117
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 0.0580434
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 6 iterations.
@@ -289,9 +199,71 @@ Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+26 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000876585, 0.056009, 0, 0.00562792
-      Total relative residual after nonlinear iteration 20: 0.056009
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00139261, 0.0437996, 0, 0.00434155
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 0.0437996
 
+   Solving temperature system... 9 iterations.
+   Solving porosity system ... 6 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000526079, 0.0538683, 0, 0.00574833
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 0.0538683
+
+   Solving temperature system... 9 iterations.
+   Solving porosity system ... 6 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000754795, 0.057319, 0, 0.00619204
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 0.057319
+
+   Solving temperature system... 9 iterations.
+   Solving porosity system ... 6 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00065743, 0.0501851, 0, 0.00478976
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 0.0501851
+
+   Solving temperature system... 9 iterations.
+   Solving porosity system ... 6 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000366453, 0.046624, 0, 0.0046039
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 0.046624
+
+   Solving temperature system... 9 iterations.
+   Solving porosity system ... 6 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000336761, 0.0488559, 0, 0.00592128
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 0.0488559
+
+   Solving temperature system... 9 iterations.
+   Solving porosity system ... 6 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+27 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000748895, 0.0527689, 0, 0.00613236
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 0.0527689
+
+   Solving temperature system... 9 iterations.
+   Solving porosity system ... 6 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000876585, 0.056009, 0, 0.00562792
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 0.056009
 
 
    Postprocessing:

--- a/tests/particle_property_integrated_strain_invariant/screen-output
+++ b/tests/particle_property_integrated_strain_invariant/screen-output
@@ -1,5 +1,3 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 
 Number of active cells: 100 (on 1 levels)
 Number of degrees of freedom: 1,444 (882+121+441)
@@ -8,7 +6,7 @@ Number of degrees of freedom: 1,444 (882+121+441)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
    Postprocessing:
@@ -24,7 +22,8 @@ Number of degrees of freedom: 1,444 (882+121+441)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 5.22529e-15
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 5.0337e-15
+
 
    Postprocessing:
      Writing particle output: output-particle_property_integrated_strain_invariant/particles/particle-00001

--- a/tests/plugin_dependency/screen-output
+++ b/tests/plugin_dependency/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.87792e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.87792e-08
+
 
    Postprocessing:
      RMS, max velocity:             0.00125 m/s, 0.00345 m/s

--- a/tests/plugin_dependency_redundant/screen-output
+++ b/tests/plugin_dependency_redundant/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.87792e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.87792e-08
+
 
    Postprocessing:
      RMS, max velocity:             0.00125 m/s, 0.00345 m/s

--- a/tests/plugin_dependency_redundant_02/screen-output
+++ b/tests/plugin_dependency_redundant_02/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.87792e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.87792e-08
+
 
    Postprocessing:
      RMS, max velocity:             0.00125 m/s, 0.00345 m/s

--- a/tests/postprocess_iterations_Stokes_only/screen-output
+++ b/tests/postprocess_iterations_Stokes_only/screen-output
@@ -6,48 +6,53 @@ Number of degrees of freedom: 13,764 (9,539+4,225)
 
 *** Timestep 0:  t=0 seconds
    Solving Stokes system... done.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_Stokes_only/solution/solution-00000.0000
      Writing heat flux map:            output-postprocess_iterations_Stokes_only/heat_flux.00000.0000
      Top/bottom flux:                  0.9091/1
-     Pressure at top/bottom of domain: -6.183e-20 Pa, 9.531 Pa
+     Pressure at top/bottom of domain: -1.927e-20 Pa, 9.531 Pa
      Computing dynamic topography      
 
    Solving Stokes system... done.
-      Relative Stokes residual after nonlinear iteration 2: 0.0138303
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0138303
+
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_Stokes_only/solution/solution-00000.0001
      Writing heat flux map:            output-postprocess_iterations_Stokes_only/heat_flux.00000.0001
      Top/bottom flux:                  0.9957/1
-     Pressure at top/bottom of domain: 1.778e-17 Pa, 9.543 Pa
+     Pressure at top/bottom of domain: 1.236e-17 Pa, 9.543 Pa
      Computing dynamic topography      
 
    Solving Stokes system... done.
-      Relative Stokes residual after nonlinear iteration 3: 0.000750098
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 3: 0.000750098
+
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_Stokes_only/solution/solution-00000.0002
      Writing heat flux map:            output-postprocess_iterations_Stokes_only/heat_flux.00000.0002
      Top/bottom flux:                  0.9999/1
-     Pressure at top/bottom of domain: 6.505e-18 Pa, 9.532 Pa
+     Pressure at top/bottom of domain: 6.028e-17 Pa, 9.532 Pa
      Computing dynamic topography      
 
    Solving Stokes system... done.
-      Relative Stokes residual after nonlinear iteration 4: 2.7127e-05
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 4: 2.7127e-05
+
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_Stokes_only/solution/solution-00000.0003
      Writing heat flux map:            output-postprocess_iterations_Stokes_only/heat_flux.00000.0003
      Top/bottom flux:                  1/1
-     Pressure at top/bottom of domain: 5.248e-17 Pa, 9.531 Pa
+     Pressure at top/bottom of domain: 6.158e-17 Pa, 9.531 Pa
      Computing dynamic topography      
 
    Solving Stokes system... done.
-      Relative Stokes residual after nonlinear iteration 5: 6.74287e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 5: 6.74287e-07
+
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_Stokes_only/solution/solution-00000.0004
      Writing heat flux map:            output-postprocess_iterations_Stokes_only/heat_flux.00000.0004
      Top/bottom flux:                  1/1
-     Pressure at top/bottom of domain: 2.472e-17 Pa, 9.531 Pa
+     Pressure at top/bottom of domain: 3.209e-17 Pa, 9.531 Pa
      Computing dynamic topography      
 
 

--- a/tests/postprocess_iterations_iterated_IMPES/screen-output
+++ b/tests/postprocess_iterations_iterated_IMPES/screen-output
@@ -7,9 +7,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 58+0 iterations.
-      Relative nonlinear residuals: 1.89643e-16, 1.57797e-16, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.89643e-16, 1.57797e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00000.0000
@@ -20,9 +19,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residuals: 1.89643e-16, 1.57797e-16, 5.20807e-13
-      Total relative residual after nonlinear iteration 2: 5.20807e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.89643e-16, 1.57797e-16, 5.20807e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.20807e-13
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00000.0001
@@ -35,9 +33,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 10 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residuals: 0.821377, 0.0571457, 0.75783
-      Total relative residual after nonlinear iteration 1: 0.821377
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.821377, 0.0571457, 0.75783
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.821377
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00001.0000
@@ -48,9 +45,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 10 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 53+0 iterations.
-      Relative nonlinear residuals: 0.0977331, 0.00375789, 0.113623
-      Total relative residual after nonlinear iteration 2: 0.113623
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0977331, 0.00375789, 0.113623
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.113623
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00001.0001
@@ -61,9 +57,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 49+0 iterations.
-      Relative nonlinear residuals: 0.0168861, 0.000513186, 0.0205037
-      Total relative residual after nonlinear iteration 3: 0.0205037
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0168861, 0.000513186, 0.0205037
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0205037
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00001.0002
@@ -74,9 +69,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 46+0 iterations.
-      Relative nonlinear residuals: 0.00320707, 0.00010333, 0.00392882
-      Total relative residual after nonlinear iteration 4: 0.00392882
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00320707, 0.00010333, 0.00392882
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00392882
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00001.0003
@@ -87,9 +81,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 0.000633249, 2.34421e-05, 0.000777886
-      Total relative residual after nonlinear iteration 5: 0.000777886
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000633249, 2.34421e-05, 0.000777886
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000777886
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00001.0004
@@ -100,9 +93,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 40+0 iterations.
-      Relative nonlinear residuals: 0.000127909, 5.42261e-06, 0.000157509
-      Total relative residual after nonlinear iteration 6: 0.000157509
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000127909, 5.42261e-06, 0.000157509
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000157509
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00001.0005
@@ -113,9 +105,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residuals: 2.62433e-05, 1.24498e-06, 3.24128e-05
-      Total relative residual after nonlinear iteration 7: 3.24128e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.62433e-05, 1.24498e-06, 3.24128e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 3.24128e-05
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00001.0006
@@ -126,9 +117,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residuals: 5.44567e-06, 2.82028e-07, 6.74805e-06
-      Total relative residual after nonlinear iteration 8: 6.74805e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.44567e-06, 2.82028e-07, 6.74805e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 6.74805e-06
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00001.0007
@@ -141,9 +131,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residuals: 0.247282, 0.00789326, 0.455259
-      Total relative residual after nonlinear iteration 1: 0.455259
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.247282, 0.00789326, 0.455259
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.455259
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00002.0000
@@ -154,9 +143,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 10 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 52+0 iterations.
-      Relative nonlinear residuals: 0.015113, 0.000446344, 0.055206
-      Total relative residual after nonlinear iteration 2: 0.055206
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.015113, 0.000446344, 0.055206
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.055206
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00002.0001
@@ -167,9 +155,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 47+0 iterations.
-      Relative nonlinear residuals: 0.00209268, 7.85134e-05, 0.00922176
-      Total relative residual after nonlinear iteration 3: 0.00922176
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00209268, 7.85134e-05, 0.00922176
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00922176
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00002.0002
@@ -180,9 +167,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 0.000380649, 2.13856e-05, 0.00168053
-      Total relative residual after nonlinear iteration 4: 0.00168053
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000380649, 2.13856e-05, 0.00168053
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00168053
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00002.0003
@@ -193,9 +179,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 40+0 iterations.
-      Relative nonlinear residuals: 7.22582e-05, 5.57131e-06, 0.000317032
-      Total relative residual after nonlinear iteration 5: 0.000317032
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.22582e-05, 5.57131e-06, 0.000317032
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000317032
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00002.0004
@@ -206,9 +191,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residuals: 1.39971e-05, 1.351e-06, 6.12444e-05
-      Total relative residual after nonlinear iteration 6: 6.12444e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.39971e-05, 1.351e-06, 6.12444e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 6.12444e-05
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00002.0005
@@ -219,9 +203,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residuals: 2.7557e-06, 3.12297e-07, 1.2047e-05
-      Total relative residual after nonlinear iteration 7: 1.2047e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.7557e-06, 3.12297e-07, 1.2047e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 1.2047e-05
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00002.0006
@@ -232,9 +215,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals: 5.4958e-07, 6.99312e-08, 2.40272e-06
-      Total relative residual after nonlinear iteration 8: 2.40272e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.4958e-07, 6.99312e-08, 2.40272e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 2.40272e-06
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00002.0007
@@ -247,9 +229,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residuals: 0.254258, 0.00608319, 0.647102
-      Total relative residual after nonlinear iteration 1: 0.647102
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.254258, 0.00608319, 0.647102
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.647102
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00003.0000
@@ -260,9 +241,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 48+0 iterations.
-      Relative nonlinear residuals: 0.00864642, 0.000460019, 0.0271297
-      Total relative residual after nonlinear iteration 2: 0.0271297
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00864642, 0.000460019, 0.0271297
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0271297
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00003.0001
@@ -273,9 +253,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residuals: 0.000401659, 2.14864e-05, 0.00147209
-      Total relative residual after nonlinear iteration 3: 0.00147209
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000401659, 2.14864e-05, 0.00147209
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00147209
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00003.0002
@@ -286,9 +265,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 40+0 iterations.
-      Relative nonlinear residuals: 3.45653e-05, 2.90915e-06, 0.000143673
-      Total relative residual after nonlinear iteration 4: 0.000143673
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.45653e-05, 2.90915e-06, 0.000143673
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000143673
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00003.0003
@@ -299,9 +277,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 6 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 36+0 iterations.
-      Relative nonlinear residuals: 4.35868e-06, 3.40281e-07, 1.83012e-05
-      Total relative residual after nonlinear iteration 5: 1.83012e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.35868e-06, 3.40281e-07, 1.83012e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.83012e-05
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00003.0004
@@ -312,9 +289,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals: 5.86969e-07, 3.66392e-08, 2.45329e-06
-      Total relative residual after nonlinear iteration 6: 2.45329e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.86969e-07, 3.66392e-08, 2.45329e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 2.45329e-06
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00003.0005
@@ -327,9 +303,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residuals: 0.120332, 0.00649854, 0.594093
-      Total relative residual after nonlinear iteration 1: 0.594093
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.120332, 0.00649854, 0.594093
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.594093
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00004.0000
@@ -340,9 +315,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 49+0 iterations.
-      Relative nonlinear residuals: 0.00420756, 0.000824451, 0.0150718
-      Total relative residual after nonlinear iteration 2: 0.0150718
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00420756, 0.000824451, 0.0150718
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0150718
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00004.0001
@@ -353,9 +327,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residuals: 0.000244847, 6.41437e-05, 0.00104033
-      Total relative residual after nonlinear iteration 3: 0.00104033
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000244847, 6.41437e-05, 0.00104033
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00104033
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00004.0002
@@ -366,9 +339,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 39+0 iterations.
-      Relative nonlinear residuals: 2.29483e-05, 6.59889e-06, 9.98032e-05
-      Total relative residual after nonlinear iteration 4: 9.98032e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.29483e-05, 6.59889e-06, 9.98032e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 9.98032e-05
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00004.0003
@@ -379,9 +351,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 35+0 iterations.
-      Relative nonlinear residuals: 2.3895e-06, 7.20227e-07, 1.05543e-05
-      Total relative residual after nonlinear iteration 5: 1.05543e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.3895e-06, 7.20227e-07, 1.05543e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.05543e-05
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00004.0004
@@ -392,9 +363,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 5 iterations.
    Solving porosity system ... 5 iterations.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals: 2.54344e-07, 7.39165e-08, 1.12433e-06
-      Total relative residual after nonlinear iteration 6: 1.12433e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.54344e-07, 7.39165e-08, 1.12433e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 1.12433e-06
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00004.0005
@@ -407,9 +377,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residuals: 0.0801971, 0.00650811, 0.383226
-      Total relative residual after nonlinear iteration 1: 0.383226
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0801971, 0.00650811, 0.383226
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.383226
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00005.0000
@@ -420,9 +389,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 48+0 iterations.
-      Relative nonlinear residuals: 0.00260234, 0.000921972, 0.0120047
-      Total relative residual after nonlinear iteration 2: 0.0120047
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00260234, 0.000921972, 0.0120047
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0120047
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00005.0001
@@ -433,9 +401,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 0.000185779, 0.000117988, 0.000929408
-      Total relative residual after nonlinear iteration 3: 0.000929408
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000185779, 0.000117988, 0.000929408
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000929408
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00005.0002
@@ -446,9 +413,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 39+0 iterations.
-      Relative nonlinear residuals: 1.754e-05, 1.23398e-05, 9.01498e-05
-      Total relative residual after nonlinear iteration 4: 9.01498e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.754e-05, 1.23398e-05, 9.01498e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 9.01498e-05
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00005.0003
@@ -459,9 +425,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residuals: 1.74434e-06, 1.25013e-06, 9.03192e-06
-      Total relative residual after nonlinear iteration 5: 9.03192e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.74434e-06, 1.25013e-06, 9.03192e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 9.03192e-06
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00005.0004
@@ -474,9 +439,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residuals: 0.0572412, 0.00689934, 0.258279
-      Total relative residual after nonlinear iteration 1: 0.258279
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0572412, 0.00689934, 0.258279
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.258279
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00006.0000
@@ -487,9 +451,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 48+0 iterations.
-      Relative nonlinear residuals: 0.00175675, 0.00107406, 0.00805902
-      Total relative residual after nonlinear iteration 2: 0.00805902
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00175675, 0.00107406, 0.00805902
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00805902
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00006.0001
@@ -500,9 +463,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 0.000127417, 0.000112878, 0.000630225
-      Total relative residual after nonlinear iteration 3: 0.000630225
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000127417, 0.000112878, 0.000630225
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000630225
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00006.0002
@@ -513,9 +475,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 38+0 iterations.
-      Relative nonlinear residuals: 1.18384e-05, 1.12086e-05, 6.03151e-05
-      Total relative residual after nonlinear iteration 4: 6.03151e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.18384e-05, 1.12086e-05, 6.03151e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 6.03151e-05
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00006.0003
@@ -526,9 +487,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 6 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residuals: 1.14789e-06, 1.10076e-06, 5.95712e-06
-      Total relative residual after nonlinear iteration 5: 5.95712e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.14789e-06, 1.10076e-06, 5.95712e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 5.95712e-06
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00006.0004
@@ -541,9 +501,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residuals: 0.038188, 0.00732507, 0.159808
-      Total relative residual after nonlinear iteration 1: 0.159808
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.038188, 0.00732507, 0.159808
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.159808
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00007.0000
@@ -554,9 +513,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 10 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 48+0 iterations.
-      Relative nonlinear residuals: 0.00121057, 0.000995593, 0.00550759
-      Total relative residual after nonlinear iteration 2: 0.00550759
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00121057, 0.000995593, 0.00550759
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00550759
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00007.0001
@@ -567,9 +525,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals: 9.03844e-05, 9.45603e-05, 0.000439483
-      Total relative residual after nonlinear iteration 3: 0.000439483
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.03844e-05, 9.45603e-05, 0.000439483
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000439483
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00007.0002
@@ -580,9 +537,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 38+0 iterations.
-      Relative nonlinear residuals: 8.20473e-06, 8.8462e-06, 4.12574e-05
-      Total relative residual after nonlinear iteration 4: 4.12574e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.20473e-06, 8.8462e-06, 4.12574e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 4.12574e-05
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00007.0003
@@ -593,9 +549,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residuals: 7.72319e-07, 8.30891e-07, 3.96441e-06
-      Total relative residual after nonlinear iteration 5: 3.96441e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.72319e-07, 8.30891e-07, 3.96441e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 3.96441e-06
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00007.0004
@@ -608,9 +563,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 53+0 iterations.
-      Relative nonlinear residuals: 0.0247562, 0.00760225, 0.0961601
-      Total relative residual after nonlinear iteration 1: 0.0961601
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0247562, 0.00760225, 0.0961601
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0961601
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00008.0000
@@ -621,9 +575,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 47+0 iterations.
-      Relative nonlinear residuals: 0.000898388, 0.000855813, 0.00400586
-      Total relative residual after nonlinear iteration 2: 0.00400586
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000898388, 0.000855813, 0.00400586
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00400586
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00008.0001
@@ -634,9 +587,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 42+0 iterations.
-      Relative nonlinear residuals: 7.01468e-05, 7.60177e-05, 0.000325253
-      Total relative residual after nonlinear iteration 3: 0.000325253
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.01468e-05, 7.60177e-05, 0.000325253
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000325253
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00008.0002
@@ -647,9 +599,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residuals: 6.16673e-06, 6.72049e-06, 2.93572e-05
-      Total relative residual after nonlinear iteration 4: 2.93572e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.16673e-06, 6.72049e-06, 2.93572e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 2.93572e-05
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00008.0003
@@ -660,9 +611,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals: 5.54728e-07, 5.98863e-07, 2.67649e-06
-      Total relative residual after nonlinear iteration 5: 2.67649e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.54728e-07, 5.98863e-07, 2.67649e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 2.67649e-06
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00008.0004
@@ -675,9 +625,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 52+0 iterations.
-      Relative nonlinear residuals: 0.0164665, 0.00766179, 0.0590716
-      Total relative residual after nonlinear iteration 1: 0.0590716
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0164665, 0.00766179, 0.0590716
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0590716
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00009.0000
@@ -688,9 +637,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 46+0 iterations.
-      Relative nonlinear residuals: 0.00068657, 0.000710171, 0.00294368
-      Total relative residual after nonlinear iteration 2: 0.00294368
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00068657, 0.000710171, 0.00294368
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00294368
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00009.0001
@@ -701,9 +649,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 41+0 iterations.
-      Relative nonlinear residuals: 5.36425e-05, 5.79232e-05, 0.000236209
-      Total relative residual after nonlinear iteration 3: 0.000236209
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.36425e-05, 5.79232e-05, 0.000236209
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000236209
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00009.0002
@@ -714,9 +661,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 36+0 iterations.
-      Relative nonlinear residuals: 4.45823e-06, 4.77118e-06, 2.00694e-05
-      Total relative residual after nonlinear iteration 4: 2.00694e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.45823e-06, 4.77118e-06, 2.00694e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 2.00694e-05
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00009.0003
@@ -727,9 +673,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals: 3.76583e-07, 3.98543e-07, 1.70762e-06
-      Total relative residual after nonlinear iteration 5: 1.70762e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.76583e-07, 3.98543e-07, 1.70762e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.70762e-06
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00009.0004
@@ -742,9 +687,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving Stokes system... 52+0 iterations.
-      Relative nonlinear residuals: 0.0123146, 0.00762178, 0.0416316
-      Total relative residual after nonlinear iteration 1: 0.0416316
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0123146, 0.00762178, 0.0416316
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0416316
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00010.0000
@@ -755,9 +699,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residuals: 0.00056907, 0.000605296, 0.00224469
-      Total relative residual after nonlinear iteration 2: 0.00224469
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00056907, 0.000605296, 0.00224469
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00224469
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00010.0001
@@ -768,9 +711,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving Stokes system... 41+0 iterations.
-      Relative nonlinear residuals: 4.14175e-05, 4.41337e-05, 0.000170268
-      Total relative residual after nonlinear iteration 3: 0.000170268
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.14175e-05, 4.41337e-05, 0.000170268
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000170268
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00010.0002
@@ -781,9 +723,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 36+0 iterations.
-      Relative nonlinear residuals: 3.17896e-06, 3.34472e-06, 1.33117e-05
-      Total relative residual after nonlinear iteration 4: 1.33117e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.17896e-06, 3.34472e-06, 1.33117e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.33117e-05
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00010.0003
@@ -794,9 +735,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals: 2.47978e-07, 2.58616e-07, 1.04354e-06
-      Total relative residual after nonlinear iteration 5: 1.04354e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.47978e-07, 2.58616e-07, 1.04354e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.04354e-06
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00010.0004
@@ -809,9 +749,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... 52+0 iterations.
-      Relative nonlinear residuals: 0.00785454, 0.00556257, 0.0254169
-      Total relative residual after nonlinear iteration 1: 0.0254169
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00785454, 0.00556257, 0.0254169
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0254169
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00011.0000
@@ -822,9 +761,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 10 iterations.
    Solving porosity system ... 10 iterations.
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residuals: 0.000300093, 0.000322736, 0.00111551
-      Total relative residual after nonlinear iteration 2: 0.00111551
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000300093, 0.000322736, 0.00111551
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00111551
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00011.0001
@@ -835,9 +773,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... 39+0 iterations.
-      Relative nonlinear residuals: 1.66866e-05, 1.763e-05, 6.51037e-05
-      Total relative residual after nonlinear iteration 3: 6.51037e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.66866e-05, 1.763e-05, 6.51037e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 6.51037e-05
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00011.0002
@@ -848,9 +785,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Solving temperature system... 7 iterations.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residuals: 9.88274e-07, 1.02788e-06, 3.9168e-06
-      Total relative residual after nonlinear iteration 4: 3.9168e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.88274e-07, 1.02788e-06, 3.9168e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 3.9168e-06
 
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_IMPES/solution/solution-00011.0003

--- a/tests/postprocess_iterations_iterated_Stokes/screen-output
+++ b/tests/postprocess_iterations_iterated_Stokes/screen-output
@@ -8,7 +8,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_Stokes/solution/solution-00000.0000
      Writing heat flux map:            output-postprocess_iterations_iterated_Stokes/heat_flux.00000.0000
@@ -18,10 +19,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
      Pressure at top/bottom of domain: -1.98e-19 Pa, 9.531 Pa
      Computing dynamic topography      
 
-
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 0.0245986
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0245986
+
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_Stokes/solution/solution-00000.0001
      Writing heat flux map:            output-postprocess_iterations_iterated_Stokes/heat_flux.00000.0001
@@ -31,10 +32,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
      Pressure at top/bottom of domain: 8.674e-16 Pa, 9.652 Pa
      Computing dynamic topography      
 
-
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 0.00133812
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.00133812
+
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_Stokes/solution/solution-00000.0002
      Writing heat flux map:            output-postprocess_iterations_iterated_Stokes/heat_flux.00000.0002
@@ -44,10 +45,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
      Pressure at top/bottom of domain: 1.214e-15 Pa, 9.544 Pa
      Computing dynamic topography      
 
-
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 4.59661e-05
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 4.59661e-05
+
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_Stokes/solution/solution-00000.0003
      Writing heat flux map:            output-postprocess_iterations_iterated_Stokes/heat_flux.00000.0003
@@ -57,10 +58,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
      Pressure at top/bottom of domain: 1.013e-15 Pa, 9.532 Pa
      Computing dynamic topography      
 
-
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-      Relative Stokes residual after nonlinear iteration 5: 2.11124e-06
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 2.11124e-06
+
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_Stokes/solution/solution-00000.0004
      Writing heat flux map:            output-postprocess_iterations_iterated_Stokes/heat_flux.00000.0004
@@ -75,7 +76,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 17 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 2.14941e-07
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 2.14941e-07
+
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_Stokes/solution/solution-00001.0000
      Writing heat flux map:            output-postprocess_iterations_iterated_Stokes/heat_flux.00001.0000
@@ -90,7 +92,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 2.01605e-07
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 2.01605e-07
+
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_Stokes/solution/solution-00002.0000
      Writing heat flux map:            output-postprocess_iterations_iterated_Stokes/heat_flux.00002.0000
@@ -105,7 +108,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 2.27322e-07
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 2.27322e-07
+
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_Stokes/solution/solution-00003.0000
      Writing heat flux map:            output-postprocess_iterations_iterated_Stokes/heat_flux.00003.0000
@@ -120,7 +124,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 13 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 8.39909e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 8.39909e-08
+
    Postprocessing:
      Writing graphical output:         output-postprocess_iterations_iterated_Stokes/solution/solution-00004.0000
      Writing heat flux map:            output-postprocess_iterations_iterated_Stokes/heat_flux.00004.0000

--- a/tests/prescribed_velocity_boundary/screen-output
+++ b/tests/prescribed_velocity_boundary/screen-output
@@ -183,7 +183,8 @@ Boundary_velocity called with boundary_id =3
 Boundary_velocity called with boundary_id =3
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 0
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 0
+
 
    Postprocessing:
      Writing graphical output:      output-prescribed_velocity_boundary/solution/solution-00000

--- a/tests/prmbackslash_2/screen-output
+++ b/tests/prmbackslash_2/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.87792e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.87792e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174944e-01, 1.069688e-04, 1.192654e-01

--- a/tests/quick_mpi/screen-output
+++ b/tests/quick_mpi/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... XYZ iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... XYZ iterations.
-      Relative Stokes residual after nonlinear iteration 2: 6.60395e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.87792e-08
+
 
    Postprocessing:
 

--- a/tests/refinement_topography/screen-output
+++ b/tests/refinement_topography/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.87792e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.87792e-08
+
 
 Number of active cells: 22 (on 4 levels)
 Number of degrees of freedom: 392 (238+35+119)
@@ -17,9 +19,11 @@ Number of degrees of freedom: 392 (238+35+119)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 2.95224e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 2.95224e-08
+
 
 Number of active cells: 46 (on 5 levels)
 Number of degrees of freedom: 791 (482+68+241)
@@ -27,9 +31,11 @@ Number of degrees of freedom: 791 (482+68+241)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 8.17095e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 8.17095e-08
+
 
    Postprocessing:
 

--- a/tests/segregation_heating/screen-output
+++ b/tests/segregation_heating/screen-output
@@ -11,9 +11,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.1459e-16, 2.33001e-16, 0, 0.333482
-      Total relative residual after nonlinear iteration 1: 0.333482
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.1459e-16, 2.33001e-16, 0, 0.333482
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.333482
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -21,9 +20,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.1459e-16, 2.33001e-16, 0, 6.05941e-13
-      Total relative residual after nonlinear iteration 2: 6.05941e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.1459e-16, 2.33001e-16, 0, 6.05941e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 6.05941e-13
 
 
    Postprocessing:
@@ -38,9 +36,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
    Solving for u_f in 2 iterations.
-      Relative nonlinear residuals: 3.21771e-05, 7.41442e-14, 0, 8.26732e-07
-      Total relative residual after nonlinear iteration 1: 3.21771e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.21771e-05, 7.41442e-14, 0, 8.26732e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 3.21771e-05
 
    Solving temperature system... 1 iterations.
    Solving porosity system ... 2 iterations.
@@ -48,9 +45,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
    Solving for u_f in 2 iterations.
-      Relative nonlinear residuals: 2.40477e-11, 1.37585e-08, 0, 7.4512e-09
-      Total relative residual after nonlinear iteration 2: 1.37585e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.40477e-11, 1.37585e-08, 0, 7.4512e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 1.37585e-08
 
 
    Postprocessing:
@@ -65,9 +61,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
    Solving for u_f in 3 iterations.
-      Relative nonlinear residuals: 2.18343e-06, 8.74672e-09, 0, 1.14892e-07
-      Total relative residual after nonlinear iteration 1: 2.18343e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.18343e-06, 8.74672e-09, 0, 1.14892e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.18343e-06
 
 
    Postprocessing:
@@ -82,9 +77,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
    Solving for u_f in 3 iterations.
-      Relative nonlinear residuals: 1.6756e-06, 1.1611e-08, 0, 9.24094e-08
-      Total relative residual after nonlinear iteration 1: 1.6756e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.6756e-06, 1.1611e-08, 0, 9.24094e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1.6756e-06
 
 
    Postprocessing:
@@ -99,9 +93,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
    Solving for u_f in 3 iterations.
-      Relative nonlinear residuals: 1.38781e-06, 1.24557e-08, 0, 6.10549e-08
-      Total relative residual after nonlinear iteration 1: 1.38781e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.38781e-06, 1.24557e-08, 0, 6.10549e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1.38781e-06
 
 
    Postprocessing:
@@ -116,9 +109,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
    Solving for u_f in 3 iterations.
-      Relative nonlinear residuals: 1.10468e-06, 1.2618e-08, 0, 4.96743e-08
-      Total relative residual after nonlinear iteration 1: 1.10468e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10468e-06, 1.2618e-08, 0, 4.96743e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1.10468e-06
 
 
    Postprocessing:
@@ -133,9 +125,8 @@ Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 3 iterations.
-      Relative nonlinear residuals: 6.1348e-13, 7.31825e-15, 0, 4.09218e-13
-      Total relative residual after nonlinear iteration 1: 6.1348e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.1348e-13, 7.31825e-15, 0, 4.09218e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 6.1348e-13
 
 
    Postprocessing:

--- a/tests/shear_bands/screen-output
+++ b/tests/shear_bands/screen-output
@@ -10,36 +10,32 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
    Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 1.44861e-16, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.44861e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
    Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 1.12357e-16, 0.0299352
-      Total relative residual after nonlinear iteration 2: 0.0299352
-
-
-   Skipping temperature solve because RHS is zero.
-   Solving porosity system ... 8 iterations.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 1.05506e-16, 0.0183976
-      Total relative residual after nonlinear iteration 3: 0.0183976
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.12357e-16, 0.0299352
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0299352
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 1.04718e-16, 0.0133444
-      Total relative residual after nonlinear iteration 4: 0.0133444
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.05506e-16, 0.0183976
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0183976
 
+   Skipping temperature solve because RHS is zero.
+   Solving porosity system ... 8 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 8+0 iterations.
+   Solving for u_f in 11 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.04718e-16, 0.0133444
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0133444
 
 
    Postprocessing:
@@ -53,36 +49,32 @@ Number of degrees of freedom: 28,857 (8,514+2,210+8,514+1,105+4,257+4,257)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 0.00249153, 0.000649887
-      Total relative residual after nonlinear iteration 1: 0.000649887
-
-
-   Skipping temperature solve because RHS is zero.
-   Solving porosity system ... 35 iterations.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 0.000708823, 0.000438238
-      Total relative residual after nonlinear iteration 2: 0.000438238
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00249153, 0.000649887
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000649887
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 35 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 0.000482201, 0.000386348
-      Total relative residual after nonlinear iteration 3: 0.000386348
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000708823, 0.000438238
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000438238
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 35 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
    Solving for u_f in 11 iterations.
-      Relative nonlinear residuals: 0, 0.000437588, 0.000355273
-      Total relative residual after nonlinear iteration 4: 0.000355273
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000482201, 0.000386348
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000386348
 
+   Skipping temperature solve because RHS is zero.
+   Solving porosity system ... 35 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 8+0 iterations.
+   Solving for u_f in 11 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000437588, 0.000355273
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000355273
 
 
    Postprocessing:

--- a/tests/shear_heating_with_melt/screen-output
+++ b/tests/shear_heating_with_melt/screen-output
@@ -9,9 +9,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 2.03902e-16, 0, 0, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.03902e-16, 0, 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -19,9 +18,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 1.45674e-16, 0, 0, 0.00615557
-      Total relative residual after nonlinear iteration 2: 0.00615557
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.45674e-16, 0, 0, 0.00615557
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00615557
 
    Solving temperature system... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -29,9 +27,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 1.87919e-16, 0, 0, 8.2488e-05
-      Total relative residual after nonlinear iteration 3: 8.2488e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.87919e-16, 0, 0, 8.2488e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 8.2488e-05
 
    Solving temperature system... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -39,9 +36,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 1.58499e-16, 0, 0, 8.03279e-07
-      Total relative residual after nonlinear iteration 4: 8.03279e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.58499e-16, 0, 0, 8.03279e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 8.03279e-07
 
 
 Number of active cells: 40 (on 1 levels)
@@ -54,9 +50,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 2.03902e-16, 0, 0, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.03902e-16, 0, 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -64,9 +59,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 1.45674e-16, 0, 0, 0.00615557
-      Total relative residual after nonlinear iteration 2: 0.00615557
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.45674e-16, 0, 0, 0.00615557
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00615557
 
    Solving temperature system... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -74,9 +68,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 1.87919e-16, 0, 0, 8.2488e-05
-      Total relative residual after nonlinear iteration 3: 8.2488e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.87919e-16, 0, 0, 8.2488e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 8.2488e-05
 
    Solving temperature system... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -84,9 +77,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 1.58499e-16, 0, 0, 8.03279e-07
-      Total relative residual after nonlinear iteration 4: 8.03279e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.58499e-16, 0, 0, 8.03279e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 8.03279e-07
 
 
    Postprocessing:
@@ -103,9 +95,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 0.164007, 0, 0, 0.000917996
-      Total relative residual after nonlinear iteration 1: 0.164007
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.164007, 0, 0, 0.000917996
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.164007
 
    Solving temperature system... 13 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -113,9 +104,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 0.00018273, 0, 0, 2.49446e-06
-      Total relative residual after nonlinear iteration 2: 0.00018273
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00018273, 0, 0, 2.49446e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00018273
 
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -123,9 +113,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 2.08159e-07, 0, 0, 8.48577e-08
-      Total relative residual after nonlinear iteration 3: 2.08159e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.08159e-07, 0, 0, 8.48577e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 2.08159e-07
 
 
    Postprocessing:
@@ -142,9 +131,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 0.0873494, 0, 0, 0.000356925
-      Total relative residual after nonlinear iteration 1: 0.0873494
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0873494, 0, 0, 0.000356925
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0873494
 
    Solving temperature system... 12 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -152,9 +140,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 0.00367302, 0, 0, 4.28979e-05
-      Total relative residual after nonlinear iteration 2: 0.00367302
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00367302, 0, 0, 4.28979e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00367302
 
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -162,9 +149,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 4.094e-06, 0, 0, 3.52638e-08
-      Total relative residual after nonlinear iteration 3: 4.094e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.094e-06, 0, 0, 3.52638e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 4.094e-06
 
 
    Postprocessing:
@@ -181,9 +167,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals: 0.0773542, 1, 1, 0.000547027
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0773542, 1, 1, 0.000547027
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 12 iterations.
    Solving porosity system ... 1 iterations.
@@ -191,9 +176,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000607014, 0.70703, 0.707053, 0.000305164
-      Total relative residual after nonlinear iteration 2: 0.707053
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000607014, 0.70703, 0.707053, 0.000305164
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.707053
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 1 iterations.
@@ -201,9 +185,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 8.19932e-05, 0.295227, 0.103102, 7.70053e-05
-      Total relative residual after nonlinear iteration 3: 0.295227
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.19932e-05, 0.295227, 0.103102, 7.70053e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.295227
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 1 iterations.
@@ -211,9 +194,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.0537e-05, 0.0139466, 0.0135943, 3.4014e-06
-      Total relative residual after nonlinear iteration 4: 0.0139466
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.0537e-05, 0.0139466, 0.0135943, 3.4014e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0139466
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 1 iterations.
@@ -221,9 +203,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.36991e-06, 0.00181435, 0.00175401, 4.44421e-07
-      Total relative residual after nonlinear iteration 5: 0.00181435
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.36991e-06, 0.00181435, 0.00175401, 4.44421e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.00181435
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 1 iterations.
@@ -231,9 +212,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.7715e-07, 0.000207501, 0.000226756, 1.20592e-07
-      Total relative residual after nonlinear iteration 6: 0.000226756
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.7715e-07, 0.000207501, 0.000226756, 1.20592e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000226756
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 1 iterations.
@@ -241,9 +221,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.35888e-08, 3.4731e-05, 2.91942e-05, 9.72058e-08
-      Total relative residual after nonlinear iteration 7: 3.4731e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.35888e-08, 3.4731e-05, 2.91942e-05, 9.72058e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 3.4731e-05
 
    Solving temperature system... 4 iterations.
    Solving porosity system ... 1 iterations.
@@ -251,9 +230,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.9635e-09, 3.78767e-06, 3.78852e-06, 9.7682e-08
-      Total relative residual after nonlinear iteration 8: 3.78852e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.9635e-09, 3.78767e-06, 3.78852e-06, 9.7682e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 3.78852e-06
 
 
    Postprocessing:
@@ -270,19 +248,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0406273, 0.797557, 0.805388, 0.00640435
-      Total relative residual after nonlinear iteration 1: 0.805388
-
-
-   Solving temperature system... 10 iterations.
-   Solving porosity system ... 1 iterations.
-   Solving peridotite system ... 1 iterations.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 17+0 iterations.
-   Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.00149317, 0.243009, 0.220319, 0.00109492
-      Total relative residual after nonlinear iteration 2: 0.243009
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0406273, 0.797557, 0.805388, 0.00640435
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.805388
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 1 iterations.
@@ -290,9 +257,17 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000124991, 0.091474, 0.109876, 9.68638e-05
-      Total relative residual after nonlinear iteration 3: 0.109876
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00149317, 0.243009, 0.220319, 0.00109492
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.243009
 
+   Solving temperature system... 10 iterations.
+   Solving porosity system ... 1 iterations.
+   Solving peridotite system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 17+0 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000124991, 0.091474, 0.109876, 9.68638e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.109876
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 1 iterations.
@@ -300,9 +275,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 7.84734e-05, 0.0222996, 0.0226801, 2.6777e-05
-      Total relative residual after nonlinear iteration 4: 0.0226801
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.84734e-05, 0.0222996, 0.0226801, 2.6777e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0226801
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 1 iterations.
@@ -310,9 +284,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 9.5432e-06, 0.00878834, 0.00893621, 1.08277e-05
-      Total relative residual after nonlinear iteration 5: 0.00893621
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.5432e-06, 0.00878834, 0.00893621, 1.08277e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.00893621
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 1 iterations.
@@ -320,9 +293,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 5.22799e-06, 0.00484052, 0.0049207, 6.07111e-06
-      Total relative residual after nonlinear iteration 6: 0.0049207
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.22799e-06, 0.00484052, 0.0049207, 6.07111e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.0049207
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 1 iterations.
@@ -330,9 +302,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 3.67242e-06, 0.00341457, 0.00347057, 4.316e-06
-      Total relative residual after nonlinear iteration 7: 0.00347057
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.67242e-06, 0.00341457, 0.00347057, 4.316e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.00347057
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 1 iterations.
@@ -340,9 +311,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 3.2689e-06, 0.00305132, 0.00310097, 3.87822e-06
-      Total relative residual after nonlinear iteration 8: 0.00310097
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.2689e-06, 0.00305132, 0.00310097, 3.87822e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.00310097
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 1 iterations.
@@ -350,9 +320,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 3.97996e-06, 0.00373316, 0.00379367, 4.82853e-06
-      Total relative residual after nonlinear iteration 9: 0.00379367
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.97996e-06, 0.00373316, 0.00379367, 4.82853e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.00379367
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 1 iterations.
@@ -360,9 +329,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000864899, 0.215071, 0.218492, 0.000294022
-      Total relative residual after nonlinear iteration 10: 0.218492
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000864899, 0.215071, 0.218492, 0.000294022
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 0.218492
 
 
    Postprocessing:
@@ -379,9 +347,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.0162566, 0.551089, 0.552608, 0.00520722
-      Total relative residual after nonlinear iteration 1: 0.552608
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0162566, 0.551089, 0.552608, 0.00520722
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.552608
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 1 iterations.
@@ -389,9 +356,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.00344014, 0.230085, 0.225227, 0.00104466
-      Total relative residual after nonlinear iteration 2: 0.230085
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00344014, 0.230085, 0.225227, 0.00104466
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.230085
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 1 iterations.
@@ -399,9 +365,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 0.000176983, 0.0792125, 0.0798588, 0.000237479
-      Total relative residual after nonlinear iteration 3: 0.0798588
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000176983, 0.0792125, 0.0798588, 0.000237479
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0798588
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 1 iterations.
@@ -409,9 +374,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 3.3797e-05, 0.0285922, 0.0282149, 9.34551e-05
-      Total relative residual after nonlinear iteration 4: 0.0285922
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.3797e-05, 0.0285922, 0.0282149, 9.34551e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0285922
 
    Solving temperature system... 6 iterations.
    Solving porosity system ... 1 iterations.
@@ -419,9 +383,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.29407e-06, 0.000877205, 0.000701574, 2.69645e-06
-      Total relative residual after nonlinear iteration 5: 0.000877205
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.29407e-06, 0.000877205, 0.000701574, 2.69645e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000877205
 
    Solving temperature system... 4 iterations.
    Solving porosity system ... 1 iterations.
@@ -429,9 +392,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.1885e-07, 0.000143656, 0.000148541, 4.66693e-07
-      Total relative residual after nonlinear iteration 6: 0.000148541
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.1885e-07, 0.000143656, 0.000148541, 4.66693e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000148541
 
    Solving temperature system... 4 iterations.
    Solving porosity system ... 1 iterations.
@@ -439,9 +401,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 4.80837e-08, 3.21998e-05, 3.28497e-05, 1.30638e-07
-      Total relative residual after nonlinear iteration 7: 3.28497e-05
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.80837e-08, 3.21998e-05, 3.28497e-05, 1.30638e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 3.28497e-05
 
    Solving temperature system... 3 iterations.
    Solving porosity system ... 1 iterations.
@@ -449,9 +410,8 @@ Number of degrees of freedom: 1,625 (486+164+486+82+243+82+82)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.07423e-08, 6.99074e-06, 7.21332e-06, 1.08037e-07
-      Total relative residual after nonlinear iteration 8: 7.21332e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.07423e-08, 6.99074e-06, 7.21332e-06, 1.08037e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 7.21332e-06
 
 
    Postprocessing:

--- a/tests/simple_compressibility_iterated_stokes/screen-output
+++ b/tests/simple_compressibility_iterated_stokes/screen-output
@@ -7,19 +7,24 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 0.0138303
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0138303
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 0.000750092
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 3: 0.000750092
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 2.71246e-05
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 4: 2.71246e-05
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-      Relative Stokes residual after nonlinear iteration 5: 6.81727e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 5: 6.81727e-07
+
 
    Postprocessing:
      Top/bottom flux: 1/1

--- a/tests/sol_cx_2/screen-output
+++ b/tests/sol_cx_2/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.87792e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.87792e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174944e-01, 1.069688e-04, 1.192654e-01

--- a/tests/sol_cx_2_conservative/screen-output
+++ b/tests/sol_cx_2_conservative/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 291 (162+48+81)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 4.99721e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 4.99721e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 6.986211e-05, 1.148187e-01, 1.007147e-04, 1.149644e-01

--- a/tests/sol_cx_2_normalized_pressure/screen-output
+++ b/tests/sol_cx_2_normalized_pressure/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.87792e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.87792e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.146308e-02, 1.069688e-04, 2.047716e-02

--- a/tests/sol_cx_2_q3/screen-output
+++ b/tests/sol_cx_2_q3/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 500 (338+81+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 7.46778e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 7.46778e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 6.425273e-06, 1.103958e-01, 8.407111e-06, 1.110898e-01

--- a/tests/sol_cx_4/screen-output
+++ b/tests/sol_cx_4/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 41+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 8.01426e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 8.01426e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 1.125997e-06, 1.101883e-01, 1.670011e-06, 1.106214e-01

--- a/tests/sol_cx_4_conservative/screen-output
+++ b/tests/sol_cx_4_conservative/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 4,035 (2,178+768+1,089)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 41+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 9.8275e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 9.8275e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 1.120287e-06, 1.097680e-01, 1.662154e-06, 1.097686e-01

--- a/tests/sol_cx_4_normalized_pressure/screen-output
+++ b/tests/sol_cx_4_normalized_pressure/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 41+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 8.01426e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 8.01426e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 1.125997e-06, 2.994139e-03, 1.670011e-06, 9.778440e-03

--- a/tests/sol_cx_4_normalized_pressure_large_static_pressure/screen-output
+++ b/tests/sol_cx_4_normalized_pressure_large_static_pressure/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 55+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 4+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 3.39704e-09
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 3.39704e-09
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 1.125999e-06, 2.994139e-03, 1.670011e-06, 9.778441e-03

--- a/tests/sol_cx_4_normalized_pressure_low_solver_tolerance/screen-output
+++ b/tests/sol_cx_4_normalized_pressure_low_solver_tolerance/screen-output
@@ -7,7 +7,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 2.208391e-06, 2.971634e-03, 2.879609e-06, 9.793513e-03

--- a/tests/sol_cx_mpi_2/screen-output
+++ b/tests/sol_cx_mpi_2/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.87792e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.87792e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 7.964441e-05, 1.174944e-01, 1.069688e-04, 1.192654e-01

--- a/tests/sol_cx_particles/screen-output
+++ b/tests/sol_cx_particles/screen-output
@@ -7,79 +7,91 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 41+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 8.01426e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 8.01426e-08
+
 
    Postprocessing:
      Writing particle output: output-sol_cx_particles/particles/particles-00000
 
 *** Timestep 1:  t=8.80814 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Writing particle output: output-sol_cx_particles/particles/particles-00001
 
 *** Timestep 2:  t=17.6163 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Writing particle output: output-sol_cx_particles/particles/particles-00002
 
 *** Timestep 3:  t=26.4244 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Writing particle output: output-sol_cx_particles/particles/particles-00003
 
 *** Timestep 4:  t=35.2326 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Writing particle output: output-sol_cx_particles/particles/particles-00004
 
 *** Timestep 5:  t=44.0407 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Writing particle output: output-sol_cx_particles/particles/particles-00005
 
 *** Timestep 6:  t=52.8489 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Writing particle output: output-sol_cx_particles/particles/particles-00006
 
 *** Timestep 7:  t=61.657 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Writing particle output: output-sol_cx_particles/particles/particles-00007
 
 *** Timestep 8:  t=70.4652 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Writing particle output: output-sol_cx_particles/particles/particles-00008
 
 *** Timestep 9:  t=79.2733 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Writing particle output: output-sol_cx_particles/particles/particles-00009
 
 *** Timestep 10:  t=88.0814 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.31346e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.31346e-08
+
 
    Postprocessing:
      Writing particle output: output-sol_cx_particles/particles/particles-00010
@@ -90,18 +102,22 @@ Number of degrees of freedom: 3,379 (2,070+274+1,035)
 *** Timestep 11:  t=96.8896 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 0.337215
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 0.337215
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 7.99688e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 7.99688e-08
+
 
    Postprocessing:
      Writing particle output: output-sol_cx_particles/particles/particles-00011
 
 *** Timestep 12:  t=100 seconds
    Solving Stokes system... 26+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 0.101315
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 0.101315
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 9.14226e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 9.14226e-08
+
 
    Postprocessing:
      Writing particle output: output-sol_cx_particles/particles/particles-00012

--- a/tests/sol_kz_2/screen-output
+++ b/tests/sol_kz_2/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 7.96927e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 7.96927e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 5.054535e-06, 1.492377e-02, 7.343797e-06, 1.993996e-02

--- a/tests/sol_kz_2_cheaper_first_phase_solver/screen-output
+++ b/tests/sol_kz_2_cheaper_first_phase_solver/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 7.96927e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 7.96927e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 5.054535e-06, 1.492377e-02, 7.343797e-06, 1.993996e-02

--- a/tests/sol_kz_2_conservative/screen-output
+++ b/tests/sol_kz_2_conservative/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 7.96927e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 7.96927e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 5.054535e-06, 1.492377e-02, 7.343797e-06, 1.993996e-02

--- a/tests/sol_kz_2_no_first_phase_solver/screen-output
+++ b/tests/sol_kz_2_no_first_phase_solver/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+10 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 4.92574e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 4.92574e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 5.054533e-06, 1.492380e-02, 7.343793e-06, 1.994001e-02

--- a/tests/sol_kz_2_q3/screen-output
+++ b/tests/sol_kz_2_q3/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 500 (338+81+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 5.57567e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 5.57567e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 7.274365e-07, 2.219141e-03, 1.423557e-06, 3.234698e-03

--- a/tests/sol_kz_4/screen-output
+++ b/tests/sol_kz_4/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 38+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 8.12645e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 8.12645e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 9.024062e-08, 6.588213e-04, 2.330062e-07, 1.068890e-03

--- a/tests/sol_kz_4_conservative/screen-output
+++ b/tests/sol_kz_4_conservative/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 years
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 38+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 8.12645e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 8.12645e-08
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 9.024062e-08, 6.588213e-04, 2.330062e-07, 1.068890e-03

--- a/tests/solitary_wave/screen-output
+++ b/tests/solitary_wave/screen-output
@@ -11,18 +11,16 @@ Number of degrees of freedom: 19,749 (5,778+1,610+5,778+805+2,889+2,889)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+23 iterations.
    Solving for u_f in 9 iterations.
-      Relative nonlinear residuals: 0, 1.61e-16, 0.9994
-      Total relative residual after nonlinear iteration 1: 0.9994
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.61e-16, 0.9994
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.9994
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 9 iterations.
-      Relative nonlinear residuals: 0, 1.61e-16, 8.24116e-11
-      Total relative residual after nonlinear iteration 2: 8.24116e-11
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.61e-16, 8.24116e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 8.24116e-11
 
 
    Postprocessing:
@@ -37,9 +35,8 @@ Number of degrees of freedom: 19,749 (5,778+1,610+5,778+805+2,889+2,889)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
    Solving for u_f in 9 iterations.
-      Relative nonlinear residuals: 0, 7.6007e-05, 6.27477e-07
-      Total relative residual after nonlinear iteration 1: 6.27477e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.6007e-05, 6.27477e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 6.27477e-07
 
 
    Postprocessing:

--- a/tests/statistics_output/screen-output
+++ b/tests/statistics_output/screen-output
@@ -9,9 +9,8 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 54+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.85418e-16, 9.58741e-17, 0, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.85418e-16, 9.58741e-17, 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
@@ -19,9 +18,8 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 1.85418e-16, 9.58741e-17, 0, 9.29021e-13
-      Total relative residual after nonlinear iteration 2: 9.29021e-13
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.85418e-16, 9.58741e-17, 0, 9.29021e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 9.29021e-13
 
 
    Postprocessing:
@@ -35,9 +33,8 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.0391e-06, 1.53408e-16, 0, 4.87025e-09
-      Total relative residual after nonlinear iteration 1: 2.0391e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.0391e-06, 1.53408e-16, 0, 4.87025e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.0391e-06
 
 
    Postprocessing:
@@ -51,9 +48,8 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 2.21934e-06, 1.21242e-16, 0, 4.20135e-09
-      Total relative residual after nonlinear iteration 1: 2.21934e-06
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.21934e-06, 1.21242e-16, 0, 4.20135e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.21934e-06
 
 
    Postprocessing:
@@ -67,9 +63,8 @@ Number of degrees of freedom: 9,270 (2,898+810+2,898+405+1,449+405+405)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
    Solving for u_f in 1 iterations.
-      Relative nonlinear residuals: 4.7975e-08, 1.56341e-16, 0, 8.51551e-10
-      Total relative residual after nonlinear iteration 1: 4.7975e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.7975e-08, 1.56341e-16, 0, 8.51551e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 4.7975e-08
 
 
    Postprocessing:

--- a/tests/stokes_residual/screen-output
+++ b/tests/stokes_residual/screen-output
@@ -6,15 +6,13 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 39+0 iterations.
-      Relative nonlinear residuals: 1.83065e-16, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.83065e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residuals: 1.83065e-16, 9.79198e-08
-      Total relative residual after nonlinear iteration 2: 9.79198e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.83065e-16, 9.79198e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 9.79198e-08
 
 
    Postprocessing:
@@ -27,9 +25,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 1:  t=0.1 seconds
    Solving temperature system... 4 iterations.
    Solving Stokes system... 6+0 iterations.
-      Relative nonlinear residuals: 1.44841e-08, 2.41617e-07
-      Total relative residual after nonlinear iteration 1: 2.41617e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.44841e-08, 2.41617e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.41617e-07
 
 
    Postprocessing:

--- a/tests/stokes_residual_cheap/screen-output
+++ b/tests/stokes_residual_cheap/screen-output
@@ -6,15 +6,13 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+15 iterations.
-      Relative nonlinear residuals: 1.83065e-16, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.83065e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 0+4 iterations.
-      Relative nonlinear residuals: 1.83065e-16, 7.13168e-08
-      Total relative residual after nonlinear iteration 2: 7.13168e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.83065e-16, 7.13167e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 7.13167e-08
 
 
    Postprocessing:
@@ -27,9 +25,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 1:  t=0.1 seconds
    Solving temperature system... 4 iterations.
    Solving Stokes system... 0+3 iterations.
-      Relative nonlinear residuals: 1.44841e-08, 2.42786e-07
-      Total relative residual after nonlinear iteration 1: 2.42786e-07
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.44841e-08, 2.42761e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.42761e-07
 
 
    Postprocessing:

--- a/tests/tangurnis_ba/screen-output
+++ b/tests/tangurnis_ba/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 3+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 9.81732e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 9.81732e-08
+
 
    Postprocessing:
      writing:                  output.csv
@@ -17,7 +19,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 1:  t=0.0001 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.03884e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.03884e-08
+
 
    Postprocessing:
      writing:                  output.csv

--- a/tests/tangurnis_ba_custom/screen-output
+++ b/tests/tangurnis_ba_custom/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 3+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 9.81732e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 9.81732e-08
+
 
    Postprocessing:
      writing:                  output.csv
@@ -17,7 +19,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 1:  t=0.0001 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.03884e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 6.03884e-08
+
 
    Postprocessing:
      writing:                  output.csv

--- a/tests/tangurnis_tala/screen-output
+++ b/tests/tangurnis_tala/screen-output
@@ -7,19 +7,26 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 23+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 4.40071
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 4.40071
+
    Solving Stokes system... 17+0 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 0.118738
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 3: 0.118738
+
    Solving Stokes system... 13+0 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 0.00883504
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 4: 0.00883504
+
    Solving Stokes system... 8+0 iterations.
-      Relative Stokes residual after nonlinear iteration 5: 0.000355793
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 5: 0.000355793
+
    Solving Stokes system... 4+0 iterations.
-      Relative Stokes residual after nonlinear iteration 6: 2.55394e-05
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 6: 2.55394e-05
+
    Solving Stokes system... 3+0 iterations.
-      Relative Stokes residual after nonlinear iteration 7: 1.26714e-06
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 7: 1.26714e-06
+
 
    Postprocessing:
      writing:                       output.csv
@@ -28,7 +35,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 1:  t=0.0001 seconds
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 5.64949e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 5.64949e-08
+
 
    Postprocessing:
      writing:                       output.csv

--- a/tests/tangurnis_tala_c/screen-output
+++ b/tests/tangurnis_tala_c/screen-output
@@ -7,17 +7,23 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 32+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 26+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.41808
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.41808
+
    Solving Stokes system... 21+0 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 0.068011
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 3: 0.068011
+
    Solving Stokes system... 15+0 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 0.00197734
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 4: 0.00197734
+
    Solving Stokes system... 11+0 iterations.
-      Relative Stokes residual after nonlinear iteration 5: 0.000153853
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 5: 0.000153853
+
    Solving Stokes system... 5+0 iterations.
-      Relative Stokes residual after nonlinear iteration 6: 7.53277e-06
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 6: 7.53277e-06
+
 
    Postprocessing:
      writing:                       output.csv
@@ -26,7 +32,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
 *** Timestep 1:  t=0.0001 seconds
    Solving Stokes system... 2+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 2.41668e-07
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 2.41668e-07
+
 
    Postprocessing:
      writing:                       output.csv

--- a/tests/tangurnis_tala_implicit/screen-output
+++ b/tests/tangurnis_tala_implicit/screen-output
@@ -7,10 +7,12 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 32+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 5.71643e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 5.71643e-08
+
 
    Postprocessing:
      writing:                       output.csv
@@ -20,7 +22,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 1:  t=0.0001 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 8.05901e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 8.05901e-08
+
 
    Postprocessing:
      writing:                       output.csv

--- a/tests/traction_ascii_data/screen-output
+++ b/tests/traction_ascii_data/screen-output
@@ -16,23 +16,20 @@ Number of degrees of freedom: 61,140 (37,570+4,785+18,785)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 200+49 iterations.
-      Relative nonlinear residuals: 1.6621e-16, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.6621e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 200+30 iterations.
-      Relative nonlinear residuals: 1.6621e-16, 0.172827
-      Total relative residual after nonlinear iteration 2: 0.172827
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.6621e-16, 0.172827
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.172827
 
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 200+33 iterations.
-      Relative nonlinear residuals: 1.6621e-16, 0.0233251
-      Total relative residual after nonlinear iteration 3: 0.0233251
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.6621e-16, 0.0233251
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0233251
 
 
    Postprocessing:

--- a/tests/velocity_divergence/screen-output
+++ b/tests/velocity_divergence/screen-output
@@ -9,17 +9,15 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
-      Relative nonlinear residuals: 2.26451e-16, 2.31216e-16, 1
-      Total relative residual after nonlinear iteration 1: 1
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.26451e-16, 2.31216e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 2.26451e-16, 2.31216e-16, 4.16982e-08
-      Total relative residual after nonlinear iteration 2: 4.16982e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.26451e-16, 2.31216e-16, 4.16982e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.16982e-08
 
 
    Postprocessing:
@@ -33,17 +31,15 @@ Number of degrees of freedom: 140,997 (66,306+8,385+33,153+33,153)
    Solving porosity system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 0.000494119, 0.993777, 4.16921e-08
-      Total relative residual after nonlinear iteration 1: 0.993777
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000494119, 0.993777, 4.16921e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.993777
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals: 3.18885e-13, 9.81588e-11, 4.16921e-08
-      Total relative residual after nonlinear iteration 2: 4.16921e-08
-
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.18886e-13, 9.81588e-11, 4.16921e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.16921e-08
 
 
    Postprocessing:

--- a/tests/visco_plastic/screen-output
+++ b/tests/visco_plastic/screen-output
@@ -6,7 +6,7 @@ Number of degrees of freedom: 1,444 (882+121+441)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
    Postprocessing:

--- a/tests/visco_plastic_complex/screen-output
+++ b/tests/visco_plastic_complex/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 2,326 (882+121+441+441+441)
    Solving crust system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
    Postprocessing:

--- a/tests/visco_plastic_yield/screen-output
+++ b/tests/visco_plastic_yield/screen-output
@@ -6,7 +6,7 @@ Number of degrees of freedom: 1,444 (882+121+441)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
    Postprocessing:

--- a/tests/visco_plastic_yield_strain_weakening/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening/screen-output
@@ -1,5 +1,3 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 
 Number of active cells: 100 (on 1 levels)
 Number of degrees of freedom: 1,885 (882+121+441+441)
@@ -9,7 +7,7 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
    Solving eii system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
    Postprocessing:

--- a/tests/visco_plastic_yield_strain_weakening_full_strain_tensor/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening_full_strain_tensor/screen-output
@@ -1,5 +1,3 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 
 Number of active cells: 100 (on 1 levels)
 Number of degrees of freedom: 3,208 (882+121+441+441+441+441+441)
@@ -12,7 +10,7 @@ Number of degrees of freedom: 3,208 (882+121+441+441+441+441+441)
    Solving s22 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+2 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
    Postprocessing:
@@ -34,7 +32,8 @@ Number of degrees of freedom: 3,208 (882+121+441+441+441+441+441)
    Solving s22 system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.8928e-15
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 5.51217e-15
+
 
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year

--- a/tests/viz_plugin_dependency/screen-output
+++ b/tests/viz_plugin_dependency/screen-output
@@ -7,9 +7,11 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 1.87792e-08
+      Relative  nonlinear residual (Stokes system) after nonlinear iteration 2: 1.87792e-08
+
 
    Postprocessing:
      RMS, max velocity:        0.00125 m/s, 0.00345 m/s

--- a/tests/zero_RHS/screen-output
+++ b/tests/zero_RHS/screen-output
@@ -8,19 +8,20 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
    Solving C_2 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 0.00375062
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.00375062
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 7.22761e-05
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 7.22761e-05
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 9.38333e-07
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 9.38333e-07
+
 
    Postprocessing:
      Writing graphical output: output-zero_RHS/solution/solution-00000
@@ -32,7 +33,8 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
    Solving C_2 system ... 18 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.70752e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 6.70752e-08
+
 
    Postprocessing:
      Writing graphical output: output-zero_RHS/solution/solution-00001
@@ -44,7 +46,8 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
    Solving C_2 system ... 20 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.70752e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 6.70752e-08
+
 
    Postprocessing:
      Writing graphical output: output-zero_RHS/solution/solution-00002
@@ -56,7 +59,8 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
    Solving C_2 system ... 19 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.70752e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 6.70752e-08
+
 
    Postprocessing:
      Writing graphical output: output-zero_RHS/solution/solution-00003
@@ -68,7 +72,8 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
    Solving C_2 system ... 18 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.70752e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 6.70752e-08
+
 
    Postprocessing:
      Writing graphical output: output-zero_RHS/solution/solution-00004
@@ -80,7 +85,8 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
    Solving C_2 system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 6.70752e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 6.70752e-08
+
 
    Postprocessing:
      Writing graphical output: output-zero_RHS/solution/solution-00005

--- a/tests/zero_matrix/screen-output
+++ b/tests/zero_matrix/screen-output
@@ -8,19 +8,20 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
    Solving C_2 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-      Relative Stokes residual after nonlinear iteration 1: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative Stokes residual after nonlinear iteration 2: 0.00375062
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.00375062
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative Stokes residual after nonlinear iteration 3: 7.22761e-05
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 7.22761e-05
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-      Relative Stokes residual after nonlinear iteration 4: 9.38333e-07
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 9.38333e-07
+
 
    Postprocessing:
      Writing graphical output: output-zero_matrix/solution/solution-00000


### PR DESCRIPTION
This addresses #1964. The line of each nonlinear solver scheme that outputs the nonlinear residual now starts with 'Nonlinear residual ...', and then specifies the system that is being solved, following @MFraters suggestion. This should make it easier to grep that line from the screen output of different models. 
In addition, there is now always one empty line between one nonliear iteration and the next, and two empty lines between the last iteration and the Postprocessing output. 