### PR TITLE
Refactor set_assemblers into separate functions

### DIFF
--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -298,6 +298,13 @@ namespace aspect
                                          std::vector<VariableDeclaration<dim> > &variables);
 
       /**
+       * Determine, based on the run-time parameters of the current simulation,
+       * which functions need to be called in order to assemble linear systems,
+       * matrices, and right hand side vectors.
+       */
+      void set_assemblers (Assemblers::Manager<dim> &assemblers) const;
+
+      /**
        * Setup SimulatorAccess for the plugins related to melt transport.
        */
       void initialize_simulator (const Simulator<dim> &simulator_object);

--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -66,6 +66,13 @@ namespace aspect
   {
     public:
       /**
+       * Determine, based on the run-time parameters of the current simulation,
+       * which functions need to be called in order to assemble linear systems,
+       * matrices, and right hand side vectors.
+       */
+      void set_assemblers (Assemblers::Manager<dim> &assemblers) const;
+
+      /**
        * Create an additional material model output object that contains
        * the additional output variables (the derivatives) needed for the
        * Newton solver.

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -759,6 +759,18 @@ namespace aspect
       void set_assemblers ();
 
       /**
+       * Determine, based on the run-time parameters of the current simulation,
+       * which functions need to be called in order to assemble linear systems,
+       * matrices, and right hand side vectors. This function handles the
+       * default operation mode of ASPECT, i.e. without considering two-phase
+       * flow, or Newton solvers.
+       *
+       * This function is implemented in
+       * <code>source/simulator/assembly.cc</code>.
+       */
+      void set_default_assemblers ();
+
+      /**
        * Initiate the assembly of the preconditioner for the Stokes system.
        *
        * This function is implemented in

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -675,6 +675,15 @@ namespace aspect
       get_pressure_scaling () const;
 
       /**
+       * Return whether we need to apply a compatibility modification
+       * to the pressure right hand side. See documentation of
+       * Simulator<dim>::do_pressure_rhs_compatibility_modification for more
+       * information.
+       */
+      bool
+      pressure_rhs_needs_compatibility_modification() const;
+
+      /**
        * A convenience function that copies the values of the compositional
        * fields at the quadrature point q given as input parameter to the
        * output vector composition_values_at_q_point.

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -664,7 +664,10 @@ namespace aspect
     // If the solver type is a Newton type of solver, we need to set make sure
     // assemble_newton_stokes_system set to true.
     if (parameters.nonlinear_solver == NonlinearSolver::Newton_Stokes)
-      assemble_newton_stokes_system = true;
+      {
+        assemble_newton_stokes_system = true;
+        newton_handler->initialize_simulator(*this);
+      }
 
     // now that all member variables have been set up, also
     // connect the functions that will actually do the assembly

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1298,12 +1298,16 @@ namespace aspect
         update_normal_vectors | update_gradients |
         update_JxW_values);
 
+
     assemblers.stokes_system_on_boundary_face.push_back(
-      std_cxx14::make_unique<Assemblers::MeltStokesSystemBoundary<dim> > ());
+      std_cxx14::make_unique<aspect::Assemblers::MeltStokesSystemBoundary<dim> >());
 
     // add the terms for traction boundary conditions
-    assemblers.stokes_system_on_boundary_face.push_back(
-      std_cxx14::make_unique<Assemblers::MeltBoundaryTraction<dim> > ());
+    if (!this->get_boundary_traction().empty())
+      {
+        assemblers.stokes_system_on_boundary_face.push_back(
+          std_cxx14::make_unique<Assemblers::MeltBoundaryTraction<dim> > ());
+      }
 
     // add the terms necessary to normalize the pressure
     if (this->pressure_rhs_needs_compatibility_modification())

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -25,11 +25,6 @@
 
 #include <aspect/simulator.h>
 
-#if DEAL_II_VERSION_GTE(9,0,0)
-#include <deal.II/base/std_cxx14/memory.h>
-#endif
-
-
 namespace aspect
 {
   namespace MaterialModel
@@ -92,8 +87,12 @@ namespace aspect
                   ExcMessage("Unknown mass conservation equation approximation. There is no assembler"
                              " defined that handles this formulation."));
 
-    assemblers.stokes_system_on_boundary_face.push_back(
-      std_cxx14::make_unique<aspect::Assemblers::StokesBoundaryTraction<dim> >());
+    // add the terms for traction boundary conditions
+    if (!this->get_boundary_traction().empty())
+      {
+        assemblers.stokes_system_on_boundary_face.push_back(
+          std_cxx14::make_unique<aspect::Assemblers::StokesBoundaryTraction<dim> >());
+      }
 
     // add the terms necessary to normalize the pressure
     if (this->pressure_rhs_needs_compatibility_modification())

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -20,8 +20,14 @@
 
 
 #include <aspect/newton.h>
+#include <aspect/simulator/assemblers/advection.h>
+#include <aspect/simulator/assemblers/stokes.h>
+
 #include <aspect/simulator.h>
 
+#if DEAL_II_VERSION_GTE(9,0,0)
+#include <deal.II/base/std_cxx14/memory.h>
+#endif
 
 
 namespace aspect
@@ -38,6 +44,91 @@ namespace aspect
     }
 
   }
+
+
+
+  template <int dim>
+  void
+  NewtonHandler<dim>::
+  set_assemblers (Assemblers::Manager<dim> &assemblers) const
+  {
+    assemblers.stokes_preconditioner.push_back(std_cxx14::make_unique<aspect::Assemblers::NewtonStokesPreconditioner<dim> >());
+    assemblers.stokes_system.push_back(std_cxx14::make_unique<aspect::Assemblers::NewtonStokesIncompressibleTerms<dim> >());
+
+    if (this->get_material_model().is_compressible())
+      {
+        assemblers.stokes_preconditioner.push_back(
+          std_cxx14::make_unique<aspect::Assemblers::StokesCompressiblePreconditioner<dim> >());
+
+        assemblers.stokes_system.push_back(
+          std_cxx14::make_unique<aspect::Assemblers::NewtonStokesCompressibleStrainRateViscosityTerm<dim> >());
+      }
+
+    if (this->get_parameters().formulation_mass_conservation ==
+        Parameters<dim>::Formulation::MassConservation::implicit_reference_density_profile)
+      {
+        assemblers.stokes_system.push_back(
+          std_cxx14::make_unique<aspect::Assemblers::NewtonStokesImplicitReferenceDensityCompressibilityTerm<dim> >());
+      }
+    else if (this->get_parameters().formulation_mass_conservation ==
+             Parameters<dim>::Formulation::MassConservation::reference_density_profile)
+      {
+        assemblers.stokes_system.push_back(
+          std_cxx14::make_unique<aspect::Assemblers::NewtonStokesReferenceDensityCompressibilityTerm<dim> >());
+      }
+    else if (this->get_parameters().formulation_mass_conservation ==
+             Parameters<dim>::Formulation::MassConservation::incompressible)
+      {
+        // do nothing, because we assembled div u =0 above already
+      }
+    else if (this->get_parameters().formulation_mass_conservation ==
+             Parameters<dim>::Formulation::MassConservation::isothermal_compression)
+      {
+        assemblers.stokes_system.push_back(
+          std_cxx14::make_unique<aspect::Assemblers::NewtonStokesIsothermalCompressionTerm<dim> >());
+      }
+    else
+      AssertThrow(false,
+                  ExcMessage("Unknown mass conservation equation approximation. There is no assembler"
+                             " defined that handles this formulation."));
+
+    assemblers.stokes_system_on_boundary_face.push_back(
+      std_cxx14::make_unique<aspect::Assemblers::StokesBoundaryTraction<dim> >());
+
+    // add the terms necessary to normalize the pressure
+    if (this->pressure_rhs_needs_compatibility_modification())
+      assemblers.stokes_system.push_back(
+        std_cxx14::make_unique<aspect::Assemblers::StokesPressureRHSCompatibilityModification<dim> >());
+
+    assemblers.advection_system.push_back(
+      std_cxx14::make_unique<aspect::Assemblers::AdvectionSystem<dim> >());
+
+    if (this->get_parameters().use_discontinuous_temperature_discretization ||
+        this->get_parameters().use_discontinuous_composition_discretization)
+      {
+        assemblers.advection_system_on_boundary_face.push_back(
+          std_cxx14::make_unique<aspect::Assemblers::AdvectionSystemBoundaryFace<dim> >());
+
+        assemblers.advection_system_on_interior_face.push_back(
+          std_cxx14::make_unique<aspect::Assemblers::AdvectionSystemInteriorFace<dim> >());
+      }
+
+    if (this->get_parameters().use_discontinuous_temperature_discretization)
+      {
+        assemblers.advection_system_assembler_on_face_properties[0].need_face_material_model_data = true;
+        assemblers.advection_system_assembler_on_face_properties[0].need_face_finite_element_evaluation = true;
+      }
+
+    if (this->get_parameters().use_discontinuous_composition_discretization)
+      {
+        for (unsigned int i = 1; i<=this->introspection().n_compositional_fields; ++i)
+          {
+            assemblers.advection_system_assembler_on_face_properties[i].need_face_material_model_data = true;
+            assemblers.advection_system_assembler_on_face_properties[i].need_face_finite_element_evaluation = true;
+          }
+      }
+  }
+
 
 
   template <int dim>

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -614,6 +614,13 @@ namespace aspect
   {
     return (simulator->pressure_scaling);
   }
+
+  template <int dim>
+  bool
+  SimulatorAccess<dim>::pressure_rhs_needs_compatibility_modification () const
+  {
+    return simulator->do_pressure_rhs_compatibility_modification;
+  }
 }
 
 


### PR DESCRIPTION
This is on top of #1785 and simplifies `set_assemblers` by outsorcing many parts into the melt handler and newton handler classes.