### PR TITLE
[post-2.0] Automate test procedure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,74 @@
+#!groovy
+
+pipeline {
+  agent {
+    docker {
+        image 'dealii/dealii:v8.5.1-gcc-mpi-fulldepscandi-debugrelease'
+	label 'has-docker'
+    }
+  }
+
+  parameters {
+    booleanParam(defaultValue: false, description: 'Is the pull request approved for testing?', name: 'TRUST_BUILD')
+  }
+
+  stages {
+    stage('Check indentation') {
+      steps {
+        sh './doc/indent'
+        sh 'git diff | tee changes-astyle.diff'
+        archiveArtifacts artifacts: 'changes-astyle.diff', fingerprint: true
+        sh 'git diff --exit-code --name-only'
+        }
+    }
+
+    stage ("Check execution") {
+      when {
+	allOf {
+            environment name: 'TRUST_BUILD', value: 'false' 
+            not {branch 'master'}
+            not {changeRequest authorEmail: "rene.gassmoeller@mailbox.org"}
+            not {changeRequest authorEmail: "timo.heister@gmail.com"}
+            not {changeRequest authorEmail: "bangerth@colostate.edu"}
+            not {changeRequest authorEmail: "judannberg@gmail.com"}
+            not {changeRequest authorEmail: "ja3170@columbia.edu"}
+            not {changeRequest authorEmail: "john.naliboff@gmail.com"}
+            not {changeRequest authorEmail: "menno.fraters@outlook.com"}
+            not {changeRequest authorEmail: "acglerum@gfz-potsdam.de"}
+	    }
+      }
+      steps {
+	  echo "Please ask an admin to rerun jenkins with TRUST_BUILD=true"
+	    sh "exit 1"
+      }
+    }
+
+    stage('Build') {
+      steps {
+        sh '''
+          mkdir -p build-gcc-fast
+          cd build-gcc-fast
+          cmake -G "Ninja" gcc -D ASPECT_TEST_GENERATOR=Ninja -D ASPECT_USE_PETSC=OFF -D ASPECT_RUN_ALL_TESTS=ON -D ASPECT_PRECOMPILE_HEADERS=ON ..
+          ninja
+        '''
+      } 
+    }
+
+    stage('Run tests') {
+      steps {
+        sh '''
+          cd build-gcc-fast
+          ASPECT_TESTS_VERBOSE=1 ../cmake/generate_reference_output.sh
+        '''
+        archiveArtifacts artifacts: 'build-gcc-fast/changes.diff', fingerprint: true
+        sh 'git diff --exit-code --name-only'
+      }
+    }
+  }
+
+  post {
+    always {
+      deleteDir()
+    }
+  }
+}

--- a/cmake/generate_reference_output.sh
+++ b/cmake/generate_reference_output.sh
@@ -14,9 +14,14 @@ SRC_PATH=`cd $SRC_PATH/..;pwd`
 OUT=$PWD/changes.diff
 
 if [ "$ASPECT_TESTS_VERBOSE" == "1" ]; then
-  ASPECT_GENERATE_REFERENCE_OUTPUT=1 ctest -j 4
+  ASPECT_GENERATE_REFERENCE_OUTPUT=1 ctest --output-on-failure -j 4
 else
-  ASPECT_GENERATE_REFERENCE_OUTPUT=1 ctest -j 4 >/dev/null
+  ASPECT_GENERATE_REFERENCE_OUTPUT=1 ctest --output-on-failure -j 4 >/dev/null
+fi
+
+if [ "$?" != "0" ]; then
+  echo "test generation failed"
+  exit $?
 fi
 
 cd $SRC_PATH

--- a/doc/modules/changes/20180502_gassmoeller
+++ b/doc/modules/changes/20180502_gassmoeller
@@ -1,0 +1,6 @@
+New: ASPECT now stores the steps for the continuous integration setup
+inside the repository in form of a Jenkins pipeline file. This file
+documents each step in our testing procedure, and allows to easily setup
+new Jenkins server that reproduce the official ASPECT tester.
+<br>
+(Rene Gassmoeller, Timo Heister, Tyler Esser, 2018/05/02)


### PR DESCRIPTION
This is @tjhei, @tjesser-ucdavis-edu, and my current version of closing issue #2143. The Jenkinsfile that this PR adds to the repository documents every step in our testing procedure, and allows to easily set up a Jenkins server to replace our test setup. It will test pull requests from maintainers automatically, for each other pull request a user with access to the jenkins server will have to click a button on the jenkins server (replacing the current /run-tests command). I tested this script with a local jenkins installation, and it seems to work fine, but it might need some tweaking when we try to let it work with Timo's jenkins server. In particular it will need some changes when we switch to the Kubernetes cluster at CIG. Either way (kubernetes or stand-alone docker) will allow us to dedicate additional resources as testing agents that can run in parallel for different PRs.