### PR TITLE
avoid deadlock when exception is thrown

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -441,11 +441,6 @@ int main (int argc, char *argv[])
 {
   using namespace dealii;
 
-  // disable the use of thread. if that is not what you want,
-  // use numbers::invalid_unsigned_int instead of 1 to use as many threads
-  // as deemed useful by TBB
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, /*n_threads =*/ 1);
-
 #ifdef DEBUG
 #ifdef ASPECT_USE_FP_EXCEPTIONS
   // Some implementations seem to not initialize the floating point exception
@@ -459,6 +454,16 @@ int main (int argc, char *argv[])
 
   try
     {
+      // Disable the use of threads. If that is not what you want,
+      // use numbers::invalid_unsigned_int instead of 1 to use as many threads
+      // as deemed useful by TBB.
+      //
+      // Note: we initialize this class inside the try/catch block and not
+      // before, so that the destructor of this instance can react if we are
+      // currently unwinding the stack if an unhandled exception is being
+      // thrown to avoid MPI deadlocks.
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, /*n_threads =*/ 1);
+
       deallog.depth_console(0);
 
       int current_idx = 1;
@@ -712,7 +717,6 @@ int main (int argc, char *argv[])
                 << "Aborting!" << std::endl
                 << "----------------------------------------------------"
                 << std::endl;
-
       return 1;
     }
   catch (std::exception &exc)
@@ -727,7 +731,6 @@ int main (int argc, char *argv[])
                 << "Aborting!" << std::endl
                 << "----------------------------------------------------"
                 << std::endl;
-
       return 1;
     }
   catch (aspect::QuietException &)

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -686,6 +686,19 @@ namespace aspect
     // wait if there is a thread that's still writing the statistics
     // object (set from the output_statistics() function)
     output_statistics_thread.join();
+
+    // Detect if we are being destroyed because an uncaught exception has
+    // been triggered. If so, reset() the TimerOutput class. This will clear
+    // the currently active timing sections. Otherwise, its destructor will try to
+    // do MPI communication when leaving the open sections, which can cause one of the
+    // following problems:
+    // 1. deadlocks or hangs in the MPI commands synchronizing the timers.
+    // 2. Incorrect error reporting about mismatched Trilinos compress() calls.
+    //
+    // In either case this might not show the real message of the exception
+    // that was being triggered.
+    if (std::uncaught_exception())
+      computing_timer.reset();
   }
 
 

--- a/tests/fail/screen-output
+++ b/tests/fail/screen-output
@@ -1,4 +1,5 @@
 
+ERROR: Uncaught exception in MPI_InitFinalize on proc 0. Skipping MPI_Finalize() to avoid a deadlock.
 
 
 Exception 'ExcMessage ("ASPECT can only be run in 2d and 3d but a " "different space dimension is given in the parameter file.")' on rank 0 on processing: 

--- a/tests/steinberger_lateral_fail/screen-output
+++ b/tests/steinberger_lateral_fail/screen-output
@@ -5,6 +5,7 @@ Number of degrees of freedom: 2,724 (1,666+225+833)
 *** Timestep 0:  t=0 years
 In computing depth averages, there is at least one depth band that does not have any quadrature points in it.
  Consider reducing number of depth layers for  averaging
+ERROR: Uncaught exception in MPI_InitFinalize on proc 0. Skipping MPI_Finalize() to avoid a deadlock.
 
 
 Exception 'ExcMessage("In computing depth averages, there is at" " least one depth band that does not have" " any quadrature points in it." " Consider reducing number of depth layers" " for averaging specified in the parameter" " file.(Number lateral average bands)")' on rank 0 on processing: 

--- a/tests/visualization_unique_list/screen-output
+++ b/tests/visualization_unique_list/screen-output
@@ -1,4 +1,5 @@
 
+ERROR: Uncaught exception in MPI_InitFinalize on proc 0. Skipping MPI_Finalize() to avoid a deadlock.
 
 
 Exception 'ExcMessage("The list of strings for the parameter " "'Postprocess/Visualization/List of output variables' contains entries more than once. " "This is not allowed. Please check your parameter file.")' on rank 0 on processing: 

--- a/tests/zero_matrix/screen-output
+++ b/tests/zero_matrix/screen-output
@@ -28,6 +28,7 @@ Number of degrees of freedom: 22,216 (8,442+1,111+4,221+4,221+4,221)
      RMS, max velocity:        0.0102 m/year, 0.0103 m/year
 
 *** Timestep 1:  t=48350 years
+ERROR: Uncaught exception in MPI_InitFinalize on proc 0. Skipping MPI_Finalize() to avoid a deadlock.
 
 
 Exception 'ExcMessage ("The " + field_name + " equation can not be solved, because the matrix is zero, " "but the right-hand side is nonzero.")' on rank 0 on processing: 


### PR DESCRIPTION
If an exception is thrown, we will call the TimerOutput destructor,
which will exit subsections and in turn call Timer functions that
trigger MPI communication. This can a) hang if only some processors
throw, or b) report incorrect messages (about Trilinos compress()).

Avoid this problem (at least in c++11 or newer), by reporting the
exception and then aborting before the destructor is executed.