### PR TITLE
Add a mesh refinement criterion based on the compaction length

### DIFF
--- a/doc/modules/changes/20180212_jdannberg
+++ b/doc/modules/changes/20180212_jdannberg
@@ -1,0 +1,5 @@
+New: There is now a new mesh refinement criterion that adds the
+option to refine cells based on the compaction length, a
+typical length scale of features in models with melt migration. 
+<br>
+(Juliane Dannberg, 2018/02/12)

--- a/include/aspect/mesh_refinement/compaction_length.h
+++ b/include/aspect/mesh_refinement/compaction_length.h
@@ -1,0 +1,81 @@
+/*
+  Copyright (C) 2015 - 2018 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef _aspect_mesh_refinement_compaction_length_h
+#define _aspect_mesh_refinement_compaction_length_h
+
+#include <aspect/mesh_refinement/interface.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+  namespace MeshRefinement
+  {
+
+    /**
+     * A class that implements a mesh refinement criterion based on the
+     * compaction length, a typical length scale in models with melt
+     * migration. The user can specify a desired ratio between the
+     * compaction length and the size of the mesh cells, and every cell
+     * where this ratio is smaller than specified is marked for refinement.
+     * This means that there will always be a given (minimum) number of
+     * mesh cells per compaction length.
+     *
+     * @ingroup MeshRefinement
+     */
+    template <int dim>
+    class CompactionLength : public Interface<dim>,
+      public SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * After cells have been marked for coarsening/refinement, apply
+         * additional criteria independent of the error estimate.
+         */
+        virtual
+        void
+        tag_additional_cells () const;
+
+        /**
+         * Declare the parameters this class takes through input files.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         */
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
+
+      private:
+        /**
+         * The desired ratio between compaction length and size of the mesh cells,
+         * in other words, how many cells the mesh should have per compaction length.
+         */
+        double cells_per_compaction_length;
+    };
+  }
+}
+
+#endif

--- a/source/mesh_refinement/compaction_length.cc
+++ b/source/mesh_refinement/compaction_length.cc
@@ -1,0 +1,158 @@
+/*
+  Copyright (C) 2015 - 2018 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/mesh_refinement/compaction_length.h>
+#include <aspect/melt.h>
+#include <aspect/simulator.h>
+
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/fe/fe_values.h>
+
+namespace aspect
+{
+  namespace MeshRefinement
+  {
+    template <int dim>
+    void
+    CompactionLength<dim>::tag_additional_cells () const
+    {
+      // tag_additional_cells is executed before the equations are solved
+      // for the very first time. If we do not have the finite element, we
+      // do not have any material properties and just do nothing in this plugin.
+      if (this->get_dof_handler().n_locally_owned_dofs() == 0)
+        return;
+
+      const Quadrature<dim> quadrature(this->get_fe().base_element(this->introspection().base_elements.compositional_fields).get_unit_support_points());
+      FEValues<dim> fe_values (this->get_mapping(),
+                               this->get_fe(),
+                               quadrature,
+                               update_quadrature_points | update_values | update_gradients);
+
+      MaterialModel::MaterialModelInputs<dim> in(quadrature.size(), this->n_compositional_fields());
+      MaterialModel::MaterialModelOutputs<dim> out(quadrature.size(), this->n_compositional_fields());
+      MeltHandler<dim>::create_material_model_outputs(out);
+
+      const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
+
+      for (typename DoFHandler<dim>::active_cell_iterator
+           cell = this->get_dof_handler().begin_active();
+           cell != this->get_dof_handler().end(); ++cell)
+        {
+          if (cell->is_locally_owned())
+            {
+              bool refine = false;
+              bool clear_coarsen = false;
+
+              fe_values.reinit(cell);
+              in.reinit(fe_values, cell, this->introspection(), this->get_solution(), true);
+              this->get_material_model().evaluate(in, out);
+
+              MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
+              AssertThrow(melt_out != NULL,
+                          ExcMessage("Need MeltOutputs from the material model for computing the melt properties."));
+
+              // for each composition dof, check if the compaction length exceeds the cell size
+              for (unsigned int i=0; i<this->get_fe().base_element(this->introspection().base_elements.compositional_fields).dofs_per_cell; ++i)
+                {
+                  const double porosity = in.composition[i][porosity_idx];
+                  const double compaction_length = std::sqrt((out.viscosities[i] + 4./3. * melt_out->compaction_viscosities[i])
+                                                             * melt_out->permeabilities[i] / melt_out->fluid_viscosities[i]);
+
+                  // If the compaction length exceeds the cell diameter anywhere in the cell, cell is marked for refinement.
+                  // Do not apply any refinement if the porosity is so small that melt can not migrate.
+                  if (compaction_length < 2.0 * cells_per_compaction_length * cell->minimum_vertex_distance()
+                      && porosity > this->get_melt_handler().melt_transport_threshold)
+                    clear_coarsen = true;
+
+                  if (compaction_length < cells_per_compaction_length * cell->minimum_vertex_distance()
+                      && porosity > this->get_melt_handler().melt_transport_threshold)
+                    {
+                      refine = true;
+                      break;
+                    }
+                }
+
+              if (clear_coarsen)
+                cell->clear_coarsen_flag ();
+              if (refine)
+                cell->set_refine_flag ();
+            }
+        }
+    }
+
+    template <int dim>
+    void
+    CompactionLength<dim>::
+    declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Mesh refinement");
+      {
+        prm.enter_subsection("Compaction length");
+        {
+          prm.declare_entry("Mesh cells per compaction length", "1.0",
+                            Patterns::Double (0),
+                            "The desired ratio between compaction length and size of the "
+                            "mesh cells, or, in other words, how many cells the mesh should "
+                            "(at least) have per compaction length. Every cell where this "
+                            "ratio is smaller than the value specified by this parameter "
+                            "(in places with fewer mesh cells per compaction length) is "
+                            "marked for refinement.");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+    template <int dim>
+    void
+    CompactionLength<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Mesh refinement");
+      {
+        prm.enter_subsection("Compaction length");
+        {
+          cells_per_compaction_length = prm.get_double ("Mesh cells per compaction length");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace MeshRefinement
+  {
+    ASPECT_REGISTER_MESH_REFINEMENT_CRITERION(CompactionLength,
+                                              "compaction length",
+                                              "A mesh refinement criterion for models with melt transport "
+                                              "that computes refinement indicators based on the compaction "
+                                              "length, defined as "
+                                              "$\\delta = \\sqrt{\\frac{(\\xi + 4 \\eta/3) k}{\\eta_f}}$. "
+                                              "$\\xi$ is the bulk viscosity, $\\eta$ is the shear viscosity, "
+                                              "$k$ is the permeability and $\\eta_f$ is the melt viscosity. "
+                                              "If the cell width or height exceeds a multiple (which is "
+                                              "specified as an input parameter) of this compaction length, "
+                                              "the cell is marked for refinement.")
+  }
+}

--- a/source/mesh_refinement/density.cc
+++ b/source/mesh_refinement/density.cc
@@ -59,11 +59,6 @@ namespace aspect
                                quadrature,
                                update_quadrature_points | update_values | update_gradients);
 
-      // the values of the compositional fields are stored as block vectors for each field
-      // we have to extract them in this structure
-      std::vector<std::vector<double> > prelim_composition_values (this->n_compositional_fields(),
-                                                                   std::vector<double> (quadrature.size()));
-
       MaterialModel::MaterialModelInputs<dim> in(quadrature.size(),
                                                  this->n_compositional_fields());
       MaterialModel::MaterialModelOutputs<dim> out(quadrature.size(),

--- a/tests/compaction_length_refinement.prm
+++ b/tests/compaction_length_refinement.prm
@@ -1,0 +1,138 @@
+# Test the compaction length refinement criterion.
+# The compaction length is 1 at the lower left boundary, 
+# and two magnitudes smaller at the top right boundary, 
+# and we specify two cells per compaction length. 
+# Hence, the finest cells should be on refinement level 8,
+# and in the top right corner.
+# The permeability changes along the x axis, the viscosity
+# along the y axis. 
+
+set Adiabatic surface temperature          = 1600               # default: 0
+set Nonlinear solver scheme                = iterated IMPES
+set Max nonlinear iterations               = 20
+
+# The number of space dimensions you want to run this program in.
+set Dimension                              = 2
+
+set End time                               = 0
+
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+
+set Use years in output instead of seconds = true
+
+subsection Compositional fields
+  set Number of fields = 2
+  set Names of fields = porosity, peridotite
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+    set Y extent = 1
+  end
+
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 1
+  end
+end
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression       = 1 + 4.605170186 * y
+  end
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Function expression = 0.5 - 0.4286 * x; 0 
+    set Variable names      = x,y
+  end
+end
+
+
+subsection Material model
+
+  set Model name = melt global 
+  subsection Melt global
+    set Thermal conductivity              = 0
+    set Reference solid density           = 1
+    set Reference melt density            = 1
+    set Thermal expansion coefficient     = 0
+    set Reference permeability            = 32 #permeability of 1 for phi=0.5
+    set Reference shear viscosity         = 0.5
+    set Reference bulk viscosity          = 0.375
+    set Exponential melt weakening factor = 0
+    set Thermal viscosity exponent        = 1
+    set Thermal bulk viscosity exponent   = 1
+    set Reference temperature             = 1
+    set Solid compressibility             = 0
+    set Melt compressibility              = 0
+    set Reference melt viscosity          = 1
+  end
+end
+
+
+subsection Mesh refinement
+  set Coarsening fraction                      = 0.5
+  set Refinement fraction                      = 0.5
+
+  set Initial adaptive refinement              = 5
+  set Initial global refinement                = 5
+  set Strategy                                 = compaction length
+  set Time steps between mesh refinement       = 0
+
+  subsection Compaction length
+    set Mesh cells per compaction length       = 2
+  end
+end
+
+
+subsection Boundary fluid pressure model
+  set Plugin name = density
+  subsection Density
+    set Density formulation = solid density
+  end
+end
+
+subsection Model settings
+  set Tangential velocity boundary indicators = 0,1,2,3
+  set Include melt transport                  = true
+end
+
+subsection Melt settings
+  set Melt transport threshold                = 0
+end
+
+
+subsection Postprocess
+
+  set List of postprocessors = visualization,composition statistics,velocity statistics, temperature statistics
+
+  subsection Visualization
+
+    set List of output variables      = material properties, nonadiabatic temperature, melt fraction, strain rate, melt material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity, reaction terms
+    end
+
+    subsection Melt material properties
+      set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
+    end
+
+    set Number of grouped files       = 0
+    set Output format                 = vtu
+    set Time between graphical output = 0
+  end
+end

--- a/tests/compaction_length_refinement/screen-output
+++ b/tests/compaction_length_refinement/screen-output
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Number of active cells: 1,024 (on 6 levels)
+Number of degrees of freedom: 32,842 (8,450+2,178+8,450+1,089+4,225+4,225+4,225)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.07834e-16, 1.65108e-16, 0, 3.72351e-14
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 3.72351e-14
+
+
+Number of active cells: 1,117 (on 7 levels)
+Number of degrees of freedom: 36,960 (9,510+2,450+9,510+1,225+4,755+4,755+4,755)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 13 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.26524e-16, 1.78403e-16, 0, 3.0894e-14
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 3.0894e-14
+
+
+Number of active cells: 1,696 (on 8 levels)
+Number of degrees of freedom: 56,069 (14,434+3,700+14,434+1,850+7,217+7,217+7,217)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 13 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.30335e-16, 1.19317e-16, 0, 2.70908e-14
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.70908e-14
+
+
+Number of active cells: 2,023 (on 9 levels)
+Number of degrees of freedom: 67,005 (17,250+4,420+17,250+2,210+8,625+8,625+8,625)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.32399e-16, 1.18962e-16, 0, 2.71343e-14
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.71343e-14
+
+
+Number of active cells: 2,026 (on 9 levels)
+Number of degrees of freedom: 67,091 (17,272+4,426+17,272+2,213+8,636+8,636+8,636)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 13 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.30336e-16, 1.19316e-16, 0, 2.70908e-14
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.70908e-14
+
+
+Number of active cells: 2,023 (on 9 levels)
+Number of degrees of freedom: 67,005 (17,250+4,420+17,250+2,210+8,625+8,625+8,625)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.32399e-16, 1.18962e-16, 0, 2.71343e-14
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.71343e-14
+
+
+   Postprocessing:
+     Writing graphical output:  output-compaction_length_refinement/solution/solution-00000
+     Compositions min/max/mass: 0.0714/0.5/0.2857 // 0/0/0
+     RMS, max velocity:         0 m/year, 0 m/year
+     Temperature min/avg/max:   1 K, 3.303 K, 5.605 K
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/compaction_length_refinement/statistics
+++ b/tests/compaction_length_refinement/statistics
@@ -1,0 +1,27 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Number of nonlinear iterations
+# 9: Iterations for temperature solver
+# 10: Iterations for composition solver 1
+# 11: Iterations for composition solver 2
+# 12: Iterations for Stokes solver
+# 13: Velocity iterations in Stokes preconditioner
+# 14: Schur complement iterations in Stokes preconditioner
+# 15: Visualization file name
+# 16: Minimal value for composition porosity
+# 17: Maximal value for composition porosity
+# 18: Global mass for composition porosity
+# 19: Minimal value for composition peridotite
+# 20: Maximal value for composition peridotite
+# 21: Global mass for composition peridotite
+# 22: RMS velocity (m/year)
+# 23: Max. velocity (m/year)
+# 24: Minimal temperature (K)
+# 25: Average temperature (K)
+# 26: Maximal temperature (K)
+0 0.000000000000e+00 0.000000000000e+00 2023 19460 8625 17250 1 0 0 0 0 0 0 output-compaction_length_refinement/solution/solution-00000 7.14000000e-02 5.00000000e-01 2.85700000e-01 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.00000000e+00 3.30258509e+00 5.60517019e+00 


### PR DESCRIPTION
This is useful in models with melt transport, as the compaction length is a typical length scale for these models. 