### PR TITLE
Disable combining particle with free surface

### DIFF
--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -826,6 +826,13 @@ namespace aspect
                              "diameter in one time step and therefore skip the layer "
                              "of ghost cells around the local subdomain."));
 
+      AssertThrow(!this->get_parameters().free_surface_enabled,
+                  ExcMessage("Combining particles and a free surface is currently untested "
+                             "and not officially supported. If you disable this assertion make "
+                             "sure you benchmark the particle accuracy, and carefully check for "
+                             "problems related to storing the particle reference coordinates for "
+                             "a deforming mesh."));
+
       prm.enter_subsection("Postprocess");
       {
         prm.enter_subsection("Particles");

--- a/tests/particle_free_surface.prm
+++ b/tests/particle_free_surface.prm
@@ -1,0 +1,124 @@
+# A test that makes sure that the model crashes with the expected
+# error message if particles are combined with a free surface.
+
+# EXPECT FAILURE
+
+set Dimension                              = 2
+set End time                               = 70
+set Use years in output instead of seconds = false
+set Pressure normalization                 = no
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent  = 0.9142
+    set Y extent  = 1.0000
+  end
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = left, right
+  set Zero velocity boundary indicators       = bottom
+end
+
+subsection Free surface
+  set Free surface boundary indicators = top
+end
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Reference density             = 1010
+    set Viscosity                     = 1e2
+    set Thermal expansion coefficient = 0
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+############### Parameters describing the temperature field
+# Note: The temperature plays no role in this model
+
+subsection Boundary temperature model
+  set List of model names = box
+end
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+
+############### Parameters describing the compositional field
+# Note: The compositional field is what drives the flow
+# in this example
+
+subsection Compositional fields
+  set Number of fields = 1
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Variable names      = x,z
+    set Function constants  = pi=3.1415926
+    set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
+  end
+end
+
+subsection Material model
+  subsection Simple model
+    set Density differential for compositional field 1 = -10
+  end
+end
+
+
+############### Parameters describing the discretization
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Strategy                           = composition
+  set Initial global refinement          = 4
+  set Time steps between mesh refinement = 0
+  set Coarsening fraction                = 0.05
+  set Refinement fraction                = 0.3
+end
+
+
+
+############### Parameters describing what to do with the solution
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, composition statistics,particles
+
+  subsection Particles
+    set Number of particles = 10
+    set Time between data output = 70
+    set Data output format = vtu
+    set List of particle properties = velocity,function, initial composition, initial position
+
+    subsection Function
+      set Variable names      = x,z
+      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+    end
+
+    set Particle generator name = uniform box
+
+    subsection Generator
+      subsection Uniform box
+        set Minimum x = 0.3
+        set Maximum x = 0.5
+        set Minimum y = 0.1
+        set Maximum y = 0.3
+      end
+    end
+  end
+end

--- a/tests/particle_free_surface/screen-output
+++ b/tests/particle_free_surface/screen-output
@@ -1,0 +1,19 @@
+
+TimerOutput objects finalize timed values printed to the
+screen by communicating over MPI in their destructors.
+Since an exception is currently uncaught, this
+synchronization (and subsequent output) will be skipped to
+avoid a possible deadlock.
+ERROR: Uncaught exception in MPI_InitFinalize on proc 0. Skipping MPI_Finalize() to avoid a deadlock.
+
+
+Exception 'ExcMessage("Combining particles and a free surface is currently untested " "and not officially supported. If you disable this assertion make " "sure you benchmark the particle accuracy, and carefully check for " "problems related to storing the particle reference coordinates for " "a deforming mesh.")' on rank 0 on processing: 
+
+An error occurred in file <world.cc> in function
+(line in output replaced by default.sh script)
+The violated condition was: 
+    !this->get_parameters().free_surface_enabled
+Additional information: 
+    Combining particles and a free surface is currently untested and not officially supported. If you disable this assertion make sure you benchmark the particle accuracy, and carefully check for problems related to storing the particle reference coordinates for a deforming mesh.
+
+Aborting!

--- a/tests/particle_free_surface/screen-output
+++ b/tests/particle_free_surface/screen-output
@@ -1,9 +1,4 @@
 
-TimerOutput objects finalize timed values printed to the
-screen by communicating over MPI in their destructors.
-Since an exception is currently uncaught, this
-synchronization (and subsequent output) will be skipped to
-avoid a possible deadlock.
 ERROR: Uncaught exception in MPI_InitFinalize on proc 0. Skipping MPI_Finalize() to avoid a deadlock.
 
 


### PR DESCRIPTION
The particles were never tested with the free surface and I am reasonably sure that at least something is broken in this case (see also #2243). Disable this feature for now until we further test it.