### PR TITLE
Remove info message

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -506,6 +506,14 @@ namespace aspect
         get_column_names() const;
 
         /**
+         * Returns whether the stored coordinates are equidistant. If
+         * coordinates are equidistant the lookup is more efficient. Returns
+         * false if no coordinates are loaded at the moment.
+         */
+        bool
+        has_equidistant_coordinates() const;
+
+        /**
          * Returns the column index of a column with the given name
          * @p column_name. Throws an exception if no such
          * column exists or no names were provided in the file.
@@ -571,6 +579,12 @@ namespace aspect
          * to transform the unit of the data.
          */
         const double scale_factor;
+
+        /**
+         * Stores whether the coordinate values are equidistant or not,
+         * this determines the type of data function stored.
+         */
+        bool coordinate_values_are_equidistant;
 
         /**
          * Computes the table indices of each entry in the input data file.

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1176,8 +1176,11 @@ namespace aspect
       components(components),
       data(components),
       maximum_component_value(components),
-      scale_factor(scale_factor)
+      scale_factor(scale_factor),
+      coordinate_values_are_equidistant(false)
     {}
+
+
 
     template <int dim>
     AsciiDataLookup<dim>::AsciiDataLookup(const double scale_factor)
@@ -1185,8 +1188,11 @@ namespace aspect
       components(numbers::invalid_unsigned_int),
       data(),
       maximum_component_value(),
-      scale_factor(scale_factor)
+      scale_factor(scale_factor),
+      coordinate_values_are_equidistant(false)
     {}
+
+
 
     template <int dim>
     std::vector<std::string>
@@ -1194,6 +1200,17 @@ namespace aspect
     {
       return data_component_names;
     }
+
+
+
+    template <int dim>
+    bool
+    AsciiDataLookup<dim>::has_equidistant_coordinates() const
+    {
+      return coordinate_values_are_equidistant;
+    }
+
+
 
     template <int dim>
     unsigned int
@@ -1378,7 +1395,7 @@ namespace aspect
       std_cxx11::array<unsigned int,dim> table_intervals;
 
       // Whether or not the grid is equidistant
-      bool equidistant_grid = true;
+      coordinate_values_are_equidistant = true;
 
       for (unsigned int i = 0; i < dim; i++)
         {
@@ -1416,7 +1433,7 @@ namespace aspect
                   // Compare current grid spacing with first grid spacing,
                   // taking into account roundoff of the read-in coordinates
                   if (std::abs(current_grid_spacing - grid_spacing) > 0.005*(current_grid_spacing+grid_spacing))
-                    equidistant_grid = false;
+                    coordinate_values_are_equidistant = false;
                 }
 
               // Set the coordinate value
@@ -1436,14 +1453,12 @@ namespace aspect
           if (data[i])
             delete data[i];
 
-          if (equidistant_grid)
+          if (coordinate_values_are_equidistant)
             data[i] = new Functions::InterpolatedUniformGridData<dim> (grid_extent,
                                                                        table_intervals,
                                                                        data_tables[dim+i]);
           else
             {
-              if (Utilities::MPI::this_mpi_process(comm) == 0)
-                std::cout << "   Ascii data file coordinates are not equidistant. " << std::endl << std::endl;
               data[i] = new Functions::InterpolatedTensorProductGridData<dim> (coordinate_values,
                                                                                data_tables[dim+i]);
             }

--- a/tests/adiabatic_boundary/screen-output
+++ b/tests/adiabatic_boundary/screen-output
@@ -1,6 +1,4 @@
 
-   Ascii data file coordinates are not equidistant. 
-
 Number of active cells: 8 (on 2 levels)
 Number of degrees of freedom: 527 (375+27+125)
 

--- a/tests/ascii_data_nonuniform_initial_composition_2d_box/screen-output
+++ b/tests/ascii_data_nonuniform_initial_composition_2d_box/screen-output
@@ -2,8 +2,6 @@
 
    Loading Ascii data initial file ASPECT_DIR/data/initial-composition/ascii-data/test/box_2d_nonuniform.txt.
 
-   Ascii data file coordinates are not equidistant. 
-
 Number of active cells: 16 (on 3 levels)
 Number of degrees of freedom: 349 (162+25+81+81)
 

--- a/tests/dynamic_core/screen-output
+++ b/tests/dynamic_core/screen-output
@@ -1,6 +1,4 @@
 
-   Ascii data file coordinates are not equidistant. 
-
 Number of active cells: 768 (on 4 levels)
 Number of degrees of freedom: 10,656 (6,528+864+3,264)
 

--- a/tests/geometric_average_crash/screen-output
+++ b/tests/geometric_average_crash/screen-output
@@ -1,6 +1,4 @@
 
-   Ascii data file coordinates are not equidistant. 
-
 Number of active cells: 512 (on 4 levels)
 Number of degrees of freedom: 20,381 (14,739+729+4,913)
 

--- a/tests/gravity_prem/screen-output
+++ b/tests/gravity_prem/screen-output
@@ -1,7 +1,3 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
-
-   Ascii data file coordinates are not equidistant. 
 
 Number of active cells: 160 (on 3 levels)
 Number of degrees of freedom: 2,392 (1,458+205+729)

--- a/tests/initial_condition_S20RTS/screen-output
+++ b/tests/initial_condition_S20RTS/screen-output
@@ -1,6 +1,4 @@
 
-   Ascii data file coordinates are not equidistant. 
-
 Number of active cells: 96 (on 1 levels)
 Number of degrees of freedom: 4,030 (2,910+150+970)
 

--- a/tests/initial_condition_S20RTS_dgp/screen-output
+++ b/tests/initial_condition_S20RTS_dgp/screen-output
@@ -1,6 +1,4 @@
 
-   Ascii data file coordinates are not equidistant. 
-
 Number of active cells: 96 (on 1 levels)
 Number of degrees of freedom: 1,516 (450+96+970)
 

--- a/tests/initial_condition_S40RTS/screen-output
+++ b/tests/initial_condition_S40RTS/screen-output
@@ -1,6 +1,4 @@
 
-   Ascii data file coordinates are not equidistant. 
-
 Number of active cells: 24 (on 2 levels)
 Number of degrees of freedom: 1,277 (915+57+305)
 

--- a/tests/initial_condition_SAVANI/screen-output
+++ b/tests/initial_condition_SAVANI/screen-output
@@ -1,6 +1,4 @@
 
-   Ascii data file coordinates are not equidistant. 
-
 Number of active cells: 24 (on 2 levels)
 Number of degrees of freedom: 1,277 (915+57+305)
 

--- a/tests/material_model_dependencies_steinberger/screen-output
+++ b/tests/material_model_dependencies_steinberger/screen-output
@@ -1,8 +1,6 @@
 
 Loading shared library <./libmaterial_model_dependencies_steinberger.so>
 
-   Ascii data file coordinates are not equidistant. 
-
 Number of active cells: 48 (on 3 levels)
 Number of degrees of freedom: 740 (450+65+225)
 

--- a/tests/passive_comp/screen-output
+++ b/tests/passive_comp/screen-output
@@ -1,6 +1,4 @@
 
-   Ascii data file coordinates are not equidistant. 
-
 Number of active cells: 768 (on 4 levels)
 Number of degrees of freedom: 13,920 (6,528+864+3,264+3,264)
 

--- a/tests/radioactive_decay/screen-output
+++ b/tests/radioactive_decay/screen-output
@@ -1,6 +1,4 @@
 
-   Ascii data file coordinates are not equidistant. 
-
 Number of active cells: 768 (on 4 levels)
 Number of degrees of freedom: 13,920 (6,528+864+3,264+3,264)
 

--- a/tests/solidus_initial_conditions/screen-output
+++ b/tests/solidus_initial_conditions/screen-output
@@ -1,9 +1,5 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 
 Loading shared library <./libsolidus_initial_conditions.so>
-
-   Ascii data file coordinates are not equidistant. 
 
 Number of active cells: 768 (on 4 levels)
 Number of degrees of freedom: 10,656 (6,528+864+3,264)

--- a/tests/topo_shell/screen-output
+++ b/tests/topo_shell/screen-output
@@ -1,6 +1,4 @@
 
-   Ascii data file coordinates are not equidistant. 
-
 Number of active cells: 768 (on 5 levels)
 Number of degrees of freedom: 10,436 (6,402+833+3,201)
 


### PR DESCRIPTION
Closes #2217. Is this what you thought about @tjhei? I agree that this message is confusing (since everything works even if the coordinates are non-equidistant). So it is more an info message than a warning. I can see that somebody might want to check though (i.e. to see if a data file was prepared correctly) that is why I introduced the get function. This might break test output.