### PR TITLE
fix time step size for zero velocity

### DIFF
--- a/doc/modules/changes/20180220_jdannberg
+++ b/doc/modules/changes/20180220_jdannberg
@@ -1,0 +1,5 @@
+Changed: If the velocity is zero, the time step size is now set to
+the maximum time step input parameter instead of arbitrarily being 
+set to 1 second.
+<br>
+(Juliane Dannberg, 2018/02/20)

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -605,10 +605,9 @@ namespace aspect
       {
         // If the velocity is zero and we either do not compute the conduction
         // timestep or do not have any conduction, then it is somewhat
-        // arbitrary what time step we should choose. In that case, do as if
-        // the velocity was one
-        new_time_step = (parameters.CFL_number /
-                         (parameters.temperature_degree * 1));
+        // arbitrary what time step we should choose. In that case, set the time
+        // step to the 'Maximum time step'.
+        new_time_step = parameters.maximum_time_step;
       }
 
     // make sure that the timestep doesn't increase too fast

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -603,10 +603,11 @@ namespace aspect
 
     if (new_time_step == std::numeric_limits<double>::max())
       {
-        // If the velocity is zero and we either do not compute the conduction
-        // timestep or do not have any conduction, then it is somewhat
-        // arbitrary what time step we should choose. In that case, set the time
-        // step to the 'Maximum time step'.
+        // In some models the velocity is zero, either because that is the prescribed
+        // Stokes solution, or just because there is no buoyancy and nothing is moving.
+        // If this is the case, and if we either do not compute the conduction time
+        // step or do not have any conduction, it is somewhat arbitrary what time step
+        // we should choose. In that case, set the time step to the 'Maximum time step'.
         new_time_step = parameters.maximum_time_step;
       }
 


### PR DESCRIPTION
This is something that annoyed me several times now: If a model has a zero velocity (either because that is the prescribed Stokes solution, or just because nothing is moving), the time step size is arbitrarily set to 1s. This doesn't make any sense, in particular as we have a parameter that allows the user to set a maximum time step. But because that setting of the time step size to 1 occurs before we apply the maximum time step, the maximum time step parameter is essentially not used in case of zero velocity, because 1s is pretty much always smaller than what you want to use as your maximum time step. 

I suggest that instead of setting the time step size to 1, it should just be set to the maximum time step (which is there for exactly that purpose). 