### PR TITLE
Simplify advection preconditioner lifetime

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -533,7 +533,7 @@ namespace aspect
        * <code>source/simulator/assembly.cc</code>.
        */
       void build_advection_preconditioner (const AdvectionField &advection_field,
-                                           std_cxx11::shared_ptr<aspect::LinearAlgebra::PreconditionILU> &preconditioner);
+                                           aspect::LinearAlgebra::PreconditionILU &preconditioner);
 
       /**
        * Initiate the assembly of the Stokes matrix and right hand side.
@@ -1582,9 +1582,6 @@ namespace aspect
 
       std_cxx11::shared_ptr<LinearAlgebra::PreconditionAMG>     Amg_preconditioner;
       std_cxx11::shared_ptr<LinearAlgebra::PreconditionILU>     Mp_preconditioner;
-      std_cxx11::shared_ptr<LinearAlgebra::PreconditionILU>     T_preconditioner;
-//TODO: use n_compositional_field separate preconditioners
-      std_cxx11::shared_ptr<LinearAlgebra::PreconditionILU>     C_preconditioner;
 
       bool                                                      rebuild_sparsity_and_matrices;
       bool                                                      rebuild_stokes_matrix;

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -726,7 +726,7 @@ namespace aspect
   template <int dim>
   void
   Simulator<dim>::build_advection_preconditioner(const AdvectionField &advection_field,
-                                                 std_cxx11::shared_ptr<aspect::LinearAlgebra::PreconditionILU> &preconditioner)
+                                                 LinearAlgebra::PreconditionILU &preconditioner)
   {
     switch (advection_field.field_type)
       {
@@ -747,8 +747,7 @@ namespace aspect
       }
 
     const unsigned int block_idx = advection_field.block_index(introspection);
-    preconditioner.reset (new LinearAlgebra::PreconditionILU());
-    preconditioner->initialize (system_matrix.block(block_idx, block_idx));
+    preconditioner.initialize (system_matrix.block(block_idx, block_idx));
     computing_timer.exit_section();
   }
 
@@ -1125,7 +1124,7 @@ namespace aspect
                                                                      const internal::Assembly::CopyData::StokesSystem<dim> &data); \
   template void Simulator<dim>::assemble_stokes_system (); \
   template void Simulator<dim>::build_advection_preconditioner (const AdvectionField &, \
-                                                                std_cxx11::shared_ptr<aspect::LinearAlgebra::PreconditionILU> &preconditioner); \
+                                                                aspect::LinearAlgebra::PreconditionILU &preconditioner); \
   template void Simulator<dim>::local_assemble_advection_system ( \
                                                                   const AdvectionField          &advection_field, \
                                                                   const Vector<double>           &viscosity_per_cell, \

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -424,17 +424,16 @@ namespace aspect
                 ExcMessage ("The " + field_name + " equation can not be solved, because the matrix is zero, "
                             "but the right-hand side is nonzero."));
 
+    LinearAlgebra::PreconditionILU preconditioner;
+    build_advection_preconditioner(advection_field, preconditioner);
+
     if (advection_field.is_temperature())
       {
-        build_advection_preconditioner(advection_field,
-                                       T_preconditioner);
         computing_timer.enter_section ("   Solve temperature system");
         pcout << "   Solving temperature system... " << std::flush;
       }
     else
       {
-        build_advection_preconditioner(advection_field,
-                                       C_preconditioner);
         computing_timer.enter_section ("   Solve composition system");
         pcout << "   Solving "
               << introspection.name_for_compositional_index(advection_field.compositional_variable)
@@ -470,11 +469,7 @@ namespace aspect
         solver.solve (system_matrix.block(block_idx,block_idx),
                       distributed_solution.block(block_idx),
                       system_rhs.block(block_idx),
-                      (advection_field.is_temperature()
-                       ?
-                       *T_preconditioner
-                       :
-                       *C_preconditioner));
+                      preconditioner);
       }
     // if the solver fails, report the error from processor 0 with some additional
     // information about its location, and throw a quiet exception on all other


### PR DESCRIPTION
The advection (temperature and composition) preconditioner is always re-
initialized before using it, so keeping them around afterwards is not
necessary. This should also save some memory.