### PR TITLE
fix bug described in [issue #2252]

### DIFF
--- a/include/aspect/simulator/assemblers/interface.h
+++ b/include/aspect/simulator/assemblers/interface.h
@@ -216,9 +216,9 @@ namespace aspect
 
           FEValues<dim> finite_element_values;
 
-          std_cxx11::shared_ptr<FEFaceValues<dim> >    face_finite_element_values;
-          std_cxx11::shared_ptr<FEFaceValues<dim> >    neighbor_face_finite_element_values;
-          std_cxx11::shared_ptr<FESubfaceValues<dim> > subface_finite_element_values;
+          std_cxx11::unique_ptr<FEFaceValues<dim> >    face_finite_element_values;
+          std_cxx11::unique_ptr<FEFaceValues<dim> >    neighbor_face_finite_element_values;
+          std_cxx11::unique_ptr<FESubfaceValues<dim> > subface_finite_element_values;
 
           std::vector<types::global_dof_index>   local_dof_indices;
 

--- a/source/simulator/assemblers/interface.cc
+++ b/source/simulator/assemblers/interface.cc
@@ -176,27 +176,27 @@ namespace aspect
           finite_element_values (mapping,
                                  finite_element, quadrature,
                                  update_flags),
-          face_finite_element_values ((face_quadrature.size() > 0
-                                       ?
-                                       new FEFaceValues<dim> (mapping,
-                                                              finite_element, face_quadrature,
-                                                              face_update_flags)
-                                       :
-                                       NULL)),
-          neighbor_face_finite_element_values ((face_quadrature.size() > 0
-                                                ?
-                                                new FEFaceValues<dim> (mapping,
-                                                                       finite_element, face_quadrature,
-                                                                       face_update_flags)
-                                                :
-                                                NULL)),
-          subface_finite_element_values ((face_quadrature.size() > 0
-                                          ?
-                                          new FESubfaceValues<dim> (mapping,
-                                                                    finite_element, face_quadrature,
-                                                                    face_update_flags)
-                                          :
-                                          NULL)),
+          face_finite_element_values (face_quadrature.size() > 0
+                                      ?
+                                      new FEFaceValues<dim> (mapping,
+                                                             finite_element, face_quadrature,
+                                                             face_update_flags)
+                                      :
+                                      NULL),
+          neighbor_face_finite_element_values (face_quadrature.size() > 0
+                                               ?
+                                               new FEFaceValues<dim> (mapping,
+                                                                      finite_element, face_quadrature,
+                                                                      face_update_flags)
+                                               :
+                                               NULL),
+          subface_finite_element_values (face_quadrature.size() > 0
+                                         ?
+                                         new FESubfaceValues<dim> (mapping,
+                                                                   finite_element, face_quadrature,
+                                                                   face_update_flags)
+                                         :
+                                         NULL),
           local_dof_indices (finite_element.dofs_per_cell),
 
           phi_field (advection_element.dofs_per_cell, numbers::signaling_nan<double>()),
@@ -263,9 +263,30 @@ namespace aspect
                                  scratch.finite_element_values.get_fe(),
                                  scratch.finite_element_values.get_quadrature(),
                                  scratch.finite_element_values.get_update_flags()),
-          face_finite_element_values (scratch.face_finite_element_values),
-          neighbor_face_finite_element_values (scratch.neighbor_face_finite_element_values),
-          subface_finite_element_values (scratch.subface_finite_element_values),
+          face_finite_element_values (scratch.face_finite_element_values.get()
+                                      ?
+                                      new FEFaceValues<dim> (scratch.face_finite_element_values->get_mapping(),
+                                                             scratch.face_finite_element_values->get_fe(),
+                                                             scratch.face_finite_element_values->get_quadrature(),
+                                                             scratch.face_finite_element_values->get_update_flags())
+                                      :
+                                      NULL),
+          neighbor_face_finite_element_values (scratch.neighbor_face_finite_element_values.get()
+                                               ?
+                                               new FEFaceValues<dim> (scratch.neighbor_face_finite_element_values->get_mapping(),
+                                                                      scratch.neighbor_face_finite_element_values->get_fe(),
+                                                                      scratch.neighbor_face_finite_element_values->get_quadrature(),
+                                                                      scratch.neighbor_face_finite_element_values->get_update_flags())
+                                               :
+                                               NULL),
+          subface_finite_element_values (scratch.subface_finite_element_values.get()
+                                         ?
+                                         new FESubfaceValues<dim> (scratch.subface_finite_element_values->get_mapping(),
+                                                                   scratch.subface_finite_element_values->get_fe(),
+                                                                   scratch.subface_finite_element_values->get_quadrature(),
+                                                                   scratch.subface_finite_element_values->get_update_flags())
+                                         :
+                                         NULL),
           local_dof_indices (scratch.finite_element_values.get_fe().dofs_per_cell),
 
           phi_field (scratch.phi_field),


### PR DESCRIPTION
This branch fixes the bug described in [issue #2252]. The modifications mostly follow the comments of @bangerth . This branch runs well with /tests/discontinuous_composition_1.prm using multi-threads now, while the master branch would fail.

However, there is a small problem when running ./aspect -j $PATH_TO_TESTS/discontinuous_composition_1.prm.  The output on my computer is like this:

`-----------------------------------------------------------------------------
-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
--     . version 2.1.0-pre (iss#2252, 5f43cb715)
--     . using deal.II 8.5.1
--     . using Trilinos 12.12.1
--     . using p4est 1.1.0
--     . running in DEBUG mode
--     . running with 1 MPI process
--     . using 8 threads 
-- How to cite ASPECT: https://aspect.geodynamics.org/cite.html
-----------------------------------------------------------------------------

... (timesteps)

Termination requested by criterion: end time


+---------------------------------------------+------------+------------+
| Total wallclock time elapsed since start    |      1.26s |            |
|                                             |            |            |
| Section                         | no. calls |  wall time | % of total |
+---------------------------------+-----------+------------+------------+
| Assemble Stokes system          |        18 |    0.0698s |       5.5% |
| Assemble composition system     |        36 |     0.399s |        32% |
| Assemble temperature system     |        18 |     0.144s |        11% |
| Build Stokes preconditioner     |        18 |    0.0992s |       7.9% |
| Build composition preconditioner|        36 |    0.0498s |         4% |
| Build temperature preconditioner|        18 |   0.00621s |      0.49% |
| Solve Stokes system             |        18 |    0.0524s |       4.2% |
| Solve composition system        |        36 |    0.0209s |       1.7% |
| Solve temperature system        |        18 |   0.00952s |      0.76% |
| Initialization                  |         1 |     0.035s |       2.8% |
| Postprocessing                  |        17 |    0.0254s |         2% |
| Refine mesh structure, part 1   |         9 |    0.0585s |       4.6% |
| Refine mesh structure, part 2   |         9 |    0.0064s |      0.51% |
| Setup dof systems               |        10 |    0.0382s |         3% |
| Setup initial conditions        |         2 |   0.00735s |      0.58% |
+---------------------------------+-----------+------------+------------+

WARNING! There are options you set that were not used!
WARNING! could be spelling mistake, etc!
Option left: name:-j value: ../tests/discontinuous_composition_1.prm
`

I don't know what the warnings mean. I'm sure that multi-thread works because the program runs faster than running without -j.

I'm a beginner of github and I don't know if it is appropriate to say so much here. The same description of the new problem is also pasted in [issue #2252 ] and I hope that someone would figure it out.

Please check my modifications. Thank you!