### PR TITLE
Update the citation page.

### DIFF
--- a/cite.html
+++ b/cite.html
@@ -55,8 +55,10 @@ We thank the Computational Infrastructure for Geodynamics (geodynamics.org) whic
 	      The canonical reference for this software is:
               <pre><code>
 @Article{heister_aspect_methods2,
-  Title                    = {High Accuracy Mantle Convection Simulation through Modern Numerical Methods. {II}: {R}ealistic Models and Problems},
-  Author                   = {Heister, Timo and Dannberg, Juliane and Gassm{\"o}ller, Rene and Bangerth, Wolfgang},
+  Title                    = {High Accuracy Mantle Convection Simulation through Modern Numerical Methods.
+                              {II}: {R}ealistic Models and Problems},
+  Author                   = {Heister, Timo and Dannberg, Juliane and
+                              Gassm{\"o}ller, Rene and Bangerth, Wolfgang},
   Journal                  = {Geophysical Journal International},
   Year                     = {2017},
   Number                   = {2},
@@ -88,8 +90,7 @@ We thank the Computational Infrastructure for Geodynamics (geodynamics.org) whic
 @Article{aspectmanual,
   Title         = {{\textsc{ASPECT}: Advanced Solver for Problems in Earth's ConvecTion, User Manual}},
   Author        = {W. Bangerth and J. Dannberg and R. Gassm{\"o}ller and T. Heister and others},
-  Year          = {2017},
-  Month         = {4},
+  Year          = {2018},
   DOI           = {10.6084/m9.figshare.4865333},
   Note          = {doi:10.6084/m9.figshare.4865333},
   URL           = {https://doi.org/10.6084/m9.figshare.4865333}

--- a/cite.html
+++ b/cite.html
@@ -55,18 +55,18 @@ We thank the Computational Infrastructure for Geodynamics (geodynamics.org) whic
 	      The canonical reference for this software is:
               <pre><code>
 @Article{heister_aspect_methods2,
-  Title                    = {High Accuracy Mantle Convection Simulation through Modern Numerical Methods.
+  title                    = {High Accuracy Mantle Convection Simulation through Modern Numerical Methods.
                               {II}: {R}ealistic Models and Problems},
-  Author                   = {Heister, Timo and Dannberg, Juliane and
+  author                   = {Heister, Timo and Dannberg, Juliane and
                               Gassm{\"o}ller, Rene and Bangerth, Wolfgang},
-  Journal                  = {Geophysical Journal International},
-  Year                     = {2017},
-  Number                   = {2},
-  Pages                    = {833-851},
-  Volume                   = {210},
+  journal                  = {Geophysical Journal International},
+  year                     = {2017},
+  number                   = {2},
+  pages                    = {833-851},
+  volume                   = {210},
 
-  Doi                      = {10.1093/gji/ggx195},
-  Url                      = {https://doi.org/10.1093/gji/ggx195}
+  DOI                      = {10.1093/gji/ggx195},
+  URL                      = {https://doi.org/10.1093/gji/ggx195}
 }</code></pre>
 	      The most recent release of ASPECT (v2.0.0) can be cited as:
               <pre><code>
@@ -79,8 +79,8 @@ We thank the Computational Infrastructure for Geodynamics (geodynamics.org) whic
                   others},
   month        = may,
   year         = 2018,
-  doi          = {10.5281/zenodo.1244587},
-  url          = {https://doi.org/10.5281/zenodo.1244587}
+  DOI          = {10.5281/zenodo.1244587},
+  URL          = {https://doi.org/10.5281/zenodo.1244587}
   organization = {Computational Infrastructure for Geodynamics},
   address      = {Davis, CA},
 }
@@ -88,11 +88,12 @@ We thank the Computational Infrastructure for Geodynamics (geodynamics.org) whic
               The manual's proper reference is:
               <pre><code>
 @Article{aspectmanual,
-  Title         = {{\textsc{ASPECT}: Advanced Solver for Problems in Earth's ConvecTion, User Manual}},
-  Author        = {W. Bangerth and J. Dannberg and R. Gassm{\"o}ller and T. Heister and others},
-  Year          = {2018},
+  title         = {{\textsc{ASPECT}: Advanced Solver for Problems in Earth's ConvecTion, User Manual}},
+  author        = {W. Bangerth and J. Dannberg and R. Gassm{\"o}ller and T. Heister and others},
+  year          = {2018},
+  month         = {5},
   DOI           = {10.6084/m9.figshare.4865333},
-  Note          = {doi:10.6084/m9.figshare.4865333},
+  note          = {doi:10.6084/m9.figshare.4865333},
   URL           = {https://doi.org/10.6084/m9.figshare.4865333}
 }</code></pre>
             </p>


### PR DESCRIPTION
Specifically: `<pre>` blocks are not formatted, so long lines break awkwardly.
Also update the year of the manual.