### PR TITLE
Restructure derivative tests

### DIFF
--- a/tests/drucker_prager_derivatives.cc
+++ b/tests/drucker_prager_derivatives.cc
@@ -4,16 +4,18 @@
 #include <aspect/material_model/drucker_prager.h>
 #include <aspect/simulator_access.h>
 #include <aspect/newton.h>
+#include <aspect/utilities.h>
 
 #include <iostream>
 
 template<int dim>
-int f(double parameter)
+int f()
 {
-
-  std::cout << std::endl << "Test for p = " << parameter << " with dimension " << dim << std::endl;
+  std::cout << std::endl << "Test with dimension " << dim << std::endl;
 
   using namespace aspect::MaterialModel;
+
+  // first set all material model values
   MaterialModelInputs<dim> in_base(5,3);
   in_base.composition[0][0] = 0;
   in_base.composition[0][1] = 0;
@@ -31,6 +33,12 @@ int f(double parameter)
   in_base.composition[4][1] = 0;
   in_base.composition[4][2] = 0;
 
+  in_base.temperature[0] = 293;
+  in_base.temperature[1] = 1600;
+  in_base.temperature[2] = 2000;
+  in_base.temperature[3] = 2100;
+  in_base.temperature[4] = 2200;
+
   in_base.pressure[0] = 1e9;
   in_base.pressure[1] = 5e9;
   in_base.pressure[2] = 2e10;
@@ -46,90 +54,70 @@ int f(double parameter)
   in_base.strain_rate[0][0][0] = 1e-12;
   in_base.strain_rate[0][0][1] = 1e-12;
   in_base.strain_rate[0][1][1] = 1e-11;
+  if (dim == 3)
+    {
+      in_base.strain_rate[0][2][0] = 1e-12;
+      in_base.strain_rate[0][2][1] = 1e-12;
+      in_base.strain_rate[0][2][2] = 1e-11;
+    }
+
   in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[1][0][0] = -1.71266e-13;
   in_base.strain_rate[1][0][1] = -5.82647e-12;
   in_base.strain_rate[1][1][1] = 4.21668e-14;
+  if (dim == 3)
+    {
+      in_base.strain_rate[1][2][0] = -5.42647e-12;
+      in_base.strain_rate[1][2][1] = -5.22647e-12;
+      in_base.strain_rate[1][2][2] = 4.21668e-14;
+    }
   in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[2][1][1] = 1e-13;
   in_base.strain_rate[2][0][1] = 1e-11;
   in_base.strain_rate[2][0][0] = -1e-12;
+  if (dim == 3)
+    {
+      in_base.strain_rate[2][2][0] = 1e-11;
+      in_base.strain_rate[2][2][1] = 1e-11;
+      in_base.strain_rate[2][2][2] = -1e-12;
+    }
   in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[3][1][1] = 4.9e-21;
   in_base.strain_rate[3][0][1] = 4.9e-21;
   in_base.strain_rate[3][0][0] = 4.9e-21;
+  if (dim == 3)
+    {
+      in_base.strain_rate[3][2][0] = 4.9e-21;
+      in_base.strain_rate[3][2][1] = 4.9e-21;
+      in_base.strain_rate[3][2][2] = 4.9e-21;
+    }
   in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[4][1][1] = 1e-11;
   in_base.strain_rate[4][0][1] = 1e-11;
   in_base.strain_rate[4][0][0] = 1e-11;
+  if (dim == 3)
+    {
+      in_base.strain_rate[4][2][0] = 1e-11;
+      in_base.strain_rate[4][2][1] = 1e-11;
+      in_base.strain_rate[4][2][2] = 1e-11;
+    }
 
-  in_base.temperature[0] = 293;
-  in_base.temperature[1] = 1600;
-  in_base.temperature[2] = 2000;
-  in_base.temperature[3] = 2100;
-  in_base.temperature[4] = 2200;
+  // initialize some variables we will need later.
+  const double finite_difference_accuracy = 1e-7;
+  const double finite_difference_factor = 1+finite_difference_accuracy;
 
-  SymmetricTensor<2,dim> zerozero = SymmetricTensor<2,dim>();
-  SymmetricTensor<2,dim> onezero = SymmetricTensor<2,dim>();
-  SymmetricTensor<2,dim> oneone = SymmetricTensor<2,dim>();
-
-  zerozero[0][0] = 1;
-  onezero[1][0]  = 0.5; // because symmetry doubles this entry
-  oneone[1][1]   = 1;
-
-  double finite_difference_accuracy = 1e-7;
-  double finite_difference_factor = 1+finite_difference_accuracy;
-
-  bool Error = false;
-
-  MaterialModelInputs<dim> in_dviscositydpressure(in_base);
-  in_dviscositydpressure.pressure[0] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[1] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[2] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[3] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[4] *= finite_difference_factor;
-
-  MaterialModelInputs<dim> in_dviscositydstrainrate_zerozero(in_base);
-  MaterialModelInputs<dim> in_dviscositydstrainrate_onezero(in_base);
-  MaterialModelInputs<dim> in_dviscositydstrainrate_oneone(in_base);
-
-  in_dviscositydstrainrate_zerozero.strain_rate[0] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[0][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[1] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[1][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[2] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[2][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[3] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[3][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[4] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[4][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_onezero.strain_rate[0]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[0][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[1]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[1][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[2]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[2][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[3]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[3][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[4]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[4][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_oneone.strain_rate[0]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[0][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[1]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[1][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[2]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[2][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[3]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[3][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[4]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[4][1][1]) * finite_difference_accuracy * oneone;
-
-  MaterialModelInputs<dim> in_dviscositydtemperature(in_base);
-  in_dviscositydtemperature.temperature[0] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[1] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[2] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[3] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[4] *= 1.0000000001;
-
+  MaterialModelInputs<dim> in_dviscositydstrainrate(in_base);
 
   MaterialModelOutputs<dim> out_base(5,3);
-
   MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate_zerozero(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate_onezero(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate_oneone(5,3);
-  MaterialModelOutputs<dim> out_dviscositydtemperature(5,3);
+  MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
 
   if (out_base.template get_additional_output<MaterialModelDerivatives<dim> >() != NULL)
     throw "error";
 
   out_base.additional_outputs.push_back(std::make_shared<MaterialModelDerivatives<dim> > (5));
 
+  // initialize the material we want to test.
   DruckerPrager<dim> mat;
   ParameterHandler prm;
   mat.declare_parameters(prm);
@@ -152,17 +140,26 @@ int f(double parameter)
   mat.parse_parameters(prm);
 
   mat.evaluate(in_base, out_base);
-  mat.evaluate(in_dviscositydpressure, out_dviscositydpressure);
-  mat.evaluate(in_dviscositydstrainrate_zerozero, out_dviscositydstrainrate_zerozero);
-  mat.evaluate(in_dviscositydstrainrate_onezero, out_dviscositydstrainrate_onezero);
-  mat.evaluate(in_dviscositydstrainrate_oneone, out_dviscositydstrainrate_oneone);
-  mat.evaluate(in_dviscositydtemperature, out_dviscositydtemperature);
 
   // set up additional output for the derivatives
   MaterialModelDerivatives<dim> *derivatives;
   derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim> >();
-
   double temp;
+
+  // have a bool so we know whether the test has succeed or not.
+  bool Error = false;
+
+
+  // test the pressure derivative.
+  MaterialModelInputs<dim> in_dviscositydpressure(in_base);
+  in_dviscositydpressure.pressure[0] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[1] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[2] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[3] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[4] *= finite_difference_factor;
+
+  mat.evaluate(in_dviscositydpressure, out_dviscositydpressure);
+
   for (unsigned int i = 0; i < 5; i++)
     {
       // prevent division by zero. If it is zero, the test has passed, because or
@@ -173,70 +170,48 @@ int f(double parameter)
         {
           temp /= (in_base.pressure[i] * finite_difference_accuracy);
         }
-      std::cout << "pressure " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i]  << std::endl;
+      std::cout << "pressure: point = " << i << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i]  << std::endl;
       if (std::fabs(temp - derivatives->viscosity_derivative_wrt_pressure[i]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_pressure[i])))
-        // if (temp > derivatives->viscosity_derivative_wrt_pressure[i] * finite_difference_factor || temp < derivatives->viscosity_derivative_wrt_pressure[i] * (2-finite_difference_factor))
         {
-          std::cout << "   Error: The derivative of the viscosity to the pressure is too different from the analitical value." << std::endl;
+          std::cout << "   Error: The derivative of the viscosity to the pressure is too different from the analytical value." << std::endl;
           Error = true;
         }
 
     }
 
-  for (unsigned int i = 0; i < 5; i++)
+  // test the strain-rate derivative.
+  for (unsigned int component = 0; component < SymmetricTensor<2,dim>::n_independent_components; ++component)
     {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = out_dviscositydstrainrate_zerozero.viscosities[i] - out_base.viscosities[i];
-      if (temp != 0)
+      const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
+
+      for (unsigned int i = 0; i < 5; i++)
         {
-          temp /= std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[i][0][0]) * finite_difference_accuracy;
-        }
-      std::cout << "zerozero " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][0][0]  << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][0][0]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][0][0])))
-        {
-          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analitical value." << std::endl;
-          Error = true;
+          in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
+                                                    + std::fabs(in_base.strain_rate[i][strain_rate_indices])
+                                                    * finite_difference_accuracy
+                                                    * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
         }
 
 
+      mat.evaluate(in_dviscositydstrainrate, out_dviscositydstrainrate);
 
-    }
+      for (unsigned int i = 0; i < 5; i++)
+        {
+          // prevent division by zero. If it is zero, the test has passed, because or
+          // the finite difference and the analytical result match perfectly, or (more
+          // likely) the material model in independent of this variable.
+          temp = out_dviscositydstrainrate.viscosities[i] - out_base.viscosities[i];
+          if (temp != 0)
+            {
+              temp /= std::fabs(in_dviscositydstrainrate.strain_rate[i][strain_rate_indices]) * finite_difference_accuracy;
+            }
+          std::cout << "strain-rate: point = " << i << ", component = " << component << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]  << std::endl;
+          if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices])))
+            {
+              std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
+              Error = true;
+            }
 
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = out_dviscositydstrainrate_onezero.viscosities[i] - out_base.viscosities[i];
-      if (temp != 0)
-        {
-          temp /= std::fabs(in_dviscositydstrainrate_onezero.strain_rate[i][1][0]) * finite_difference_accuracy;
-        }
-      std::cout << "onezero " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]   << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][0])) )
-        {
-          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analitical value." << std::endl;
-          Error = true;
-        }
-    }
-
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = out_dviscositydstrainrate_oneone.viscosities[i] - out_base.viscosities[i];
-      if (temp != 0)
-        {
-          temp /= std::fabs(in_dviscositydstrainrate_oneone.strain_rate[i][1][1]) * finite_difference_accuracy;
-        }
-      std::cout << "oneone " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]  << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][1])) )
-        {
-          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analitical value." << std::endl;
-          Error = true;
         }
 
     }
@@ -258,25 +233,12 @@ int exit_function()
   exit(0);
   return 42;
 }
+
 // run this function by initializing a global variable by it
 // test 2D
-int ii2 = f<2>(-1000); // Testing min function
-int iz2 = f<2>(-2); // Testing generalized p norm mean with negative p
-int ij2 = f<2>(-1.5); // Testing generalized p norm mean with negative, non int p
-int ik2 = f<2>(-1); // Testing harmonic mean
-int ji2 = f<2>(0); // Testing geometric mean
-int jj2 = f<2>(1); // Testing arithmetic mean
-int jk2 = f<2>(2); // Testing generalized p norm mean with positive p
-int kj2 = f<2>(1000); // Testing max function
+int test2d = f<2>(); // Testing min function
 // test 3D
-int ii3 = f<3>(-1000); // Testing min function
-int iz3 = f<3>(-2); // Testing generalized p norm mean with negative p
-int ij3 = f<3>(-1.5); // Testing generalized p norm mean with negative, non int p
-int ik3 = f<3>(-1); // Testing harmonic mean
-int ji3 = f<3>(0); // Testing geometric mean
-int jj3 = f<3>(1); // Testing arithmetic mean
-int jk3 = f<3>(2); // Testing generalized p norm mean with positive p
-int kj3 = f<3>(1000); // Testing max function
+int test3d = f<3>(); // Testing min function
 // exit
 int kl = exit_function();
 

--- a/tests/drucker_prager_derivatives/screen-output
+++ b/tests/drucker_prager_derivatives/screen-output
@@ -3,418 +3,74 @@
 
 Loading shared library <./libdrucker_prager_derivatives.so>
 
-Test for p = -1000 with dimension 2
-pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
-pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
-pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
-pressure 3: Finite difference = 496606. Analytical derivative = 489830
-   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
-pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
-zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
-zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
-zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
-onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
-onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
-onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
-oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
-oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
-oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
+Test with dimension 2
+pressure: point = 0, Finite difference = 5.42254e+10, Analytical derivative = 5.42254e+10
+pressure: point = 1, Finite difference = 4.2881e+10, Analytical derivative = 4.2881e+10
+pressure: point = 2, Finite difference = 2.49368e+10, Analytical derivative = 2.49368e+10
+pressure: point = 3, Finite difference = 496606, Analytical derivative = 489830
+   Error: The derivative of the viscosity to the pressure is too different from the analytical value.
+pressure: point = 4, Finite difference = 2.26753e+10, Analytical derivative = 2.26753e+10
+strain-rate: point = 0, component = 0, Finite difference = 5.94041e+30, Analytical derivative = 5.94041e+30
+strain-rate: point = 1, component = 0, Finite difference = 3.39217e+29, Analytical derivative = 3.39218e+29
+strain-rate: point = 2, component = 0, Finite difference = 1.36976e+30, Analytical derivative = 1.36976e+30
+strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 0, Finite difference = -5.03316e+25, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: point = 0, component = 1, Finite difference = -5.94041e+30, Analytical derivative = -5.94041e+30
+strain-rate: point = 1, component = 1, Finite difference = -3.39214e+29, Analytical derivative = -3.39218e+29
+strain-rate: point = 2, component = 1, Finite difference = -1.36975e+30, Analytical derivative = -1.36976e+30
+strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 1, Finite difference = -5.03316e+25, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: point = 0, component = 2, Finite difference = -1.32009e+30, Analytical derivative = -1.32009e+30
+strain-rate: point = 1, component = 2, Finite difference = 1.85205e+31, Analytical derivative = 1.85205e+31
+strain-rate: point = 2, component = 2, Finite difference = -2.49047e+31, Analytical derivative = -2.49047e+31
+strain-rate: point = 3, component = 2, Finite difference = -9.86089e+36, Analytical derivative = -9.99827e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: point = 4, component = 2, Finite difference = -2.26757e+33, Analytical derivative = -2.26757e+33
 Some parts of the test where not succesful.
 
-Test for p = -2 with dimension 2
-pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
-pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
-pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
-pressure 3: Finite difference = 496606. Analytical derivative = 489830
-   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
-pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
-zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
-zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
-zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
-onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
-onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
-onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
-oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
-oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
-oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-Some parts of the test where not succesful.
-
-Test for p = -1.5 with dimension 2
-pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
-pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
-pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
-pressure 3: Finite difference = 496606. Analytical derivative = 489830
-   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
-pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
-zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
-zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
-zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
-onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
-onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
-onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
-oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
-oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
-oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-Some parts of the test where not succesful.
-
-Test for p = -1 with dimension 2
-pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
-pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
-pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
-pressure 3: Finite difference = 496606. Analytical derivative = 489830
-   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
-pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
-zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
-zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
-zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
-onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
-onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
-onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
-oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
-oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
-oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-Some parts of the test where not succesful.
-
-Test for p = 0 with dimension 2
-pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
-pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
-pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
-pressure 3: Finite difference = 496606. Analytical derivative = 489830
-   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
-pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
-zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
-zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
-zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
-onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
-onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
-onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
-oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
-oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
-oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-Some parts of the test where not succesful.
-
-Test for p = 1 with dimension 2
-pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
-pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
-pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
-pressure 3: Finite difference = 496606. Analytical derivative = 489830
-   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
-pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
-zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
-zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
-zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
-onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
-onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
-onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
-oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
-oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
-oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-Some parts of the test where not succesful.
-
-Test for p = 2 with dimension 2
-pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
-pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
-pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
-pressure 3: Finite difference = 496606. Analytical derivative = 489830
-   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
-pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
-zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
-zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
-zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
-onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
-onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
-onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
-oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
-oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
-oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-Some parts of the test where not succesful.
-
-Test for p = 1000 with dimension 2
-pressure 0: Finite difference = 5.42254e+10. Analytical derivative = 5.42254e+10
-pressure 1: Finite difference = 4.2881e+10. Analytical derivative = 4.2881e+10
-pressure 2: Finite difference = 2.49368e+10. Analytical derivative = 2.49368e+10
-pressure 3: Finite difference = 496606. Analytical derivative = 489830
-   Error: The derivative of the viscosity to the pressure is too different from the analitical value.
-pressure 4: Finite difference = 2.26753e+10. Analytical derivative = 2.26753e+10
-zerozero 0: Finite difference = 5.94041e+30. Analytical derivative = 5.94041e+30
-zerozero 1: Finite difference = 3.39217e+29. Analytical derivative = 3.39218e+29
-zerozero 2: Finite difference = 1.36976e+30. Analytical derivative = 1.36976e+30
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 0: Finite difference = -1.32009e+30. Analytical derivative = -1.32009e+30
-onezero 1: Finite difference = 1.85205e+31. Analytical derivative = 1.85205e+31
-onezero 2: Finite difference = -2.49047e+31. Analytical derivative = -2.49047e+31
-onezero 3: Finite difference = -9.86089e+36. Analytical derivative = -9.99827e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-onezero 4: Finite difference = -2.26757e+33. Analytical derivative = -2.26757e+33
-oneone 0: Finite difference = -5.94041e+30. Analytical derivative = -5.94041e+30
-oneone 1: Finite difference = -3.39214e+29. Analytical derivative = -3.39218e+29
-oneone 2: Finite difference = -1.36975e+30. Analytical derivative = -1.36976e+30
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -5.03316e+25. Analytical derivative = 0
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-Some parts of the test where not succesful.
-
-Test for p = -1000 with dimension 3
-pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
-pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
-pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
-pressure 3: Finite difference = 570425. Analytical derivative = 571469
-pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
-zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
-zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
-zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
-zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
-onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
-onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
-onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
-onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
-onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
-oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
-oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
-oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
-oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
-Some parts of the test where not succesful.
-
-Test for p = -2 with dimension 3
-pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
-pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
-pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
-pressure 3: Finite difference = 570425. Analytical derivative = 571469
-pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
-zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
-zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
-zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
-zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
-onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
-onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
-onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
-onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
-onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
-oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
-oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
-oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
-oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
-Some parts of the test where not succesful.
-
-Test for p = -1.5 with dimension 3
-pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
-pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
-pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
-pressure 3: Finite difference = 570425. Analytical derivative = 571469
-pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
-zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
-zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
-zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
-zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
-onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
-onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
-onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
-onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
-onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
-oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
-oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
-oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
-oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
-Some parts of the test where not succesful.
-
-Test for p = -1 with dimension 3
-pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
-pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
-pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
-pressure 3: Finite difference = 570425. Analytical derivative = 571469
-pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
-zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
-zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
-zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
-zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
-onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
-onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
-onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
-onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
-onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
-oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
-oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
-oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
-oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
-Some parts of the test where not succesful.
-
-Test for p = 0 with dimension 3
-pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
-pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
-pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
-pressure 3: Finite difference = 570425. Analytical derivative = 571469
-pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
-zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
-zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
-zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
-zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
-onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
-onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
-onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
-onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
-onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
-oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
-oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
-oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
-oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
-Some parts of the test where not succesful.
-
-Test for p = 1 with dimension 3
-pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
-pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
-pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
-pressure 3: Finite difference = 570425. Analytical derivative = 571469
-pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
-zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
-zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
-zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
-zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
-onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
-onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
-onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
-onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
-onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
-oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
-oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
-oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
-oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
-Some parts of the test where not succesful.
-
-Test for p = 2 with dimension 3
-pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
-pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
-pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
-pressure 3: Finite difference = 570425. Analytical derivative = 571469
-pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
-zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
-zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
-zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
-zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
-onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
-onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
-onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
-onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
-onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
-oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
-oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
-oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
-oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
-Some parts of the test where not succesful.
-
-Test for p = 1000 with dimension 3
-pressure 0: Finite difference = 4.41988e+10. Analytical derivative = 4.41988e+10
-pressure 1: Finite difference = 4.24406e+10. Analytical derivative = 4.24406e+10
-pressure 2: Finite difference = 2.4673e+10. Analytical derivative = 2.4673e+10
-pressure 3: Finite difference = 570425. Analytical derivative = 571469
-pressure 4: Finite difference = 1.97031e+10. Analytical derivative = 1.97031e+10
-zerozero 0: Finite difference = 1.94595e+30. Analytical derivative = 1.94595e+30
-zerozero 1: Finite difference = 4.0341e+29. Analytical derivative = 4.03408e+29
-zerozero 2: Finite difference = 1.72372e+30. Analytical derivative = 1.72372e+30
-zerozero 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-zerozero 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
-onezero 0: Finite difference = -7.29733e+29. Analytical derivative = -7.29733e+29
-onezero 1: Finite difference = 1.83295e+31. Analytical derivative = 1.83295e+31
-onezero 2: Finite difference = -2.46246e+31. Analytical derivative = -2.46246e+31
-onezero 3: Finite difference = -8.76524e+36. Analytical derivative = -8.74848e+36
-onezero 4: Finite difference = -1.47776e+33. Analytical derivative = -1.47776e+33
-oneone 0: Finite difference = -4.62164e+30. Analytical derivative = -4.62164e+30
-oneone 1: Finite difference = -2.68015e+29. Analytical derivative = -2.6803e+29
-oneone 2: Finite difference = -9.84986e+29. Analytical derivative = -9.84986e+29
-oneone 3: Finite difference = -3.01305e+36. Analytical derivative = -2.91616e+36
-   Error: The derivative of the viscosity to the strain rate is too different from the analitical value.
-oneone 4: Finite difference = -4.92586e+32. Analytical derivative = -4.92586e+32
+Test with dimension 3
+pressure: point = 0, Finite difference = 4.51703e+10, Analytical derivative = 4.51703e+10
+pressure: point = 1, Finite difference = 2.59702e+10, Analytical derivative = 2.59702e+10
+pressure: point = 2, Finite difference = 1.42677e+10, Analytical derivative = 1.42677e+10
+pressure: point = 3, Finite difference = 852283, Analytical derivative = 857203
+   Error: The derivative of the viscosity to the pressure is too different from the analytical value.
+pressure: point = 4, Finite difference = 1.35028e+10, Analytical derivative = 1.35028e+10
+strain-rate: point = 0, component = 0, Finite difference = 4.6735e+30, Analytical derivative = 4.6735e+30
+strain-rate: point = 1, component = 0, Finite difference = 1.02532e+29, Analytical derivative = 1.02531e+29
+strain-rate: point = 2, component = 0, Finite difference = 1.74451e+29, Analytical derivative = 1.7445e+29
+strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 0, Finite difference = -1.67772e+25, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: point = 0, component = 1, Finite difference = -2.33675e+30, Analytical derivative = -2.33675e+30
+strain-rate: point = 1, component = 1, Finite difference = -5.12656e+28, Analytical derivative = -5.12654e+28
+strain-rate: point = 2, component = 1, Finite difference = -3.48887e+29, Analytical derivative = -3.489e+29
+strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 1, Finite difference = -1.67772e+25, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: point = 0, component = 2, Finite difference = -2.33675e+30, Analytical derivative = -2.33675e+30
+strain-rate: point = 1, component = 2, Finite difference = -5.12656e+28, Analytical derivative = -5.12654e+28
+strain-rate: point = 2, component = 2, Finite difference = 1.74451e+29, Analytical derivative = 1.7445e+29
+strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 2, Finite difference = -1.67772e+25, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: point = 0, component = 3, Finite difference = -7.78917e+29, Analytical derivative = -7.78917e+29
+strain-rate: point = 1, component = 3, Finite difference = 4.19846e+30, Analytical derivative = 4.19846e+30
+strain-rate: point = 2, component = 3, Finite difference = -4.75773e+30, Analytical derivative = -4.75773e+30
+strain-rate: point = 3, component = 3, Finite difference = -6.0261e+36, Analytical derivative = -5.83232e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: point = 4, component = 3, Finite difference = -4.50101e+32, Analytical derivative = -4.50101e+32
+strain-rate: point = 0, component = 4, Finite difference = -7.78917e+29, Analytical derivative = -7.78917e+29
+strain-rate: point = 1, component = 4, Finite difference = 3.91023e+30, Analytical derivative = 3.91023e+30
+strain-rate: point = 2, component = 4, Finite difference = -4.75773e+30, Analytical derivative = -4.75773e+30
+strain-rate: point = 3, component = 4, Finite difference = -6.0261e+36, Analytical derivative = -5.83232e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: point = 4, component = 4, Finite difference = -4.50101e+32, Analytical derivative = -4.50101e+32
+strain-rate: point = 0, component = 5, Finite difference = -7.78917e+29, Analytical derivative = -7.78917e+29
+strain-rate: point = 1, component = 5, Finite difference = 3.76611e+30, Analytical derivative = 3.76611e+30
+strain-rate: point = 2, component = 5, Finite difference = -4.75773e+30, Analytical derivative = -4.75773e+30
+strain-rate: point = 3, component = 5, Finite difference = -6.0261e+36, Analytical derivative = -5.83232e+36
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: point = 4, component = 5, Finite difference = -4.50101e+32, Analytical derivative = -4.50101e+32
 Some parts of the test where not succesful.

--- a/tests/simple_nonlinear.cc
+++ b/tests/simple_nonlinear.cc
@@ -17,6 +17,8 @@ int f(double parameter)
   std::cout << std::endl << "Test for p = " << parameter << " with dimension " << dim << std::endl;
 
   using namespace aspect::MaterialModel;
+
+  // first set all material model values
   MaterialModelInputs<dim> in_base(5,3);
   in_base.composition[0][0] = 0;
   in_base.composition[0][1] = 0;
@@ -34,6 +36,12 @@ int f(double parameter)
   in_base.composition[4][1] = 0;
   in_base.composition[4][2] = 0;
 
+  in_base.temperature[0] = 293;
+  in_base.temperature[1] = 1600;
+  in_base.temperature[2] = 2000;
+  in_base.temperature[3] = 2100;
+  in_base.temperature[4] = 2200;
+
   in_base.pressure[0] = 1e9;
   in_base.pressure[1] = 5e9;
   in_base.pressure[2] = 2e10;
@@ -49,90 +57,70 @@ int f(double parameter)
   in_base.strain_rate[0][0][0] = 1e-12;
   in_base.strain_rate[0][0][1] = 1e-12;
   in_base.strain_rate[0][1][1] = 1e-11;
+  if (dim == 3)
+    {
+      in_base.strain_rate[0][2][0] = 1e-12;
+      in_base.strain_rate[0][2][1] = 1e-12;
+      in_base.strain_rate[0][2][2] = 1e-11;
+    }
+
   in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[1][0][0] = -1.71266e-13;
   in_base.strain_rate[1][0][1] = -5.82647e-12;
   in_base.strain_rate[1][1][1] = 4.21668e-14;
+  if (dim == 3)
+    {
+      in_base.strain_rate[1][2][0] = -5.42647e-12;
+      in_base.strain_rate[1][2][1] = -5.22647e-12;
+      in_base.strain_rate[1][2][2] = 4.21668e-14;
+    }
   in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[2][1][1] = 1e-13;
   in_base.strain_rate[2][0][1] = 1e-11;
   in_base.strain_rate[2][0][0] = -1e-12;
+  if (dim == 3)
+    {
+      in_base.strain_rate[2][2][0] = 1e-11;
+      in_base.strain_rate[2][2][1] = 1e-11;
+      in_base.strain_rate[2][2][2] = -1e-12;
+    }
   in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[3][1][1] = 4.9e-21;
   in_base.strain_rate[3][0][1] = 4.9e-21;
   in_base.strain_rate[3][0][0] = 4.9e-21;
+  if (dim == 3)
+    {
+      in_base.strain_rate[3][2][0] = 4.9e-21;
+      in_base.strain_rate[3][2][1] = 4.9e-21;
+      in_base.strain_rate[3][2][2] = 4.9e-21;
+    }
   in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[4][1][1] = 1e-11;
   in_base.strain_rate[4][0][1] = 1e-11;
   in_base.strain_rate[4][0][0] = 1e-11;
+  if (dim == 3)
+    {
+      in_base.strain_rate[4][2][0] = 1e-11;
+      in_base.strain_rate[4][2][1] = 1e-11;
+      in_base.strain_rate[4][2][2] = 1e-11;
+    }
 
-  in_base.temperature[0] = 293;
-  in_base.temperature[1] = 1600;
-  in_base.temperature[2] = 2000;
-  in_base.temperature[3] = 2100;
-  in_base.temperature[4] = 2200;
-
-  SymmetricTensor<2,dim> zerozero = SymmetricTensor<2,dim>();
-  SymmetricTensor<2,dim> onezero = SymmetricTensor<2,dim>();
-  SymmetricTensor<2,dim> oneone = SymmetricTensor<2,dim>();
-
-  zerozero[0][0] = 1;
-  onezero[1][0]  = 0.5; // because symmetry doubles this entry
-  oneone[1][1]   = 1;
-
+  // initialize some variables we will need later.
   double finite_difference_accuracy = 1e-7;
   double finite_difference_factor = 1+finite_difference_accuracy;
 
-  bool Error = false;
 
-  MaterialModelInputs<dim> in_dviscositydpressure(in_base);
-  in_dviscositydpressure.pressure[0] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[1] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[2] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[3] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[4] *= finite_difference_factor;
-
-  MaterialModelInputs<dim> in_dviscositydstrainrate_zerozero(in_base);
-  MaterialModelInputs<dim> in_dviscositydstrainrate_onezero(in_base);
-  MaterialModelInputs<dim> in_dviscositydstrainrate_oneone(in_base);
-
-  in_dviscositydstrainrate_zerozero.strain_rate[0] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[0][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[1] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[1][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[2] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[2][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[3] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[3][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[4] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[4][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_onezero.strain_rate[0]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[0][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[1]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[1][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[2]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[2][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[3]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[3][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[4]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[4][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_oneone.strain_rate[0]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[0][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[1]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[1][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[2]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[2][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[3]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[3][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[4]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[4][1][1]) * finite_difference_accuracy * oneone;
-
-  MaterialModelInputs<dim> in_dviscositydtemperature(in_base);
-  in_dviscositydtemperature.temperature[0] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[1] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[2] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[3] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[4] *= 1.0000000001;
-
+  MaterialModelInputs<dim> in_dviscositydstrainrate(in_base);
 
   MaterialModelOutputs<dim> out_base(5,3);
-
-  MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate_zerozero(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate_onezero(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate_oneone(5,3);
-  MaterialModelOutputs<dim> out_dviscositydtemperature(5,3);
+  MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
 
   if (out_base.template get_additional_output<MaterialModelDerivatives<dim> >() != NULL)
     throw "error";
 
   out_base.additional_outputs.push_back(std::make_shared<MaterialModelDerivatives<dim> > (5));
 
+  // initialize the material we want to test.
   SimpleNonlinear<dim> mat;
   ParameterHandler prm;
   mat.declare_parameters(prm);
@@ -157,90 +145,50 @@ int f(double parameter)
   mat.parse_parameters(prm);
 
   mat.evaluate(in_base, out_base);
-  mat.evaluate(in_dviscositydpressure, out_dviscositydpressure);
-  mat.evaluate(in_dviscositydstrainrate_zerozero, out_dviscositydstrainrate_zerozero);
-  mat.evaluate(in_dviscositydstrainrate_onezero, out_dviscositydstrainrate_onezero);
-  mat.evaluate(in_dviscositydstrainrate_oneone, out_dviscositydstrainrate_oneone);
-  mat.evaluate(in_dviscositydtemperature, out_dviscositydtemperature);
 
-  //set up additional output for the derivatives
+  // set up additional output for the derivatives
   MaterialModelDerivatives<dim> *derivatives;
   derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim> >();
-
   double temp;
-  for (unsigned int i = 0; i < 5; i++)
+
+  // have a bool so we know whether the test has succeed or not.
+  bool Error = false;
+
+  // this material is not pressure dependent, so we do not test it.
+
+  // test the strain-rate derivative.
+  for (unsigned int component = 0; component < SymmetricTensor<2,dim>::n_independent_components; ++component)
     {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = (out_dviscositydpressure.viscosities[i] - out_base.viscosities[i]);
-      if (in_base.pressure[i] != 0)
-        {
-          temp /= (in_base.pressure[i] * finite_difference_accuracy);
-        }
+      const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
 
-      if (temp > derivatives->viscosity_derivative_wrt_pressure[i] * finite_difference_factor || temp < derivatives->viscosity_derivative_wrt_pressure[i] * (2-finite_difference_factor))
+      for (unsigned int i = 0; i < 5; i++)
         {
-          std::cout << "Error: The derivative of the viscosity to the pressure is too different from the analytical value." << std::endl;
-          Error = true;
-        }
-
-    }
-
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = out_dviscositydstrainrate_zerozero.viscosities[i] - out_base.viscosities[i];
-      if (temp != 0)
-        {
-          temp /= std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[i][0][0]) * finite_difference_accuracy;
-        }
-      std::cout << "zerozero " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][0][0]  << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][0][0]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][0][0])))
-        {
-          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
-          Error = true;
+          in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
+                                                    + std::fabs(in_base.strain_rate[i][strain_rate_indices])
+                                                    * finite_difference_accuracy
+                                                    * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
         }
 
 
+      mat.evaluate(in_dviscositydstrainrate, out_dviscositydstrainrate);
 
-    }
+      for (unsigned int i = 0; i < 5; i++)
+        {
+          // prevent division by zero. If it is zero, the test has passed, because or
+          // the finite difference and the analytical result match perfectly, or (more
+          // likely) the material model in independent of this variable.
+          temp = out_dviscositydstrainrate.viscosities[i] - out_base.viscosities[i];
+          if (temp != 0)
+            {
+              temp /= std::fabs(in_dviscositydstrainrate.strain_rate[i][strain_rate_indices]) * finite_difference_accuracy;
+            }
+          std::cout << "strain-rate: component = " << component << ", point = " << i << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]  << std::endl;
+          if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices])))
+            {
+              std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
+              Error = true;
+            }
 
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = out_dviscositydstrainrate_onezero.viscosities[i] - out_base.viscosities[i];
-      if (temp != 0)
-        {
-          temp /= std::fabs(in_dviscositydstrainrate_onezero.strain_rate[i][1][0]) * finite_difference_accuracy;
-        }
-      std::cout << "onezero " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]   << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][0])) )
-        {
-          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
-          Error = true;
-        }
-    }
-
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = out_dviscositydstrainrate_oneone.viscosities[i] - out_base.viscosities[i];
-      if (temp != 0)
-        {
-          temp /= std::fabs(in_dviscositydstrainrate_oneone.strain_rate[i][1][1]) * finite_difference_accuracy;
-        }
-      std::cout << "oneone " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]  << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][1])) )
-        {
-          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
-          Error = true;
         }
 
     }

--- a/tests/simple_nonlinear/screen-output
+++ b/tests/simple_nonlinear/screen-output
@@ -1,304 +1,447 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
 
 Loading shared library <./libsimple_nonlinear.so>
 
 Test for p = -1000 with dimension 2
-zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
-zerozero 1: Finite difference = 9.45819e+27. Analytical derivative = 9.45833e+27
-zerozero 2: Finite difference = 1.15028e+28. Analytical derivative = 1.15029e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+strain-rate: component = 0, point = 0, Finite difference = 3.4588e+30, Analytical derivative = 3.4588e+30
+strain-rate: component = 0, point = 1, Finite difference = 9.45819e+27, Analytical derivative = 9.45833e+27
+strain-rate: component = 0, point = 2, Finite difference = 1.15028e+28, Analytical derivative = 1.15029e+28
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = -1.4336e+22, Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
-onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
-onezero 1: Finite difference = 5.16403e+29. Analytical derivative = 5.16403e+29
-onezero 2: Finite difference = -2.09143e+29. Analytical derivative = -2.09143e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
-oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
-oneone 1: Finite difference = -9.45857e+27. Analytical derivative = -9.45833e+27
-oneone 2: Finite difference = -1.1503e+28. Analytical derivative = -1.15029e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+strain-rate: component = 1, point = 0, Finite difference = -3.4588e+30, Analytical derivative = -3.4588e+30
+strain-rate: component = 1, point = 1, Finite difference = -9.45857e+27, Analytical derivative = -9.45833e+27
+strain-rate: component = 1, point = 2, Finite difference = -1.1503e+28, Analytical derivative = -1.15029e+28
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = -1.4336e+22, Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 2, point = 0, Finite difference = -7.68623e+29, Analytical derivative = -7.68623e+29
+strain-rate: component = 2, point = 1, Finite difference = 5.16403e+29, Analytical derivative = 5.16403e+29
+strain-rate: component = 2, point = 2, Finite difference = -2.09143e+29, Analytical derivative = -2.09143e+29
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = -4.52403e+29, Analytical derivative = -4.52403e+29
 Some parts of the test where not succesfull.
 
 Test for p = -2 with dimension 2
-zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
-zerozero 1: Finite difference = 1.54539e+28. Analytical derivative = 1.54541e+28
-zerozero 2: Finite difference = 1.67688e+28. Analytical derivative = 1.67688e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+strain-rate: component = 0, point = 0, Finite difference = 3.4588e+30, Analytical derivative = 3.4588e+30
+strain-rate: component = 0, point = 1, Finite difference = 1.54539e+28, Analytical derivative = 1.54541e+28
+strain-rate: component = 0, point = 2, Finite difference = 1.67688e+28, Analytical derivative = 1.67688e+28
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = -1.4336e+22, Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
-onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
-onezero 1: Finite difference = 8.43757e+29. Analytical derivative = 8.43757e+29
-onezero 2: Finite difference = -3.04888e+29. Analytical derivative = -3.04888e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
-oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
-oneone 1: Finite difference = -1.54542e+28. Analytical derivative = -1.54541e+28
-oneone 2: Finite difference = -1.6769e+28. Analytical derivative = -1.67688e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+strain-rate: component = 1, point = 0, Finite difference = -3.4588e+30, Analytical derivative = -3.4588e+30
+strain-rate: component = 1, point = 1, Finite difference = -1.54542e+28, Analytical derivative = -1.54541e+28
+strain-rate: component = 1, point = 2, Finite difference = -1.6769e+28, Analytical derivative = -1.67688e+28
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = -1.4336e+22, Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 2, point = 0, Finite difference = -7.68623e+29, Analytical derivative = -7.68623e+29
+strain-rate: component = 2, point = 1, Finite difference = 8.43757e+29, Analytical derivative = 8.43757e+29
+strain-rate: component = 2, point = 2, Finite difference = -3.04888e+29, Analytical derivative = -3.04888e+29
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = -4.52403e+29, Analytical derivative = -4.52403e+29
 Some parts of the test where not succesfull.
 
 Test for p = -1.5 with dimension 2
-zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
-zerozero 1: Finite difference = 1.59213e+28. Analytical derivative = 1.59213e+28
-zerozero 2: Finite difference = 1.77238e+28. Analytical derivative = 1.77239e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+strain-rate: component = 0, point = 0, Finite difference = 3.4588e+30, Analytical derivative = 3.4588e+30
+strain-rate: component = 0, point = 1, Finite difference = 1.59213e+28, Analytical derivative = 1.59213e+28
+strain-rate: component = 0, point = 2, Finite difference = 1.77238e+28, Analytical derivative = 1.77239e+28
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = -1.4336e+22, Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
-onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
-onezero 1: Finite difference = 8.69267e+29. Analytical derivative = 8.69267e+29
-onezero 2: Finite difference = -3.22252e+29. Analytical derivative = -3.22252e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
-oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
-oneone 1: Finite difference = -1.59209e+28. Analytical derivative = -1.59213e+28
-oneone 2: Finite difference = -1.7724e+28. Analytical derivative = -1.77239e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+strain-rate: component = 1, point = 0, Finite difference = -3.4588e+30, Analytical derivative = -3.4588e+30
+strain-rate: component = 1, point = 1, Finite difference = -1.59209e+28, Analytical derivative = -1.59213e+28
+strain-rate: component = 1, point = 2, Finite difference = -1.7724e+28, Analytical derivative = -1.77239e+28
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = -1.4336e+22, Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 2, point = 0, Finite difference = -7.68623e+29, Analytical derivative = -7.68623e+29
+strain-rate: component = 2, point = 1, Finite difference = 8.69267e+29, Analytical derivative = 8.69267e+29
+strain-rate: component = 2, point = 2, Finite difference = -3.22252e+29, Analytical derivative = -3.22252e+29
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = -4.52403e+29, Analytical derivative = -4.52403e+29
 Some parts of the test where not succesfull.
 
 Test for p = -1 with dimension 2
-zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
-zerozero 1: Finite difference = 1.63782e+28. Analytical derivative = 1.63784e+28
-zerozero 2: Finite difference = 1.90553e+28. Analytical derivative = 1.90553e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+strain-rate: component = 0, point = 0, Finite difference = 3.4588e+30, Analytical derivative = 3.4588e+30
+strain-rate: component = 0, point = 1, Finite difference = 1.63782e+28, Analytical derivative = 1.63784e+28
+strain-rate: component = 0, point = 2, Finite difference = 1.90553e+28, Analytical derivative = 1.90553e+28
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = -1.4336e+22, Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
-onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
-onezero 1: Finite difference = 8.94221e+29. Analytical derivative = 8.94221e+29
-onezero 2: Finite difference = -3.46459e+29. Analytical derivative = -3.46459e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
-oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
-oneone 1: Finite difference = -1.63784e+28. Analytical derivative = -1.63784e+28
-oneone 2: Finite difference = -1.90554e+28. Analytical derivative = -1.90553e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+strain-rate: component = 1, point = 0, Finite difference = -3.4588e+30, Analytical derivative = -3.4588e+30
+strain-rate: component = 1, point = 1, Finite difference = -1.63784e+28, Analytical derivative = -1.63784e+28
+strain-rate: component = 1, point = 2, Finite difference = -1.90554e+28, Analytical derivative = -1.90553e+28
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = -1.4336e+22, Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 2, point = 0, Finite difference = -7.68623e+29, Analytical derivative = -7.68623e+29
+strain-rate: component = 2, point = 1, Finite difference = 8.94221e+29, Analytical derivative = 8.94221e+29
+strain-rate: component = 2, point = 2, Finite difference = -3.46459e+29, Analytical derivative = -3.46459e+29
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = -4.52403e+29, Analytical derivative = -4.52403e+29
 Some parts of the test where not succesfull.
 
 Test for p = 0 with dimension 2
-zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
-zerozero 1: Finite difference = 1.72138e+28. Analytical derivative = 1.72127e+28
-zerozero 2: Finite difference = 2.33127e+28. Analytical derivative = 2.33136e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = 0. Analytical derivative = 0
-onezero 0: Finite difference = -7.68624e+29. Analytical derivative = -7.68623e+29
-onezero 1: Finite difference = 9.39773e+29. Analytical derivative = 9.39773e+29
-onezero 2: Finite difference = -4.23884e+29. Analytical derivative = -4.23884e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
-oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
-oneone 1: Finite difference = -1.72231e+28. Analytical derivative = -1.72127e+28
-oneone 2: Finite difference = -2.33099e+28. Analytical derivative = -2.33136e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = 0. Analytical derivative = 0
+strain-rate: component = 0, point = 0, Finite difference = 3.4588e+30, Analytical derivative = 3.4588e+30
+strain-rate: component = 0, point = 1, Finite difference = 1.72138e+28, Analytical derivative = 1.72127e+28
+strain-rate: component = 0, point = 2, Finite difference = 2.33127e+28, Analytical derivative = 2.33136e+28
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 0, Finite difference = -3.4588e+30, Analytical derivative = -3.4588e+30
+strain-rate: component = 1, point = 1, Finite difference = -1.72231e+28, Analytical derivative = -1.72127e+28
+strain-rate: component = 1, point = 2, Finite difference = -2.33099e+28, Analytical derivative = -2.33136e+28
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 0, Finite difference = -7.68624e+29, Analytical derivative = -7.68623e+29
+strain-rate: component = 2, point = 1, Finite difference = 9.39773e+29, Analytical derivative = 9.39773e+29
+strain-rate: component = 2, point = 2, Finite difference = -4.23884e+29, Analytical derivative = -4.23884e+29
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = -4.52403e+29, Analytical derivative = -4.52403e+29
 OK
 
 Test for p = 1 with dimension 2
-zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
-zerozero 1: Finite difference = 1.78932e+28. Analytical derivative = 1.78934e+28
-zerozero 2: Finite difference = 2.94542e+28. Analytical derivative = 2.94543e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+strain-rate: component = 0, point = 0, Finite difference = 3.4588e+30, Analytical derivative = 3.4588e+30
+strain-rate: component = 0, point = 1, Finite difference = 1.78932e+28, Analytical derivative = 1.78934e+28
+strain-rate: component = 0, point = 2, Finite difference = 2.94542e+28, Analytical derivative = 2.94543e+28
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = -1.4336e+22, Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
-onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
-onezero 1: Finite difference = 9.7694e+29. Analytical derivative = 9.7694e+29
-onezero 2: Finite difference = -5.35532e+29. Analytical derivative = -5.35532e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
-oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
-oneone 1: Finite difference = -1.78938e+28. Analytical derivative = -1.78934e+28
-oneone 2: Finite difference = -2.94545e+28. Analytical derivative = -2.94543e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+strain-rate: component = 1, point = 0, Finite difference = -3.4588e+30, Analytical derivative = -3.4588e+30
+strain-rate: component = 1, point = 1, Finite difference = -1.78938e+28, Analytical derivative = -1.78934e+28
+strain-rate: component = 1, point = 2, Finite difference = -2.94545e+28, Analytical derivative = -2.94543e+28
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = -1.4336e+22, Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 2, point = 0, Finite difference = -7.68623e+29, Analytical derivative = -7.68623e+29
+strain-rate: component = 2, point = 1, Finite difference = 9.7694e+29, Analytical derivative = 9.7694e+29
+strain-rate: component = 2, point = 2, Finite difference = -5.35532e+29, Analytical derivative = -5.35532e+29
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = -4.52403e+29, Analytical derivative = -4.52403e+29
 Some parts of the test where not succesfull.
 
 Test for p = 2 with dimension 2
-zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
-zerozero 1: Finite difference = 1.84129e+28. Analytical derivative = 1.84132e+28
-zerozero 2: Finite difference = 3.53658e+28. Analytical derivative = 3.53658e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+strain-rate: component = 0, point = 0, Finite difference = 3.4588e+30, Analytical derivative = 3.4588e+30
+strain-rate: component = 0, point = 1, Finite difference = 1.84129e+28, Analytical derivative = 1.84132e+28
+strain-rate: component = 0, point = 2, Finite difference = 3.53658e+28, Analytical derivative = 3.53658e+28
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = -1.4336e+22, Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
-onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
-onezero 1: Finite difference = 1.00532e+30. Analytical derivative = 1.00532e+30
-onezero 2: Finite difference = -6.43015e+29. Analytical derivative = -6.43015e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
-oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
-oneone 1: Finite difference = -1.8414e+28. Analytical derivative = -1.84132e+28
-oneone 2: Finite difference = -3.53661e+28. Analytical derivative = -3.53658e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+strain-rate: component = 1, point = 0, Finite difference = -3.4588e+30, Analytical derivative = -3.4588e+30
+strain-rate: component = 1, point = 1, Finite difference = -1.8414e+28, Analytical derivative = -1.84132e+28
+strain-rate: component = 1, point = 2, Finite difference = -3.53661e+28, Analytical derivative = -3.53658e+28
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = -1.4336e+22, Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 2, point = 0, Finite difference = -7.68623e+29, Analytical derivative = -7.68623e+29
+strain-rate: component = 2, point = 1, Finite difference = 1.00532e+30, Analytical derivative = 1.00532e+30
+strain-rate: component = 2, point = 2, Finite difference = -6.43015e+29, Analytical derivative = -6.43015e+29
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = -4.52403e+29, Analytical derivative = -4.52403e+29
 Some parts of the test where not succesfull.
 
 Test for p = 1000 with dimension 2
-zerozero 0: Finite difference = 3.4588e+30. Analytical derivative = 3.4588e+30
-zerozero 1: Finite difference = 2.03772e+28. Analytical derivative = 2.03773e+28
-zerozero 2: Finite difference = 5.33915e+28. Analytical derivative = 5.33915e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+strain-rate: component = 0, point = 0, Finite difference = 3.4588e+30, Analytical derivative = 3.4588e+30
+strain-rate: component = 0, point = 1, Finite difference = 2.03772e+28, Analytical derivative = 2.03773e+28
+strain-rate: component = 0, point = 2, Finite difference = 5.33915e+28, Analytical derivative = 5.33915e+28
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = -1.4336e+22, Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
-onezero 0: Finite difference = -7.68623e+29. Analytical derivative = -7.68623e+29
-onezero 1: Finite difference = 1.11256e+30. Analytical derivative = 1.11256e+30
-onezero 2: Finite difference = -9.70755e+29. Analytical derivative = -9.70755e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -4.52403e+29. Analytical derivative = -4.52403e+29
-oneone 0: Finite difference = -3.4588e+30. Analytical derivative = -3.4588e+30
-oneone 1: Finite difference = -2.03776e+28. Analytical derivative = -2.03773e+28
-oneone 2: Finite difference = -5.33922e+28. Analytical derivative = -5.33915e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.4336e+22. Analytical derivative = 0
+strain-rate: component = 1, point = 0, Finite difference = -3.4588e+30, Analytical derivative = -3.4588e+30
+strain-rate: component = 1, point = 1, Finite difference = -2.03776e+28, Analytical derivative = -2.03773e+28
+strain-rate: component = 1, point = 2, Finite difference = -5.33922e+28, Analytical derivative = -5.33915e+28
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = -1.4336e+22, Analytical derivative = 0
    Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 2, point = 0, Finite difference = -7.68623e+29, Analytical derivative = -7.68623e+29
+strain-rate: component = 2, point = 1, Finite difference = 1.11256e+30, Analytical derivative = 1.11256e+30
+strain-rate: component = 2, point = 2, Finite difference = -9.70755e+29, Analytical derivative = -9.70755e+29
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = -4.52403e+29, Analytical derivative = -4.52403e+29
 Some parts of the test where not succesfull.
 
 Test for p = -1000 with dimension 3
-zerozero 0: Finite difference = 1.22129e+30. Analytical derivative = 1.22129e+30
-zerozero 1: Finite difference = 1.13647e+28. Analytical derivative = 1.13647e+28
-zerozero 2: Finite difference = 1.46269e+28. Analytical derivative = 1.46269e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
-onezero 0: Finite difference = -4.57984e+29. Analytical derivative = -4.57984e+29
-onezero 1: Finite difference = 5.16375e+29. Analytical derivative = 5.16375e+29
-onezero 2: Finite difference = -2.08955e+29. Analytical derivative = -2.08955e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -3.08276e+29. Analytical derivative = -3.08277e+29
-oneone 0: Finite difference = -2.90056e+30. Analytical derivative = -2.90056e+30
-oneone 1: Finite difference = -7.55054e+27. Analytical derivative = -7.55089e+27
-oneone 2: Finite difference = -8.35819e+27. Analytical derivative = -8.35821e+27
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
-OK
+strain-rate: component = 0, point = 0, Finite difference = 2.91193e+30, Analytical derivative = 2.91193e+30
+strain-rate: component = 0, point = 1, Finite difference = 3.40193e+27, Analytical derivative = 3.40191e+27
+strain-rate: component = 0, point = 2, Finite difference = 1.77633e+27, Analytical derivative = 1.77633e+27
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 1, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 1, point = 1, Finite difference = -1.70064e+27, Analytical derivative = -1.70095e+27
+strain-rate: component = 1, point = 2, Finite difference = -3.55267e+27, Analytical derivative = -3.55266e+27
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 2, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 2, point = 1, Finite difference = -1.70064e+27, Analytical derivative = -1.70095e+27
+strain-rate: component = 2, point = 2, Finite difference = 1.77633e+27, Analytical derivative = 1.77633e+27
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 3, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 3, point = 1, Finite difference = 1.39302e+29, Analytical derivative = 1.39302e+29
+strain-rate: component = 3, point = 2, Finite difference = -4.84454e+28, Analytical derivative = -4.84454e+28
+strain-rate: component = 3, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 3, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 4, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 4, point = 1, Finite difference = 1.29739e+29, Analytical derivative = 1.29739e+29
+strain-rate: component = 4, point = 2, Finite difference = -4.84454e+28, Analytical derivative = -4.84454e+28
+strain-rate: component = 4, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 4, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 5, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 5, point = 1, Finite difference = 1.24957e+29, Analytical derivative = 1.24957e+29
+strain-rate: component = 5, point = 2, Finite difference = -4.84454e+28, Analytical derivative = -4.84454e+28
+strain-rate: component = 5, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 5, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+Some parts of the test where not succesfull.
 
 Test for p = -2 with dimension 3
-zerozero 0: Finite difference = 1.22129e+30. Analytical derivative = 1.22129e+30
-zerozero 1: Finite difference = 1.8569e+28. Analytical derivative = 1.8569e+28
-zerozero 2: Finite difference = 2.1323e+28. Analytical derivative = 2.1323e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
-onezero 0: Finite difference = -4.57984e+29. Analytical derivative = -4.57984e+29
-onezero 1: Finite difference = 8.43711e+29. Analytical derivative = 8.43711e+29
-onezero 2: Finite difference = -3.04614e+29. Analytical derivative = -3.04614e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -3.08276e+29. Analytical derivative = -3.08277e+29
-oneone 0: Finite difference = -2.90056e+30. Analytical derivative = -2.90056e+30
-oneone 1: Finite difference = -1.23365e+28. Analytical derivative = -1.23375e+28
-oneone 2: Finite difference = -1.21847e+28. Analytical derivative = -1.21846e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
-OK
+strain-rate: component = 0, point = 0, Finite difference = 2.91193e+30, Analytical derivative = 2.91193e+30
+strain-rate: component = 0, point = 1, Finite difference = 5.55832e+27, Analytical derivative = 5.55842e+27
+strain-rate: component = 0, point = 2, Finite difference = 2.58953e+27, Analytical derivative = 2.58953e+27
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 1, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 1, point = 1, Finite difference = -2.77912e+27, Analytical derivative = -2.77921e+27
+strain-rate: component = 1, point = 2, Finite difference = -5.17908e+27, Analytical derivative = -5.17906e+27
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 2, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 2, point = 1, Finite difference = -2.77912e+27, Analytical derivative = -2.77921e+27
+strain-rate: component = 2, point = 2, Finite difference = 2.58953e+27, Analytical derivative = 2.58953e+27
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 3, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 3, point = 1, Finite difference = 2.27608e+29, Analytical derivative = 2.27608e+29
+strain-rate: component = 3, point = 2, Finite difference = -7.06235e+28, Analytical derivative = -7.06235e+28
+strain-rate: component = 3, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 3, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 4, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 4, point = 1, Finite difference = 2.11982e+29, Analytical derivative = 2.11982e+29
+strain-rate: component = 4, point = 2, Finite difference = -7.06235e+28, Analytical derivative = -7.06235e+28
+strain-rate: component = 4, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 4, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 5, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 5, point = 1, Finite difference = 2.04169e+29, Analytical derivative = 2.04169e+29
+strain-rate: component = 5, point = 2, Finite difference = -7.06235e+28, Analytical derivative = -7.06235e+28
+strain-rate: component = 5, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 5, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+Some parts of the test where not succesfull.
 
 Test for p = -1.5 with dimension 3
-zerozero 0: Finite difference = 1.22129e+30. Analytical derivative = 1.22129e+30
-zerozero 1: Finite difference = 1.91304e+28. Analytical derivative = 1.91304e+28
-zerozero 2: Finite difference = 2.25374e+28. Analytical derivative = 2.25374e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
-onezero 0: Finite difference = -4.57984e+29. Analytical derivative = -4.57984e+29
-onezero 1: Finite difference = 8.6922e+29. Analytical derivative = 8.6922e+29
-onezero 2: Finite difference = -3.21963e+29. Analytical derivative = -3.21963e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -3.08276e+29. Analytical derivative = -3.08277e+29
-oneone 0: Finite difference = -2.90056e+30. Analytical derivative = -2.90056e+30
-oneone 1: Finite difference = -1.27091e+28. Analytical derivative = -1.27105e+28
-oneone 2: Finite difference = -1.28786e+28. Analytical derivative = -1.28785e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
-OK
+strain-rate: component = 0, point = 0, Finite difference = 2.91193e+30, Analytical derivative = 2.91193e+30
+strain-rate: component = 0, point = 1, Finite difference = 5.72645e+27, Analytical derivative = 5.72648e+27
+strain-rate: component = 0, point = 2, Finite difference = 2.73702e+27, Analytical derivative = 2.73701e+27
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 1, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 1, point = 1, Finite difference = -2.86314e+27, Analytical derivative = -2.86324e+27
+strain-rate: component = 1, point = 2, Finite difference = -5.47389e+27, Analytical derivative = -5.47402e+27
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 2, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 2, point = 1, Finite difference = -2.86314e+27, Analytical derivative = -2.86324e+27
+strain-rate: component = 2, point = 2, Finite difference = 2.73702e+27, Analytical derivative = 2.73701e+27
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 3, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 3, point = 1, Finite difference = 2.34489e+29, Analytical derivative = 2.34489e+29
+strain-rate: component = 3, point = 2, Finite difference = -7.46457e+28, Analytical derivative = -7.46457e+28
+strain-rate: component = 3, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 3, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 4, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 4, point = 1, Finite difference = 2.18391e+29, Analytical derivative = 2.18391e+29
+strain-rate: component = 4, point = 2, Finite difference = -7.46457e+28, Analytical derivative = -7.46457e+28
+strain-rate: component = 4, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 4, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 5, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 5, point = 1, Finite difference = 2.10342e+29, Analytical derivative = 2.10342e+29
+strain-rate: component = 5, point = 2, Finite difference = -7.46457e+28, Analytical derivative = -7.46457e+28
+strain-rate: component = 5, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 5, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+Some parts of the test where not succesfull.
 
 Test for p = -1 with dimension 3
-zerozero 0: Finite difference = 1.22129e+30. Analytical derivative = 1.22129e+30
-zerozero 1: Finite difference = 1.96797e+28. Analytical derivative = 1.96796e+28
-zerozero 2: Finite difference = 2.42304e+28. Analytical derivative = 2.42304e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
-onezero 0: Finite difference = -4.57984e+29. Analytical derivative = -4.57984e+29
-onezero 1: Finite difference = 8.94172e+29. Analytical derivative = 8.94172e+29
-onezero 2: Finite difference = -3.46149e+29. Analytical derivative = -3.46149e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -3.08276e+29. Analytical derivative = -3.08277e+29
-oneone 0: Finite difference = -2.90056e+30. Analytical derivative = -2.90056e+30
-oneone 1: Finite difference = -1.30743e+28. Analytical derivative = -1.30754e+28
-oneone 2: Finite difference = -1.38459e+28. Analytical derivative = -1.3846e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
-OK
+strain-rate: component = 0, point = 0, Finite difference = 2.91193e+30, Analytical derivative = 2.91193e+30
+strain-rate: component = 0, point = 1, Finite difference = 5.89099e+27, Analytical derivative = 5.89086e+27
+strain-rate: component = 0, point = 2, Finite difference = 2.94261e+27, Analytical derivative = 2.94261e+27
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 1, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 1, point = 1, Finite difference = -2.94474e+27, Analytical derivative = -2.94543e+27
+strain-rate: component = 1, point = 2, Finite difference = -5.88523e+27, Analytical derivative = -5.88523e+27
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 2, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 2, point = 1, Finite difference = -2.94474e+27, Analytical derivative = -2.94543e+27
+strain-rate: component = 2, point = 2, Finite difference = 2.94261e+27, Analytical derivative = 2.94261e+27
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 3, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 3, point = 1, Finite difference = 2.41221e+29, Analytical derivative = 2.41221e+29
+strain-rate: component = 3, point = 2, Finite difference = -8.02531e+28, Analytical derivative = -8.02531e+28
+strain-rate: component = 3, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 3, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 4, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 4, point = 1, Finite difference = 2.2466e+29, Analytical derivative = 2.2466e+29
+strain-rate: component = 4, point = 2, Finite difference = -8.02531e+28, Analytical derivative = -8.02531e+28
+strain-rate: component = 4, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 4, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 5, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 5, point = 1, Finite difference = 2.1638e+29, Analytical derivative = 2.1638e+29
+strain-rate: component = 5, point = 2, Finite difference = -8.02531e+28, Analytical derivative = -8.02531e+28
+strain-rate: component = 5, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 5, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+Some parts of the test where not succesfull.
 
 Test for p = 0 with dimension 3
-zerozero 0: Finite difference = 1.22129e+30. Analytical derivative = 1.22129e+30
-zerozero 1: Finite difference = 2.06903e+28. Analytical derivative = 2.0682e+28
-zerozero 2: Finite difference = 2.96447e+28. Analytical derivative = 2.96453e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
-onezero 0: Finite difference = -4.57984e+29. Analytical derivative = -4.57984e+29
-onezero 1: Finite difference = 9.39722e+29. Analytical derivative = 9.39722e+29
-onezero 2: Finite difference = -4.23504e+29. Analytical derivative = -4.23504e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -3.08276e+29. Analytical derivative = -3.08277e+29
-oneone 0: Finite difference = -2.90056e+30. Analytical derivative = -2.90056e+30
-oneone 1: Finite difference = -1.37339e+28. Analytical derivative = -1.37415e+28
-oneone 2: Finite difference = -1.69439e+28. Analytical derivative = -1.69402e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
+strain-rate: component = 0, point = 0, Finite difference = 2.91193e+30, Analytical derivative = 2.91193e+30
+strain-rate: component = 0, point = 1, Finite difference = 6.19054e+27, Analytical derivative = 6.19095e+27
+strain-rate: component = 0, point = 2, Finite difference = 3.60018e+27, Analytical derivative = 3.60021e+27
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 1, point = 1, Finite difference = -3.09336e+27, Analytical derivative = -3.09547e+27
+strain-rate: component = 1, point = 2, Finite difference = -7.19913e+27, Analytical derivative = -7.20042e+27
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 2, point = 1, Finite difference = -3.09336e+27, Analytical derivative = -3.09547e+27
+strain-rate: component = 2, point = 2, Finite difference = 3.60018e+27, Analytical derivative = 3.60021e+27
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 3, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 3, point = 1, Finite difference = 2.53509e+29, Analytical derivative = 2.53509e+29
+strain-rate: component = 3, point = 2, Finite difference = -9.81875e+28, Analytical derivative = -9.81875e+28
+strain-rate: component = 3, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 3, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 4, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 4, point = 1, Finite difference = 2.36105e+29, Analytical derivative = 2.36105e+29
+strain-rate: component = 4, point = 2, Finite difference = -9.81875e+28, Analytical derivative = -9.81875e+28
+strain-rate: component = 4, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 4, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 5, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 5, point = 1, Finite difference = 2.27403e+29, Analytical derivative = 2.27403e+29
+strain-rate: component = 5, point = 2, Finite difference = -9.81875e+28, Analytical derivative = -9.81875e+28
+strain-rate: component = 5, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 5, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
 OK
 
 Test for p = 1 with dimension 3
-zerozero 0: Finite difference = 1.22129e+30. Analytical derivative = 1.22129e+30
-zerozero 1: Finite difference = 2.15e+28. Analytical derivative = 2.15e+28
-zerozero 2: Finite difference = 3.74536e+28. Analytical derivative = 3.74536e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
-onezero 0: Finite difference = -4.57984e+29. Analytical derivative = -4.57984e+29
-onezero 1: Finite difference = 9.76887e+29. Analytical derivative = 9.76887e+29
-onezero 2: Finite difference = -5.35052e+29. Analytical derivative = -5.35052e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -3.08276e+29. Analytical derivative = -3.08277e+29
-oneone 0: Finite difference = -2.90056e+30. Analytical derivative = -2.90056e+30
-oneone 1: Finite difference = -1.42837e+28. Analytical derivative = -1.42849e+28
-oneone 2: Finite difference = -2.1402e+28. Analytical derivative = -2.14021e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
-OK
+strain-rate: component = 0, point = 0, Finite difference = 2.91193e+30, Analytical derivative = 2.91193e+30
+strain-rate: component = 0, point = 1, Finite difference = 6.43568e+27, Analytical derivative = 6.43579e+27
+strain-rate: component = 0, point = 2, Finite difference = 4.54849e+27, Analytical derivative = 4.54848e+27
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 1, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 1, point = 1, Finite difference = -3.2177e+27, Analytical derivative = -3.2179e+27
+strain-rate: component = 1, point = 2, Finite difference = -9.09681e+27, Analytical derivative = -9.09696e+27
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 2, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 2, point = 1, Finite difference = -3.2177e+27, Analytical derivative = -3.2179e+27
+strain-rate: component = 2, point = 2, Finite difference = 4.54849e+27, Analytical derivative = 4.54848e+27
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 3, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 3, point = 1, Finite difference = 2.63535e+29, Analytical derivative = 2.63535e+29
+strain-rate: component = 3, point = 2, Finite difference = -1.24049e+29, Analytical derivative = -1.24049e+29
+strain-rate: component = 3, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 3, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 4, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 4, point = 1, Finite difference = 2.45442e+29, Analytical derivative = 2.45442e+29
+strain-rate: component = 4, point = 2, Finite difference = -1.24049e+29, Analytical derivative = -1.24049e+29
+strain-rate: component = 4, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 4, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 5, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 5, point = 1, Finite difference = 2.36396e+29, Analytical derivative = 2.36396e+29
+strain-rate: component = 5, point = 2, Finite difference = -1.24049e+29, Analytical derivative = -1.24049e+29
+strain-rate: component = 5, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 5, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+Some parts of the test where not succesfull.
 
 Test for p = 2 with dimension 3
-zerozero 0: Finite difference = 1.22129e+30. Analytical derivative = 1.22129e+30
-zerozero 1: Finite difference = 2.21246e+28. Analytical derivative = 2.21246e+28
-zerozero 2: Finite difference = 4.49707e+28. Analytical derivative = 4.49707e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
-onezero 0: Finite difference = -4.57984e+29. Analytical derivative = -4.57984e+29
-onezero 1: Finite difference = 1.00527e+30. Analytical derivative = 1.00527e+30
-onezero 2: Finite difference = -6.42438e+29. Analytical derivative = -6.42438e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -3.08276e+29. Analytical derivative = -3.08277e+29
-oneone 0: Finite difference = -2.90056e+30. Analytical derivative = -2.90056e+30
-oneone 1: Finite difference = -1.46984e+28. Analytical derivative = -1.46999e+28
-oneone 2: Finite difference = -2.56975e+28. Analytical derivative = -2.56975e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
-OK
+strain-rate: component = 0, point = 0, Finite difference = 2.91193e+30, Analytical derivative = 2.91193e+30
+strain-rate: component = 0, point = 1, Finite difference = 6.6227e+27, Analytical derivative = 6.62275e+27
+strain-rate: component = 0, point = 2, Finite difference = 5.46138e+27, Analytical derivative = 5.46137e+27
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 1, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 1, point = 1, Finite difference = -3.31046e+27, Analytical derivative = -3.31138e+27
+strain-rate: component = 1, point = 2, Finite difference = -1.0923e+28, Analytical derivative = -1.09227e+28
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 2, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 2, point = 1, Finite difference = -3.31046e+27, Analytical derivative = -3.31138e+27
+strain-rate: component = 2, point = 2, Finite difference = 5.46138e+27, Analytical derivative = 5.46137e+27
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 3, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 3, point = 1, Finite difference = 2.7119e+29, Analytical derivative = 2.7119e+29
+strain-rate: component = 3, point = 2, Finite difference = -1.48947e+29, Analytical derivative = -1.48947e+29
+strain-rate: component = 3, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 3, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 4, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 4, point = 1, Finite difference = 2.52572e+29, Analytical derivative = 2.52572e+29
+strain-rate: component = 4, point = 2, Finite difference = -1.48947e+29, Analytical derivative = -1.48947e+29
+strain-rate: component = 4, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 4, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 5, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 5, point = 1, Finite difference = 2.43264e+29, Analytical derivative = 2.43264e+29
+strain-rate: component = 5, point = 2, Finite difference = -1.48947e+29, Analytical derivative = -1.48947e+29
+strain-rate: component = 5, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 5, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+Some parts of the test where not succesfull.
 
 Test for p = 1000 with dimension 3
-zerozero 0: Finite difference = 1.22129e+30. Analytical derivative = 1.22129e+30
-zerozero 1: Finite difference = 2.44845e+28. Analytical derivative = 2.44846e+28
-zerozero 2: Finite difference = 6.78919e+28. Analytical derivative = 6.78919e+28
-zerozero 3: Finite difference = 0. Analytical derivative = 0
-zerozero 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
-onezero 0: Finite difference = -4.57984e+29. Analytical derivative = -4.57984e+29
-onezero 1: Finite difference = 1.1125e+30. Analytical derivative = 1.1125e+30
-onezero 2: Finite difference = -9.69885e+29. Analytical derivative = -9.69885e+29
-onezero 3: Finite difference = 0. Analytical derivative = 0
-onezero 4: Finite difference = -3.08276e+29. Analytical derivative = -3.08277e+29
-oneone 0: Finite difference = -2.90056e+30. Analytical derivative = -2.90056e+30
-oneone 1: Finite difference = -1.62667e+28. Analytical derivative = -1.62679e+28
-oneone 2: Finite difference = -3.87953e+28. Analytical derivative = -3.87954e+28
-oneone 3: Finite difference = 0. Analytical derivative = 0
-oneone 4: Finite difference = -1.02759e+29. Analytical derivative = -1.02759e+29
-OK
+strain-rate: component = 0, point = 0, Finite difference = 2.91193e+30, Analytical derivative = 2.91193e+30
+strain-rate: component = 0, point = 1, Finite difference = 7.32918e+27, Analytical derivative = 7.32919e+27
+strain-rate: component = 0, point = 2, Finite difference = 8.245e+27, Analytical derivative = 8.245e+27
+strain-rate: component = 0, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 0, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 1, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 1, point = 1, Finite difference = -3.66405e+27, Analytical derivative = -3.6646e+27
+strain-rate: component = 1, point = 2, Finite difference = -1.64901e+28, Analytical derivative = -1.649e+28
+strain-rate: component = 1, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 1, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 2, point = 0, Finite difference = -1.45597e+30, Analytical derivative = -1.45597e+30
+strain-rate: component = 2, point = 1, Finite difference = -3.66405e+27, Analytical derivative = -3.6646e+27
+strain-rate: component = 2, point = 2, Finite difference = 8.245e+27, Analytical derivative = 8.245e+27
+strain-rate: component = 2, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 2, point = 4, Finite difference = -2.048e+21, Analytical derivative = 0
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: component = 3, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 3, point = 1, Finite difference = 3.00118e+29, Analytical derivative = 3.00118e+29
+strain-rate: component = 3, point = 2, Finite difference = -2.24864e+29, Analytical derivative = -2.24864e+29
+strain-rate: component = 3, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 3, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 4, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 4, point = 1, Finite difference = 2.79514e+29, Analytical derivative = 2.79514e+29
+strain-rate: component = 4, point = 2, Finite difference = -2.24864e+29, Analytical derivative = -2.24864e+29
+strain-rate: component = 4, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 4, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+strain-rate: component = 5, point = 0, Finite difference = -4.85322e+29, Analytical derivative = -4.85322e+29
+strain-rate: component = 5, point = 1, Finite difference = 2.69212e+29, Analytical derivative = 2.69212e+29
+strain-rate: component = 5, point = 2, Finite difference = -2.24864e+29, Analytical derivative = -2.24864e+29
+strain-rate: component = 5, point = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: component = 5, point = 4, Finite difference = -1.0456e+29, Analytical derivative = -1.0456e+29
+Some parts of the test where not succesfull.

--- a/tests/visco_plastic_derivatives_2d.cc
+++ b/tests/visco_plastic_derivatives_2d.cc
@@ -23,6 +23,8 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   std::cout << std::endl << "Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter " << averaging_parameter << std::endl;
 
   using namespace aspect::MaterialModel;
+
+  // first set all material model values
   MaterialModelInputs<dim> in_base(5,3);
   in_base.composition[0][0] = 0;
   in_base.composition[0][1] = 0;
@@ -40,6 +42,12 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   in_base.composition[4][1] = 0;
   in_base.composition[4][2] = 0;
 
+  in_base.temperature[0] = 293;
+  in_base.temperature[1] = 1600;
+  in_base.temperature[2] = 2000;
+  in_base.temperature[3] = 2100;
+  in_base.temperature[4] = 600;
+
   in_base.pressure[0] = 1e9;
   in_base.pressure[1] = 5e9;
   in_base.pressure[2] = 2e10;
@@ -55,85 +63,40 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   in_base.strain_rate[0][0][0] = 1e-12;
   in_base.strain_rate[0][0][1] = 1e-12;
   in_base.strain_rate[0][1][1] = 1e-11;
+
   in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[1][0][0] = -1.71266e-13;
   in_base.strain_rate[1][0][1] = -5.82647e-12;
   in_base.strain_rate[1][1][1] = 4.21668e-14;
+
   in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[2][1][1] = 1e-13;
   in_base.strain_rate[2][0][1] = 1e-11;
   in_base.strain_rate[2][0][0] = -1e-12;
+
   in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[3][1][1] = 4.9e-21;
   in_base.strain_rate[3][0][1] = 4.9e-21;
   in_base.strain_rate[3][0][0] = 4.9e-21;
+
   in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[4][1][1] = 1e-11;
   in_base.strain_rate[4][0][1] = 1e-11;
   in_base.strain_rate[4][0][0] = -1e-11;
 
-  in_base.temperature[0] = 293;
-  in_base.temperature[1] = 1600;
-  in_base.temperature[2] = 2000;
-  in_base.temperature[3] = 2100;
-  in_base.temperature[4] = 600;
 
-  SymmetricTensor<2,dim> zerozero = SymmetricTensor<2,dim>();
-  SymmetricTensor<2,dim> onezero = SymmetricTensor<2,dim>();
-  SymmetricTensor<2,dim> oneone = SymmetricTensor<2,dim>();
-
-  zerozero[0][0] = 1;
-  onezero[1][0]  = 0.5; // because symmetry doubles this entry
-  oneone[1][1]   = 1;
-
+  // initialize some variables we will need later.
   double finite_difference_accuracy = 1e-7;
   double finite_difference_factor = 1+finite_difference_accuracy;
 
-  bool Error = false;
 
-  MaterialModelInputs<dim> in_dviscositydpressure(in_base);
-  in_dviscositydpressure.pressure[0] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[1] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[2] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[3] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[4] *= finite_difference_factor;
-
-  MaterialModelInputs<dim> in_dviscositydstrainrate_zerozero(in_base);
-  MaterialModelInputs<dim> in_dviscositydstrainrate_onezero(in_base);
-  MaterialModelInputs<dim> in_dviscositydstrainrate_oneone(in_base);
-
-  in_dviscositydstrainrate_zerozero.strain_rate[0] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[0][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[1] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[1][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[2] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[2][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[3] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[3][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[4] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[4][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_onezero.strain_rate[0]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[0][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[1]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[1][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[2]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[2][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[3]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[3][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[4]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[4][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_oneone.strain_rate[0]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[0][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[1]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[1][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[2]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[2][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[3]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[3][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[4]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[4][1][1]) * finite_difference_accuracy * oneone;
-
-  MaterialModelInputs<dim> in_dviscositydtemperature(in_base);
-  in_dviscositydtemperature.temperature[0] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[1] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[2] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[3] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[4] *= 1.0000000001;
-
+  MaterialModelInputs<dim> in_dviscositydstrainrate(in_base);
 
   MaterialModelOutputs<dim> out_base(5,3);
-
   MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate_zerozero(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate_onezero(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate_oneone(5,3);
-  MaterialModelOutputs<dim> out_dviscositydtemperature(5,3);
+  MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
 
+  // initialize the material we want to test.
   aspect::ParameterHandler prm;
 
   const aspect::MaterialModel::ViscoPlastic<dim> const_material_model = dynamic_cast<const aspect::MaterialModel::ViscoPlastic<dim> &>(simulator_access.get_material_model());
@@ -157,17 +120,25 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   out_base.additional_outputs.push_back(std_cxx11::make_shared<MaterialModelDerivatives<dim> > (5));
 
   simulator_access.get_material_model().evaluate(in_base, out_base);
-  simulator_access.get_material_model().evaluate(in_dviscositydpressure, out_dviscositydpressure);
-  simulator_access.get_material_model().evaluate(in_dviscositydstrainrate_zerozero, out_dviscositydstrainrate_zerozero);
-  simulator_access.get_material_model().evaluate(in_dviscositydstrainrate_onezero, out_dviscositydstrainrate_onezero);
-  simulator_access.get_material_model().evaluate(in_dviscositydstrainrate_oneone, out_dviscositydstrainrate_oneone);
-  simulator_access.get_material_model().evaluate(in_dviscositydtemperature, out_dviscositydtemperature);
 
   // set up additional output for the derivatives
   MaterialModelDerivatives<dim> *derivatives;
   derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim> >();
-
   double temp;
+
+  // have a bool so we know whether the test has succeed or not.
+  bool Error = false;
+
+  // test the pressure derivative.
+  MaterialModelInputs<dim> in_dviscositydpressure(in_base);
+  in_dviscositydpressure.pressure[0] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[1] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[2] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[3] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[4] *= finite_difference_factor;
+
+  simulator_access.get_material_model().evaluate(in_dviscositydpressure, out_dviscositydpressure);
+
   for (unsigned int i = 0; i < 5; i++)
     {
       // prevent division by zero. If it is zero, the test has passed, because or
@@ -178,70 +149,48 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
         {
           temp /= (in_base.pressure[i] * finite_difference_accuracy);
         }
-      std::cout << "pressure at point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i]  << std::endl;
+      std::cout << "pressure: point = " << i << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i]  << std::endl;
       if (std::fabs(temp - derivatives->viscosity_derivative_wrt_pressure[i]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_pressure[i])))
-        // if (temp > derivatives->viscosity_derivative_wrt_pressure[i] * finite_difference_factor || temp < derivatives->viscosity_derivative_wrt_pressure[i] * (2-finite_difference_factor))
         {
-          std::cout << "   Error: The derivative of the viscosity to the pressure is too different from the analitical value." << std::endl;
+          std::cout << "   Error: The derivative of the viscosity to the pressure is too different from the analytical value." << std::endl;
           Error = true;
         }
 
     }
 
-  for (unsigned int i = 0; i < 5; i++)
+  // test the strain-rate derivative.
+  for (unsigned int component = 0; component < SymmetricTensor<2,dim>::n_independent_components; ++component)
     {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = out_dviscositydstrainrate_zerozero.viscosities[i] - out_base.viscosities[i];
-      if (temp != 0)
+      const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
+
+      for (unsigned int i = 0; i < 5; i++)
         {
-          temp /= std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[i][0][0]) * finite_difference_accuracy;
-        }
-      std::cout << "zerozero at point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][0][0]  << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][0][0]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][0][0])))
-        {
-          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analitical value." << std::endl;
-          Error = true;
+          in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
+                                                    + std::fabs(in_base.strain_rate[i][strain_rate_indices])
+                                                    * finite_difference_accuracy
+                                                    * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
         }
 
 
+      simulator_access.get_material_model().evaluate(in_dviscositydstrainrate, out_dviscositydstrainrate);
 
-    }
+      for (unsigned int i = 0; i < 5; i++)
+        {
+          // prevent division by zero. If it is zero, the test has passed, because or
+          // the finite difference and the analytical result match perfectly, or (more
+          // likely) the material model in independent of this variable.
+          temp = out_dviscositydstrainrate.viscosities[i] - out_base.viscosities[i];
+          if (temp != 0)
+            {
+              temp /= std::fabs(in_dviscositydstrainrate.strain_rate[i][strain_rate_indices]) * finite_difference_accuracy;
+            }
+          std::cout << "strain-rate: point = " << i << ", component = " << component << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]  << std::endl;
+          if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices])))
+            {
+              std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
+              Error = true;
+            }
 
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = out_dviscositydstrainrate_onezero.viscosities[i] - out_base.viscosities[i];
-      if (temp != 0)
-        {
-          temp /= std::fabs(in_dviscositydstrainrate_onezero.strain_rate[i][1][0]) * finite_difference_accuracy;
-        }
-      std::cout << "onezero at point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]   << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][0])) )
-        {
-          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
-          Error = true;
-        }
-    }
-
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = out_dviscositydstrainrate_oneone.viscosities[i] - out_base.viscosities[i];
-      if (temp != 0)
-        {
-          temp /= std::fabs(in_dviscositydstrainrate_oneone.strain_rate[i][1][1]) * finite_difference_accuracy;
-        }
-      std::cout << "oneone at point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]  << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][1])) )
-        {
-          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
-          Error = true;
         }
 
     }

--- a/tests/visco_plastic_derivatives_2d/screen-output
+++ b/tests/visco_plastic_derivatives_2d/screen-output
@@ -6,95 +6,95 @@ Loading shared library <./libvisco_plastic_derivatives_2d.so>
 * Connecting signals
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter harmonic
-pressure at point 0: Finite difference = 0. Analytical derivative = 0
-pressure at point 1: Finite difference = 2.12594e+08. Analytical derivative = 2.12594e+08
-pressure at point 2: Finite difference = 2.68615e+08. Analytical derivative = 2.68615e+08
-pressure at point 3: Finite difference = 0. Analytical derivative = 0
-pressure at point 4: Finite difference = 1.8585e+16. Analytical derivative = 1.8585e+16
-zerozero at point 0: Finite difference = 0. Analytical derivative = 0
-zerozero at point 1: Finite difference = 6.58655e+26. Analytical derivative = 6.58655e+26
-zerozero at point 2: Finite difference = 1.23761e+27. Analytical derivative = 1.23761e+27
-zerozero at point 3: Finite difference = 0. Analytical derivative = 0
-zerozero at point 4: Finite difference = 4.13904e+35. Analytical derivative = 4.13904e+35
-onezero at point 0: Finite difference = 0. Analytical derivative = 0
-onezero at point 1: Finite difference = 3.5961e+28. Analytical derivative = 3.5961e+28
-onezero at point 2: Finite difference = -2.2502e+28. Analytical derivative = -2.2502e+28
-onezero at point 3: Finite difference = 0. Analytical derivative = 0
-onezero at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
-oneone at point 0: Finite difference = 0. Analytical derivative = 0
-oneone at point 1: Finite difference = -6.58657e+26. Analytical derivative = -6.58657e+26
-oneone at point 2: Finite difference = -1.23761e+27. Analytical derivative = -1.23761e+27
-oneone at point 3: Finite difference = 0. Analytical derivative = 0
-oneone at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
+pressure: point = 0, Finite difference = 0, Analytical derivative = 0
+pressure: point = 1, Finite difference = 2.12594e+08, Analytical derivative = 2.12594e+08
+pressure: point = 2, Finite difference = 2.68615e+08, Analytical derivative = 2.68615e+08
+pressure: point = 3, Finite difference = 0, Analytical derivative = 0
+pressure: point = 4, Finite difference = 1.8585e+16, Analytical derivative = 1.8585e+16
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 6.58655e+26, Analytical derivative = 6.58655e+26
+strain-rate: point = 2, component = 0, Finite difference = 1.23761e+27, Analytical derivative = 1.23761e+27
+strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 0, Finite difference = 4.13904e+35, Analytical derivative = 4.13904e+35
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = -6.58657e+26, Analytical derivative = -6.58657e+26
+strain-rate: point = 2, component = 1, Finite difference = -1.23761e+27, Analytical derivative = -1.23761e+27
+strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 1, Finite difference = -4.13904e+35, Analytical derivative = -4.13904e+35
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = 3.5961e+28, Analytical derivative = 3.5961e+28
+strain-rate: point = 2, component = 2, Finite difference = -2.2502e+28, Analytical derivative = -2.2502e+28
+strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 2, Finite difference = -4.13904e+35, Analytical derivative = -4.13904e+35
 OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter geometric
-pressure at point 0: Finite difference = 0. Analytical derivative = 0
-pressure at point 1: Finite difference = 2.12594e+08. Analytical derivative = 2.12594e+08
-pressure at point 2: Finite difference = 2.68615e+08. Analytical derivative = 2.68615e+08
-pressure at point 3: Finite difference = 0. Analytical derivative = 0
-pressure at point 4: Finite difference = 1.8585e+16. Analytical derivative = 1.8585e+16
-zerozero at point 0: Finite difference = 0. Analytical derivative = 0
-zerozero at point 1: Finite difference = 6.58587e+26. Analytical derivative = 6.58655e+26
-zerozero at point 2: Finite difference = 1.23759e+27. Analytical derivative = 1.23761e+27
-zerozero at point 3: Finite difference = 0. Analytical derivative = 0
-zerozero at point 4: Finite difference = 4.13904e+35. Analytical derivative = 4.13904e+35
-onezero at point 0: Finite difference = 0. Analytical derivative = 0
-onezero at point 1: Finite difference = 3.5961e+28. Analytical derivative = 3.5961e+28
-onezero at point 2: Finite difference = -2.2502e+28. Analytical derivative = -2.2502e+28
-onezero at point 3: Finite difference = 0. Analytical derivative = 0
-onezero at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
-oneone at point 0: Finite difference = 0. Analytical derivative = 0
-oneone at point 1: Finite difference = -6.58596e+26. Analytical derivative = -6.58657e+26
-oneone at point 2: Finite difference = -1.23785e+27. Analytical derivative = -1.23761e+27
-oneone at point 3: Finite difference = 0. Analytical derivative = 0
-oneone at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
+pressure: point = 0, Finite difference = 0, Analytical derivative = 0
+pressure: point = 1, Finite difference = 2.12594e+08, Analytical derivative = 2.12594e+08
+pressure: point = 2, Finite difference = 2.68615e+08, Analytical derivative = 2.68615e+08
+pressure: point = 3, Finite difference = 0, Analytical derivative = 0
+pressure: point = 4, Finite difference = 1.8585e+16, Analytical derivative = 1.8585e+16
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 6.58587e+26, Analytical derivative = 6.58655e+26
+strain-rate: point = 2, component = 0, Finite difference = 1.23759e+27, Analytical derivative = 1.23761e+27
+strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 0, Finite difference = 4.13904e+35, Analytical derivative = 4.13904e+35
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = -6.58596e+26, Analytical derivative = -6.58657e+26
+strain-rate: point = 2, component = 1, Finite difference = -1.23785e+27, Analytical derivative = -1.23761e+27
+strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 1, Finite difference = -4.13904e+35, Analytical derivative = -4.13904e+35
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = 3.5961e+28, Analytical derivative = 3.5961e+28
+strain-rate: point = 2, component = 2, Finite difference = -2.2502e+28, Analytical derivative = -2.2502e+28
+strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 2, Finite difference = -4.13904e+35, Analytical derivative = -4.13904e+35
 OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter arithmetic
-pressure at point 0: Finite difference = 0. Analytical derivative = 0
-pressure at point 1: Finite difference = 2.12594e+08. Analytical derivative = 2.12594e+08
-pressure at point 2: Finite difference = 2.68615e+08. Analytical derivative = 2.68615e+08
-pressure at point 3: Finite difference = 0. Analytical derivative = 0
-pressure at point 4: Finite difference = 1.8585e+16. Analytical derivative = 1.8585e+16
-zerozero at point 0: Finite difference = 0. Analytical derivative = 0
-zerozero at point 1: Finite difference = 6.58655e+26. Analytical derivative = 6.58655e+26
-zerozero at point 2: Finite difference = 1.23761e+27. Analytical derivative = 1.23761e+27
-zerozero at point 3: Finite difference = 0. Analytical derivative = 0
-zerozero at point 4: Finite difference = 4.13904e+35. Analytical derivative = 4.13904e+35
-onezero at point 0: Finite difference = 0. Analytical derivative = 0
-onezero at point 1: Finite difference = 3.5961e+28. Analytical derivative = 3.5961e+28
-onezero at point 2: Finite difference = -2.2502e+28. Analytical derivative = -2.2502e+28
-onezero at point 3: Finite difference = 0. Analytical derivative = 0
-onezero at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
-oneone at point 0: Finite difference = 0. Analytical derivative = 0
-oneone at point 1: Finite difference = -6.58657e+26. Analytical derivative = -6.58657e+26
-oneone at point 2: Finite difference = -1.23761e+27. Analytical derivative = -1.23761e+27
-oneone at point 3: Finite difference = 0. Analytical derivative = 0
-oneone at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
+pressure: point = 0, Finite difference = 0, Analytical derivative = 0
+pressure: point = 1, Finite difference = 2.12594e+08, Analytical derivative = 2.12594e+08
+pressure: point = 2, Finite difference = 2.68615e+08, Analytical derivative = 2.68615e+08
+pressure: point = 3, Finite difference = 0, Analytical derivative = 0
+pressure: point = 4, Finite difference = 1.8585e+16, Analytical derivative = 1.8585e+16
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 6.58655e+26, Analytical derivative = 6.58655e+26
+strain-rate: point = 2, component = 0, Finite difference = 1.23761e+27, Analytical derivative = 1.23761e+27
+strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 0, Finite difference = 4.13904e+35, Analytical derivative = 4.13904e+35
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = -6.58657e+26, Analytical derivative = -6.58657e+26
+strain-rate: point = 2, component = 1, Finite difference = -1.23761e+27, Analytical derivative = -1.23761e+27
+strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 1, Finite difference = -4.13904e+35, Analytical derivative = -4.13904e+35
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = 3.5961e+28, Analytical derivative = 3.5961e+28
+strain-rate: point = 2, component = 2, Finite difference = -2.2502e+28, Analytical derivative = -2.2502e+28
+strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 2, Finite difference = -4.13904e+35, Analytical derivative = -4.13904e+35
 OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter maximum composition
-pressure at point 0: Finite difference = 0. Analytical derivative = 0
-pressure at point 1: Finite difference = 2.12594e+08. Analytical derivative = 2.12594e+08
-pressure at point 2: Finite difference = 2.68615e+08. Analytical derivative = 2.68615e+08
-pressure at point 3: Finite difference = 0. Analytical derivative = 0
-pressure at point 4: Finite difference = 1.8585e+16. Analytical derivative = 1.8585e+16
-zerozero at point 0: Finite difference = 0. Analytical derivative = 0
-zerozero at point 1: Finite difference = 6.58655e+26. Analytical derivative = 6.58655e+26
-zerozero at point 2: Finite difference = 1.23761e+27. Analytical derivative = 1.23761e+27
-zerozero at point 3: Finite difference = 0. Analytical derivative = 0
-zerozero at point 4: Finite difference = 4.13904e+35. Analytical derivative = 4.13904e+35
-onezero at point 0: Finite difference = 0. Analytical derivative = 0
-onezero at point 1: Finite difference = 3.5961e+28. Analytical derivative = 3.5961e+28
-onezero at point 2: Finite difference = -2.2502e+28. Analytical derivative = -2.2502e+28
-onezero at point 3: Finite difference = 0. Analytical derivative = 0
-onezero at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
-oneone at point 0: Finite difference = 0. Analytical derivative = 0
-oneone at point 1: Finite difference = -6.58657e+26. Analytical derivative = -6.58657e+26
-oneone at point 2: Finite difference = -1.23761e+27. Analytical derivative = -1.23761e+27
-oneone at point 3: Finite difference = 0. Analytical derivative = 0
-oneone at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
+pressure: point = 0, Finite difference = 0, Analytical derivative = 0
+pressure: point = 1, Finite difference = 2.12594e+08, Analytical derivative = 2.12594e+08
+pressure: point = 2, Finite difference = 2.68615e+08, Analytical derivative = 2.68615e+08
+pressure: point = 3, Finite difference = 0, Analytical derivative = 0
+pressure: point = 4, Finite difference = 1.8585e+16, Analytical derivative = 1.8585e+16
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 6.58655e+26, Analytical derivative = 6.58655e+26
+strain-rate: point = 2, component = 0, Finite difference = 1.23761e+27, Analytical derivative = 1.23761e+27
+strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 0, Finite difference = 4.13904e+35, Analytical derivative = 4.13904e+35
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = -6.58657e+26, Analytical derivative = -6.58657e+26
+strain-rate: point = 2, component = 1, Finite difference = -1.23761e+27, Analytical derivative = -1.23761e+27
+strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 1, Finite difference = -4.13904e+35, Analytical derivative = -4.13904e+35
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = 3.5961e+28, Analytical derivative = 3.5961e+28
+strain-rate: point = 2, component = 2, Finite difference = -2.2502e+28, Analytical derivative = -2.2502e+28
+strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 2, Finite difference = -4.13904e+35, Analytical derivative = -4.13904e+35
 OK
 Number of active cells: 100 (on 1 levels)
 Number of degrees of freedom: 2,767 (882+121+441+441+441+441)

--- a/tests/visco_plastic_derivatives_3d.cc
+++ b/tests/visco_plastic_derivatives_3d.cc
@@ -23,6 +23,8 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   std::cout << std::endl << "Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter " << averaging_parameter << std::endl;
 
   using namespace aspect::MaterialModel;
+
+  // first set all material model values
   MaterialModelInputs<dim> in_base(5,3);
   in_base.composition[0][0] = 0;
   in_base.composition[0][1] = 0;
@@ -40,6 +42,12 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   in_base.composition[4][1] = 0;
   in_base.composition[4][2] = 0;
 
+  in_base.temperature[0] = 293;
+  in_base.temperature[1] = 1600;
+  in_base.temperature[2] = 2000;
+  in_base.temperature[3] = 2100;
+  in_base.temperature[4] = 600;
+
   in_base.pressure[0] = 1e9;
   in_base.pressure[1] = 5e9;
   in_base.pressure[2] = 2e10;
@@ -55,85 +63,55 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   in_base.strain_rate[0][0][0] = 1e-12;
   in_base.strain_rate[0][0][1] = 1e-12;
   in_base.strain_rate[0][1][1] = 1e-11;
+  in_base.strain_rate[0][2][0] = 1e-12;
+  in_base.strain_rate[0][2][1] = 1e-12;
+  in_base.strain_rate[0][2][2] = 1e-11;
+
   in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[1][0][0] = -1.71266e-13;
   in_base.strain_rate[1][0][1] = -5.82647e-12;
   in_base.strain_rate[1][1][1] = 4.21668e-14;
+  in_base.strain_rate[1][2][0] = -5.42647e-12;
+  in_base.strain_rate[1][2][1] = -5.22647e-12;
+  in_base.strain_rate[1][2][2] = 4.21668e-14;
+
   in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[2][1][1] = 1e-13;
   in_base.strain_rate[2][0][1] = 1e-11;
   in_base.strain_rate[2][0][0] = -1e-12;
+  in_base.strain_rate[2][2][0] = 1e-11;
+  in_base.strain_rate[2][2][1] = 1e-11;
+  in_base.strain_rate[2][2][2] = -1e-12;
+
   in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[3][1][1] = 4.9e-21;
   in_base.strain_rate[3][0][1] = 4.9e-21;
   in_base.strain_rate[3][0][0] = 4.9e-21;
+  in_base.strain_rate[3][2][0] = 4.9e-21;
+  in_base.strain_rate[3][2][1] = 4.9e-21;
+  in_base.strain_rate[3][2][2] = 4.9e-21;
+
   in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
   in_base.strain_rate[4][1][1] = 1e-11;
   in_base.strain_rate[4][0][1] = 1e-11;
-  in_base.strain_rate[4][0][0] = -1e-11;
+  in_base.strain_rate[4][0][0] = -5e-12;
+  in_base.strain_rate[4][2][0] = 1e-11;
+  in_base.strain_rate[4][2][1] = 1e-11;
+  in_base.strain_rate[4][2][2] = -5e-12;
 
-  in_base.temperature[0] = 293;
-  in_base.temperature[1] = 1600;
-  in_base.temperature[2] = 2000;
-  in_base.temperature[3] = 2100;
-  in_base.temperature[4] = 600;
 
-  SymmetricTensor<2,dim> zerozero = SymmetricTensor<2,dim>();
-  SymmetricTensor<2,dim> onezero = SymmetricTensor<2,dim>();
-  SymmetricTensor<2,dim> oneone = SymmetricTensor<2,dim>();
-
-  zerozero[0][0] = 1;
-  onezero[1][0]  = 0.5; // because symmetry doubles this entry
-  oneone[1][1]   = 1;
-
+  // initialize some variables we will need later.
   double finite_difference_accuracy = 1e-7;
   double finite_difference_factor = 1+finite_difference_accuracy;
 
-  bool Error = false;
 
-  MaterialModelInputs<dim> in_dviscositydpressure(in_base);
-  in_dviscositydpressure.pressure[0] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[1] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[2] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[3] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[4] *= finite_difference_factor;
-
-  MaterialModelInputs<dim> in_dviscositydstrainrate_zerozero(in_base);
-  MaterialModelInputs<dim> in_dviscositydstrainrate_onezero(in_base);
-  MaterialModelInputs<dim> in_dviscositydstrainrate_oneone(in_base);
-
-  in_dviscositydstrainrate_zerozero.strain_rate[0] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[0][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[1] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[1][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[2] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[2][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[3] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[3][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[4] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[4][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_onezero.strain_rate[0]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[0][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[1]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[1][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[2]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[2][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[3]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[3][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[4]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[4][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_oneone.strain_rate[0]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[0][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[1]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[1][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[2]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[2][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[3]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[3][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[4]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[4][1][1]) * finite_difference_accuracy * oneone;
-
-  MaterialModelInputs<dim> in_dviscositydtemperature(in_base);
-  in_dviscositydtemperature.temperature[0] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[1] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[2] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[3] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[4] *= 1.0000000001;
-
+  MaterialModelInputs<dim> in_dviscositydstrainrate(in_base);
 
   MaterialModelOutputs<dim> out_base(5,3);
-
   MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate_zerozero(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate_onezero(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate_oneone(5,3);
-  MaterialModelOutputs<dim> out_dviscositydtemperature(5,3);
+  MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
 
+  // initialize the material we want to test.
   aspect::ParameterHandler prm;
 
   const aspect::MaterialModel::ViscoPlastic<dim> const_material_model = dynamic_cast<const aspect::MaterialModel::ViscoPlastic<dim> &>(simulator_access.get_material_model());
@@ -157,17 +135,25 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   out_base.additional_outputs.push_back(std_cxx11::make_shared<MaterialModelDerivatives<dim> > (5));
 
   simulator_access.get_material_model().evaluate(in_base, out_base);
-  simulator_access.get_material_model().evaluate(in_dviscositydpressure, out_dviscositydpressure);
-  simulator_access.get_material_model().evaluate(in_dviscositydstrainrate_zerozero, out_dviscositydstrainrate_zerozero);
-  simulator_access.get_material_model().evaluate(in_dviscositydstrainrate_onezero, out_dviscositydstrainrate_onezero);
-  simulator_access.get_material_model().evaluate(in_dviscositydstrainrate_oneone, out_dviscositydstrainrate_oneone);
-  simulator_access.get_material_model().evaluate(in_dviscositydtemperature, out_dviscositydtemperature);
 
   // set up additional output for the derivatives
   MaterialModelDerivatives<dim> *derivatives;
   derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim> >();
-
   double temp;
+
+  // have a bool so we know whether the test has succeed or not.
+  bool Error = false;
+
+  // test the pressure derivative.
+  MaterialModelInputs<dim> in_dviscositydpressure(in_base);
+  in_dviscositydpressure.pressure[0] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[1] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[2] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[3] *= finite_difference_factor;
+  in_dviscositydpressure.pressure[4] *= finite_difference_factor;
+
+  simulator_access.get_material_model().evaluate(in_dviscositydpressure, out_dviscositydpressure);
+
   for (unsigned int i = 0; i < 5; i++)
     {
       // prevent division by zero. If it is zero, the test has passed, because or
@@ -178,70 +164,48 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
         {
           temp /= (in_base.pressure[i] * finite_difference_accuracy);
         }
-      std::cout << "pressure at point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i]  << std::endl;
+      std::cout << "pressure: point = " << i << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i]  << std::endl;
       if (std::fabs(temp - derivatives->viscosity_derivative_wrt_pressure[i]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_pressure[i])))
-        // if (temp > derivatives->viscosity_derivative_wrt_pressure[i] * finite_difference_factor || temp < derivatives->viscosity_derivative_wrt_pressure[i] * (2-finite_difference_factor))
         {
-          std::cout << "   Error: The derivative of the viscosity to the pressure is too different from the analitical value." << std::endl;
+          std::cout << "   Error: The derivative of the viscosity to the pressure is too different from the analytical value." << std::endl;
           Error = true;
         }
 
     }
 
-  for (unsigned int i = 0; i < 5; i++)
+  // test the strain-rate derivative.
+  for (unsigned int component = 0; component < SymmetricTensor<2,dim>::n_independent_components; ++component)
     {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = out_dviscositydstrainrate_zerozero.viscosities[i] - out_base.viscosities[i];
-      if (temp != 0)
+      const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
+
+      for (unsigned int i = 0; i < 5; i++)
         {
-          temp /= std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[i][0][0]) * finite_difference_accuracy;
-        }
-      std::cout << "zerozero at point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][0][0]  << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][0][0]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][0][0])))
-        {
-          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analitical value." << std::endl;
-          Error = true;
+          in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
+                                                    + std::fabs(in_base.strain_rate[i][strain_rate_indices])
+                                                    * finite_difference_accuracy
+                                                    * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
         }
 
 
+      simulator_access.get_material_model().evaluate(in_dviscositydstrainrate, out_dviscositydstrainrate);
 
-    }
+      for (unsigned int i = 0; i < 5; i++)
+        {
+          // prevent division by zero. If it is zero, the test has passed, because or
+          // the finite difference and the analytical result match perfectly, or (more
+          // likely) the material model in independent of this variable.
+          temp = out_dviscositydstrainrate.viscosities[i] - out_base.viscosities[i];
+          if (temp != 0)
+            {
+              temp /= std::fabs(in_dviscositydstrainrate.strain_rate[i][strain_rate_indices]) * finite_difference_accuracy;
+            }
+          std::cout << "strain-rate: point = " << i << ", component = " << component << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]  << std::endl;
+          if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices])))
+            {
+              std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
+              Error = true;
+            }
 
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = out_dviscositydstrainrate_onezero.viscosities[i] - out_base.viscosities[i];
-      if (temp != 0)
-        {
-          temp /= std::fabs(in_dviscositydstrainrate_onezero.strain_rate[i][1][0]) * finite_difference_accuracy;
-        }
-      std::cout << "onezero at point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]   << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][0])) )
-        {
-          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
-          Error = true;
-        }
-    }
-
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = out_dviscositydstrainrate_oneone.viscosities[i] - out_base.viscosities[i];
-      if (temp != 0)
-        {
-          temp /= std::fabs(in_dviscositydstrainrate_oneone.strain_rate[i][1][1]) * finite_difference_accuracy;
-        }
-      std::cout << "oneone at point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]  << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][1])) )
-        {
-          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
-          Error = true;
         }
 
     }

--- a/tests/visco_plastic_derivatives_3d/screen-output
+++ b/tests/visco_plastic_derivatives_3d/screen-output
@@ -6,95 +6,158 @@ Loading shared library <./libvisco_plastic_derivatives_3d.so>
 * Connecting signals
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter harmonic
-pressure at point 0: Finite difference = 0. Analytical derivative = 0
-pressure at point 1: Finite difference = 2.12591e+08. Analytical derivative = 2.12591e+08
-pressure at point 2: Finite difference = 2.68566e+08. Analytical derivative = 2.68566e+08
-pressure at point 3: Finite difference = 0. Analytical derivative = 0
-pressure at point 4: Finite difference = 1.8585e+16. Analytical derivative = 1.8585e+16
-zerozero at point 0: Finite difference = 0. Analytical derivative = 0
-zerozero at point 1: Finite difference = 7.91418e+26. Analytical derivative = 7.91418e+26
-zerozero at point 2: Finite difference = 1.57396e+27. Analytical derivative = 1.57396e+27
-zerozero at point 3: Finite difference = 0. Analytical derivative = 0
-zerozero at point 4: Finite difference = 4.13904e+35. Analytical derivative = 4.13904e+35
-onezero at point 0: Finite difference = 0. Analytical derivative = 0
-onezero at point 1: Finite difference = 3.59591e+28. Analytical derivative = 3.59591e+28
-onezero at point 2: Finite difference = -2.24851e+28. Analytical derivative = -2.24851e+28
-onezero at point 3: Finite difference = 0. Analytical derivative = 0
-onezero at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
-oneone at point 0: Finite difference = 0. Analytical derivative = 0
-oneone at point 1: Finite difference = -5.2582e+26. Analytical derivative = -5.2582e+26
-oneone at point 2: Finite difference = -8.99379e+26. Analytical derivative = -8.99379e+26
-oneone at point 3: Finite difference = 0. Analytical derivative = 0
-oneone at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
+pressure: point = 0, Finite difference = 0, Analytical derivative = 0
+pressure: point = 1, Finite difference = 1.52812e+08, Analytical derivative = 1.52812e+08
+pressure: point = 2, Finite difference = 1.96803e+08, Analytical derivative = 1.96803e+08
+pressure: point = 3, Finite difference = 0, Analytical derivative = 0
+pressure: point = 4, Finite difference = 1.48478e+16, Analytical derivative = 1.48478e+16
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 2.48798e+26, Analytical derivative = 2.48801e+26
+strain-rate: point = 2, component = 0, Finite difference = 2.34886e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 0, Finite difference = 8.81796e+34, Analytical derivative = 8.81796e+34
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = -1.24397e+26, Analytical derivative = -1.24382e+26
+strain-rate: point = 2, component = 1, Finite difference = -4.69773e+26, Analytical derivative = -4.69773e+26
+strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 1, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = -1.24397e+26, Analytical derivative = -1.24382e+26
+strain-rate: point = 2, component = 2, Finite difference = 2.34886e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 2, Finite difference = 8.81796e+34, Analytical derivative = 8.81796e+34
+strain-rate: point = 0, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 3, Finite difference = 1.01879e+28, Analytical derivative = 1.01879e+28
+strain-rate: point = 2, component = 3, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 3, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 3, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
+strain-rate: point = 0, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 4, Finite difference = 9.48845e+27, Analytical derivative = 9.48845e+27
+strain-rate: point = 2, component = 4, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 3, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 4, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
+strain-rate: point = 0, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 5, Finite difference = 9.13874e+27, Analytical derivative = 9.13874e+27
+strain-rate: point = 2, component = 5, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 3, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 5, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
 OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter geometric
-pressure at point 0: Finite difference = 0. Analytical derivative = 0
-pressure at point 1: Finite difference = 2.12591e+08. Analytical derivative = 2.12591e+08
-pressure at point 2: Finite difference = 2.68566e+08. Analytical derivative = 2.68566e+08
-pressure at point 3: Finite difference = 0. Analytical derivative = 0
-pressure at point 4: Finite difference = 1.8585e+16. Analytical derivative = 1.8585e+16
-zerozero at point 0: Finite difference = 0. Analytical derivative = 0
-zerozero at point 1: Finite difference = 7.91403e+26. Analytical derivative = 7.91418e+26
-zerozero at point 2: Finite difference = 1.57395e+27. Analytical derivative = 1.57396e+27
-zerozero at point 3: Finite difference = 0. Analytical derivative = 0
-zerozero at point 4: Finite difference = 4.13904e+35. Analytical derivative = 4.13904e+35
-onezero at point 0: Finite difference = 0. Analytical derivative = 0
-onezero at point 1: Finite difference = 3.59591e+28. Analytical derivative = 3.59591e+28
-onezero at point 2: Finite difference = -2.24851e+28. Analytical derivative = -2.24851e+28
-onezero at point 3: Finite difference = 0. Analytical derivative = 0
-onezero at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
-oneone at point 0: Finite difference = 0. Analytical derivative = 0
-oneone at point 1: Finite difference = -5.25972e+26. Analytical derivative = -5.2582e+26
-oneone at point 2: Finite difference = -8.98394e+26. Analytical derivative = -8.99379e+26
-oneone at point 3: Finite difference = 0. Analytical derivative = 0
-oneone at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
-OK
+pressure: point = 0, Finite difference = 0, Analytical derivative = 0
+pressure: point = 1, Finite difference = 1.52812e+08, Analytical derivative = 1.52812e+08
+pressure: point = 2, Finite difference = 1.96803e+08, Analytical derivative = 1.96803e+08
+pressure: point = 3, Finite difference = 0, Analytical derivative = 0
+pressure: point = 4, Finite difference = 1.48478e+16, Analytical derivative = 1.48478e+16
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 2.48652e+26, Analytical derivative = 2.48801e+26
+strain-rate: point = 2, component = 0, Finite difference = 2.3492e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 0, Finite difference = 8.81796e+34, Analytical derivative = 8.81796e+34
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = -1.24701e+26, Analytical derivative = -1.24382e+26
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: point = 2, component = 1, Finite difference = -4.68813e+26, Analytical derivative = -4.69773e+26
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 1, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = -1.24701e+26, Analytical derivative = -1.24382e+26
+   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: point = 2, component = 2, Finite difference = 2.3492e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 2, Finite difference = 8.81796e+34, Analytical derivative = 8.81796e+34
+strain-rate: point = 0, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 3, Finite difference = 1.01879e+28, Analytical derivative = 1.01879e+28
+strain-rate: point = 2, component = 3, Finite difference = -6.40594e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 3, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 3, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
+strain-rate: point = 0, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 4, Finite difference = 9.48844e+27, Analytical derivative = 9.48845e+27
+strain-rate: point = 2, component = 4, Finite difference = -6.40594e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 3, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 4, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
+strain-rate: point = 0, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 5, Finite difference = 9.13873e+27, Analytical derivative = 9.13874e+27
+strain-rate: point = 2, component = 5, Finite difference = -6.40594e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 3, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 5, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
+Some parts of the test where not successful.
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter arithmetic
-pressure at point 0: Finite difference = 0. Analytical derivative = 0
-pressure at point 1: Finite difference = 2.12591e+08. Analytical derivative = 2.12591e+08
-pressure at point 2: Finite difference = 2.68566e+08. Analytical derivative = 2.68566e+08
-pressure at point 3: Finite difference = 0. Analytical derivative = 0
-pressure at point 4: Finite difference = 1.8585e+16. Analytical derivative = 1.8585e+16
-zerozero at point 0: Finite difference = 0. Analytical derivative = 0
-zerozero at point 1: Finite difference = 7.91426e+26. Analytical derivative = 7.91418e+26
-zerozero at point 2: Finite difference = 1.57396e+27. Analytical derivative = 1.57396e+27
-zerozero at point 3: Finite difference = 0. Analytical derivative = 0
-zerozero at point 4: Finite difference = 4.13904e+35. Analytical derivative = 4.13904e+35
-onezero at point 0: Finite difference = 0. Analytical derivative = 0
-onezero at point 1: Finite difference = 3.59591e+28. Analytical derivative = 3.59591e+28
-onezero at point 2: Finite difference = -2.24851e+28. Analytical derivative = -2.24851e+28
-onezero at point 3: Finite difference = 0. Analytical derivative = 0
-onezero at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
-oneone at point 0: Finite difference = 0. Analytical derivative = 0
-oneone at point 1: Finite difference = -5.2582e+26. Analytical derivative = -5.2582e+26
-oneone at point 2: Finite difference = -8.99366e+26. Analytical derivative = -8.99379e+26
-oneone at point 3: Finite difference = 0. Analytical derivative = 0
-oneone at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
+pressure: point = 0, Finite difference = 0, Analytical derivative = 0
+pressure: point = 1, Finite difference = 1.52812e+08, Analytical derivative = 1.52812e+08
+pressure: point = 2, Finite difference = 1.96803e+08, Analytical derivative = 1.96803e+08
+pressure: point = 3, Finite difference = 0, Analytical derivative = 0
+pressure: point = 4, Finite difference = 1.48478e+16, Analytical derivative = 1.48478e+16
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 2.48801e+26, Analytical derivative = 2.48801e+26
+strain-rate: point = 2, component = 0, Finite difference = 2.34884e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 0, Finite difference = 8.81796e+34, Analytical derivative = 8.81796e+34
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = -1.24382e+26, Analytical derivative = -1.24382e+26
+strain-rate: point = 2, component = 1, Finite difference = -4.69773e+26, Analytical derivative = -4.69773e+26
+strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 1, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = -1.24382e+26, Analytical derivative = -1.24382e+26
+strain-rate: point = 2, component = 2, Finite difference = 2.34884e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 2, Finite difference = 8.81796e+34, Analytical derivative = 8.81796e+34
+strain-rate: point = 0, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 3, Finite difference = 1.01879e+28, Analytical derivative = 1.01879e+28
+strain-rate: point = 2, component = 3, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 3, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 3, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
+strain-rate: point = 0, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 4, Finite difference = 9.48845e+27, Analytical derivative = 9.48845e+27
+strain-rate: point = 2, component = 4, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 3, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 4, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
+strain-rate: point = 0, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 5, Finite difference = 9.13874e+27, Analytical derivative = 9.13874e+27
+strain-rate: point = 2, component = 5, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 3, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 5, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
 OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter maximum composition
-pressure at point 0: Finite difference = 0. Analytical derivative = 0
-pressure at point 1: Finite difference = 2.12591e+08. Analytical derivative = 2.12591e+08
-pressure at point 2: Finite difference = 2.68566e+08. Analytical derivative = 2.68566e+08
-pressure at point 3: Finite difference = 0. Analytical derivative = 0
-pressure at point 4: Finite difference = 1.8585e+16. Analytical derivative = 1.8585e+16
-zerozero at point 0: Finite difference = 0. Analytical derivative = 0
-zerozero at point 1: Finite difference = 7.91418e+26. Analytical derivative = 7.91418e+26
-zerozero at point 2: Finite difference = 1.57396e+27. Analytical derivative = 1.57396e+27
-zerozero at point 3: Finite difference = 0. Analytical derivative = 0
-zerozero at point 4: Finite difference = 4.13904e+35. Analytical derivative = 4.13904e+35
-onezero at point 0: Finite difference = 0. Analytical derivative = 0
-onezero at point 1: Finite difference = 3.59591e+28. Analytical derivative = 3.59591e+28
-onezero at point 2: Finite difference = -2.24851e+28. Analytical derivative = -2.24851e+28
-onezero at point 3: Finite difference = 0. Analytical derivative = 0
-onezero at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
-oneone at point 0: Finite difference = 0. Analytical derivative = 0
-oneone at point 1: Finite difference = -5.2582e+26. Analytical derivative = -5.2582e+26
-oneone at point 2: Finite difference = -8.99379e+26. Analytical derivative = -8.99379e+26
-oneone at point 3: Finite difference = 0. Analytical derivative = 0
-oneone at point 4: Finite difference = -4.13904e+35. Analytical derivative = -4.13904e+35
+pressure: point = 0, Finite difference = 0, Analytical derivative = 0
+pressure: point = 1, Finite difference = 1.52812e+08, Analytical derivative = 1.52812e+08
+pressure: point = 2, Finite difference = 1.96803e+08, Analytical derivative = 1.96803e+08
+pressure: point = 3, Finite difference = 0, Analytical derivative = 0
+pressure: point = 4, Finite difference = 1.48478e+16, Analytical derivative = 1.48478e+16
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 2.48801e+26, Analytical derivative = 2.48801e+26
+strain-rate: point = 2, component = 0, Finite difference = 2.34885e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 0, Finite difference = 8.81796e+34, Analytical derivative = 8.81796e+34
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = -1.24382e+26, Analytical derivative = -1.24382e+26
+strain-rate: point = 2, component = 1, Finite difference = -4.69773e+26, Analytical derivative = -4.69773e+26
+strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 1, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = -1.24382e+26, Analytical derivative = -1.24382e+26
+strain-rate: point = 2, component = 2, Finite difference = 2.34885e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 2, Finite difference = 8.81796e+34, Analytical derivative = 8.81796e+34
+strain-rate: point = 0, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 3, Finite difference = 1.01879e+28, Analytical derivative = 1.01879e+28
+strain-rate: point = 2, component = 3, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 3, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 3, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
+strain-rate: point = 0, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 4, Finite difference = 9.48845e+27, Analytical derivative = 9.48845e+27
+strain-rate: point = 2, component = 4, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 3, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 4, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
+strain-rate: point = 0, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 5, Finite difference = 9.13874e+27, Analytical derivative = 9.13874e+27
+strain-rate: point = 2, component = 5, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 3, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 4, component = 5, Finite difference = -1.76359e+35, Analytical derivative = -1.76359e+35
 OK
 Number of active cells: 100 (on 1 levels)
 Number of degrees of freedom: 9,503 (3,969+242+1,323+1,323+1,323+1,323)


### PR DESCRIPTION
This is a large restructuring of the derivatives tests. This makes them cleaner, shorter, more uniform and better documented :)

The 2d values should be the same as before, but the order in which they appear is different. The 3d cases now use full 3d strain-rate tensors.

