### PR TITLE
clang 6 requires deprecation attribute in front

### DIFF
--- a/include/aspect/boundary_traction/interface.h
+++ b/include/aspect/boundary_traction/interface.h
@@ -85,10 +85,11 @@ namespace aspect
          * @deprecated Use boundary_traction(const types::boundary_id boundary_indicator,
          * const Point<dim> &position, const Tensor<1,dim> &normal_vector) const instead.
          */
+        DEAL_II_DEPRECATED
         virtual
         Tensor<1,dim>
         traction (const Point<dim> &position,
-                  const Tensor<1,dim> &normal_vector) const DEAL_II_DEPRECATED;
+                  const Tensor<1,dim> &normal_vector) const;
 
         /**
          * Return the boundary traction as a function of position. The

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -163,12 +163,13 @@ namespace aspect
         /**
          * Return the specific heating rate as a function of position.
          */
+        DEAL_II_DEPRECATED
         virtual
         double
         specific_heating_rate (const double temperature,
                                const double pressure,
                                const std::vector<double> &compositional_fields,
-                               const Point<dim> &position) const DEAL_II_DEPRECATED;
+                               const Point<dim> &position) const;
 
         /**
          * Declare the parameters this class takes through input files. The

--- a/include/aspect/particle/interpolator/interface.h
+++ b/include/aspect/particle/interpolator/interface.h
@@ -73,11 +73,12 @@ namespace aspect
            * @return A vector with as many entries as @p positions. Every entry
            * is a vector of interpolated particle properties at this position.
            */
+          DEAL_II_DEPRECATED
           virtual
           std::vector<std::vector<double> >
           properties_at_points(const ParticleHandler<dim> &particle_handler,
                                const std::vector<Point<dim> > &positions,
-                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell = typename parallel::distributed::Triangulation<dim>::active_cell_iterator()) const DEAL_II_DEPRECATED;
+                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell = typename parallel::distributed::Triangulation<dim>::active_cell_iterator()) const;
 
           /**
            * Perform an interpolation of the properties of the particles in

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -569,8 +569,9 @@ namespace aspect
            * @deprecated This function will be replaced by
            * ParticlePropertyInformation::get_position_by_fieldname(name)
            */
+          DEAL_II_DEPRECATED
           unsigned int
-          get_property_component_by_name(const std::string &name) const DEAL_II_DEPRECATED;
+          get_property_component_by_name(const std::string &name) const;
 
           /**
            * A function that is used to register particle property

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -234,8 +234,9 @@ namespace aspect
          * get_matching_postprocessor() instead.
          */
         template <typename PostprocessorType>
+        DEAL_II_DEPRECATED
         PostprocessorType *
-        find_postprocessor () const DEAL_II_DEPRECATED;
+        find_postprocessor () const;
 
         /**
          * Go through the list of all postprocessors that have been selected

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -530,8 +530,9 @@ namespace aspect
        *
        * @deprecated: Use get_boundary_temperature_manager() instead.
        */
+      DEAL_II_DEPRECATED
       const BoundaryTemperature::Interface<dim> &
-      get_boundary_temperature () const DEAL_II_DEPRECATED;
+      get_boundary_temperature () const;
 
       /**
        * Return an reference to the manager of the boundary temperature models.
@@ -557,8 +558,9 @@ namespace aspect
        *
        * @deprecated: Use get_boundary_composition_manager() instead.
        */
+      DEAL_II_DEPRECATED
       const BoundaryComposition::Interface<dim> &
-      get_boundary_composition () const DEAL_II_DEPRECATED;
+      get_boundary_composition () const;
 
       /**
        * Return an reference to the manager of the boundary composition models.
@@ -582,8 +584,9 @@ namespace aspect
        *
        * @deprecated Use <code> get_initial_temperature_manager </code> instead.
        */
+      DEAL_II_DEPRECATED
       const InitialTemperature::Interface<dim> &
-      get_initial_temperature () const DEAL_II_DEPRECATED;
+      get_initial_temperature () const;
 
       /**
        * Return a reference to the manager of the initial temperature models.
@@ -598,8 +601,9 @@ namespace aspect
        * Return a pointer to the object that describes the composition initial
        * values.
        */
+      DEAL_II_DEPRECATED
       const InitialComposition::Interface<dim> &
-      get_initial_composition () const DEAL_II_DEPRECATED;
+      get_initial_composition () const;
 
       /**
        * Return a pointer to the manager of the initial composition model.
@@ -635,8 +639,9 @@ namespace aspect
        *
        * @deprecated: Use get_boundary_velocity_manager() instead.
        */
+      DEAL_II_DEPRECATED
       const std::map<types::boundary_id,std_cxx11::shared_ptr<BoundaryVelocity::Interface<dim> > >
-      get_prescribed_boundary_velocity () const DEAL_II_DEPRECATED;
+      get_prescribed_boundary_velocity () const;
 
       /**
        * Return an reference to the manager of the boundary velocity models.
@@ -757,8 +762,9 @@ namespace aspect
        * and get_postprocess_manager().get_matching_postprocessor() instead.
        */
       template <typename PostprocessorType>
+      DEAL_II_DEPRECATED
       PostprocessorType *
-      find_postprocessor () const DEAL_II_DEPRECATED;
+      find_postprocessor () const;
 
       /**
        * Return a reference to the melt handler.


### PR DESCRIPTION
Fixes errors like:
```
../include/aspect/simulator_access.h:762:35: error: 'deprecated'
attribute cannot be applied to types
      find_postprocessor () const DEAL_II_DEPRECATED;
```