### PR TITLE
fix drucker prager 3d derivatives and extend test to catch this in the future.

### DIFF
--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -132,10 +132,12 @@ namespace aspect
                                                       / ((eta_plastic + minimum_viscosity + maximum_viscosity) * (eta_plastic + minimum_viscosity + maximum_viscosity));
                       const SymmetricTensor<2,dim> effective_viscosity_strain_rate_derivatives
                         = -0.5 * averaging_factor * (eta_plastic / edot_ii_strict) * strain_rate_deviator;
-                      const double effective_viscosity_pressure_derivatives = averaging_factor * (dim == 2 ?
-                                                                                                  sin_phi * strain_rate_effective_inv
-                                                                                                  :
-                                                                                                  (sin_phi*strength_inv_part));
+                      const double effective_viscosity_pressure_derivatives = averaging_factor * sin_phi * strain_rate_effective_inv *
+                                                                              (dim == 3
+                                                                               ?
+                                                                               (6.0 * strength_inv_part)
+                                                                               :
+                                                                               1);
 
                       derivatives->viscosity_derivative_wrt_strain_rate[i] = deviator_tensor<dim>() * effective_viscosity_strain_rate_derivatives;
 

--- a/tests/drucker_prager_derivatives.cc
+++ b/tests/drucker_prager_derivatives.cc
@@ -7,12 +7,12 @@
 
 #include <iostream>
 
+template<int dim>
 int f(double parameter)
 {
 
-  std::cout << std::endl << "Test for p = " << parameter << std::endl;
+  std::cout << std::endl << "Test for p = " << parameter << " with dimension " << dim << std::endl;
 
-  const int dim=2;
   using namespace aspect::MaterialModel;
   MaterialModelInputs<dim> in_base(5,3);
   in_base.composition[0][0] = 0;
@@ -125,7 +125,7 @@ int f(double parameter)
   MaterialModelOutputs<dim> out_dviscositydstrainrate_oneone(5,3);
   MaterialModelOutputs<dim> out_dviscositydtemperature(5,3);
 
-  if (out_base.get_additional_output<MaterialModelDerivatives<dim> >() != NULL)
+  if (out_base.template get_additional_output<MaterialModelDerivatives<dim> >() != NULL)
     throw "error";
 
   out_base.additional_outputs.push_back(std::make_shared<MaterialModelDerivatives<dim> > (5));
@@ -160,7 +160,7 @@ int f(double parameter)
 
   // set up additional output for the derivatives
   MaterialModelDerivatives<dim> *derivatives;
-  derivatives = out_base.get_additional_output<MaterialModelDerivatives<dim> >();
+  derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim> >();
 
   double temp;
   for (unsigned int i = 0; i < 5; i++)
@@ -259,14 +259,25 @@ int exit_function()
   return 42;
 }
 // run this function by initializing a global variable by it
-int ii = f(-1000); // Testing min function
-int iz = f(-2); // Testing generalized p norm mean with negative p
-int ij = f(-1.5); // Testing generalized p norm mean with negative, non int p
-int ik = f(-1); // Testing harmonic mean
-int ji = f(0); // Testing geometric mean
-int jj = f(1); // Testing arithmetic mean
-int jk = f(2); // Testing generalized p norm mean with positive p
-int kj = f(1000); // Testing max function
+// test 2D
+int ii2 = f<2>(-1000); // Testing min function
+int iz2 = f<2>(-2); // Testing generalized p norm mean with negative p
+int ij2 = f<2>(-1.5); // Testing generalized p norm mean with negative, non int p
+int ik2 = f<2>(-1); // Testing harmonic mean
+int ji2 = f<2>(0); // Testing geometric mean
+int jj2 = f<2>(1); // Testing arithmetic mean
+int jk2 = f<2>(2); // Testing generalized p norm mean with positive p
+int kj2 = f<2>(1000); // Testing max function
+// test 3D
+int ii3 = f<3>(-1000); // Testing min function
+int iz3 = f<3>(-2); // Testing generalized p norm mean with negative p
+int ij3 = f<3>(-1.5); // Testing generalized p norm mean with negative, non int p
+int ik3 = f<3>(-1); // Testing harmonic mean
+int ji3 = f<3>(0); // Testing geometric mean
+int jj3 = f<3>(1); // Testing arithmetic mean
+int jk3 = f<3>(2); // Testing generalized p norm mean with positive p
+int kj3 = f<3>(1000); // Testing max function
+// exit
 int kl = exit_function();
 
 

--- a/tests/drucker_prager_derivatives/screen-output
+++ b/tests/drucker_prager_derivatives/screen-output
@@ -3,7 +3,7 @@
 
 Loading shared library <./libdrucker_prager_derivatives.so>
 
-Test for p = -1000
+Test for p = -1000 with dimension 2
 pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
 pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
 pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
@@ -13,8 +13,8 @@ pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
 zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
 zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
 zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
 onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
@@ -25,12 +25,12 @@ onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+3
 oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
 oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
 oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesful.
 
-Test for p = -2
+Test for p = -2 with dimension 2
 pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
 pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
 pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
@@ -40,8 +40,8 @@ pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
 zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
 zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
 zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
 onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
@@ -52,12 +52,12 @@ onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+3
 oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
 oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
 oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesful.
 
-Test for p = -1.5
+Test for p = -1.5 with dimension 2
 pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
 pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
 pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
@@ -67,8 +67,8 @@ pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
 zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
 zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
 zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
 onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
@@ -79,12 +79,12 @@ onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+3
 oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
 oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
 oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesful.
 
-Test for p = -1
+Test for p = -1 with dimension 2
 pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
 pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
 pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
@@ -94,8 +94,8 @@ pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
 zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
 zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
 zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
 onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
@@ -106,12 +106,12 @@ onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+3
 oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
 oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
 oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesful.
 
-Test for p = 0
+Test for p = 0 with dimension 2
 pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
 pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
 pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
@@ -121,8 +121,8 @@ pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
 zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
 zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
 zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
 onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
@@ -133,12 +133,12 @@ onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+3
 oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
 oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
 oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesful.
 
-Test for p = 1
+Test for p = 1 with dimension 2
 pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
 pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
 pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
@@ -148,8 +148,8 @@ pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
 zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
 zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
 zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
 onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
@@ -160,12 +160,12 @@ onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+3
 oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
 oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
 oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesful.
 
-Test for p = 2
+Test for p = 2 with dimension 2
 pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
 pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
 pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
@@ -175,8 +175,8 @@ pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
 zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
 zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
 zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
 onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
@@ -187,12 +187,12 @@ onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+3
 oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
 oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
 oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 Some parts of the test where not succesful.
 
-Test for p = 1000
+Test for p = 1000 with dimension 2
 pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
 pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
 pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
@@ -202,8 +202,8 @@ pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
 zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
 zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
 zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = -0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+zerozero 3: Finite difference = 0. Analytical derivative = 0
+zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
 onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
 onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
@@ -214,7 +214,207 @@ onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+3
 oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
 oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
 oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = -0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = -0
+oneone 3: Finite difference = 0. Analytical derivative = 0
+oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Some parts of the test where not succesful.
+
+Test for p = -1000 with dimension 3
+pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
+pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
+pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
+pressure 3: Finite difference = 570425. Analytical derivative = 571469
+pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
+zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
+zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
+zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
+zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
+onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
+onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
+onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
+onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
+oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
+oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
+oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
+oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+Some parts of the test where not succesful.
+
+Test for p = -2 with dimension 3
+pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
+pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
+pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
+pressure 3: Finite difference = 570425. Analytical derivative = 571469
+pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
+zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
+zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
+zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
+zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
+onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
+onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
+onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
+onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
+oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
+oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
+oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
+oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+Some parts of the test where not succesful.
+
+Test for p = -1.5 with dimension 3
+pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
+pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
+pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
+pressure 3: Finite difference = 570425. Analytical derivative = 571469
+pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
+zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
+zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
+zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
+zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
+onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
+onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
+onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
+onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
+oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
+oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
+oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
+oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+Some parts of the test where not succesful.
+
+Test for p = -1 with dimension 3
+pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
+pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
+pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
+pressure 3: Finite difference = 570425. Analytical derivative = 571469
+pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
+zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
+zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
+zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
+zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
+onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
+onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
+onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
+onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
+oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
+oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
+oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
+oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+Some parts of the test where not succesful.
+
+Test for p = 0 with dimension 3
+pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
+pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
+pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
+pressure 3: Finite difference = 570425. Analytical derivative = 571469
+pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
+zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
+zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
+zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
+zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
+onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
+onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
+onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
+onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
+oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
+oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
+oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
+oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+Some parts of the test where not succesful.
+
+Test for p = 1 with dimension 3
+pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
+pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
+pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
+pressure 3: Finite difference = 570425. Analytical derivative = 571469
+pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
+zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
+zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
+zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
+zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
+onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
+onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
+onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
+onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
+oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
+oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
+oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
+oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+Some parts of the test where not succesful.
+
+Test for p = 2 with dimension 3
+pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
+pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
+pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
+pressure 3: Finite difference = 570425. Analytical derivative = 571469
+pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
+zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
+zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
+zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
+zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
+onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
+onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
+onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
+onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
+oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
+oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
+oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
+oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+Some parts of the test where not succesful.
+
+Test for p = 1000 with dimension 3
+pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
+pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
+pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
+pressure 3: Finite difference = 570425. Analytical derivative = 571469
+pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
+zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
+zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
+zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
+zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
+onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
+onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
+onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
+onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
+oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
+oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
+oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
+oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
 Some parts of the test where not succesful.


### PR DESCRIPTION
Found this bug when I looking at the equations to make a analytical solution for the visco-plastic derivatives. I have extended the test to now also test the 3d implementation and fixed the bug (as the test shows). I will now also look at and update the other derivative tests.