### PR TITLE
Initialize nonlinear iteration count

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -193,6 +193,7 @@ namespace aspect
     time_step (0),
     old_time_step (0),
     timestep_number (0),
+    nonlinear_iteration (numbers::invalid_unsigned_int),
 
     triangulation (mpi_communicator,
                    typename Triangulation<dim>::MeshSmoothing


### PR DESCRIPTION
So far we do not initialize `Simulator::nonlinear_iteration`, but it would be nice to be able to check against a specific value (e.g. in my particular application to test in a signal if we are in the process of setting up initial conditions, or within the nonlinear solver loop of the first timestep).