### PR TITLE
Allow to run official ASPECT tester at home

### DIFF
--- a/cmake/compile_and_update_tests.sh
+++ b/cmake/compile_and_update_tests.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
-# This script can modify the test results in the source
+# This script can modify the test results in the tests/
 # directory to the official tester results, if docker is installed
-# on the system. Start this script by running the following command
-# after replacing ASPECT_SOURCE_DIR with the directory of your ASPECT
-# folder:
+# on the system. This script has to be started from the main ASPECT
+# folder (the one containing include/, cmake/, source/, and tests/).
+# Navigate to that folder and run the following command in a terminal:
 #
-# docker run -v ASPECT_SOURCE_DIR:/home/dealii/aspect --name=aspect-tester --rm -it dealii/dealii:v8.5.0-gcc-mpi-fulldepscandi-debugrelease bash /home/dealii/aspect/cmake/compile_and_update_tests.sh
+# docker run -v $PWD:/home/dealii/aspect --name=aspect-tester --rm -it dealii/dealii:v8.5.0-gcc-mpi-fulldepscandi-debugrelease bash /home/dealii/aspect/cmake/compile_and_update_tests.sh
 
 # This command executes the following shell script *inside* the docker container
 # that contains the official ASPECT test system. Note that by mounting your
 # ASPECT folder into the container you are actually changing reference test
-# results on the host system (i.e. your computer).
+# results on the host system (i.e. your computer) instead of inside the
+# container, and you also keep the build folder outside of the container in
+# the new directory 'tester-build'.
 
 echo "Starting official tester and compiling source ..."
 

--- a/cmake/compile_and_update_tests.sh
+++ b/cmake/compile_and_update_tests.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This script can modify the test results in the source
+# directory to the official tester results, if docker is installed
+# on the system. Start this script by running the following command
+# after replacing ASPECT_SOURCE_DIR with the directory of your ASPECT
+# folder:
+#
+# docker run -v ASPECT_SOURCE_DIR:/home/dealii/aspect --name=aspect-tester --rm -it dealii/dealii:v8.5.0-gcc-mpi-fulldepscandi-debugrelease bash /home/dealii/aspect/cmake/compile_and_update_tests.sh
+
+# This command executes the following shell script *inside* the docker container
+# that contains the official ASPECT test system. Note that by mounting your
+# ASPECT folder into the container you are actually changing reference test
+# results on the host system (i.e. your computer).
+
+echo "Starting official tester and compiling source ..."
+
+SRC_PATH=`dirname $0`
+SRC_PATH=`cd $SRC_PATH/..;pwd`
+
+mkdir -p ${SRC_PATH}/tester-build
+cd ${SRC_PATH}/tester-build
+cmake -G "Ninja" gcc -D ASPECT_TEST_GENERATOR=Ninja -D ASPECT_USE_PETSC=OFF -D ASPECT_RUN_ALL_TESTS=ON -D ASPECT_PRECOMPILE_HEADERS=ON $SRC_PATH
+ninja
+ASPECT_TESTS_VERBOSE=1 bash ${SRC_PATH}/cmake/generate_reference_output.sh

--- a/cmake/generate_reference_output.sh
+++ b/cmake/generate_reference_output.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# This script is being executed by the make target
-# 'generate_reference_output'. The script executes all tests and overwrites
+# This script executes all tests and overwrites
 # the reference output in the source directory for all failing
 # outputs. Finally, a file changes.diff is generated in the build directory
 # with the diffs. The current directory is assumed to be the build directory,
@@ -13,7 +12,12 @@ echo "Overwriting test output with reference output ..."
 SRC_PATH=`dirname $0`
 SRC_PATH=`cd $SRC_PATH/..;pwd`
 OUT=$PWD/changes.diff
-ASPECT_GENERATE_REFERENCE_OUTPUT=1 ctest -j 4 >/dev/null
+
+if [ "$ASPECT_TESTS_VERBOSE" = "1" ]; then
+  ASPECT_GENERATE_REFERENCE_OUTPUT=1 ctest -j 4
+else
+  ASPECT_GENERATE_REFERENCE_OUTPUT=1 ctest -j 4 > /dev/null
+fi
 
 cd $SRC_PATH
 git diff tests/ >$OUT

--- a/cmake/generate_reference_output.sh
+++ b/cmake/generate_reference_output.sh
@@ -13,10 +13,10 @@ SRC_PATH=`dirname $0`
 SRC_PATH=`cd $SRC_PATH/..;pwd`
 OUT=$PWD/changes.diff
 
-if [ "$ASPECT_TESTS_VERBOSE" = "1" ]; then
+if [ "$ASPECT_TESTS_VERBOSE" == "1" ]; then
   ASPECT_GENERATE_REFERENCE_OUTPUT=1 ctest -j 4
 else
-  ASPECT_GENERATE_REFERENCE_OUTPUT=1 ctest -j 4 > /dev/null
+  ASPECT_GENERATE_REFERENCE_OUTPUT=1 ctest -j 4 >/dev/null
 fi
 
 cd $SRC_PATH

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2450,6 +2450,7 @@ setup problems, and performance penalties.
 \end{enumerate}
 
 \subsection{Docker Container}
+\label{subsec:docker_container}
 
 \subsubsection{Installing Docker and downloading the \aspect{} image}
 
@@ -11836,7 +11837,24 @@ requests by others, one of the trusted maintainers has to specifically request a
 test run, and this will usually happen
 as soon as the patch developer indicates the patch is ready for review.}
 Upon completion of the test suite, both the general summary (pass/fail) and a
-full verbose log will available from the GitHub page.
+full verbose log will available from the GitHub page. Because the official test
+setup is set up in a Docker container, it is simple to replicate the results on
+a local machine. To this end, follow the instructions in
+Section~\ref{subsec:docker_container} to set up Docker, and then run the
+following command in any terminal (replace \texttt{ASPECT\_SOURCE\_DIR} with
+the path to your \aspect{} directory):
+\begin{lstlisting}[frame=single,language=ksh] 
+    docker run -v ASPECT_SOURCE_DIR:/home/dealii/aspect \
+    --name=aspect-tester --rm -it \
+    dealii/dealii:v8.5.0-gcc-mpi-fulldepscandi-debugrelease \
+    bash /home/dealii/aspect/cmake/compile_and_update_tests.sh
+\end{lstlisting}
+
+This command executes the shell script 
+\texttt{cmake/compile\_and\_update\_tests.sh} \textit{inside} the docker
+container that contains the official \aspect{} test system. Note that by
+mounting your \aspect{} folder into the container you are actually updating the
+reference test results on the host system (i.e. your computer).
 
 
 \subsubsection{Writing tests}


### PR DESCRIPTION
This is related to #2143 and allows everybody to run the official ASPECT tester setup (currently only `aspect-8.5-gcc-hd`) on their local machine. This is super helpful if you know the tester is busy, or to check and update test results yourself if you are offline. It also allows with a little hack to `generate_reference_output` to only run certain tests you are interested in. This is a step towards having all the tester information as part of the official repository.