### PR TITLE
Do not look at output if ASPECT_COMPARE_TEST_RESULTS=OFF

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -292,56 +292,58 @@ FOREACH(_test ${_tests})
 
     GET_FILENAME_COMPONENT(ASPECT_BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR} PATH)
 
-    # Commands to normalize each output. Note that we depend on screen-output
-    # instead of ${_output_name} here, to avoid having to specify BYPRODUCTS
-    # for ninja.
-    FOREACH(_output_name ${_output_files})
-	ADD_CUSTOM_COMMAND(OUTPUT ${_output_name}.notime
-	  COMMAND ${PERL_EXECUTABLE}
-		  ${CMAKE_CURRENT_SOURCE_DIR}/normalize.pl
-		  ${_output_name} ${ASPECT_BASE_DIR}
-		  >${_output_name}.notime
-          DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/output-${_testname}/screen-output)
-    ENDFOREACH()
-
-    # Create commands to copy and normalize reference output
-    FOREACH(_name ${_relative_output_filenames})
-	ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/output-${_testname}/${_name}.cmp.notime
-	  COMMAND ${PERL_EXECUTABLE}
-		  ${CMAKE_CURRENT_SOURCE_DIR}/normalize.pl
-		  ${CMAKE_CURRENT_SOURCE_DIR}/${_testname}/${_name} ${ASPECT_BASE_DIR}
-		  >${CMAKE_CURRENT_BINARY_DIR}/output-${_testname}/${_name}.cmp.notime
-          DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_testname}/${_name})
-    ENDFOREACH()
-
-    # Now create commands to diff reference with output file:
-    FOREACH(_name ${_relative_output_filenames})
-      # the normalized reference file:
-      SET(_ref_file ${CMAKE_CURRENT_BINARY_DIR}/output-${_testname}/${_name}.cmp.notime)
-      # the normalized output file:
-      SET(_run_file ${CMAKE_CURRENT_BINARY_DIR}/output-${_testname}/${_name}.notime)
-
-      # generate .diff file:
-      ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/output-${_testname}/${_name}.diff
-	COMMAND
-	    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/diff_test.sh 
-		${TEST_DIFF}
-		${_testname}/${_name}
-		${CMAKE_CURRENT_SOURCE_DIR}
-		${CMAKE_CURRENT_BINARY_DIR}
-		${ASPECT_COMPARE_TEST_RESULTS}
-	DEPENDS ${_ref_file}
-		${_run_file})
-
-      # Add the target for this output file to the dependencies of this
-      # test. Note that a target may not contain "/" but outputs can be
-      # in subdirectories (for example solution/solution...), so replace them.
-      STRING(REPLACE "/" "-" _target_name ${_testname}.${_name}.diff)
-      ADD_CUSTOM_TARGET(${_target_name}
-	DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/output-${_testname}/${_name}.diff)
-      ADD_DEPENDENCIES(tests.${_testname} ${_target_name})
-
-    ENDFOREACH()
+    IF(ASPECT_COMPARE_TEST_RESULTS)
+      # Commands to normalize each output. Note that we depend on screen-output
+      # instead of ${_output_name} here, to avoid having to specify BYPRODUCTS
+      # for ninja.
+      FOREACH(_output_name ${_output_files})
+  	ADD_CUSTOM_COMMAND(OUTPUT ${_output_name}.notime
+  	  COMMAND ${PERL_EXECUTABLE}
+  		  ${CMAKE_CURRENT_SOURCE_DIR}/normalize.pl
+  		  ${_output_name} ${ASPECT_BASE_DIR}
+  		  >${_output_name}.notime
+            DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/output-${_testname}/screen-output)
+      ENDFOREACH()
+  
+      # Create commands to copy and normalize reference output
+      FOREACH(_name ${_relative_output_filenames})
+  	ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/output-${_testname}/${_name}.cmp.notime
+  	  COMMAND ${PERL_EXECUTABLE}
+  		  ${CMAKE_CURRENT_SOURCE_DIR}/normalize.pl
+  		  ${CMAKE_CURRENT_SOURCE_DIR}/${_testname}/${_name} ${ASPECT_BASE_DIR}
+  		  >${CMAKE_CURRENT_BINARY_DIR}/output-${_testname}/${_name}.cmp.notime
+            DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_testname}/${_name})
+      ENDFOREACH()
+  
+      # Now create commands to diff reference with output file:
+      FOREACH(_name ${_relative_output_filenames})
+        # the normalized reference file:
+        SET(_ref_file ${CMAKE_CURRENT_BINARY_DIR}/output-${_testname}/${_name}.cmp.notime)
+        # the normalized output file:
+        SET(_run_file ${CMAKE_CURRENT_BINARY_DIR}/output-${_testname}/${_name}.notime)
+  
+        # generate .diff file:
+        ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/output-${_testname}/${_name}.diff
+  	COMMAND
+  	    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/diff_test.sh 
+  		${TEST_DIFF}
+  		${_testname}/${_name}
+  		${CMAKE_CURRENT_SOURCE_DIR}
+  		${CMAKE_CURRENT_BINARY_DIR}
+  		${ASPECT_COMPARE_TEST_RESULTS}
+  	DEPENDS ${_ref_file}
+  		${_run_file})
+  
+        # Add the target for this output file to the dependencies of this
+        # test. Note that a target may not contain "/" but outputs can be
+        # in subdirectories (for example solution/solution...), so replace them.
+        STRING(REPLACE "/" "-" _target_name ${_testname}.${_name}.diff)
+        ADD_CUSTOM_TARGET(${_target_name}
+  	DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/output-${_testname}/${_name}.diff)
+        ADD_DEPENDENCIES(tests.${_testname} ${_target_name})
+  
+      ENDFOREACH()
+    ENDIF()
 
     # add this test to the dependencies of the overall 'tests' target
     # and declare it to ctest

--- a/tests/cmake/diff_test.sh
+++ b/tests/cmake/diff_test.sh
@@ -6,7 +6,7 @@
 # command that failed, which will be really long and ugly. This way, only the
 # line executing this script will show up.
 
-# Call this script with 5 parameters:
+# Call this script with 4 parameters:
 
 # 1. name/path of diff executable
 DIFF_EXE=$1
@@ -20,8 +20,6 @@ CMAKE_CURRENT_SOURCE_DIR=$3
 # 4. absolute cmake binary directory
 CMAKE_CURRENT_BINARY_DIR=$4
 
-# 5. when "ON" also compare the results, otherwise just run the tests
-FULL_COMPARISON=$5
 
 # Grab ASPECT_GENERATE_REFERENCE_OUTPUT from the environment. If set to
 # something (not ""), do not run tests normally but generate reference output
@@ -59,20 +57,15 @@ ORIGINAL_GEN_FULL_PATH=${CMAKE_CURRENT_BINARY_DIR}/output-${PRETTY_TEST_AND_FILE
 
 rm -f ${DIFF_OUTPUT}.failed ${DIFF_OUTPUT}
 
-if [ "${FULL_COMPARISON}" == "ON" ]; then
-  case ${DIFF_EXE} in
-      *numdiff)
+case ${DIFF_EXE} in
+    *numdiff)
 	${DIFF_EXE} -V -a 1e-6 -r 1e-8 -s ' \t\n:<>=,;' \
-	${REF_FILE} ${GEN_FILE} > ${DIFF_OUTPUT}.tmp
+	    ${REF_FILE} ${GEN_FILE} > ${DIFF_OUTPUT}.tmp
 	;;
-      *)
+    *)
 	"${DIFF_EXE}" \
 	    ${REF_FILE} ${GEN_FILE} > ${DIFF_OUTPUT}.tmp
-  esac
-else
-  rm -f ${DIFF_OUTPUT}.tmp
-  touch ${DIFF_OUTPUT}.tmp
-fi
+esac
 
 if [ $? -ne 0 ]; then
 


### PR DESCRIPTION
Only perform normalization of output files if we actually look at the results. This fixes the last remaining test failures for deal.II-dev with ASPECT_COMPARE_TEST_RESULTS=OFF. 
This PR makes some of the earlier changes in #1973 unnecessary, because we now only call `tests/cmake/diff_test.sh` if we want to compare the results. Should I revert the now unnecessary changes to that file?