### PR TITLE
Fix visco plastic floating point exception

### DIFF
--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -537,7 +537,7 @@ namespace aspect
           // which represents the second invariant of the strain tensor
           double edot_ii = 0.;
           double e_ii = 0.;
-          if  (use_strain_weakening == true && use_finite_strain_tensor == false && this->get_timestep_number() > 0)
+          if  (in.strain_rate.size() > 0 && use_strain_weakening == true && use_finite_strain_tensor == false && this->get_timestep_number() > 0)
             {
               edot_ii = std::max(sqrt(std::fabs(second_invariant(deviator(strain_rate)))),min_strain_rate);
               e_ii = edot_ii*this->get_timestep();

--- a/tests/visco_plastic_yield_strain_weakening.prm
+++ b/tests/visco_plastic_yield_strain_weakening.prm
@@ -1,7 +1,7 @@
 # Global parameters
 set Dimension                              = 2
 set Start time                             = 0
-set End time                               = 0
+set End time                               = 1
 set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = single Advection, iterated Stokes
 set Max nonlinear iterations               = 1

--- a/tests/visco_plastic_yield_strain_weakening/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening/screen-output
@@ -21,6 +21,24 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
 +---------------------------------+-----------+------------+------------+
 +---------------------------------+-----------+------------+------------+
 
+*** Timestep 1:  t=1 years
+   Solving temperature system... 0 iterations.
+   Solving eii system ... 5 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+6 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.000253206
+
+
+   Postprocessing:
+     RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
+     Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
+
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
 Termination requested by criterion: end time
 
 

--- a/tests/visco_plastic_yield_strain_weakening/statistics
+++ b/tests/visco_plastic_yield_strain_weakening/statistics
@@ -19,3 +19,4 @@
 # 19: Outward mass flux through boundary with indicator 3 ("top") (kg/yr)
 # 20: Visualization file name
 0 0.000000000000e+00 0.000000000000e+00 100 1003 441 441 1 0 0 7 20 16 4.08249672e-04 6.91118644e-04 1.65115500e+05 1.65115500e+05 -1.65115500e+05 -1.65115500e+05 output-visco_plastic_yield_strain_weakening/solution/solution-00000 
+1 1.000000000000e+00 1.000000000000e+00 100 1003 441 441 1 0 5 6 21 14 4.08253150e-04 6.91043493e-04 1.65115500e+05 1.65115500e+05 -1.65115500e+05 -1.65115500e+05                                                                  "" 


### PR DESCRIPTION
The visco plastic material model throws floating point exceptions when used with strain weakening, because it assumes to always get a strain rate, which is not the case. This was not covered by the existing test, because the test only solves the first timestep (for which strain weakening is explicitly disabled). The fix is simple, and might be important enough to be cherry picked to the release branch. But I will leave that decision up to @naliboff and @tjhei.