### PR TITLE
provide base class to fix warning

### DIFF
--- a/include/aspect/lateral_averaging.h
+++ b/include/aspect/lateral_averaging.h
@@ -70,12 +70,12 @@ namespace aspect
         setup(const unsigned int q_points);
 
         /**
-        * This takes @p in material model inputs and @p out outputs (which are filled
-        * if need_material_properties() == true), an initialized FEValues
-        * object for a cell, and the current solution vector as inputs.
-        * Functions in derived classes should then evaluate the desired quantity
-        * and return the results in the output vector, which is q_points long.
-        */
+         * This takes @p in material model inputs and @p out outputs (which are filled
+         * if need_material_properties() == true), an initialized FEValues
+         * object for a cell, and the current solution vector as inputs.
+         * Functions in derived classes should then evaluate the desired quantity
+         * and return the results in the output vector, which is q_points long.
+         */
         virtual
         void
         operator()(const MaterialModel::MaterialModelInputs<dim> &in,
@@ -83,6 +83,12 @@ namespace aspect
                    const FEValues<dim> &fe_values,
                    const LinearAlgebra::BlockVector &solution,
                    std::vector<double> &output) = 0;
+
+        /**
+         * Provide an (empty) virtual destructor.
+         */
+        virtual
+        ~FunctorBase();
     };
   }
 

--- a/source/simulator/lateral_averaging.cc
+++ b/source/simulator/lateral_averaging.cc
@@ -274,6 +274,12 @@ namespace aspect
 
 
     template <int dim>
+    FunctorBase<dim>::~FunctorBase()
+    {}
+
+
+
+    template <int dim>
     void
     FunctorBase<dim>::create_additional_material_model_outputs (const unsigned int /*n_points*/,
                                                                 MaterialModel::MaterialModelOutputs<dim> &/*outputs*/) const


### PR DESCRIPTION
fixes clang 6 warning:
```
/usr/lib/gcc/x86_64-linux-
gnu/4.8/../../../../include/c++/4.8/bits/unique_ptr.h:67:2: warning:
delete called on 'aspect::internal::FunctorBase<2>' that is abstract but
has non-virtual destructor [-Wdelete-non-virtual-dtor]
```