### PR TITLE
avoid clang warning

### DIFF
--- a/source/simulator/simulator_signals.cc
+++ b/source/simulator/simulator_signals.cc
@@ -99,13 +99,8 @@ namespace aspect
 namespace aspect
 {
 #define INSTANTIATE(dim) \
-  template struct SimulatorSignals<dim>; \
-  namespace internals {\
-    namespace SimulatorSignals {\
-      template void call_connector_functions<dim> (aspect::SimulatorSignals<dim> &signals);\
-    }\
-  }\
-   
+  template struct SimulatorSignals<dim>;
+
 
   ASPECT_INSTANTIATE(INSTANTIATE)
 }


### PR DESCRIPTION
remove:
```
simulator_signals.cc:110:22: warning: explicit instantiation of
'call_connector_functions<2>' that occurs after an explicit
specialization has no effect [-Winstantiation-after-specialization]
```