### PR TITLE
Fix version if using deal.II release

### DIFF
--- a/source/global.cc
+++ b/source/global.cc
@@ -118,13 +118,13 @@ void print_aspect_header(Stream &stream)
   stream << "-----------------------------------------------------------------------------\n"
          << "-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.\n"
          << "--     . version " << ASPECT_PACKAGE_VERSION;
-  if (strcmp(ASPECT_GIT_SHORTREV,"") != 0)
+  if (strcmp(ASPECT_GIT_BRANCH,"") != 0)
     stream << " (" << ASPECT_GIT_BRANCH << ", " << ASPECT_GIT_SHORTREV << ")\n";
   else
     stream << "\n";
 
   stream << "--     . using deal.II " << DEAL_II_PACKAGE_VERSION;
-  if (strcmp(DEAL_II_GIT_SHORTREV,"") != 0)
+  if (strcmp(DEAL_II_GIT_BRANCH,"") != 0)
     stream << " (" << DEAL_II_GIT_BRANCH << ", " << DEAL_II_GIT_SHORTREV << ")\n";
   else
     stream << "\n";


### PR DESCRIPTION
A deal.II release has a commit ID, but no branch information in revision.h. In this case currently we output a strange string `(, commitID)`. 
Do not output anything about ID or branch in this case, because a release version is unique already (I could have fixed if with more complicated logic about which of the two is present, but this seems easier, and provides the same information.

One problem I just noticed while testing this patch is that we use a deal.II cmake macro to generate Aspect's version information. That means if we use a deal.II installation (not a build folder) we can not use that script (cmake scripts are not installed), and even if git is available we have no version information for aspect. Is it possible to find the source or build folder for an installation (if those still exist)? Or would it be ok to copy that macro (macro_deal_ii_query_git_information.cmake) into aspect/cmake?