### PR TITLE
Only rebuild Stokes preconditioner if necessary

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1679,6 +1679,7 @@ namespace aspect
       bool                                                      assemble_newton_stokes_matrix;
       bool                                                      assemble_newton_stokes_system;
       bool                                                      rebuild_stokes_preconditioner;
+      bool                                                      reinitialize_stokes_preconditioner;
 
       /**
        * @}

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -391,8 +391,18 @@ namespace aspect
   void
   Simulator<dim>::build_stokes_preconditioner ()
   {
-    if (rebuild_stokes_preconditioner == false)
+    if (rebuild_stokes_preconditioner == false
+        && reinitialize_stokes_preconditioner == false)
       return;
+    else if (rebuild_stokes_preconditioner == false
+             && reinitialize_stokes_preconditioner == true)
+      {
+        TimerOutput::Scope timer (computing_timer, "   Reinitialize Stokes preconditioner");
+        Amg_preconditioner->reinit();
+        Mp_preconditioner->initialize (system_preconditioner_matrix.block(1,1));
+        reinitialize_stokes_preconditioner = false;
+        return;
+      }
 
     if (parameters.use_direct_stokes_solver)
       return;
@@ -456,6 +466,7 @@ namespace aspect
                                       Amg_data);
 
     rebuild_stokes_preconditioner = false;
+    reinitialize_stokes_preconditioner = false;
 
     pcout << std::endl;
   }

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -394,15 +394,6 @@ namespace aspect
     if (rebuild_stokes_preconditioner == false
         && reinitialize_stokes_preconditioner == false)
       return;
-    else if (rebuild_stokes_preconditioner == false
-             && reinitialize_stokes_preconditioner == true)
-      {
-        TimerOutput::Scope timer (computing_timer, "   Reinitialize Stokes preconditioner");
-        Amg_preconditioner->reinit();
-        Mp_preconditioner->initialize (system_preconditioner_matrix.block(1,1));
-        reinitialize_stokes_preconditioner = false;
-        return;
-      }
 
     if (parameters.use_direct_stokes_solver)
       return;
@@ -412,6 +403,18 @@ namespace aspect
 
     // first assemble the raw matrices necessary for the preconditioner
     assemble_stokes_preconditioner ();
+
+    if (rebuild_stokes_preconditioner == false
+             && reinitialize_stokes_preconditioner == true)
+      {
+        TimerOutput::Scope timer (computing_timer, "   Reinitialize Stokes preconditioner");
+        Amg_preconditioner->reinit();
+        Mp_preconditioner->initialize (system_preconditioner_matrix.block(1,1));
+        reinitialize_stokes_preconditioner = false;
+        pcout << std::endl;
+
+        return;
+      }
 
     // then extract the other information necessary to build the
     // AMG preconditioners for the A and M blocks

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -206,7 +206,8 @@ namespace aspect
     rebuild_stokes_matrix (true),
     assemble_newton_stokes_matrix (true),
     assemble_newton_stokes_system (parameters.nonlinear_solver == NonlinearSolver::Newton_Stokes ? true : false),
-    rebuild_stokes_preconditioner (true)
+    rebuild_stokes_preconditioner (true),
+    reinitialize_stokes_preconditioner (true)
   {
     if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
       {
@@ -816,7 +817,7 @@ namespace aspect
         rebuild_sparsity_and_matrices = false;
         setup_system_matrix (introspection.index_sets.system_partitioning);
         setup_system_preconditioner (introspection.index_sets.system_partitioning);
-        rebuild_stokes_matrix = rebuild_stokes_preconditioner = true;
+        rebuild_stokes_matrix = rebuild_stokes_preconditioner = reinitialize_stokes_preconditioner = true;
       }
 
     // notify different system components that we started the next time step
@@ -1388,6 +1389,7 @@ namespace aspect
 
     rebuild_stokes_matrix         = true;
     rebuild_stokes_preconditioner = true;
+    reinitialize_stokes_preconditioner = true;
   }
 
 

--- a/source/simulator/free_surface.cc
+++ b/source/simulator/free_surface.cc
@@ -293,7 +293,7 @@ namespace aspect
     interpolate_mesh_velocity();
 
     // After changing the mesh we need to rebuild things
-    sim.rebuild_stokes_matrix = sim.rebuild_stokes_preconditioner = true;
+    sim.rebuild_stokes_matrix = sim.rebuild_stokes_preconditioner = sim.reinitialize_stokes_preconditioner = true;
   }
 
 

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -481,7 +481,8 @@ namespace aspect
         // for a restarted computation than for one that ran straight
         // through
         rebuild_stokes_matrix =
-          rebuild_stokes_preconditioner = true;
+          rebuild_stokes_preconditioner =
+            reinitialize_stokes_preconditioner = true;
       }
     return write_checkpoint;
   }

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -240,7 +240,7 @@ namespace aspect
     if (stokes_matrix_depends_on_solution()
         ||
         (boundary_velocity_manager.get_active_boundary_velocity_conditions().size() > 0))
-      rebuild_stokes_matrix = rebuild_stokes_preconditioner = true;
+      rebuild_stokes_matrix = reinitialize_stokes_preconditioner = true;
 
     assemble_stokes_system ();
     build_stokes_preconditioner();
@@ -558,7 +558,7 @@ namespace aspect
         // update the Stokes matrix in every time step and so need to set
         // the following flag. if we change the Stokes matrix we also
         // need to update the Stokes preconditioner.
-        rebuild_stokes_matrix = rebuild_stokes_preconditioner = assemble_newton_stokes_matrix = true;
+        rebuild_stokes_matrix = reinitialize_stokes_preconditioner = assemble_newton_stokes_matrix = true;
 
         assemble_stokes_system();
 
@@ -614,7 +614,7 @@ namespace aspect
                 pcout << "Solve failed and catched, try again with stabilisation" << std::endl;
                 newton_handler->parameters.preconditioner_stabilization = Newton::Parameters::Stabilization::SPD;
                 newton_handler->parameters.velocity_block_stabilization = Newton::Parameters::Stabilization::SPD;
-                rebuild_stokes_matrix = rebuild_stokes_preconditioner = assemble_newton_stokes_matrix = true;
+                rebuild_stokes_matrix = reinitialize_stokes_preconditioner = assemble_newton_stokes_matrix = true;
 
                 assemble_stokes_system();
                 /**


### PR DESCRIPTION
This came out of a discussion with @bangerth here at SIAM PP. Most of the time we do not need to rebuild the AMG preconditioner completely if the mesh has not changed. We just need to update it for the changed matrix values, which is much cheaper. I thought I give this a try (it is a small change), and it seems to work at least for a very small test model I ran on my laptop. I open this mostly to see if all tests work, and also to ask for comments from @tjhei and @bangerth. 
There are two motivations why I think this improves performance significantly:
1. This is a typical timing output of one of my large scale mantle convection models:
```
+---------------------------------------------+------------+------------+
| Total wallclock time elapsed since start    |  4.23e+04s |            |
|                                             |            |            |
| Section                         | no. calls |  wall time | % of total |
+---------------------------------+-----------+------------+------------+
| Assemble Stokes system          |      2878 |  7.17e+03s |        17% |
| Assemble composition system     |      5756 |  5.25e+03s |        12% |
| Assemble temperature system     |      2878 |  3.26e+03s |       7.7% |
| Build Stokes preconditioner     |      2878 |  8.19e+03s |        19% |
| Build composition preconditioner|      5756 |       610s |       1.4% |
| Build temperature preconditioner|      2878 |       314s |      0.74% |
| Solve Stokes system             |      2878 |   6.4e+03s |        15% |
| Solve composition system        |      5756 |       997s |       2.4% |
| Solve temperature system        |      2878 |       506s |       1.2% |
| Create snapshot                 |        23 |       530s |       1.3% |
| Initialization                  |         1 |      1.09s |         0% |
| Postprocessing                  |      1705 |  1.54e+03s |       3.6% |
| Refine mesh structure, part 1   |       569 |  5.04e+03s |        12% |
| Refine mesh structure, part 2   |       569 |       192s |      0.45% |
| Setup dof systems               |       570 |  1.71e+03s |         4% |
+---------------------------------+-----------+------------+------------+
```
Building the Stokes preconditioner is actually more expensive than solving the system. In this model I do mesh refinement every 3rd timestep, so reducing the time spent building the preconditioner by a factor of 2-3 (depending on how expensive the reinitialization is compared to a rebuild), would save me 10-15% of the runtime (10-15% of 40,000 CPU hours for this model alone).

2. Building the Stokes preconditioner can become the strong scaling limit for our models. Not for all of my scaling tests, but the worst case of one of my scaling models on Lonestar 5 (12,288 cores for 130 million dofs) looks like this:
```
+---------------------------------------------+------------+------------+
| Total wallclock time elapsed since start    |       286s |            |
|                                             |            |            |
| Section                         | no. calls |  wall time | % of total |
+---------------------------------+-----------+------------+------------+
| Assemble Stokes system          |         1 |     0.918s |      0.32% |
| Assemble composition system     |         1 |     0.365s |      0.13% |
| Assemble temperature system     |         1 |     0.498s |      0.17% |
| Build Stokes preconditioner     |         1 |       214s |        75% |
| Build composition preconditioner|         1 |    0.0516s |     0.018% |
| Build temperature preconditioner|         1 |    0.0456s |     0.016% |
| Solve Stokes system             |         1 |      49.7s |        17% |
| Solve composition system        |         1 |     0.167s |     0.058% |
| Solve temperature system        |         1 |     0.272s |     0.095% |
| Initialization                  |         2 |      15.3s |       5.3% |
| Postprocessing                  |         1 |    0.0232s |    0.0081% |
| Setup dof systems               |         1 |      4.08s |       1.4% |
+---------------------------------+-----------+------------+------------+
``` 
Reducing the numer of times we build the preconditioner does of course not avoid this scaling limit, but at least it makes it less significant if we call the function less often (for models that are not quite as dramatically bad). 

Opinions? Do I miss something, or do we get 10-15% speedup essentially for free?