### PR TITLE
Add GRMES solver restart length as an input parameter

### DIFF
--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -337,6 +337,7 @@ namespace aspect
     double                         temperature_solver_tolerance;
     double                         composition_solver_tolerance;
     bool                           use_operator_splitting;
+    unsigned int                   n_solver_restart_length;
 
     /**
      * @}

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -334,10 +334,10 @@ namespace aspect
     unsigned int                   max_nonlinear_iterations_in_prerefinement;
     unsigned int                   n_cheap_stokes_solver_steps;
     unsigned int                   n_expensive_stokes_solver_steps;
+    unsigned int                   stokes_gmres_restart_length;
     double                         temperature_solver_tolerance;
     double                         composition_solver_tolerance;
     bool                           use_operator_splitting;
-    unsigned int                   n_solver_restart_length;
 
     /**
      * @}

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -347,6 +347,13 @@ namespace aspect
                            "not converge and return an error message pointing out that the user didn't allow "
                            "a sufficiently large number of iterations for the iterative solver to converge.");
 
+	prm.declare_entry("GMRES solver restart length", "50",
+			  Patterns::Integer(0),
+			  "This is the number of iterations that define the GMRES solver restart length. It "
+			  "helps with convergence issues arising from high viscosity jumps in the domain. "
+			  "Increasing this number to 200 iterations allows convergence with several orders "
+			  "magnitude viscosity jumps.");
+
         prm.declare_entry ("Linear solver A block tolerance", "1e-2",
                            Patterns::Double(0,1),
                            "A relative tolerance up to which the approximate inverse of the $A$ block "
@@ -1028,6 +1035,7 @@ namespace aspect
         n_expensive_stokes_solver_steps = prm.get_integer ("Maximum number of expensive Stokes solver steps");
         linear_solver_A_block_tolerance = prm.get_double ("Linear solver A block tolerance");
         linear_solver_S_block_tolerance = prm.get_double ("Linear solver S block tolerance");
+	n_solver_restart_length         = prm.get_integer("GMRES solver restart length");
       }
       prm.leave_subsection ();
       prm.enter_subsection ("AMG parameters");

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -348,12 +348,12 @@ namespace aspect
                            "a sufficiently large number of iterations for the iterative solver to converge.");
 
 	prm.declare_entry("GMRES solver restart length", "50",
-			  Patterns::Integer(1),
-			  "This is the number of iterations that define the GMRES solver restart length. "
-			  "Increasing this parameter helps with convergence issues arising from high localized "
-			  "viscosity jumps in the domain. Be aware that increasing this number increases the "
-			  "memory usage of the Stokes solver, and makes individual Stokes iterations more "
-			  "expensive."); 
+                          Patterns::Integer(1),
+                          "This is the number of iterations that define the GMRES solver restart length. "
+                          "Increasing this parameter helps with convergence issues arising from high localized "
+                          "viscosity jumps in the domain. Be aware that increasing this number increases the "
+                          "memory usage of the Stokes solver, and makes individual Stokes iterations more "
+                          "expensive."); 
 
         prm.declare_entry ("Linear solver A block tolerance", "1e-2",
                            Patterns::Double(0,1),

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1036,7 +1036,7 @@ namespace aspect
         n_expensive_stokes_solver_steps = prm.get_integer ("Maximum number of expensive Stokes solver steps");
         linear_solver_A_block_tolerance = prm.get_double ("Linear solver A block tolerance");
         linear_solver_S_block_tolerance = prm.get_double ("Linear solver S block tolerance");
-	stokes_gmres_restart_length     = prm.get_integer("GMRES solver restart length");
+        stokes_gmres_restart_length     = prm.get_integer("GMRES solver restart length");
       }
       prm.leave_subsection ();
       prm.enter_subsection ("AMG parameters");

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -348,11 +348,12 @@ namespace aspect
                            "a sufficiently large number of iterations for the iterative solver to converge.");
 
 	prm.declare_entry("GMRES solver restart length", "50",
-			  Patterns::Integer(0),
-			  "This is the number of iterations that define the GMRES solver restart length. It "
-			  "helps with convergence issues arising from high viscosity jumps in the domain. "
-			  "Increasing this number to 200 iterations allows convergence with several orders "
-			  "magnitude viscosity jumps.");
+			  Patterns::Integer(1),
+			  "This is the number of iterations that define the GMRES solver restart length. "
+			  "Increasing this parameter helps with convergence issues arising from high localized "
+			  "viscosity jumps in the domain. Be aware that increasing this number increases the "
+			  "memory usage of the Stokes solver, and makes individual Stokes iterations more "
+			  "expensive."); 
 
         prm.declare_entry ("Linear solver A block tolerance", "1e-2",
                            Patterns::Double(0,1),
@@ -1035,7 +1036,7 @@ namespace aspect
         n_expensive_stokes_solver_steps = prm.get_integer ("Maximum number of expensive Stokes solver steps");
         linear_solver_A_block_tolerance = prm.get_double ("Linear solver A block tolerance");
         linear_solver_S_block_tolerance = prm.get_double ("Linear solver S block tolerance");
-	n_solver_restart_length         = prm.get_integer("GMRES solver restart length");
+	stokes_gmres_restart_length     = prm.get_integer("GMRES solver restart length");
       }
       prm.leave_subsection ();
       prm.enter_subsection ("AMG parameters");

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -347,13 +347,13 @@ namespace aspect
                            "not converge and return an error message pointing out that the user didn't allow "
                            "a sufficiently large number of iterations for the iterative solver to converge.");
 
-	prm.declare_entry("GMRES solver restart length", "50",
+        prm.declare_entry("GMRES solver restart length", "50",
                           Patterns::Integer(1),
                           "This is the number of iterations that define the GMRES solver restart length. "
                           "Increasing this parameter helps with convergence issues arising from high localized "
                           "viscosity jumps in the domain. Be aware that increasing this number increases the "
                           "memory usage of the Stokes solver, and makes individual Stokes iterations more "
-                          "expensive."); 
+                          "expensive.");
 
         prm.declare_entry ("Linear solver A block tolerance", "1e-2",
                            Patterns::Double(0,1),

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -809,8 +809,8 @@ namespace aspect
             // use the value defined by the user
             // OR
             // at least a restart length of 100 for melt models
-            const unsigned int number_of_temporary_vectors = (parameters.include_melt_transport == false ? 
-                                                              parameters.stokes_gmres_restart_length : 
+            const unsigned int number_of_temporary_vectors = (parameters.include_melt_transport == false ?
+                                                              parameters.stokes_gmres_restart_length :
                                                               std::max(parameters.stokes_gmres_restart_length, 100U));
 
             SolverFGMRES<LinearAlgebra::BlockVector>

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -806,7 +806,12 @@ namespace aspect
         // it in n_expensive_stokes_solver_steps steps or less.
         catch (SolverControl::NoConvergence)
           {
-            const unsigned int number_of_temporary_vectors = (parameters.include_melt_transport ? 100 : 50);
+            const unsigned int number_of_temporary_vectors = parameters.n_solver_restart_length;
+
+	    if (parameters.include_melt_transport &&
+		number_of_temporary_vectors < 100 )
+	      number_of_temporary_vectors = 100; 
+
             SolverFGMRES<LinearAlgebra::BlockVector>
             solver(solver_control_expensive, mem,
                    SolverFGMRES<LinearAlgebra::BlockVector>::

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -806,12 +806,12 @@ namespace aspect
         // it in n_expensive_stokes_solver_steps steps or less.
         catch (SolverControl::NoConvergence)
           {
-            unsigned int number_of_temporary_vectors = parameters.stokes_gmres_restart_length;
-
-	    // use at least a restart length of 100 for melt models
-	    if (parameters.include_melt_transport &&
-		number_of_temporary_vectors < 100 )
-	      number_of_temporary_vectors = 100; 
+            // use the value defined by the user
+            // OR
+            // at least a restart length of 100 for melt models
+            const unsigned int number_of_temporary_vectors = (parameters.include_melt_transport == false ? 
+                                                              parameters.stokes_gmres_restart_length : 
+                                                              std::max(parameters.stokes_gmres_restart_length, 100U));
 
             SolverFGMRES<LinearAlgebra::BlockVector>
             solver(solver_control_expensive, mem,

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -806,7 +806,7 @@ namespace aspect
         // it in n_expensive_stokes_solver_steps steps or less.
         catch (SolverControl::NoConvergence)
           {
-            const unsigned int number_of_temporary_vectors = parameters.n_solver_restart_length;
+            unsigned int number_of_temporary_vectors = parameters.n_solver_restart_length;
 
 	    if (parameters.include_melt_transport &&
 		number_of_temporary_vectors < 100 )

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -806,8 +806,9 @@ namespace aspect
         // it in n_expensive_stokes_solver_steps steps or less.
         catch (SolverControl::NoConvergence)
           {
-            unsigned int number_of_temporary_vectors = parameters.n_solver_restart_length;
+            unsigned int number_of_temporary_vectors = parameters.stokes_gmres_restart_length;
 
+	    // use at least a restart length of 100 for melt models
 	    if (parameters.include_melt_transport &&
 		number_of_temporary_vectors < 100 )
 	      number_of_temporary_vectors = 100; 


### PR DESCRIPTION
Add variable "GRMES solver restart length" as an input parameter. Solves convergence problems due to high viscosity jumps in the domain, and very likely will be helpful in other sorts of problems. 

Right now I left (though edited) the original version of increasing the number of restart iterations to 100 if melt transport is included, but maybe that it is not necessary anymore since it is now an input parameter? 