### PR TITLE
Fix Mac sed commands in update scripts

### DIFF
--- a/doc/update_prm_files_to_2.0.0.sed
+++ b/doc/update_prm_files_to_2.0.0.sed
@@ -24,11 +24,11 @@ s/subsection Initial conditions/Initial temperature model/g
 # belongs to the opening subsection (i.e. if the parameter is set
 # after a subsection nested inside the 'Boundary temperature model'
 # subsection the following will simply do nothing).
-/subsection Boundary temperature model/,/\<end\>/ {
+/subsection Boundary temperature model/,/\bend\b/ {
      s/set Model name/set List of model names/g
 }
 
-/subsection Boundary composition model/,/\<end\>/ {
+/subsection Boundary composition model/,/\bend\b/ {
      s/set Model name/set List of model names/g
 }
 

--- a/doc/update_source_files_to_2.0.0.sed
+++ b/doc/update_source_files_to_2.0.0.sed
@@ -17,7 +17,7 @@ s/FluidPressureBoundaryConditions/BoundaryFluidPressure/g
 s/fluid_pressure_boundary/boundary_fluid_pressure/g
 s/Fluid pressure boundary/Boundary fluid pressure/g
 s/FLUID_PRESSURE_BOUNDARY_CONDITIONS/BOUNDARY_FLUID_PRESSURE_MODEL/g
-s/\<\@ingroup BoundaryFluidPressure\>/\@ingroup BoundaryFluidPressures/g
+s/\b\@ingroup BoundaryFluidPressure\b/\@ingroup BoundaryFluidPressures/g
 
 # Rename traction boundary conditions
 s/traction_boundary_conditions_model/boundary_traction/g


### PR DESCRIPTION
It looks like `\<` and `\>` (beginning or end of word) are GNU extensions to sed, and not available on Mac, while `\b` (boundary of word) is available. Thus this change should fix #1857. I was able to verify that this does not break anything on my Ubuntu, and at least one Mac I had available for testing (thanks @MarineLasbleis :smile:) seems to work.