### PR TITLE
Fix reference to solver tolerance parameters in manual

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -3712,7 +3712,7 @@ a smaller tolerance. The default value of these tolerances are chosen so that
 the approximation is typically sufficient. You can make \aspect{} run faster if
 you choose these tolerances larger.
 The parameters you can adjust are all listed in
-Section~\ref{parameters:global} and are located at the top level of the input
+Section~\ref{parameters:Solver_20parameters} and are located in the \texttt{Solver parameters} subsection of the input
 file. In particular, the parameters you want to look at are \texttt{Linear
 solver tolerance}, \texttt{Temperature solver tolerance} and
 \texttt{Composition solver tolerance}.


### PR DESCRIPTION
changed a bit of the manual so that it correctly locates parameters in the "solver parameters" subsection