### PR TITLE
Only set time step number and timestep sizes after initialization is finished.

### DIFF
--- a/doc/modules/changes/20180620_bangerth
+++ b/doc/modules/changes/20180620_bangerth
@@ -1,0 +1,12 @@
+Changed: We now only set time step number and timestep sizes after
+initialization is finished. 
+
+Right now, there is no way to find out, for example in the hook that
+is called from the function that builds constraints, whether we
+are already in the process of time stepping, or only in the
+initialization phase. So move the initialization of the time
+step number and time step variables to the very end of the
+initialization phase. Before this, these variables have invalid
+values.
+<br>
+(Wolfgang Bangerth, 2018/06/20)

--- a/source/geometry_model/box.cc
+++ b/source/geometry_model/box.cc
@@ -264,7 +264,8 @@ namespace aspect
     Box<dim>::point_is_in_domain(const Point<dim> &point) const
     {
       AssertThrow(this->get_free_surface_boundary_indicators().size() == 0 ||
-                  this->get_timestep_number() == 0,
+                  // we are still before the first time step has started
+                  this->get_timestep_number() == numbers::invalid_unsigned_int,
                   ExcMessage("After displacement of the free surface, this function can no longer be used to determine whether a point lies in the domain or not."));
 
       AssertThrow(dynamic_cast<const InitialTopographyModel::ZeroTopography<dim>*>(&this->get_initial_topography_model()) != 0,

--- a/source/material_model/viscoelastic.cc
+++ b/source/material_model/viscoelastic.cc
@@ -172,7 +172,12 @@ namespace aspect
       // On the first (0) time step the elastic time step is always equal to the value
       // specified in 'fixed_elastic_time_step', which is also used in all subsequent time
       // steps if 'use_fixed_elastic_time_step' is set to true.
-      const double dte = ( ( this->get_timestep_number() > 0 && use_fixed_elastic_time_step == false )
+      //
+      // We also use this parameter when we are still *before* the first time step,
+      // i.e., if the time step number is numbers::invalid_unsigned_int.
+      const double dte = ( ( this->get_timestep_number() > 0 &&
+                             this->get_timestep_number() != numbers::invalid_unsigned_int &&
+                             use_fixed_elastic_time_step == false )
                            ?
                            this->get_timestep()
                            :

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1603,27 +1603,27 @@ namespace aspect
 
   start_time_iteration:
 
-    // Only set initial conditions if we do not resume, and are not in pre-refinement,
-    // or we do not want to skip initial conditions in pre-refinement.
-    if (parameters.resume_computation == false
-        &&
-        ! (parameters.skip_setup_initial_conditions_on_initial_refinement
-           && pre_refinement_step < parameters.initial_adaptive_refinement))
+    if (parameters.resume_computation == false)
       {
         TimerOutput::Scope timer (computing_timer, "Setup initial conditions");
 
         timestep_number           = 0;
         time_step = old_time_step = 0;
 
-        // Add topography to box models after all initial refinement
-        // is completed.
-        if (pre_refinement_step == parameters.initial_adaptive_refinement)
-          signals.pre_set_initial_state (triangulation);
+        if (! parameters.skip_setup_initial_conditions_on_initial_refinement
+            ||
+            ! (pre_refinement_step < parameters.initial_adaptive_refinement))
+          {
+            // Add topography to box models after all initial refinement
+            // is completed.
+            if (pre_refinement_step == parameters.initial_adaptive_refinement)
+              signals.pre_set_initial_state (triangulation);
 
-        set_initial_temperature_and_compositional_fields ();
-        compute_initial_pressure_field ();
+            set_initial_temperature_and_compositional_fields ();
+            compute_initial_pressure_field ();
 
-        signals.post_set_initial_state (*this);
+            signals.post_set_initial_state (*this);
+          }
       }
 
     // start the principal loop over time steps:

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -167,9 +167,9 @@ namespace aspect
     boundary_heat_flux (BoundaryHeatFlux::create_boundary_heat_flux<dim>(prm)),
 
     time (numbers::signaling_nan<double>()),
-    time_step (0),
-    old_time_step (0),
-    timestep_number (0),
+    time_step (numbers::signaling_nan<double>()),
+    old_time_step (numbers::signaling_nan<double>()),
+    timestep_number (numbers::invalid_unsigned_int),
     nonlinear_iteration (numbers::invalid_unsigned_int),
 
     triangulation (mpi_communicator,
@@ -1575,9 +1575,7 @@ namespace aspect
       }
     else
       {
-        time                      = parameters.start_time;
-        timestep_number           = 0;
-        time_step = old_time_step = 0;
+        time = parameters.start_time;
 
         // Instead of calling global_refine(n) we flag all cells for
         // refinement and then allow the mesh refinement plugins to unflag
@@ -1613,6 +1611,9 @@ namespace aspect
            && pre_refinement_step < parameters.initial_adaptive_refinement))
       {
         TimerOutput::Scope timer (computing_timer, "Setup initial conditions");
+
+        timestep_number           = 0;
+        time_step = old_time_step = 0;
 
         // Add topography to box models after all initial refinement
         // is completed.

--- a/tests/edit_parameters.cc
+++ b/tests/edit_parameters.cc
@@ -35,7 +35,11 @@ namespace aspect
   void change_boundary_condition (const SimulatorAccess<dim> &simulator_access,
                                   Parameters<dim> &parameters)
   {
-    if ( simulator_access.get_timestep_number() >= switch_step && !switched )
+    if (simulator_access.get_timestep_number() != numbers::invalid_unsigned_int
+        &&
+        simulator_access.get_timestep_number() >= switch_step
+        &&
+        !switched )
       {
         simulator_access.get_pcout()<<"Reducing CFL number!"<<std::endl;
         parameters.CFL_number *= 0.5;

--- a/tests/melting_rate.cc
+++ b/tests/melting_rate.cc
@@ -50,10 +50,19 @@ namespace aspect
                 const double y = in.position[i][1] - 50000.0;
                 const double c0 = 10000.0;
                 const double deltaT = this->get_timestep();
-                if (c == peridotite_idx && deltaT>0.0)
+                if (c == peridotite_idx &&
+                    // check whether we are past the initialization
+                    // phase before the first time step
+                    this->get_timestep_number()!=numbers::invalid_unsigned_int &&
+                    deltaT>0.0)
                   out.reaction_terms[i][c] = 0.0001 * std::exp(-(x*x+y*y)/(2*c0*c0));
-                else if (c == porosity_idx && deltaT>0.0)
-                  out.reaction_terms[i][c] = 0.0001 * std::exp(-(x*x+y*y)/(2*c0*c0)) * 3000.0 / this->get_timestep();
+                else if (c == porosity_idx &&
+                         // check whether we are past the
+                         // initialization phase before the first time
+                         // step
+                         this->get_timestep_number()!=numbers::invalid_unsigned_int &&
+                         deltaT>0.0)
+                  out.reaction_terms[i][c] = 0.0001 * std::exp(-(x*x+y*y)/(2*c0*c0)) * 3000.0 / deltaT;
                 else
                   out.reaction_terms[i][c] = 0.0;
               }


### PR DESCRIPTION
This way, the initialization code and other places have a way of determining
whether we are still in initialization, or whether we have already started time
stepping.

Right now, there is no way to find out, for example in the hook that
is called from the function that builds constraints, whether we
are already in the process of time stepping, or only in the
initialization phase. So move the initialization of the time
step number and time step variables to the very end of the
initialization phase.