### PR TITLE
Abbreviate first names for manuals.

### DIFF
--- a/doc/manual/manual.bib
+++ b/doc/manual/manual.bib
@@ -11285,10 +11285,10 @@ year = {1992}
 
 @misc{aspect-doi-v1.5.0,
   title        = {{ASPECT} v1.5.0 [software]},
-  author       = {Wolfgang Bangerth and
-                  Juliane Dannberg and
-                  Rene Gassmoeller and
-                  Timo Heister and
+  author       = {W. Bangerth and
+                  J. Dannberg and
+                  R. Gassmoeller and
+                  T. Heister and
                   others},
   month        = {mar},
   year         = {2017},
@@ -11301,10 +11301,10 @@ year = {1992}
 
 @misc{aspect-doi-v2.0.0,
   title        = {{ASPECT} v2.0.0 [software]},
-  author       = {Wolfgang Bangerth and
-                  Juliane Dannberg and
-                  Rene Gassmoeller and
-                  Timo Heister and
+  author       = {W. Bangerth and
+                  J. Dannberg and
+                  R. Gassmoeller and
+                  T. Heister and
                   others},
   month        = may,
   year         = 2018,


### PR DESCRIPTION
In the list of references of the manual, we list the 1.5 and 2.0 manuals right
next to the figshare link to the generic manual. The latter uses abbreviated
first names, but the former written out first names. This looks awkward. Make
it look the same.

Somewhat related to #1476.