### PR TITLE
Fix pressure normalization for DGP element with deal.II 9.0

### DIFF
--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -922,7 +922,8 @@ namespace aspect
                       ExcInternalError());
 
               // then adjust its value
-              distributed_vector(local_dof_indices[first_pressure_dof]) += pressure_adjustment;
+              distributed_vector(local_dof_indices[first_pressure_dof]) = vector(local_dof_indices[first_pressure_dof])
+                                                                          + pressure_adjustment;
             }
         distributed_vector.compress(VectorOperation::insert);
       }
@@ -1022,10 +1023,11 @@ namespace aspect
                       ExcInternalError());
 
               // then adjust its value
-              vector (local_dof_indices[first_pressure_dof]) -= pressure_adjustment;
+              vector (local_dof_indices[first_pressure_dof]) = relevant_vector(local_dof_indices[first_pressure_dof])
+                                                               - pressure_adjustment;
             }
 
-        vector.compress(VectorOperation::add);
+        vector.compress(VectorOperation::insert);
       }
   }
 

--- a/tests/initial_condition_S20RTS_dgp.prm
+++ b/tests/initial_condition_S20RTS_dgp.prm
@@ -1,0 +1,84 @@
+set Dimension                              = 3
+set Use years in output instead of seconds = false
+set Start time                             = 0
+set End time                               = 0
+
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Thermal expansion coefficient = 4e-5
+    set Viscosity                     = 1e22
+  end
+end
+
+subsection Discretization
+  set Stokes velocity polynomial degree            = 1
+  set Use locally conservative discretization      = true
+end
+
+subsection Geometry model
+  set Model name = spherical shell
+
+  subsection Spherical shell
+    set Inner radius  = 3481000
+    set Outer radius  = 6336000
+  end
+end
+
+
+subsection Model settings
+  set Zero velocity boundary indicators       = 0
+  set Tangential velocity boundary indicators = 1
+  set Prescribed velocity boundary indicators =
+
+  set Fixed temperature boundary indicators   = 0,1
+
+end
+
+
+subsection Boundary temperature model
+  set List of model names = spherical constant
+  subsection Spherical constant
+    set Inner temperature = 1600
+    set Outer temperature = 1600
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = S40RTS perturbation
+  subsection S40RTS perturbation
+    set Initial condition file name           = S20RTS.sph
+    set Vs to density scaling                 = 0.3
+    set Thermal expansion coefficient in initial temperature scaling = 4e-5
+    set Reference temperature                 = 1600
+    set Remove degree 0 from perturbation     = true
+  end
+end
+
+
+subsection Gravity model
+  set Model name = radial earth-like
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement          = 0
+  set Initial adaptive refinement        = 0
+  set Strategy                           = temperature
+  set Time steps between mesh refinement = 15
+end
+
+
+subsection Postprocess
+  set List of postprocessors = visualization, temperature statistics
+
+  subsection Visualization
+    set Output format                 = gnuplot
+    set Time between graphical output = 0
+  end
+
+end
+

--- a/tests/initial_condition_S20RTS_dgp/screen-output
+++ b/tests/initial_condition_S20RTS_dgp/screen-output
@@ -1,0 +1,20 @@
+
+Number of active cells: 96 (on 1 levels)
+Number of degrees of freedom: 1,516 (450+96+970)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 179+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-initial_condition_S20RTS_dgp/solution/solution-00000
+     Temperature min/avg/max:  1493 K, 1600 K, 1693 K
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/initial_condition_S20RTS_dgp/statistics
+++ b/tests/initial_condition_S20RTS_dgp/statistics
@@ -1,0 +1,15 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Visualization file name
+# 12: Minimal temperature (K)
+# 13: Average temperature (K)
+# 14: Maximal temperature (K)
+0 0.000000000000e+00 0.000000000000e+00 96 546 970 0 179 183 182 output-initial_condition_S20RTS_dgp/solution/solution-00000 1.49325928e+03 1.59992733e+03 1.69265163e+03 


### PR DESCRIPTION
With deal.II 9.0 (but not 8.5) I trigger the following assert in `normalize_pressure` and `denormalize_pressure`. This fix changes the access to the vector to the same operations we already do for the continuous pressure case. I am not sure why this was not found by our tests, or what has changed in deal.II to cause this. I vaguely remember some changes to prevent a bug in the distributed vector, but can not find the discussion. Does anyone remember?

```
--------------------------------------------------------
An error occurred in line <545> of file </home/rengas/Software/dealii/source/lac/trilinos_vector.cc> in function
    void dealii::TrilinosWrappers::MPI::Vector::compress(dealii::VectorOperation::values)
The violated condition was: 
    ((last_action == Add) && (given_last_action==::dealii::VectorOperation::add)) || ((last_action == Insert) && (given_last_action==::dealii::VectorOperation::insert))
Additional information: 
    The last operation on the Vector and the given last action in the compress() call do not agree!

Stacktrace:
-----------
#0  /home/rengas/Software/deal.II-dev/lib/libdeal_II.g.so.9.0.0-pre: dealii::TrilinosWrappers::MPI::Vector::compress(dealii::VectorOperation::values)
#1  aspect: dealii::BlockVectorBase<dealii::TrilinosWrappers::MPI::Vector>::compress(dealii::VectorOperation::values)
#2  aspect: aspect::Simulator<3>::normalize_pressure(dealii::TrilinosWrappers::MPI::BlockVector&) const
#3  aspect: aspect::Simulator<3>::compute_initial_pressure_field()
#4  aspect: aspect::Simulator<3>::run()
#5  aspect: main
--------------------------------------------------------
```