### PR TITLE
grain_size: do not copy arguments

### DIFF
--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -128,8 +128,8 @@ namespace aspect
            * computed for each substep and then averaged.
            */
           std_cxx11::array<std::pair<double, unsigned int>,2>
-          enthalpy_derivatives(const std::vector<double> temperatures,
-                               const std::vector<double> pressures,
+          enthalpy_derivatives(const std::vector<double> &temperatures,
+                               const std::vector<double> &pressures,
                                const unsigned int n_substeps = 1) const;
 
           double

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -144,8 +144,8 @@ namespace aspect
       }
 
       std_cxx11::array<std::pair<double, unsigned int>,2>
-      MaterialLookup::enthalpy_derivatives(const std::vector<double> temperatures,
-                                           const std::vector<double> pressures,
+      MaterialLookup::enthalpy_derivatives(const std::vector<double> &temperatures,
+                                           const std::vector<double> &pressures,
                                            const unsigned int n_substeps) const
       {
         Assert(temperatures.size() == pressures.size(),ExcInternalError());


### PR DESCRIPTION
for performance reasons