### PR TITLE
A redundant inverse sign in the comment here?

### DIFF
--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -353,7 +353,7 @@ namespace aspect
 
     // compute and remove angular momentum from velocity field, by computing
     // \int \rho u \cdot r_orth = \omega  * \int \rho x^2    ( 2 dimensions)
-    // \int \rho r \times u =  I^{-1} \cdot \omega  (3 dimensions)
+    // \int \rho r \times u =  I \cdot \omega  (3 dimensions)
 
     QGauss<dim> quadrature(parameters.stokes_velocity_degree+1);
     const unsigned int n_q_points = quadrature.size();


### PR DESCRIPTION
When I read through this part, the inverse sign in this comment seems redundant because the left side is angular momentum and the right side is moment of inertial times angular velocity (\omega)?