### PR TITLE
[Bugfix] Make models that use melt heating models work with operator splitting

### DIFF
--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -214,8 +214,15 @@ namespace aspect
           else
             {
               out.viscosities[i] = eta_0;
+
+              // no melting/freezing is used in the model --> set all reactions to zero
               for (unsigned int c=0; c<in.composition[i].size(); ++c)
-                out.reaction_terms[i][c] = 0.0;
+                {
+                  out.reaction_terms[i][c] = 0.0;
+
+                  if (this->get_parameters().use_operator_splitting && reaction_rate_out != NULL)
+                    reaction_rate_out->reaction_rates[i][c] = 0.0;
+                }
             }
 
           out.entropy_derivative_pressure[i]    = 0.0;

--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -334,8 +334,15 @@ namespace aspect
           else
             {
               out.viscosities[i] = eta_0;
+
+              // no melting/freezing is used in the model --> set all reactions to zero
               for (unsigned int c=0; c<in.composition[i].size(); ++c)
-                out.reaction_terms[i][c] = 0.0;
+                {
+                  out.reaction_terms[i][c] = 0.0;
+
+                  if (this->get_parameters().use_operator_splitting && reaction_rate_out != NULL)
+                    reaction_rate_out->reaction_rates[i][c] = 0.0;
+                }
             }
 
           out.entropy_derivative_pressure[i]    = entropy_change (in.temperature[i], this->get_adiabatic_conditions().pressure(in.position[i]), maximum_melt_fractions[i], NonlinearDependence::pressure);

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1561,6 +1561,10 @@ namespace aspect
                            "(it does not create ReactionRateOutputs, which are required for this "
                            "solver scheme)."));
 
+    // some heating models require the additional outputs
+    heating_model_manager.create_additional_material_model_outputs(out_C);
+    heating_model_manager.create_additional_material_model_outputs(out_T);
+
     // Make a loop first over all cells, than over all reaction time steps, and then over
     // all degrees of freedom in each element to compute the reactions. This is possible
     // because the reactions only depend on the temperature and composition values at a given

--- a/tests/heat_advection_by_melt_operator_splitting.cc
+++ b/tests/heat_advection_by_melt_operator_splitting.cc
@@ -1,0 +1,1 @@
+#include "heat_advection_by_melt.cc"

--- a/tests/heat_advection_by_melt_operator_splitting.prm
+++ b/tests/heat_advection_by_melt_operator_splitting.prm
@@ -1,0 +1,138 @@
+# This test is a copy of the heat_advection_by_melt test, 
+# even with the same results, the only difference is that
+# operator splitting is enabled. 
+# It tests if melt heating models work also with operator 
+# splitting.
+#
+set Dimension                              = 2
+set Nonlinear solver scheme                = iterated IMPES
+set Linear solver tolerance                = 1e-12
+
+set Use operator splitting                 = true
+
+# There are several global variables that have to do with what
+# time system we want to work in and what the end time is.
+set Use years in output instead of seconds = false
+set End time                               = 0.1
+
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+set Adiabatic surface temperature          = 1600
+
+subsection Discretization
+  set Stokes velocity polynomial degree    = 2
+  set Composition polynomial degree        = 1
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+    set Y extent = 1
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 2
+  set Names of fields = porosity, peridotite
+end
+
+subsection Initial temperature model
+  set Model name = function
+    subsection Function
+      set Function expression       = 1 + y
+      set Variable names        = x,y
+  end
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Function expression = 0.1; 0.0
+  end
+end
+
+subsection Boundary temperature model
+  set List of model names = initial temperature
+end
+
+subsection Boundary composition model
+  set List of model names = initial composition
+end
+
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = 0;0
+  end
+end
+
+subsection Model settings
+  set Zero velocity boundary indicators       =
+  set Prescribed velocity boundary indicators = 
+  set Tangential velocity boundary indicators = 0,1,2,3
+  set Fixed temperature boundary indicators   = 2
+  set Fixed composition boundary indicators   = 2
+
+  set Include melt transport                  = true
+end
+
+subsection Melt settings
+  set Heat advection by melt = true
+end
+
+subsection Heating model
+  set List of model names = shear heating, shear heating with melt
+end
+
+subsection Boundary fluid pressure model
+  set Plugin name = PressureBdry
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 1.1111111111111
+  end
+end
+
+
+subsection Material model
+  set Model name = melt global advection
+
+  subsection Melt global
+    set Reference solid density    = 2
+    set Reference melt density     = 1
+    set Reference specific heat    = 1
+    set Reference temperature      = 1600 
+    set Thermal conductivity       = 0.0
+    set Surface solidus            = 10000.0
+    set Include melting and freezing = false
+    set Reference permeability       = 1
+    set Reference shear viscosity    = 1
+    set Reference bulk viscosity     = 1
+    set Reference melt viscosity     = 10
+    set Thermal viscosity exponent   = 0
+    set Exponential melt weakening factor = 0
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 4
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+end
+
+
+subsection Postprocess
+  set List of postprocessors = temperature statistics, heating statistics, visualization
+
+  subsection Visualization
+    set Time between graphical output = 0.01
+    set List of output variables = viscosity, density, nonadiabatic temperature, heating
+  end
+end
+

--- a/tests/heat_advection_by_melt_operator_splitting/screen-output
+++ b/tests/heat_advection_by_melt_operator_splitting/screen-output
@@ -1,0 +1,133 @@
+
+Loading shared library <./libheat_advection_by_melt_operator_splitting.so>
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 6,890 (2,178+578+2,178+289+1,089+289+289)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 26+0 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.80371e-16, 2.44479e-16, 0, 0.0526341
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0526341
+
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.80371e-16, 2.44479e-16, 0, 6.93218e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 6.93218e-13
+
+
+   Postprocessing:
+     Temperature min/avg/max:       1 K, 1.5 K, 2 K
+     Heating rate (average/total):  1.294e-23 W/kg, 2.587e-23 W
+     Writing graphical output:      output-heat_advection_by_melt_operator_splitting/solution/solution-00000
+
+*** Timestep 1:  t=0.03125 seconds
+   Solving composition reactions in 1 substep(s).
+   Solving temperature system... 5 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000399056, 1.08876e-13, 0, 6.93183e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000399056
+
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.52837e-13, 1.08876e-13, 0, 6.93183e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 6.93183e-13
+
+
+   Postprocessing:
+     Temperature min/avg/max:       1 K, 1.5 K, 1.991 K
+     Heating rate (average/total):  0.05 W/kg, 0.1 W
+     Writing graphical output:      output-heat_advection_by_melt_operator_splitting/solution/solution-00001
+
+*** Timestep 2:  t=0.0625 seconds
+   Solving composition reactions in 1 substep(s).
+   Solving temperature system... 8 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000216977, 7.25484e-14, 0, 6.93183e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000216977
+
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.2583e-13, 7.25484e-14, 0, 6.93183e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 6.93183e-13
+
+
+   Postprocessing:
+     Temperature min/avg/max:       1 K, 1.5 K, 1.987 K
+     Heating rate (average/total):  0.05 W/kg, 0.1 W
+     Writing graphical output:      output-heat_advection_by_melt_operator_splitting/solution/solution-00002
+
+*** Timestep 3:  t=0.09375 seconds
+   Solving composition reactions in 1 substep(s).
+   Solving temperature system... 8 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000120759, 7.25484e-14, 0, 6.93183e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000120759
+
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.67559e-13, 7.25484e-14, 0, 6.93183e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 6.93183e-13
+
+
+   Postprocessing:
+     Temperature min/avg/max:       1 K, 1.5 K, 1.986 K
+     Heating rate (average/total):  0.05 W/kg, 0.1 W
+     Writing graphical output:      output-heat_advection_by_melt_operator_splitting/solution/solution-00003
+
+*** Timestep 4:  t=0.1 seconds
+   Solving composition reactions in 1 substep(s).
+   Solving temperature system... 7 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.46056e-06, 1.8684e-14, 0, 6.93183e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 8.46056e-06
+
+
+   Postprocessing:
+     Temperature min/avg/max:       1 K, 1.5 K, 1.986 K
+     Heating rate (average/total):  0.05 W/kg, 0.1 W
+     Writing graphical output:      output-heat_advection_by_melt_operator_splitting/solution/solution-00004
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/heat_advection_by_melt_operator_splitting/statistics
+++ b/tests/heat_advection_by_melt_operator_splitting/statistics
@@ -1,0 +1,28 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Number of nonlinear iterations
+# 9: Iterations for temperature solver
+# 10: Iterations for composition solver 1
+# 11: Iterations for composition solver 2
+# 12: Iterations for Stokes solver
+# 13: Velocity iterations in Stokes preconditioner
+# 14: Schur complement iterations in Stokes preconditioner
+# 15: Minimal temperature (K)
+# 16: Average temperature (K)
+# 17: Maximal temperature (K)
+# 18: Average nondimensional temperature (K)
+# 19: Average shear heating rate (W/kg) 
+# 20: Total shear heating rate (W) 
+# 21: Average shear heating with melt rate (W/kg) 
+# 22: Total shear heating with melt rate (W) 
+# 23: Visualization file name
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 578 2 0 0 0 26 27 418 1.00000000e+00 1.50000000e+00 2.00000000e+00 1.32520541e-04 1.26582251e-23 2.53164503e-23 2.77322578e-25 5.54645156e-25 output-heat_advection_by_melt_operator_splitting/solution/solution-00000 
+1 3.124999999569e-02 3.124999999569e-02 256 2467 1089 578 2 5 0 0  0  0   0 1.00000000e+00 1.49990061e+00 1.99148513e+00 1.32494199e-04 1.26582251e-23 2.53164503e-23 5.00000000e-02 1.00000000e-01 output-heat_advection_by_melt_operator_splitting/solution/solution-00001 
+2 6.249999999138e-02 3.124999999569e-02 256 2467 1089 578 2 8 0 0  0  0   0 1.00000000e+00 1.49987322e+00 1.98741590e+00 1.32486939e-04 1.26582251e-23 2.53164503e-23 5.00000000e-02 1.00000000e-01 output-heat_advection_by_melt_operator_splitting/solution/solution-00002 
+3 9.374999998706e-02 3.124999999569e-02 256 2467 1089 578 2 8 0 0  0  0   0 1.00000000e+00 1.49987160e+00 1.98561783e+00 1.32486510e-04 1.26582251e-23 2.53164503e-23 5.00000000e-02 1.00000000e-01 output-heat_advection_by_melt_operator_splitting/solution/solution-00003 
+4 1.000000000000e-01 6.250000012937e-03 256 2467 1089 578 1 7 0 0  0  0   0 1.00000000e+00 1.49987346e+00 1.98553594e+00 1.32487003e-04 1.26582251e-23 2.53164503e-23 5.00000000e-02 1.00000000e-01 output-heat_advection_by_melt_operator_splitting/solution/solution-00004 


### PR DESCRIPTION
Due to some missing lines in the operator splitting routine, heating models did not get additional material model outputs (like melt outputs) and so any heating model that requires these outputs did not work with operator splitting. 
In addition, if melt transport was switched off, the reaction rate outputs were not filled correctly in the melt material models, and so they could not be used together with operator splitting. 

This pull request fixes both issues. 