### PR TITLE
Replace the word 'abort' by 'terminate' if we exit with a zero error code

### DIFF
--- a/tests/checkpoint_01.cc
+++ b/tests/checkpoint_01.cc
@@ -3,7 +3,7 @@
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT
- * twice to test checkpoint/resume and then abort the outer ASPECT run.
+ * twice to test checkpoint/resume and then terminate the outer ASPECT run.
  */
 int f()
 {
@@ -70,7 +70,7 @@ int f()
   if (ret!=0)
     std::cout << "system() returned error " << ret << std::endl;
 
-  // abort current process:
+  // terminate current process:
   exit (0);
   return 42;
 }

--- a/tests/checkpoint_02.cc
+++ b/tests/checkpoint_02.cc
@@ -2,7 +2,7 @@
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT
- * twice to test checkpoint/resume and then abort the outer ASPECT run.
+ * twice to test checkpoint/resume and then terminate the outer ASPECT run.
  */
 int f()
 {
@@ -67,7 +67,7 @@ int f()
   if (ret!=0)
     std::cout << "system() returned error " << ret << std::endl;
 
-  // abort current process:
+  // terminate current process:
   exit (0);
   return 42;
 }

--- a/tests/checkpoint_02_direct.cc
+++ b/tests/checkpoint_02_direct.cc
@@ -2,7 +2,7 @@
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT
- * twice to test checkpoint/resume and then abort the outer ASPECT run.
+ * twice to test checkpoint/resume and then terminate the outer ASPECT run.
  */
 int f()
 {
@@ -67,7 +67,7 @@ int f()
   if (ret!=0)
     std::cout << "system() returned error " << ret << std::endl;
 
-  // abort current process:
+  // terminate current process:
   exit (0);
   return 42;
 }

--- a/tests/checkpoint_02_petsc.cc
+++ b/tests/checkpoint_02_petsc.cc
@@ -2,7 +2,7 @@
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT
- * twice to test checkpoint/resume and then abort the outer ASPECT run.
+ * twice to test checkpoint/resume and then terminate the outer ASPECT run.
  */
 int f()
 {
@@ -67,7 +67,7 @@ int f()
   if (ret!=0)
     std::cout << "system() returned error " << ret << std::endl;
 
-  // abort current process:
+  // terminate current process:
   exit (0);
   return 42;
 }

--- a/tests/checkpoint_03_particles.cc
+++ b/tests/checkpoint_03_particles.cc
@@ -3,7 +3,7 @@
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT
- * twice to test checkpoint/resume and then abort the outer ASPECT run.
+ * twice to test checkpoint/resume and then terminate the outer ASPECT run.
  */
 int f()
 {
@@ -68,7 +68,7 @@ int f()
   if (ret!=0)
     std::cout << "system() returned error " << ret << std::endl;
 
-  // abort current process:
+  // terminate current process:
   exit (0);
   return 42;
 }

--- a/tests/checkpoint_04_particles_no_output.cc
+++ b/tests/checkpoint_04_particles_no_output.cc
@@ -3,7 +3,7 @@
 
 /*
  * Launch the following function when this plugin is created. Launch ASPECT
- * twice to test checkpoint/resume and then abort the outer ASPECT run.
+ * twice to test checkpoint/resume and then terminate the outer ASPECT run.
  */
 int f()
 {
@@ -66,7 +66,7 @@ int f()
   if (ret!=0)
     std::cout << "system() returned error " << ret << std::endl;
 
-  // abort current process:
+  // terminate current process:
   exit (0);
   return 42;
 }


### PR DESCRIPTION
`abort` has the connotation of being an error, but we just do `exit(0)`, which is totally acceptable way to say that we just end the program.