### PR TITLE
Fix update script and add test

### DIFF
--- a/doc/update_prm_files_to_2.0.0.sed
+++ b/doc/update_prm_files_to_2.0.0.sed
@@ -22,7 +22,25 @@ s/subsection Initial profile/subsection Compute profile/g
 s/set Model name = initial profile/set Model name = compute profile/g
 
 # Recover previous behavior of the 'Radial linear' gravity model
-s/subsection Radial linear/subsection Radial linear\n    set Magnitude at bottom = 0.0/g
+# In the following we read the whole subsection 'Radial linear'
+# when we find it (N adds the next line), check if 
+# 'Magnitude at bottom' is inside, and insert (i) it, if not.
+:jump_before_gravity
+/subsection Radial linear/,/\bend\b/ {
+n
+/^ *end/b jump_before_gravity
+
+:jump_in_gravity
+N
+/end/!b jump_in_gravity
+# If we get here, we found an end, either we found the new parameter,
+# or it needs to be added. Then jump up to finish this subsection
+/set Magnitude at bottom/!{
+i\    set Magnitude at bottom = 0.0
+}
+
+b jump_before_gravity
+}
 
 # Replace the 'model name' parameter by 'List of model names'
 # in all subsections that now use the new parameter.

--- a/doc/update_prm_files_to_2.0.0.sed
+++ b/doc/update_prm_files_to_2.0.0.sed
@@ -22,23 +22,28 @@ s/subsection Initial profile/subsection Compute profile/g
 s/set Model name = initial profile/set Model name = compute profile/g
 
 # Recover previous behavior of the 'Radial linear' gravity model
-# In the following we read the whole subsection 'Radial linear'
-# when we find it (N adds the next line), check if 
-# 'Magnitude at bottom' is inside, and insert (i) it, if not.
+# In the following part we read the whole subsection 'Radial linear'
+# when we find it, check if 'Magnitude at bottom' is inside, and
+# insert it, if not.
 :jump_before_gravity
 /subsection Radial linear/,/\bend\b/ {
+# Print the line 'subsection ...' and read next line
 n
+# If next line was already 'end' jump out of this part
 /^ *end/b jump_before_gravity
 
 :jump_in_gravity
+# Add next line to current pattern space until we found 'end'
 N
 /end/!b jump_in_gravity
-# If we get here, we found an end, either we found the new parameter,
-# or it needs to be added. Then jump up to finish this subsection
+
+# If we get here, we found an end. If we did not find the new parameter,
+# it needs to be added.
 /set Magnitude at bottom/!{
 i\    set Magnitude at bottom = 0.0
 }
 
+# Then jump up to finish this part, and print the whole modified subsection
 b jump_before_gravity
 }
 

--- a/tests/update_script_2.cc
+++ b/tests/update_script_2.cc
@@ -1,0 +1,49 @@
+#include <aspect/simulator.h>
+#include <iostream>
+
+/*
+ * Launch the following function when this plugin is created. Use the update
+ * script to update this parameter file. Unfortunately at this point the file
+ * has already been loaded, so the current ASPECT instance would get the old
+ * file. Thus we start a new ASPECT instance that will load the new file.
+ * To avoid an endless recursion we remove the shared library from the new
+ * input file (otherwise the new instance would call this library again, and so
+ * on). After finishing the new instance we exit to not continue the old one.
+ *
+ * This test in particular calls the update script multiple times on the same
+ * file, and ensures that only the first time changes happen. Every subsequent
+ * application should not change the file any more.
+ */
+int f()
+{
+  // call ASPECT with "--" and pipe an existing input file into it.
+  int ret;
+  std::string command;
+
+  command = ("cat update_script_2.x.prm | sed 's:set Additional shared libraries = ./libupdate_script_2.so::' | "
+             "sed -f " ASPECT_SOURCE_DIR "/doc/update_prm_files_to_2.0.0.sed > output-update_script_2/updated.prm && "
+             "cat output-update_script_2/updated.prm | sed -f " ASPECT_SOURCE_DIR "/doc/update_prm_files_to_2.0.0.sed > output-update_script_2/updated2.prm && "
+             "diff output-update_script_2/updated.prm output-update_script_2/updated2.prm");
+  std::cout << "Executing the update script:\n"
+            << command
+            << std::endl;
+  ret = system (command.c_str());
+  if (ret!=0)
+    std::cout << "system() returned error " << ret << std::endl;
+
+  command = ("../aspect output-update_script_2/updated2.prm");
+  std::cout << "Running ASPECT with updated parameter file:\n"
+            << command
+            << std::endl;
+  ret = system (command.c_str());
+  if (ret!=0)
+    std::cout << "system() returned error " << ret << std::endl;
+
+  // abort current process:
+  exit (0);
+  return 42;
+}
+
+
+// run this function by initializing a global variable by it
+int i = f();

--- a/tests/update_script_2.prm
+++ b/tests/update_script_2.prm
@@ -1,13 +1,14 @@
-# This is a test for the .prm update script in
-# doc/update_prm_files_to_2.0.0.sed. The content of this prm
-# file is only executable by ASPECT <=1.5, but the corresponding
-# shared library in update_script.cc will first execute the update
-# script on this .prm file before running ASPECT with the updated
-# version of the file. The success of this test means the script did
-# its job and ASPECT 2.0 is able to read the updated file. This
-# test differs from update_script.prm by applying the script twice,
+# This test is a modified copy of update_script.prm.
+# It differs from update_script.prm by applying the update script twice,
 # and checking that it does not add additional lines after the
 # first run.
+
+# The content of this prm file is only executable by ASPECT <=1.5, but the
+# corresponding shared library in update_script.cc will first execute the
+# update script on this .prm file before running ASPECT with the updated
+# version of the file. The success of this test means the script did its job
+# and ASPECT 2.0 is able to read the twice updated file and the twice updated
+# file does not differ from the once updated file.
 
 set CFL number                             = 1.0
 set End time                               = 1e5

--- a/tests/update_script_2.prm
+++ b/tests/update_script_2.prm
@@ -1,0 +1,138 @@
+# This is a test for the .prm update script in
+# doc/update_prm_files_to_2.0.0.sed. The content of this prm
+# file is only executable by ASPECT <=1.5, but the corresponding
+# shared library in update_script.cc will first execute the update
+# script on this .prm file before running ASPECT with the updated
+# version of the file. The success of this test means the script did
+# its job and ASPECT 2.0 is able to read the updated file. This
+# test differs from update_script.prm by applying the script twice,
+# and checking that it does not add additional lines after the
+# first run.
+
+set CFL number                             = 1.0
+set End time                               = 1e5
+set Adiabatic surface temperature          = 1600.0
+set Use years in output instead of seconds = true
+
+subsection Adiabatic conditions model
+  set Model name = initial profile
+
+  subsection Initial profile
+    set Use surface condition function = true
+    subsection Surface condition function
+      set Function expression = 1e-2*t; 1613.0+1e-13*t
+    end
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 1
+end
+
+subsection Boundary composition model
+  set Model name = function
+end
+
+subsection Compositional initial conditions
+  set Model name = function
+end
+
+subsection Boundary temperature model
+  set Model name = spherical constant
+  subsection Spherical constant
+    set Inner temperature = 4250
+    set Outer temperature = 273
+  end
+end
+
+subsection Geometry model
+  set Model name = spherical shell
+
+  subsection Spherical shell
+    set Inner radius  = 3481000
+    set Opening angle = 90
+    set Outer radius  = 6371000
+  end
+end
+
+subsection Gravity model
+  set Model name = radial linear
+
+  subsection Radial linear
+    set Magnitude at bottom = 10.7
+    set Magnitude at surface = 9.81
+  end
+end
+
+
+subsection Initial conditions
+  set Model name = harmonic perturbation
+  subsection Harmonic perturbation
+    set Magnitude = 200.0
+  end
+end
+
+subsection Material model
+  set Model name = simple compressible
+
+  subsection Simple compressible model
+    set Reference density = 3340
+    set Reference specific heat = 1200
+    set Thermal expansion coefficient = 3e-5
+    set Viscosity = 1e21
+    set Reference compressibility = 2.5e-12
+  end
+
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+
+  set Initial global refinement          = 3
+
+  set Refinement fraction                = 0.0
+  set Coarsening fraction                = 0.0
+
+  set Strategy                           = velocity
+
+  set Time steps between mesh refinement = 0
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = 0,1
+
+
+  set Tangential velocity boundary indicators = 0,2,3
+  set Zero velocity boundary indicators       = 1
+end
+
+
+subsection Postprocess
+  set List of postprocessors = visualization,velocity statistics, basic statistics, temperature statistics,heat flux statistics, depth average, dynamic topography, tracers, viscous dissipation statistics
+
+  subsection Tracers
+    set Number of tracers = 50
+  end
+
+  subsection Dynamic Topography
+    set Subtract mean of dynamic topography = true
+  end
+
+  subsection Visualization
+    set Output format                 = vtu
+    set List of output variables      = density, friction heating
+    set Time between graphical output = 0
+  end
+
+  subsection Depth average
+    set Time between graphical output = 0
+    set Number of zones = 10
+  end
+
+end
+
+subsection Heating model
+  set List of model names = adiabatic heating
+end

--- a/tests/update_script_2/screen-output
+++ b/tests/update_script_2/screen-output
@@ -1,0 +1,50 @@
+
+Loading shared library <./libupdate_script_2.so>
+Executing the update script:
+cat update_script_2.x.prm | sed 's:set Additional shared libraries = ./libupdate_script_2.so::' | sed -f ASPECT_DIR/doc/update_prm_files_to_2.0.0.sed > output-update_script_2/updated.prm && cat output-update_script_2/updated.prm | sed -f ASPECT_DIR/doc/update_prm_files_to_2.0.0.sed > output-update_script_2/updated2.prm && diff output-update_script_2/updated.prm output-update_script_2/updated2.prm
+Running ASPECT with updated parameter file:
+../aspect output-update_script_2/updated2.prm
+
+Number of active cells: 192 (on 4 levels)
+Number of degrees of freedom: 3,557 (1,666+225+833+833)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Skipping C_1 composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 18+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:           output-update_script_2/solution/solution-00000
+     RMS, max velocity:                  0.613 m/year, 1.18 m/year
+     Temperature min/avg/max:            273 K, 2295 K, 4250 K
+     Heat fluxes through boundary parts: -2.071e+05 W, 5.442e+05 W, 2170 W, 2170 W
+     Writing depth average:              output-update_script_2/depth_average.gnuplot
+     Writing particle output:            output-update_script_2/particles/particles-00000
+     Heating rate (average/total):       -3.806e-10 W/kg, -3.213e+07 W
+     Pressure at top/bottom of domain:   6.109e-08 Pa, 1.136e+11 Pa
+     Computing dynamic topography        
+
+*** Timestep 1:  t=100000 years
+   Solving temperature system... 12 iterations.
+   Skipping C_1 composition solve because RHS is zero.
+   Solving Stokes system... 15+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:           output-update_script_2/solution/solution-00001
+     RMS, max velocity:                  0.606 m/year, 1.17 m/year
+     Temperature min/avg/max:            273 K, 2292 K, 4250 K
+     Heat fluxes through boundary parts: -1.963e+05 W, 5.186e+05 W, 1925 W, 1925 W
+     Writing depth average:              output-update_script_2/depth_average.gnuplot
+     Number of advected particles:       50
+     Heating rate (average/total):       -3.748e-10 W/kg, -3.165e+07 W
+     Pressure at top/bottom of domain:   7.299e-08 Pa, 1.136e+11 Pa
+     Computing dynamic topography        
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/update_script_2/statistics
+++ b/tests/update_script_2/statistics
@@ -1,0 +1,31 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for Stokes solver
+# 11: Velocity iterations in Stokes preconditioner
+# 12: Schur complement iterations in Stokes preconditioner
+# 13: Visualization file name
+# 14: RMS velocity (m/year)
+# 15: Max. velocity (m/year)
+# 16: Minimal temperature (K)
+# 17: Average temperature (K)
+# 18: Maximal temperature (K)
+# 19: Average nondimensional temperature (K)
+# 20: Outward heat flux through boundary with indicator 0 ("bottom") (W)
+# 21: Outward heat flux through boundary with indicator 1 ("top") (W)
+# 22: Outward heat flux through boundary with indicator 2 ("left") (W)
+# 23: Outward heat flux through boundary with indicator 3 ("right") (W)
+# 24: Number of advected particles
+# 25: Particle file name
+# 26: Average adiabatic heating rate (W/kg)
+# 27: Total adiabatic heating rate (W)
+# 28: Pressure at top (Pa)
+# 29: Pressure at bottom (Pa)
+0 0.000000000000e+00 0.000000000000e+00 192 1891 833 833  0 0 18 19 19 output-update_script_2/solution/solution-00000 6.12503263e-01 1.17599847e+00 2.73000000e+02 2.29523784e+03 4.25000000e+03 5.08483239e-01 -2.07093395e+05 5.44191103e+05 2.17027488e+03 2.17027488e+03 50 output-update_script_2/output-update_script_2/particles/particles-00000 -3.80595985e-10 -3.21314982e+07 6.10867321e-08 1.13610118e+11 
+1 1.000000000000e+05 1.000000000000e+05 192 1891 833 833 12 0 15 16 16 output-update_script_2/solution/solution-00001 6.06407969e-01 1.17476617e+00 2.73000000e+02 2.29236572e+03 4.25000000e+03 5.07761056e-01 -1.96304970e+05 5.18599050e+05 1.92538744e+03 1.92532896e+03 50                                                                      "" -3.74837865e-10 -3.16487436e+07 7.29918141e-08 1.13611669e+11 

--- a/tests/update_script_2/updated2.prm
+++ b/tests/update_script_2/updated2.prm
@@ -1,13 +1,14 @@
-# This is a test for the .prm update script in
-# doc/update_prm_files_to_2.0.0.sed. The content of this prm
-# file is only executable by ASPECT <=1.5, but the corresponding
-# shared library in update_script.cc will first execute the update
-# script on this .prm file before running ASPECT with the updated
-# version of the file. The success of this test means the script did
-# its job and ASPECT 2.0 is able to read the updated file. This
-# test differs from update_script.prm by applying the script twice,
+# This test is a modified copy of update_script.prm.
+# It differs from update_script.prm by applying the update script twice,
 # and checking that it does not add additional lines after the
 # first run.
+
+# The content of this prm file is only executable by ASPECT <=1.5, but the
+# corresponding shared library in update_script.cc will first execute the
+# update script on this .prm file before running ASPECT with the updated
+# version of the file. The success of this test means the script did its job
+# and ASPECT 2.0 is able to read the twice updated file and the twice updated
+# file does not differ from the once updated file.
 
 set CFL number                             = 1.0
 set End time                               = 1e5

--- a/tests/update_script_2/updated2.prm
+++ b/tests/update_script_2/updated2.prm
@@ -1,0 +1,140 @@
+# This is a test for the .prm update script in
+# doc/update_prm_files_to_2.0.0.sed. The content of this prm
+# file is only executable by ASPECT <=1.5, but the corresponding
+# shared library in update_script.cc will first execute the update
+# script on this .prm file before running ASPECT with the updated
+# version of the file. The success of this test means the script did
+# its job and ASPECT 2.0 is able to read the updated file. This
+# test differs from update_script.prm by applying the script twice,
+# and checking that it does not add additional lines after the
+# first run.
+
+set CFL number                             = 1.0
+set End time                               = 1e5
+set Adiabatic surface temperature          = 1600.0
+set Use years in output instead of seconds = true
+
+subsection Adiabatic conditions model
+  set Model name = compute profile
+
+  subsection Compute profile
+    set Use surface condition function = true
+    subsection Surface condition function
+      set Function expression = 1e-2*t; 1613.0+1e-13*t
+    end
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 1
+end
+
+subsection Boundary composition model
+  set List of model names = function
+end
+
+subsection Initial composition model
+  set Model name = function
+end
+
+subsection Boundary temperature model
+  set List of model names = spherical constant
+  subsection Spherical constant
+    set Inner temperature = 4250
+    set Outer temperature = 273
+  end
+end
+
+subsection Geometry model
+  set Model name = spherical shell
+
+  subsection Spherical shell
+    set Inner radius  = 3481000
+    set Opening angle = 90
+    set Outer radius  = 6371000
+  end
+end
+
+subsection Gravity model
+  set Model name = radial linear
+
+  subsection Radial linear
+    set Magnitude at bottom = 10.7
+    set Magnitude at surface = 9.81
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = harmonic perturbation
+  subsection Harmonic perturbation
+    set Magnitude = 200.0
+  end
+end
+
+subsection Material model
+  set Model name = simple compressible
+
+  subsection Simple compressible model
+    set Reference density = 3340
+    set Reference specific heat = 1200
+    set Thermal expansion coefficient = 3e-5
+    set Viscosity = 1e21
+    set Reference compressibility = 2.5e-12
+  end
+
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+
+  set Initial global refinement          = 3
+
+  set Refinement fraction                = 0.0
+  set Coarsening fraction                = 0.0
+
+  set Strategy                           = velocity
+
+  set Time steps between mesh refinement = 0
+end
+
+
+subsection Model settings
+  set Fixed temperature boundary indicators   = 0,1
+
+
+  set Tangential velocity boundary indicators = 0,2,3
+  set Zero velocity boundary indicators       = 1
+end
+
+
+subsection Postprocess
+  set List of postprocessors = visualization,velocity statistics, basic statistics, temperature statistics,heat flux statistics, depth average, dynamic topography, particles, heating statistics
+
+  subsection Particles
+    set Number of particles = 50
+  end
+
+  subsection Dynamic topography
+  end
+
+  subsection Visualization
+    set Output format                 = vtu
+    set List of output variables      = density, heating
+    set Time between graphical output = 0
+  end
+
+  subsection Depth average
+    set Time between graphical output = 0
+    set Number of zones = 10
+  end
+
+end
+
+subsection Heating model
+  set List of model names = adiabatic heating
+end
+
+set Output directory = output-update_script_2
+


### PR DESCRIPTION
Since #2152 there was an ugly bug in the update_prm script that repeatedly added lines if the script was applied more than once and the `radial linear` gravity profile subsection existed in the parameter file. The fix is some ugly sed-magic, but I also added a new test that checks this behavior. The test essentially copies the first update script test, but applies the script twice. I checked that the test fails, if one of the following happens:
- diff reports a difference in the parameter file between the first and second application of the update script
- aspect can not run the twice updated version of the parameter file
- updated2.prm (the twice updated version) differs from the stored reference version in the test output