### PR TITLE
Bring a bibtex entry back in synch with manual.bib.

### DIFF
--- a/cite.html
+++ b/cite.html
@@ -90,7 +90,7 @@ We thank the Computational Infrastructure for Geodynamics (geodynamics.org) whic
   title         = {{\textsc{ASPECT}: Advanced Solver for Problems in Earth's ConvecTion, User Manual}},
   author        = {W. Bangerth and J. Dannberg and R. Gassm{\"o}ller and T. Heister and others},
   year          = {2018},
-  month         = {5},
+  month         = {may},
   DOI           = {10.6084/m9.figshare.4865333},
   note          = {doi:10.6084/m9.figshare.4865333},
   URL           = {https://doi.org/10.6084/m9.figshare.4865333}


### PR DESCRIPTION
This is the companion patch to #2306.