### PR TITLE
Fix remaining cookbook that uses p_c in the input file

### DIFF
--- a/cookbooks/global_melt.prm
+++ b/cookbooks/global_melt.prm
@@ -347,7 +347,7 @@ subsection Postprocess
     end
 
     subsection Melt material properties
-      set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity, p_c
+      set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
     end
 
     set Number of grouped files       = 0


### PR DESCRIPTION
Closes #2179. It was only this cookbook (I checked cookbooks, benchmarks, and files in doc/), and the parameter existed in the main code for less than two weeks, so I do not think there is a need for an inclusion into the update script.