### PR TITLE
Add citation info to header

### DIFF
--- a/source/global.cc
+++ b/source/global.cc
@@ -157,6 +157,7 @@ void print_aspect_header(Stream &stream)
   if (n_threads>1)
     stream << "--     . using " << n_threads << " threads " << (n_tasks == 1 ? "\n" : "each\n");
 
+  stream << "-- How to cite ASPECT: https://aspect.geodynamics.org/cite.html\n";
 
   stream << "-----------------------------------------------------------------------------\n"
          << std::endl;


### PR DESCRIPTION
Adds to #2195 and #2196 a note to the header of the model output. I am aware we do not want to put too much into the header, but this seems like an important enough notice that many might forget otherwise.