### PR TITLE
Fix melt in parallel computations

### DIFF
--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -266,7 +266,7 @@ namespace aspect
         // and will therefore be updated as well.
         const unsigned int fluid_velocity_block = introspection.variable("fluid velocity").block_index;
         const unsigned int fluid_pressure_block = introspection.variable("fluid pressure").block_index;
-        current_linearization_point.block(fluid_velocity_block) = solution(fluid_velocity_block);
+        current_linearization_point.block(fluid_velocity_block) = solution.block(fluid_velocity_block);
         current_linearization_point.block(fluid_pressure_block) = solution.block(fluid_pressure_block);
       }
 

--- a/tests/global_melt_parallel.prm
+++ b/tests/global_melt_parallel.prm
@@ -1,0 +1,227 @@
+# Listing of Parameters
+# ---------------------
+# Test for melt migration in a global-scale model
+
+# MPI: 2
+
+set Adiabatic surface temperature          = 1600               # default: 0
+set CFL number                             = 1.0
+set Maximum time step                      = 1e6
+set Composition solver tolerance           = 1e-14
+set Temperature solver tolerance           = 1e-14
+set Nonlinear solver scheme                = iterated IMPES
+set Output directory                       = with_melt
+set Max nonlinear iterations               = 20
+set Linear solver tolerance                = 1e-8
+set Nonlinear solver tolerance             = 1e-5
+
+# The number of space dimensions you want to run this program in.
+set Dimension                              = 2
+
+# The end time of the simulation. Units: years if the 'Use years in output
+# instead of seconds' parameter is set; seconds otherwise.
+# This end time is chosen in such a way that the solitary wave travels
+# approximately 5 times its wavelength during the model time.
+set End time                               = 3e6
+
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+set Resume computation                     = false
+set Start time                             = 0
+
+set Use years in output instead of seconds = true
+set Use direct solver for Stokes system    = false
+set Number of cheap Stokes solver steps    = 0
+
+subsection Discretization
+  set Stokes velocity polynomial degree    = 2
+  set Composition polynomial degree        = 1
+  subsection Stabilization parameters
+    set beta  = 0.2
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 2
+  set Names of fields = porosity, peridotite
+end
+
+
+subsection Boundary temperature model
+  set List of model names = initial temperature
+
+  subsection Initial temperature
+    set Minimal temperature = 293 # default: 6000
+    set Maximal temperature = 3700  # default: 0
+  end
+end
+
+subsection Boundary composition model
+  set List of model names = initial composition
+end
+
+subsection Boundary velocity model
+  subsection Function
+    set Function constants  = b=100000, c=20000
+    set Variable names      = x,y
+    set Function expression = 0.0; -0.024995 + 0.1 * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
+  end
+end
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 8700000
+    set Y extent = 2900000
+#    set X periodic = true
+    set X repetitions = 3
+  end
+
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 9.81
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = adiabatic
+  subsection Adiabatic
+    set Age bottom boundary layer = 5e8
+    set Age top boundary layer    = 3e8
+    set Amplitude                 = 50
+    set Position                  = center
+    set Radius                    = 350000
+
+    subsection Function
+      set Function expression       = 0;0
+    end
+  end
+
+  subsection Harmonic perturbation
+    set Magnitude = 50
+  end
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Function constants  = pi=3.1415926,a = 0.0, b = 2500000, c = 100000, d=1450000
+    set Function expression = a * exp(-((y-b)*(y-b)+(0.2*(x-d))*(0.2*(x-d)))/(2*c*c)); a * exp(-((y-b)*(y-b)+(0.2*(x-d))*(0.2*(x-d)))/(2*c*c))
+    set Variable names      = x,y
+  end
+end
+
+
+subsection Material model
+
+  set Model name = melt global 
+  subsection Melt global
+    set Thermal conductivity              = 4.7
+    set Reference solid density           = 3400
+    set Reference melt density            = 3000
+    set Thermal expansion coefficient     = 2e-5
+    set Reference permeability            = 1e-8
+    set Reference shear viscosity         = 5e21
+    set Reference bulk viscosity          = 1e19
+    set Exponential melt weakening factor = 10
+    set Thermal viscosity exponent        = 7
+    set Thermal bulk viscosity exponent   = 7
+    set Reference temperature             = 1600
+    set Solid compressibility             = 4.2e-12
+    set Melt compressibility              = 1.25e-11
+    set Reference melt viscosity          = 10
+    set Depletion density change          = -200.0 # -100.0 # 0.0
+  end
+end
+
+
+subsection Mesh refinement
+  set Coarsening fraction                      = 0.05
+  set Refinement fraction                      = 0.8
+
+  set Initial adaptive refinement              = 0                    # default: 2
+  set Initial global refinement                = 3                    # default: 2
+  set Strategy                                 = composition threshold, minimum refinement function #, nonadiabatic temperature
+  set Time steps between mesh refinement       = 0
+
+  subsection Minimum refinement function
+    set Coordinate system   = depth
+    set Function expression = if (depth>1500000,5,4)
+    set Variable names      = depth,phi
+  end
+
+  subsection Composition threshold
+    set Compositional field thresholds = 1e-4,1.0
+  end
+end
+
+
+subsection Boundary fluid pressure model
+  set Plugin name = density
+  subsection Density
+    set Density formulation = solid density
+  end
+end
+
+subsection Heating model
+  set List of model names = adiabatic heating #, latent heat melt, shear heating
+end
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = 2,3
+  set Fixed composition boundary indicators   = #2,3
+  set Prescribed velocity boundary indicators =
+
+  set Tangential velocity boundary indicators = 0,1,2,3
+  set Zero velocity boundary indicators       =
+#  set Remove nullspace                        = net x translation
+
+  set Include melt transport                  = true
+end
+
+subsection Melt settings
+  set Melt transport threshold                = 1e-4
+end
+
+
+subsection Postprocess
+
+  set List of postprocessors = visualization,composition statistics,velocity statistics, temperature statistics, depth average
+
+  subsection Visualization
+
+    set List of output variables      = material properties, nonadiabatic temperature, melt fraction, strain rate, melt material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity, reaction terms
+    end
+
+    subsection Melt material properties
+      set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
+    end
+
+    set Number of grouped files       = 0
+    set Interpolate output            = false
+    set Output format                 = vtu
+    set Time between graphical output = 0
+    set Interpolate output            = true
+  end
+
+  subsection Depth average
+    set Number of zones = 12
+    set Time between graphical output = 6e5
+  end
+
+end
+
+subsection Checkpointing
+  set Time between checkpoint = 1700
+end
+
+

--- a/tests/global_melt_parallel/screen-output
+++ b/tests/global_melt_parallel/screen-output
@@ -1,0 +1,245 @@
+
+Number of active cells: 192 (on 4 levels)
+Number of degrees of freedom: 5,290 (1,666+450+1,666+225+833+225+225)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.97921e-16, 0, 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
+
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.24019e-16, 0, 0, 0.799766
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.799766
+
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.1806e-16, 0, 0, 0.173272
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.173272
+
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+12 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.10725e-16, 0, 0, 0.0272016
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0272016
+
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+11 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.40884e-16, 0, 0, 0.0032544
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.0032544
+
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+8 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.1276e-16, 0, 0, 0.000312907
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000312907
+
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+7 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.25235e-16, 0, 0, 2.51035e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 2.51035e-05
+
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+6 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.30109e-16, 0, 0, 1.72283e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.72283e-06
+
+
+   Postprocessing:
+     Writing graphical output:  output-global_melt_parallel/solution/solution-00000
+     Compositions min/max/mass: 0/0/0 // 0/0/0
+     RMS, max velocity:         0.00109 m/year, 0.00296 m/year
+     Temperature min/avg/max:   293 K, 2023 K, 3700 K
+     Writing depth average:     output-global_melt_parallel/depth_average.gnuplot
+
+*** Timestep 1:  t=1e+06 years
+   Solving temperature system... 13 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+8 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000991159, 0, 0, 0.0240528
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0240528
+
+   Solving temperature system... 11 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+7 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.3476e-05, 0, 0, 0.000984558
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000984558
+
+   Solving temperature system... 9 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+6 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.32673e-07, 0, 0, 0.000187049
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000187049
+
+   Solving temperature system... 8 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+6 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.41153e-08, 0, 0, 3.96407e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 3.96407e-05
+
+   Solving temperature system... 6 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+6 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.16644e-10, 0, 0, 5.74468e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 5.74468e-06
+
+
+   Postprocessing:
+     Writing graphical output:  output-global_melt_parallel/solution/solution-00001
+     Compositions min/max/mass: 0/0/0 // 0/0/0
+     RMS, max velocity:         0.00111 m/year, 0.00303 m/year
+     Temperature min/avg/max:   293 K, 2023 K, 3700 K
+     Writing depth average:     output-global_melt_parallel/depth_average.gnuplot
+
+*** Timestep 2:  t=2e+06 years
+   Solving temperature system... 13 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+7 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000138201, 0, 0, 0.0033994
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0033994
+
+   Solving temperature system... 9 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+6 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.14814e-07, 0, 0, 0.000241799
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000241799
+
+   Solving temperature system... 8 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+6 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.74313e-08, 0, 0, 7.72146e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 7.72146e-05
+
+   Solving temperature system... 6 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+6 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.00056e-09, 0, 0, 1.522e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.522e-05
+
+   Solving temperature system... 4 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+6 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.49235e-11, 0, 0, 2.14799e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 2.14799e-06
+
+
+   Postprocessing:
+     Writing graphical output:  output-global_melt_parallel/solution/solution-00002
+     Compositions min/max/mass: 0/0/0 // 0/0/0
+     RMS, max velocity:         0.00113 m/year, 0.0031 m/year
+     Temperature min/avg/max:   293 K, 2023 K, 3700 K
+     Writing depth average:     output-global_melt_parallel/depth_average.gnuplot
+
+*** Timestep 3:  t=3e+06 years
+   Solving temperature system... 12 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+6 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.2938e-05, 0, 0, 0.000284218
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000284218
+
+   Solving temperature system... 9 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+6 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.97021e-07, 0, 0, 5.37867e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.37867e-05
+
+   Solving temperature system... 5 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+6 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.96537e-10, 0, 0, 1.59854e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 1.59854e-05
+
+   Solving temperature system... 4 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+6 iterations.
+   Solving for u_f in 0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.238e-11, 0, 0, 3.03742e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 3.03742e-06
+
+
+   Postprocessing:
+     Writing graphical output:  output-global_melt_parallel/solution/solution-00003
+     Compositions min/max/mass: 0/0/0 // 0/0/0
+     RMS, max velocity:         0.00114 m/year, 0.00317 m/year
+     Temperature min/avg/max:   293 K, 2024 K, 3700 K
+     Writing depth average:     output-global_melt_parallel/depth_average.gnuplot
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/global_melt_parallel/statistics
+++ b/tests/global_melt_parallel/statistics
@@ -1,0 +1,31 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Number of nonlinear iterations
+# 9: Iterations for temperature solver
+# 10: Iterations for composition solver 1
+# 11: Iterations for composition solver 2
+# 12: Iterations for Stokes solver
+# 13: Velocity iterations in Stokes preconditioner
+# 14: Schur complement iterations in Stokes preconditioner
+# 15: Visualization file name
+# 16: Minimal value for composition porosity
+# 17: Maximal value for composition porosity
+# 18: Global mass for composition porosity
+# 19: Minimal value for composition peridotite
+# 20: Maximal value for composition peridotite
+# 21: Global mass for composition peridotite
+# 22: RMS velocity (m/year)
+# 23: Max. velocity (m/year)
+# 24: Minimal temperature (K)
+# 25: Average temperature (K)
+# 26: Maximal temperature (K)
+# 27: Average nondimensional temperature (K)
+0 0.000000000000e+00 0.000000000000e+00 192 1891 833 450 8  0 0 0 83 209 595 output-global_melt_parallel/solution/solution-00000 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.08902163e-03 2.96202826e-03 2.93000000e+02 2.02282918e+03 3.70000000e+03 5.07727967e-01 
+1 1.000000000000e+06 1.000000000000e+06 192 1891 833 450 5 47 0 0 33  58 241 output-global_melt_parallel/solution/solution-00001 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.10769519e-03 3.03266844e-03 2.93000000e+02 2.02310388e+03 3.70000000e+03 5.07808595e-01 
+2 2.000000000000e+06 1.000000000000e+06 192 1891 833 450 5 40 0 0 31  49 227 output-global_melt_parallel/solution/solution-00002 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.12581401e-03 3.10116873e-03 2.93000000e+02 2.02340011e+03 3.70000000e+03 5.07895541e-01 
+3 3.000000000000e+06 1.000000000000e+06 192 1891 833 450 4 30 0 0 24  36 172 output-global_melt_parallel/solution/solution-00003 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.14357964e-03 3.16811315e-03 2.93000000e+02 2.02369158e+03 3.70000000e+03 5.07981092e-01 


### PR DESCRIPTION
Apparently, we had no test for parallel melt models, because parallel melt transport was likely broken since #1850. Should be fixed now though.