### PR TITLE
Speed up depth average postprocessor

### DIFF
--- a/doc/modules/changes/20180321_gassmoeller
+++ b/doc/modules/changes/20180321_gassmoeller
@@ -1,0 +1,4 @@
+Improved: The 'depth average' postprocessor was significantly optimized, and
+now uses approximately ten times less computing time.
+<br>
+(Rene Gassmoeller, 2018/03/21)

--- a/include/aspect/lateral_averaging.h
+++ b/include/aspect/lateral_averaging.h
@@ -235,8 +235,8 @@ namespace aspect
        * @param functors Instances of a class satisfying the signature above
        * that are used to fill the values vectors.
        */
-      void compute_lateral_averages(std::vector<std::vector<double> > &values,
-                                    std::vector<std_cxx11::unique_ptr<FunctorBase<dim> > > &functors) const;
+      void compute_lateral_averages(std::vector<std_cxx11::unique_ptr<FunctorBase<dim> > > &functors,
+                                    std::vector<std::vector<double> > &values) const;
 
       /**
        * A version of the function above for a single property.

--- a/include/aspect/lateral_averaging.h
+++ b/include/aspect/lateral_averaging.h
@@ -137,13 +137,13 @@ namespace aspect
       get_vertical_heat_flux_averages(std::vector<double> &values) const;
 
     private:
-
       /**
-       * Internal routine to compute the depth average of a certain quantity.
+       * Internal routine to compute the depth averages of several quantities.
        *
-       * The functor @p fctr must be an object of a user defined type that can
-       * be arbitrary but has to satisfy certain requirements. In essence,
-       * this class type needs to implement the following interface of member
+       * The vector of functors @p functors must contain one or mroe objects of
+       * a user defined type that can
+       * be arbitrary but have to satisfy certain requirements. In essence,
+       * each class type needs to implement the following interface of member
        * functions:
        * @code
        * template <int dim>
@@ -170,14 +170,23 @@ namespace aspect
        * };
        * @endcode
        *
-       * @param values The output vector of depth averaged values. The
-       * function takes the pre-existing size of this vector as the number of
-       * depth slices.
-       * @param fctr Instance of a class satisfying the signature above.
+       * @param values The output vectors of depth averaged values. The
+       * function expects one vector of doubles per property and uses the
+       * pre-existing size of these vectors as the number of depth slices.
+       * Each property vector needs to have the same size.
+       * @param functors Instances of a class satisfying the signature above
+       * that are used to fill the values vectors.
+       */
+      template <class FUNCTOR>
+      void compute_lateral_averages(std::vector<std::vector<double> > &values,
+                                    std::vector<FUNCTOR> &functors) const;
+
+      /**
+       * A version of the function above for a single property.
        */
       template <class FUNCTOR>
       void compute_lateral_average(std::vector<double> &values,
-                                   FUNCTOR &fctr) const;
+                                   FUNCTOR &fctr) const DEAL_II_DEPRECATED;
 
       /**
        * Compute a depth average of the current temperature/composition. The

--- a/include/aspect/lateral_averaging.h
+++ b/include/aspect/lateral_averaging.h
@@ -242,7 +242,7 @@ namespace aspect
        * A version of the function above for a single property.
        */
       void compute_lateral_average(std::vector<double> &values,
-                                   FunctorBase<dim> &fctr) const DEAL_II_DEPRECATED;
+                                   FunctorBase<dim> &fctr) const;
 
       /**
        * Compute a depth average of the current temperature/composition. The

--- a/include/aspect/postprocess/depth_average.h
+++ b/include/aspect/postprocess/depth_average.h
@@ -116,12 +116,7 @@ namespace aspect
         /**
          * List of the quantities to calculate for each depth zone.
          */
-        std::vector<std::string> output_variables;
-
-        /**
-         * Whether to calculate all available quantities when averaging.
-         */
-        bool output_all_variables;
+        std::vector<std::string> variables;
 
         /**
          * Whether to use plain ascii text output

--- a/source/postprocess/depth_average.cc
+++ b/source/postprocess/depth_average.cc
@@ -40,6 +40,10 @@ namespace aspect
   {
     namespace
     {
+      // This function takes a vector of variables names and returns a vector
+      // of the same variable names, except it removes all variables that are
+      // not computed by the LateralAveraging class. In other words the
+      // returned vector is a proper input for LateralAveraging<dim>::get_averages().
       std::vector<std::string>
       filter_non_averaging_variables(const std::vector<std::string> &variables)
       {
@@ -73,7 +77,7 @@ namespace aspect
       // initialize this to a nonsensical value; set it to the actual time
       // the first time around we get to check it
       last_output_time (std::numeric_limits<double>::quiet_NaN()),
-      n_depth_zones (100),
+      n_depth_zones (numbers::invalid_unsigned_int),
       ascii_output(false)
     {}
 
@@ -99,10 +103,9 @@ namespace aspect
       // Add all the requested fields
       {
         const std::vector<std::string> averaging_variables = filter_non_averaging_variables(variables);
-        data_point.values.resize(averaging_variables.size(), std::vector<double> (n_depth_zones));
 
         // Compute averaged variables
-        this->get_lateral_averaging().get_averages(averaging_variables,data_point.values);
+        data_point.values = this->get_lateral_averaging().get_averages(n_depth_zones,averaging_variables);
 
         // Grow data_point.values to include adiabatic properties, and reorder
         // starting from end (to avoid unnecessary copies), and fill in the adiabatic variables.

--- a/source/postprocess/depth_average.cc
+++ b/source/postprocess/depth_average.cc
@@ -38,6 +38,24 @@ namespace aspect
 {
   namespace Postprocess
   {
+    namespace
+    {
+      std::vector<std::string>
+      filter_non_averaging_variables(const std::vector<std::string> &variables)
+      {
+        std::vector<std::string> averaging_variables;
+        averaging_variables.reserve(variables.size());
+
+        for (unsigned int i=0; i<variables.size(); ++i)
+          if (!((variables[i] == "adiabatic_temperature")
+                || (variables[i] == "adiabatic_pressure")
+                || (variables[i] == "adiabatic_density")
+                || (variables[i] == "adiabatic_density_derivative")))
+            averaging_variables.push_back(variables[i]);
+        return averaging_variables;
+      }
+    }
+
     template <int dim>
     template <class Archive>
     void DepthAverage<dim>::DataPoint::serialize (Archive &ar,
@@ -75,104 +93,44 @@ namespace aspect
       if (this->get_time() < last_output_time + output_interval)
         return std::pair<std::string,std::string>();
 
-      // Set up the header for the requested output variables
-      std::vector<std::string> variables;
-      // we have to parse the list in this order to match the output below
-      {
-        if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "temperature") != output_variables.end() )
-          variables.push_back("temperature");
-
-        if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "composition") != output_variables.end() )
-          for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-            variables.push_back(std::string("C_") + Utilities::int_to_string(c));
-
-        if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "adiabatic temperature") != output_variables.end() )
-          variables.push_back("adiabatic_temperature");
-
-        if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "adiabatic pressure") != output_variables.end() )
-          variables.push_back("adiabatic_pressure");
-
-        if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "adiabatic density") != output_variables.end() )
-          variables.push_back("adiabatic_density");
-
-        if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "adiabatic density derivative") != output_variables.end() )
-          variables.push_back("adiabatic_density_derivative");
-
-        if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "velocity magnitude") != output_variables.end() )
-          variables.push_back("velocity_magnitude");
-
-        if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "sinking velocity") != output_variables.end() )
-          variables.push_back("sinking_velocity");
-
-        if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "Vs") != output_variables.end() )
-          variables.push_back("Vs");
-
-        if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "Vp") != output_variables.end() )
-          variables.push_back("Vp");
-
-        if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "viscosity") != output_variables.end() )
-          variables.push_back("viscosity");
-
-        if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "vertical heat flux") != output_variables.end() )
-          variables.push_back("vertical_heat_flux");
-      }
-
       DataPoint data_point;
       data_point.time       = this->get_time();
-      data_point.values.resize(variables.size(), std::vector<double> (n_depth_zones));
 
       // Add all the requested fields
       {
-        unsigned int index = 0;
+        const std::vector<std::string> averaging_variables = filter_non_averaging_variables(variables);
+        data_point.values.resize(averaging_variables.size(), std::vector<double> (n_depth_zones));
 
-        // temperature
-        if ( std::find( variables.begin(), variables.end(), "temperature") != variables.end() )
-          this->get_lateral_averaging().get_temperature_averages(data_point.values[index++]);
+        // Compute averaged variables
+        this->get_lateral_averaging().get_averages(averaging_variables,data_point.values);
 
-        // composition (search output_variables for this, since it has a different name in variables)
-        if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "composition") != output_variables.end() )
-          for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-            this->get_lateral_averaging().get_composition_averages(c, data_point.values[index++]);
-
-        // adiabatic temperature
-        if ( std::find( variables.begin(), variables.end(), "adiabatic_temperature") != variables.end() )
-          this->get_adiabatic_conditions().get_adiabatic_temperature_profile(data_point.values[index++]);
-
-        // adiabatic pressure
-        if ( std::find( variables.begin(), variables.end(), "adiabatic_pressure") != variables.end() )
-          this->get_adiabatic_conditions().get_adiabatic_pressure_profile(data_point.values[index++]);
-
-        // adiabatic density
-        if ( std::find( variables.begin(), variables.end(), "adiabatic_density") != variables.end() )
-          this->get_adiabatic_conditions().get_adiabatic_density_profile(data_point.values[index++]);
-
-        // adiabatic density derivative
-        if ( std::find( variables.begin(), variables.end(), "adiabatic_density_derivative") != variables.end() )
-          this->get_adiabatic_conditions().get_adiabatic_density_derivative_profile(data_point.values[index++]);
-
-        // velocity magnitude
-        if ( std::find( variables.begin(), variables.end(), "velocity_magnitude") != variables.end() )
-          this->get_lateral_averaging().get_velocity_magnitude_averages(data_point.values[index++]);
-
-        // sinking velocity
-        if ( std::find( variables.begin(), variables.end(), "sinking_velocity") != variables.end() )
-          this->get_lateral_averaging().get_sinking_velocity_averages(data_point.values[index++]);
-
-        // Vs
-        if ( std::find( variables.begin(), variables.end(), "Vs") != variables.end() )
-          this->get_lateral_averaging().get_Vs_averages(data_point.values[index++]);
-
-        // Vp
-        if ( std::find( variables.begin(), variables.end(), "Vp") != variables.end() )
-          this->get_lateral_averaging().get_Vp_averages(data_point.values[index++]);
-
-        // viscosity
-        if ( std::find( variables.begin(), variables.end(), "viscosity") != variables.end() )
-          this->get_lateral_averaging().get_viscosity_averages(data_point.values[index++]);
-
-        // vertical heat flux
-        if ( std::find( variables.begin(), variables.end(), "vertical_heat_flux") != variables.end() )
-          this->get_lateral_averaging().get_vertical_heat_flux_averages(data_point.values[index++]);
+        // Grow data_point.values to include adiabatic properties, and reorder
+        // starting from end (to avoid unnecessary copies), and fill in the adiabatic variables.
+        data_point.values.resize(variables.size(), std::vector<double> (n_depth_zones));
+        for (unsigned int i = variables.size(), j = averaging_variables.size(); i>0; --i)
+          {
+            // Swap averaged values to correct field, and move to next one
+            if (variables[i-1] == averaging_variables[j-1])
+              {
+                data_point.values[i-1].swap(data_point.values[j-1]);
+                --j;
+              }
+            // We are in an adiabatic property field, compute it and move on
+            // without decrementing j
+            else
+              {
+                if (variables[i-1] == "adiabatic_temperature")
+                  this->get_adiabatic_conditions().get_adiabatic_temperature_profile(data_point.values[i-1]);
+                else if (variables[i-1] == "adiabatic_pressure")
+                  this->get_adiabatic_conditions().get_adiabatic_pressure_profile(data_point.values[i-1]);
+                else if (variables[i-1] == "adiabatic_density")
+                  this->get_adiabatic_conditions().get_adiabatic_density_profile(data_point.values[i-1]);
+                else if (variables[i-1] == "adiabatic_density_derivative")
+                  this->get_adiabatic_conditions().get_adiabatic_density_derivative_profile(data_point.values[i-1]);
+                else
+                  Assert(false,ExcInternalError());
+              }
+          }
       }
       entries.push_back (data_point);
 
@@ -368,16 +326,55 @@ namespace aspect
                                      "output' in the Depth average postprocessor is set to zero."));
             }
 
-          output_variables = Utilities::split_string_list(prm.get("List of output variables"));
+          std::vector<std::string> output_variables = Utilities::split_string_list(prm.get("List of output variables"));
           AssertThrow(Utilities::has_unique_entries(output_variables),
                       ExcMessage("The list of strings for the parameter "
                                  "'Postprocess/Depth average/List of output variables' contains entries more than once. "
                                  "This is not allowed. Please check your parameter file."));
 
+          bool output_all_variables = false;
           if ( std::find( output_variables.begin(), output_variables.end(), "all") != output_variables.end())
             output_all_variables = true;
-          else
-            output_all_variables = false;
+
+          // we have to parse the list in this order to match the output columns
+          {
+            if (output_all_variables || std::find( output_variables.begin(), output_variables.end(), "temperature") != output_variables.end() )
+              variables.push_back("temperature");
+
+            if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "composition") != output_variables.end() )
+              for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
+                variables.push_back(std::string("C_") + Utilities::int_to_string(c));
+
+            if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "adiabatic temperature") != output_variables.end() )
+              variables.push_back("adiabatic_temperature");
+
+            if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "adiabatic pressure") != output_variables.end() )
+              variables.push_back("adiabatic_pressure");
+
+            if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "adiabatic density") != output_variables.end() )
+              variables.push_back("adiabatic_density");
+
+            if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "adiabatic density derivative") != output_variables.end() )
+              variables.push_back("adiabatic_density_derivative");
+
+            if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "velocity magnitude") != output_variables.end() )
+              variables.push_back("velocity_magnitude");
+
+            if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "sinking velocity") != output_variables.end() )
+              variables.push_back("sinking_velocity");
+
+            if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "Vs") != output_variables.end() )
+              variables.push_back("Vs");
+
+            if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "Vp") != output_variables.end() )
+              variables.push_back("Vp");
+
+            if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "viscosity") != output_variables.end() )
+              variables.push_back("viscosity");
+
+            if ( output_all_variables || std::find( output_variables.begin(), output_variables.end(), "vertical heat flux") != output_variables.end() )
+              variables.push_back("vertical_heat_flux");
+          }
 
           std::string x_output_format = prm.get("Output format");
           if (x_output_format == "txt")

--- a/source/simulator/lateral_averaging.cc
+++ b/source/simulator/lateral_averaging.cc
@@ -36,7 +36,7 @@ namespace aspect
 
   template <int dim>
   void LateralAveraging<dim>::compute_lateral_averages(std::vector<std_cxx11::unique_ptr<FunctorBase<dim> > > &functors,
-      std::vector<std::vector<double> > &values) const
+                                                       std::vector<std::vector<double> > &values) const
   {
     Assert (values.size() > 0,
             ExcMessage ("To call this function, you need to request a positive "
@@ -46,7 +46,7 @@ namespace aspect
                         "number of depth slices."));
     Assert (functors.size() == values.size(),
             ExcMessage ("To call this function, you need supply as many data "
-                "vectors as properties you want to compute."));
+                        "vectors as properties you want to compute."));
 
     const unsigned int n_properties = values.size();
     const unsigned int n_slices = values[0].size();
@@ -171,9 +171,9 @@ namespace aspect
     vector_of_functors[0].reset(&functor);
 
     compute_lateral_averages(vector_of_functors,vector_of_values);
-    values = vector_of_values[0];
+    values.swap(vector_of_values[0]);
 
-    // Security measure to prevent destruction of object that is owned by calling
+    // Security measure to prevent destruction of functor that is owned by calling
     // function.
     vector_of_functors[0].release();
   }
@@ -525,10 +525,10 @@ namespace aspect
         else if (property_names[property_index].substr(0,2) == "C_")
           {
             const unsigned int c =
-                Utilities::string_to_int(property_names[property_index].substr(2,std::string::npos));
+              Utilities::string_to_int(property_names[property_index].substr(2,std::string::npos));
 
             functors.push_back(std_cxx11::unique_ptr<FunctorBase<dim> >(
-                new FunctorDepthAverageField<dim> (this->introspection().extractors.compositional_fields[c])));
+                                 new FunctorDepthAverageField<dim> (this->introspection().extractors.compositional_fields[c])));
           }
         else if (property_names[property_index] == "velocity_magnitude")
           {

--- a/tests/depth_average_underres/screen-output
+++ b/tests/depth_average_underres/screen-output
@@ -1,3 +1,5 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
 
 Number of active cells: 4 (on 2 levels)
 Number of degrees of freedom: 84 (50+9+25)
@@ -8,20 +10,11 @@ Number of degrees of freedom: 84 (50+9+25)
    Solving Stokes system... 30+0 iterations.
 
    Postprocessing:
-In computing depth averages, there is at least one depth band that does not have any quadrature points in it.
- Consider reducing number of depth layers for  averaging
-In computing depth averages, there is at least one depth band that does not have any quadrature points in it.
- Consider reducing number of depth layers for  averaging
-In computing depth averages, there is at least one depth band that does not have any quadrature points in it.
- Consider reducing number of depth layers for  averaging
-In computing depth averages, there is at least one depth band that does not have any quadrature points in it.
- Consider reducing number of depth layers for  averaging
-In computing depth averages, there is at least one depth band that does not have any quadrature points in it.
- Consider reducing number of depth layers for  averaging
-In computing depth averages, there is at least one depth band that does not have any quadrature points in it.
- Consider reducing number of depth layers for  averaging
-In computing depth averages, there is at least one depth band that does not have any quadrature points in it.
- Consider reducing number of depth layers for  averaging
+
+**** Warning: When computing depth averages, there is at least one depth band
+     that does not have any quadrature points in it.
+     Consider reducing the number of depth layers for averaging.
+
      Writing depth average: output-depth_average_underres/depth_average.gnuplot
 
 Termination requested by criterion: end time

--- a/tests/steinberger_lateral_fail/screen-output
+++ b/tests/steinberger_lateral_fail/screen-output
@@ -3,8 +3,11 @@ Number of active cells: 192 (on 4 levels)
 Number of degrees of freedom: 2,724 (1,666+225+833)
 
 *** Timestep 0:  t=0 years
-In computing depth averages, there is at least one depth band that does not have any quadrature points in it.
- Consider reducing number of depth layers for  averaging
+
+**** Warning: When computing depth averages, there is at least one depth band
+     that does not have any quadrature points in it.
+     Consider reducing the number of depth layers for averaging.
+
 ERROR: Uncaught exception in MPI_InitFinalize on proc 0. Skipping MPI_Finalize() to avoid a deadlock.
 
 


### PR DESCRIPTION
This began as a small optimization project and ended up as nearly complete rewrite of the lateral averaging functionality. All external interfaces are kept, and all functionality should work as before, but by reducing duplication the depth average postprocessor is now nearly ten times faster than before. Instead of n loops over all cells for n properties, lateral averaging now performs 1 loop for n properties (by providing n functors that are all executed for each cell). The `compute_average` function no longer takes a `FUNCTOR` template argument, but instead each functor is derived from a common base class, which makes creating a vector of functors much simpler. I am quite happy with the current state so I would like to ask for a review. In particular I would like to ask for comments about the position of the base class `FunctorBase`. I would like to hide it from the header file, but I could not forward declare its type.

I have another improvement lined up, but that one changes the functionality by reducing the number of quadrature points if possible, and I will open that as a separate PR.