### PR TITLE
Fix two performance problems in the Newton assembly.

### DIFF
--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -53,6 +53,7 @@ namespace aspect
       const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
       const unsigned int n_q_points           = scratch.finite_element_values.n_quadrature_points;
       const double derivative_scaling_factor = this->get_newton_handler().parameters.newton_derivative_scaling_factor;
+      const double pressure_scaling = this->get_pressure_scaling();
 
       // First loop over all dofs and find those that are in the Stokes system
       // save the component (pressure and dim velocities) each belongs to.
@@ -122,8 +123,8 @@ namespace aspect
                                                  // only be scaled by 1/eta, without considering
                                                  // the derivatives
                                                  one_over_eta
-                                                 * this->get_pressure_scaling()
-                                                 * this->get_pressure_scaling()
+                                                 * pressure_scaling
+                                                 * pressure_scaling
                                                  * (scratch.phi_p[i] * scratch.phi_p[j]))
                                                * JxW;
             }
@@ -170,8 +171,8 @@ namespace aspect
                                // consider the derivatives deta/deps
                                // here, but we leave this as a TODO
                                one_over_eta
-                               * this->get_pressure_scaling()
-                               * this->get_pressure_scaling()
+                               * pressure_scaling
+                               * pressure_scaling
                                * (scratch.phi_p[i] * scratch.phi_p[j])
                              )
                              * JxW;
@@ -197,8 +198,8 @@ namespace aspect
                                // consider the derivatives deta/deps
                                // here, but we leave this as a TODO
                                one_over_eta
-                               * this->get_pressure_scaling()
-                               * this->get_pressure_scaling()
+                               * pressure_scaling
+                               * pressure_scaling
                                * (scratch.phi_p[i] * scratch.phi_p[j])
                              )
                              * JxW;
@@ -297,12 +298,13 @@ namespace aspect
           const double density = scratch.material_model_outputs.densities[q];
 
           const double JxW = scratch.finite_element_values.JxW(q);
+          const double pressure_scaling = this->get_pressure_scaling();
 
           // first assemble the rhs
           for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
             data.local_rhs(i) -= (eta * 2.0 * (scratch.grads_phi_u[i] * strain_rate)
                                   - (scratch.div_phi_u[i] * pressure)
-                                  - (this->get_pressure_scaling() * scratch.phi_p[i] * velocity_divergence)
+                                  - (pressure_scaling * scratch.phi_p[i] * velocity_divergence)
                                   -(density * gravity * scratch.phi_u[i]))
                                  * JxW;
 
@@ -316,12 +318,12 @@ namespace aspect
                     data.local_matrix(i,j) += (
                                                 eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j])
                                                 // assemble \nabla p as -(p, div v):
-                                                - (this->get_pressure_scaling() *
+                                                - (pressure_scaling *
                                                    scratch.div_phi_u[i] * scratch.phi_p[j])
                                                 // assemble the term -div(u) as -(div u, q).
                                                 // Note the negative sign to make this
                                                 // operator adjoint to the grad p term:
-                                                - (this->get_pressure_scaling() *
+                                                - (pressure_scaling *
                                                    scratch.phi_p[i] * scratch.div_phi_u[j]))
                                               * JxW;
                   }
@@ -524,6 +526,7 @@ namespace aspect
       const FiniteElement<dim> &fe = this->get_fe();
       const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
       const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
+      const double pressure_scaling = this->get_pressure_scaling();
 
       for (unsigned int q=0; q<n_q_points; ++q)
         {
@@ -545,7 +548,7 @@ namespace aspect
           const double JxW = scratch.finite_element_values.JxW(q);
 
           for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
-            data.local_rhs(i) += (this->get_pressure_scaling() *
+            data.local_rhs(i) += (pressure_scaling *
                                   one_over_rho * drho_dz_u * scratch.phi_p[i])
                                  * JxW;
         }
@@ -575,6 +578,7 @@ namespace aspect
       const FiniteElement<dim> &fe = this->get_fe();
       const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
       const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
+      const double pressure_scaling = this->get_pressure_scaling();
 
       for (unsigned int q=0; q<n_q_points; ++q)
         {
@@ -598,7 +602,7 @@ namespace aspect
 
           for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
             for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
-              data.local_matrix(i,j) += (this->get_pressure_scaling() *
+              data.local_matrix(i,j) += (pressure_scaling *
                                          one_over_rho * drho_dz * scratch.phi_u[j] * scratch.phi_p[i])
                                         * JxW;
         }
@@ -625,6 +629,7 @@ namespace aspect
       const FiniteElement<dim> &fe = this->get_fe();
       const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
       const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
+      const double pressure_scaling = this->get_pressure_scaling();
 
       for (unsigned int q=0; q<n_q_points; ++q)
         {
@@ -653,7 +658,7 @@ namespace aspect
                                    // to the manual, this term seems to have the wrong sign, but this
                                    // is because we negate the entire equation to make sure we get
                                    // -div(u) as the adjoint operator of grad(p)
-                                   (this->get_pressure_scaling() *
+                                   (pressure_scaling *
                                     compressibility * density *
                                     (scratch.velocity_values[q] * gravity) *
                                     scratch.phi_p[i])


### PR DESCRIPTION
This fixes two problems in the Newton solver assembly discovered by @gassmoeller. The first problem is that the functions call in the inner most loop the function `this->get_pressure_scaling()`. We now store this value in the beginning and reuse it. The second problem was that the tensor contraction for the symmetrisation was very expensive. We could use a similar trick here, making it a lot cheaper.

The stats before:
```
+---------------------------------------------+------------+------------+
| Total wallclock time elapsed since start    |      88.6s |            |
|                                             |            |            |
| Section                         | no. calls |  wall time | % of total |
+---------------------------------+-----------+------------+------------+
| Assemble Stokes system          |         1 |      1.66s |       1.9% |
| Assemble Stokes system Newton   |         4 |      16.8s |        19% |
| Assemble Stokes system Picard   |         3 |      7.36s |       8.3% |
| Assemble Stokes system rhs      |         6 |      5.07s |       5.7% |
| Assemble temperature system     |         7 |      12.5s |        14% |
| Build Stokes preconditioner     |         7 |      19.5s |        22% |
| Solve Stokes system             |         7 |      12.6s |        14% |
| Initialization                  |         1 |       5.7s |       6.4% |
| Postprocessing                  |         1 |      2.55s |       2.9% |
| Setup dof systems               |         1 |     0.887s |         1% |
| Setup initial conditions        |         1 |      1.24s |       1.4% |
+---------------------------------+-----------+------------+------------+
```

stats after storing the pressure normalization:
```
+---------------------------------------------+------------+------------+
| Total wallclock time elapsed since start    |      75.2s |            |
|                                             |            |            |
| Section                         | no. calls |  wall time | % of total |
+---------------------------------+-----------+------------+------------+
| Assemble Stokes system          |         1 |      1.41s |       1.9% |
| Assemble Stokes system Newton   |         4 |      10.9s |        15% |
| Assemble Stokes system Picard   |         3 |      4.29s |       5.7% |
| Assemble Stokes system rhs      |         6 |      5.09s |       6.8% |
| Assemble temperature system     |         7 |      11.9s |        16% |
| Build Stokes preconditioner     |         7 |      16.6s |        22% |
| Solve Stokes system             |         7 |      13.1s |        17% |
| Initialization                  |         1 |      5.23s |       6.9% |
| Postprocessing                  |         1 |       2.5s |       3.3% |
| Setup dof systems               |         1 |     0.816s |       1.1% |
| Setup initial conditions        |         1 |      1.01s |       1.3% |
+---------------------------------+-----------+------------+------------+
```
Stats after fixing both:
```
+---------------------------------------------+------------+------------+
| Total wallclock time elapsed since start    |      70.9s |            |
|                                             |            |            |
| Section                         | no. calls |  wall time | % of total |
+---------------------------------+-----------+------------+------------+
| Assemble Stokes system          |         1 |      1.39s |         2% |
| Assemble Stokes system Newton   |         4 |      9.34s |        13% |
| Assemble Stokes system Picard   |         3 |      4.21s |       5.9% |
| Assemble Stokes system rhs      |         6 |       4.6s |       6.5% |
| Assemble temperature system     |         7 |      11.2s |        16% |
| Build Stokes preconditioner     |         7 |        16s |        23% |
| Solve Stokes system             |         7 |      12.4s |        17% |
| Initialization                  |         1 |      5.23s |       7.4% |
| Postprocessing                  |         1 |      2.35s |       3.3% |
| Setup dof systems               |         1 |     0.793s |       1.1% |
| Setup initial conditions        |         1 |      1.02s |       1.4% |
+---------------------------------+-----------+------------+------------+
```