### PR TITLE
Create boundary velocity manager

### DIFF
--- a/doc/modules/changes/20180105_gassmoeller
+++ b/doc/modules/changes/20180105_gassmoeller
@@ -1,0 +1,8 @@
+Changed: The boundary velocity plugins are now controlled by
+a manager class that allows assigning several plugins at the same boundary. 
+This behavior is identical to the boundary temperature and boundary
+composition plugins with the additional possibiltiy of assigning different
+plugins to different boundaries, and only prescribing certain
+components of the velocity.
+<br>
+(Rene Gassmoeller, 2018/01/05)

--- a/include/aspect/boundary_velocity/interface.h
+++ b/include/aspect/boundary_velocity/interface.h
@@ -138,22 +138,6 @@ namespace aspect
         update ();
 
         /**
-         * Declare the parameters of all known boundary velocity plugins, as
-         * well as the ones this class has itself.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * This determines which boundary velocity objects will be created;
-         * then let these objects read their parameters as well.
-         */
-        void
-        parse_parameters (ParameterHandler &prm);
-
-        /**
          * A function that calls the boundary_velocity functions of all the
          * individual boundary velocity objects and uses the stored operators
          * to combine them.
@@ -214,6 +198,22 @@ namespace aspect
          */
         const std::set<types::boundary_id> &
         get_tangential_boundary_velocity_indicators () const;
+
+        /**
+         * Declare the parameters of all known boundary velocity plugins, as
+         * well as the ones this class has itself.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         * This determines which boundary velocity objects will be created;
+         * then let these objects read their parameters as well.
+         */
+        void
+        parse_parameters (ParameterHandler &prm);
 
         /**
          * Go through the list of all boundary velocity models that have been selected in

--- a/include/aspect/boundary_velocity/interface.h
+++ b/include/aspect/boundary_velocity/interface.h
@@ -172,28 +172,41 @@ namespace aspect
 
 
         /**
-         * Return a list of names of all boundary velocity models currently
-         * used in the computation, as specified in the input file.
+         * Return the names of all prescribed boundary velocity models currently
+         * used in the computation as specified in the input file. The function
+         * returns a map between a boundary identifier and a pair. The
+         * first part of the pair is a string that represents the prescribed
+         * velocity components on this boundary (e.g. y, xz, or xyz) and the
+         * second part is a vector of strings that represent the names of
+         * boundary velocity plugins for this boundary.
+         * If there are no prescribed boundary velocity plugins
+         * for a particular boundary, this boundary identifier will not appear
+         * in the map.
          */
         const std::map<types::boundary_id, std::pair<std::string,std::vector<std::string> > > &
         get_active_boundary_velocity_names () const;
 
         /**
-         * Return a list of pointers to all boundary velocity models
+         * Return pointers to all boundary velocity models
          * currently used in the computation, as specified in the input file.
+         * The function returns a map between a boundary identifier and a vector
+         * of shared pointers that represent the names of prescribed velocity
+         * boundary models for this boundary. If there are no prescribed
+         * boundary velocity plugins for a particular boundary this boundary
+         * identifier will not appear in the map.
          */
         const std::map<types::boundary_id,std::vector<std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > > > &
         get_active_boundary_velocity_conditions () const;
 
         /**
-         * Return a list of boundary ids, on which the velocity is prescribed
+         * Return a list of boundary ids on which the velocity is prescribed
          * to be zero (no-slip).
          */
         const std::set<types::boundary_id> &
         get_zero_boundary_velocity_indicators () const;
 
         /**
-         * Return a list of boundary ids, on which the velocity is prescribed
+         * Return a list of boundary ids on which the velocity is prescribed
          * to be tangential (free-slip).
          */
         const std::set<types::boundary_id> &

--- a/include/aspect/boundary_velocity/interface.h
+++ b/include/aspect/boundary_velocity/interface.h
@@ -202,6 +202,20 @@ namespace aspect
         get_active_boundary_velocity_conditions () const;
 
         /**
+         * Return a list of boundary ids, on which the velocity is prescribed
+         * to be zero (no-slip).
+         */
+        const std::set<types::boundary_id> &
+        get_zero_boundary_velocity_indicators () const;
+
+        /**
+         * Return a list of boundary ids, on which the velocity is prescribed
+         * to be tangential (free-slip).
+         */
+        const std::set<types::boundary_id> &
+        get_tangential_boundary_velocity_indicators () const;
+
+        /**
          * Go through the list of all boundary velocity models that have been selected in
          * the input file (and are consequently currently active) and see if one
          * of them has the desired type specified by the template argument. If so,
@@ -250,6 +264,18 @@ namespace aspect
          * plugins are used for all components.
          */
         std::map<types::boundary_id, std::pair<std::string,std::vector<std::string> > > boundary_velocity_indicators;
+
+        /**
+         * A set of boundary indicators, on which velocities are prescribed to
+         * zero (no-slip).
+         */
+        std::set<types::boundary_id> zero_velocity_boundary_indicators;
+
+        /**
+         * A set of boundary indicators, on which velocities are prescribed to
+         * be tangential (free-slip).
+         */
+        std::set<types::boundary_id> tangential_velocity_boundary_indicators;
     };
 
 

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -388,8 +388,6 @@ namespace aspect
 
     std::set<types::boundary_id> fixed_temperature_boundary_indicators;
     std::set<types::boundary_id> fixed_composition_boundary_indicators;
-    std::set<types::boundary_id> zero_velocity_boundary_indicators;
-    std::set<types::boundary_id> tangential_velocity_boundary_indicators;
 
     /**
      * Map from boundary id to a pair "components", "traction boundary type",

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -392,14 +392,6 @@ namespace aspect
     std::set<types::boundary_id> tangential_velocity_boundary_indicators;
 
     /**
-     * Map from boundary id to a pair "components", "velocity boundary type",
-     * where components is of the format "[x][y][z]" and the velocity type is
-     * mapped to one of the plugins of velocity boundary conditions (e.g.
-     * "function")
-     */
-    std::map<types::boundary_id, std::pair<std::string,std::string> > prescribed_velocity_boundary_indicators;
-
-    /**
      * Map from boundary id to a pair "components", "traction boundary type",
      * where components is of the format "[x][y][z]" and the traction type is
      * mapped to one of the plugins of traction boundary conditions (e.g.

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1459,7 +1459,7 @@ namespace aspect
       InitialComposition::Manager<dim>                                        initial_composition_manager;
       InitialTemperature::Manager<dim>                                        initial_temperature_manager;
       const std_cxx11::unique_ptr<AdiabaticConditions::Interface<dim> >       adiabatic_conditions;
-      std::map<types::boundary_id,std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > > boundary_velocity;
+      BoundaryVelocity::Manager<dim>                                          boundary_velocity_manager;
       std::map<types::boundary_id,std_cxx11::shared_ptr<BoundaryTraction::Interface<dim> > > boundary_traction;
 
       /**

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -80,6 +80,7 @@ namespace aspect
 
   namespace BoundaryVelocity
   {
+    template <int dim> class Manager;
     template <int dim> class Interface;
   }
 
@@ -625,9 +626,20 @@ namespace aspect
 
       /**
        * Return the map of prescribed_boundary_velocity
+       *
+       * @deprecated: Use get_boundary_velocity_manager() instead.
        */
       const std::map<types::boundary_id,std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > >
-      get_prescribed_boundary_velocity () const;
+      get_prescribed_boundary_velocity () const DEAL_II_DEPRECATED;
+
+      /**
+       * Return an reference to the manager of the boundary velocity models.
+       * This can then i.e. be used to get the names of the boundary velocity
+       * models used in a computation, or to compute the boundary velocity
+       * for a given position.
+       */
+      const BoundaryVelocity::Manager<dim> &
+      get_boundary_velocity_manager () const;
 
       /**
        * Return a pointer to the manager of the heating model.

--- a/source/boundary_velocity/ascii_data.cc
+++ b/source/boundary_velocity/ascii_data.cc
@@ -38,13 +38,15 @@ namespace aspect
     void
     AsciiData<dim>::initialize ()
     {
-      const std::map<types::boundary_id,std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > >
-      bvs = this->get_prescribed_boundary_velocity();
-      for (typename std::map<types::boundary_id,std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > >::const_iterator
+      const std::map<types::boundary_id,std::vector<std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > > >
+      bvs = this->get_boundary_velocity_manager().get_active_boundary_velocity_conditions();
+      for (typename std::map<types::boundary_id,std::vector<std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > > >::const_iterator
            p = bvs.begin();
            p != bvs.end(); ++p)
         {
-          if (p->second.get() == this)
+          for (typename std::vector<std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > >::const_iterator
+              plugin = p->second.begin(); plugin != p->second.end();++plugin)
+          if (plugin->get() == this)
             boundary_ids.insert(p->first);
         }
       AssertThrow(*(boundary_ids.begin()) != numbers::invalid_boundary_id,

--- a/source/boundary_velocity/ascii_data.cc
+++ b/source/boundary_velocity/ascii_data.cc
@@ -45,9 +45,9 @@ namespace aspect
            p != bvs.end(); ++p)
         {
           for (typename std::vector<std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > >::const_iterator
-              plugin = p->second.begin(); plugin != p->second.end();++plugin)
-          if (plugin->get() == this)
-            boundary_ids.insert(p->first);
+               plugin = p->second.begin(); plugin != p->second.end(); ++plugin)
+            if (plugin->get() == this)
+              boundary_ids.insert(p->first);
         }
       AssertThrow(*(boundary_ids.begin()) != numbers::invalid_boundary_id,
                   ExcMessage("Did not find the boundary indicator for the prescribed data plugin."));

--- a/source/boundary_velocity/interface.cc
+++ b/source/boundary_velocity/interface.cc
@@ -53,38 +53,6 @@ namespace aspect
 
 
     template <int dim>
-    Tensor<1,dim>
-    Interface<dim>::boundary_velocity (const Point<dim> &) const
-    {
-      /**
-       * We can only get here if the new-style boundary_velocity function (with
-       * two arguments) calls it. This means that the derived class did not override
-       * the new-style boundary_velocity function, and because we are here, it also
-       * did not override this old-style boundary_velocity function (with one argument).
-       */
-      Assert (false, ExcMessage ("A derived class needs to override either the "
-                                 "boundary_velocity(position) (deprecated) or "
-                                 "boundary_velocity(types::boundary_id,position) "
-                                 "function."));
-
-      return Tensor<1,dim>();
-    }
-
-
-    DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-    template <int dim>
-    Tensor<1,dim>
-    Interface<dim>::boundary_velocity (const types::boundary_id ,
-                                       const Point<dim> &position) const
-    {
-      // Call the old-style function without the boundary id to maintain backwards
-      // compatibility. Normally the derived class should override this function.
-      return this->boundary_velocity(position);
-    }
-    DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
-
-
-    template <int dim>
     void
     Interface<dim>::
     declare_parameters (dealii::ParameterHandler &)
@@ -97,8 +65,33 @@ namespace aspect
     {}
 
 
-// -------------------------------- Deal with registering boundary_velocity models and automating
-// -------------------------------- their setup and selection at run time
+
+    // ------------------------------ Manager -----------------------------
+    // -------------------------------- Deal with registering boundary_velocity models and automating
+    // -------------------------------- their setup and selection at run time
+
+    template <int dim>
+    Manager<dim>::~Manager()
+    {}
+
+
+
+    template <int dim>
+    void
+    Manager<dim>::update ()
+    {
+      for (typename std::map<types::boundary_id,std::vector<std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > > >::const_iterator
+           boundary = boundary_velocity_objects.begin();
+           boundary != boundary_velocity_objects.end(); ++boundary)
+        for (typename std::vector<std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim>>>::const_iterator
+             p = boundary->second.begin();
+             p != boundary->second.end(); ++p)
+          (*p)->update();
+
+      return;
+    }
+
+
 
     namespace
     {
@@ -110,13 +103,12 @@ namespace aspect
     }
 
 
-
     template <int dim>
     void
-    register_boundary_velocity (const std::string &name,
-                                const std::string &description,
-                                void (*declare_parameters_function) (ParameterHandler &),
-                                Interface<dim> *(*factory_function) ())
+    Manager<dim>::register_boundary_velocity (const std::string &name,
+                                              const std::string &description,
+                                              void (*declare_parameters_function) (ParameterHandler &),
+                                              Interface<dim> *(*factory_function) ())
     {
       std_cxx11::get<dim>(registered_plugins).register_plugin (name,
                                                                description,
@@ -126,28 +118,290 @@ namespace aspect
 
 
     template <int dim>
-    Interface<dim> *
-    create_boundary_velocity (const std::string &name)
+    void
+    Manager<dim>::parse_parameters (ParameterHandler &prm)
     {
-      Interface<dim> *plugin = std_cxx11::get<dim>(registered_plugins).create_plugin (name,
-                                                                                      "Boundary velocity model::Plugin name");
-      return plugin;
+      // Check if the deprecated parameter was set
+      std::string input_string;
+      {
+        std::string deprecated_input_string;
+
+        prm.enter_subsection ("Model settings");
+        {
+          deprecated_input_string = prm.get("Prescribed velocity boundary indicators");
+        }
+        prm.leave_subsection ();
+
+        prm.enter_subsection("Boundary velocity model");
+        {
+          input_string = prm.get("List of model names");
+        }
+        prm.leave_subsection ();
+
+        if (input_string != "")
+          {
+            Assert(deprecated_input_string == "unspecified", ExcMessage(""));
+          }
+
+        if (deprecated_input_string != "unspecified")
+          {
+            Assert(input_string == "", ExcMessage(""));
+            input_string = deprecated_input_string;
+          }
+      }
+
+      // find out which plugins are requested and the various other
+      // parameters we declare here
+      const std::vector<std::string> x_boundary_velocity_indicators
+        = Utilities::split_string_list(input_string);
+
+      for (std::vector<std::string>::const_iterator p = x_boundary_velocity_indicators.begin();
+           p != x_boundary_velocity_indicators.end(); ++p)
+        {
+          // each entry has the format (white space is optional):
+          // <id> [x][y][z] : <value (might have spaces)>
+          //
+          // first tease apart the two halves
+          const std::vector<std::string> split_parts = Utilities::split_string_list (*p, ':');
+          AssertThrow (split_parts.size() == 2,
+                       ExcMessage ("The format for prescribed velocity boundary indicators "
+                                   "requires that each entry has the form `"
+                                   "<id> [x][y][z] : <value>', but there does not "
+                                   "appear to be a colon in the entry <"
+                                   + *p
+                                   + ">."));
+
+          // the easy part: get the value
+          const std::string value = split_parts[1];
+
+          // now for the rest. since we don't know whether there is a
+          // component selector, start reading at the end and subtracting
+          // letters x, y and z
+          std::string key_and_comp = split_parts[0];
+          std::string comp;
+          while ((key_and_comp.size()>0) &&
+                 ((key_and_comp[key_and_comp.size()-1] == 'x')
+                  ||
+                  (key_and_comp[key_and_comp.size()-1] == 'y')
+                  ||
+                  ((key_and_comp[key_and_comp.size()-1] == 'z') && (dim==3))))
+            {
+              comp += key_and_comp[key_and_comp.size()-1];
+              key_and_comp.erase (--key_and_comp.end());
+            }
+
+          // we've stopped reading component selectors now. there are three
+          // possibilities:
+          // - no characters are left. this means that key_and_comp only
+          //   consisted of a single word that only consisted of 'x', 'y'
+          //   and 'z's. then this would have been a mistake to classify
+          //   as a component selector, and we better undo it
+          // - the last character of key_and_comp is not a whitespace. this
+          //   means that the last word in key_and_comp ended in an 'x', 'y'
+          //   or 'z', but this was not meant to be a component selector.
+          //   in that case, put these characters back.
+          // - otherwise, we split successfully. eat spaces that may be at
+          //   the end of key_and_comp to get key
+          if (key_and_comp.size() == 0)
+            key_and_comp.swap (comp);
+          else if (key_and_comp[key_and_comp.size()-1] != ' ')
+            {
+              key_and_comp += comp;
+              comp = "";
+            }
+          else
+            {
+              while ((key_and_comp.size()>0) && (key_and_comp[key_and_comp.size()-1] == ' '))
+                key_and_comp.erase (--key_and_comp.end());
+            }
+
+          // finally, try to translate the key into a boundary_id. then
+          // make sure we haven't seen it yet
+          types::boundary_id boundary_id;
+          try
+            {
+              boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id(key_and_comp);
+            }
+          catch (const std::string &error)
+            {
+              AssertThrow (false, ExcMessage ("While parsing the entry <Model settings/Prescribed "
+                                              "velocity indicators>, there was an error. Specifically, "
+                                              "the conversion function complained as follows: "
+                                              + error));
+            }
+
+          if (boundary_velocity_indicators.find(boundary_id) != boundary_velocity_indicators.end())
+            {
+              Assert(boundary_velocity_indicators[boundary_id].first == comp,
+                     ExcMessage("Different velocity plugins for the same boundary have to have the same component selector. "
+                                "This was not the case for boundary: " + key_and_comp +
+                                ", for plugin: " + value + ", with component selector: " + comp));
+
+              // finally, put it into the list
+              boundary_velocity_indicators[boundary_id].second.push_back(value);
+            }
+          else
+            {
+              boundary_velocity_indicators[boundary_id] = std::make_pair(comp,std::vector<std::string>(1,value));
+            }
+        }
+
+      // go through the list, create objects and let them parse
+      // their own parameters
+      for (std::map<types::boundary_id, std::pair<std::string,std::vector<std::string> > >::iterator
+           boundary_id = boundary_velocity_indicators.begin();
+           boundary_id != boundary_velocity_indicators.end(); ++boundary_id)
+        {
+          for (std::vector<std::string>::iterator
+               name = boundary_id->second.second.begin();
+               name != boundary_id->second.second.end(); ++name)
+            {
+              boundary_velocity_objects[boundary_id->first].push_back(
+                std_cxx11::shared_ptr<Interface<dim> > (std_cxx11::get<dim>(registered_plugins)
+                                                        .create_plugin (*name,
+                                                                        "Boundary velocity::Model names")));
+
+              if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(boundary_velocity_objects[boundary_id->first].back().get()))
+                sim->initialize_simulator (this->get_simulator());
+
+              boundary_velocity_objects[boundary_id->first].back()->parse_parameters (prm);
+              boundary_velocity_objects[boundary_id->first].back()->initialize ();
+            }
+        }
     }
 
 
 
     template <int dim>
-    std::string
-    get_names ()
+    Tensor<1,dim>
+    Manager<dim>::boundary_velocity (const types::boundary_id boundary_indicator,
+                                     const Point<dim> &position) const
     {
-      return std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ();
+      typename std::map<types::boundary_id,std::vector<std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > > >::const_iterator boundary_plugins =
+        boundary_velocity_objects.find(boundary_indicator);
+
+      Assert(boundary_plugins != boundary_velocity_objects.end(),
+             ExcMessage("The boundary velocity manager class was asked for the "
+                        "boundary velocity at a boundary that contains no active "
+                        "boundary velocity plugin."));
+
+      Tensor<1,dim> velocity = Tensor<1,dim>();
+
+      for (typename std::vector<std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > >::const_iterator
+           plugin = boundary_plugins->second.begin();
+           plugin != boundary_plugins->second.end(); ++plugin)
+        velocity += (*plugin)->boundary_velocity(boundary_indicator,
+                                                 position);
+
+      return velocity;
+    }
+
+
+
+    template <int dim>
+    const std::map<types::boundary_id, std::pair<std::string,std::vector<std::string> > > &
+    Manager<dim>::get_active_boundary_velocity_names () const
+    {
+      return boundary_velocity_indicators;
+    }
+
+
+    template <int dim>
+    const std::map<types::boundary_id,std::vector<std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > > > &
+    Manager<dim>::get_active_boundary_velocity_conditions () const
+    {
+      return boundary_velocity_objects;
     }
 
 
     template <int dim>
     void
-    declare_parameters (ParameterHandler &prm)
+    Manager<dim>::declare_parameters (ParameterHandler &prm)
     {
+      const std::string pattern_of_names
+        = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names () + "|unspecified";
+
+      // declare the deprecated entry in the model settings subsection
+      prm.enter_subsection ("Model settings");
+      {
+        prm.declare_entry ("Prescribed velocity boundary indicators", "unspecified:unspecified",
+                           Patterns::Map (Patterns::Anything(),
+                                          Patterns::Selection(pattern_of_names)),
+                           "A comma separated list denoting those boundaries "
+                           "on which the velocity is prescribed, i.e., where unknown "
+                           "external forces act to prescribe a particular velocity. This is "
+                           "often used to prescribe a velocity that equals that of "
+                           "overlying plates."
+                           "\n\n"
+                           "The format of valid entries for this parameter is that of a map "
+                           "given as ``key1 [selector]: value1, key2 [selector]: value2, key3: value3, ...'' where "
+                           "each key must be a valid boundary indicator (which is either an "
+                           "integer or the symbolic name the geometry model in use may have "
+                           "provided for this part of the boundary) "
+                           "and each value must be one of the currently implemented boundary "
+                           "velocity models. ``selector'' is an optional string given as a subset "
+                           "of the letters `xyz' that allows you to apply the boundary conditions "
+                           "only to the components listed. As an example, '1 y: function' applies "
+                           "the type `function' to the y component on boundary 1. Without a selector "
+                           "it will affect all components of the velocity."
+                           "\n\n"
+                           "Note that the no-slip boundary condition is "
+                           "a special case of the current one where the prescribed velocity "
+                           "happens to be zero. It can thus be implemented by indicating that "
+                           "a particular boundary is part of the ones selected "
+                           "using the current parameter and using ``zero velocity'' as "
+                           "the boundary values. Alternatively, you can simply list the "
+                           "part of the boundary on which the velocity is to be zero with "
+                           "the parameter ``Zero velocity boundary indicator'' in the "
+                           "current parameter section."
+                           "\n\n"
+                           "Note that when ``Use years in output instead of seconds'' is set "
+                           "to true, velocity should be given in m/yr. "
+                           "The following boundary velocity models are available:\n\n"
+                           +
+                           std_cxx11::get<dim>(registered_plugins).get_description_string());
+      }
+      prm.leave_subsection ();
+
+      // declare the entry in the parameter file
+      prm.enter_subsection ("Boundary velocity model");
+      {
+        prm.declare_entry("List of model names","",
+                          Patterns::Map (Patterns::Anything(),
+                                         Patterns::Selection(pattern_of_names)),
+                          "A comma separated list denoting those boundaries "
+                          "on which the velocity is prescribed, i.e., where unknown "
+                          "external forces act to prescribe a particular velocity. This is "
+                          "often used to prescribe a velocity that equals that of "
+                          "overlying plates."
+                          "\n\n"
+                          "The format of valid entries for this parameter is that of a map "
+                          "given as ``key1 [selector]: value1, key2 [selector]: value2, key3: value3, ...'' where "
+                          "each key must be a valid boundary indicator (which is either an "
+                          "integer or the symbolic name the geometry model in use may have "
+                          "provided for this part of the boundary) "
+                          "and each value must be one of the currently implemented boundary "
+                          "velocity models. ``selector'' is an optional string given as a subset "
+                          "of the letters `xyz' that allows you to apply the boundary conditions "
+                          "only to the components listed. As an example, '1 y: function' applies "
+                          "the type `function' to the y component on boundary 1. Without a selector "
+                          "it will affect all components of the velocity."
+                          "\n\n"
+                          "Note that the no-slip boundary condition is "
+                          "a special case of the current one where the prescribed velocity "
+                          "happens to be zero. It can thus be implemented by indicating that "
+                          "a particular boundary is part of the ones selected "
+                          "using the current parameter and using ``zero velocity'' as "
+                          "the boundary values. "
+                          "\n\n"
+                          "Note that when ``Use years in output instead of seconds'' is set "
+                          "to true, velocity should be given in m/yr. "
+                          "The following boundary velocity models are available:\n\n"
+                          +
+                          std_cxx11::get<dim>(registered_plugins).get_description_string());
+      }
+      prm.leave_subsection ();
+
       std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
     }
 
@@ -155,7 +409,7 @@ namespace aspect
 
     template <int dim>
     void
-    write_plugin_graph (std::ostream &out)
+    Manager<dim>::write_plugin_graph (std::ostream &out)
     {
       std_cxx11::get<dim>(registered_plugins).write_plugin_graph ("Boundary velocity interface",
                                                                   out);
@@ -183,29 +437,7 @@ namespace aspect
   {
 #define INSTANTIATE(dim) \
   template class Interface<dim>; \
-  \
-  template \
-  void \
-  register_boundary_velocity<dim> (const std::string &, \
-                                   const std::string &, \
-                                   void ( *) (ParameterHandler &), \
-                                   Interface<dim> *( *) ()); \
-  \
-  template  \
-  void \
-  declare_parameters<dim> (ParameterHandler &); \
-  \
-  template \
-  void \
-  write_plugin_graph<dim> (std::ostream &); \
-  \
-  template  \
-  std::string \
-  get_names<dim> (); \
-  \
-  template \
-  Interface<dim> * \
-  create_boundary_velocity<dim> (const std::string &);
+  template class Manager<dim>;
 
     ASPECT_INSTANTIATE(INSTANTIATE)
   }

--- a/source/boundary_velocity/interface.cc
+++ b/source/boundary_velocity/interface.cc
@@ -117,198 +117,6 @@ namespace aspect
     }
 
 
-    template <int dim>
-    void
-    Manager<dim>::parse_parameters (ParameterHandler &prm)
-    {
-      prm.enter_subsection ("Model settings");
-      {
-        try
-          {
-            const std::vector<types::boundary_id> x_zero_velocity_boundary_indicators
-              = this->get_geometry_model().translate_symbolic_boundary_names_to_ids(Utilities::split_string_list
-                                                                                    (prm.get ("Zero velocity boundary indicators")));
-            zero_velocity_boundary_indicators
-              = std::set<types::boundary_id> (x_zero_velocity_boundary_indicators.begin(),
-                                              x_zero_velocity_boundary_indicators.end());
-          }
-        catch (const std::string &error)
-          {
-            AssertThrow (false, ExcMessage ("While parsing the entry <Model settings/Zero velocity "
-                                            "boundary indicators>, there was an error. Specifically, "
-                                            "the conversion function complained as follows: "
-                                            + error));
-          }
-
-        try
-          {
-            const std::vector<types::boundary_id> x_tangential_velocity_boundary_indicators
-              = this->get_geometry_model().translate_symbolic_boundary_names_to_ids(Utilities::split_string_list
-                                                                                    (prm.get ("Tangential velocity boundary indicators")));
-            tangential_velocity_boundary_indicators
-              = std::set<types::boundary_id> (x_tangential_velocity_boundary_indicators.begin(),
-                                              x_tangential_velocity_boundary_indicators.end());
-          }
-        catch (const std::string &error)
-          {
-            AssertThrow (false, ExcMessage ("While parsing the entry <Model settings/Tangential velocity "
-                                            "boundary indicators>, there was an error. Specifically, "
-                                            "the conversion function complained as follows: "
-                                            + error));
-          }
-      }
-      prm.leave_subsection ();
-
-      // Check if the deprecated parameter was set
-      std::string input_string;
-      {
-        std::string deprecated_input_string;
-
-        prm.enter_subsection ("Model settings");
-        {
-          deprecated_input_string = prm.get("Prescribed velocity boundary indicators");
-        }
-        prm.leave_subsection ();
-
-        prm.enter_subsection("Boundary velocity model");
-        {
-          input_string = prm.get("List of model names");
-        }
-        prm.leave_subsection ();
-
-        if (input_string != "")
-          {
-            Assert(deprecated_input_string == "unspecified", ExcMessage(""));
-          }
-
-        if (deprecated_input_string != "unspecified:unspecified")
-          {
-            Assert(input_string == "", ExcMessage(""));
-            input_string = deprecated_input_string;
-          }
-      }
-
-      // find out which plugins are requested and the various other
-      // parameters we declare here
-      const std::vector<std::string> x_boundary_velocity_indicators
-        = Utilities::split_string_list(input_string);
-
-      for (std::vector<std::string>::const_iterator p = x_boundary_velocity_indicators.begin();
-           p != x_boundary_velocity_indicators.end(); ++p)
-        {
-          // each entry has the format (white space is optional):
-          // <id> [x][y][z] : <value (might have spaces)>
-          //
-          // first tease apart the two halves
-          const std::vector<std::string> split_parts = Utilities::split_string_list (*p, ':');
-          AssertThrow (split_parts.size() == 2,
-                       ExcMessage ("The format for prescribed velocity boundary indicators "
-                                   "requires that each entry has the form `"
-                                   "<id> [x][y][z] : <value>', but there does not "
-                                   "appear to be a colon in the entry <"
-                                   + *p
-                                   + ">."));
-
-          // the easy part: get the value
-          const std::string value = split_parts[1];
-
-          // now for the rest. since we don't know whether there is a
-          // component selector, start reading at the end and subtracting
-          // letters x, y and z
-          std::string key_and_comp = split_parts[0];
-          std::string comp;
-          while ((key_and_comp.size()>0) &&
-                 ((key_and_comp[key_and_comp.size()-1] == 'x')
-                  ||
-                  (key_and_comp[key_and_comp.size()-1] == 'y')
-                  ||
-                  ((key_and_comp[key_and_comp.size()-1] == 'z') && (dim==3))))
-            {
-              comp += key_and_comp[key_and_comp.size()-1];
-              key_and_comp.erase (--key_and_comp.end());
-            }
-
-          // we've stopped reading component selectors now. there are three
-          // possibilities:
-          // - no characters are left. this means that key_and_comp only
-          //   consisted of a single word that only consisted of 'x', 'y'
-          //   and 'z's. then this would have been a mistake to classify
-          //   as a component selector, and we better undo it
-          // - the last character of key_and_comp is not a whitespace. this
-          //   means that the last word in key_and_comp ended in an 'x', 'y'
-          //   or 'z', but this was not meant to be a component selector.
-          //   in that case, put these characters back.
-          // - otherwise, we split successfully. eat spaces that may be at
-          //   the end of key_and_comp to get key
-          if (key_and_comp.size() == 0)
-            key_and_comp.swap (comp);
-          else if (key_and_comp[key_and_comp.size()-1] != ' ')
-            {
-              key_and_comp += comp;
-              comp = "";
-            }
-          else
-            {
-              while ((key_and_comp.size()>0) && (key_and_comp[key_and_comp.size()-1] == ' '))
-                key_and_comp.erase (--key_and_comp.end());
-            }
-
-          // finally, try to translate the key into a boundary_id. then
-          // make sure we haven't seen it yet
-          types::boundary_id boundary_id;
-          try
-            {
-              boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id(key_and_comp);
-            }
-          catch (const std::string &error)
-            {
-              AssertThrow (false, ExcMessage ("While parsing the entry <Model settings/Prescribed "
-                                              "velocity indicators>, there was an error. Specifically, "
-                                              "the conversion function complained as follows: "
-                                              + error));
-            }
-
-          if (boundary_velocity_indicators.find(boundary_id) != boundary_velocity_indicators.end())
-            {
-              Assert(boundary_velocity_indicators[boundary_id].first == comp,
-                     ExcMessage("Different velocity plugins for the same boundary have to have the same component selector. "
-                                "This was not the case for boundary: " + key_and_comp +
-                                ", for plugin: " + value + ", with component selector: " + comp));
-
-              // finally, put it into the list
-              boundary_velocity_indicators[boundary_id].second.push_back(value);
-            }
-          else
-            {
-              boundary_velocity_indicators[boundary_id] = std::make_pair(comp,std::vector<std::string>(1,value));
-            }
-        }
-
-      // go through the list, create objects and let them parse
-      // their own parameters
-      for (std::map<types::boundary_id, std::pair<std::string,std::vector<std::string> > >::iterator
-           boundary_id = boundary_velocity_indicators.begin();
-           boundary_id != boundary_velocity_indicators.end(); ++boundary_id)
-        {
-          for (std::vector<std::string>::iterator
-               name = boundary_id->second.second.begin();
-               name != boundary_id->second.second.end(); ++name)
-            {
-              boundary_velocity_objects[boundary_id->first].push_back(
-                std_cxx11::shared_ptr<Interface<dim> > (std_cxx11::get<dim>(registered_plugins)
-                                                        .create_plugin (*name,
-                                                                        "Boundary velocity::Model names")));
-
-              if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(boundary_velocity_objects[boundary_id->first].back().get()))
-                sim->initialize_simulator (this->get_simulator());
-
-              boundary_velocity_objects[boundary_id->first].back()->parse_parameters (prm);
-              boundary_velocity_objects[boundary_id->first].back()->initialize ();
-            }
-        }
-    }
-
-
 
     template <int dim>
     Tensor<1,dim>
@@ -376,15 +184,11 @@ namespace aspect
     void
     Manager<dim>::declare_parameters (ParameterHandler &prm)
     {
-      const std::string pattern_of_names
-        = std_cxx11::get<dim>(registered_plugins).get_pattern_of_names () + "|unspecified";
-
-      // declare the deprecated entry in the model settings subsection
       prm.enter_subsection ("Model settings");
       {
-        prm.declare_entry ("Prescribed velocity boundary indicators", "unspecified:unspecified",
+        prm.declare_entry ("Prescribed velocity boundary indicators", "",
                            Patterns::Map (Patterns::Anything(),
-                                          Patterns::Selection(pattern_of_names)),
+                                          Patterns::Selection(std_cxx11::get<dim>(registered_plugins).get_pattern_of_names ())),
                            "A comma separated list denoting those boundaries "
                            "on which the velocity is prescribed, i.e., where unknown "
                            "external forces act to prescribe a particular velocity. This is "
@@ -448,46 +252,171 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      // declare the entry in the parameter file
-      prm.enter_subsection ("Boundary velocity model");
-      {
-        prm.declare_entry("List of model names","",
-                          Patterns::Map (Patterns::Anything(),
-                                         Patterns::Selection(pattern_of_names)),
-                          "A comma separated list denoting those boundaries "
-                          "on which the velocity is prescribed, i.e., where unknown "
-                          "external forces act to prescribe a particular velocity. This is "
-                          "often used to prescribe a velocity that equals that of "
-                          "overlying plates."
-                          "\n\n"
-                          "The format of valid entries for this parameter is that of a map "
-                          "given as ``key1 [selector]: value1, key2 [selector]: value2, key3: value3, ...'' where "
-                          "each key must be a valid boundary indicator (which is either an "
-                          "integer or the symbolic name the geometry model in use may have "
-                          "provided for this part of the boundary) "
-                          "and each value must be one of the currently implemented boundary "
-                          "velocity models. ``selector'' is an optional string given as a subset "
-                          "of the letters `xyz' that allows you to apply the boundary conditions "
-                          "only to the components listed. As an example, '1 y: function' applies "
-                          "the type `function' to the y component on boundary 1. Without a selector "
-                          "it will affect all components of the velocity."
-                          "\n\n"
-                          "Note that the no-slip boundary condition is "
-                          "a special case of the current one where the prescribed velocity "
-                          "happens to be zero. It can thus be implemented by indicating that "
-                          "a particular boundary is part of the ones selected "
-                          "using the current parameter and using ``zero velocity'' as "
-                          "the boundary values. "
-                          "\n\n"
-                          "Note that when ``Use years in output instead of seconds'' is set "
-                          "to true, velocity should be given in m/yr. "
-                          "The following boundary velocity models are available:\n\n"
-                          +
-                          std_cxx11::get<dim>(registered_plugins).get_description_string());
-      }
-      prm.leave_subsection ();
-
       std_cxx11::get<dim>(registered_plugins).declare_parameters (prm);
+    }
+
+
+
+    template <int dim>
+    void
+    Manager<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection ("Model settings");
+      {
+        try
+          {
+            const std::vector<types::boundary_id> x_zero_velocity_boundary_indicators
+              = this->get_geometry_model().translate_symbolic_boundary_names_to_ids(Utilities::split_string_list
+                                                                                    (prm.get ("Zero velocity boundary indicators")));
+            zero_velocity_boundary_indicators
+              = std::set<types::boundary_id> (x_zero_velocity_boundary_indicators.begin(),
+                                              x_zero_velocity_boundary_indicators.end());
+          }
+        catch (const std::string &error)
+          {
+            AssertThrow (false, ExcMessage ("While parsing the entry <Model settings/Zero velocity "
+                                            "boundary indicators>, there was an error. Specifically, "
+                                            "the conversion function complained as follows: "
+                                            + error));
+          }
+
+        try
+          {
+            const std::vector<types::boundary_id> x_tangential_velocity_boundary_indicators
+              = this->get_geometry_model().translate_symbolic_boundary_names_to_ids(Utilities::split_string_list
+                                                                                    (prm.get ("Tangential velocity boundary indicators")));
+            tangential_velocity_boundary_indicators
+              = std::set<types::boundary_id> (x_tangential_velocity_boundary_indicators.begin(),
+                                              x_tangential_velocity_boundary_indicators.end());
+          }
+        catch (const std::string &error)
+          {
+            AssertThrow (false, ExcMessage ("While parsing the entry <Model settings/Tangential velocity "
+                                            "boundary indicators>, there was an error. Specifically, "
+                                            "the conversion function complained as follows: "
+                                            + error));
+          }
+
+        // find out which plugins are requested and the various other
+        // parameters we declare here
+        const std::vector<std::string> x_boundary_velocity_indicators
+          = Utilities::split_string_list(prm.get("Prescribed velocity boundary indicators"));
+
+        for (std::vector<std::string>::const_iterator p = x_boundary_velocity_indicators.begin();
+             p != x_boundary_velocity_indicators.end(); ++p)
+          {
+            // each entry has the format (white space is optional):
+            // <id> [x][y][z] : <value (might have spaces)>
+            //
+            // first tease apart the two halves
+            const std::vector<std::string> split_parts = Utilities::split_string_list (*p, ':');
+            AssertThrow (split_parts.size() == 2,
+                         ExcMessage ("The format for prescribed velocity boundary indicators "
+                                     "requires that each entry has the form `"
+                                     "<id> [x][y][z] : <value>', but there does not "
+                                     "appear to be a colon in the entry <"
+                                     + *p
+                                     + ">."));
+
+            // the easy part: get the value
+            const std::string value = split_parts[1];
+
+            // now for the rest. since we don't know whether there is a
+            // component selector, start reading at the end and subtracting
+            // letters x, y and z
+            std::string key_and_comp = split_parts[0];
+            std::string comp;
+            while ((key_and_comp.size()>0) &&
+                   ((key_and_comp[key_and_comp.size()-1] == 'x')
+                    ||
+                    (key_and_comp[key_and_comp.size()-1] == 'y')
+                    ||
+                    ((key_and_comp[key_and_comp.size()-1] == 'z') && (dim==3))))
+              {
+                comp += key_and_comp[key_and_comp.size()-1];
+                key_and_comp.erase (--key_and_comp.end());
+              }
+
+            // we've stopped reading component selectors now. there are three
+            // possibilities:
+            // - no characters are left. this means that key_and_comp only
+            //   consisted of a single word that only consisted of 'x', 'y'
+            //   and 'z's. then this would have been a mistake to classify
+            //   as a component selector, and we better undo it
+            // - the last character of key_and_comp is not a whitespace. this
+            //   means that the last word in key_and_comp ended in an 'x', 'y'
+            //   or 'z', but this was not meant to be a component selector.
+            //   in that case, put these characters back.
+            // - otherwise, we split successfully. eat spaces that may be at
+            //   the end of key_and_comp to get key
+            if (key_and_comp.size() == 0)
+              key_and_comp.swap (comp);
+            else if (key_and_comp[key_and_comp.size()-1] != ' ')
+              {
+                key_and_comp += comp;
+                comp = "";
+              }
+            else
+              {
+                while ((key_and_comp.size()>0) && (key_and_comp[key_and_comp.size()-1] == ' '))
+                  key_and_comp.erase (--key_and_comp.end());
+              }
+
+            // finally, try to translate the key into a boundary_id. then
+            // make sure we haven't seen it yet
+            types::boundary_id boundary_id;
+            try
+              {
+                boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id(key_and_comp);
+              }
+            catch (const std::string &error)
+              {
+                AssertThrow (false, ExcMessage ("While parsing the entry <Model settings/Prescribed "
+                                                "velocity indicators>, there was an error. Specifically, "
+                                                "the conversion function complained as follows: "
+                                                + error));
+              }
+
+            if (boundary_velocity_indicators.find(boundary_id) != boundary_velocity_indicators.end())
+              {
+                Assert(boundary_velocity_indicators[boundary_id].first == comp,
+                       ExcMessage("Different velocity plugins for the same boundary have to have the same component selector. "
+                                  "This was not the case for boundary: " + key_and_comp +
+                                  ", for plugin: " + value + ", with component selector: " + comp));
+
+                // finally, put it into the list
+                boundary_velocity_indicators[boundary_id].second.push_back(value);
+              }
+            else
+              {
+                boundary_velocity_indicators[boundary_id] = std::make_pair(comp,std::vector<std::string>(1,value));
+              }
+          }
+      }
+      prm.leave_subsection();
+
+      // go through the list, create objects and let them parse
+      // their own parameters
+      for (std::map<types::boundary_id, std::pair<std::string,std::vector<std::string> > >::iterator
+           boundary_id = boundary_velocity_indicators.begin();
+           boundary_id != boundary_velocity_indicators.end(); ++boundary_id)
+        {
+          for (std::vector<std::string>::iterator
+               name = boundary_id->second.second.begin();
+               name != boundary_id->second.second.end(); ++name)
+            {
+              boundary_velocity_objects[boundary_id->first].push_back(
+                std_cxx11::shared_ptr<Interface<dim> > (std_cxx11::get<dim>(registered_plugins)
+                                                        .create_plugin (*name,
+                                                                        "Boundary velocity::Model names")));
+
+              if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(boundary_velocity_objects[boundary_id->first].back().get()))
+                sim->initialize_simulator (this->get_simulator());
+
+              boundary_velocity_objects[boundary_id->first].back()->parse_parameters (prm);
+              boundary_velocity_objects[boundary_id->first].back()->initialize ();
+            }
+        }
     }
 
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -226,8 +226,8 @@ namespace aspect
     {
       // make sure velocity and traction boundary indicators don't appear in multiple lists
       std::set<types::boundary_id> boundary_indicator_lists[6]
-        = { parameters.zero_velocity_boundary_indicators,
-            parameters.tangential_velocity_boundary_indicators,
+        = { boundary_velocity_manager.get_zero_boundary_velocity_indicators(),
+            boundary_velocity_manager.get_tangential_boundary_velocity_indicators(),
             parameters.free_surface_boundary_indicators,
             std::set<types::boundary_id>()   // to be prescribed velocity and traction boundary indicators
           };
@@ -600,13 +600,13 @@ namespace aspect
          ++p)
       open_velocity_boundary_indicators.erase (p->first);
     for (std::set<types::boundary_id>::const_iterator
-         p = parameters.zero_velocity_boundary_indicators.begin();
-         p != parameters.zero_velocity_boundary_indicators.end();
+         p = boundary_velocity_manager.get_zero_boundary_velocity_indicators().begin();
+         p != boundary_velocity_manager.get_zero_boundary_velocity_indicators().end();
          ++p)
       open_velocity_boundary_indicators.erase (*p);
     for (std::set<types::boundary_id>::const_iterator
-         p = parameters.tangential_velocity_boundary_indicators.begin();
-         p != parameters.tangential_velocity_boundary_indicators.end();
+         p = boundary_velocity_manager.get_tangential_boundary_velocity_indicators().begin();
+         p != boundary_velocity_manager.get_tangential_boundary_velocity_indicators().end();
          ++p)
       open_velocity_boundary_indicators.erase (*p);
 
@@ -1346,8 +1346,8 @@ namespace aspect
     {
       // do the interpolation for zero velocity
       for (std::set<types::boundary_id>::const_iterator
-           p = parameters.zero_velocity_boundary_indicators.begin();
-           p != parameters.zero_velocity_boundary_indicators.end(); ++p)
+           p = boundary_velocity_manager.get_zero_boundary_velocity_indicators().begin();
+           p != boundary_velocity_manager.get_zero_boundary_velocity_indicators().end(); ++p)
         VectorTools::interpolate_boundary_values (*mapping,
                                                   dof_handler,
                                                   *p,
@@ -1360,7 +1360,7 @@ namespace aspect
       VectorTools::compute_no_normal_flux_constraints (dof_handler,
                                                        /* first_vector_component= */
                                                        introspection.component_indices.velocities[0],
-                                                       parameters.tangential_velocity_boundary_indicators,
+                                                       boundary_velocity_manager.get_tangential_boundary_velocity_indicators(),
                                                        constraints,
                                                        *mapping);
     }

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -494,6 +494,9 @@ namespace aspect
         boundary_composition_manager.parse_parameters (prm);
       }
 
+    boundary_velocity_manager.initialize_simulator (*this);
+    boundary_velocity_manager.parse_parameters (prm);
+
     // Make sure we only have a prescribed Stokes plugin if needed
     if (parameters.nonlinear_solver==NonlinearSolver::Advection_only)
       {
@@ -567,9 +570,6 @@ namespace aspect
 
     geometry_model->create_coarse_mesh (triangulation);
     global_Omega_diameter = GridTools::diameter (triangulation);
-
-    boundary_velocity_manager.initialize_simulator (*this);
-    boundary_velocity_manager.parse_parameters (prm);
 
     for (std::map<types::boundary_id,std::pair<std::string,std::string> >::const_iterator
          p = parameters.prescribed_traction_boundary_indicators.begin();

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -236,9 +236,9 @@ namespace aspect
       std::set<types::boundary_id> velocity_bi;
       std::set<types::boundary_id> traction_bi;
 
-      for (std::map<types::boundary_id,std::pair<std::string, std::string> >::const_iterator
-           p = parameters.prescribed_velocity_boundary_indicators.begin();
-           p != parameters.prescribed_velocity_boundary_indicators.end();
+      for (std::map<types::boundary_id, std::pair<std::string,std::vector<std::string> > >::const_iterator
+           p = boundary_velocity_manager.get_active_boundary_velocity_names().begin();
+           p != boundary_velocity_manager.get_active_boundary_velocity_names().end();
            ++p)
         velocity_bi.insert(p->first);
 
@@ -264,12 +264,17 @@ namespace aspect
                it != intersection.end();
                ++it)
             {
+              const std::map<types::boundary_id, std::pair<std::string,std::vector<std::string> > >::const_iterator
+              boundary_velocity_names = boundary_velocity_manager.get_active_boundary_velocity_names().find(*it);
+              Assert(boundary_velocity_names != boundary_velocity_manager.get_active_boundary_velocity_names().end(),
+                     ExcInternalError());
+
               std::set<char> velocity_selector;
               std::set<char> traction_selector;
 
               for (std::string::const_iterator
-                   it_selector  = parameters.prescribed_velocity_boundary_indicators[*it].first.begin();
-                   it_selector != parameters.prescribed_velocity_boundary_indicators[*it].first.end();
+                   it_selector  = boundary_velocity_names->second.first.begin();
+                   it_selector != boundary_velocity_names->second.first.end();
                    ++it_selector)
                 velocity_selector.insert(*it_selector);
 
@@ -563,20 +568,8 @@ namespace aspect
     geometry_model->create_coarse_mesh (triangulation);
     global_Omega_diameter = GridTools::diameter (triangulation);
 
-    for (std::map<types::boundary_id,std::pair<std::string,std::string> >::const_iterator
-         p = parameters.prescribed_velocity_boundary_indicators.begin();
-         p != parameters.prescribed_velocity_boundary_indicators.end();
-         ++p)
-      {
-        BoundaryVelocity::Interface<dim> *bv
-          = BoundaryVelocity::create_boundary_velocity<dim>
-            (p->second.second);
-        boundary_velocity[p->first].reset (bv);
-        if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(bv))
-          sim->initialize_simulator(*this);
-        bv->parse_parameters (prm);
-        bv->initialize ();
-      }
+    boundary_velocity_manager.initialize_simulator (*this);
+    boundary_velocity_manager.parse_parameters (prm);
 
     for (std::map<types::boundary_id,std::pair<std::string,std::string> >::const_iterator
          p = parameters.prescribed_traction_boundary_indicators.begin();
@@ -601,9 +594,9 @@ namespace aspect
 
     std::set<types::boundary_id> open_velocity_boundary_indicators
       = geometry_model->get_used_boundary_indicators();
-    for (std::map<types::boundary_id,std::pair<std::string,std::string> >::const_iterator
-         p = parameters.prescribed_velocity_boundary_indicators.begin();
-         p != parameters.prescribed_velocity_boundary_indicators.end();
+    for (std::map<types::boundary_id,std::pair<std::string,std::vector<std::string> > >::const_iterator
+         p = boundary_velocity_manager.get_active_boundary_velocity_names().begin();
+         p != boundary_velocity_manager.get_active_boundary_velocity_names().end();
          ++p)
       open_velocity_boundary_indicators.erase (p->first);
     for (std::set<types::boundary_id>::const_iterator
@@ -867,23 +860,23 @@ namespace aspect
     {
       // set the current time and do the interpolation
       // for the prescribed velocity fields
-      for (typename std::map<types::boundary_id,std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > >::iterator
-           p = boundary_velocity.begin();
-           p != boundary_velocity.end(); ++p)
+      boundary_velocity_manager.update();
+      for (typename std::map<types::boundary_id,std::pair<std::string, std::vector<std::string> > >::const_iterator
+           p = boundary_velocity_manager.get_active_boundary_velocity_names().begin();
+           p != boundary_velocity_manager.get_active_boundary_velocity_names().end(); ++p)
         {
-          p->second->update ();
           VectorFunctionFromVelocityFunctionObject<dim> vel
           (introspection.n_components,
-           std_cxx11::bind (static_cast<Tensor<1,dim> (BoundaryVelocity::Interface<dim>::*)(
+           std_cxx11::bind (static_cast<Tensor<1,dim> (BoundaryVelocity::Manager<dim>::*)(
                               const types::boundary_id,
-                              const Point<dim> &) const> (&BoundaryVelocity::Interface<dim>::boundary_velocity),
-                            p->second,
+                              const Point<dim> &) const> (&BoundaryVelocity::Manager<dim>::boundary_velocity),
+                            std_cxx11::cref(boundary_velocity_manager),
                             p->first,
                             std_cxx11::_1));
 
           // here we create a mask for interpolate_boundary_values out of the 'selector'
           std::vector<bool> mask(introspection.component_masks.velocities.size(), false);
-          const std::string &comp = parameters.prescribed_velocity_boundary_indicators[p->first].first;
+          const std::string &comp = p->second.first;
 
           if (comp.length()>0)
             {

--- a/source/simulator/free_surface.cc
+++ b/source/simulator/free_surface.cc
@@ -315,8 +315,8 @@ namespace aspect
 
     // Zero out the displacement for the prescribed velocity boundaries
     // if the boundary is not in the set of tangential mesh boundaries
-    for (std::map<types::boundary_id, std::pair<std::string, std::string> >::const_iterator p = sim.parameters.prescribed_velocity_boundary_indicators.begin();
-         p != sim.parameters.prescribed_velocity_boundary_indicators.end(); ++p)
+    for (std::map<types::boundary_id, std::pair<std::string, std::vector<std::string> > >::const_iterator p = sim.boundary_velocity_manager.get_active_boundary_velocity_names().begin();
+         p != sim.boundary_velocity_manager.get_active_boundary_velocity_names().end(); ++p)
       {
         if (tangential_mesh_boundary_indicators.find(p->first) == tangential_mesh_boundary_indicators.end())
           {

--- a/source/simulator/free_surface.cc
+++ b/source/simulator/free_surface.cc
@@ -242,7 +242,7 @@ namespace aspect
             = sim.geometry_model->translate_symbolic_boundary_names_to_ids(Utilities::split_string_list
                                                                            (prm.get ("Additional tangential mesh velocity boundary indicators")));
 
-          tangential_mesh_boundary_indicators = sim.parameters.tangential_velocity_boundary_indicators;
+          tangential_mesh_boundary_indicators = sim.boundary_velocity_manager.get_tangential_boundary_velocity_indicators();
           tangential_mesh_boundary_indicators.insert(x_additional_tangential_mesh_boundary_indicators.begin(),
                                                      x_additional_tangential_mesh_boundary_indicators.end());
         }
@@ -308,8 +308,8 @@ namespace aspect
       DoFTools::make_periodicity_constraints(free_surface_dof_handler, (*p).first.first, (*p).first.second, (*p).second, mesh_displacement_constraints);
 
     // Zero out the displacement for the zero-velocity boundary indicators
-    for (std::set<types::boundary_id>::const_iterator p = sim.parameters.zero_velocity_boundary_indicators.begin();
-         p != sim.parameters.zero_velocity_boundary_indicators.end(); ++p)
+    for (std::set<types::boundary_id>::const_iterator p = sim.boundary_velocity_manager.get_zero_boundary_velocity_indicators().begin();
+         p != sim.boundary_velocity_manager.get_zero_boundary_velocity_indicators().end(); ++p)
       VectorTools::interpolate_boundary_values (free_surface_dof_handler, *p,
                                                 ZeroFunction<dim>(dim), mesh_displacement_constraints);
 

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -263,7 +263,7 @@ namespace aspect
     BoundaryFluidPressure::write_plugin_graph<dim>(out);
     BoundaryTemperature::Manager<dim>::write_plugin_graph(out);
     BoundaryTraction::write_plugin_graph<dim>(out);
-    BoundaryVelocity::write_plugin_graph<dim>(out);
+    BoundaryVelocity::Manager<dim>::write_plugin_graph(out);
     InitialTopographyModel::write_plugin_graph<dim>(out);
     GeometryModel::write_plugin_graph<dim>(out);
     GravityModel::write_plugin_graph<dim>(out);

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -538,33 +538,6 @@ namespace aspect
                          "implemented in a plugin in the BoundaryComposition "
                          "group, unless an existing implementation in this group "
                          "already provides what you want.");
-      prm.declare_entry ("Zero velocity boundary indicators", "",
-                         Patterns::List (Patterns::Anything()),
-                         "A comma separated list of names denoting those boundaries "
-                         "on which the velocity is zero."
-                         "\n\n"
-                         "The names of the boundaries listed here can either by "
-                         "numbers (in which case they correspond to the numerical "
-                         "boundary indicators assigned by the geometry object), or they "
-                         "can correspond to any of the symbolic names the geometry object "
-                         "may have provided for each part of the boundary. You may want "
-                         "to compare this with the documentation of the geometry model you "
-                         "use in your model.");
-      prm.declare_entry ("Tangential velocity boundary indicators", "",
-                         Patterns::List (Patterns::Anything()),
-                         "A comma separated list of names denoting those boundaries "
-                         "on which the velocity is tangential and unrestrained, i.e., free-slip where "
-                         "no external forces act to prescribe a particular tangential "
-                         "velocity (although there is a force that requires the flow to "
-                         "be tangential)."
-                         "\n\n"
-                         "The names of the boundaries listed here can either by "
-                         "numbers (in which case they correspond to the numerical "
-                         "boundary indicators assigned by the geometry object), or they "
-                         "can correspond to any of the symbolic names the geometry object "
-                         "may have provided for each part of the boundary. You may want "
-                         "to compare this with the documentation of the geometry model you "
-                         "use in your model.");
       prm.declare_entry ("Free surface boundary indicators", "",
                          Patterns::List (Patterns::Anything()),
                          "A comma separated list of names denoting those boundaries "
@@ -1618,40 +1591,6 @@ namespace aspect
       catch (const std::string &error)
         {
           AssertThrow (false, ExcMessage ("While parsing the entry <Model settings/Fixed composition "
-                                          "boundary indicators>, there was an error. Specifically, "
-                                          "the conversion function complained as follows: "
-                                          + error));
-        }
-
-      try
-        {
-          const std::vector<types::boundary_id> x_zero_velocity_boundary_indicators
-            = geometry_model.translate_symbolic_boundary_names_to_ids(Utilities::split_string_list
-                                                                      (prm.get ("Zero velocity boundary indicators")));
-          zero_velocity_boundary_indicators
-            = std::set<types::boundary_id> (x_zero_velocity_boundary_indicators.begin(),
-                                            x_zero_velocity_boundary_indicators.end());
-        }
-      catch (const std::string &error)
-        {
-          AssertThrow (false, ExcMessage ("While parsing the entry <Model settings/Zero velocity "
-                                          "boundary indicators>, there was an error. Specifically, "
-                                          "the conversion function complained as follows: "
-                                          + error));
-        }
-
-      try
-        {
-          const std::vector<types::boundary_id> x_tangential_velocity_boundary_indicators
-            = geometry_model.translate_symbolic_boundary_names_to_ids(Utilities::split_string_list
-                                                                      (prm.get ("Tangential velocity boundary indicators")));
-          tangential_velocity_boundary_indicators
-            = std::set<types::boundary_id> (x_tangential_velocity_boundary_indicators.begin(),
-                                            x_tangential_velocity_boundary_indicators.end());
-        }
-      catch (const std::string &error)
-        {
-          AssertThrow (false, ExcMessage ("While parsing the entry <Model settings/Tangential velocity "
                                           "boundary indicators>, there was an error. Specifically, "
                                           "the conversion function complained as follows: "
                                           + error));

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -578,39 +578,6 @@ namespace aspect
                          "may have provided for each part of the boundary. You may want "
                          "to compare this with the documentation of the geometry model you "
                          "use in your model.");
-      prm.declare_entry ("Prescribed velocity boundary indicators", "",
-                         Patterns::Map (Patterns::Anything(),
-                                        Patterns::Selection(BoundaryVelocity::get_names<dim>())),
-                         "A comma separated list denoting those boundaries "
-                         "on which the velocity is prescribed, i.e., where unknown "
-                         "external forces act to prescribe a particular velocity. This is "
-                         "often used to prescribe a velocity that equals that of "
-                         "overlying plates."
-                         "\n\n"
-                         "The format of valid entries for this parameter is that of a map "
-                         "given as ``key1 [selector]: value1, key2 [selector]: value2, key3: value3, ...'' where "
-                         "each key must be a valid boundary indicator (which is either an "
-                         "integer or the symbolic name the geometry model in use may have "
-                         "provided for this part of the boundary) "
-                         "and each value must be one of the currently implemented boundary "
-                         "velocity models. ``selector'' is an optional string given as a subset "
-                         "of the letters `xyz' that allows you to apply the boundary conditions "
-                         "only to the components listed. As an example, '1 y: function' applies "
-                         "the type `function' to the y component on boundary 1. Without a selector "
-                         "it will affect all components of the velocity."
-                         "\n\n"
-                         "Note that the no-slip boundary condition is "
-                         "a special case of the current one where the prescribed velocity "
-                         "happens to be zero. It can thus be implemented by indicating that "
-                         "a particular boundary is part of the ones selected "
-                         "using the current parameter and using ``zero velocity'' as "
-                         "the boundary values. Alternatively, you can simply list the "
-                         "part of the boundary on which the velocity is to be zero with "
-                         "the parameter ``Zero velocity boundary indicator'' in the "
-                         "current parameter section."
-                         "\n\n"
-                         "Note that when ``Use years in output instead of seconds'' is set "
-                         "to true, velocity should be given in m/yr. ");
       prm.declare_entry ("Prescribed traction boundary indicators", "",
                          Patterns::Map (Patterns::Anything(),
                                         Patterns::Selection(BoundaryTraction::get_names<dim>())),
@@ -1709,95 +1676,6 @@ namespace aspect
                                           + error));
         }
 
-      const std::vector<std::string> x_prescribed_velocity_boundary_indicators
-        = Utilities::split_string_list
-          (prm.get ("Prescribed velocity boundary indicators"));
-      for (std::vector<std::string>::const_iterator p = x_prescribed_velocity_boundary_indicators.begin();
-           p != x_prescribed_velocity_boundary_indicators.end(); ++p)
-        {
-          // each entry has the format (white space is optional):
-          // <id> [x][y][z] : <value (might have spaces)>
-          //
-          // first tease apart the two halves
-          const std::vector<std::string> split_parts = Utilities::split_string_list (*p, ':');
-          AssertThrow (split_parts.size() == 2,
-                       ExcMessage ("The format for prescribed velocity boundary indicators "
-                                   "requires that each entry has the form `"
-                                   "<id> [x][y][z] : <value>', but there does not "
-                                   "appear to be a colon in the entry <"
-                                   + *p
-                                   + ">."));
-
-          // the easy part: get the value
-          const std::string value = split_parts[1];
-
-          // now for the rest. since we don't know whether there is a
-          // component selector, start reading at the end and subtracting
-          // letters x, y and z
-          std::string key_and_comp = split_parts[0];
-          std::string comp;
-          while ((key_and_comp.size()>0) &&
-                 ((key_and_comp[key_and_comp.size()-1] == 'x')
-                  ||
-                  (key_and_comp[key_and_comp.size()-1] == 'y')
-                  ||
-                  ((key_and_comp[key_and_comp.size()-1] == 'z') && (dim==3))))
-            {
-              comp += key_and_comp[key_and_comp.size()-1];
-              key_and_comp.erase (--key_and_comp.end());
-            }
-
-          // we've stopped reading component selectors now. there are three
-          // possibilities:
-          // - no characters are left. this means that key_and_comp only
-          //   consisted of a single word that only consisted of 'x', 'y'
-          //   and 'z's. then this would have been a mistake to classify
-          //   as a component selector, and we better undo it
-          // - the last character of key_and_comp is not a whitespace. this
-          //   means that the last word in key_and_comp ended in an 'x', 'y'
-          //   or 'z', but this was not meant to be a component selector.
-          //   in that case, put these characters back.
-          // - otherwise, we split successfully. eat spaces that may be at
-          //   the end of key_and_comp to get key
-          if (key_and_comp.size() == 0)
-            key_and_comp.swap (comp);
-          else if (key_and_comp[key_and_comp.size()-1] != ' ')
-            {
-              key_and_comp += comp;
-              comp = "";
-            }
-          else
-            {
-              while ((key_and_comp.size()>0) && (key_and_comp[key_and_comp.size()-1] == ' '))
-                key_and_comp.erase (--key_and_comp.end());
-            }
-
-          // finally, try to translate the key into a boundary_id. then
-          // make sure we haven't seen it yet
-          types::boundary_id boundary_id;
-          try
-            {
-              boundary_id = geometry_model.translate_symbolic_boundary_name_to_id(key_and_comp);
-            }
-          catch (const std::string &error)
-            {
-              AssertThrow (false, ExcMessage ("While parsing the entry <Model settings/Prescribed "
-                                              "velocity indicators>, there was an error. Specifically, "
-                                              "the conversion function complained as follows: "
-                                              + error));
-            }
-
-          AssertThrow (prescribed_velocity_boundary_indicators.find(boundary_id)
-                       == prescribed_velocity_boundary_indicators.end(),
-                       ExcMessage ("Boundary indicator <" + Utilities::int_to_string(boundary_id) +
-                                   "> appears more than once in the list of indicators "
-                                   "for nonzero velocity boundaries."));
-
-          // finally, put it into the list
-          prescribed_velocity_boundary_indicators[boundary_id] =
-            std::pair<std::string,std::string>(comp,value);
-        }
-
       const std::vector<std::string> x_prescribed_traction_boundary_indicators
         = Utilities::split_string_list
           (prm.get ("Prescribed traction boundary indicators"));
@@ -1912,7 +1790,7 @@ namespace aspect
     BoundaryTemperature::Manager<dim>::declare_parameters (prm);
     BoundaryComposition::Manager<dim>::declare_parameters (prm);
     AdiabaticConditions::declare_parameters<dim> (prm);
-    BoundaryVelocity::declare_parameters<dim> (prm);
+    BoundaryVelocity::Manager<dim>::declare_parameters (prm);
     BoundaryTraction::declare_parameters<dim> (prm);
   }
 }

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -466,7 +466,29 @@ namespace aspect
   const std::map<types::boundary_id,std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > >
   SimulatorAccess<dim>::get_prescribed_boundary_velocity () const
   {
-    return simulator->boundary_velocity;
+    const std::map<types::boundary_id,std::vector<std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > > > &
+    boundary_map = simulator->boundary_velocity_manager.get_active_boundary_velocity_conditions();
+
+    std::map<types::boundary_id,std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > >
+    legacy_map;
+
+    for (typename std::map<types::boundary_id,std::vector<std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > > >::const_iterator
+         boundary = boundary_map.begin(); boundary != boundary_map.end(); ++boundary)
+      {
+        Assert (boundary->second.size() <= 1,
+                ExcMessage("You can only use this function if there is at most one boundary velocity plugin per boundary."));
+        legacy_map[boundary->first] = boundary->second.front();
+      }
+
+    return legacy_map;
+  }
+
+
+  template <int dim>
+  const BoundaryVelocity::Manager<dim> &
+  SimulatorAccess<dim>::get_boundary_velocity_manager () const
+  {
+    return simulator->boundary_velocity_manager;
   }
 
 

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -232,7 +232,7 @@ namespace aspect
     // before solving.
     if (stokes_matrix_depends_on_solution()
         ||
-        (parameters.prescribed_velocity_boundary_indicators.size() > 0))
+        (boundary_velocity_manager.get_active_boundary_velocity_conditions().size() > 0))
       rebuild_stokes_matrix = rebuild_stokes_preconditioner = true;
 
     assemble_stokes_system ();

--- a/tests/ascii_data_boundary_velocity_2d_box_list.prm
+++ b/tests/ascii_data_boundary_velocity_2d_box_list.prm
@@ -1,0 +1,87 @@
+# test for the boundary velocity plugins, in particular for
+# summing several plugins and prescribing components on certain boundaries.
+
+set Dimension                              = 2
+
+set Use years in output instead of seconds = true
+set End time                               = 1e6
+
+set Adiabatic surface temperature          = 1613.0
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 3300000
+    set Y extent = 660000
+    set X repetitions = 5
+  end
+end
+
+subsection Initial temperature model
+  set Model name = adiabatic
+  subsection Adiabatic
+    set Amplitude = 300
+    set Radius    = 250000
+  end
+end
+
+
+subsection Boundary temperature model
+  set List of model names = box
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = top,bottom
+
+  set Zero velocity boundary indicators       =
+  set Prescribed velocity boundary indicators = left x: ascii data,right: ascii data, left x: function, right: function
+
+  set Tangential velocity boundary indicators = top, bottom
+
+end
+
+
+subsection Boundary velocity model
+  subsection Ascii data model
+    set Data file name       = box_2d_%s.0.txt
+    
+    set Data directory = $ASPECT_SOURCE_DIR/data/boundary-velocity/ascii-data/test/
+    set Scale factor = 0.01
+  end
+  subsection Function
+    set Function expression = 0.01;0.0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Viscosity = 1e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 2
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+  set Strategy                                 = temperature
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, heat flux statistics
+end
+

--- a/tests/ascii_data_boundary_velocity_2d_box_list/screen-output
+++ b/tests/ascii_data_boundary_velocity_2d_box_list/screen-output
@@ -1,0 +1,45 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+
+   Loading Ascii data boundary file /home/rengas/Software/Aspect-Versionen/aspect/data/boundary-velocity/ascii-data/test/box_2d_left.0.txt.
+
+
+   Loading new data file did not succeed.
+   Assuming constant boundary conditions for rest of model run.
+
+
+   Loading Ascii data boundary file /home/rengas/Software/Aspect-Versionen/aspect/data/boundary-velocity/ascii-data/test/box_2d_right.0.txt.
+
+
+   Loading new data file did not succeed.
+   Assuming constant boundary conditions for rest of model run.
+
+Number of active cells: 80 (on 3 levels)
+Number of degrees of freedom: 1,212 (738+105+369)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 17+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.0162 m/year, 0.0366 m/year
+     Heat fluxes through boundary parts: 7.474e-12 W, 4.484e-12 W, 4.647e+05 W, 4.549e+05 W
+
+*** Timestep 1:  t=1e+06 years
+   Solving temperature system... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 16+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.0162 m/year, 0.0347 m/year
+     Heat fluxes through boundary parts: -165.3 W, 67.6 W, 4.423e+05 W, 4.285e+05 W
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/ascii_data_boundary_velocity_2d_box_list/screen-output
+++ b/tests/ascii_data_boundary_velocity_2d_box_list/screen-output
@@ -2,14 +2,14 @@
 -----------------------------------------------------------------------------
 
 
-   Loading Ascii data boundary file /home/rengas/Software/Aspect-Versionen/aspect/data/boundary-velocity/ascii-data/test/box_2d_left.0.txt.
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_left.0.txt.
 
 
    Loading new data file did not succeed.
    Assuming constant boundary conditions for rest of model run.
 
 
-   Loading Ascii data boundary file /home/rengas/Software/Aspect-Versionen/aspect/data/boundary-velocity/ascii-data/test/box_2d_right.0.txt.
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_right.0.txt.
 
 
    Loading new data file did not succeed.

--- a/tests/ascii_data_boundary_velocity_2d_box_list/statistics
+++ b/tests/ascii_data_boundary_velocity_2d_box_list/statistics
@@ -1,0 +1,18 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: RMS velocity (m/year)
+# 12: Max. velocity (m/year)
+# 13: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 14: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 15: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 16: Outward heat flux through boundary with indicator 3 ("top") (W)
+0 0.000000000000e+00 0.000000000000e+00 80 843 369  0 17 18 18 1.62148194e-02 3.65600593e-02  7.47376698e-12 4.48426019e-12 4.64736000e+05 4.54866000e+05 
+1 1.000000000000e+06 1.000000000000e+06 80 843 369 10 16 17 17 1.62276243e-02 3.46604910e-02 -1.65311511e+02 6.76027545e+01 4.42319776e+05 4.28461086e+05 


### PR DESCRIPTION
Same as #2043, but for velocity plugins. This one is much more complicated, because we already allow different velocity plugins for different boundaries, and there is the additional complication of component selectors. I need to clean the code one more time before a proper review, but there are a few design decisions I would like to hear an opinion about:

1. Long term I would like to move all input parameters like "Prescribed velocity boundary indicators" from the generic "Model settings" subsection into the more appropriate "Boundary velocity model" subsection (same for temperature, composition, and so on). This is why I created a new "List of model names" parameter in the boundary velocity subsection. I feel this is easier to understand, also this would logically mean the Simulator should not longer know which boundaries have which plugins, this is the responsibility of the manager (and Simulator can ask for it). Is this appropriate?

2. Currently I enforce to have the same component selector for all plugins on a certain boundary. This seems reasonable for velocities, because one either wants to prescribe a component (with all selected plugins), or leave it unconstrained. For the composition however, I can easily imagine cases in which certain plugins are only responsible for certain compositions (=components). So the question is: Should I allow different component selectors for velocity also, to be consistent, or is this overdesigning things?

3. Currently I create multiple plugin objects if the names of plugins appear for different boundaries. This is consistent with the previous behavior, but feels a bit weird (it means a certain boundary object is only called for one boundary, and the boundary_id input parameter to `boundary_velocity` is more or less redundant). I could reuse objects by simply copying shared pointers into the lists of other boundaries upon construction, but I do not know if some user plugins rely on the fact that a plugin only serves a single boundary (for example the ascii data plugin does rely on this fact). Should I just keep things as before for now, and we only change it if it becomes a problem in the future?