### PR TITLE
Avoid the use of the deprecated FunctionMap typedef.

### DIFF
--- a/source/mesh_refinement/composition.cc
+++ b/source/mesh_refinement/composition.cc
@@ -45,7 +45,7 @@ namespace aspect
           KellyErrorEstimator<dim>::estimate (this->get_mapping(),
                                               this->get_dof_handler(),
                                               quadrature,
-                                              typename FunctionMap<dim>::type(),
+                                              std::map<types::boundary_id,const Function<dim>*>(),
                                               this->get_solution(),
                                               this_indicator,
                                               this->introspection().component_masks.compositional_fields[c],

--- a/source/mesh_refinement/temperature.cc
+++ b/source/mesh_refinement/temperature.cc
@@ -39,7 +39,7 @@ namespace aspect
       KellyErrorEstimator<dim>::estimate (this->get_mapping(),
                                           this->get_dof_handler(),
                                           quadrature,
-                                          typename FunctionMap<dim>::type(),
+                                          std::map<types::boundary_id,const Function<dim>*>(),
                                           this->get_solution(),
                                           indicators,
                                           this->introspection().component_masks.temperature,

--- a/source/mesh_refinement/velocity.cc
+++ b/source/mesh_refinement/velocity.cc
@@ -37,7 +37,7 @@ namespace aspect
       KellyErrorEstimator<dim>::estimate (this->get_mapping(),
                                           this->get_dof_handler(),
                                           QGauss<dim-1>(this->introspection().polynomial_degree.velocities+1),
-                                          typename FunctionMap<dim>::type(),
+                                          std::map<types::boundary_id,const Function<dim>*>(),
                                           this->get_solution(),
                                           indicators,
                                           this->introspection().component_masks.velocities,


### PR DESCRIPTION
Fixes #2330.