### PR TITLE
Fix nullspace removal

### DIFF
--- a/doc/modules/changes/20180503_gassmoeller
+++ b/doc/modules/changes/20180503_gassmoeller
@@ -1,0 +1,5 @@
+Fixed: The nullspace removal had a minor bug that caused a small
+remaining rotation in three dimensional models even if the net rotation
+or angular momentum should have been removed. The bug was fixed.
+<br>
+(Rene Gassmoeller, Shangxin Liu, 2018/05/03)

--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -425,9 +425,9 @@ namespace aspect
                   local_moment_of_inertia[0][0] += (r_vec.square() - r_vec[0]*r_vec[0])*rho * fe.JxW(k);
                   local_moment_of_inertia[1][1] += (r_vec.square() - r_vec[1]*r_vec[1])*rho * fe.JxW(k);
                   local_moment_of_inertia[2][2] += (r_vec.square() - r_vec[2]*r_vec[2])*rho * fe.JxW(k);
-                  local_moment_of_inertia[0][1] += ( r_vec[0]*r_vec[1])*rho * fe.JxW(k);
-                  local_moment_of_inertia[0][2] += ( r_vec[0]*r_vec[2])*rho * fe.JxW(k);
-                  local_moment_of_inertia[1][2] += ( r_vec[1]*r_vec[2])*rho * fe.JxW(k);
+                  local_moment_of_inertia[0][1] -= ( r_vec[0]*r_vec[1])*rho * fe.JxW(k);
+                  local_moment_of_inertia[0][2] -= ( r_vec[0]*r_vec[2])*rho * fe.JxW(k);
+                  local_moment_of_inertia[1][2] -= ( r_vec[1]*r_vec[2])*rho * fe.JxW(k);
                 }
             }
         }


### PR DESCRIPTION
This is the fix for the bug described in #2198. I am working on a test and postprocessor for the rotation properties, but it is more complicated than I expected, since I need to find a case where it matters (I will open a separate pull request for that). Since @Shangxin-Liu @ian-r-rose and I agree this is a bug, we should get this merged before the release (even if the test has to wait).