### PR TITLE
add the exit timer in the linear solver catch

### DIFF
--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -841,6 +841,8 @@ namespace aspect
 
                     f.close();
 
+                    computing_timer.exit_section();
+
                     // avoid a deadlock that was fixed after deal.II 8.5.0
 #if DEAL_II_VERSION_GTE(9,0,0)
                     AssertThrow (false,


### PR DESCRIPTION
Based on a discussion in #2006. When the expensive linear sovler crashes, the section `   Solve Stokes system` is never exited. This can cause problems for the failsafe in #2006. I am just not sure what happens with this solution when the cheap solver fails with anything else then a non-convergence.