### PR TITLE
Validate MaterialModelOutputs

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -468,6 +468,11 @@ namespace aspect
        */
       template <class AdditionalOutputType>
       const AdditionalOutputType *get_additional_output() const;
+
+      /**
+       * Check if all outputs were filled correctly.
+       **/
+      void validate() const;
     };
 
 

--- a/source/material_model/composition_reaction.cc
+++ b/source/material_model/composition_reaction.cc
@@ -111,6 +111,9 @@ namespace aspect
           out.thermal_conductivities[i] = k_value;
           out.thermal_expansion_coefficients[i] = thermal_alpha;
           out.compressibilities[i] = 0.0;
+
+          out.entropy_derivative_pressure[i] = 0.0;
+          out.entropy_derivative_temperature[i] = 0.0;
         }
     }
 

--- a/source/material_model/simpler.cc
+++ b/source/material_model/simpler.cc
@@ -57,6 +57,9 @@ namespace aspect
           out.thermal_conductivities[i] = k_value;
           out.compressibilities[i] = 0.0;
 
+          out.entropy_derivative_pressure[i] = 0.0;
+          out.entropy_derivative_temperature[i] = 0.0;
+
           for (unsigned int c=0; c<in.composition[i].size(); ++c)
             out.reaction_terms[i][c] = 0.0;
         }

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -822,6 +822,21 @@ namespace aspect
 
     material_model->evaluate(scratch.material_model_inputs,
                              scratch.material_model_outputs);
+
+#ifdef DEBUG
+    {
+      // Check that the user filled all entries inside the material model and
+      // hasn't messed with the size of the objects:
+      static bool first = true;
+      if (first)
+        {
+          first = false;
+          scratch.material_model_outputs.validate();
+        }
+    }
+#endif
+
+
     if (parameters.formulation_temperature_equation ==
         Parameters<dim>::Formulation::TemperatureEquation::reference_density_profile)
       {


### PR DESCRIPTION
It is easy to forget filling all values inside ``MaterialModel::evaluate()`` and we actually did for at least two. This patch checks that all NaNs in the outputs are correctly overwritten. I am only doing this on the first cell of the advection assembler and only in debug mode.
Note that ``std::isnan`` should not trigger an exception checking a signaling nan, but it does on my machine, so I have to disable the FPE checks first.

relates: #2024 