### PR TITLE
Fix initialization warning with PETSc

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -584,13 +584,18 @@ int main (int argc, char *argv[])
         }
     }
 
+  // There might be remaining arguments for PETSc, only hand those over to
+  // the MPI initialization, but not the ones we parsed above.
+  int n_remaining_arguments = argc - current_argument;
+  char **remaining_arguments = (n_remaining_arguments > 0) ? &argv[current_argument] : NULL;
+
   try
     {
       // Note: we initialize this class inside the try/catch block and not
       // before, so that the destructor of this instance can react if we are
       // currently unwinding the stack if an unhandled exception is being
       // thrown to avoid MPI deadlocks.
-      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, use_threads ? numbers::invalid_unsigned_int : 1);
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(n_remaining_arguments, remaining_arguments, use_threads ? numbers::invalid_unsigned_int : 1);
 
       deallog.depth_console(0);
 


### PR DESCRIPTION
This fixes the warnings reported in #2252 if deal.II is compiled with PETSc, and ASPECT has additional command line options unrecognized by PETSc (e.g. -j). I just filter out all ASPECT related options before initializing PETSc.