### PR TITLE
Close output directory handle

### DIFF
--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -698,7 +698,8 @@ namespace aspect
 
       if ((Utilities::MPI::this_mpi_process(comm) == 0))
         {
-          if (opendir(pathname.c_str()) == NULL)
+          DIR *output_directory = opendir(pathname.c_str());
+          if (output_directory == NULL)
             {
               if (!silent)
                 std::cout << "\n"
@@ -714,7 +715,7 @@ namespace aspect
             }
           else
             {
-              error = 0;
+              error = closedir(output_directory);
             }
           // Broadcast error code
           MPI_Bcast (&error, 1, MPI_INT, 0, comm);


### PR DESCRIPTION
I was looking into #2210 and #2211 and found this instead. We do not close the directory handle for the output directory, if the directory already exists. Valgrind reports this as a resource leak (which is correct).