### PR TITLE
[bugfix] fix average density implementation for boundary fluid pressure

### DIFF
--- a/source/boundary_fluid_pressure/density.cc
+++ b/source/boundary_fluid_pressure/density.cc
@@ -87,7 +87,7 @@ namespace aspect
         prm.enter_subsection("Density");
         {
           prm.declare_entry ("Density formulation", "solid density",
-                             Patterns::Selection ("solid density|fluid density"),
+                             Patterns::Selection ("solid density|fluid density|average density"),
                              "The density formulation used to compute the fluid pressure gradient "
                              "at the model boundary."
                              "\n\n"
@@ -128,6 +128,8 @@ namespace aspect
             density_formulation = DensityFormulation::solid_density;
           else if (prm.get ("Density formulation") == "fluid density")
             density_formulation = DensityFormulation::fluid_density;
+          else if (prm.get ("Density formulation") == "average density")
+            density_formulation = DensityFormulation::average_density;
           else
             AssertThrow (false, ExcNotImplemented());
         }

--- a/tests/average_density_boundary_fluid_pressure.prm
+++ b/tests/average_density_boundary_fluid_pressure.prm
@@ -1,0 +1,288 @@
+# This is a variation of the melt and traction test, with the only 
+# difference that it uses the product of the average (solid and melt)
+# density as the boundary fluid pressure, and that the domain is only
+# half as large in y direction so that there is melt present at the 
+# lower boundary. 
+
+# This is a test to see if traction boundary conditions work in models
+# with melt migration.  
+# At the right and bottom boundary, the lithostatic pressure is applied, 
+# so both the solid and the melt velocity should be approximately zero. 
+
+set Dimension                              = 2
+set Adiabatic surface temperature          = 1600
+set Maximum time step                      = 1e6
+set Linear solver tolerance                = 1e-8
+set Use years in output instead of seconds = true
+set Nonlinear solver scheme                = iterated IMPES
+set Max nonlinear iterations               = 20
+set Nonlinear solver tolerance             = 1e-7
+set Number of cheap Stokes solver steps    = 100
+
+# In addition, melting and freezing normally happens on a much faster
+# time scale than the flow of melt, so we want to decouple the advection
+# of melt (and temperature) and the melting process itself. To do that, 
+# we use the operator splitting scheme, and define that for every 
+# advection time step, we want to do at least 50 reaction time step, 
+# and in addition, we limit the maximum reaction time step size to 
+# 500,000 years. 
+set Use operator splitting                     = true
+subsection Solver parameters
+  subsection Operator splitting parameters
+    set Reaction time step                     = 1e5
+    set Reaction time steps per advection step = 50
+  end
+end
+
+# The end time of the simulation. We only do one time step. 
+set End time                               = 1e5
+
+# We apply the lithostatic pressure at the bottom and the right side. 
+subsection Model settings
+  set Fixed temperature boundary indicators   = top, bottom
+  set Prescribed velocity boundary indicators = top:function
+  set Tangential velocity boundary indicators = left
+  set Prescribed traction boundary indicators = right:initial lithostatic pressure, bottom y:initial lithostatic pressure
+  
+  # In addition, we now also specify in the model settings that we want to
+  # run a model with melt transport. 
+  set Include melt transport                  = true
+end 
+
+subsection Boundary traction model
+  subsection Initial lithostatic pressure
+    set Number of integration points = 10000
+    set Representative point         = 300000,150000 
+  end
+end
+
+subsection Boundary velocity model
+  subsection Function
+    set Function constants  =
+    set Function expression = 0; 0
+  end
+end
+
+
+##################### Settings for melt transport ########################
+
+subsection Compositional fields
+  set Number of fields = 2
+  set Names of fields = porosity, peridotite
+end
+
+subsection Discretization
+  set Stokes velocity polynomial degree    = 2
+  set Composition polynomial degree        = 1
+  subsection Stabilization parameters
+    set beta  = 0.5
+    set cR    = 1
+  end
+end
+
+##################### Initial temperature model ########################
+
+# We choose an adiabatic temperature profile as initial condition. 
+subsection Initial temperature model
+  set List of model names = adiabatic
+  subsection Adiabatic
+    set Age bottom boundary layer = 0
+    set Age top boundary layer    = 5e7
+
+    subsection Function
+      set Function expression       = 0;0
+    end
+  end
+end
+
+# Now that our model uses compositional fields, we also need initial
+# conditions for the composition. 
+# We use the function plugin to set both fields to zero at the beginning
+# of the model run. 
+subsection Initial composition model
+  set List of model names = function, porosity
+  subsection Function
+    set Function expression = 0; 0
+    set Variable names      = x,y
+  end
+end
+
+##################### Boundary conditions ########################
+
+# As boundary conditions for the temperature, we just use the
+# initial conditions again. This temperature is applied as a prescribed
+# temperature at the top and bottom boundary, as specified above.
+subsection Boundary temperature model
+  set List of model names = initial temperature
+
+  subsection Initial temperature
+    set Minimal temperature = 293
+    set Maximal temperature = 3700
+  end
+end
+
+# We again choose the initial composition as boundary condition
+# for all compositional fields. 
+subsection Boundary composition model
+  set List of model names = initial composition
+end
+
+# Models with melt transport also need an additional boundary condition. 
+subsection Boundary fluid pressure model
+  set Plugin name = density
+  subsection Density
+    set Density formulation = average density
+  end
+end
+
+##################### Model geometry ########################
+
+# The model geometry is a square with a dimension of 300 km.
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 300000
+    set Y extent = 150000
+    set X repetitions = 2
+  end
+
+end
+
+################ Gravity and material properties ##################
+
+# The model has a constant gravity. 
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 9.81
+  end
+end
+
+# We use the melt global material model, which is one of the
+# material models that works with melt transport, as it also
+# specifies the material properties needed for melt migration, 
+# such as the permeability, the melt density and the melt 
+# viscosity.
+subsection Material model
+
+  set Model name = melt global 
+  subsection Melt global
+    
+    # First we describe the parameters for the solid, in the same way
+    # we did in the model without melt transport
+    set Thermal conductivity              = 4.7
+    set Reference solid density           = 3400
+    set Thermal expansion coefficient     = 2e-5
+    set Reference shear viscosity         = 5e21
+    set Thermal viscosity exponent        = 7
+    set Reference temperature             = 1600
+    
+    # The melt usually has a different (lower) density than the solid.
+    set Reference melt density            = 3400
+    
+    # The permeability describes how well the pores of a porous material
+    # are connected (and hence how fast melt can flow through the rock).
+    # It is computed as the product of the reference value given here 
+    # and the porosity cubed. This means that the lower the porosity is
+    # the more difficult it is for the melt to flow. 
+    set Reference permeability            = 1e-8
+    
+    # The bulk viscosity describes the resistance of the rock to dilation
+    # and compaction. Melt can only flow into a region that had no melt 
+    # before if the matrix of the solid rock expands, so this parameter 
+    # also limits how fast melt can flow upwards. 
+    # The bulk viscosity is computed as the reference value given here times
+    # a term that scales with one over the porosity. This means that for zero 
+    # porosity, the rock can not dilate/compact any more, which is the same
+    # behaviour that we have for solid mantle convection. 
+    set Reference bulk viscosity          = 1e19
+    
+    # In dependence of how much melt is present, we also weaken the shear
+    # viscosity: The more melt is present, the weaker the rock gets. 
+    # This scaling is exponential, following the relation
+    # viscosity ~ exp(-alpha * phi),
+    # where alpha is the parameter given here, and phi is the porosity.  
+    set Exponential melt weakening factor = 10
+    
+    # In the same way the shear viscosity is reduced with increasing temperature, 
+    # we also prescribe the temperature-dependence of the bulk viscosity. 
+    set Thermal bulk viscosity exponent   = 7
+       
+    # Finally, we prescribe the viscosity of the melt, which is used in Darcy's
+    # law. The lower this viscosity, the faster melt can flow.  
+    set Reference melt viscosity          = 1
+    
+    # change the density contrast of depleted material (in kg/m^3)
+    set Depletion density change          = -200.0
+
+    # How much melt has been generated and subsequently extracted from a particular 
+    # volume of rock (how 'depleted' that volume of rock is) usually changes the 
+    # solidus. The more the material has been molten already, the less melt will be
+    # generated afterwards for the same pressure and temperature conditions. We 
+    # model this using a simplified, linear relationship, saying that to melt 100%
+    # of the rock the temperature has to be 200 K higher than to melt it initially.
+    set Depletion solidus change          = 200
+
+    set Melting time scale for operator splitting = 1e100
+    set Include melting and freezing      = false
+  end
+end
+
+##################### Mesh refinement #########################
+
+# For the model with melt migration, we use adaptive refinement. 
+# We make use of two different refinement criteria: we set a minimum of 4 global
+# refinements everywhere in the model (which is the same resolution as for the 
+# model without melt), and we refine in regions where melt is present, to be 
+# precise, everywhere where the porosity is bigger than 1e-4. 
+# We adapt the mesh every 5 time steps. 
+subsection Mesh refinement
+  set Coarsening fraction                      = 0.05
+  set Refinement fraction                      = 0.8
+
+  set Initial adaptive refinement              = 0
+  set Initial global refinement                = 4
+  set Time steps between mesh refinement       = 0
+end
+
+# As the model is compressible and has an adiabatic temperature profile, we include 
+# adiabatic heating in the list of heating models. 
+# To make this model as simple as possible, we do not include shear heating (although
+# usually, adiabatic heating and shear heating should always be used together).  
+subsection Heating model
+  set List of model names = adiabatic heating
+end 
+
+##################### Postprocessing ########################
+
+subsection Postprocess
+
+  set List of postprocessors = visualization, composition statistics, velocity statistics, temperature statistics, mass flux statistics
+  set Run postprocessors on nonlinear iterations = true
+
+  # For the model with melt migration, also add a visualization
+  # postprocessor that computes the material properties relevant
+  # to migration (permeability, viscosity of the melt, etc.).
+
+  subsection Visualization
+    set List of output variables      = material properties, nonadiabatic temperature, strain rate, melt material properties, nonadiabatic pressure
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
+    end
+
+    subsection Melt material properties
+      set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
+    end
+
+    set Number of grouped files       = 0
+    set Output format                 = vtu
+    set Time between graphical output = 0
+    set Interpolate output            = true
+  end
+
+end
+
+

--- a/tests/average_density_boundary_fluid_pressure/screen-output
+++ b/tests/average_density_boundary_fluid_pressure/screen-output
@@ -1,0 +1,112 @@
+
+Number of active cells: 512 (on 5 levels)
+Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 38+0 iterations.
+   Solving for u_f in 13 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.50805e-16, 1.17203e-16, 0, 0.000971354
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000971354
+
+   Postprocessing:
+     Writing graphical output:           output-average_density_boundary_fluid_pressure/solution/solution-00000.0000
+     Compositions min/max/mass:          0/0.07253/8.923e+08 // 0/0/0
+     RMS, max velocity:                  1.48e-07 m/year, 1.11e-06 m/year
+     Temperature min/avg/max:            293 K, 1210 K, 1624 K
+     Mass fluxes through boundary parts: 0 kg/yr, -12.37 kg/yr, 10.82 kg/yr, 0 kg/yr
+
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 13 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.50805e-16, 1.17203e-16, 0, 8.45216e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 8.45216e-09
+
+   Postprocessing:
+     Writing graphical output:           output-average_density_boundary_fluid_pressure/solution/solution-00000.0001
+     Compositions min/max/mass:          0/0.07253/8.923e+08 // 0/0/0
+     RMS, max velocity:                  1.48e-07 m/year, 1.11e-06 m/year
+     Temperature min/avg/max:            293 K, 1210 K, 1624 K
+     Mass fluxes through boundary parts: 0 kg/yr, -12.37 kg/yr, 10.82 kg/yr, 0 kg/yr
+
+
+*** Timestep 1:  t=100000 years
+   Solving composition reactions in 50 substep(s).
+   Solving temperature system... 5 iterations.
+   Solving porosity system ... 3 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 18+0 iterations.
+   Solving for u_f in 13 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000362753, 0.00212797, 0, 1.24947e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00212797
+
+   Postprocessing:
+     Writing graphical output:           output-average_density_boundary_fluid_pressure/solution/solution-00001.0000
+     Compositions min/max/mass:          -6.889e-05/0.07254/8.923e+08 // 0/0/0
+     RMS, max velocity:                  9.12e-07 m/year, 4.52e-06 m/year
+     Temperature min/avg/max:            293 K, 1210 K, 1624 K
+     Mass fluxes through boundary parts: 0 kg/yr, -360.3 kg/yr, 359.7 kg/yr, 0 kg/yr
+
+   Solving temperature system... 3 iterations.
+   Solving porosity system ... 3 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 2+0 iterations.
+   Solving for u_f in 13 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.67347e-07, 8.3372e-05, 0, 1.99602e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 8.3372e-05
+
+   Postprocessing:
+     Writing graphical output:           output-average_density_boundary_fluid_pressure/solution/solution-00001.0001
+     Compositions min/max/mass:          -7.626e-05/0.07254/8.922e+08 // 0/0/0
+     RMS, max velocity:                  9.14e-07 m/year, 4.53e-06 m/year
+     Temperature min/avg/max:            293 K, 1210 K, 1624 K
+     Mass fluxes through boundary parts: 0 kg/yr, -362 kg/yr, 360.3 kg/yr, 0 kg/yr
+
+   Solving temperature system... 2 iterations.
+   Solving porosity system ... 2 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 13 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.22052e-10, 2.09974e-07, 0, 7.98581e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 2.09974e-07
+
+   Postprocessing:
+     Writing graphical output:           output-average_density_boundary_fluid_pressure/solution/solution-00001.0002
+     Compositions min/max/mass:          -7.628e-05/0.07254/8.922e+08 // 0/0/0
+     RMS, max velocity:                  9.14e-07 m/year, 4.53e-06 m/year
+     Temperature min/avg/max:            293 K, 1210 K, 1624 K
+     Mass fluxes through boundary parts: 0 kg/yr, -362 kg/yr, 360.3 kg/yr, 0 kg/yr
+
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving for u_f in 13 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.14817e-13, 1.64801e-14, 0, 7.98581e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 7.98581e-09
+
+   Postprocessing:
+     Writing graphical output:           output-average_density_boundary_fluid_pressure/solution/solution-00001.0003
+     Compositions min/max/mass:          -7.628e-05/0.07254/8.922e+08 // 0/0/0
+     RMS, max velocity:                  9.14e-07 m/year, 4.53e-06 m/year
+     Temperature min/avg/max:            293 K, 1210 K, 1624 K
+     Mass fluxes through boundary parts: 0 kg/yr, -362 kg/yr, 360.3 kg/yr, 0 kg/yr
+
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/average_density_boundary_fluid_pressure/statistics
+++ b/tests/average_density_boundary_fluid_pressure/statistics
@@ -1,0 +1,37 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Number of nonlinear iterations
+# 9: Iterations for temperature solver
+# 10: Iterations for composition solver 1
+# 11: Iterations for composition solver 2
+# 12: Iterations for Stokes solver
+# 13: Velocity iterations in Stokes preconditioner
+# 14: Schur complement iterations in Stokes preconditioner
+# 15: Visualization file name
+# 16: Minimal value for composition porosity
+# 17: Maximal value for composition porosity
+# 18: Global mass for composition porosity
+# 19: Minimal value for composition peridotite
+# 20: Maximal value for composition peridotite
+# 21: Global mass for composition peridotite
+# 22: RMS velocity (m/year)
+# 23: Max. velocity (m/year)
+# 24: Minimal temperature (K)
+# 25: Average temperature (K)
+# 26: Maximal temperature (K)
+# 27: Average nondimensional temperature (K)
+# 28: Outward mass flux through boundary with indicator 0 ("left") (kg/yr)
+# 29: Outward mass flux through boundary with indicator 1 ("right") (kg/yr)
+# 30: Outward mass flux through boundary with indicator 2 ("bottom") (kg/yr)
+# 31: Outward mass flux through boundary with indicator 3 ("top") (kg/yr)
+0 0.000000000000e+00 0.000000000000e+00 512 4851 2145 1122 1 0 0 0 38 39 869 output-average_density_boundary_fluid_pressure/solution/solution-00000.0000  0.00000000e+00 7.25339508e-02 8.92259377e+08 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.48091172e-07 1.10723081e-06 2.93000000e+02 1.21010849e+03 1.62359346e+03 2.69183589e-01 0.00000000e+00 -1.23674582e+01 1.08153885e+01 0.00000000e+00 
+0 0.000000000000e+00 0.000000000000e+00 512 4851 2145 1122 1 0 0 0  0  0   0 output-average_density_boundary_fluid_pressure/solution/solution-00000.0001  0.00000000e+00 7.25339508e-02 8.92259377e+08 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.48091172e-07 1.10723081e-06 2.93000000e+02 1.21010849e+03 1.62359346e+03 2.69183589e-01 0.00000000e+00 -1.23674582e+01 1.08153885e+01 0.00000000e+00 
+1 1.000000000000e+05 1.000000000000e+05 512 4851 2145 1122 1 5 3 0 18 19 429 output-average_density_boundary_fluid_pressure/solution/solution-00001.0000 -6.88866346e-05 7.25432968e-02 8.92254264e+08 0.00000000e+00 0.00000000e+00 0.00000000e+00 9.12009140e-07 4.51762870e-06 2.93000000e+02 1.20972479e+03 1.62359346e+03 2.69070970e-01 0.00000000e+00 -3.60306540e+02 3.59739944e+02 0.00000000e+00 
+1 1.000000000000e+05 1.000000000000e+05 512 4851 2145 1122 1 3 3 0  2  3  67 output-average_density_boundary_fluid_pressure/solution/solution-00001.0001 -7.62598287e-05 7.25406100e-02 8.92244268e+08 0.00000000e+00 0.00000000e+00 0.00000000e+00 9.13950273e-07 4.52707922e-06 2.93000000e+02 1.20972468e+03 1.62359346e+03 2.69070937e-01 0.00000000e+00 -3.61976866e+02 3.60312576e+02 0.00000000e+00 
+1 1.000000000000e+05 1.000000000000e+05 512 4851 2145 1122 1 2 2 0  0  0   0 output-average_density_boundary_fluid_pressure/solution/solution-00001.0002 -7.62803091e-05 7.25406069e-02 8.92244202e+08 0.00000000e+00 0.00000000e+00 0.00000000e+00 9.13950273e-07 4.52707922e-06 2.93000000e+02 1.20972468e+03 1.62359346e+03 2.69070937e-01 0.00000000e+00 -3.61976866e+02 3.60312576e+02 0.00000000e+00 
+1 1.000000000000e+05 1.000000000000e+05 512 4851 2145 1122 1 0 0 0  0  0   0 output-average_density_boundary_fluid_pressure/solution/solution-00001.0003 -7.62803091e-05 7.25406069e-02 8.92244202e+08 0.00000000e+00 0.00000000e+00 0.00000000e+00 9.13950273e-07 4.52707922e-06 2.93000000e+02 1.20972468e+03 1.62359346e+03 2.69070937e-01 0.00000000e+00 -3.61976866e+02 3.60312576e+02 0.00000000e+00 


### PR DESCRIPTION
I don't know how we missed that in the melt solver pull request, but apparently in my rebase some lines got messed up and the new "average density" option for the boundary fluid pressure did not work. This pull request fixes this and also adds a test. 