### PR TITLE
Fix wrongly defined analytic function

### DIFF
--- a/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
+++ b/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
@@ -268,7 +268,7 @@ namespace aspect
   class RefFunction : public Function<dim>
   {
     public:
-      RefFunction () : Function<dim>(dim+2) {}
+      RefFunction () : Function<dim>(dim+3) {}
       virtual void vector_value (const Point< dim >   &p,
                                  Vector< double >   &values) const
       {
@@ -406,6 +406,8 @@ namespace aspect
   std::pair<std::string,std::string>
   ExponentialDecayPostprocessor<dim>::execute (TableHandler & /*statistics*/)
   {
+    AssertThrow (this->n_compositional_fields() == 1, ExcInternalError());
+
     RefFunction<dim> ref_func;
     ref_func.set_time(this->get_time());
 
@@ -416,8 +418,8 @@ namespace aspect
     Vector<float> cellwise_errors_composition (this->get_triangulation().n_active_cells());
     Vector<float> cellwise_errors_temperature (this->get_triangulation().n_active_cells());
 
-    ComponentSelectFunction<dim> comp_C(dim+2, n_total_comp);
-    ComponentSelectFunction<dim> comp_T(dim+1, n_total_comp);
+    ComponentSelectFunction<dim> comp_C(this->introspection().component_indices.compositional_fields[0], n_total_comp);
+    ComponentSelectFunction<dim> comp_T(this->introspection().component_indices.temperature, n_total_comp);
 
     VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
                                        this->get_solution(),

--- a/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
+++ b/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
@@ -266,7 +266,7 @@ namespace aspect
   class RefFunction : public Function<dim>
   {
     public:
-      RefFunction () : Function<dim>(dim+2) {}
+      RefFunction () : Function<dim>(dim+3) {}
       virtual void vector_value (const Point< dim > &/*position*/,
                                  Vector< double >   &values) const
       {
@@ -312,6 +312,8 @@ namespace aspect
   std::pair<std::string,std::string>
   ExponentialDecayPostprocessor<dim>::execute (TableHandler & /*statistics*/)
   {
+    AssertThrow (this->n_compositional_fields() == 1, ExcInternalError());
+
     RefFunction<dim> ref_func;
     ref_func.set_time(this->get_time());
 
@@ -322,8 +324,8 @@ namespace aspect
     Vector<float> cellwise_errors_composition (this->get_triangulation().n_active_cells());
     Vector<float> cellwise_errors_temperature (this->get_triangulation().n_active_cells());
 
-    ComponentSelectFunction<dim> comp_C(dim+2, n_total_comp);
-    ComponentSelectFunction<dim> comp_T(dim+1, n_total_comp);
+    ComponentSelectFunction<dim> comp_C(this->introspection().component_indices.compositional_fields[0], n_total_comp);
+    ComponentSelectFunction<dim> comp_T(this->introspection().component_indices.temperature, n_total_comp);
 
     VectorTools::integrate_difference (this->get_mapping(),this->get_dof_handler(),
                                        this->get_solution(),

--- a/benchmarks/solcx/solcx.h
+++ b/benchmarks/solcx/solcx.h
@@ -2905,7 +2905,7 @@ namespace aspect
                         const double background_density,
                         const unsigned int n_compositional_fields)
             :
-            Function<dim>(),
+            Function<dim>(dim+2),
             eta_B_(eta_B),
             background_density(background_density),
             n_compositional_fields(n_compositional_fields) {}

--- a/benchmarks/solitary_wave/solitary_wave.cc
+++ b/benchmarks/solitary_wave/solitary_wave.cc
@@ -247,9 +247,9 @@ namespace aspect
       class FunctionSolitaryWave : public Function<dim>
       {
         public:
-          FunctionSolitaryWave (const double offset, const double delta, const std::vector<double> &initial_pressure, const double max_z)
+          FunctionSolitaryWave (const double offset, const double delta, const std::vector<double> &initial_pressure, const double max_z, const unsigned int n_components)
             :
-            Function<dim>(dim+2),
+            Function<dim>(n_components),
             offset_(offset),
             delta_(delta),
             initial_pressure_(initial_pressure),
@@ -931,7 +931,7 @@ namespace aspect
         {
           store_initial_pressure();
           ref_func.reset (new AnalyticSolutions::FunctionSolitaryWave<dim>(offset,0.0,initial_pressure,
-                                                                           this->get_geometry_model().maximal_depth()));
+                                                                           this->get_geometry_model().maximal_depth(), this->introspection().n_components));
         }
 
       double delta=0;

--- a/benchmarks/solkz/solkz.h
+++ b/benchmarks/solkz/solkz.h
@@ -627,7 +627,7 @@ namespace aspect
       class FunctionSolKz : public Function<dim>
       {
         public:
-          FunctionSolKz() : Function<dim>() {}
+          FunctionSolKz(unsigned int n_components) : Function<dim>(n_components) {}
 
           virtual void vector_value(const Point<dim> &p,
                                     Vector<double> &values) const
@@ -745,7 +745,7 @@ namespace aspect
         std::pair<std::string, std::string>
         execute(TableHandler &/*statistics*/)
         {
-          AnalyticSolutions::FunctionSolKz<dim> ref_func;
+          AnalyticSolutions::FunctionSolKz<dim> ref_func(this->introspection().n_components);
 
           if (dynamic_cast<const SolKzMaterial<dim> *>(&this->get_material_model()) == NULL)
             {

--- a/tests/melt_force_vector.cc
+++ b/tests/melt_force_vector.cc
@@ -136,7 +136,7 @@ namespace aspect
   class RefFunction : public Function<dim>
   {
     public:
-      RefFunction () : Function<dim>(dim+2) {}
+      RefFunction () : Function<dim>(2*dim+3+2) {}
       virtual void vector_value (const Point< dim >   &p,
                                  Vector< double >   &values) const
       {

--- a/tests/melt_transport_adaptive.cc
+++ b/tests/melt_transport_adaptive.cc
@@ -268,7 +268,7 @@ namespace aspect
   class RefFunction : public Function<dim>, public ::aspect::SimulatorAccess<dim>
   {
     public:
-      RefFunction () : Function<dim>(dim+2) {}
+      RefFunction () : Function<dim>(2*dim+3+2) {}
       virtual void vector_value (const Point< dim >   &p,
                                  Vector< double >   &values) const
       {


### PR DESCRIPTION
This triggers an assert with deal.II 9.0, I guess because of a newly intoduced assert. Anyway, it is clearly a bug.