### PR TITLE
Split newton stabilisation as options and add a failsafe

### DIFF
--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -62,19 +62,36 @@ namespace aspect
    * material model outputs for the Newton solver.
    */
 
-  enum class PreconditionerStabilization
-  {
-    SPD, PD, symmetric, none
-  };
-  enum class VelocityBlockStabilization
-  {
-    SPD, PD, symmetric, none
-  };
-
   template <int dim>
   class NewtonHandler: public SimulatorAccess<dim>
   {
     public:
+
+      /**
+       * This enum describes the type of stabilization is used
+       * for the Newton solver. None represents no stabilization,
+       * SPD represent that the resulting matrix is made Symmetric
+       * Positive Definite, symmetric represents that the matrix is
+       * only symmetrized, and PD represents that we do the same as
+       * what we do for SPD, but without the symmetrization.
+       */
+      enum NewtonStabilization
+      {
+        none = 0,
+        symmetric = 1,
+        PD = 2,
+        SPD = symmetric | PD
+      };
+
+      friend
+      NewtonStabilization
+      operator| (const NewtonStabilization a,
+                 const NewtonStabilization b)
+      {
+        return static_cast<NewtonStabilization>(
+                 static_cast<int>(a) | static_cast<int>(b));
+      }
+
       /**
        * Determine, based on the run-time parameters of the current simulation,
        * which functions need to be called in order to assemble linear systems,
@@ -118,22 +135,22 @@ namespace aspect
       /**
        * Get the stabilization type used in the preconditioner.
        */
-      PreconditionerStabilization get_preconditioner_stabilization() const;
+      NewtonStabilization get_preconditioner_stabilization() const;
 
       /**
        * Set the stabilization type used in the preconditioner.
        */
-      void set_preconditioner_stabilization(const PreconditionerStabilization preconditioner_stabilization);
+      void set_preconditioner_stabilization(const NewtonStabilization preconditioner_stabilization);
 
       /**
        * Get the stabilization type used in the velocity block.
        */
-      VelocityBlockStabilization get_velocity_block_stabilization() const;
+      NewtonStabilization get_velocity_block_stabilization() const;
 
       /**
        * Sets the stabilization type used in the velocity block.
        */
-      void set_velocity_block_stabilization(const VelocityBlockStabilization velocity_block_stabilization);
+      void set_velocity_block_stabilization(const NewtonStabilization velocity_block_stabilization);
 
       /**
        * Get whether to use the Newton failsafe. If the failsafe is used, a failure
@@ -172,13 +189,7 @@ namespace aspect
       /**
        * get a std::string describing the stabilization type used for the preconditioner.
        */
-      std::string get_preconditioner_stabilization_string(PreconditionerStabilization preconditioner_stabilization);
-
-      /**
-       * get a std::string describing the stabilization type used for the velocity block.
-       */
-      std::string get_velocity_block_stabilization_string(VelocityBlockStabilization velocity_block_stabilization);
-
+      std::string get_newton_stabilization_string(const NewtonStabilization preconditioner_stabilization) const;
 
       /**
        * Declare additional parameters that are needed for the Newton.
@@ -200,15 +211,15 @@ namespace aspect
        * See the get_newton_derivative_scaling_factor() function for an
        * explanation of the purpose of this factor.
        */
-      double                      newton_derivative_scaling_factor;
-      PreconditionerStabilization preconditioner_stabilization;
-      VelocityBlockStabilization  velocity_block_stabilization;
-      bool                        use_Newton_failsafe;
-      double                      nonlinear_switch_tolerance;
-      unsigned int                max_pre_newton_nonlinear_iterations;
-      unsigned int                max_newton_line_search_iterations;
-      bool                        use_newton_residual_scaling_method;
-      double                      maximum_linear_stokes_solver_tolerance;
+      double              newton_derivative_scaling_factor;
+      NewtonStabilization preconditioner_stabilization;
+      NewtonStabilization velocity_block_stabilization;
+      bool                use_Newton_failsafe;
+      double              nonlinear_switch_tolerance;
+      unsigned int        max_pre_newton_nonlinear_iterations;
+      unsigned int        max_newton_line_search_iterations;
+      bool                use_newton_residual_scaling_method;
+      double              maximum_linear_stokes_solver_tolerance;
   };
 
   namespace Assemblers

--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -109,13 +109,13 @@ namespace aspect
        * Gets the Newton derivative scaling factor used for scaling the
        * derivative part of the Newton Stokes solver in the assembly.
        */
-      bool get_use_spd_factor() const;
+      std::pair<std::string,std::string> get_Newton_stabilisation() const;
 
       /**
        * Sets the Newton derivative scaling factor used for scaling the
        * derivative part of the Newton Stokes solver in the assembly.
        */
-      void set_use_spd_factor(const bool set_spd_factor);
+      void set_Newton_stabilisation(const std::string use_Newton_stabilisation_preconditioner,const std::string use_Newton_stabilisation_A_block);
 
     private:
       /**
@@ -126,7 +126,7 @@ namespace aspect
        * explanation of the purpose of this factor.
        */
       double newton_derivative_scaling_factor;
-      bool use_spd_factor;
+      std::pair<std::string,std::string> Newton_stabilisation;
   };
 
   namespace Assemblers

--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -105,6 +105,17 @@ namespace aspect
        */
       void set_newton_derivative_scaling_factor(const double newton_derivative_scaling_factor);
 
+      /**
+       * Gets the Newton derivative scaling factor used for scaling the
+       * derivative part of the Newton Stokes solver in the assembly.
+       */
+      bool get_use_spd_factor() const;
+
+      /**
+       * Sets the Newton derivative scaling factor used for scaling the
+       * derivative part of the Newton Stokes solver in the assembly.
+       */
+      void set_use_spd_factor(const bool set_spd_factor);
 
     private:
       /**
@@ -115,6 +126,7 @@ namespace aspect
        * explanation of the purpose of this factor.
        */
       double newton_derivative_scaling_factor;
+      bool use_spd_factor;
   };
 
   namespace Assemblers

--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -61,6 +61,16 @@ namespace aspect
    * A Class which can declare and parse parameters and creates
    * material model outputs for the Newton solver.
    */
+
+  enum class PreconditionerStabilization
+  {
+    SPD, PD, symmetric, none
+  };
+  enum class VelocityBlockStabilization
+  {
+    SPD, PD, symmetric, none
+  };
+
   template <int dim>
   class NewtonHandler: public SimulatorAccess<dim>
   {
@@ -108,63 +118,76 @@ namespace aspect
       /**
        * Get the stabilization type used in the preconditioner.
        */
-      std::string get_preconditioner_stabilization() const;
+      PreconditionerStabilization get_preconditioner_stabilization() const;
 
       /**
        * Set the stabilization type used in the preconditioner.
        */
-      void set_preconditioner_stabilization(const std::string preconditioner_stabilization);
+      void set_preconditioner_stabilization(const PreconditionerStabilization preconditioner_stabilization);
 
       /**
        * Get the stabilization type used in the velocity block.
        */
-      std::string get_velocity_block_stabilization() const;
+      VelocityBlockStabilization get_velocity_block_stabilization() const;
 
       /**
        * Sets the stabilization type used in the velocity block.
        */
-      void set_velocity_block_stabilization(const std::string velocity_block_stabilization);
+      void set_velocity_block_stabilization(const VelocityBlockStabilization velocity_block_stabilization);
 
       /**
-       * Get whether to use the Newton failsafe
+       * Get whether to use the Newton failsafe. If the failsafe is used, a failure
+       * of the linear solver is catched and we try to solve it again with both the
+       * preconditioner and the velocity block being stabilized with the SPD stabilization.
        */
       bool get_use_Newton_failsafe();
 
       /**
        * Get the nonlinear tolerance at which to switch the
-       * nonlinear solver from defect corrected Piccard to
+       * nonlinear solver from defect correction Picard to
        * Newton.
        */
       double get_nonlinear_switch_tolerance();
 
       /**
-       * Get the maximum amount of pre-Newton nonlinear iterations
+       * Get the maximum number of pre-Newton nonlinear iterations.
        */
       unsigned int get_max_pre_newton_nonlinear_iterations();
 
       /**
-       * Get the maximum amount of line search iterations
+       * Get the maximum number of line search iterations.
        */
       unsigned int get_max_newton_line_search_iterations();
 
       /**
-       * Get whether to use the residual scaling method
+       * Get whether to use the residual scaling method.
        */
       bool get_use_newton_residual_scaling_method();
 
       /**
-       * Get the maximum linear Stokes solver tolerance
+       * Get the maximum linear Stokes solver tolerance.
        */
       double get_maximum_linear_stokes_solver_tolerance();
 
       /**
-       * Declare additional parameters that are needed for the Newton
+       * get a std::string describing the stabilization type used for the preconditioner.
+       */
+      std::string get_preconditioner_stabilization_string(PreconditionerStabilization preconditioner_stabilization);
+
+      /**
+       * get a std::string describing the stabilization type used for the velocity block.
+       */
+      std::string get_velocity_block_stabilization_string(VelocityBlockStabilization velocity_block_stabilization);
+
+
+      /**
+       * Declare additional parameters that are needed for the Newton.
        * solver.
        */
       static void declare_parameters (ParameterHandler &prm);
 
       /**
-       * Parse additional parameters that are needed for the Newton
+       * Parse additional parameters that are needed for the Newton.
        * solver.
        */
       void parse_parameters (ParameterHandler &prm);
@@ -177,15 +200,15 @@ namespace aspect
        * See the get_newton_derivative_scaling_factor() function for an
        * explanation of the purpose of this factor.
        */
-      double       newton_derivative_scaling_factor;
-      std::string  preconditioner_stabilization;
-      std::string  velocity_block_stabilization;
-      bool         use_Newton_failsafe;
-      double       nonlinear_switch_tolerance;
-      unsigned int max_pre_newton_nonlinear_iterations;
-      unsigned int max_newton_line_search_iterations;
-      bool         use_newton_residual_scaling_method;
-      double       maximum_linear_stokes_solver_tolerance;
+      double                      newton_derivative_scaling_factor;
+      PreconditionerStabilization preconditioner_stabilization;
+      VelocityBlockStabilization  velocity_block_stabilization;
+      bool                        use_Newton_failsafe;
+      double                      nonlinear_switch_tolerance;
+      unsigned int                max_pre_newton_nonlinear_iterations;
+      unsigned int                max_newton_line_search_iterations;
+      bool                        use_newton_residual_scaling_method;
+      double                      maximum_linear_stokes_solver_tolerance;
   };
 
   namespace Assemblers

--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -106,16 +106,68 @@ namespace aspect
       void set_newton_derivative_scaling_factor(const double newton_derivative_scaling_factor);
 
       /**
-       * Gets the Newton derivative scaling factor used for scaling the
-       * derivative part of the Newton Stokes solver in the assembly.
+       * Get the stabilization type used in the preconditioner.
        */
-      std::pair<std::string,std::string> get_Newton_stabilisation() const;
+      std::string get_preconditioner_stabilization() const;
 
       /**
-       * Sets the Newton derivative scaling factor used for scaling the
-       * derivative part of the Newton Stokes solver in the assembly.
+       * Set the stabilization type used in the preconditioner.
        */
-      void set_Newton_stabilisation(const std::string use_Newton_stabilisation_preconditioner,const std::string use_Newton_stabilisation_A_block);
+      void set_preconditioner_stabilization(const std::string preconditioner_stabilization);
+
+      /**
+       * Get the stabilization type used in the velocity block.
+       */
+      std::string get_velocity_block_stabilization() const;
+
+      /**
+       * Sets the stabilization type used in the velocity block.
+       */
+      void set_velocity_block_stabilization(const std::string velocity_block_stabilization);
+
+      /**
+       * Get whether to use the Newton failsafe
+       */
+      bool get_use_Newton_failsafe();
+
+      /**
+       * Get the nonlinear tolerance at which to switch the
+       * nonlinear solver from defect corrected Piccard to
+       * Newton.
+       */
+      double get_nonlinear_switch_tolerance();
+
+      /**
+       * Get the maximum amount of pre-Newton nonlinear iterations
+       */
+      unsigned int get_max_pre_newton_nonlinear_iterations();
+
+      /**
+       * Get the maximum amount of line search iterations
+       */
+      unsigned int get_max_newton_line_search_iterations();
+
+      /**
+       * Get whether to use the residual scaling method
+       */
+      bool get_use_newton_residual_scaling_method();
+
+      /**
+       * Get the maximum linear Stokes solver tolerance
+       */
+      double get_maximum_linear_stokes_solver_tolerance();
+
+      /**
+       * Declare additional parameters that are needed for the Newton
+       * solver.
+       */
+      static void declare_parameters (ParameterHandler &prm);
+
+      /**
+       * Parse additional parameters that are needed for the Newton
+       * solver.
+       */
+      void parse_parameters (ParameterHandler &prm);
 
     private:
       /**
@@ -125,8 +177,15 @@ namespace aspect
        * See the get_newton_derivative_scaling_factor() function for an
        * explanation of the purpose of this factor.
        */
-      double newton_derivative_scaling_factor;
-      std::pair<std::string,std::string> Newton_stabilisation;
+      double       newton_derivative_scaling_factor;
+      std::string  preconditioner_stabilization;
+      std::string  velocity_block_stabilization;
+      bool         use_Newton_failsafe;
+      double       nonlinear_switch_tolerance;
+      unsigned int max_pre_newton_nonlinear_iterations;
+      unsigned int max_newton_line_search_iterations;
+      bool         use_newton_residual_scaling_method;
+      double       maximum_linear_stokes_solver_tolerance;
   };
 
   namespace Assemblers

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -308,6 +308,9 @@ namespace aspect
 
     double                         nonlinear_tolerance;
     double                         nonlinear_switch_tolerance;
+    std::string                    use_Newton_stabilisation_preconditioner;
+    std::string                    use_Newton_stabilisation_A_block;
+    bool                           use_Newton_failsafe;
     bool                           resume_computation;
     double                         start_time;
     double                         CFL_number;

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -308,9 +308,6 @@ namespace aspect
 
     double                         nonlinear_tolerance;
     double                         nonlinear_switch_tolerance;
-    std::string                    use_Newton_stabilisation_preconditioner;
-    std::string                    use_Newton_stabilisation_A_block;
-    bool                           use_Newton_failsafe;
     bool                           resume_computation;
     double                         start_time;
     double                         CFL_number;
@@ -340,10 +337,6 @@ namespace aspect
     double                         temperature_solver_tolerance;
     double                         composition_solver_tolerance;
     bool                           use_operator_splitting;
-    unsigned int                   max_pre_newton_nonlinear_iterations;
-    unsigned int                   max_newton_line_search_iterations;
-    bool                           use_newton_residual_scaling_method;
-    double                         maximum_linear_stokes_solver_tolerance;
 
     /**
      * @}

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -119,8 +119,9 @@ namespace aspect
               const SymmetricTensor<2,dim> viscosity_derivative_wrt_strain_rate = derivatives->viscosity_derivative_wrt_strain_rate[q];
               const SymmetricTensor<2,dim> strain_rate = scratch.material_model_inputs.strain_rate[q];
 
+              // In the preconditioning, the S.P.D. factor should always be used.
               // todo: make this 0.9 into a global input parameter
-              double alpha = Utilities::compute_spd_factor<dim>(eta, strain_rate, viscosity_derivative_wrt_strain_rate, 0.9);
+              const double alpha = Utilities::compute_spd_factor<dim>(eta, strain_rate, viscosity_derivative_wrt_strain_rate, 0.9);
 
               for (unsigned int i = 0; i < stokes_dofs_per_cell; ++i)
                 for (unsigned int j = 0; j < stokes_dofs_per_cell; ++j)
@@ -188,6 +189,7 @@ namespace aspect
       const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
       const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
       const double derivative_scaling_factor = this->get_newton_handler().get_newton_derivative_scaling_factor();
+      const bool use_spd_factor = this->get_newton_handler().get_use_spd_factor();
 
       for (unsigned int q=0; q<n_q_points; ++q)
         {
@@ -278,7 +280,9 @@ namespace aspect
                   const double viscosity_derivative_wrt_pressure = derivatives->viscosity_derivative_wrt_pressure[q];
 
                   // todo: make this 0.9 into a global input parameter
-                  const double alpha  = Utilities::compute_spd_factor<dim>(eta, strain_rate, viscosity_derivative_wrt_strain_rate, 0.9);
+                  const double alpha  = use_spd_factor ? Utilities::compute_spd_factor<dim>(eta, strain_rate, viscosity_derivative_wrt_strain_rate, 0.9)
+                                        :
+                                        1;
 
                   for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
                     for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -96,7 +96,6 @@ namespace aspect
 
           const double JxW = scratch.finite_element_values.JxW(q);
 
-
           // TODO: Find out why in this version of ASPECT adding the derivative to the preconditioning
           // is way worse than the normal preconditioning
           if (derivative_scaling_factor == 0)
@@ -120,15 +119,14 @@ namespace aspect
               const SymmetricTensor<2,dim> viscosity_derivative_wrt_strain_rate = derivatives->viscosity_derivative_wrt_strain_rate[q];
               const SymmetricTensor<2,dim> strain_rate = scratch.material_model_inputs.strain_rate[q];
 
-              const std::pair<std::string,std::string> Newton_stabilisation = this->get_newton_handler().get_Newton_stabilisation();
-              // In the preconditioning, the S.P.D. factor should always be used.
+              const std::string preconditioner_stabilization = this->get_newton_handler().get_preconditioner_stabilization();
               // todo: make this 0.9 into a global input parameter
-              const double alpha = Newton_stabilisation.first =="SPD" || Newton_stabilisation.first =="PD" ?
+              const double alpha = preconditioner_stabilization =="SPD" || preconditioner_stabilization =="PD" ?
                                    Utilities::compute_spd_factor<dim>(eta, strain_rate, viscosity_derivative_wrt_strain_rate, 0.9)
                                    :
                                    1;
 
-              if (Newton_stabilisation.first == "SPD" || Newton_stabilisation.first == "symmetric")
+              if (preconditioner_stabilization == "SPD" || preconditioner_stabilization == "symmetric")
                 {
                   for (unsigned int i = 0; i < stokes_dofs_per_cell; ++i)
                     for (unsigned int j = 0; j < stokes_dofs_per_cell; ++j)
@@ -167,7 +165,7 @@ namespace aspect
         }
 #if DEBUG
       {
-        if (this->get_newton_handler().get_Newton_stabilisation().first == "SPD")
+        if (this->get_newton_handler().get_preconditioner_stabilization() == "SPD")
           {
             // regardless of whether we do or do not add the Newton
             // linearization terms, we ought to test whether the top-left
@@ -306,15 +304,14 @@ namespace aspect
 
                   const SymmetricTensor<2,dim> viscosity_derivative_wrt_strain_rate = derivatives->viscosity_derivative_wrt_strain_rate[q];
                   const double viscosity_derivative_wrt_pressure = derivatives->viscosity_derivative_wrt_pressure[q];
-                  const std::pair<std::string,std::string> Newton_stabilisation = this->get_newton_handler().get_Newton_stabilisation();
-
+                  const std::string velocity_block_stabilization = this->get_newton_handler().get_velocity_block_stabilization();
                   // todo: make this 0.9 into a global input parameter
-                  const double alpha =  Newton_stabilisation.second =="SPD" || Newton_stabilisation.second =="PD" ?
+                  const double alpha =  velocity_block_stabilization =="SPD" || velocity_block_stabilization =="PD" ?
                                         Utilities::compute_spd_factor<dim>(eta, strain_rate, viscosity_derivative_wrt_strain_rate, 0.9)
                                         :
                                         1;
 
-                  if (Newton_stabilisation.second == "SPD" || Newton_stabilisation.second == "symmetric")
+                  if (velocity_block_stabilization == "SPD" || velocity_block_stabilization == "symmetric")
                     {
                       for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
                         for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
@@ -352,7 +349,7 @@ namespace aspect
 #if DEBUG
       if (scratch.rebuild_newton_stokes_matrix)
         {
-          if (this->get_newton_handler().get_Newton_stabilisation().second == "SPD")
+          if (this->get_newton_handler().get_velocity_block_stabilization() == "SPD")
             {
               // regardless of whether we do or do not add the Newton
               // linearization terms, we ought to test whether the top-left

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -119,14 +119,14 @@ namespace aspect
               const SymmetricTensor<2,dim> viscosity_derivative_wrt_strain_rate = derivatives->viscosity_derivative_wrt_strain_rate[q];
               const SymmetricTensor<2,dim> strain_rate = scratch.material_model_inputs.strain_rate[q];
 
-              const std::string preconditioner_stabilization = this->get_newton_handler().get_preconditioner_stabilization();
+              const PreconditionerStabilization preconditioner_stabilization = this->get_newton_handler().get_preconditioner_stabilization();
               // todo: make this 0.9 into a global input parameter
-              const double alpha = preconditioner_stabilization =="SPD" || preconditioner_stabilization =="PD" ?
+              const double alpha = preconditioner_stabilization == PreconditionerStabilization::SPD || preconditioner_stabilization == PreconditionerStabilization::PD ?
                                    Utilities::compute_spd_factor<dim>(eta, strain_rate, viscosity_derivative_wrt_strain_rate, 0.9)
                                    :
                                    1;
 
-              if (preconditioner_stabilization == "SPD" || preconditioner_stabilization == "symmetric")
+              if (preconditioner_stabilization == PreconditionerStabilization::SPD || preconditioner_stabilization == PreconditionerStabilization::symmetric)
                 {
                   for (unsigned int i = 0; i < stokes_dofs_per_cell; ++i)
                     for (unsigned int j = 0; j < stokes_dofs_per_cell; ++j)
@@ -165,7 +165,7 @@ namespace aspect
         }
 #if DEBUG
       {
-        if (this->get_newton_handler().get_preconditioner_stabilization() == "SPD")
+        if (this->get_newton_handler().get_preconditioner_stabilization() == PreconditionerStabilization::SPD)
           {
             // regardless of whether we do or do not add the Newton
             // linearization terms, we ought to test whether the top-left
@@ -304,14 +304,14 @@ namespace aspect
 
                   const SymmetricTensor<2,dim> viscosity_derivative_wrt_strain_rate = derivatives->viscosity_derivative_wrt_strain_rate[q];
                   const double viscosity_derivative_wrt_pressure = derivatives->viscosity_derivative_wrt_pressure[q];
-                  const std::string velocity_block_stabilization = this->get_newton_handler().get_velocity_block_stabilization();
+                  const VelocityBlockStabilization velocity_block_stabilization = this->get_newton_handler().get_velocity_block_stabilization();
                   // todo: make this 0.9 into a global input parameter
-                  const double alpha =  velocity_block_stabilization =="SPD" || velocity_block_stabilization =="PD" ?
+                  const double alpha =  velocity_block_stabilization == VelocityBlockStabilization::SPD || velocity_block_stabilization ==VelocityBlockStabilization::PD ?
                                         Utilities::compute_spd_factor<dim>(eta, strain_rate, viscosity_derivative_wrt_strain_rate, 0.9)
                                         :
                                         1;
 
-                  if (velocity_block_stabilization == "SPD" || velocity_block_stabilization == "symmetric")
+                  if (velocity_block_stabilization == VelocityBlockStabilization::SPD || velocity_block_stabilization == VelocityBlockStabilization::symmetric)
                     {
                       for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
                         for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
@@ -349,7 +349,7 @@ namespace aspect
 #if DEBUG
       if (scratch.rebuild_newton_stokes_matrix)
         {
-          if (this->get_newton_handler().get_velocity_block_stabilization() == "SPD")
+          if (this->get_newton_handler().get_velocity_block_stabilization() == VelocityBlockStabilization::SPD)
             {
               // regardless of whether we do or do not add the Newton
               // linearization terms, we ought to test whether the top-left

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -152,8 +152,8 @@ namespace aspect
                       if (scratch.dof_component_indices[i] ==
                           scratch.dof_component_indices[j])
                         {
-                          data.local_matrix(i, j) += ((2.0 * eta * alpha * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
-                                                      + derivative_scaling_factor * alpha * (scratch.grads_phi_u[i] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[j]) * strain_rate)
+                          data.local_matrix(i, j) += ((2.0 * eta * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
+                                                      + derivative_scaling_factor * alpha * 2.0 * (scratch.grads_phi_u[i] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[j]) * strain_rate)
                                                       + one_over_eta * this->get_pressure_scaling()
                                                       * this->get_pressure_scaling()
                                                       * (scratch.phi_p[i] * scratch
@@ -335,7 +335,7 @@ namespace aspect
                       for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
                         for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
                           {
-                            data.local_matrix(i,j) += ( derivative_scaling_factor * alpha * (scratch.grads_phi_u[i] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[j]) * strain_rate)
+                            data.local_matrix(i,j) += ( derivative_scaling_factor * alpha * 2.0 * (scratch.grads_phi_u[i] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[j]) * strain_rate)
                                                         + derivative_scaling_factor * this->get_pressure_scaling() * scratch.grads_phi_u[i] * 2.0 * viscosity_derivative_wrt_pressure * scratch.phi_p[j] * strain_rate )
                                                       * JxW;
 

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -138,8 +138,8 @@ namespace aspect
                           data.local_matrix(i, j) += ((2.0 * eta * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
                                                       + derivative_scaling_factor * alpha * (scratch.grads_phi_u[i] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[j]) * strain_rate
                                                                                              + scratch.grads_phi_u[j] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[i]) * strain_rate)
-                                                      + one_over_eta * pressure_scaling
-                                                      * pressure_scaling
+                                                      + one_over_eta * this->get_pressure_scaling()
+                                                      * this->get_pressure_scaling()
                                                       * (scratch.phi_p[i] * scratch
                                                          .phi_p[j]))
                                                      * JxW;
@@ -154,8 +154,8 @@ namespace aspect
                         {
                           data.local_matrix(i, j) += ((2.0 * eta * alpha * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
                                                       + derivative_scaling_factor * alpha * (scratch.grads_phi_u[i] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[j]) * strain_rate)
-                                                      + one_over_eta * pressure_scaling
-                                                      * pressure_scaling
+                                                      + one_over_eta * this->get_pressure_scaling()
+                                                      * this->get_pressure_scaling()
                                                       * (scratch.phi_p[i] * scratch
                                                          .phi_p[j]))
                                                      * JxW;
@@ -314,24 +314,6 @@ namespace aspect
                                         :
                                         1;
 
-<<<<<<< 9c070c9492be916a7195c2cbb62f971e435fee95
-                  if(use_spd_factor)
-                  {
-                  for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
-                    for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
-                      {
-                        data.local_matrix(i,j) += ( derivative_scaling_factor * alpha * (scratch.grads_phi_u[i] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[j]) * strain_rate
-                                                                                         + scratch.grads_phi_u[j] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[i]) * strain_rate)
-                                                    + derivative_scaling_factor * this->get_pressure_scaling() * scratch.grads_phi_u[i] * 2.0 * viscosity_derivative_wrt_pressure * scratch.phi_p[j] * strain_rate )
-                                                  * JxW;
-
-                        Assert(dealii::numbers::is_finite(data.local_matrix(i,j)),
-                               ExcMessage ("Error: Assembly matrix is not finite." +
-                                           Utilities::to_string(data.local_matrix(i,j)) +
-                                           " = " + Utilities::to_string(eta)));
-                      }
-                  }
-=======
                   if (Newton_stabilisation.second == "SPD" || Newton_stabilisation.second == "symmetric")
                     {
                       for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
@@ -339,7 +321,7 @@ namespace aspect
                           {
                             data.local_matrix(i,j) += ( derivative_scaling_factor * alpha * (scratch.grads_phi_u[i] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[j]) * strain_rate
                                                                                              + scratch.grads_phi_u[j] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[i]) * strain_rate)
-                                                        + derivative_scaling_factor * pressure_scaling * scratch.grads_phi_u[i] * 2.0 * viscosity_derivative_wrt_pressure * scratch.phi_p[j] * strain_rate )
+                                                        + derivative_scaling_factor * this->get_pressure_scaling() * scratch.grads_phi_u[i] * 2.0 * viscosity_derivative_wrt_pressure * scratch.phi_p[j] * strain_rate )
                                                       * JxW;
 
                             Assert(dealii::numbers::is_finite(data.local_matrix(i,j)),
@@ -348,14 +330,13 @@ namespace aspect
                                                " = " + Utilities::to_string(eta)));
                           }
                     }
->>>>>>> implement the failsafe in a more flexible way togheter with giving more control over the way both the preconditioner and the A block are stabelized.
                   else
                     {
                       for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
                         for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
                           {
                             data.local_matrix(i,j) += ( derivative_scaling_factor * alpha * (scratch.grads_phi_u[i] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[j]) * strain_rate)
-                                                        + derivative_scaling_factor * pressure_scaling * scratch.grads_phi_u[i] * 2.0 * viscosity_derivative_wrt_pressure * scratch.phi_p[j] * strain_rate )
+                                                        + derivative_scaling_factor * this->get_pressure_scaling() * scratch.grads_phi_u[i] * 2.0 * viscosity_derivative_wrt_pressure * scratch.phi_p[j] * strain_rate )
                                                       * JxW;
 
                             Assert(dealii::numbers::is_finite(data.local_matrix(i,j)),
@@ -369,7 +350,7 @@ namespace aspect
         }
 
 #if DEBUG
-      if (assemble_newton_stokes_matrix)
+      if (scratch.rebuild_newton_stokes_matrix)
         {
           if (this->get_newton_handler().get_Newton_stabilisation().second == "SPD")
             {

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -152,7 +152,7 @@ namespace aspect
                       if (scratch.dof_component_indices[i] ==
                           scratch.dof_component_indices[j])
                         {
-                          data.local_matrix(i, j) += ((2.0 * eta * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
+                          data.local_matrix(i, j) += ((2.0 * eta * alpha * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
                                                       + derivative_scaling_factor * alpha * (scratch.grads_phi_u[i] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[j]) * strain_rate)
                                                       + one_over_eta * pressure_scaling
                                                       * pressure_scaling
@@ -354,7 +354,7 @@ namespace aspect
                       for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
                         for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
                           {
-                            data.local_matrix(i,j) += ( derivative_scaling_factor * (scratch.grads_phi_u[i] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[j]) * strain_rate)
+                            data.local_matrix(i,j) += ( derivative_scaling_factor * alpha * (scratch.grads_phi_u[i] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[j]) * strain_rate)
                                                         + derivative_scaling_factor * pressure_scaling * scratch.grads_phi_u[i] * 2.0 * viscosity_derivative_wrt_pressure * scratch.phi_p[j] * strain_rate )
                                                       * JxW;
 

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -284,6 +284,8 @@ namespace aspect
                                         :
                                         1;
 
+                  if(use_spd_factor)
+                  {
                   for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
                     for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
                       {
@@ -297,12 +299,28 @@ namespace aspect
                                            Utilities::to_string(data.local_matrix(i,j)) +
                                            " = " + Utilities::to_string(eta)));
                       }
+                  }
+                  else
+                  {
+                      for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
+                        for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
+                          {
+                            data.local_matrix(i,j) += ( derivative_scaling_factor * (scratch.grads_phi_u[i] * (viscosity_derivative_wrt_strain_rate * scratch.grads_phi_u[j]) * strain_rate)
+                                                        + derivative_scaling_factor * pressure_scaling * scratch.grads_phi_u[i] * 2.0 * viscosity_derivative_wrt_pressure * scratch.phi_p[j] * strain_rate )
+                                                      * JxW;
+
+                            Assert(dealii::numbers::is_finite(data.local_matrix(i,j)),
+                                   ExcMessage ("Error: Assembly matrix is not finite." +
+                                               Utilities::to_string(data.local_matrix(i,j)) +
+                                               " = " + Utilities::to_string(eta)));
+                          }
+                  }
                 }
             }
         }
 
 #if DEBUG
-      if (scratch.rebuild_newton_stokes_matrix)
+      /*if (assemble_newton_stokes_matrix)
         {
           // regardless of whether we do or do not add the Newton
           // linearization terms, we ought to test whether the top-left
@@ -332,7 +350,7 @@ namespace aspect
                                   + Utilities::to_string (data.local_matrix.matrix_norm_square(tmp)/(tmp*tmp))
                                   + " < 0. This should not happen."));
             }
-        }
+        }*/
 #endif
     }
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -551,6 +551,15 @@ namespace aspect
         melt_handler->initialize_simulator (*this);
       }
 
+    // If the solver type is a Newton type of solver, we need to set make sure
+    // assemble_newton_stokes_system set to true.
+    if (parameters.nonlinear_solver == NonlinearSolver::Newton_Stokes)
+      {
+        assemble_newton_stokes_system = true;
+        newton_handler->initialize_simulator(*this);
+        newton_handler->parse_parameters(prm);
+      }
+
     postprocess_manager.initialize_simulator (*this);
     postprocess_manager.parse_parameters (prm);
 
@@ -639,14 +648,6 @@ namespace aspect
 
     // check that the setup of equations, material models, and heating terms is consistent
     check_consistency_of_formulation();
-
-    // If the solver type is a Newton type of solver, we need to set make sure
-    // assemble_newton_stokes_system set to true.
-    if (parameters.nonlinear_solver == NonlinearSolver::Newton_Stokes)
-      {
-        assemble_newton_stokes_system = true;
-        newton_handler->initialize_simulator(*this);
-      }
 
     // now that all member variables have been set up, also
     // connect the functions that will actually do the assembly

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -21,6 +21,7 @@
 
 #include <aspect/simulator.h>
 #include <aspect/melt.h>
+#include <aspect/newton.h>
 #include <aspect/global.h>
 
 #include <aspect/geometry_model/interface.h>
@@ -1887,7 +1888,7 @@ namespace aspect
           }
         else
           {
-            new_linear_stokes_solver_tolerance = std::min(parameters.maximum_linear_stokes_solver_tolerance,
+            new_linear_stokes_solver_tolerance = std::min(newton_handler->get_maximum_linear_stokes_solver_tolerance(),
                                                           std::max(0.9 * std::fabs(newton_residual*newton_residual) / (newton_residual_old*newton_residual_old),
                                                                    0.9*linear_stokes_solver_tolerance*linear_stokes_solver_tolerance));
           }

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -161,6 +161,23 @@ namespace aspect
   {
     newton_derivative_scaling_factor = set_newton_derivative_scaling_factor;
   }
+
+  template <int dim>
+  bool
+  NewtonHandler<dim>::
+  get_use_spd_factor() const
+  {
+    return use_spd_factor;
+  }
+
+
+  template <int dim>
+  void
+  NewtonHandler<dim>::
+  set_use_spd_factor(const bool set_use_spd_factor)
+  {
+    use_spd_factor = set_use_spd_factor;
+  }
 }
 
 

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -163,7 +163,7 @@ namespace aspect
   }
 
   template <int dim>
-  std::string
+  PreconditionerStabilization
   NewtonHandler<dim>::
   get_preconditioner_stabilization() const
   {
@@ -174,13 +174,13 @@ namespace aspect
   template <int dim>
   void
   NewtonHandler<dim>::
-  set_preconditioner_stabilization(const std::string preconditioner_stabilization_)
+  set_preconditioner_stabilization(const PreconditionerStabilization preconditioner_stabilization_)
   {
     preconditioner_stabilization = preconditioner_stabilization_;
   }
 
   template <int dim>
-  std::string
+  VelocityBlockStabilization
   NewtonHandler<dim>::
   get_velocity_block_stabilization() const
   {
@@ -191,7 +191,7 @@ namespace aspect
   template <int dim>
   void
   NewtonHandler<dim>::
-  set_velocity_block_stabilization(const std::string velocity_block_stabilization_)
+  set_velocity_block_stabilization(const VelocityBlockStabilization velocity_block_stabilization_)
   {
     velocity_block_stabilization = velocity_block_stabilization_;
   }
@@ -242,6 +242,50 @@ namespace aspect
   get_maximum_linear_stokes_solver_tolerance()
   {
     return maximum_linear_stokes_solver_tolerance;
+  }
+
+  template <int dim>
+  std::string
+  NewtonHandler<dim>::
+  get_preconditioner_stabilization_string(PreconditionerStabilization preconditioner_stabilization)
+  {
+    switch (preconditioner_stabilization)
+      {
+        case PreconditionerStabilization::SPD:
+          return "SPD";
+          break;
+        case PreconditionerStabilization::PD:
+          return "PD";
+          break;
+        case PreconditionerStabilization::symmetric:
+          return "symmetric";
+          break;
+        case PreconditionerStabilization::none:
+          return "none";
+          break;
+      }
+  }
+
+  template <int dim>
+  std::string
+  NewtonHandler<dim>::
+  get_velocity_block_stabilization_string(VelocityBlockStabilization velocity_block_stabilization)
+  {
+    switch (velocity_block_stabilization)
+      {
+        case VelocityBlockStabilization::SPD:
+          return "SPD";
+          break;
+        case VelocityBlockStabilization::PD:
+          return "PD";
+          break;
+        case VelocityBlockStabilization::symmetric:
+          return "symmetric";
+          break;
+        case VelocityBlockStabilization::none:
+          return "none";
+          break;
+      }
   }
 
   template <int dim>
@@ -320,8 +364,26 @@ namespace aspect
         max_newton_line_search_iterations = prm.get_integer ("Max Newton line search iterations");
         use_newton_residual_scaling_method = prm.get_bool("Use Newton residual scaling method");
         maximum_linear_stokes_solver_tolerance = prm.get_double("Maximum linear Stokes solver tolerance");
-        preconditioner_stabilization = prm.get("Stabilization preconditioner");
-        velocity_block_stabilization = prm.get("Stabilization velocity block");
+        std::string preconditioner_stabilization_string = prm.get("Stabilization preconditioner");
+        if (preconditioner_stabilization_string == "SPD")
+          preconditioner_stabilization = PreconditionerStabilization::SPD;
+        else if (preconditioner_stabilization_string == "PD")
+          preconditioner_stabilization = PreconditionerStabilization::PD;
+        else if (preconditioner_stabilization_string == "symmetric")
+          preconditioner_stabilization = PreconditionerStabilization::symmetric;
+        else if (preconditioner_stabilization_string == "none")
+          preconditioner_stabilization = PreconditionerStabilization::none;
+
+        std::string velocity_block_stabilization_string = prm.get("Stabilization velocity block");
+        if (velocity_block_stabilization_string == "SPD")
+          velocity_block_stabilization = VelocityBlockStabilization::SPD;
+        else if (velocity_block_stabilization_string == "PD")
+          velocity_block_stabilization = VelocityBlockStabilization::PD;
+        else if (velocity_block_stabilization_string == "symmetric")
+          velocity_block_stabilization = VelocityBlockStabilization::symmetric;
+        else if (velocity_block_stabilization_string == "none")
+          velocity_block_stabilization = VelocityBlockStabilization::none;
+
         use_Newton_failsafe = prm.get_bool("Use Newton failsafe");
 
         AssertThrow((!DEAL_II_VERSION_GTE(9,0,0) && !use_Newton_failsafe) || DEAL_II_VERSION_GTE(9,0,0),

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -283,10 +283,20 @@ namespace aspect
 
         prm.declare_entry ("Stabilization preconditioner", "SPD",
                            Patterns::Selection ("SPD|PD|symmetric|none"),
-                           "TODO");
+                           "This parameters allows for the stabilisation of the preconditioner. By default, the "
+                           "matrix created for the preconditioning is not necessarily Symmetric Positive Definite. "
+                           "This is problematic (see Fraters et al, in prep). When none is chosen, the perconitioner "
+                           "is not stabilized. The Symmetric parameters symmetrizes the matrix, and PD makes the matrix "
+                           "Positive Definite. SPD is the full stabilization, where the matrix is garanteed Symmetric "
+                           "Positive Definite.");
         prm.declare_entry ("Stabilization velocity block", "SPD",
                            Patterns::Selection ("SPD|PD|symmetric|none"),
-                           "TODO");
+                           "This parameters allows for the stabilisation of the velocity block. By default, the "
+                           "matrix created for the velocity block is not necessarily Symmetric Positive Definite. "
+                           "This is problematic (see Fraters et al, in prep). When none is chosen, the velocity block "
+                           "is not stabilized. The Symmetric parameters symmetrizes the matrix, and PD makes the matrix "
+                           "Positive Definite. SPD is the full stabilization, where the matrix is garanteed Symmetric "
+                           "Positive Definite.");
         prm.declare_entry ("Use Newton failsafe", "false",
                            Patterns::Bool (),
                            "Switches on SPD stabilization when solver fails.");

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -163,7 +163,7 @@ namespace aspect
   }
 
   template <int dim>
-  PreconditionerStabilization
+  typename NewtonHandler<dim>::NewtonStabilization
   NewtonHandler<dim>::
   get_preconditioner_stabilization() const
   {
@@ -174,13 +174,13 @@ namespace aspect
   template <int dim>
   void
   NewtonHandler<dim>::
-  set_preconditioner_stabilization(const PreconditionerStabilization preconditioner_stabilization_)
+  set_preconditioner_stabilization(const NewtonStabilization preconditioner_stabilization_)
   {
     preconditioner_stabilization = preconditioner_stabilization_;
   }
 
   template <int dim>
-  VelocityBlockStabilization
+  typename NewtonHandler<dim>::NewtonStabilization
   NewtonHandler<dim>::
   get_velocity_block_stabilization() const
   {
@@ -191,7 +191,7 @@ namespace aspect
   template <int dim>
   void
   NewtonHandler<dim>::
-  set_velocity_block_stabilization(const VelocityBlockStabilization velocity_block_stabilization_)
+  set_velocity_block_stabilization(const NewtonStabilization velocity_block_stabilization_)
   {
     velocity_block_stabilization = velocity_block_stabilization_;
   }
@@ -247,44 +247,21 @@ namespace aspect
   template <int dim>
   std::string
   NewtonHandler<dim>::
-  get_preconditioner_stabilization_string(PreconditionerStabilization preconditioner_stabilization)
+  get_newton_stabilization_string(const NewtonStabilization preconditioner_stabilization) const
   {
     switch (preconditioner_stabilization)
       {
-        case PreconditionerStabilization::SPD:
+        case NewtonStabilization::SPD:
           return "SPD";
-          break;
-        case PreconditionerStabilization::PD:
+        case NewtonStabilization::PD:
           return "PD";
-          break;
-        case PreconditionerStabilization::symmetric:
+        case NewtonStabilization::symmetric:
           return "symmetric";
-          break;
-        case PreconditionerStabilization::none:
+        case NewtonStabilization::none:
           return "none";
-          break;
-      }
-  }
-
-  template <int dim>
-  std::string
-  NewtonHandler<dim>::
-  get_velocity_block_stabilization_string(VelocityBlockStabilization velocity_block_stabilization)
-  {
-    switch (velocity_block_stabilization)
-      {
-        case VelocityBlockStabilization::SPD:
-          return "SPD";
-          break;
-        case VelocityBlockStabilization::PD:
-          return "PD";
-          break;
-        case VelocityBlockStabilization::symmetric:
-          return "symmetric";
-          break;
-        case VelocityBlockStabilization::none:
-          return "none";
-          break;
+        default:
+          Assert(false,ExcNotImplemented());
+          return "";
       }
   }
 
@@ -301,49 +278,59 @@ namespace aspect
                            Patterns::Double(0,1),
                            "A relative tolerance with respect to the residual of the first "
                            "iteration, up to which the nonlinear Picard solver will iterate, "
-                           "before changing to the newton solver.");
+                           "before changing to the Newton solver.");
 
         prm.declare_entry ("Max pre-Newton nonlinear iterations", "10",
                            Patterns::Integer (0),
-                           "The maximum number of Picard nonlinear iterations to be performed "
-                           "before switching to Newton iterations.");
+                           "If the 'Nonlinear Newton solver switch tolerance' is reached before the "
+                           "maximal number of Picard iteration, then the solver switches to Newton "
+                           "solves anyway.");
 
         prm.declare_entry ("Max Newton line search iterations", "5",
                            Patterns::Integer (0),
                            "The maximum number of line search iterations allowed. If the "
-                           "criterion is not reached after this iteration, we apply the scaled "
-                           "increment to the solution and continue.");
+                           "criterion is not reached after this number of iteration, we apply "
+                           "the scaled increment even though it does not satisfy the necessary "
+                           "criteria and simply continue with the next Newton iteration.");
 
         prm.declare_entry ("Use Newton residual scaling method", "false",
                            Patterns::Bool (),
                            "This method allows to slowly introduce the derivatives based on the improvement "
                            "of the residual. If set to false, the scaling factor for the Newton derivatives "
-                           "is set to one immediately when switching on the Newton solver.");
+                           "is set to one immediately when switching on the Newton solver. When this is set to "
+                           "true, the derivatives are slowly introduced by the following equation: max(0.0, "
+                           "(1.0-(residual/switch_initial_residual))), where switch_initial_residual is the "
+                           "residual at the time when the Newton solver is switched on.");
 
         prm.declare_entry ("Maximum linear Stokes solver tolerance", "0.9",
                            Patterns::Double (0,1),
-                           "When the linear Stokes solver tolerance is dynamically chosen, this defines "
-                           "the most loose tolerance allowed.");
+                           "The linear Stokes solver tolerance is dynamically chosen for the Newton solver, based "
+                           "on the Eisenstat walker 1994 paper (https://doi.org/10.1137/0917003), equation 2.2. "
+                           "Because this value can become larger then one, we limit this value by this parameter.");
 
         prm.declare_entry ("Stabilization preconditioner", "SPD",
                            Patterns::Selection ("SPD|PD|symmetric|none"),
-                           "This parameters allows for the stabilisation of the preconditioner. By default, the "
-                           "matrix created for the preconditioning is not necessarily Symmetric Positive Definite. "
-                           "This is problematic (see Fraters et al, in prep). When none is chosen, the perconitioner "
-                           "is not stabilized. The Symmetric parameters symmetrizes the matrix, and PD makes the matrix "
-                           "Positive Definite. SPD is the full stabilization, where the matrix is garanteed Symmetric "
+                           "This parameters allows for the stabilization of the preconditioner. If one derives the Newton "
+                           "method without any modifications, the matrix created for the preconditioning is not necessarily "
+                           "Symmetric Positive Definite. This is problematic (see Fraters et al., in prep). When `none' is chosen, "
+                           "the preconditioner is not stabilized. The `symmetric' parameters symmetrizes the matrix, and `PD' makes "
+                           "the matrix Positive Definite. `SPD' is the full stabilization, where the matrix is guaranteed Symmetric "
                            "Positive Definite.");
+
         prm.declare_entry ("Stabilization velocity block", "SPD",
                            Patterns::Selection ("SPD|PD|symmetric|none"),
-                           "This parameters allows for the stabilisation of the velocity block. By default, the "
-                           "matrix created for the velocity block is not necessarily Symmetric Positive Definite. "
-                           "This is problematic (see Fraters et al, in prep). When none is chosen, the velocity block "
-                           "is not stabilized. The Symmetric parameters symmetrizes the matrix, and PD makes the matrix "
-                           "Positive Definite. SPD is the full stabilization, where the matrix is garanteed Symmetric "
+                           "This parameters allows for the stabilization of the velocity block. If one derives the Newton "
+                           "method without any modifications, the matrix created for the velocity block is not necessarily "
+                           "Symmetric Positive Definite. This is problematic (see Fraters et al., in prep). When `none' is chosen, "
+                           "the velocity block is not stabilized. The `symmetric' parameters symmetrizes the matrix, and `PD' makes "
+                           "the matrix Positive Definite. `SPD' is the full stabilization, where the matrix is guaranteed Symmetric "
                            "Positive Definite.");
+
         prm.declare_entry ("Use Newton failsafe", "false",
                            Patterns::Bool (),
-                           "Switches on SPD stabilization when solver fails.");
+                           "When this parameter is true and the linear solver fails, we try again, but now with SPD stabilization "
+                           "for both the preconditioner and the velocity block. The SPD stabilization will remain active untill "
+                           "the next timestep, when the default values are restored.");
       }
       prm.leave_subsection ();
     }
@@ -366,23 +353,23 @@ namespace aspect
         maximum_linear_stokes_solver_tolerance = prm.get_double("Maximum linear Stokes solver tolerance");
         std::string preconditioner_stabilization_string = prm.get("Stabilization preconditioner");
         if (preconditioner_stabilization_string == "SPD")
-          preconditioner_stabilization = PreconditionerStabilization::SPD;
+          preconditioner_stabilization = NewtonStabilization::SPD;
         else if (preconditioner_stabilization_string == "PD")
-          preconditioner_stabilization = PreconditionerStabilization::PD;
+          preconditioner_stabilization = NewtonStabilization::PD;
         else if (preconditioner_stabilization_string == "symmetric")
-          preconditioner_stabilization = PreconditionerStabilization::symmetric;
+          preconditioner_stabilization = NewtonStabilization::symmetric;
         else if (preconditioner_stabilization_string == "none")
-          preconditioner_stabilization = PreconditionerStabilization::none;
+          preconditioner_stabilization = NewtonStabilization::none;
 
         std::string velocity_block_stabilization_string = prm.get("Stabilization velocity block");
         if (velocity_block_stabilization_string == "SPD")
-          velocity_block_stabilization = VelocityBlockStabilization::SPD;
+          velocity_block_stabilization = NewtonStabilization::SPD;
         else if (velocity_block_stabilization_string == "PD")
-          velocity_block_stabilization = VelocityBlockStabilization::PD;
+          velocity_block_stabilization = NewtonStabilization::PD;
         else if (velocity_block_stabilization_string == "symmetric")
-          velocity_block_stabilization = VelocityBlockStabilization::symmetric;
+          velocity_block_stabilization = NewtonStabilization::symmetric;
         else if (velocity_block_stabilization_string == "none")
-          velocity_block_stabilization = VelocityBlockStabilization::none;
+          velocity_block_stabilization = NewtonStabilization::none;
 
         use_Newton_failsafe = prm.get_bool("Use Newton failsafe");
 

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -163,20 +163,20 @@ namespace aspect
   }
 
   template <int dim>
-  bool
+  std::pair<std::string,std::string>
   NewtonHandler<dim>::
-  get_use_spd_factor() const
+  get_Newton_stabilisation() const
   {
-    return use_spd_factor;
+    return Newton_stabilisation;
   }
 
 
   template <int dim>
   void
   NewtonHandler<dim>::
-  set_use_spd_factor(const bool set_use_spd_factor)
+  set_Newton_stabilisation(const std::string use_Newton_stabilisation_preconditioner,const std::string use_Newton_stabilisation_A_block)
   {
-    use_spd_factor = set_use_spd_factor;
+    Newton_stabilisation = std::make_pair(use_Newton_stabilisation_preconditioner,use_Newton_stabilisation_A_block);
   }
 }
 

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1068,8 +1068,8 @@ namespace aspect
         use_Newton_stabilisation_A_block = prm.get("Use Newton stabilization A block");
         use_Newton_failsafe = prm.get_bool("Use Newton failsafe");
 
-        AssertThrow(!DEAL_II_VERSION_GTE(9,0,0) && !use_Newton_failsafe, ExcMessage("The failsafe option can't be used with a deal.ii "
-                                                                                    " les then 9.0.0."));
+//        AssertThrow(!DEAL_II_VERSION_GTE(9,0,0) && !use_Newton_failsafe, ExcMessage("The failsafe option can't be used with a deal.ii "
+//                                                                                    " les then 9.0.0."));
       }
       prm.leave_subsection ();
       prm.enter_subsection ("AMG parameters");

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1067,6 +1067,8 @@ namespace aspect
         use_Newton_stabilisation_preconditioner = prm.get("Use Newton stabilization preconditioner");
         use_Newton_stabilisation_A_block = prm.get("Use Newton stabilization A block");
         use_Newton_failsafe = prm.get_bool("Use Newton failsafe");
+        AssertThrow(DEAL_II_VERSION_GTE(9,0,0) || !use_Newton_failsafe, ExcMessage("The failsafe option can't be used with a deal.ii "
+                                                                                   " les then 9.0.0."));
       }
       prm.leave_subsection ();
       prm.enter_subsection ("AMG parameters");

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -367,6 +367,17 @@ namespace aspect
                            "When the linear Stokes solver tolerance is dynamically chosen, this defines "
                            "the most loose tolerance allowed.");
 
+        prm.declare_entry ("Use Newton stabilization preconditioner", "SPD",
+                           Patterns::Selection ("SPD|PD|symmetric|none"),
+                           "TODO");
+        prm.declare_entry ("Use Newton stabilization A block", "SPD",
+                           Patterns::Selection ("SPD|PD|symmetric|none"),
+                           "TODO");
+        prm.declare_entry ("Use Newton failsafe", "true",
+                           Patterns::Bool (),
+                           "Switches on SPD stabilization when solver fails.");
+
+
       }
       prm.leave_subsection ();
       prm.enter_subsection ("AMG parameters");
@@ -1053,6 +1064,9 @@ namespace aspect
         max_newton_line_search_iterations = prm.get_integer ("Max Newton line search iterations");
         use_newton_residual_scaling_method = prm.get_bool("Use Newton residual scaling method");
         maximum_linear_stokes_solver_tolerance = prm.get_double("Maximum linear Stokes solver tolerance");
+        use_Newton_stabilisation_preconditioner = prm.get("Use Newton stabilization preconditioner");
+        use_Newton_stabilisation_A_block = prm.get("Use Newton stabilization A block");
+        use_Newton_failsafe = prm.get_bool("Use Newton failsafe");
       }
       prm.leave_subsection ();
       prm.enter_subsection ("AMG parameters");

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -23,6 +23,7 @@
 #include <aspect/global.h>
 #include <aspect/utilities.h>
 #include <aspect/melt.h>
+#include <aspect/newton.h>
 #include <aspect/free_surface.h>
 
 #include <deal.II/base/parameter_handler.h>
@@ -337,49 +338,6 @@ namespace aspect
 
     prm.enter_subsection ("Solver parameters");
     {
-      prm.enter_subsection ("Newton solver parameters");
-      {
-        prm.declare_entry ("Nonlinear Newton solver switch tolerance", "1e-5",
-                           Patterns::Double(0,1),
-                           "A relative tolerance with respect to the residual of the first "
-                           "iteration, up to which the nonlinear Picard solver will iterate, "
-                           "before changing to the newton solver.");
-
-        prm.declare_entry ("Max pre-Newton nonlinear iterations", "10",
-                           Patterns::Integer (0),
-                           "The maximum number of Picard nonlinear iterations to be performed "
-                           "before switching to Newton iterations.");
-
-        prm.declare_entry ("Max Newton line search iterations", "5",
-                           Patterns::Integer (0),
-                           "The maximum number of line search iterations allowed. If the "
-                           "criterion is not reached after this iteration, we apply the scaled "
-                           "increment to the solution and continue.");
-
-        prm.declare_entry ("Use Newton residual scaling method", "false",
-                           Patterns::Bool (),
-                           "This method allows to slowly introduce the derivatives based on the improvement "
-                           "of the residual. If set to false, the scaling factor for the Newton derivatives "
-                           "is set to one immediately when switching on the Newton solver.");
-
-        prm.declare_entry ("Maximum linear Stokes solver tolerance", "0.9",
-                           Patterns::Double (0,1),
-                           "When the linear Stokes solver tolerance is dynamically chosen, this defines "
-                           "the most loose tolerance allowed.");
-
-        prm.declare_entry ("Use Newton stabilization preconditioner", "SPD",
-                           Patterns::Selection ("SPD|PD|symmetric|none"),
-                           "TODO");
-        prm.declare_entry ("Use Newton stabilization A block", "SPD",
-                           Patterns::Selection ("SPD|PD|symmetric|none"),
-                           "TODO");
-        prm.declare_entry ("Use Newton failsafe", "false",
-                           Patterns::Bool (),
-                           "Switches on SPD stabilization when solver fails.");
-
-
-      }
-      prm.leave_subsection ();
       prm.enter_subsection ("AMG parameters");
       {
         prm.declare_entry ("AMG smoother type", "Chebyshev",
@@ -1057,21 +1015,6 @@ namespace aspect
 
     prm.enter_subsection ("Solver parameters");
     {
-      prm.enter_subsection ("Newton solver parameters");
-      {
-        nonlinear_switch_tolerance = prm.get_double("Nonlinear Newton solver switch tolerance");
-        max_pre_newton_nonlinear_iterations = prm.get_integer ("Max pre-Newton nonlinear iterations");
-        max_newton_line_search_iterations = prm.get_integer ("Max Newton line search iterations");
-        use_newton_residual_scaling_method = prm.get_bool("Use Newton residual scaling method");
-        maximum_linear_stokes_solver_tolerance = prm.get_double("Maximum linear Stokes solver tolerance");
-        use_Newton_stabilisation_preconditioner = prm.get("Use Newton stabilization preconditioner");
-        use_Newton_stabilisation_A_block = prm.get("Use Newton stabilization A block");
-        use_Newton_failsafe = prm.get_bool("Use Newton failsafe");
-
-//        AssertThrow(!DEAL_II_VERSION_GTE(9,0,0) && !use_Newton_failsafe, ExcMessage("The failsafe option can't be used with a deal.ii "
-//                                                                                    " les then 9.0.0."));
-      }
-      prm.leave_subsection ();
       prm.enter_subsection ("AMG parameters");
       {
         AMG_smoother_type                      = prm.get ("AMG smoother type");
@@ -1743,6 +1686,7 @@ namespace aspect
   {
     Parameters<dim>::declare_parameters (prm);
     MeltHandler<dim>::declare_parameters (prm);
+    NewtonHandler<dim>::declare_parameters (prm);
     Postprocess::Manager<dim>::declare_parameters (prm);
     MeshRefinement::Manager<dim>::declare_parameters (prm);
     TerminationCriteria::Manager<dim>::declare_parameters (prm);

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -373,7 +373,7 @@ namespace aspect
         prm.declare_entry ("Use Newton stabilization A block", "SPD",
                            Patterns::Selection ("SPD|PD|symmetric|none"),
                            "TODO");
-        prm.declare_entry ("Use Newton failsafe", "true",
+        prm.declare_entry ("Use Newton failsafe", "false",
                            Patterns::Bool (),
                            "Switches on SPD stabilization when solver fails.");
 
@@ -1067,8 +1067,9 @@ namespace aspect
         use_Newton_stabilisation_preconditioner = prm.get("Use Newton stabilization preconditioner");
         use_Newton_stabilisation_A_block = prm.get("Use Newton stabilization A block");
         use_Newton_failsafe = prm.get_bool("Use Newton failsafe");
-        AssertThrow(DEAL_II_VERSION_GTE(9,0,0) || !use_Newton_failsafe, ExcMessage("The failsafe option can't be used with a deal.ii "
-                                                                                   " les then 9.0.0."));
+
+        AssertThrow(!DEAL_II_VERSION_GTE(9,0,0) && !use_Newton_failsafe, ExcMessage("The failsafe option can't be used with a deal.ii "
+                                                                                    " les then 9.0.0."));
       }
       prm.leave_subsection ();
       prm.enter_subsection ("AMG parameters");

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -579,8 +579,8 @@ namespace aspect
                                                             residual,
                                                             residual_old);
 
-                const std::string preconditioner_stabilization = newton_handler->get_preconditioner_stabilization();
-                const std::string velocity_block_stabilization = newton_handler->get_velocity_block_stabilization();
+                const std::string preconditioner_stabilization = newton_handler->get_preconditioner_stabilization_string(newton_handler->get_preconditioner_stabilization());
+                const std::string velocity_block_stabilization = newton_handler->get_velocity_block_stabilization_string(newton_handler->get_velocity_block_stabilization());
                 pcout << "   The linear solver tolerance is set to " << parameters.linear_stokes_solver_tolerance << ". Stabilisation Preconditioner is " << preconditioner_stabilization << " and A block is " << velocity_block_stabilization << "." << std::endl;
               }
           }
@@ -600,8 +600,8 @@ namespace aspect
             catch (...)
               {
                 pcout << "Solve failed and catched, try again with stabilisation" << std::endl;
-                newton_handler->set_preconditioner_stabilization("SPD");
-                newton_handler->set_velocity_block_stabilization("SPD");
+                newton_handler->set_preconditioner_stabilization(PreconditionerStabilization::SPD);
+                newton_handler->set_velocity_block_stabilization(VelocityBlockStabilization::SPD);
                 rebuild_stokes_matrix = rebuild_stokes_preconditioner = assemble_newton_stokes_matrix = true;
 
                 assemble_stokes_system();

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -579,9 +579,9 @@ namespace aspect
                                                             residual,
                                                             residual_old);
 
-                const std::string preconditioner_stabilization = newton_handler->get_preconditioner_stabilization_string(newton_handler->get_preconditioner_stabilization());
-                const std::string velocity_block_stabilization = newton_handler->get_velocity_block_stabilization_string(newton_handler->get_velocity_block_stabilization());
-                pcout << "   The linear solver tolerance is set to " << parameters.linear_stokes_solver_tolerance << ". Stabilisation Preconditioner is " << preconditioner_stabilization << " and A block is " << velocity_block_stabilization << "." << std::endl;
+                const std::string preconditioner_stabilization = newton_handler->get_newton_stabilization_string(newton_handler->get_preconditioner_stabilization());
+                const std::string velocity_block_stabilization = newton_handler->get_newton_stabilization_string(newton_handler->get_velocity_block_stabilization());
+                pcout << "   The linear solver tolerance is set to " << parameters.linear_stokes_solver_tolerance << ". Stabilization Preconditioner is " << preconditioner_stabilization << " and A block is " << velocity_block_stabilization << "." << std::endl;
               }
           }
 
@@ -599,9 +599,10 @@ namespace aspect
               }
             catch (...)
               {
+                // start the solve over again and try with a stabilized version
                 pcout << "Solve failed and catched, try again with stabilisation" << std::endl;
-                newton_handler->set_preconditioner_stabilization(PreconditionerStabilization::SPD);
-                newton_handler->set_velocity_block_stabilization(VelocityBlockStabilization::SPD);
+                newton_handler->set_preconditioner_stabilization(NewtonHandler<dim>::NewtonStabilization::SPD);
+                newton_handler->set_velocity_block_stabilization(NewtonHandler<dim>::NewtonStabilization::SPD);
                 rebuild_stokes_matrix = rebuild_stokes_preconditioner = assemble_newton_stokes_matrix = true;
 
                 assemble_stokes_system();

--- a/tests/nonlinear_channel_flow_tractions_Newton_Stokes/screen-output
+++ b/tests/nonlinear_channel_flow_tractions_Newton_Stokes/screen-output
@@ -26,181 +26,181 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.109645, norm of the rhs: 2.03031e+11, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.0693982, norm of the rhs: 1.28505e+11, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.0382081, norm of the rhs: 7.07501e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.0224287, norm of the rhs: 4.15314e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.0121241, norm of the rhs: 2.24502e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 34+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.00922581, norm of the rhs: 1.70835e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 38+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 0.00656156, norm of the rhs: 1.21501e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 37+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 0.00648748, norm of the rhs: 1.20129e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 0.00421184, norm of the rhs: 7.79909e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 0.00361081, norm of the rhs: 6.68617e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 0.00288189, norm of the rhs: 5.33641e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 0.00231211, norm of the rhs: 4.28135e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 0.00220375, norm of the rhs: 4.0807e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 0.00175022, norm of the rhs: 3.24089e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 0.00160637, norm of the rhs: 2.97454e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 0.00141183, norm of the rhs: 2.6143e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 0.00104573, norm of the rhs: 1.93639e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 0.000942199, norm of the rhs: 1.74468e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 9.33285e-05, norm of the rhs: 1.72817e+08, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.00435305
+   The linear solver tolerance is set to 0.00435305. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 200+1 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 7.18978e-06, norm of the rhs: 1.33134e+07, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 106+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 2.60905e-06, norm of the rhs: 4.8312e+06, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 132+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 9.12158e-07, norm of the rhs: 1.68905e+06, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 94+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 3.1951e-07, norm of the rhs: 591638, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 95+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 1.1075e-07, norm of the rhs: 205077, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 94+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 3.95081e-08, norm of the rhs: 73157.4, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 85+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 1.40218e-08, norm of the rhs: 25964.2, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 86+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 4.9427e-09, norm of the rhs: 9152.44, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 82+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 31: 1.76428e-09, norm of the rhs: 3266.92, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 91+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 32: 6.48372e-10, norm of the rhs: 1200.59, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 90+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 33: 2.42257e-10, norm of the rhs: 448.589, newton_derivative_scaling_factor: 1
@@ -232,31 +232,31 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 43+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 3.8899e-10, norm of the rhs: 133.799, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 45+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 3.29126e-10, norm of the rhs: 113.208, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 35+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 3.02026e-10, norm of the rhs: 103.887, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 2.78843e-10, norm of the rhs: 95.9122, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
    Line search iteration 0, with norm of the rhs 115.342 and going to 95.9024, relative residual: 3.3533e-10
@@ -289,37 +289,37 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 43+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 4.01339e-10, norm of the rhs: 138.047, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 44+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 3.50409e-10, norm of the rhs: 120.528, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 36+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 3.28835e-10, norm of the rhs: 113.108, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 3.25546e-10, norm of the rhs: 111.977, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 3.08028e-10, norm of the rhs: 105.951, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 2.37177e-10, norm of the rhs: 81.5805, newton_derivative_scaling_factor: 1
@@ -351,13 +351,13 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 2.53466e-10, norm of the rhs: 87.1836, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 2.34088e-10, norm of the rhs: 80.518, newton_derivative_scaling_factor: 1
@@ -388,13 +388,13 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 2.82087e-10, norm of the rhs: 97.0281, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
    Line search iteration 0, with norm of the rhs 107.151 and going to 97.0191, relative residual: 3.11518e-10

--- a/tests/nonlinear_channel_flow_velocities_Newton_Stokes/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_Newton_Stokes/screen-output
@@ -26,166 +26,166 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 3.03039e-07, norm of the rhs: 2.20771e+11, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 2.39921e-07, norm of the rhs: 1.74787e+11, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 1.66327e-07, norm of the rhs: 1.21173e+11, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 1.33824e-07, norm of the rhs: 9.74935e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.08804e-07, norm of the rhs: 7.92663e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 8.90245e-08, norm of the rhs: 6.48564e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 6.93e-08, norm of the rhs: 5.04866e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 6.3841e-08, norm of the rhs: 4.65096e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 5.58361e-08, norm of the rhs: 4.06778e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 5.25213e-08, norm of the rhs: 3.82629e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 4.48367e-08, norm of the rhs: 3.26645e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 4.35367e-08, norm of the rhs: 3.17174e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 3.67544e-08, norm of the rhs: 2.67764e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 3.60439e-08, norm of the rhs: 2.62587e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 2.94364e-08, norm of the rhs: 2.14451e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
    Line search iteration 0, with norm of the rhs 2.20883e+10 and going to 2.14429e+10, relative residual: 3.03193e-08
       Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 1.48582e-08, norm of the rhs: 1.08245e+10, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 1.00039e-08, norm of the rhs: 7.28805e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 8.96958e-09, norm of the rhs: 6.53454e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 6.31025e-09, norm of the rhs: 4.59716e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
    Line search iteration 0, with norm of the rhs 5.46014e+09 and going to 4.5967e+09, relative residual: 7.49482e-09
       Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 3.48909e-09, norm of the rhs: 2.54188e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
    Line search iteration 0, with norm of the rhs 2.59879e+09 and going to 2.54163e+09, relative residual: 3.56721e-09
       Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 3.2318e-09, norm of the rhs: 2.35444e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 1.99595e-09, norm of the rhs: 1.45409e+09, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 2.38686e-10, norm of the rhs: 1.73888e+08, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 65+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 9.80562e-11, norm of the rhs: 7.14361e+07, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 58+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 6.3613e-11, norm of the rhs: 4.63435e+07, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 45+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 2.12235e-11, norm of the rhs: 1.54618e+07, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 47+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 9.1214e-12, norm of the rhs: 6.64515e+06, newton_derivative_scaling_factor: 1
@@ -217,37 +217,37 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.22109e-12, norm of the rhs: 889594, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 37+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 5.51399e-13, norm of the rhs: 401706, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 35+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 1.97696e-13, norm of the rhs: 144026, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 67+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 3.86861e-14, norm of the rhs: 28183.7, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 84+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.92326e-14, norm of the rhs: 14011.4, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 40+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 6.48135e-15, norm of the rhs: 4721.81, newton_derivative_scaling_factor: 1
@@ -278,37 +278,37 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.22006e-12, norm of the rhs: 888840, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 37+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 5.50911e-13, norm of the rhs: 401351, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 35+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 1.97498e-13, norm of the rhs: 143882, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 67+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 3.85581e-14, norm of the rhs: 28090.5, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 84+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.92382e-14, norm of the rhs: 14015.5, newton_derivative_scaling_factor: 1
 
    Skipping temperature solve because RHS is zero.
-   The linear solver tolerance is set to 0.1
+   The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 40+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 6.49109e-15, norm of the rhs: 4728.91, newton_derivative_scaling_factor: 1


### PR DESCRIPTION
This is something which I have been working on and with for a while now, and since #1996 is (hopefully) nearly merged, it seems me like a good time to discuss this now. This pull request actually add two features at the same time, because they used to be intertwined, but I untangled them just before this pull request. If you want I can make two pull requests from this one.

The first feature is that it will  now be possible to chose whether to use the stabilisation or not (and which of the two) for both the preconditioner and the A block. 

My tests with the Spiegelman benchmark (I only tested with preconditioner being `SPD`) seem to indicate that if the solver doesn't fail, the convergence rate is by far the best if you only symmetrise the the A block (`symmetric`), then much closer together `SPD`, `none`, `PD`. But both the `symmetric` and the `none` fail when problems get tougher. This is why I introduce the second feature.

The second feature is that when the solver doesn't converge, we try again, but set everything to `SPD`. This way I can get the best of both world (being `symmetric` and `SPD`).

If you all agree with this approach, then will actually clean up the code, add more documentation and for example change the strings of `"SPD"` and `"none"` into enums.