### PR TITLE
Reorganize update scripts

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -4061,6 +4061,26 @@ an if-statement that has the general form
 the syntax understood, reference the documentation of the muparser library
 linked to above.
 
+\subsubsection{Compatibility of input files with newer \aspect{} versions}
+
+We strive to maintain compatibility for options in input files as long as
+possible. However, occasionally we have to reorder, rename, or remove options
+from parameter files to improve \aspect{} further. This is in particular true
+for new major versions. In order to allow running old parameter files with
+newer \aspect{} versions we provide scripts that can automatically update
+existing parameter files to the new syntax. Executing
+\texttt{doc/update\_prm\_files.sh} with one or more parameter files as
+arguments will create a backup of the old parameter file (named
+\texttt{old\_filename.bak}), and replace the existing file with a version that
+should work with the current \aspect{} version.
+
+\note{Not all text replacements are unique, and the structure of input files
+allows for constructions the script can not properly parse. Also we can not
+guarantee to preserve the structure and position of comments, as it is not
+always clear to which part of the input file they refer. Thus, it is important
+that you check your updated input file for errors. That being said, all input
+files in the main \aspect{} repository are updated successfully using this
+script.}
   
 \subsection{A graphical user interface for editing \aspect{} parameter files}
 Preparing a parameter file in a text editor can be a tedious task, not

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -4072,7 +4072,12 @@ existing parameter files to the new syntax. Executing
 \texttt{doc/update\_prm\_files.sh} with one or more parameter files as
 arguments will create a backup of the old parameter file (named
 \texttt{old\_filename.bak}), and replace the existing file with a version that
-should work with the current \aspect{} version.
+should work with the current \aspect{} version. Using this script would look
+like this:
+
+\begin{lstlisting}[frame=single,language=ksh,showstringspaces=false]
+bash doc/update_prm_files.sh cookbooks/convection_box.prm
+\end{lstlisting}
 
 \note{Not all text replacements are unique, and the structure of input files
 allows for constructions the script can not properly parse. Also we can not
@@ -11661,6 +11666,30 @@ The purpose
 of the last two functions has been discussed in the general overview of
 plugins above.
 
+
+\subsection{Compatibility of plugins with newer \aspect{} versions}
+
+We strive to maintain compatibility for user written plugins with new versions
+of \aspect{} for as long as possible. However, occasionally we have to
+restructure interface classes to improve \aspect{} further. This is in
+particular true for new major versions. In order to allow running old plugins
+with newer \aspect{} versions we provide scripts that can automatically update
+existing plugins to the new syntax. Executing
+\texttt{doc/update\_source\_files.sh} with one or more plugin files as
+arguments will create a backup of the old file (named
+\texttt{old\_filename.bak}), and replace the existing file with a version that
+should work with the current \aspect{} version. Using this script would look
+like this:
+
+\begin{lstlisting}[frame=single,language=ksh,showstringspaces=false]
+bash doc/update_source_files.sh cookbooks/finite_strain/finite_strain.cc
+\end{lstlisting}
+
+\note{Not all text replacements are unique, and the structure of plugin files
+allows for constructs the script can not properly parse. Thus, it is important
+that you check your updated plugin file for errors. That being said, all plugin
+files in the main \aspect{} repository are updated successfully using this
+script.}
 
 
 \subsection{Extending \aspect{} through the signals mechanism}

--- a/doc/modules/changes/20180420_gassmoeller
+++ b/doc/modules/changes/20180420_gassmoeller
@@ -1,0 +1,6 @@
+Changed: The update scripts for old parameter and source files have been moved
+and renamed. The official way to update old files is now to call
+doc/update_prm_files.sh or doc/update_source_files.sh with all file names that
+should be updated.
+<br>
+(Rene Gassmoeller, 2018/04/20)

--- a/doc/update_all_files.sh
+++ b/doc/update_all_files.sh
@@ -9,11 +9,11 @@ DOC_DIR=`dirname $0`
 BASE_DIR=`pwd $DOC_DIR/..`
 
 # Update source files
-SOURCE_FILES=`find $BASE_DIR -type f -name *.cc -or -name *.h -not -path */doc/*`
+SOURCE_FILES=`find $BASE_DIR -type f -name *.cc -or -name *.h -not -name *.bak -path doc/ -prune`
 bash ${DOC_DIR}/update_source_files.sh $SOURCE_FILES
 
 # Update prm files
-PRM_FILES=`find $BASE_DIR -type f -name *.prm* -not -name *update_script*`
+PRM_FILES=`find $BASE_DIR -type f -name *.prm* -not -name *update_script* -not -name *.bak`
 bash ${DOC_DIR}/update_prm_files.sh $PRM_FILES
 
 # To remove the backup files that are created you will likely want to use the

--- a/doc/update_all_files.sh
+++ b/doc/update_all_files.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This script executes 'update_source_files.sh' and 'update_prm_files.sh' for
+# all applicable files in the ASPECT repository. It should usually not have any
+# effect, because all files should be on the current version, but if you change
+# the code, or add new files it can be handy to execute this script.
+
+DOC_DIR=`dirname $0`
+BASE_DIR=`pwd $DOC_DIR/..`
+
+# Update source files
+SOURCE_FILES=`find $BASE_DIR -type f -name *.cc -or -name *.h -not -path */doc/*`
+bash ${DOC_DIR}/update_source_files.sh $SOURCE_FILES
+
+# Update prm files
+PRM_FILES=`find $BASE_DIR -type f -name *.prm* -not -name *update_script*`
+bash ${DOC_DIR}/update_prm_files.sh $PRM_FILES
+
+# To remove the backup files that are created you will likely want to use the
+# following command. It is commented out by default, because you should think
+# carefully before automatically removing files.
+# find ${BASE_DIR} -name *.bak -delete

--- a/doc/update_prm_files.sh
+++ b/doc/update_prm_files.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# A script to update .prm files to the current ASPECT naming scheme. This
+# script correctly updated all files within the official development version of
+# ASPECT, but it is not guaranteed to work for all possible names in user
+# files. Consequently a backup of files is created, and the changes by this
+# script should be investigated to ensure a correct renaming.
+#
+# Usage for a parameter file named FILENAME
+# (possibly containing wildcards such as '*.prm'):
+#
+# bash update_prm_files.sh FILENAME
+
+FOLDER=`dirname $0`
+SCRIPT_FOLDER=${FOLDER}/update_scripts/prm_files
+
+# Create the backup
+for parameter_file in "$@"; do
+  cp $parameter_file ${parameter_file}.bak
+done
+
+# Run all update scripts in ${SCRIPT_FOLDER} on all files.
+# In order to make the -i command portable between Linux and MacOS,
+# we need to provide a backup file-ending (.tmp) and then later
+# remove the backup file. We can not use this file
+# instead of the .bak file, because it is overwritten by every script,
+# and so it is only a backup of the last execution.
+for script in `ls ${SCRIPT_FOLDER}/*.sed`; do
+  sed -i.tmp -f $script "$@"
+done
+
+for parameter_file in "$@"; do
+  rm ${parameter_file}.tmp
+done

--- a/doc/update_scripts/prm_files/update_prm_files_to_2.0.0.sed
+++ b/doc/update_scripts/prm_files/update_prm_files_to_2.0.0.sed
@@ -1,15 +1,5 @@
 # A script for the stream editor sed to update .prm files from the
-# naming scheme used in ASPECT 1.5.0 to ASPECT 2.0.0. This script correctly
-# updated all files within the official development version of ASPECT,
-# but it is not guaranteed to work for all possible names in user files.
-# Consequently a backup of files is strongly recommended, and the changes
-# created by this script should be investigated to ensure a correct renaming.
-#
-# Usage for a parameter file named FILENAME (possibly containing
-# wildcards such as '*.prm'):
-# sed -i -f update_prm_files_to_2.0.0.sed FILENAME
-# On MacOS:
-# sed -i "" -f update_source_files_to_2.0.0.sed FILENAME
+# naming scheme used in ASPECT 1.5.0 to ASPECT 2.0.0.
 
 # Rename compositional initial conditions
 s/subsection Compositional initial conditions/subsection Initial composition model/g

--- a/doc/update_scripts/prm_files/update_prm_files_to_2.0.0.sed
+++ b/doc/update_scripts/prm_files/update_prm_files_to_2.0.0.sed
@@ -30,7 +30,8 @@ N
 # If we get here, we found an end. If we did not find the new parameter,
 # it needs to be added.
 /set Magnitude at bottom/!{
-i\    set Magnitude at bottom = 0.0
+i\
+    set Magnitude at bottom = 0.0
 }
 
 # Then jump up to finish this part, and print the whole modified subsection

--- a/doc/update_scripts/source_files/update_source_files_to_2.0.0.sed
+++ b/doc/update_scripts/source_files/update_source_files_to_2.0.0.sed
@@ -1,15 +1,5 @@
 # A script for the stream editor sed to update .cc and .h files from the
-# naming scheme used in ASPECT 1.5.0 to ASPECT 2.0.0. This script correctly
-# updated all files within the official development version of ASPECT,
-# but it is not guaranteed to work for all possible names in user plugins.
-# Consequently a backup of files is strongly recommended, and the changes
-# created by this script should be investigated to ensure a correct renaming.
-#
-# Usage for a c++ source or header file named FILENAME (possibly containing
-# wildcards such as '*.cc') on Linux:
-# sed -i -f update_source_files_to_2.0.0.sed FILENAME
-# On MacOS:
-# sed -i "" -f update_source_files_to_2.0.0.sed FILENAME
+# naming scheme used in ASPECT 1.5.0 to ASPECT 2.0.0.
 
 # Rename fluid pressure boundary conditions
 s/fluid_pressure_boundary_conditions/boundary_fluid_pressure/g

--- a/doc/update_source_files.sh
+++ b/doc/update_source_files.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# A script to update .cc and .h files to the current ASPECT naming scheme. This
+# script correctly updated all files within the official development version of
+# ASPECT, but it is not guaranteed to work for all possible names in user
+# files. Consequently a backup of files is created, and the changes by this
+# script should be investigated to ensure a correct renaming.
+#
+# Usage for a source file named FILENAME
+# (possibly containing wildcards such as '*.cc'):
+#
+# bash update_source_files.sh FILENAME
+
+FOLDER=`dirname $0`
+SCRIPT_FOLDER=${FOLDER}/update_scripts/source_files
+
+# Create the backup
+for source_file in "$@"; do
+  cp $source_file ${source_file}.bak
+done
+
+# Run all update scripts in ${SCRIPT_FOLDER} on all files.
+# In order to make the -i command portable between Linux and MacOS,
+# we need to provide a backup file-ending (.tmp) and then later
+# remove the backup file. We can not use this file
+# instead of the .bak file, because it is overwritten by every script,
+# and so it is only a backup of the last execution.
+for script in `ls ${SCRIPT_FOLDER}/*.sed`; do
+  sed -i.tmp -f $script "$@"
+done
+
+for source_file in "$@"; do
+  rm ${source_file}.tmp
+done

--- a/tests/update_script.cc
+++ b/tests/update_script.cc
@@ -12,12 +12,14 @@
  */
 int f()
 {
-  // call ASPECT with "--" and pipe an existing input file into it.
   int ret;
   std::string command;
 
-  command = ("cat update_script.x.prm | sed -f " ASPECT_SOURCE_DIR "/doc/update_prm_files_to_2.0.0.sed "
-             "| sed 's:set Additional shared libraries = ./libupdate_script.so::' > output-update_script/updated.prm");
+  command = ("cp update_script.x.prm output-update_script/updated.prm &&"
+             "sed -i.bak 's:set Additional shared libraries = ./libupdate_script.so::' output-update_script/updated.prm &&"
+             "bash " ASPECT_SOURCE_DIR "/doc/update_prm_files.sh output-update_script/updated.prm &&"
+             "rm output-update_script/updated.prm.bak");
+
   std::cout << "Executing the update script:\n"
             << command
             << std::endl;

--- a/tests/update_script/screen-output
+++ b/tests/update_script/screen-output
@@ -1,7 +1,7 @@
 
 Loading shared library <./libupdate_script.so>
 Executing the update script:
-cat update_script.x.prm | sed -f ASPECT_DIR/doc/update_prm_files_to_2.0.0.sed | sed 's:set Additional shared libraries = ./libupdate_script.so::' > output-update_script/updated.prm
+cp update_script.x.prm output-update_script/updated.prm &&sed -i.bak 's:set Additional shared libraries = ./libupdate_script.so::' output-update_script/updated.prm &&bash ASPECT_DIR/doc/update_prm_files.sh output-update_script/updated.prm &&rm output-update_script/updated.prm.bak
 Running ASPECT with updated parameter file:
 ../aspect output-update_script/updated.prm
 

--- a/tests/update_script_2.cc
+++ b/tests/update_script_2.cc
@@ -16,14 +16,15 @@
  */
 int f()
 {
-  // call ASPECT with "--" and pipe an existing input file into it.
   int ret;
   std::string command;
 
-  command = ("cat update_script_2.x.prm | sed 's:set Additional shared libraries = ./libupdate_script_2.so::' | "
-             "sed -f " ASPECT_SOURCE_DIR "/doc/update_prm_files_to_2.0.0.sed > output-update_script_2/updated.prm && "
-             "cat output-update_script_2/updated.prm | sed -f " ASPECT_SOURCE_DIR "/doc/update_prm_files_to_2.0.0.sed > output-update_script_2/updated2.prm && "
-             "diff output-update_script_2/updated.prm output-update_script_2/updated2.prm");
+  command = ("cp update_script_2.x.prm output-update_script_2/updated2.prm;"
+             "sed -i.bak 's:set Additional shared libraries = ./libupdate_script_2.so::' output-update_script_2/updated2.prm;"
+             "bash " ASPECT_SOURCE_DIR "/doc/update_prm_files.sh output-update_script_2/updated2.prm;"
+             "bash " ASPECT_SOURCE_DIR "/doc/update_prm_files.sh output-update_script_2/updated2.prm;"
+             "rm output-update_script_2/updated2.prm.bak");
+
   std::cout << "Executing the update script:\n"
             << command
             << std::endl;

--- a/tests/update_script_2/screen-output
+++ b/tests/update_script_2/screen-output
@@ -1,7 +1,7 @@
 
 Loading shared library <./libupdate_script_2.so>
 Executing the update script:
-cat update_script_2.x.prm | sed 's:set Additional shared libraries = ./libupdate_script_2.so::' | sed -f ASPECT_DIR/doc/update_prm_files_to_2.0.0.sed > output-update_script_2/updated.prm && cat output-update_script_2/updated.prm | sed -f ASPECT_DIR/doc/update_prm_files_to_2.0.0.sed > output-update_script_2/updated2.prm && diff output-update_script_2/updated.prm output-update_script_2/updated2.prm
+cp update_script_2.x.prm output-update_script_2/updated2.prm;sed -i.bak 's:set Additional shared libraries = ./libupdate_script_2.so::' output-update_script_2/updated2.prm;bash ASPECT_DIR/doc/update_prm_files.sh output-update_script_2/updated2.prm;bash ASPECT_DIR/doc/update_prm_files.sh output-update_script_2/updated2.prm;rm output-update_script_2/updated2.prm.bak
 Running ASPECT with updated parameter file:
 ../aspect output-update_script_2/updated2.prm
 


### PR DESCRIPTION
This will make #2157 and #2163 simpler to merge, and also improves the organization of the update scripts. Currently, the update script is one sed-script that tries to update everything. Unfortunately, sed was a bad choice by me for this type of operation, because it has only one hold space, and its syntax is very hard to understand. With the new organization (one shell script in doc/ that calls all existing scripts in a subfolder), it will be simpler to add future changes in whatever language we prefer, and it prevents conflicts between different renaming operations. I also added more documentation to the manual, and made the application of the update script safer, by always generating backup files with the ending .bak. I also added a changelog entry.
