### PR TITLE
Introduce conversion functions for plugins

### DIFF
--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -24,7 +24,6 @@
 
 #include <aspect/global.h>
 #include <aspect/plugins.h>
-#include <aspect/utilities.h>
 #include <aspect/simulator_access.h>
 
 #include <deal.II/base/std_cxx11/shared_ptr.h>
@@ -230,7 +229,8 @@ namespace aspect
          * if one of them has the desired type specified by the template
          * argument. If so, return a pointer to it. If no postprocessor is
          * active that matches the given type, return a NULL pointer.
-         * @deprecated: Use has_matching_postprocessor() and
+         *
+         * @deprecated Use has_matching_postprocessor() and
          * get_matching_postprocessor() instead.
          */
         template <typename PostprocessorType>
@@ -240,7 +240,7 @@ namespace aspect
         /**
          * Go through the list of all postprocessors that have been selected
          * in the input file (and are consequently currently active) and return
-         * if one of them has the desired type specified by the template
+         * true if one of them has the desired type specified by the template
          * argument.
          */
         template <typename PostprocessorType>
@@ -250,9 +250,10 @@ namespace aspect
         /**
          * Go through the list of all postprocessors that have been selected
          * in the input file (and are consequently currently active) and see
-         * if one of them has the desired type specified by the template
-         * argument. If so, return a reference to it. If no postprocessor is
-         * active that matches the given type, throw an exception.
+         * if one of them has the type specified by the template
+         * argument or can be casted to that type. If so, return a reference
+         * to it. If no postprocessor is active that matches the given type,
+         * throw an exception.
          */
         template <typename PostprocessorType>
         PostprocessorType &
@@ -411,7 +412,7 @@ namespace aspect
       for (typename std::vector<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
            p = postprocessors.begin();
            p != postprocessors.end(); ++p)
-        if (Utilities::plugin_type_matches<PostprocessorType>(*(*p)))
+        if (Plugins::plugin_type_matches<PostprocessorType>(*(*p)))
           return true;
 
       return false;
@@ -435,11 +436,11 @@ namespace aspect
       for (typename std::vector<std_cxx11::shared_ptr<Interface<dim> > >::const_iterator
            p = postprocessors.begin();
            p != postprocessors.end(); ++p)
-        if (Utilities::plugin_type_matches<PostprocessorType>(*(*p)))
-          return Utilities::get_plugin_as_type<PostprocessorType>(*(*p));
+        if (Plugins::plugin_type_matches<PostprocessorType>(*(*p)))
+          return Plugins::get_plugin_as_type<PostprocessorType>(*(*p));
 
       // We will never get here, because we had the Assert above. Just to avoid warnings.
-      return Utilities::get_plugin_as_type<PostprocessorType>(*(*postprocessor));
+      return Plugins::get_plugin_as_type<PostprocessorType>(*(*postprocessor));
     }
 
 

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -100,6 +100,11 @@ namespace aspect
     template <int dim> class Interface;
   }
 
+  namespace Postprocess
+  {
+    template <int dim> class Manager;
+  }
+
   template <int dim> class MeltHandler;
   template <int dim> class FreeSurfaceHandler;
 
@@ -745,6 +750,12 @@ namespace aspect
       template <typename PostprocessorType>
       PostprocessorType *
       find_postprocessor () const;
+
+      /**
+       * Return a reference to the melt handler.
+       */
+      const Postprocess::Manager<dim> &
+      get_postprocess_manager () const;
 
       /** @} */
 

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1069,6 +1069,28 @@ namespace aspect
     template <int dim>
     SymmetricTensor<2,dim> nth_basis_for_symmetric_tensors (const unsigned int k);
 
+    template <typename TestType, typename ObjectType>
+    inline
+    bool
+    object_is_of_type (const ObjectType &object)
+    {
+      return (dynamic_cast<const TestType *> (&object) != 0);
+    }
+
+    template <typename TestType, typename ObjectType>
+    inline
+    TestType &
+    get_object_as_type (ObjectType &object)
+    {
+      if (!object_is_of_type<TestType>(object))
+        AssertThrow(false,
+                    ExcMessage("You have requested to convert an object into a type "
+                               "in which it can not be converted."));
+
+      // We can safely dereference the pointer, because we checked above that
+      // the object is actually of type TestType, and so it is not a nullptr.
+      return *dynamic_cast<TestType *> (&object);
+    }
   }
 }
 

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -34,8 +34,6 @@
 
 #include <aspect/geometry_model/interface.h>
 
-#include <typeinfo>
-#include <boost/core/demangle.hpp>
 
 
 namespace aspect
@@ -1071,51 +1069,6 @@ namespace aspect
     template <int dim>
     SymmetricTensor<2,dim> nth_basis_for_symmetric_tensors (const unsigned int k);
 
-    /**
-     * This function returns if a given plugin (e.g. a material model returned
-     * from SimulatorAccess::get_material_model() ) matches a certain plugin
-     * type (e.g. MaterialModel::Simple). This check is needed, because often
-     * it is only possible to get a reference to an Interface, not the actual
-     * plugin type, but the actual plugin type might be important. For example
-     * a radial gravity model might only be implemented for spherical geometry
-     * models, and would want to check if the current geometry is in fact a
-     * spherical shell.
-     */
-    template <typename TestType, typename PluginType>
-    inline
-    bool
-    plugin_type_matches (const PluginType &object)
-    {
-      return (dynamic_cast<const TestType *> (&object) != 0);
-    }
-
-    /**
-     * This function converts a reference to a type (in particular a reference
-     * to an interface class) into a reference to a different type (in
-     * particular a plugin class). This allows accessing members of the plugin
-     * that are not specified in the interface class. Note that you should
-     * first check if the plugin type is actually convertible by calling
-     * plugin_matches_type() before calling this function. If the plugin is
-     * not convertible this function throws an exception.
-     */
-    template <typename TestType, typename PluginType>
-    inline
-    TestType &
-    get_plugin_as_type (PluginType &object)
-    {
-      if (!plugin_type_matches<TestType>(object))
-        AssertThrow(false,
-                    ExcMessage("You have requested to convert a plugin of type <"
-                               + boost::core::demangle(typeid(PluginType).name())
-                               + "> into type <"
-                               + boost::core::demangle(typeid(TestType).name()) +
-                               "> in which it can not be converted."));
-
-      // We can safely dereference the pointer, because we checked above that
-      // the object is actually of type TestType, and so the result
-      // is not a nullptr.
-      return *dynamic_cast<TestType *> (&object);
-    }
   }
 }
 

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -580,11 +580,11 @@ namespace aspect
       // It is not available at the time initialize() function of boundary temperature is called.
       if (is_first_call==true)
         {
-          AssertThrow(this->get_postprocess_manager().template has_postprocessor_of_type<const Postprocess::CoreStatistics<dim> >(),
+          AssertThrow(this->get_postprocess_manager().template has_matching_postprocessor<const Postprocess::CoreStatistics<dim> >(),
                       ExcMessage ("Dynamic core boundary condition has to work with dynamic core statistics postprocessor."));
 
           const Postprocess::CoreStatistics<dim> &core_statistics
-            = this->get_postprocess_manager().template get_postprocessor_of_type<const Postprocess::CoreStatistics<dim> >();
+            = this->get_postprocess_manager().template get_matching_postprocessor<const Postprocess::CoreStatistics<dim> >();
           // The restart data is stored in 'core statistics' postprocessor.
           // If restart from checkpoint, extract data from there.
           core_data = core_statistics.get_core_data();

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -580,13 +580,14 @@ namespace aspect
       // It is not available at the time initialize() function of boundary temperature is called.
       if (is_first_call==true)
         {
-          const Postprocess::CoreStatistics<dim> *core_statistics
-            = this->template find_postprocessor<const Postprocess::CoreStatistics<dim> >();
-          AssertThrow(core_statistics!=NULL,
+          AssertThrow(this->get_postprocess_manager().template has_postprocessor_of_type<const Postprocess::CoreStatistics<dim> >(),
                       ExcMessage ("Dynamic core boundary condition has to work with dynamic core statistics postprocessor."));
+
+          const Postprocess::CoreStatistics<dim> &core_statistics
+            = this->get_postprocess_manager().template get_postprocessor_of_type<const Postprocess::CoreStatistics<dim> >();
           // The restart data is stored in 'core statistics' postprocessor.
           // If restart from checkpoint, extract data from there.
-          core_data = core_statistics->get_core_data();
+          core_data = core_statistics.get_core_data();
 
           // Read data of other energy source
           read_data_OES();

--- a/source/gravity_model/radial.cc
+++ b/source/gravity_model/radial.cc
@@ -79,10 +79,10 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      Assert (Utilities::plugin_type_matches<const GeometryModel::Box<dim> >(this->get_geometry_model()) == false,
+      Assert (Plugins::plugin_type_matches<const GeometryModel::Box<dim> >(this->get_geometry_model()) == false,
               ExcMessage ("Gravity model 'radial constant' should not be used with geometry model 'box'."));
 
-      Assert (Utilities::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim> >(this->get_geometry_model()) == false,
+      Assert (Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim> >(this->get_geometry_model()) == false,
               ExcMessage ("Gravity model 'radial constant' should not be used with geometry model 'box with "
                           "lithosphere boundary indicators'."));
     }

--- a/source/gravity_model/radial.cc
+++ b/source/gravity_model/radial.cc
@@ -24,6 +24,7 @@
 #include <aspect/geometry_model/box.h>
 #include <aspect/geometry_model/two_merged_boxes.h>
 #include <aspect/geometry_model/sphere.h>
+#include <aspect/utilities.h>
 
 #include <deal.II/base/tensor.h>
 
@@ -77,9 +78,11 @@ namespace aspect
         prm.leave_subsection ();
       }
       prm.leave_subsection ();
-      Assert (dynamic_cast<const GeometryModel::Box<dim>*> (&this->get_geometry_model()) == 0,
+
+      Assert (Utilities::object_is_of_type<const GeometryModel::Box<dim> >(this->get_geometry_model()) == false,
               ExcMessage ("Gravity model 'radial constant' should not be used with geometry model 'box'."));
-      Assert (dynamic_cast<const GeometryModel::TwoMergedBoxes<dim>*> (&this->get_geometry_model()) == 0,
+
+      Assert (Utilities::object_is_of_type<const GeometryModel::TwoMergedBoxes<dim> >(this->get_geometry_model()) == false,
               ExcMessage ("Gravity model 'radial constant' should not be used with geometry model 'box with "
                           "lithosphere boundary indicators'."));
     }

--- a/source/gravity_model/radial.cc
+++ b/source/gravity_model/radial.cc
@@ -79,10 +79,10 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      Assert (Utilities::object_is_of_type<const GeometryModel::Box<dim> >(this->get_geometry_model()) == false,
+      Assert (Utilities::plugin_type_matches<const GeometryModel::Box<dim> >(this->get_geometry_model()) == false,
               ExcMessage ("Gravity model 'radial constant' should not be used with geometry model 'box'."));
 
-      Assert (Utilities::object_is_of_type<const GeometryModel::TwoMergedBoxes<dim> >(this->get_geometry_model()) == false,
+      Assert (Utilities::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim> >(this->get_geometry_model()) == false,
               ExcMessage ("Gravity model 'radial constant' should not be used with geometry model 'box with "
                           "lithosphere boundary indicators'."));
     }

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -654,6 +654,15 @@ namespace aspect
   {
     return simulator->do_pressure_rhs_compatibility_modification;
   }
+
+
+
+  template <int dim>
+  const Postprocess::Manager<dim> &
+  SimulatorAccess<dim>::get_postprocess_manager() const
+  {
+    return simulator->postprocess_manager;
+  }
 }
 
 

--- a/tests/find_postprocess.cc
+++ b/tests/find_postprocess.cc
@@ -42,19 +42,35 @@ namespace aspect
     template <int dim>
     void Box2<dim>::update()
     {
-
-      const Postprocess::HeatFluxStatistics<dim> *heat_flux_postprocess=
-        this->template find_postprocessor<const Postprocess::HeatFluxStatistics<dim> >();
-      const Postprocess::PressureStatistics<dim> *pressure_postprocess=
-        this->template find_postprocessor<const Postprocess::PressureStatistics<dim> >();
-      if (pressure_postprocess==NULL)
-        std::cout << "PressureStatistics is not found!" << std::endl;
-      else
+      if (this->get_postprocess_manager().template has_postprocessor_of_type<Postprocess::PressureStatistics<dim> >())
         std::cout << "PressureStatistics is found!" << std::endl;
-      if (heat_flux_postprocess==NULL)
-        std::cout << "HeatFluxStatistics is not found!" << std::endl;
       else
+        std::cout << "PressureStatistics is not found!" << std::endl;
+
+      if (this->get_postprocess_manager().template has_postprocessor_of_type<Postprocess::HeatFluxStatistics<dim> >())
         std::cout << "HeatFluxStatistics is found!" << std::endl;
+      else
+        std::cout << "HeatFluxStatistics is not found!" << std::endl;
+
+      try
+        {
+          this->get_postprocess_manager().template get_postprocessor_of_type<Postprocess::PressureStatistics<dim> >();
+          std::cout << "PressureStatistics is found!" << std::endl;
+        }
+      catch (...)
+        {
+          std::cout << "PressureStatistics is not found!" << std::endl;
+        }
+
+      try
+        {
+          this->get_postprocess_manager().template get_postprocessor_of_type<Postprocess::HeatFluxStatistics<dim> >();
+          std::cout << "HeatFluxStatistics is found!" << std::endl;
+        }
+      catch (...)
+        {
+          std::cout << "HeatFluxStatistics is not found!" << std::endl;
+        }
     }
   }
 }

--- a/tests/find_postprocess/screen-output
+++ b/tests/find_postprocess/screen-output
@@ -1,3 +1,5 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
 
 Loading shared library <./libfind_postprocess.so>
 
@@ -6,7 +8,11 @@ Number of degrees of freedom: 948 (578+81+289)
 
 PressureStatistics is not found!
 HeatFluxStatistics is found!
+PressureStatistics is not found!
+HeatFluxStatistics is found!
 *** Timestep 0:  t=0 seconds
+PressureStatistics is not found!
+HeatFluxStatistics is found!
 PressureStatistics is not found!
 HeatFluxStatistics is found!
    Solving temperature system... 0 iterations.

--- a/tests/find_postprocess_fail_1.cc
+++ b/tests/find_postprocess_fail_1.cc
@@ -42,35 +42,8 @@ namespace aspect
     template <int dim>
     void Box2<dim>::update()
     {
-      if (this->get_postprocess_manager().template has_matching_postprocessor<Postprocess::PressureStatistics<dim> >())
-        std::cout << "PressureStatistics is found!" << std::endl;
-      else
-        std::cout << "PressureStatistics is not found!" << std::endl;
-
-      if (this->get_postprocess_manager().template has_matching_postprocessor<Postprocess::HeatFluxStatistics<dim> >())
-        std::cout << "HeatFluxStatistics is found!" << std::endl;
-      else
-        std::cout << "HeatFluxStatistics is not found!" << std::endl;
-
-      try
-        {
-          this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::PressureStatistics<dim> >();
-          std::cout << "PressureStatistics is found!" << std::endl;
-        }
-      catch (...)
-        {
-          std::cout << "PressureStatistics is not found!" << std::endl;
-        }
-
-      try
-        {
-          this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::HeatFluxStatistics<dim> >();
-          std::cout << "HeatFluxStatistics is found!" << std::endl;
-        }
-      catch (...)
-        {
-          std::cout << "HeatFluxStatistics is not found!" << std::endl;
-        }
+      this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::PressureStatistics<dim> >();
+      std::cout << "PressureStatistics is found!" << std::endl;
     }
   }
 }

--- a/tests/find_postprocess_fail_1.prm
+++ b/tests/find_postprocess_fail_1.prm
@@ -1,0 +1,74 @@
+# This test will request a non-activated postprocessor and
+# will not catch the resulting exception to check if the
+# exception output works correctly.
+
+# EXPECT FAILURE
+
+set Dimension = 2
+set CFL number                             = 1.0
+set End time                               = 0
+set Start time                             = 0
+set Adiabatic surface temperature          = 0
+set Surface pressure                       = 0
+set Use years in output instead of seconds = false  # default: true
+set Nonlinear solver scheme                = IMPES
+
+
+subsection Boundary temperature model
+  set List of model names = box2
+end
+
+
+
+subsection Gravity model
+  set Model name = vertical
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1.2 # default: 1
+    set Y extent = 1
+    set Z extent = 1
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = perturbed box
+end
+
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1    # default: 3300
+    set Reference specific heat       = 1250
+    set Reference temperature         = 1    # default: 293
+    set Thermal conductivity          = 1e-6 # default: 4.7
+    set Thermal expansion coefficient = 2e-5
+    set Viscosity                     = 1    # default: 5e24
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 3
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = 0, 1
+  set Prescribed velocity boundary indicators =
+  set Tangential velocity boundary indicators = 1
+  set Zero velocity boundary indicators       = 0, 2, 3
+end
+
+subsection Postprocess
+  set List of postprocessors =  heat flux statistics
+end
+

--- a/tests/find_postprocess_fail_1/screen-output
+++ b/tests/find_postprocess_fail_1/screen-output
@@ -1,0 +1,19 @@
+
+Loading shared library <./libfind_postprocess_fail_1.so>
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 948 (578+81+289)
+
+ERROR: Uncaught exception in MPI_InitFinalize on proc 0. Skipping MPI_Finalize() to avoid a deadlock.
+
+
+Exception 'ExcMessage("You asked Postprocess:Manager::get_postprocessor_of_type() for a " "postprocessor of type <" + boost::core::demangle(typeid(PostprocessorType).name()) + "> " "that could not be found in the current model. Activate this " "postprocessor in the input file.")' on rank 0 on processing: 
+
+An error occurred in file <interface.h> in function
+(line in output replaced by default.sh script)
+The violated condition was: 
+    has_matching_postprocessor<PostprocessorType> ()
+Additional information: 
+    You asked Postprocess:Manager::get_postprocessor_of_type() for a postprocessor of type <aspect::Postprocess::PressureStatistics<2>> that could not be found in the current model. Activate this postprocessor in the input file.
+
+Aborting!

--- a/tests/find_postprocess_fail_2.cc
+++ b/tests/find_postprocess_fail_2.cc
@@ -48,10 +48,10 @@ namespace aspect
             this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::HeatFluxStatistics<dim> >();
 
           std::cout << "HeatFluxStatistics is PressureStatistics:"
-                    << Utilities::plugin_type_matches<Postprocess::PressureStatistics<dim> >(heat_flux_statistics)
+                    << Plugins::plugin_type_matches<Postprocess::PressureStatistics<dim> >(heat_flux_statistics)
                     << std::endl;
 
-          Utilities::get_plugin_as_type<Postprocess::PressureStatistics<dim> >(heat_flux_statistics);
+          Plugins::get_plugin_as_type<Postprocess::PressureStatistics<dim> >(heat_flux_statistics);
         }
     }
   }

--- a/tests/find_postprocess_fail_2.cc
+++ b/tests/find_postprocess_fail_2.cc
@@ -42,34 +42,16 @@ namespace aspect
     template <int dim>
     void Box2<dim>::update()
     {
-      if (this->get_postprocess_manager().template has_matching_postprocessor<Postprocess::PressureStatistics<dim> >())
-        std::cout << "PressureStatistics is found!" << std::endl;
-      else
-        std::cout << "PressureStatistics is not found!" << std::endl;
-
       if (this->get_postprocess_manager().template has_matching_postprocessor<Postprocess::HeatFluxStatistics<dim> >())
-        std::cout << "HeatFluxStatistics is found!" << std::endl;
-      else
-        std::cout << "HeatFluxStatistics is not found!" << std::endl;
+        {
+          Postprocess::HeatFluxStatistics<dim> &heat_flux_statistics =
+            this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::HeatFluxStatistics<dim> >();
 
-      try
-        {
-          this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::PressureStatistics<dim> >();
-          std::cout << "PressureStatistics is found!" << std::endl;
-        }
-      catch (...)
-        {
-          std::cout << "PressureStatistics is not found!" << std::endl;
-        }
+          std::cout << "HeatFluxStatistics is PressureStatistics:"
+                    << Utilities::plugin_type_matches<Postprocess::PressureStatistics<dim> >(heat_flux_statistics)
+                    << std::endl;
 
-      try
-        {
-          this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::HeatFluxStatistics<dim> >();
-          std::cout << "HeatFluxStatistics is found!" << std::endl;
-        }
-      catch (...)
-        {
-          std::cout << "HeatFluxStatistics is not found!" << std::endl;
+          Utilities::get_plugin_as_type<Postprocess::PressureStatistics<dim> >(heat_flux_statistics);
         }
     }
   }

--- a/tests/find_postprocess_fail_2.prm
+++ b/tests/find_postprocess_fail_2.prm
@@ -1,0 +1,74 @@
+# This test will try to convert a postprocessor into a different type and
+# will not catch the resulting exception to check if the
+# exception output works correctly.
+
+# EXPECT FAILURE
+
+set Dimension = 2
+set CFL number                             = 1.0
+set End time                               = 0
+set Start time                             = 0
+set Adiabatic surface temperature          = 0
+set Surface pressure                       = 0
+set Use years in output instead of seconds = false  # default: true
+set Nonlinear solver scheme                = IMPES
+
+
+subsection Boundary temperature model
+  set List of model names = box2
+end
+
+
+
+subsection Gravity model
+  set Model name = vertical
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1.2 # default: 1
+    set Y extent = 1
+    set Z extent = 1
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = perturbed box
+end
+
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1    # default: 3300
+    set Reference specific heat       = 1250
+    set Reference temperature         = 1    # default: 293
+    set Thermal conductivity          = 1e-6 # default: 4.7
+    set Thermal expansion coefficient = 2e-5
+    set Viscosity                     = 1    # default: 5e24
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 3
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = 0, 1
+  set Prescribed velocity boundary indicators =
+  set Tangential velocity boundary indicators = 1
+  set Zero velocity boundary indicators       = 0, 2, 3
+end
+
+subsection Postprocess
+  set List of postprocessors =  heat flux statistics
+end
+

--- a/tests/find_postprocess_fail_2/screen-output
+++ b/tests/find_postprocess_fail_2/screen-output
@@ -1,0 +1,20 @@
+
+Loading shared library <./libfind_postprocess_fail_2.so>
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 948 (578+81+289)
+
+HeatFluxStatistics is PressureStatistics:0
+ERROR: Uncaught exception in MPI_InitFinalize on proc 0. Skipping MPI_Finalize() to avoid a deadlock.
+
+
+Exception 'ExcMessage("You have requested to convert a plugin of type <" + boost::core::demangle(typeid(PluginType).name()) + "> into type <" + boost::core::demangle(typeid(TestType).name()) + "> in which it can not be converted.")' on rank 0 on processing: 
+
+An error occurred in file <utilities.h> in function
+(line in output replaced by default.sh script)
+The violated condition was: 
+    false
+Additional information: 
+    You have requested to convert a plugin of type <aspect::Postprocess::HeatFluxStatistics<2>> into type <aspect::Postprocess::PressureStatistics<2>> in which it can not be converted.
+
+Aborting!

--- a/tests/find_postprocess_fail_2/screen-output
+++ b/tests/find_postprocess_fail_2/screen-output
@@ -8,13 +8,13 @@ HeatFluxStatistics is PressureStatistics:0
 ERROR: Uncaught exception in MPI_InitFinalize on proc 0. Skipping MPI_Finalize() to avoid a deadlock.
 
 
-Exception 'ExcMessage("You have requested to convert a plugin of type <" + boost::core::demangle(typeid(PluginType).name()) + "> into type <" + boost::core::demangle(typeid(TestType).name()) + "> in which it can not be converted.")' on rank 0 on processing: 
+Exception 'ExcMessage("You have requested to convert a plugin of type <" + boost::core::demangle(typeid(PluginType).name()) + "> into type <" + boost::core::demangle(typeid(TestType).name()) + ">, but this cast cannot be performed.")' on rank 0 on processing: 
 
-An error occurred in file <utilities.h> in function
+An error occurred in file <plugins.h> in function
 (line in output replaced by default.sh script)
 The violated condition was: 
-    false
+    plugin_type_matches<TestType>(object)
 Additional information: 
-    You have requested to convert a plugin of type <aspect::Postprocess::HeatFluxStatistics<2>> into type <aspect::Postprocess::PressureStatistics<2>> in which it can not be converted.
+    You have requested to convert a plugin of type <aspect::Postprocess::HeatFluxStatistics<2>> into type <aspect::Postprocess::PressureStatistics<2>>, but this cast cannot be performed.
 
 Aborting!


### PR DESCRIPTION
One of the features of ASPECT I understood the least in the beginning was the use of `dynamic_cast` to determine the actual type of an interface plugin pointer. This is a proposal to make this more explicit and easier to understand. There are two main advantages to the new functions:
- No `dynamic_cast` that confuses users, instead function names that describe what is done
- No use of null pointers anymore. Therefore, nobody can forget to check for a null pointer before using the object. Always return references.

If this is something that we would like to do, there are dozens of places over the whole codebase which can be simplified with the new functions.
Comments?

