### PR TITLE
only ask for the derivatives when actually needed.

### DIFF
--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -31,6 +31,9 @@ namespace aspect
     void
     NewtonInterface<dim>::create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const
     {
+      if (this->get_newton_handler().parameters.newton_derivative_scaling_factor == 0)
+        return;
+
       NewtonHandler<dim>::create_material_model_outputs(outputs);
     }
 


### PR DESCRIPTION
This pull request optimizes the defect correction Picard scheme in the Newton solver code. It does it by only adding the derivatives as additional output when they are actually needed.