### PR TITLE
Fix visco_plastic and diffusion_dislocation thermal diffusivity

### DIFF
--- a/doc/modules/changes/20180430_naliboff
+++ b/doc/modules/changes/20180430_naliboff
@@ -1,0 +1,6 @@
+Fixed: The material models <code>visco plastic</code> and <code>diffusion 
+dislocation</code> now use the reference density to calculate thermal
+conductivity if the <code>Temperature equation</code> formulation is set
+to <code>reference density profile</code>.
+<br>
+(John Naliboff, 2018/04/30)

--- a/source/material_model/diffusion_dislocation.cc
+++ b/source/material_model/diffusion_dislocation.cc
@@ -307,9 +307,11 @@ namespace aspect
           out.specific_heat[i] = heat_capacity;
           // Thermal conductivity at the given positions. If the temperature equation uses
           // the reference density profile formulation, use the reference density to
-          // calculate thermal conductivity. Otherwise, use the real density.
+          // calculate thermal conductivity. Otherwise, use the real density. If the adiabatic
+          // conditions are not yet initialized, the real density will still be used.
           if (this->get_parameters().formulation_temperature_equation ==
-              Parameters<dim>::Formulation::TemperatureEquation::reference_density_profile)
+              Parameters<dim>::Formulation::TemperatureEquation::reference_density_profile &&
+              this->get_adiabatic_conditions().is_initialized())
             out.thermal_conductivities[i] = thermal_diffusivity * heat_capacity *
                                             this->get_adiabatic_conditions().density(in.position[i]);
           else

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -511,9 +511,11 @@ namespace aspect
           out.specific_heat[i] = heat_capacity;
           // Thermal conductivity at the given positions. If the temperature equation uses
           // the reference density profile formulation, use the reference density to
-          // calculate thermal conductivity. Otherwise, use the real density.
+          // calculate thermal conductivity. Otherwise, use the real density. If the adiabatic
+          // conditions are not yet initialized, the real density will still be used.
           if (this->get_parameters().formulation_temperature_equation ==
-              Parameters<dim>::Formulation::TemperatureEquation::reference_density_profile)
+              Parameters<dim>::Formulation::TemperatureEquation::reference_density_profile &&
+              this->get_adiabatic_conditions().is_initialized())
             out.thermal_conductivities[i] = thermal_diffusivity * heat_capacity *
                                             this->get_adiabatic_conditions().density(in.position[i]);
           else

--- a/tests/diffusion_dislocation_reference_density_profile.prm
+++ b/tests/diffusion_dislocation_reference_density_profile.prm
@@ -1,0 +1,136 @@
+# Identical to the test diffusion_dislocation, except the
+# reference density profile formulation is used for the
+# temperature equation.
+
+set Dimension = 2
+set CFL number                             = 1.0
+set Resume computation                     = false
+set Start time                             = 0
+set Adiabatic surface temperature          = 0
+set Surface pressure                       = 0
+set Pressure normalization = surface
+set Use years in output instead of seconds = true
+set Nonlinear solver scheme                = iterated Advection and Stokes
+set Output directory                       = diffusion_dislocation_reference_density_profile
+
+# Use 'reference density profile' formulation for the temperature equation
+subsection Formulation
+  set Formulation          = custom
+  set Mass conservation    = incompressible
+  set Temperature equation = reference density profile
+end
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent    = 3000e3
+    set Y extent    = 750e3
+  end
+end
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = bottom, top
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = left, right, bottom, top
+end
+
+subsection Compositional fields
+  set Number of fields = 1
+  set Names of fields  = depleted_lithosphere
+end
+
+subsection Initial composition model
+  set Model name = function
+
+  subsection Function
+    set Variable names = x,y
+    set Function expression = if(y>=650e3,1,0)
+  end
+end
+
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Variable names = x,y
+    set Function constants = h=750e3, w=3000e3
+    set Function expression = \
+      if( y < 100e3, \
+        (100e3-y)/100e3*100+1635, \
+        if(y>650e3, \
+          (h-y)/(100e3)*1342+293, \
+          1635))
+  end
+end
+
+subsection Material model
+  set Model name = diffusion dislocation
+
+  subsection Diffusion dislocation
+    set Reference temperature = 293
+    set Minimum strain rate = 5e-19
+    set Minimum viscosity = 1e1
+    set Maximum viscosity = 1e28
+    set Effective viscosity coefficient = 1.0
+    set Reference viscosity = 1e22
+
+    set Thermal diffusivity = 0.8e-6
+    set Heat capacity = 1.25e3
+    set Densities = 3330, 3300
+    set Thermal expansivities = 2e-5
+
+    set Viscosity averaging scheme = harmonic
+
+    set Grain size = 1e-3
+    set Prefactors for diffusion creep = 1.5e-15
+    set Stress exponents for diffusion creep = 1
+    set Grain size exponents for diffusion creep = 3
+    set Activation energies for diffusion creep = 3.75e5
+    set Activation volumes for diffusion creep = 6e-6
+
+    set Prefactors for dislocation creep = 1.1e-16
+    set Stress exponents for dislocation creep = 3.5
+    set Activation energies for dislocation creep = 5.3e5
+    set Activation volumes for dislocation creep = 1.4e-5
+  end
+end
+
+subsection Boundary temperature model
+  set List of model names = initial temperature
+end
+
+subsection Boundary composition model
+  set List of model names = initial composition
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+subsection Mesh refinement
+  set Initial global refinement                 = 3
+  set Initial adaptive refinement               = 0
+end
+
+subsection Termination criteria
+  set Termination criteria = end step
+  set End step = 0
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Linear solver tolerance = 1.e-7
+    set Number of cheap Stokes solver steps = 30
+  end
+end

--- a/tests/diffusion_dislocation_reference_density_profile/screen-output
+++ b/tests/diffusion_dislocation_reference_density_profile/screen-output
@@ -1,0 +1,61 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (fix_thermal_diffusivity, b720dae)
+--     . using deal.II 9.0.0-pre (master, a7c2e20)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+-----------------------------------------------------------------------------
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 1,237 (578+81+289+289)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving depleted_lithosphere system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 10+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.04449e-16, 1.05609e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
+
+   Solving temperature system... 0 iterations.
+   Solving depleted_lithosphere system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 7+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.04449e-16, 1.05609e-16, 0.000712092
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000712092
+
+   Solving temperature system... 0 iterations.
+   Solving depleted_lithosphere system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 3+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.04449e-16, 1.05609e-16, 1.47593e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 1.47593e-07
+
+
+   Postprocessing:
+
+Termination requested by criterion: end step
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.224s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         3 |    0.0287s |        13% |
+| Assemble composition system     |         3 |    0.0324s |        14% |
+| Assemble temperature system     |         3 |    0.0374s |        17% |
+| Build Stokes preconditioner     |         3 |    0.0305s |        14% |
+| Build composition preconditioner|         3 |   0.00131s |      0.58% |
+| Build temperature preconditioner|         3 |   0.00141s |      0.63% |
+| Solve Stokes system             |         3 |   0.00642s |       2.9% |
+| Solve composition system        |         3 |  0.000684s |       0.3% |
+| Solve temperature system        |         3 |  0.000854s |      0.38% |
+| Initialization                  |         1 |    0.0233s |        10% |
+| Postprocessing                  |         1 |  0.000126s |         0% |
+| Setup dof systems               |         1 |   0.00803s |       3.6% |
+| Setup initial conditions        |         1 |    0.0108s |       4.8% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/diffusion_dislocation_reference_density_profile/statistics
+++ b/tests/diffusion_dislocation_reference_density_profile/statistics
@@ -1,0 +1,14 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Number of nonlinear iterations
+# 9: Iterations for temperature solver
+# 10: Iterations for composition solver 1
+# 11: Iterations for Stokes solver
+# 12: Velocity iterations in Stokes preconditioner
+# 13: Schur complement iterations in Stokes preconditioner
+0 0.000000000000e+00 0.000000000000e+00 64 659 289 289 3 0 0 20 23 22 

--- a/tests/visco_plastic_reference_density_profile.prm
+++ b/tests/visco_plastic_reference_density_profile.prm
@@ -1,0 +1,107 @@
+# Global parameters
+set Dimension                              = 2
+set Start time                             = 0
+set End time                               = 0
+set Use years in output instead of seconds = true
+set Nonlinear solver scheme                = single Advection, iterated Stokes
+set Max nonlinear iterations               = 1
+set Output directory                       = visco_plastic_reference_density_profile
+set Timing output frequency                = 1
+
+# Formulation
+subsection Formulation
+  set Formulation          = custom 
+  set Mass conservation    = incompressible
+  set Temperature equation = reference density profile
+end
+
+
+# Model geometry (100x100 km, 10 km spacing)
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X repetitions = 10
+    set Y repetitions = 10
+    set X extent      = 100e3
+    set Y extent      = 100e3
+  end
+end
+
+# Mesh refinement specifications 
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 0
+  set Time steps between mesh refinement = 0
+end
+
+
+# Boundary classifications (fixed T boundaries, prescribed velocity) 
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = bottom, top, left, right
+end
+
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = bottom y: function, top y: function, left x: function, right x: function
+end
+
+# Velocity on boundaries characterized by functions
+subsection Boundary velocity model
+  subsection Function
+    set Variable names      = x,y
+    set Function constants  = m=0.0005, year=1
+    set Function expression = if (x<50e3 , -1*m/year, 1*m/year); if (y<50e3 , 1*m/year, -1*m/year);
+  end
+end
+
+# Temperature boundary and initial conditions
+subsection Boundary temperature model
+  set List of model names = box
+  subsection Box
+    set Bottom temperature = 273
+    set Left temperature   = 273
+    set Right temperature  = 273
+    set Top temperature    = 273
+  end
+end
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 273
+  end
+end
+
+# Material model (values for background material)
+subsection Material model
+  set Model name = visco plastic
+  subsection Visco Plastic
+    set Reference strain rate = 1.e-16
+    set Viscous flow law = dislocation
+    set Prefactors for dislocation creep = 5.e-23
+    set Stress exponents for dislocation creep = 1.0
+    set Activation energies for dislocation creep = 0.
+    set Activation volumes for dislocation creep = 0.
+  end
+end
+
+# Gravity model
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+end
+
+# Post processing
+subsection Postprocess
+  set List of postprocessors = velocity statistics, mass flux statistics
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Number of cheap Stokes solver steps = 0
+  end
+end

--- a/tests/visco_plastic_reference_density_profile/screen-output
+++ b/tests/visco_plastic_reference_density_profile/screen-output
@@ -1,0 +1,63 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (subduction_cookbook, b720dae)
+--     . using deal.II 9.0.0-pre (master, a7c2e20)
+--     . using Trilinos 12.10.1
+--     . using p4est 1.1.0
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+-----------------------------------------------------------------------------
+
+Number of active cells: 100 (on 1 levels)
+Number of degrees of freedom: 1,444 (882+121+441)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+2 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
+
+   Postprocessing:
+     RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
+     Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.144s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |    0.0191s |        13% |
+| Assemble temperature system     |         1 |    0.0182s |        13% |
+| Build Stokes preconditioner     |         1 |    0.0186s |        13% |
+| Build temperature preconditioner|         1 |  0.000921s |      0.64% |
+| Solve Stokes system             |         1 |   0.00334s |       2.3% |
+| Solve temperature system        |         1 |  0.000463s |      0.32% |
+| Initialization                  |         1 |    0.0319s |        22% |
+| Postprocessing                  |         1 |   0.00236s |       1.6% |
+| Setup dof systems               |         1 |    0.0116s |         8% |
+| Setup initial conditions        |         1 |    0.0178s |        12% |
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.144s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         1 |    0.0191s |        13% |
+| Assemble temperature system     |         1 |    0.0182s |        13% |
+| Build Stokes preconditioner     |         1 |    0.0186s |        13% |
+| Build temperature preconditioner|         1 |  0.000921s |      0.64% |
+| Solve Stokes system             |         1 |   0.00334s |       2.3% |
+| Solve temperature system        |         1 |  0.000463s |      0.32% |
+| Initialization                  |         1 |    0.0319s |        22% |
+| Postprocessing                  |         1 |   0.00236s |       1.6% |
+| Setup dof systems               |         1 |    0.0116s |         8% |
+| Setup initial conditions        |         1 |    0.0178s |        12% |
++---------------------------------+-----------+------------+------------+
+


### PR DESCRIPTION
Follow up to #2170. It turns out none of the `diffusion_dislocation` or `visco_plastic` tests use the `reference density profile` formulation for the temperature equation (I have no idea why I assumed they did .. careless error). 

As previously written, the two material models did not check whether adiabatic conditions are initialized before asking for the density from `adiabatic_conditions`. This is now fixed and I've added tests that use `reference density profile` in both material models. I also checked that the other changes (`basic statistics` & `thermal diffusivity` post processors) in #2170 work with `reference density profile`, but did not add any associated tests.