### PR TITLE
Include access to dealii manifold_lib in sphere.h

### DIFF
--- a/include/aspect/geometry_model/sphere.h
+++ b/include/aspect/geometry_model/sphere.h
@@ -20,6 +20,7 @@
 #ifndef _aspect_geometry_model_sphere_h
 #define _aspect_geometry_model_sphere_h
 
+#include <deal.II/grid/manifold_lib.h>
 #include <aspect/geometry_model/interface.h>
 #include <aspect/simulator_access.h>
 


### PR DESCRIPTION
Adding `#include <deal.II/grid/manifold_lib.h>` to` include/aspect/geometry_model/sphere.h` enables ASPECT to compile correctly when using the development version of deal.II. Thanks to @bangerth for pointing out the fix in #1912. 