### PR TITLE
Remove arbitrary limits in Steinberger material model

### DIFF
--- a/doc/modules/changes/20180116_gassmoeller
+++ b/doc/modules/changes/20180116_gassmoeller
@@ -1,0 +1,7 @@
+Changed: Removed min/max bounds on the specific heat capacity and
+thermal expansivity inside the 'Steinberger' material model. 
+These bounds were only used if the 'Use latent heat' parameter
+was set to true. To prevent silently changing the solution these
+bounds were removed.
+<br>
+(Rene Gassmoeller, 2018/01/16)

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -536,7 +536,6 @@ namespace aspect
             {
               for (unsigned i = 0; i < material_lookup.size(); ++i)
                 cp += compositional_fields[i] * material_lookup[i]->dHdT(temperature,pressure);
-              cp = std::max(std::min(cp,6000.0),500.0);
             }
         }
       return cp;
@@ -639,7 +638,6 @@ namespace aspect
                 dHdp += compositional_fields[i] * material_lookup[i]->dHdp(temperature,pressure);
             }
           alpha = (1 - density(temperature,pressure,compositional_fields,position) * dHdp) / temperature;
-          alpha = std::max(std::min(alpha,1e-3),1e-5);
         }
       return alpha;
     }


### PR DESCRIPTION
These limits were introduced at a time when I wanted to stabilize things, but they fooled us for a day thinking our model was wrong, and they are bad for at least two reasons:
1. They give wrong results instead of crashing when things go wrong.
2. Their numbers are arbitrary, at least they would need to be input parameters.

I think it is best to remove them, bad things should happen when these get unreasonable, and it is not possible to provide bounds for what "unreasonable" means.