### PR TITLE
Fix bibtex entries for ASPECT.

### DIFF
--- a/doc/manual/manual.bib
+++ b/doc/manual/manual.bib
@@ -129,8 +129,8 @@
 @ARTICLE{G09,
   Author = "Geenen, T. and ur Rehman, M. and MacLachlan, S. P. and Segal,
                   G. and Vuik, C. and van den Berg, A. P. and Spakman, W.",
-  Title = "{Scalable robust solvers for unstructured FE geodynamic modeling
-                  applications: Solving the Stokes equation for models with
+  Title = "{Scalable robust solvers for unstructured {FE} geodynamic modeling
+                  applications: Solving the {S}tokes equation for models with
                   large localized viscosity contrasts}",
   Journal = {Geochem. Geophys. Geosyst.},
   year =         2009,
@@ -152,7 +152,7 @@
 
 @BOOK{HW91,
         AUTHOR = "Hairer, E. and Wanner, G.",
-        TITLE = "Solving Ordinary Differential Equations II. Stiff and
+        TITLE = "Solving Ordinary Differential Equations {II}. Stiff and
                   Differential-Algebraic Problems",
         PUBLISHER = "Springer-Verlag",
         ADDRESS = "Berlin",
@@ -278,7 +278,7 @@ YEAR = "2003"
 
 @Article{BR97,
   author =       {Bassi, F. and Rebay, S.},
-  title =        {High-order accurate discontinuous finite element solution of the 2D
+  title =        {High-order accurate discontinuous finite element solution of the {2D}
 {E}uler equations},
   journal =      {J. Comput. Phys.},
   year =         {1997},
@@ -666,7 +666,7 @@ YEAR = "2003"
 
 @Article{Ful95,
   author =       {Fullsack, P.},
-  title =        {An arbitrary Lagrangian-Eulerian formulation
+  title =        {An arbitrary {L}agrangian-{E}ulerian formulation
      for creeping flows and its applications in tectonic models},
   journal =      {Geoph. J. Int.},
   year =         1995,
@@ -1054,7 +1054,7 @@ YEAR = "2003"
 
 @Book{ABM06,
   author =       {Attouch, H. and Buttazzo, G. and Michaille, G.},
-  title =        {Variational Analysis in Sobolev and BV spaces},
+  title =        {Variational Analysis in {S}obolev and {BV} spaces},
   publisher =    {SIAM-MPS},
   year =         2060,
   series =       {MPS-SIAM Series on Optimization}
@@ -1395,7 +1395,7 @@ YEAR = "2003"
 
 @Book{BP86,
   author =       {Barbu, V. and Precupanu, T.},
-  title =        {Convexity and Optimization in Banach Spaces},
+  title =        {Convexity and Optimization in {B}anach Spaces},
   publisher =    {Reidl Publishing, Dordrecht},
   year =         1986
 }
@@ -1608,7 +1608,7 @@ Turbine Blades},
 
 @Book{CKS00,
   editor =       {Cockburn, B. and Karniadakis, G. E. and Shu, C.-W.},
-  title =        {Discontinuous Galerkin Methods},
+  title =        {Discontinuous {G}alerkin Methods},
   publisher =    {Springer},
   year =         2000,
   volume =       11,
@@ -4036,7 +4036,7 @@ in finite element methods},
 @MastersThesis{Fuh93,
   author =       {F{\"u}hrer, C.},
   title =        {{F}inite--{E}lemente--{D}is\-kre\-ti\-sie\-run\-gen
-                  der 2D--{S}trah\-lungs\-trans\-port\-gleich\-ung},
+                  der {2D}--{S}trah\-lungs\-trans\-port\-gleich\-ung},
   school =       {Universit{\"a}t Heidelberg},
   year =         1993,
   type =         {Diplomarbeit}
@@ -4114,7 +4114,7 @@ laws involving discontinuous solutions},
 
 @Article{HH06,
   author =       {Hartmann, R. and Houston, P.},
-  title =        {Symmetric Interior Penalty DG Methods for the Compressible Navier-Stokes Equations II: Goal-Oriented A Posteriori Error Estimation},
+  title =        {Symmetric Interior Penalty {DG} Methods for the Compressible {N}avier-{S}tokes Equations {II}: Goal-Oriented A Posteriori Error Estimation},
   journal =      {Int. J. Numer. Anal. Model.},
   year =         2006,
   volume =       3,
@@ -4259,14 +4259,14 @@ laws involving discontinuous solutions},
 
 @PhdThesis{Har02,
   author =       {Hartmann, R.},
-  title =        {Adaptive Finite Element Methods for the Compressible Euler Equations},
+  title =        {Adaptive Finite Element Methods for the Compressible {E}uler Equations},
   school =       {University of Heidelberg},
   year =         2002
 }
 
 @Article{Har06,
   author =       {Hartmann, R.},
-  title =        {Adaptive discontinuous Galerkin methods with shock-capturing for the compressible Navier-Stokes equations},
+  title =        {Adaptive discontinuous {G}alerkin methods with shock-capturing for the compressible {N}avier-{S}tokes equations},
   journal =      {Int. J. Numer. Meth. Fluids},
   year =         {2006, to appear}
 }
@@ -5081,7 +5081,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 @TechReport{TW94,
   author =       {Turek, S. and Wehrse, R.},
   title =        {Spectral Appearance of Dust Enshrouded Stars: A
-                  Finite Element Approach to 2D Radiative Transfer},
+                  Finite Element Approach to {2D} Radiative Transfer},
   institution =  {IWR, Universit{\"a}t Heidelberg},
   year =         1994,
   type =         {Preprint},
@@ -5188,7 +5188,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 }
 
 @Proceedings{enumath97,
-  title =        {ENUMATH 97, Proceedings of the 2nd European Conference on Numerical Mathematics and Advanced Applications},
+  title =        {{ENUMATH 97}, Proceedings of the 2nd European Conference on Numerical Mathematics and Advanced Applications},
   year =         1998,
   editor =       {Bock, H. G. and Brezzi, F. and 
                   Glowinsky, R. and Kanschat, G. and Kuznetsov, Y. A.
@@ -6267,7 +6267,7 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
 
 @InProceedings{DW97,
   author =       {P. Deuflhard and M. Weiser},
-  title =        {Local inexact Newton multilevel {FEM} for nonlinear
+  title =        {Local inexact {N}ewton multilevel {FEM} for nonlinear
                   elliptic problems},
   booktitle =    {Computational science for the 21st century.},
   pages =        {128--138},
@@ -6777,7 +6777,7 @@ tomography",
 
 @Article{HIK02,
   author =       {M. Hinterm{\"u}ller and K. Ito and K. Kunisch},
-  title =        {The Primal-Dual Active Set Strategy as a Semismooth Newton Method},
+  title =        {The Primal-Dual Active Set Strategy as a Semismooth {N}ewton Method},
   journal =      {SIAM J. Optim.},
   year =         2002,
   volume =       13,
@@ -11012,7 +11012,7 @@ author = "H. L. Stone and A. O. Garder"
 }
 
 @InBook {DHPR2004,
-title = {Arbitrary Lagrangian-Eulerian Methods},
+title = {Arbitrary {L}agrangian-{E}ulerian Methods},
 author = {Donea, J. and Huerta, A. and Ponthot, J.-Ph. and Rodr{\'i}guez-Ferran, A.},
 publisher = {John Wiley \& Sons, Ltd},
 isbn = {9780470091357},
@@ -11034,7 +11034,7 @@ year = {2004},
 
 @Article{dobo04,
   author =       {Dohrmann, C. R. and Bochev, P. B.},
-  title =        {A stabilized finite element method for the Stokes problem based on polynomial pressure projections},
+  title =        {A stabilized finite element method for the {S}tokes problem based on polynomial pressure projections},
   journal =      {International Journal for Numerical Methods in Fluids},
   year =         20014,
   volume =       46,
@@ -11080,7 +11080,7 @@ a free surface},
 
 @Article{Deu08,
   author =       {Y. Deubelbeiss and B. J. P. Kaus},
-  title =        {Comparison of Eulerian and Lagrangian numerical techniques for the Stokes equations in the presence of strongly varying viscosity},
+  title =        {Comparison of {E}ulerian and {L}agrangian numerical techniques for the {S}tokes equations in the presence of strongly varying viscosity},
   journal =      {Physics of the Earth and Planetary Interiors},
   year =         2008,
   volume =       171,
@@ -11106,7 +11106,7 @@ Year = {1999}}
 @article{alht12,
 Author = {V. Allken and R. Huismans and C. Thieulot},
 Journal = g3,
-Title = {Factors controlling the mode of rift interaction in brittle-ductile coupled systems: a 3D numerical study},
+Title = {Factors controlling the mode of rift interaction in brittle-ductile coupled systems: a {3D} numerical study},
 Volume = {13},
 Number = {5},
 Pages = {Q05010},
@@ -11315,7 +11315,7 @@ year = {1992}
 }
 
 @article{aspectmanual,
-  title         = {{\textsc{ASPECT}: Advanced Solver for Problems in Earth's ConvecTion, User Manual}},
+  title         = {{\textsc{ASPECT}: {A}dvanced {S}olver for {P}roblems in {E}arth's {C}onvec{T}ion, User Manual}},
   author        = {W. Bangerth and J. Dannberg and R. Gassm{\"o}ller and T. Heister and others},
   year          = {2018},
   month         = {may},
@@ -11332,7 +11332,7 @@ year = {1992}
 }
 
 @article{He_2017_DG,
-  Title                    = {A discontinuous Galerkin method with a bound preserving limiter for the advection of non-diffusive fields in solid Earth geodynamics },
+  Title                    = {A discontinuous {G}alerkin method with a bound preserving limiter for the advection of non-diffusive fields in solid Earth geodynamics },
   Author                   = {Ying He and Elbridge Gerry Puckett and Magali I. Billen},
   Journal                  = {Physics of the Earth and Planetary Interiors },
   Year                     = {2017},


### PR DESCRIPTION
There are several bibtex entries issues in the tree for ASPECT where some necessary capital letters such as in  "Advanced Solver for Problems in Earth ConvecTion" or in names like "Stokes" turns out to show small letters when bibtex runs. We fix this issue by enclosing all necessary capital letters into curly braces.