### PR TITLE
[WIP] Fix density used for thermal conductivity in visco_plastic and diffusion_dislocation models

### DIFF
--- a/source/material_model/diffusion_dislocation.cc
+++ b/source/material_model/diffusion_dislocation.cc
@@ -20,7 +20,7 @@
 
 #include <aspect/material_model/diffusion_dislocation.h>
 #include <aspect/utilities.h>
-
+#include <aspect/adiabatic_conditions/interface.h>
 
 namespace aspect
 {
@@ -305,8 +305,15 @@ namespace aspect
           out.thermal_expansion_coefficients[i] = thermal_expansivity;
           // Specific heat at the given positions.
           out.specific_heat[i] = heat_capacity;
-          // Thermal conductivity at the given positions.
-          out.thermal_conductivities[i] = thermal_diffusivity * heat_capacity * density;
+          // Thermal conductivity at the given positions. If the temperature equation uses
+          // the reference density profile formulation, use the reference density to
+          // calculate thermal conductivity. Otherwise, use the real density.
+          if (this->get_parameters().formulation_temperature_equation ==
+              Parameters<dim>::Formulation::TemperatureEquation::reference_density_profile)
+            out.thermal_conductivities[i] = thermal_diffusivity * heat_capacity *
+                                            this->get_adiabatic_conditions().density(in.position[i]);
+          else
+            out.thermal_conductivities[i] = thermal_diffusivity * heat_capacity * density;
           // Compressibility at the given positions.
           // The compressibility is given as
           // $\frac 1\rho \frac{\partial\rho}{\partial p}$.

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -23,6 +23,7 @@
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/base/signaling_nan.h>
 #include <aspect/newton.h>
+#include <aspect/adiabatic_conditions/interface.h>
 
 namespace aspect
 {
@@ -508,8 +509,15 @@ namespace aspect
           out.thermal_expansion_coefficients[i] = thermal_expansivity;
           // Specific heat at the given positions.
           out.specific_heat[i] = heat_capacity;
-          // Thermal conductivity at the given positions.
-          out.thermal_conductivities[i] = thermal_diffusivity * heat_capacity * density;
+          // Thermal conductivity at the given positions. If the temperature equation uses
+          // the reference density profile formulation, use the reference density to
+          // calculate thermal conductivity. Otherwise, use the real density.
+          if (this->get_parameters().formulation_temperature_equation ==
+              Parameters<dim>::Formulation::TemperatureEquation::reference_density_profile)
+            out.thermal_conductivities[i] = thermal_diffusivity * heat_capacity *
+                                            this->get_adiabatic_conditions().density(in.position[i]);
+          else
+            out.thermal_conductivities[i] = thermal_diffusivity * heat_capacity * density;
           // Compressibility at the given positions.
           // The compressibility is given as
           // $\frac 1\rho \frac{\partial\rho}{\partial p}$.


### PR DESCRIPTION
In the` visco_plastic` and `diffusion_dislocation` models the thermal diffusivity is specified as an input file parameter instead of the thermal conductivity. The thermal conductivity is then calculated from the thermal diffusivity, density and heat capacity. 

This leads to an inconsistency when set `Temperature equation = reference density profile`. 

The same inconsistency is present in any heating model that uses the material model density output. @gassmoeller @jdannberg - I was planning to use the structure to enforce that the heating models use the correct density. Any objections before I do this in another commit?

Thanks and credit to Phillip Heron and Jeroen van Hunen for identifying an issue by running the `Blankenbach` benchmarks  with these two material models! 