### PR TITLE
inclusion benchmarks: use seconds not years

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 /benchmarks/**/cmake_install.cmake
 /benchmarks/**/lib*.so
 /benchmarks/**/output/
+/benchmarks/**/aspect
+/benchmarks/**/temp.prm
 /benchmarks/tangurnis/*/*csv
 /benchmarks/tangurnis/*/solution*
 /build*/

--- a/benchmarks/inclusion/adaptive.prm.base
+++ b/benchmarks/inclusion/adaptive.prm.base
@@ -11,6 +11,7 @@ set End time                               = 0
 set Pressure normalization                 = volume
 set Nonlinear solver scheme                = Stokes only
 
+set Use years in output instead of seconds = false
 
 ############### Parameters describing the model
 

--- a/benchmarks/inclusion/global.prm.base
+++ b/benchmarks/inclusion/global.prm.base
@@ -11,6 +11,7 @@ set End time                               = 0
 set Pressure normalization                 = volume
 set Nonlinear solver scheme                = Stokes only
 
+set Use years in output instead of seconds = false
 
 ############### Parameters describing the model
 


### PR DESCRIPTION
The graphical output for the inclusion benchmark were set to "Use years
in output instead of seconds" which doesn't make much sense for a
problem on a unit square. The computed errors are independent of this
change.