### PR TITLE
require c++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,13 @@ ENDIF()
 
 MESSAGE(STATUS "Found deal.II version ${DEAL_II_PACKAGE_VERSION} at '${deal.II_DIR}'")
 
+IF(NOT DEAL_II_WITH_CXX11)
+  MESSAGE(FATAL_ERROR "\n*** ASPECT requires C++11 but your version of deal.II is not "
+    "configured with it. This likely means that your compiler is too old. Check "
+    "DEAL_II_WITH_CXX11 in deal.II.")
+ENDIF()
+
+
 SET(ASPECT_USE_PETSC OFF CACHE BOOL "Use PETSc instead of Trilinos if set to 'on'.")
 
 MESSAGE(STATUS "Using ASPECT_USE_PETSC = '${ASPECT_USE_PETSC}'")


### PR DESCRIPTION
We need a compiler with c++ 11 starting with deal.II 9.0 anyways. Can we require this already? We are not testing on older compilers anyways.