### PR TITLE
add a link to the ASPECT 2.0 webinar

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,6 +258,11 @@
 
 	    <p>
 	      2018/05/10:
+	      <a href="https://www.youtube.com/watch?v=5lfZDGMlPY4"> Webinar about new features in <abbr>ASPECT</abbr> 2.0</a>
+	    </p>
+
+	    <p>
+	      2018/05/10:
 	      <a href="https://github.com/geodynamics/aspect/releases/tag/v2.0.0"><abbr>ASPECT</abbr> 2.0 released</a>
 	    </p>
 


### PR DESCRIPTION
I thought we should link to the webinar so that people can go and watch it if they missed it and want to hear about the new features. If you think there's a better places than in the "News" column, let me know!