### PR TITLE
Add error messages

### DIFF
--- a/source/postprocess/visualization/named_additional_outputs.cc
+++ b/source/postprocess/visualization/named_additional_outputs.cc
@@ -63,6 +63,14 @@ namespace aspect
               }
           }
 
+        AssertThrow(out.additional_outputs.size() > 0,
+                    ExcMessage("You activated the postprocessor <named additional outputs>, but there are no additional outputs "
+                               "provided by the material model. Either remove the postprocessor, or check why no output is provided."));
+        AssertThrow(property_names.size() > 0,
+                    ExcMessage("You activated the postprocessor <named additional outputs>, but none of the additional outputs "
+                               "provided by the material model are named outputs. Either remove the postprocessor, or check why no "
+                               "named output is provided."));
+
         for (unsigned int i=0; i<property_names.size(); ++i)
           std::replace(property_names[i].begin(),property_names[i].end(),' ', '_');
       }


### PR DESCRIPTION
The 'named additional outputs' postprocessor offers only a cryptic error message if no named outputs are provided by the material model. Make this check more clear and immediately crash at model start.