### PR TITLE
Fix: Do not allocate unnecessary preconditioner matrix blocks

### DIFF
--- a/doc/modules/changes/20171222_tjhei
+++ b/doc/modules/changes/20171222_tjhei
@@ -1,0 +1,3 @@
+Fixed: Memory consumption for matrix storage got reduced significantly by not allocating unused entries in the preconditioner matrix.
+<br>
+(Timo Heister, 2017/12/22)

--- a/tests/matrix_nonzeros_1/screen-output
+++ b/tests/matrix_nonzeros_1/screen-output
@@ -18,13 +18,13 @@ system matrix nnz by block:
            0           0         972           0
            0           0           0         289
 
-Total system preconditioner matrix memory consumption: 0.04 MB.
-Total system preconditioner matrix nnz: 1,472
+Total system preconditioner matrix memory consumption: 0.02 MB.
+Total system preconditioner matrix nnz: 211
 system preconditioner matrix nnz by block: 
          162           0           0           0
            0          49           0           0
-           0           0         972           0
-           0           0           0         289
+           0           0           0           0
+           0           0           0           0
 
 
 Termination requested by criterion: end time

--- a/tests/matrix_nonzeros_2/screen-output
+++ b/tests/matrix_nonzeros_2/screen-output
@@ -19,13 +19,13 @@ system matrix nnz by block:
            0           0           0         289           0
            0           0           0           0           0
 
-Total system preconditioner matrix memory consumption: 0.04 MB.
-Total system preconditioner matrix nnz: 629
+Total system preconditioner matrix memory consumption: 0.03 MB.
+Total system preconditioner matrix nnz: 221
 system preconditioner matrix nnz by block: 
          162           0           0           0           0
            0          49           0           0           0
-           0           0         129           0           0
-           0           0           0         289           0
+           0           0          10           0           0
+           0           0           0           0           0
            0           0           0           0           0
 
      Number of advected particles: 100

--- a/tests/matrix_nonzeros_3/screen-output
+++ b/tests/matrix_nonzeros_3/screen-output
@@ -19,13 +19,13 @@ system matrix nnz by block:
            0           0           0         972           0
            0           0           0           0           0
 
-Total system preconditioner matrix memory consumption: 0.05 MB.
-Total system preconditioner matrix nnz: 1,312
+Total system preconditioner matrix memory consumption: 0.03 MB.
+Total system preconditioner matrix nnz: 221
 system preconditioner matrix nnz by block: 
          162           0           0           0           0
            0          49           0           0           0
-           0           0         129           0           0
-           0           0           0         972           0
+           0           0          10           0           0
+           0           0           0           0           0
            0           0           0           0           0
 
      Number of advected particles: 100

--- a/tests/pressure_constraint/screen-output
+++ b/tests/pressure_constraint/screen-output
@@ -23,12 +23,12 @@ system matrix nnz by block:
          570           1           0
            0           0         777
 
-Total system preconditioner matrix memory consumption: 0.04 MB.
-Total system preconditioner matrix nnz: 2,062
+Total system preconditioner matrix memory consumption: 0.03 MB.
+Total system preconditioner matrix nnz: 1,303
 system preconditioner matrix nnz by block: 
        1,122           0           0
            0         163           0
-           0           0         777
+           0           0          18
 
 
 *** Timestep 1:  t=0.1 seconds
@@ -49,12 +49,12 @@ system matrix nnz by block:
          570           1           0
            0           0         777
 
-Total system preconditioner matrix memory consumption: 0.04 MB.
-Total system preconditioner matrix nnz: 2,062
+Total system preconditioner matrix memory consumption: 0.03 MB.
+Total system preconditioner matrix nnz: 1,303
 system preconditioner matrix nnz by block: 
        1,122           0           0
            0         163           0
-           0           0         777
+           0           0          18
 
 
 Termination requested by criterion: end time


### PR DESCRIPTION
The system_preconditioner_matrix is only used for the Stokes system, so
there is no need to allocate entries for temperature/composition. Fix
this.