### PR TITLE
Add a machine readable JSON file for parameters

### DIFF
--- a/doc/modules/changes/20180311_gassmoeller
+++ b/doc/modules/changes/20180311_gassmoeller
@@ -1,0 +1,6 @@
+New: We now also write a machine readable .json file that contains all
+parameters of each model additionally to the .prm and .tex files. This
+allows automated evaluation of model output (e.g. plotting statistics
+over input parameters).
+<br>
+(Rene Gassmoeller, 2018/03/11)

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -636,14 +636,18 @@ namespace aspect
                      ExcMessage (std::string("Could not open file <") +
                                  parameters.output_directory + "parameters.prm>."));
         prm.print_parameters(prm_out, ParameterHandler::Text);
-      }
-    if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
-      {
-        std::ofstream prm_out ((parameters.output_directory + "parameters.tex").c_str());
-        AssertThrow (prm_out,
+
+        std::ofstream tex_out ((parameters.output_directory + "parameters.tex").c_str());
+        AssertThrow (tex_out,
                      ExcMessage (std::string("Could not open file <") +
                                  parameters.output_directory + "parameters.tex>."));
-        prm.print_parameters(prm_out, ParameterHandler::LaTeX);
+        prm.print_parameters(tex_out, ParameterHandler::LaTeX);
+
+        std::ofstream json_out ((parameters.output_directory + "parameters.json").c_str());
+        AssertThrow (json_out,
+                     ExcMessage (std::string("Could not open file <") +
+                                 parameters.output_directory + "parameters.json>."));
+        prm.print_parameters(json_out, ParameterHandler::JSON);
       }
 
     // check that the setup of equations, material models, and heating terms is consistent


### PR DESCRIPTION
Following a discussion on the mailing list with @MarineLasbleis this writes a machine readable JSON version of the parameter file to the output directory.