### PR TITLE
fix deprecation warning

### DIFF
--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -216,7 +216,7 @@ namespace aspect
                                      * JxW;
 
               if (elastic_outputs != NULL && this->get_parameters().enable_elasticity)
-                data.local_rhs(i) += (double_contract(elastic_outputs->elastic_force[q],Tensor<2,dim>(scratch.grads_phi_u[i])))
+                data.local_rhs(i) += (scalar_product(elastic_outputs->elastic_force[q],Tensor<2,dim>(scratch.grads_phi_u[i])))
                                      * JxW;
 
               if (scratch.rebuild_stokes_matrix)


### PR DESCRIPTION
fix:
```
../source/simulator/assemblers/stokes.cc:219:54: warning: ‘Number
dealii::double_contract(const dealii::Tensor<2, dim, Number>&, const
dealii::Tensor<2, dim, Number>&) [with int dim = 2; Number = double]’ is
deprecated [-Wdeprecated-declarations]
                 data.local_rhs(i) +=
(double_contract(elastic_outputs->elastic_force[q],Tensor<2,dim>(scratch.grads_phi_u[i])))
```