### PR TITLE
Correct depth average gnuplot labels

### DIFF
--- a/doc/modules/changes/20180619_myhill
+++ b/doc/modules/changes/20180619_myhill
@@ -1,0 +1,5 @@
+Fixed: When gnuplot was used as the output format for the 'depth average'
+postprocessor plugin, the first two columns were labelled <x> <y>, even though
+<depth> and <time> are always the first two variables. This is now fixed.
+<br>
+(Bob Myhill, 2018/06/19)

--- a/source/postprocess/depth_average.cc
+++ b/source/postprocess/depth_average.cc
@@ -203,8 +203,17 @@ namespace aspect
                           "depth_average" +
                           DataOutBase::default_suffix(output_format));
               std::ofstream f (filename.c_str());
-              data_out_stack.write (f, output_format);
 
+	      if (output_format == DataOutBase::gnuplot)
+		{
+		  DataOutBase::GnuplotFlags gnuplot_flags;
+		  gnuplot_flags.space_dimension_labels.resize(2);
+		  gnuplot_flags.space_dimension_labels[0] = "depth";
+		  gnuplot_flags.space_dimension_labels[1] = "time";
+		  data_out_stack.set_flags(gnuplot_flags);
+		}
+	      data_out_stack.write (f, output_format);
+	      
               AssertThrow (f, ExcMessage("Writing data to <" + filename +
                                          "> did not succeed in the `point values' "
                                          "postprocessor."));

--- a/source/postprocess/depth_average.cc
+++ b/source/postprocess/depth_average.cc
@@ -204,7 +204,8 @@ namespace aspect
                           DataOutBase::default_suffix(output_format));
               std::ofstream f (filename.c_str());
 
-              if (output_format == DataOutBase::gnuplot)
+              if (output_format == DataOutBase::gnuplot and
+                  DEAL_II_VERSION_GTE(9,0,0))
                 {
                   DataOutBase::GnuplotFlags gnuplot_flags;
                   gnuplot_flags.space_dimension_labels.resize(2);

--- a/source/postprocess/depth_average.cc
+++ b/source/postprocess/depth_average.cc
@@ -204,16 +204,16 @@ namespace aspect
                           DataOutBase::default_suffix(output_format));
               std::ofstream f (filename.c_str());
 
-	      if (output_format == DataOutBase::gnuplot)
-		{
-		  DataOutBase::GnuplotFlags gnuplot_flags;
-		  gnuplot_flags.space_dimension_labels.resize(2);
-		  gnuplot_flags.space_dimension_labels[0] = "depth";
-		  gnuplot_flags.space_dimension_labels[1] = "time";
-		  data_out_stack.set_flags(gnuplot_flags);
-		}
-	      data_out_stack.write (f, output_format);
-	      
+              if (output_format == DataOutBase::gnuplot)
+                {
+                  DataOutBase::GnuplotFlags gnuplot_flags;
+                  gnuplot_flags.space_dimension_labels.resize(2);
+                  gnuplot_flags.space_dimension_labels[0] = "depth";
+                  gnuplot_flags.space_dimension_labels[1] = "time";
+                  data_out_stack.set_flags(gnuplot_flags);
+                }
+              data_out_stack.write (f, output_format);
+
               AssertThrow (f, ExcMessage("Writing data to <" + filename +
                                          "> did not succeed in the `point values' "
                                          "postprocessor."));


### PR DESCRIPTION
Depth average output files using gnuplot format labelled the first two columns as `<x> <y>`. This has now been corrected to `<depth> <time>`.

This PR resolves Issue #945.