### PR TITLE
manual: switch to named anchor labels

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -55,7 +55,7 @@
 % files in the aspect tree without having to specify the
 % location relative to the directory where the pdf actually
 % resides
-\usepackage[colorlinks,linkcolor=blue,urlcolor=blue,citecolor=blue,baseurl=../]{hyperref}
+\usepackage[colorlinks,linkcolor=blue,urlcolor=blue,citecolor=blue,destlabel=true,baseurl=../]{hyperref}
 
 \newcommand{\dealii}{{\textsc{deal.II}}}
 \newcommand{\pfrst}{{\normalfont\textsc{p4est}}}


### PR DESCRIPTION
right now the internal links are "section_2.4", etc.. This means they
are not stable when the number of sections change. Currently we don't
care, but this change allows us to deeplink into section of the pdf.
Demo:
http://www.math.clemson.edu/~heister/aspect-pdf-manual/web/viewer.html?file=b.pdf#sec%3Apressure

related to: https://github.com/geodynamics/aspect/issues/2231