### PR TITLE
Improve documentation of output formats

### DIFF
--- a/source/particle/output/interface.cc
+++ b/source/particle/output/interface.cc
@@ -126,7 +126,7 @@ namespace aspect
                                Patterns::Selection (pattern_of_names + "|none"),
                                "File format to output raw particle data in. "
                                "If you select `none' no output will be "
-                               "written."
+                               "written. "
                                "Select one of the following models:\n\n"
                                +
                                std_cxx1x::get<dim>(registered_plugins).get_description_string());

--- a/source/postprocess/depth_average.cc
+++ b/source/postprocess/depth_average.cc
@@ -294,9 +294,10 @@ namespace aspect
                              Patterns::Selection(DataOutBase::get_output_format_names().append("|txt")),
                              "The format in which the output shall be produced. The "
                              "format in which the output is generated also determines "
-                             "the extension of the file into which data is written. See "
-                             "the corresponding appendix of the manual for possible "
-                             "output formats.");
+                             "the extension of the file into which data is written. "
+                             "The list of possible output formats that can be given "
+                             "here is documented in the appendix of the manual where "
+                             "the current parameter is described.");
           const std::string variables =
             "all|temperature|composition|"
             "adiabatic temperature|adiabatic pressure|adiabatic density|adiabatic density derivative|"

--- a/source/postprocess/depth_average.cc
+++ b/source/postprocess/depth_average.cc
@@ -294,7 +294,9 @@ namespace aspect
                              Patterns::Selection(DataOutBase::get_output_format_names().append("|txt")),
                              "The format in which the output shall be produced. The "
                              "format in which the output is generated also determines "
-                             "the extension of the file into which data is written.");
+                             "the extension of the file into which data is written. See "
+                             "the corresponding appendix of the manual for possible "
+                             "output formats.");
           const std::string variables =
             "all|temperature|composition|"
             "adiabatic temperature|adiabatic pressure|adiabatic density|adiabatic density derivative|"

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -619,8 +619,9 @@ namespace aspect
           prm.declare_entry ("Data output format", "vtu",
                              Patterns::MultipleSelection (DataOutBase::get_output_format_names ()+"|ascii"),
                              "A comma separated list of file formats to be used for graphical "
-                             "output. See the corresponding appendix of the manual for possible "
-                             "output formats.");
+                             "output. The list of possible output formats that can be given "
+                             "here is documented in the appendix of the manual where the current "
+                             "parameter is described.");
 
           prm.declare_entry ("Number of grouped files", "16",
                              Patterns::Integer(0),

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -618,8 +618,9 @@ namespace aspect
           // we now simply replace "ascii" by "gnuplot" should it be selected.
           prm.declare_entry ("Data output format", "vtu",
                              Patterns::MultipleSelection (DataOutBase::get_output_format_names ()+"|ascii"),
-                             "A comma seperated list of file formats to be used for graphical "
-                             "output.");
+                             "A comma separated list of file formats to be used for graphical "
+                             "output. See the corresponding appendix of the manual for possible "
+                             "output formats.");
 
           prm.declare_entry ("Number of grouped files", "16",
                              Patterns::Integer(0),

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -752,7 +752,9 @@ namespace aspect
           // now also see about the file format we're supposed to write in
           prm.declare_entry ("Output format", "vtu",
                              Patterns::Selection (DataOutBase::get_output_format_names ()),
-                             "The file format to be used for graphical output.");
+                             "The file format to be used for graphical output. See "
+                             "the corresponding appendix of the manual for possible "
+                             "output formats.");
 
           prm.declare_entry ("Number of grouped files", "16",
                              Patterns::Integer(0),

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -752,9 +752,10 @@ namespace aspect
           // now also see about the file format we're supposed to write in
           prm.declare_entry ("Output format", "vtu",
                              Patterns::Selection (DataOutBase::get_output_format_names ()),
-                             "The file format to be used for graphical output. See "
-                             "the corresponding appendix of the manual for possible "
-                             "output formats.");
+                             "The file format to be used for graphical output. The list "
+                             "of possible output formats that can be given here is documented "
+                             "in the appendix of the manual where the current parameter "
+                             "is described.");
 
           prm.declare_entry ("Number of grouped files", "16",
                              Patterns::Integer(0),


### PR DESCRIPTION
Fixes #2055. I did not include the format options themselves, because that would duplicate them in the manual. Instead I just refer to the manual.