### PR TITLE
Let solve_stokes() return something more uniform.

### DIFF
--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1233,9 +1233,11 @@ namespace aspect
                                                                      linearized_stokes_variables.block(1),
                                                                      system_rhs.block(0));
         const double residual_p = system_rhs.block(block_p).l2_norm();
-        return sqrt(residual_u*residual_u+residual_p*residual_p);
+        return std::sqrt(residual_u*residual_u+residual_p*residual_p);
       }
   }
+
+
 
   template <int dim>
   bool


### PR DESCRIPTION
Previously, solve_stokes() returned something in some contexts, and something else in others.
Make this more uniform by just returning a pair of values.

While there, also adjust some naming of variables to indicate that they refer to
*nonlinear* residuals.

Fixes #2082.