### PR TITLE
Fix manual referencing removed file

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -5039,26 +5039,22 @@ for the components of the velocity.
 To illustrate this, let us consider the \url{cookbooks/platelike-boundary.prm}
 input file. It essentially extends the input file considered in the previous example.
 The part of this file that we are particularly interested in in the current
-context is the selection of the kind of boundary conditions on the four
+context is the selection of the kind of velocity boundary conditions on the four
 sides of the box geometry, which we do using a section like this:
-\lstinputlisting[language=prmfile]{cookbooks/platelike-boundary/modelsettings.part.prm.out}
+\lstinputlisting[language=prmfile]{cookbooks/platelike-boundary/boundary.part.prm.out}
 
-Following the convention for numbering boundaries described in the previous
-section, this means that we prescribe a fixed temperature at the bottom and top sides of the box (boundary
-numbers two and three). We use tangential flow at boundaries zero, one and two
-(left, right and bottom).
-Finally, the last entry above is a comma separated list (here with only a single element) of pairs consisting of the
-number of a boundary and the name of the prescribed velocity boundary model to
-be used on this boundary. Here, we use the \texttt{function} boundary model,
-which allows us to provide a function-like notation for the components of the
-velocity vector at the boundary.
+We use tangential flow at boundaries named left, right and bottom.
+Additionally, we specify a comma separated list (here with only a single
+element) of pairs consisting of the name of a boundary and the name of a
+prescribed velocity boundary model. Here, we use the \texttt{function} model on
+the \texttt{top} boundary, which allows us to provide a function-like notation
+for the components of the velocity vector at the boundary.
 
 The second part we need is that we actually describe the function that sets the
-velocity. We do this as follows:
-\lstinputlisting[language=prmfile]{cookbooks/platelike-boundary/boundary.part.prm.out}
-The first of these gives names to the components of the position vector (here,
-we are in 2d and we use $x$ and $z$ as spatial variable names) and the time.
-We could have left this entry at its default, \texttt{x,y,t}, but since we
+velocity. We do this in the subsection \texttt{Function}. The first of these
+parameters gives names to the components of the position vector (here, we are
+in 2d and we use $x$ and $z$ as spatial variable names) and the time. We could
+have left this entry at its default, \texttt{x,y,t}, but since we
 often think in terms of ``depth'' as the vertical direction, let us use
 \texttt{z} for the second coordinate.
 In the second parameter we define symbolic constants that can be used


### PR DESCRIPTION
This section of the manual referenced a file that was removed in #2157. I did not notice the missing file, because the corresponding .prm.out file was still in my folder, and so the manual compiled for me.