### PR TITLE
Include more version information in header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ MESSAGE(STATUS "====================================================")
 SET(TARGET "aspect")
 
 FILE(GLOB_RECURSE TARGET_SRC  "source/*.cc" "include/*.h")
-INCLUDE_DIRECTORIES(include)
+INCLUDE_DIRECTORIES(include ${CMAKE_BINARY_DIR}/include)
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.8)
 
@@ -99,8 +99,12 @@ FOREACH(_source_file ${TARGET_SRC})
 ENDFOREACH()
 
 
+
 # load in version info and export it
 FILE(STRINGS "${CMAKE_SOURCE_DIR}/VERSION" ASPECT_PACKAGE_VERSION LIMIT_COUNT 1)
+
+DEAL_II_QUERY_GIT_INFORMATION("ASPECT")
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/include/aspect/revision.h.in ${CMAKE_BINARY_DIR}/include/aspect/revision.h @ONLY)
 
 INCLUDE(CMakePackageConfigHelpers)
 WRITE_BASIC_PACKAGE_VERSION_FILE(

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2838,8 +2838,8 @@ something like this (numbers will all be different, of course):
 \begin{lstlisting}[frame=single,language=ksh]
 -----------------------------------------------------------------------------
 -- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
---     . version 2.0.0-pre (git revision c620893)
---     . using deal.II 9.0.0-pre (git revision 952baa0)
+--     . version 2.0.0-pre (include_dealii_version, c20eba0)
+--     . using deal.II 9.0.0-pre (master, 952baa0)
 --     . using Trilinos 12.10.1
 --     . using p4est 2.0.0
 --     . running in DEBUG mode
@@ -2896,17 +2896,17 @@ Number of degrees of freedom: 33,859 (20,786+2,680+10,393)
 ...
 \end{lstlisting}
 
-The output starts with a header that lists the used \aspect{}, \dealii{}, and
-\pfrst{} versions as well as compiler settings and the number of parallel
-processes used\footnote{If you used the \texttt{git} version control system to
-download \aspect{} and/or \dealii{}, as in this example, you will also get the
-unique revision identifier for the current version. This is very important if
-you modify either software between releases, or you use a development version
-that is not an official release. Note that this revision can not track changes
-you made to the software that are not part of a git commit.  Also it will
-only be updated every time the \texttt{cmake} configuration script is run.}.
-With this information we strive to make \aspect{} models as reproducible as
-possible.
+The output starts with a header that lists the used \aspect{}, \dealii{},
+\trilinos{} and \pfrst{} versions as well as the mode you compiled \aspect{} in
+(see \ref{sec:debug-mode}), and the number of parallel processes
+used\footnote{If you used the \texttt{git} version control system to download
+\aspect{} and/or \dealii{}, as in this example, you will also get the current
+branch, and unique revision identifier for the current version. This is very
+important if you modify either software between releases, or you use a
+development version that is not an official release. Note that this revision
+can not track changes you made to the software that are not part of a git
+commit.}.  With this information we strive to make
+\aspect{} models as reproducible as possible.
 
 The following output depends on the model, and in this case was produced by
 a parameter file that, among other settings, contained the following values

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2836,6 +2836,16 @@ is given in Section~\ref{sec:parameters}.
 Running \aspect{} with an input file will produce output that will look
 something like this (numbers will all be different, of course):
 \begin{lstlisting}[frame=single,language=ksh]
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (git revision c620893)
+--     . using deal.II 9.0.0-pre (git revision 952baa0)
+--     . using Trilinos 12.10.1
+--     . using p4est 2.0.0
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+-----------------------------------------------------------------------------
+
 Number of active cells: 1,536 (on 5 levels)
 Number of degrees of freedom: 20,756 (12,738+1,649+6,369)
 
@@ -2886,9 +2896,21 @@ Number of degrees of freedom: 33,859 (20,786+2,680+10,393)
 ...
 \end{lstlisting}
 
-This output was produced by a parameter file that, among other settings,
-contained the following values (we will discuss many such input files in
-Section~\ref{sec:cookbooks}:
+The output starts with a header that lists the used \aspect{}, \dealii{}, and
+\pfrst{} versions as well as compiler settings and the number of parallel
+processes used\footnote{If you used the \texttt{git} version control system to
+download \aspect{} and/or \dealii{}, as in this example, you will also get the
+unique revision identifier for the current version. This is very important if
+you modify either software between releases, or you use a development version
+that is not an official release. Note that this revision can not track changes
+you made to the software that are not part of a git commit.  Also it will
+only be updated every time the \texttt{cmake} configuration script is run.}.
+With this information we strive to make \aspect{} models as reproducible as
+possible.
+
+The following output depends on the model, and in this case was produced by
+a parameter file that, among other settings, contained the following values
+(we will discuss many such input files in Section~\ref{sec:cookbooks}:
 \lstinputlisting[language=prmfile]{cookbooks/overview/simple.prm.out}
 
 In other words, these run-time parameters specify that we should start with a

--- a/doc/modules/changes/20171212_gassmoeller
+++ b/doc/modules/changes/20171212_gassmoeller
@@ -1,0 +1,6 @@
+Changed: The ASPECT header (the first lines of each output and the
+beginning of log.txt files) now contains more information about the
+version of the software and the used dependencies. This will
+improve the reproducibility of old model results.
+<br>
+(Rene Gassmoeller, 2017/12/12)

--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -46,8 +46,6 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <aspect/compat.h>
 
-#include <cstring>
-
 namespace aspect
 {
   /**

--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -24,6 +24,7 @@
 
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/multithread_info.h>
+#include <deal.II/base/revision.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 
@@ -364,11 +365,24 @@ void print_aspect_header(Stream &stream)
     dealii::MultithreadInfo::n_threads();
   if (n_threads>1)
     stream << "--     . using " << n_threads << " threads " << (n_tasks == 1 ? "\n" : "each\n");
+
+  stream << "--     . using deal.II version " << DEAL_II_PACKAGE_VERSION << " (git revision "
+         << DEAL_II_GIT_SHORTREV << ")\n";
 #ifdef ASPECT_USE_PETSC
-  stream << "--     . using PETSc\n";
+  stream << "--     . using PETSc version "
+         << PETSC_VERSION_MAJOR    << '.'
+         << PETSC_VERSION_MINOR    << '.'
+         << PETSC_VERSION_SUBMINOR << '\n';
 #else
-  stream << "--     . using Trilinos\n";
+  stream << "--     . using Trilinos version "
+         << DEAL_II_TRILINOS_VERSION_MAJOR    << '.'
+         << DEAL_II_TRILINOS_VERSION_MINOR    << '.'
+         << DEAL_II_TRILINOS_VERSION_SUBMINOR << '\n';
 #endif
+  stream << "--     . using p4est version "
+         << DEAL_II_P4EST_VERSION_MAJOR << '.'
+         << DEAL_II_P4EST_VERSION_MINOR << '.'
+         << DEAL_II_P4EST_VERSION_SUBMINOR << '\n';
   stream << "-----------------------------------------------------------------------------\n"
          << std::endl;
 }

--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -23,8 +23,6 @@
 #define _aspect_global_h
 
 #include <deal.II/base/mpi.h>
-#include <deal.II/base/multithread_info.h>
-#include <deal.II/base/revision.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 
@@ -47,6 +45,8 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 
 #include <aspect/compat.h>
+
+#include <cstring>
 
 namespace aspect
 {
@@ -348,45 +348,7 @@ namespace aspect
  * running, with how many processes, and using which linear algebra library.
  */
 template <class Stream>
-void print_aspect_header(Stream &stream)
-{
-  const int n_tasks = dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
-
-  stream << "-----------------------------------------------------------------------------\n"
-         << "-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.\n"
-         << "--     . version 2.0.0-pre\n" //VERSION-INFO. Do not edit by hand.
-#ifdef DEBUG
-         << "--     . running in DEBUG mode\n"
-#else
-         << "--     . running in OPTIMIZED mode\n"
-#endif
-         << "--     . running with " << n_tasks << " MPI process" << (n_tasks == 1 ? "\n" : "es\n");
-  const int n_threads =
-    dealii::MultithreadInfo::n_threads();
-  if (n_threads>1)
-    stream << "--     . using " << n_threads << " threads " << (n_tasks == 1 ? "\n" : "each\n");
-
-  stream << "--     . using deal.II version " << DEAL_II_PACKAGE_VERSION << " (git revision "
-         << DEAL_II_GIT_SHORTREV << ")\n";
-#ifdef ASPECT_USE_PETSC
-  stream << "--     . using PETSc version "
-         << PETSC_VERSION_MAJOR    << '.'
-         << PETSC_VERSION_MINOR    << '.'
-         << PETSC_VERSION_SUBMINOR << '\n';
-#else
-  stream << "--     . using Trilinos version "
-         << DEAL_II_TRILINOS_VERSION_MAJOR    << '.'
-         << DEAL_II_TRILINOS_VERSION_MINOR    << '.'
-         << DEAL_II_TRILINOS_VERSION_SUBMINOR << '\n';
-#endif
-  stream << "--     . using p4est version "
-         << DEAL_II_P4EST_VERSION_MAJOR << '.'
-         << DEAL_II_P4EST_VERSION_MINOR << '.'
-         << DEAL_II_P4EST_VERSION_SUBMINOR << '\n';
-  stream << "-----------------------------------------------------------------------------\n"
-         << std::endl;
-}
-
+void print_aspect_header(Stream &stream);
 
 /**
  * A macro that is used in instantiating the ASPECT classes and functions for

--- a/include/aspect/revision.h.in
+++ b/include/aspect/revision.h.in
@@ -1,0 +1,49 @@
+/*
+  Copyright (C) 2017 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef _aspect_revision_h
+#define _aspect_revision_h
+
+// This configuration file will be copied to
+// ${CMAKE_BINARY_DIR}/include/aspect/revision.h
+// and filled with the current values by cmake upon configuration.
+
+/**
+ * Full version number of the ASPECT version.
+ */
+#define ASPECT_PACKAGE_VERSION "@ASPECT_PACKAGE_VERSION@"
+
+/**
+ * Name of the local git branch of the source directory.
+ */
+#define ASPECT_GIT_BRANCH "@ASPECT_GIT_BRANCH@"
+
+/**
+ * Full sha1 revision of the current git HEAD.
+ */
+#define ASPECT_GIT_REVISION "@ASPECT_GIT_REVISION@"
+
+/**
+ * Short sha1 revision of the current git HEAD.
+ */
+#define ASPECT_GIT_SHORTREV "@ASPECT_GIT_SHORTREV@"
+
+#endif

--- a/source/global.cc
+++ b/source/global.cc
@@ -20,9 +20,12 @@
 
 
 #include <aspect/global.h>
+#include <aspect/revision.h>
 
 #include <deal.II/base/multithread_info.h>
 #include <deal.II/base/revision.h>
+
+#include <cstring>
 
 namespace aspect
 {
@@ -114,39 +117,47 @@ void print_aspect_header(Stream &stream)
 
   stream << "-----------------------------------------------------------------------------\n"
          << "-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.\n"
-         << "--     . version 2.0.0-pre\n" //VERSION-INFO. Do not edit by hand.
-#ifdef DEBUG
-         << "--     . running in DEBUG mode\n"
-#else
-         << "--     . running in OPTIMIZED mode\n"
-#endif
-         << "--     . running with " << n_tasks << " MPI process" << (n_tasks == 1 ? "\n" : "es\n");
-  const int n_threads =
-    dealii::MultithreadInfo::n_threads();
-  if (n_threads>1)
-    stream << "--     . using " << n_threads << " threads " << (n_tasks == 1 ? "\n" : "each\n");
+         << "--     . version " << ASPECT_PACKAGE_VERSION;
+  if (strcmp(ASPECT_GIT_SHORTREV,"") != 0)
+    stream << " (git revision " << ASPECT_GIT_SHORTREV << ")\n";
+  else
+    stream << "\n";
 
-  stream << "--     . using deal.II version " << DEAL_II_PACKAGE_VERSION;
+  stream << "--     . using deal.II " << DEAL_II_PACKAGE_VERSION;
   if (strcmp(DEAL_II_GIT_SHORTREV,"") != 0)
     stream << " (git revision " << DEAL_II_GIT_SHORTREV << ")\n";
   else
     stream << "\n";
 
 #ifdef ASPECT_USE_PETSC
-  stream << "--     . using PETSc version "
+  stream << "--     . using PETSc "
          << PETSC_VERSION_MAJOR    << '.'
          << PETSC_VERSION_MINOR    << '.'
          << PETSC_VERSION_SUBMINOR << '\n';
 #else
-  stream << "--     . using Trilinos version "
+  stream << "--     . using Trilinos "
          << DEAL_II_TRILINOS_VERSION_MAJOR    << '.'
          << DEAL_II_TRILINOS_VERSION_MINOR    << '.'
          << DEAL_II_TRILINOS_VERSION_SUBMINOR << '\n';
 #endif
-  stream << "--     . using p4est version "
+  stream << "--     . using p4est "
          << DEAL_II_P4EST_VERSION_MAJOR << '.'
          << DEAL_II_P4EST_VERSION_MINOR << '.'
          << DEAL_II_P4EST_VERSION_SUBMINOR << '\n';
+
+#ifdef DEBUG
+         stream << "--     . running in DEBUG mode\n"
+#else
+         stream << "--     . running in OPTIMIZED mode\n"
+#endif
+                << "--     . running with " << n_tasks << " MPI process" << (n_tasks == 1 ? "\n" : "es\n");
+
+  const int n_threads =
+    dealii::MultithreadInfo::n_threads();
+  if (n_threads>1)
+    stream << "--     . using " << n_threads << " threads " << (n_tasks == 1 ? "\n" : "each\n");
+
+
   stream << "-----------------------------------------------------------------------------\n"
          << std::endl;
 }

--- a/source/global.cc
+++ b/source/global.cc
@@ -21,6 +21,9 @@
 
 #include <aspect/global.h>
 
+#include <deal.II/base/multithread_info.h>
+#include <deal.II/base/revision.h>
+
 namespace aspect
 {
   // The following are a set of global constants which may be used by ASPECT:
@@ -101,3 +104,52 @@ namespace aspect
   }
 
 }
+
+
+
+template <class Stream>
+void print_aspect_header(Stream &stream)
+{
+  const int n_tasks = dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+
+  stream << "-----------------------------------------------------------------------------\n"
+         << "-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.\n"
+         << "--     . version 2.0.0-pre\n" //VERSION-INFO. Do not edit by hand.
+#ifdef DEBUG
+         << "--     . running in DEBUG mode\n"
+#else
+         << "--     . running in OPTIMIZED mode\n"
+#endif
+         << "--     . running with " << n_tasks << " MPI process" << (n_tasks == 1 ? "\n" : "es\n");
+  const int n_threads =
+    dealii::MultithreadInfo::n_threads();
+  if (n_threads>1)
+    stream << "--     . using " << n_threads << " threads " << (n_tasks == 1 ? "\n" : "each\n");
+
+  stream << "--     . using deal.II version " << DEAL_II_PACKAGE_VERSION;
+  if (strcmp(DEAL_II_GIT_SHORTREV,"") != 0)
+    stream << " (git revision " << DEAL_II_GIT_SHORTREV << ")\n";
+  else
+    stream << "\n";
+
+#ifdef ASPECT_USE_PETSC
+  stream << "--     . using PETSc version "
+         << PETSC_VERSION_MAJOR    << '.'
+         << PETSC_VERSION_MINOR    << '.'
+         << PETSC_VERSION_SUBMINOR << '\n';
+#else
+  stream << "--     . using Trilinos version "
+         << DEAL_II_TRILINOS_VERSION_MAJOR    << '.'
+         << DEAL_II_TRILINOS_VERSION_MINOR    << '.'
+         << DEAL_II_TRILINOS_VERSION_SUBMINOR << '\n';
+#endif
+  stream << "--     . using p4est version "
+         << DEAL_II_P4EST_VERSION_MAJOR << '.'
+         << DEAL_II_P4EST_VERSION_MINOR << '.'
+         << DEAL_II_P4EST_VERSION_SUBMINOR << '\n';
+  stream << "-----------------------------------------------------------------------------\n"
+         << std::endl;
+}
+
+template void print_aspect_header<std::ostream> (std::ostream &stream);
+template void print_aspect_header<std::ofstream> (std::ofstream &stream);

--- a/source/global.cc
+++ b/source/global.cc
@@ -119,13 +119,13 @@ void print_aspect_header(Stream &stream)
          << "-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.\n"
          << "--     . version " << ASPECT_PACKAGE_VERSION;
   if (strcmp(ASPECT_GIT_SHORTREV,"") != 0)
-    stream << " (git revision " << ASPECT_GIT_SHORTREV << ")\n";
+    stream << " (" << ASPECT_GIT_BRANCH << ", " << ASPECT_GIT_SHORTREV << ")\n";
   else
     stream << "\n";
 
   stream << "--     . using deal.II " << DEAL_II_PACKAGE_VERSION;
   if (strcmp(DEAL_II_GIT_SHORTREV,"") != 0)
-    stream << " (git revision " << DEAL_II_GIT_SHORTREV << ")\n";
+    stream << " (" << DEAL_II_GIT_BRANCH << ", " << DEAL_II_GIT_SHORTREV << ")\n";
   else
     stream << "\n";
 

--- a/source/global.cc
+++ b/source/global.cc
@@ -146,11 +146,11 @@ void print_aspect_header(Stream &stream)
          << DEAL_II_P4EST_VERSION_SUBMINOR << '\n';
 
 #ifdef DEBUG
-         stream << "--     . running in DEBUG mode\n"
+  stream << "--     . running in DEBUG mode\n"
 #else
-         stream << "--     . running in OPTIMIZED mode\n"
+  stream << "--     . running in OPTIMIZED mode\n"
 #endif
-                << "--     . running with " << n_tasks << " MPI process" << (n_tasks == 1 ? "\n" : "es\n");
+         << "--     . running with " << n_tasks << " MPI process" << (n_tasks == 1 ? "\n" : "es\n");
 
   const int n_threads =
     dealii::MultithreadInfo::n_threads();


### PR DESCRIPTION
As mentioned in the changelog entry. This change will only require a rerun of cmake and a recompilation of global.cc if the git HEAD changes, no full recompilation required. I several times wished I had this output for old models.
+1 for reproducibility of old models.