### PR TITLE
Added error messages for boundaries that do not work in chunk geometry model

### DIFF
--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -728,6 +728,10 @@ namespace aspect
 
               AssertThrow (point1[2] < point2[2],
                            ExcMessage ("Minimum latitude must be less than maximum latitude."));
+              AssertThrow (point1[2] > -0.5*numbers::PI,
+                           ExcMessage ("Minimum latitude needs to be larger than -90 degrees."));
+              AssertThrow (point2[2] < 0.5*numbers::PI,
+                           ExcMessage ("Maximum latitude needs to be less than 90 degrees."));
             }
 
         }


### PR DESCRIPTION
Addressing issue #2331 - added error messages when lat =90/-90