### PR TITLE
Remove anisotropic viscosity from main code (move to tests)

### DIFF
--- a/doc/modules/changes/20180322_gassmoeller
+++ b/doc/modules/changes/20180322_gassmoeller
@@ -1,0 +1,7 @@
+Removed: Due to low usage, and the lack of realistic applications, the code
+paths for using anisotropic viscosity have been removed from the main assembly.
+They are still available and tested as plugins for the anisotropic_viscosity
+test and can be utilized if needed. This optimization speeds up the Stokes
+assembly by up to 25%.
+<br>
+(Rene Gassmoeller, 2018/03/22)

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -353,20 +353,6 @@ namespace aspect
       std::vector<double> viscosities;
 
       /**
-       * Stress-strain "director" tensors at the given positions. This
-       * variable can be used to implement exotic rheologies such as
-       * anisotropic viscosity.
-       *
-       * @note The strain rate term in equation (1) of the manual will be
-       * multiplied by this tensor *and* the viscosity scalar ($\eta$), as
-       * described in the manual section titled "Constitutive laws". This
-       * variable is assigned the rank-four identity tensor by default.
-       * This leaves the isotropic constitutive law unchanged if the material
-       * model does not explicitly assign a value.
-       */
-      std::vector<SymmetricTensor<4,dim> > stress_strain_directors;
-
-      /**
        * Density values at the given positions.
        */
       std::vector<double> densities;

--- a/source/heating_model/shear_heating.cc
+++ b/source/heating_model/shear_heating.cc
@@ -47,22 +47,6 @@ namespace aspect
 
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
         {
-          // If there is an anisotropic viscosity, use it to compute the correct stress
-          const SymmetricTensor<4,dim> &C = material_model_outputs.stress_strain_directors[q];
-          const SymmetricTensor<2,dim> &directed_strain_rate = ((C != dealii::identity_tensor<dim> ())
-                                                                ?
-                                                                C * material_model_inputs.strain_rate[q]
-                                                                :
-                                                                material_model_inputs.strain_rate[q]);
-
-          const SymmetricTensor<2,dim> stress =
-            2 * material_model_outputs.viscosities[q] *
-            (this->get_material_model().is_compressible()
-             ?
-             directed_strain_rate - 1./3. * trace(directed_strain_rate) * unit_symmetric_tensor<dim>()
-             :
-             directed_strain_rate);
-
           const SymmetricTensor<2,dim> compressible_strain_rate =
             (this->get_material_model().is_compressible()
              ?
@@ -70,6 +54,10 @@ namespace aspect
              - 1./3. * trace(material_model_inputs.strain_rate[q]) * unit_symmetric_tensor<dim>()
              :
              material_model_inputs.strain_rate[q]);
+
+          const SymmetricTensor<2,dim> stress =
+            2 * material_model_outputs.viscosities[q] *
+            compressible_strain_rate;
 
           heating_model_outputs.heating_source_terms[q] = stress * compressible_strain_rate;
 

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -382,7 +382,6 @@ namespace aspect
                                                     const unsigned int n_comp)
       :
       viscosities(n_points, numbers::signaling_nan<double>()),
-      stress_strain_directors(n_points, dealii::identity_tensor<dim> ()),
       densities(n_points, numbers::signaling_nan<double>()),
       thermal_expansion_coefficients(n_points, numbers::signaling_nan<double>()),
       specific_heat(n_points, numbers::signaling_nan<double>()),

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -92,13 +92,6 @@ namespace aspect
 
           const double eta = scratch.material_model_outputs.viscosities[q];
           const double one_over_eta = 1. / eta;
-
-          const SymmetricTensor<4, dim> &stress_strain_director = scratch
-                                                                  .material_model_outputs.stress_strain_directors[q];
-
-          AssertThrow(stress_strain_director == dealii::identity_tensor<dim>(),
-                      ExcMessage ("Error: The newton method currently doesn't support anisotropic viscosities."));
-
           const double JxW = scratch.finite_element_values.JxW(q);
 
           // TODO: Find out why in this version of ASPECT adding the derivative to the preconditioning
@@ -294,13 +287,6 @@ namespace aspect
 
           // Viscosity scalar
           const double eta = scratch.material_model_outputs.viscosities[q];
-
-          const SymmetricTensor<4,dim> &stress_strain_director =
-            scratch.material_model_outputs.stress_strain_directors[q];
-
-          AssertThrow(stress_strain_director == dealii::identity_tensor<dim>(),
-                      ExcMessage ("Error: The newton method currently doesn't support anisotropic viscosities."));
-
           const SymmetricTensor<2,dim> strain_rate = scratch.material_model_inputs.strain_rate[q];
           const double pressure = scratch.material_model_inputs.pressure[q];
           const double velocity_divergence = scratch.velocity_divergence[q];
@@ -478,13 +464,6 @@ namespace aspect
           // Viscosity scalar
           const double two_thirds = 2.0 / 3.0;
           const double eta_two_thirds = scratch.material_model_outputs.viscosities[q] * two_thirds;
-
-          const SymmetricTensor<4,dim> &stress_strain_director =
-            scratch.material_model_outputs.stress_strain_directors[q];
-
-          AssertThrow(stress_strain_director == dealii::identity_tensor<dim>(),
-                      ExcMessage ("Error: The newton method currently doesn't support anisotropic viscosities."));
-
           const double velocity_divergence = trace(scratch.grads_phi_u[q]);
 
           const double JxW = scratch.finite_element_values.JxW(q);

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -76,24 +76,14 @@ namespace aspect
           const double eta = scratch.material_model_outputs.viscosities[q];
           const double one_over_eta = 1. / eta;
 
-          const SymmetricTensor<4, dim> &stress_strain_director = scratch
-                                                                  .material_model_outputs.stress_strain_directors[q];
-          const bool use_tensor = (stress_strain_director
-                                   != dealii::identity_tensor<dim>());
-
           const double JxW = scratch.finite_element_values.JxW(q);
 
           for (unsigned int i = 0; i < stokes_dofs_per_cell; ++i)
             for (unsigned int j = 0; j < stokes_dofs_per_cell; ++j)
               if (scratch.dof_component_indices[i] ==
                   scratch.dof_component_indices[j])
-                data.local_matrix(i, j) += ((
-                                              use_tensor ?
-                                              2.0 * eta * (scratch.grads_phi_u[i]
-                                                           * stress_strain_director
-                                                           * scratch.grads_phi_u[j]) :
-                                              2.0 * eta * (scratch.grads_phi_u[i]
-                                                           * scratch.grads_phi_u[j]))
+                data.local_matrix(i, j) += ((2.0 * eta * (scratch.grads_phi_u[i]
+                                                          * scratch.grads_phi_u[j]))
                                             + one_over_eta * pressure_scaling
                                             * pressure_scaling
                                             * (scratch.phi_p[i]
@@ -148,22 +138,14 @@ namespace aspect
 
           const double eta_two_thirds = scratch.material_model_outputs.viscosities[q] * 2.0 / 3.0;
 
-          const SymmetricTensor<4, dim> &stress_strain_director = scratch
-                                                                  .material_model_outputs.stress_strain_directors[q];
-          const bool use_tensor = (stress_strain_director
-                                   != dealii::identity_tensor<dim>());
-
           const double JxW = scratch.finite_element_values.JxW(q);
 
           for (unsigned int i = 0; i < stokes_dofs_per_cell; ++i)
             for (unsigned int j = 0; j < stokes_dofs_per_cell; ++j)
               if (scratch.dof_component_indices[i] ==
                   scratch.dof_component_indices[j])
-                data.local_matrix(i, j) += (- (use_tensor ?
-                                               eta_two_thirds * (scratch.div_phi_u[i] * trace(stress_strain_director * scratch.grads_phi_u[j]))
-                                               :
-                                               eta_two_thirds * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
-                                              ))
+                data.local_matrix(i, j) += (- eta_two_thirds * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
+                                           )
                                            * JxW;
         }
     }
@@ -214,10 +196,6 @@ namespace aspect
                               :
                               numbers::signaling_nan<double>());
 
-          const SymmetricTensor<4,dim> &stress_strain_director =
-            scratch.material_model_outputs.stress_strain_directors[q];
-          const bool use_tensor = (stress_strain_director !=  dealii::identity_tensor<dim> ());
-
           const Tensor<1,dim>
           gravity = this->get_gravity_model().gravity_vector (scratch.finite_element_values.quadrature_point(q));
 
@@ -237,10 +215,7 @@ namespace aspect
               if (scratch.rebuild_stokes_matrix)
                 for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
                   {
-                    data.local_matrix(i,j) += ( (use_tensor ?
-                                                 eta * 2.0 * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
-                                                 :
-                                                 eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
+                    data.local_matrix(i,j) += ( (eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
                                                 // assemble \nabla p as -(p, div v):
                                                 - (pressure_scaling *
                                                    scratch.div_phi_u[i] * scratch.phi_p[j])
@@ -313,19 +288,12 @@ namespace aspect
           // Viscosity scalar
           const double eta_two_thirds = scratch.material_model_outputs.viscosities[q] * 2.0 / 3.0;
 
-          const SymmetricTensor<4,dim> &stress_strain_director =
-            scratch.material_model_outputs.stress_strain_directors[q];
-          const bool use_tensor = (stress_strain_director !=  dealii::identity_tensor<dim> ());
-
           const double JxW = scratch.finite_element_values.JxW(q);
 
           for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
             for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
               {
-                data.local_matrix(i,j) += (- (use_tensor ?
-                                              eta_two_thirds * (scratch.div_phi_u[i] * trace(stress_strain_director * scratch.grads_phi_u[j]))
-                                              :
-                                              eta_two_thirds * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
+                data.local_matrix(i,j) += (- (eta_two_thirds * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
                                              ))
                                           * JxW;
               }

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -227,26 +227,15 @@ namespace aspect
             S = - (1/eta + 1/viscosity_c)  M_p  for p_c
           */
           const double viscosity_c = melt_outputs->compaction_viscosities[q];
-
-          const SymmetricTensor<4,dim> &stress_strain_director =
-            scratch.material_model_outputs.stress_strain_directors[q];
-          const bool use_tensor = (stress_strain_director != dealii::identity_tensor<dim> ());
-
           const double JxW = scratch.finite_element_values.JxW(q);
 
           for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
             for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
               {
                 if (scratch.dof_component_indices[i] == scratch.dof_component_indices[j])
-                  data.local_matrix(i,j) += ((use_tensor ?
-                                              2.0 * eta * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
-                                              :
-                                              2.0 * eta * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
+                  data.local_matrix(i,j) += (2.0 * eta * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j])
                                              -
-                                             (use_tensor ?
-                                              eta_two_thirds * (scratch.div_phi_u[i] * trace(stress_strain_director * scratch.grads_phi_u[j]))
-                                              :
-                                              eta_two_thirds * (scratch.div_phi_u[i] * scratch.div_phi_u[j]))
+                                             eta_two_thirds * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
                                              +
                                              (one_over_eta *
                                               pressure_scaling *
@@ -428,9 +417,6 @@ namespace aspect
                                          numbers::signaling_nan<double>());
           const Tensor<1,dim>
           gravity = this->get_gravity_model().gravity_vector (scratch.finite_element_values.quadrature_point(q));
-          const SymmetricTensor<4,dim> &stress_strain_director =
-            scratch.material_model_outputs.stress_strain_directors[q];
-          const bool use_tensor = (stress_strain_director !=  dealii::identity_tensor<dim> ());
 
           const double compressibility
             = (this->get_material_model().is_compressible()
@@ -493,14 +479,8 @@ namespace aspect
               if (scratch.rebuild_stokes_matrix)
                 for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
                   {
-                    data.local_matrix(i,j) += ( (use_tensor ?
-                                                 eta * 2.0 * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
-                                                 :
-                                                 eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
-                                                - (use_tensor ?
-                                                   eta_two_thirds * (scratch.div_phi_u[i] * trace(stress_strain_director * scratch.grads_phi_u[j]))
-                                                   :
-                                                   eta_two_thirds * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
+                    data.local_matrix(i,j) += ( (eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
+                                                - (eta_two_thirds * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
                                                   )
                                                 - (pressure_scaling *
                                                    scratch.div_phi_u[i] * scratch.phi_p[j])

--- a/tests/anisotropic_viscosity.cc
+++ b/tests/anisotropic_viscosity.cc
@@ -1,8 +1,594 @@
-#include <aspect/material_model/simple.h>
 #include <aspect/simulator_access.h>
+
+#include <aspect/material_model/simple.h>
+#include <aspect/material_model/grain_size.h>
+#include <aspect/heating_model/interface.h>
+#include <aspect/gravity_model/interface.h>
+#include <aspect/simulator/assemblers/stokes.h>
+#include <aspect/simulator_signals.h>
+
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/signaling_nan.h>
 
 namespace aspect
 {
+  namespace MaterialModel
+  {
+    /**
+      * Additional output fields for anisotropic viscosities to be added to
+      * the MaterialModel::MaterialModelOutputs structure and filled in the
+      * MaterialModel::Interface::evaluate() function.
+      */
+    template <int dim>
+    class AnisotropicViscosity : public NamedAdditionalMaterialOutputs<dim>
+    {
+      public:
+        AnisotropicViscosity(const unsigned int n_points);
+
+        virtual std::vector<double> get_nth_output(const unsigned int idx) const;
+
+        /**
+         * Stress-strain "director" tensors at the given positions. This
+         * variable is used to implement anisotropic viscosity.
+         *
+         * @note The strain rate term in equation (1) of the manual will be
+         * multiplied by this tensor *and* the viscosity scalar ($\eta$), as
+         * described in the manual section titled "Constitutive laws". This
+         * variable is assigned the rank-four identity tensor by default.
+         * This leaves the isotropic constitutive law unchanged if the material
+         * model does not explicitly assign a value.
+         */
+        std::vector<SymmetricTensor<4,dim> > stress_strain_directors;
+    };
+
+    template <int dim>
+    AnisotropicViscosity<dim>::AnisotropicViscosity (const unsigned int n_points)
+      :
+      NamedAdditionalMaterialOutputs<dim>(std::vector<std::string>(1,"anisotropic_viscosity")),
+      stress_strain_directors(n_points, dealii::identity_tensor<dim> ())
+    {}
+
+
+
+    template <int dim>
+    std::vector<double>
+    AnisotropicViscosity<dim>::get_nth_output(const unsigned int /*idx*/) const
+    {
+      return std::vector<double>();
+    }
+  }
+
+  namespace Assemblers
+  {
+    /**
+     * A class containing the functions to assemble the Stokes preconditioner.
+     */
+    template <int dim>
+    class StokesPreconditionerAnisotropicViscosity : public Assemblers::Interface<dim>,
+      public SimulatorAccess<dim>
+    {
+      public:
+        virtual
+        void
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+
+        /**
+         * Create AnisotropicViscosities.
+         */
+        virtual void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const;
+    };
+
+    /**
+     * A class containing the functions to assemble the compressible adjustment
+     * to the Stokes preconditioner.
+     */
+    template <int dim>
+    class StokesCompressiblePreconditionerAnisotropicViscosity : public Assemblers::Interface<dim>,
+      public SimulatorAccess<dim>
+    {
+      public:
+        virtual
+        void
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+    };
+
+    /**
+     * This class assembles the terms for the matrix and right-hand-side of the incompressible
+     * Stokes equation for the current cell.
+     */
+    template <int dim>
+    class StokesIncompressibleTermsAnisotropicViscosity : public Assemblers::Interface<dim>,
+      public SimulatorAccess<dim>
+    {
+      public:
+        virtual
+        void
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+
+        /**
+         * Create AdditionalMaterialOutputsStokesRHS if we need to do so.
+         */
+        virtual void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const;
+    };
+
+    /**
+     * This class assembles the term that arises in the viscosity term of Stokes matrix for
+     * compressible models, because the divergence of the velocity is not longer zero.
+     */
+    template <int dim>
+    class StokesCompressibleStrainRateViscosityTermAnisotropicViscosity : public Assemblers::Interface<dim>,
+      public SimulatorAccess<dim>
+    {
+      public:
+        virtual
+        void
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+    };
+
+    template <int dim>
+    void
+    StokesPreconditionerAnisotropicViscosity<dim>::
+    execute (internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+             internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const
+    {
+      internal::Assembly::Scratch::StokesPreconditioner<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesPreconditioner<dim>& > (scratch_base);
+      internal::Assembly::CopyData::StokesPreconditioner<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesPreconditioner<dim>& > (data_base);
+
+      const MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
+        scratch.material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >();
+
+      const Introspection<dim> &introspection = this->introspection();
+      const FiniteElement<dim> &fe = this->get_fe();
+      const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
+      const unsigned int n_q_points           = scratch.finite_element_values.n_quadrature_points;
+      const double pressure_scaling = this->get_pressure_scaling();
+
+      // First loop over all dofs and find those that are in the Stokes system
+      // save the component (pressure and dim velocities) each belongs to.
+      for (unsigned int i = 0, i_stokes = 0; i_stokes < stokes_dofs_per_cell; /*increment at end of loop*/)
+        {
+          if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
+            {
+              scratch.dof_component_indices[i_stokes] = fe.system_to_component_index(i).first;
+              ++i_stokes;
+            }
+          ++i;
+        }
+
+      // Loop over all quadrature points and assemble their contributions to
+      // the preconditioner matrix
+      for (unsigned int q = 0; q < n_q_points; ++q)
+        {
+          for (unsigned int i = 0, i_stokes = 0; i_stokes < stokes_dofs_per_cell; /*increment at end of loop*/)
+            {
+              if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
+                {
+                  scratch.grads_phi_u[i_stokes] =
+                    scratch.finite_element_values[introspection.extractors
+                                                  .velocities].symmetric_gradient(i, q);
+                  scratch.phi_p[i_stokes] = scratch.finite_element_values[introspection
+                                                                          .extractors.pressure].value(i, q);
+                  ++i_stokes;
+                }
+              ++i;
+            }
+
+          const double eta = scratch.material_model_outputs.viscosities[q];
+          const double one_over_eta = 1. / eta;
+
+          const bool use_tensor = (anisotropic_viscosity != NULL);
+
+          const SymmetricTensor<4, dim> &stress_strain_director = (use_tensor)
+                                                                  ?
+                                                                  anisotropic_viscosity->stress_strain_directors[q]
+                                                                  :
+                                                                  dealii::identity_tensor<dim>();
+
+
+
+          const double JxW = scratch.finite_element_values.JxW(q);
+
+          for (unsigned int i = 0; i < stokes_dofs_per_cell; ++i)
+            for (unsigned int j = 0; j < stokes_dofs_per_cell; ++j)
+              if (scratch.dof_component_indices[i] ==
+                  scratch.dof_component_indices[j])
+                data.local_matrix(i, j) += ((
+                                              use_tensor ?
+                                              2.0 * eta * (scratch.grads_phi_u[i]
+                                                           * stress_strain_director
+                                                           * scratch.grads_phi_u[j]) :
+                                              2.0 * eta * (scratch.grads_phi_u[i]
+                                                           * scratch.grads_phi_u[j]))
+                                            + one_over_eta * pressure_scaling
+                                            * pressure_scaling
+                                            * (scratch.phi_p[i]
+                                               * scratch.phi_p[j]))
+                                           * JxW;
+        }
+    }
+
+
+
+    template <int dim>
+    void
+    StokesPreconditionerAnisotropicViscosity<dim>::
+    create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const
+    {
+      const unsigned int n_points = outputs.viscosities.size();
+
+      if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >() == NULL)
+        {
+          outputs.additional_outputs.push_back(
+            std_cxx11::shared_ptr<MaterialModel::AnisotropicViscosity<dim> >
+            (new MaterialModel::AnisotropicViscosity<dim> (n_points)));
+        }
+    }
+
+
+
+    template <int dim>
+    void
+    StokesCompressiblePreconditionerAnisotropicViscosity<dim>::
+    execute (internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+             internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const
+    {
+      internal::Assembly::Scratch::StokesPreconditioner<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesPreconditioner<dim>& > (scratch_base);
+      internal::Assembly::CopyData::StokesPreconditioner<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesPreconditioner<dim>& > (data_base);
+
+      const MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
+        scratch.material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >();
+
+      const Introspection<dim> &introspection = this->introspection();
+      const FiniteElement<dim> &fe = this->get_fe();
+      const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
+      const unsigned int n_q_points           = scratch.finite_element_values.n_quadrature_points;
+
+      // First loop over all dofs and find those that are in the Stokes system
+      // save the component (pressure and dim velocities) each belongs to.
+      for (unsigned int i = 0, i_stokes = 0; i_stokes < stokes_dofs_per_cell; /*increment at end of loop*/)
+        {
+          if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
+            {
+              scratch.dof_component_indices[i_stokes] = fe.system_to_component_index(i).first;
+              ++i_stokes;
+            }
+          ++i;
+        }
+
+      // Loop over all quadrature points and assemble their contributions to
+      // the preconditioner matrix
+      for (unsigned int q = 0; q < n_q_points; ++q)
+        {
+          for (unsigned int i = 0, i_stokes = 0; i_stokes < stokes_dofs_per_cell; /*increment at end of loop*/)
+            {
+              if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
+                {
+                  scratch.grads_phi_u[i_stokes] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(i,q);
+                  scratch.div_phi_u[i_stokes]   = scratch.finite_element_values[introspection.extractors.velocities].divergence (i, q);
+
+                  ++i_stokes;
+                }
+              ++i;
+            }
+
+          const double eta_two_thirds = scratch.material_model_outputs.viscosities[q] * 2.0 / 3.0;
+
+          const bool use_tensor = (anisotropic_viscosity != NULL);
+
+          const SymmetricTensor<4, dim> &stress_strain_director = (use_tensor)
+                                                                  ?
+                                                                  anisotropic_viscosity->stress_strain_directors[q]
+                                                                  :
+                                                                  dealii::identity_tensor<dim>();
+
+          const double JxW = scratch.finite_element_values.JxW(q);
+
+          for (unsigned int i = 0; i < stokes_dofs_per_cell; ++i)
+            for (unsigned int j = 0; j < stokes_dofs_per_cell; ++j)
+              if (scratch.dof_component_indices[i] ==
+                  scratch.dof_component_indices[j])
+                data.local_matrix(i, j) += (- (use_tensor ?
+                                               eta_two_thirds * (scratch.div_phi_u[i] * trace(stress_strain_director * scratch.grads_phi_u[j]))
+                                               :
+                                               eta_two_thirds * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
+                                              ))
+                                           * JxW;
+        }
+    }
+
+
+
+    template <int dim>
+    void
+    StokesIncompressibleTermsAnisotropicViscosity<dim>::
+    execute (internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+             internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const
+    {
+      internal::Assembly::Scratch::StokesSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesSystem<dim>& > (scratch_base);
+      internal::Assembly::CopyData::StokesSystem<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesSystem<dim>& > (data_base);
+
+      const MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
+        scratch.material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >();
+
+      const Introspection<dim> &introspection = this->introspection();
+      const FiniteElement<dim> &fe = this->get_fe();
+      const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
+      const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
+      const double pressure_scaling = this->get_pressure_scaling();
+
+      const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>
+      *force = scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >();
+
+      for (unsigned int q=0; q<n_q_points; ++q)
+        {
+          for (unsigned int i=0, i_stokes=0; i_stokes<stokes_dofs_per_cell; /*increment at end of loop*/)
+            {
+              if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
+                {
+                  scratch.phi_u[i_stokes] = scratch.finite_element_values[introspection.extractors.velocities].value (i,q);
+                  scratch.phi_p[i_stokes] = scratch.finite_element_values[introspection.extractors.pressure].value (i, q);
+                  if (scratch.rebuild_stokes_matrix)
+                    {
+                      scratch.grads_phi_u[i_stokes] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(i,q);
+                      scratch.div_phi_u[i_stokes]   = scratch.finite_element_values[introspection.extractors.velocities].divergence (i, q);
+                    }
+                  ++i_stokes;
+                }
+              ++i;
+            }
+
+
+          // Viscosity scalar
+          const double eta = (scratch.rebuild_stokes_matrix
+                              ?
+                              scratch.material_model_outputs.viscosities[q]
+                              :
+                              numbers::signaling_nan<double>());
+
+          const bool use_tensor = (anisotropic_viscosity != NULL);
+
+          const SymmetricTensor<4, dim> &stress_strain_director = (use_tensor)
+                                                                  ?
+                                                                  anisotropic_viscosity->stress_strain_directors[q]
+                                                                  :
+                                                                  dealii::identity_tensor<dim>();
+
+          const Tensor<1,dim>
+          gravity = this->get_gravity_model().gravity_vector (scratch.finite_element_values.quadrature_point(q));
+
+          const double density = scratch.material_model_outputs.densities[q];
+          const double JxW = scratch.finite_element_values.JxW(q);
+
+          for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
+            {
+              data.local_rhs(i) += (density * gravity * scratch.phi_u[i])
+                                   * JxW;
+
+              if (force != NULL)
+                data.local_rhs(i) += (force->rhs_u[q] * scratch.phi_u[i]
+                                      + pressure_scaling * force->rhs_p[q] * scratch.phi_p[i])
+                                     * JxW;
+
+              if (scratch.rebuild_stokes_matrix)
+                for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
+                  {
+                    data.local_matrix(i,j) += ( (use_tensor ?
+                                                 eta * 2.0 * (scratch.grads_phi_u[i] * stress_strain_director * scratch.grads_phi_u[j])
+                                                 :
+                                                 eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j]))
+                                                // assemble \nabla p as -(p, div v):
+                                                - (pressure_scaling *
+                                                   scratch.div_phi_u[i] * scratch.phi_p[j])
+                                                // assemble the term -div(u) as -(div u, q).
+                                                // Note the negative sign to make this
+                                                // operator adjoint to the grad p term:
+                                                - (pressure_scaling *
+                                                   scratch.phi_p[i] * scratch.div_phi_u[j]))
+                                              * JxW;
+                  }
+            }
+        }
+    }
+
+
+
+    template <int dim>
+    void
+    StokesIncompressibleTermsAnisotropicViscosity<dim>::
+    create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const
+    {
+      const unsigned int n_points = outputs.viscosities.size();
+
+      if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >() == NULL)
+        {
+          outputs.additional_outputs.push_back(
+            std_cxx11::shared_ptr<MaterialModel::AnisotropicViscosity<dim> >
+            (new MaterialModel::AnisotropicViscosity<dim> (n_points)));
+        }
+
+      if (this->get_parameters().enable_additional_stokes_rhs
+          && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >() == NULL)
+        {
+          outputs.additional_outputs.push_back(
+            std_cxx11::shared_ptr<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >
+            (new MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> (n_points)));
+        }
+      Assert(!this->get_parameters().enable_additional_stokes_rhs
+             ||
+             outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >()->rhs_u.size()
+             == n_points, ExcInternalError());
+    }
+
+
+
+    template <int dim>
+    void
+    StokesCompressibleStrainRateViscosityTermAnisotropicViscosity<dim>::
+    execute (internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+             internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const
+    {
+      internal::Assembly::Scratch::StokesSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesSystem<dim>& > (scratch_base);
+      internal::Assembly::CopyData::StokesSystem<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesSystem<dim>& > (data_base);
+
+      if (!scratch.rebuild_stokes_matrix)
+        return;
+
+      const MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
+        scratch.material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >();
+
+      const Introspection<dim> &introspection = this->introspection();
+      const FiniteElement<dim> &fe = this->get_fe();
+      const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
+      const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
+
+      for (unsigned int q=0; q<n_q_points; ++q)
+        {
+          for (unsigned int i=0, i_stokes=0; i_stokes<stokes_dofs_per_cell; /*increment at end of loop*/)
+            {
+              if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
+                {
+                  scratch.grads_phi_u[i_stokes] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(i,q);
+                  scratch.div_phi_u[i_stokes]   = scratch.finite_element_values[introspection.extractors.velocities].divergence (i, q);
+
+                  ++i_stokes;
+                }
+              ++i;
+            }
+
+          // Viscosity scalar
+          const double eta_two_thirds = scratch.material_model_outputs.viscosities[q] * 2.0 / 3.0;
+
+          const bool use_tensor = (anisotropic_viscosity != NULL);
+
+          const SymmetricTensor<4, dim> &stress_strain_director = (use_tensor)
+                                                                  ?
+                                                                  anisotropic_viscosity->stress_strain_directors[q]
+                                                                  :
+                                                                  dealii::identity_tensor<dim>();
+
+          const double JxW = scratch.finite_element_values.JxW(q);
+
+          for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
+            for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
+              {
+                data.local_matrix(i,j) += (- (use_tensor ?
+                                              eta_two_thirds * (scratch.div_phi_u[i] * trace(stress_strain_director * scratch.grads_phi_u[j]))
+                                              :
+                                              eta_two_thirds * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
+                                             ))
+                                          * JxW;
+              }
+        }
+    }
+  }
+
+
+  namespace HeatingModel
+  {
+    template <int dim>
+    class ShearHeatingAnisotropicViscosity : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * Compute the heating model outputs for this class.
+         */
+        virtual
+        void
+        evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+                  const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
+                  HeatingModel::HeatingModelOutputs &heating_model_outputs) const;
+
+        /**
+         * Allow the heating model to attach additional material model outputs.
+         */
+        virtual
+        void
+        create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &material_model_outputs) const;
+    };
+
+    template <int dim>
+    void
+    ShearHeatingAnisotropicViscosity<dim>::
+    evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+              const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
+              HeatingModel::HeatingModelOutputs &heating_model_outputs) const
+    {
+      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.position.size(),
+             ExcMessage ("Heating outputs need to have the same number of entries as the material model inputs."));
+
+      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.strain_rate.size(),
+             ExcMessage ("The shear heating plugin needs the strain rate!"));
+
+      // Some material models provide dislocation viscosities and boundary area work fractions
+      // as additional material outputs. If they are attached, use them.
+      const MaterialModel::DislocationViscosityOutputs<dim> *disl_viscosities_out =
+        material_model_outputs.template get_additional_output<MaterialModel::DislocationViscosityOutputs<dim> >();
+
+      const MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
+        material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >();
+
+      for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
+        {
+          // If there is an anisotropic viscosity, use it to compute the correct stress
+          const SymmetricTensor<2,dim> &directed_strain_rate = ((anisotropic_viscosity != NULL)
+                                                                ?
+                                                                anisotropic_viscosity->stress_strain_directors[q]
+                                                                * material_model_inputs.strain_rate[q]
+                                                                :
+                                                                material_model_inputs.strain_rate[q]);
+
+          const SymmetricTensor<2,dim> stress =
+            2 * material_model_outputs.viscosities[q] *
+            (this->get_material_model().is_compressible()
+             ?
+             directed_strain_rate - 1./3. * trace(directed_strain_rate) * unit_symmetric_tensor<dim>()
+             :
+             directed_strain_rate);
+
+          const SymmetricTensor<2,dim> compressible_strain_rate =
+            (this->get_material_model().is_compressible()
+             ?
+             material_model_inputs.strain_rate[q]
+             - 1./3. * trace(material_model_inputs.strain_rate[q]) * unit_symmetric_tensor<dim>()
+             :
+             material_model_inputs.strain_rate[q]);
+
+          heating_model_outputs.heating_source_terms[q] = stress * compressible_strain_rate;
+
+          // If dislocation viscosities and boundary area work fractions are provided, reduce the
+          // overall heating by this amount (which is assumed to increase surface energy)
+          if (disl_viscosities_out != 0)
+            {
+              heating_model_outputs.heating_source_terms[q] *= 1 - disl_viscosities_out->boundary_area_change_work_fractions[q] *
+                                                               material_model_outputs.viscosities[q] / disl_viscosities_out->dislocation_viscosities[q];
+            }
+
+          heating_model_outputs.lhs_latent_heat_terms[q] = 0.0;
+        }
+    }
+
+    template <int dim>
+    void
+    ShearHeatingAnisotropicViscosity<dim>::
+    create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &material_model_outputs) const
+    {
+      const unsigned int n_points = material_model_outputs.viscosities.size();
+
+      if (material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >() == NULL)
+        {
+          material_model_outputs.additional_outputs.push_back(
+            std_cxx11::shared_ptr<MaterialModel::AnisotropicViscosity<dim> >
+            (new MaterialModel::AnisotropicViscosity<dim> (n_points)));
+        }
+
+      this->get_material_model().create_additional_named_outputs(material_model_outputs);
+    }
+  }
+
   namespace MaterialModel
   {
     using namespace dealii;
@@ -11,6 +597,7 @@ namespace aspect
     class Anisotropic : public MaterialModel::Simple<dim>
     {
       public:
+        virtual void initialize();
 
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const;
@@ -25,7 +612,11 @@ namespace aspect
         is_compressible () const;
 
       private:
-        SymmetricTensor<4,dim> C; // Constitutive tensor
+        void set_assemblers(const SimulatorAccess<dim> &,
+                            Assemblers::Manager<dim> &assemblers) const;
+
+        // Constitutive tensor
+        SymmetricTensor<4,dim> C;
     };
 
   }
@@ -35,6 +626,38 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    template <int dim>
+    void
+    Anisotropic<dim>::set_assemblers(const SimulatorAccess<dim> &,
+                                     Assemblers::Manager<dim> &assemblers) const
+    {
+      for (unsigned int i=0; i<assemblers.stokes_preconditioner.size(); ++i)
+        {
+          if (dynamic_cast<Assemblers::StokesPreconditioner<dim> *>(assemblers.stokes_preconditioner[i].get()) != NULL)
+            assemblers.stokes_preconditioner[i] = std_cxx14::make_unique<Assemblers::StokesPreconditionerAnisotropicViscosity<dim> > ();
+          if (dynamic_cast<Assemblers::StokesCompressiblePreconditioner<dim> *>(assemblers.stokes_preconditioner[i].get()) != NULL)
+            assemblers.stokes_preconditioner[i] = std_cxx14::make_unique<Assemblers::StokesCompressiblePreconditionerAnisotropicViscosity<dim> > ();
+        }
+
+      for (unsigned int i=0; i<assemblers.stokes_system.size(); ++i)
+        {
+          if (dynamic_cast<Assemblers::StokesIncompressibleTerms<dim> *>(assemblers.stokes_system[i].get()) != NULL)
+            assemblers.stokes_system[i] = std_cxx14::make_unique<Assemblers::StokesIncompressibleTermsAnisotropicViscosity<dim> > ();
+          if (dynamic_cast<Assemblers::StokesCompressibleStrainRateViscosityTerm<dim> *>(assemblers.stokes_system[i].get()) != NULL)
+            assemblers.stokes_system[i] = std_cxx14::make_unique<Assemblers::StokesCompressibleStrainRateViscosityTermAnisotropicViscosity<dim> > ();
+        }
+    }
+
+    template <int dim>
+    void
+    Anisotropic<dim>::
+    initialize()
+    {
+      this->get_signals().set_assemblers.connect (std_cxx11::bind(&Anisotropic<dim>::set_assemblers,
+                                                                  std_cxx11::cref(*this),
+                                                                  std_cxx11::_1,
+                                                                  std_cxx11::_2));
+    }
 
     template <int dim>
     void
@@ -42,6 +665,9 @@ namespace aspect
     evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
+      MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
+        out.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >();
+
       Simple<dim>::evaluate(in, out);
       Point<dim> center;
       center[0] = 0.5;
@@ -55,7 +681,8 @@ namespace aspect
           out.compressibilities[i] = 1.0 / (1. + pressure);
           if ((in.position[i]-center).norm() < 0.25)
             {
-              out.stress_strain_directors[i] = C;
+              if (anisotropic_viscosity != NULL)
+                anisotropic_viscosity->stress_strain_directors[i] = C;
             }
         }
     }
@@ -149,6 +776,35 @@ namespace aspect
 // explicit instantiations
 namespace aspect
 {
+  namespace Assemblers
+  {
+#define INSTANTIATE(dim) \
+  template class StokesPreconditioner<dim>; \
+  template class StokesCompressiblePreconditioner<dim>; \
+  template class StokesIncompressibleTerms<dim>; \
+  template class StokesCompressibleStrainRateViscosityTerm<dim>; \
+  template class StokesReferenceDensityCompressibilityTerm<dim>; \
+  template class StokesImplicitReferenceDensityCompressibilityTerm<dim>; \
+  template class StokesIsothermalCompressionTerm<dim>; \
+  template class StokesHydrostaticCompressionTerm<dim>; \
+  template class StokesPressureRHSCompatibilityModification<dim>; \
+  template class StokesBoundaryTraction<dim>;
+
+    ASPECT_INSTANTIATE(INSTANTIATE)
+  }
+
+  namespace HeatingModel
+  {
+    ASPECT_REGISTER_HEATING_MODEL(ShearHeatingAnisotropicViscosity,
+                                  "anisotropic shear heating",
+                                  "Implementation of a standard model for shear heating. "
+                                  "Adds the term: "
+                                  "$  2 \\eta \\left( \\varepsilon - \\frac{1}{3} \\text{tr} "
+                                  "\\varepsilon \\mathbf 1 \\right) : \\left( \\varepsilon - \\frac{1}{3} "
+                                  "\\text{tr} \\varepsilon \\mathbf 1 \\right)$ to the "
+                                  "right-hand side of the temperature equation.")
+  }
+
   namespace MaterialModel
   {
     ASPECT_REGISTER_MATERIAL_MODEL(Anisotropic,

--- a/tests/anisotropic_viscosity.prm
+++ b/tests/anisotropic_viscosity.prm
@@ -64,7 +64,7 @@ subsection Material model
 end
 
 subsection Heating model
-  set List of model names = shear heating
+  set List of model names = anisotropic shear heating
 end
 
 subsection Mesh refinement

--- a/tests/anisotropic_viscosity.prm
+++ b/tests/anisotropic_viscosity.prm
@@ -1,3 +1,14 @@
+# This tests an implementation of anisotropic viscosity terms in the Stokes
+# equation. In this test we create new assembler
+# classes in anisotropic_viscosity.cc that extend the standard assemblers
+# with a fourth order viscosity tensor. The chosen material model 'anisotropic'
+# then replaces the standard assemblers with the custom ones during the call
+# to the set_assemblers signal, and during every call to evaluate()
+# fills the AdditionalMaterialOutputs object of type AnisotropicViscosity with
+# the chosen viscosity tensor that is selected in this input file.
+# This way the solved equations are changed without modifying the main codei
+# base.
+
 set Dimension = 2
 set CFL number                             = 1.0
 set End time                               = 0

--- a/tests/anisotropic_viscosity/statistics
+++ b/tests/anisotropic_viscosity/statistics
@@ -8,8 +8,8 @@
 # 8: Iterations for Stokes solver
 # 9: Velocity iterations in Stokes preconditioner
 # 10: Schur complement iterations in Stokes preconditioner
-# 11: Average shear heating rate (W/kg) 
-# 12: Total shear heating rate (W) 
+# 11: Average anisotropic shear heating rate (W/kg) 
+# 12: Total anisotropic shear heating rate (W) 
 # 13: RMS velocity (m/s)
 # 14: Max. velocity (m/s)
 0 0.000000000000e+00 0.000000000000e+00 1024 9539 4225 1 209 944 215 4.70996179e+00 6.19299117e+00 1.22476550e+00 2.04950484e+00 


### PR DESCRIPTION
It does not seem as if the anisotropic viscosity is used in practical applications a lot. On the other hand we now have all the infrastructure to remove it from the main assemblers, and restrict its use to the models that actually need it. The only model that uses it so far is our test/anisotropic viscosity (and we have no normal material model that supports it, only the plugin for anisotropic viscosity).
I did this mostly to clean up the code of the assemblers, but it turns out that the performance influence was bigger than expected. The change speeds up the assembly of the Stokes system and the preconditioner by about 25% in terms of instructions measured by callgrind (in 3d, optimized mode, using the geoid.prm test as reference). I am not sure why, but in the example we save about 10 instructions per innermost loop cycle, which is now down from 25 to 15 instructions per loop. It looks like the tensor contract function is inlined in the new version, but was not before, though that is a guess, it is not exactly clear to me what is happening.

Anyway, nice speedup, cleaner code, functionality still around if someone needs it.