### PR TITLE
Update documentation of Simulator::solve_stokes().

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -618,7 +618,7 @@ namespace aspect
        * system involving the velocity and pressure variables).
        *
        * @note If this function is called from a nonlinear solver -- e.g., the
-       * iterated Stokes, iterated IMPES, or Newton solver --, then the
+       * iterated Stokes, or iterated IMPES --, then the
        * @p current_linearization_point is the solution of the previous
        * iteration (or the solution extrapolated from the previous time
        * steps, if this is the first nonlinear iteration). Let us call
@@ -646,7 +646,12 @@ namespace aspect
        * with them, whether or not the solution was already good. If it
        * happens to have been good already, then it will be even better after
        * the solve. If it was not good enough yet, then we have to solve
-       * anyway.)
+       * anyway.) In contrast to all of this, if we are using a Newton
+       * solver, then $x_{k+1}$ is actually the Newton <i>update</i>
+       * vector, for which we have no initial guess other than the zero
+       * vector. In this case, the function simply returns $\|F_k\|$ where
+       * $F_k=F(x_k)$ is the residual vector for the previous solution
+       * $x_k$.
        *
        * This function is implemented in
        * <code>source/simulator/solver.cc</code>.

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -611,11 +611,42 @@ namespace aspect
       /**
        * Solve the Stokes linear system. Return the initial nonlinear
        * residual, i.e., if the linear system to be solved is $Ax=b$, then
-       * return $\|Ax_0-b\|$ where $x_0$ is the initial guess for the solution
-       * variable and is taken from the current_linearization_point member
+       * return $\|Ax_k-b\|$ where $x_k$ is the initial guess for the solution
+       * variable and is taken from the @p current_linearization_point member
        * variable. For the purpose of this function, this residual is computed
-       * only the velocity and pressure equations (i.e., for the 2x2 block
+       * only from the velocity and pressure equations (i.e., for the 2x2 block
        * system involving the velocity and pressure variables).
+       *
+       * @note If this function is called from a nonlinear solver -- e.g., the
+       * iterated Stokes, iterated IMPES, or Newton solver --, then the
+       * @p current_linearization_point is the solution of the previous
+       * iteration (or the solution extrapolated from the previous time
+       * steps, if this is the first nonlinear iteration). Let us call
+       * this solution $x_k$ as above, where $x$ is a two-component
+       * block vector that consists of velocity and pressure. This function
+       * then assumes that we have already built the system matrix $A_k=A(x_k)$
+       * and $F_k=F(x_k)$, both linearized around the previous solution. The
+       * function solves the linear system $A_k x_{k+1} = F_k$ for the
+       * solution $x_{k+1}$. If the linear system were solved exactly, then
+       * that would imply that the <i>linear residual</i>
+       * $\|A_k x_{k+1} - F_k\|$ were zero, or at least small. In other words,
+       * its size does not tell us anything about how accurately we have
+       * solved the nonlinear system. On the other hand, the <i>nonlinear
+       * residual</i> $\|A_k x_k - F_k\|$ tells us something about how
+       * accurately the previous guess $x_k$ already solved the nonlinear
+       * system. Consequently, this is what this function returns. (In some
+       * sense, this is not really what we are interested in: it tells us
+       * how accurate the solution <i>already</i> was, and if it was already
+       * pretty accurate, then we may not want to actually solve for
+       * $x_{k+1}$. But, this would require that this function receives a
+       * tolerance so that it can bail out early without actually solving
+       * for $x_{k+1}$ if the tolerance is already reached. This function does
+       * not actually do that -- in some sense, one may argue that if we have
+       * already built the matrix and right hand side, we may as well solve
+       * with them, whether or not the solution was already good. If it
+       * happens to have been good already, then it will be even better after
+       * the solve. If it was not good enough yet, then we have to solve
+       * anyway.)
        *
        * This function is implemented in
        * <code>source/simulator/solver.cc</code>.

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -550,6 +550,7 @@ namespace aspect
         // (it will be ignored by the solver anyway), we need this if we are
         // using a nonlinear scheme, because we use this to compute the current
         // nonlinear residual (see initial_residual below).
+
         // TODO: if there was an easy way to know if the caller needs the
         // initial residual we could skip all of this stuff.
         distributed_stokes_solution.block(0) = solution.block(0);


### PR DESCRIPTION
While there, also use an empty line to better delineate two parts of a
comment.

@mfraters: this is what we talked about last week. Can you take a look?
I didn't update comments in the solve_stokes() function itself so as not to
step onto the changes you make in #2070.