### PR TITLE
Try something with the format for references.

### DIFF
--- a/jabref-template/listrefs.layout
+++ b/jabref-template/listrefs.layout
@@ -1,17 +1,70 @@
-\begingroup{year}<tr class="show"><td><h3>\format[HTMLChars]{\year}</td></tr></h3>
+\begingroup{year}
+  <tr class="show"><td><h3>\format[HTMLChars]{\year}</td></tr></h3>
 \endgroup{year}
 
 <tr id="\format{\bibtexkey}" class="entry">
-	<td>\begin{author}\format[Authors(FirstFirst,Initials,Comma,Comma),HTMLChars]{\author}\end{author} (\year)<br> <b>\format[HTMLChars]{\title}</b><br>\begin{journal}\format[HTMLChars]{\journal}.\end{journal}\begin{booktitle}, In \format[HTMLChars]{\booktitle}.\end{booktitle}\begin{howpublished}, \howpublished.\end{howpublished}\begin{school}. Thesis at: \format[HTMLChars]{\school}.\end{school}\begin{address} \format[HTMLChars]{\address}\end{address}\begin{month}, \format[HTMLChars]{\month}, \year.\end{month} \begin{volume} Vol. \volume\end{volume}\begin{number}(\format[FormatPagesForHTML]{\number})\end{number}\begin{pages}, pp. \format[FormatPagesForHTML]{\pages}.\end{pages}\begin{publisher} \format[HTMLChars]{\publisher}.\end{publisher}
-	<p class="infolinks">\begin{review} [<a href="javascript:toggleInfo('\format{\bibtexkey}','review')">Review</a>] \end{review} [<a href="javascript:toggleInfo('\format{\bibtexkey}','bibtex')">BibTeX</a>]\begin{doi} [<a href="\format[DOICheck]{\doi}" target="_blank">DOI</a>]\end{doi}\begin{url} [<a href="\format{\url}" target="_blank">URL</a>]\end{url}\begin{file} [<a href="\format[WrapFileLinks(\r,,pdf)]{\file}" target="_blank">PDF</a>]\end{file}</p>
-	</td>
-</tr>\begin{abstract}
-<tr id="abs_\format{\bibtexkey}" class="abstract noshow">
-	<td><b>Abstract</b>: \format[HTMLChars]{\abstract}</td>
-</tr>\end{abstract}\begin{review}
-<tr id="rev_\format{\bibtexkey}" class="review noshow">
-	<td><b>Review</b>: \format[HTMLChars]{\review}</td>
-</tr>\end{review}
+  <td>
+    \begin{author}\format[Authors(FirstFirst,Initials,Comma,Comma),HTMLChars]{\author}\end{author}
+    (\year)
+    <br>
+    <b>
+      \format[HTMLChars]{\title}
+    </b>
+
+    <br>
+
+    \begin{journal} \format[HTMLChars]{\journal}.\end{journal}
+    \begin{booktitle}, In: \format[HTMLChars]{\booktitle}.\end{booktitle}
+    \begin{howpublished}, \howpublished.\end{howpublished}
+    \begin{school}. Thesis at: \format[HTMLChars]{\school}.\end{school}
+    \begin{address} \format[HTMLChars]{\address}\end{address}
+    \begin{month}, \format[HTMLChars]{\month}, \year.\end{month}
+    \begin{volume} vol. \volume\end{volume}
+    \begin{number}(\format[FormatPagesForHTML]{\number})\end{number}
+    \begin{pages}, pp. \format[FormatPagesForHTML]{\pages}.\end{pages}
+    \begin{publisher} \format[HTMLChars]{\publisher}.\end{publisher}
+    
+    <p class="infolinks">
+      \begin{review}
+        [<a href="javascript:toggleInfo('\format{\bibtexkey}','review')">Review</a>]
+      \end{review}
+
+      [<a href="javascript:toggleInfo('\format{\bibtexkey}','bibtex')">BibTeX</a>]
+
+      \begin{doi}
+	[<a href="\format[DOICheck]{\doi}" target="_blank">DOI</a>]
+      \end{doi}
+
+      \begin{url}
+        [<a href="\format{\url}" target="_blank">URL</a>]
+      \end{url}
+
+      \begin{file}
+        [<a href="\format[WrapFileLinks(\r,,pdf)]{\file}" target="_blank">PDF</a>]
+      \end{file}
+    </p>
+
+    <br>
+  </td>
+</tr>
+
+\begin{abstract}
+  <tr id="abs_\format{\bibtexkey}" class="abstract noshow">
+    <td>
+      <b>Abstract</b>: \format[HTMLChars]{\abstract}
+    </td>
+  </tr>
+\end{abstract}
+
+\begin{review}
+  <tr id="rev_\format{\bibtexkey}" class="review noshow">
+    <td>
+      <b>Review</b>: \format[HTMLChars]{\review}
+    </td>
+  </tr>
+\end{review}
+
+
 <tr id="bib_\format{\bibtexkey}" class="bibtex noshow">
 <td><b>BibTeX</b>:
 <pre>


### PR DESCRIPTION
The patch disentangles the formatting used in the file (without any actual change other than making it more readable what is happening here).

The only change is adding a `<br>` at the end of each entry. That's because https://aspect.geodynamics.org/publications.html just looks a bit unkempt between entries -- the text would be easier to read if there was more space between entries.

I don't know how this new formatting is going to work out, but thought I'd give it a shot. I may tweak it some further later on.