### PR TITLE
[2.0.1] cherry-pick #2292 and #2329

### DIFF
--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -25,7 +25,9 @@
 #include <aspect/geometry_model/interface.h>
 #include <aspect/simulator_access.h>
 
+#if !DEAL_II_VERSION_GTE(9,0,0)
 #include <deal.II/grid/tria_boundary_lib.h>
+#endif
 #include <deal.II/grid/manifold_lib.h>
 
 namespace aspect

--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -36,6 +36,9 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <deal.II/lac/trilinos_precondition.h>
 #endif
 
+#if DEAL_II_VERSION_GTE(9,1,0)
+#  include <deal.II/lac/affine_constraints.h>
+#endif
 #include <deal.II/lac/generic_linear_algebra.h>
 
 #include <boost/archive/binary_oarchive.hpp>
@@ -48,6 +51,18 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 namespace aspect
 {
+#if DEAL_II_VERSION_GTE(9,1,0)
+  /**
+   * The ConstraintMatrix class was deprecated in deal.II 9.1 in favor
+   * of AffineConstraints. To make the name available for ASPECT
+   * nonetheless, use a `using` declaration. This injects the name
+   * into the `aspect` namespace, where it is visible before the
+   * deprecated name in the `dealii` namespace, thereby suppressing
+   * the deprecation message.
+   */
+  using ConstraintMatrix = class dealii::AffineConstraints<double>;
+#endif
+
   /**
    * The following are a set of global constants which may be used by ASPECT:
    * (for sources of data and values used by ASPECT, see source/global.cc)

--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -27,7 +27,9 @@
 #include <aspect/parameters.h>
 
 #include <deal.II/base/parameter_handler.h>
-#include <deal.II/lac/constraint_matrix.h>
+#if !DEAL_II_VERSION_GTE(9,1,0)
+#  include <deal.II/lac/constraint_matrix.h>
+#endif
 
 #include <boost/signals2.hpp>
 

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -27,8 +27,10 @@
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/grid_tools.h>
+
+#if !DEAL_II_VERSION_GTE(9,0,0)
 #include <deal.II/grid/tria_boundary_lib.h>
-#include <deal.II/grid/manifold_lib.h>
+#endif
 
 
 namespace aspect

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -22,7 +22,11 @@
 #include <aspect/geometry_model/ellipsoidal_chunk.h>
 #include <aspect/utilities.h>
 #include <deal.II/grid/tria_iterator.h>
+
+#if !DEAL_II_VERSION_GTE(9,0,0)
 #include <deal.II/grid/tria_boundary_lib.h>
+#endif
+
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>

--- a/source/geometry_model/sphere.cc
+++ b/source/geometry_model/sphere.cc
@@ -23,8 +23,10 @@
 #include <aspect/geometry_model/initial_topography_model/zero_topography.h>
 
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria_boundary_lib.h>
 
+#if !DEAL_II_VERSION_GTE(9,0,0)
+#include <deal.II/grid/tria_boundary_lib.h>
+#endif
 
 namespace aspect
 {

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -23,8 +23,6 @@
 #include <aspect/geometry_model/initial_topography_model/zero_topography.h>
 
 #include <deal.II/grid/grid_generator.h>
-#include <deal.II/grid/tria_boundary_lib.h>
-#include <deal.II/grid/manifold_lib.h>
 #include <aspect/utilities.h>
 
 namespace aspect

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -35,7 +35,9 @@
 #include <deal.II/base/work_stream.h>
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/lac/full_matrix.h>
-#include <deal.II/lac/constraint_matrix.h>
+#if !DEAL_II_VERSION_GTE(9,1,0)
+#  include <deal.II/lac/constraint_matrix.h>
+#endif
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/dofs/dof_accessor.h>

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -33,7 +33,9 @@
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/signaling_nan.h>
-#include <deal.II/lac/constraint_matrix.h>
+#if !DEAL_II_VERSION_GTE(9,1,0)
+#  include <deal.II/lac/constraint_matrix.h>
+#endif
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/sparsity_tools.h>
 #include <deal.II/grid/grid_tools.h>

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -38,7 +38,9 @@
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/signaling_nan.h>
-#include <deal.II/lac/constraint_matrix.h>
+#if !DEAL_II_VERSION_GTE(9,1,0)
+#  include <deal.II/lac/constraint_matrix.h>
+#endif
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/grid/grid_tools.h>
 

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -29,7 +29,9 @@
 #include <deal.II/base/function.h>
 
 #include <deal.II/lac/full_matrix.h>
-#include <deal.II/lac/constraint_matrix.h>
+#if !DEAL_II_VERSION_GTE(9,1,0)
+#  include <deal.II/lac/constraint_matrix.h>
+#endif
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -23,7 +23,9 @@
 #include <aspect/global.h>
 
 #include <deal.II/lac/solver_gmres.h>
-#include <deal.II/lac/constraint_matrix.h>
+#if !DEAL_II_VERSION_GTE(9,1,0)
+#  include <deal.II/lac/constraint_matrix.h>
+#endif
 
 #ifdef ASPECT_USE_PETSC
 #include <deal.II/lac/solver_cg.h>

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -25,7 +25,9 @@
 
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/lac/solver_gmres.h>
-#include <deal.II/lac/constraint_matrix.h>
+#if !DEAL_II_VERSION_GTE(9,1,0)
+#  include <deal.II/lac/constraint_matrix.h>
+#endif
 
 #ifdef ASPECT_USE_PETSC
 #include <deal.II/lac/solver_cg.h>


### PR DESCRIPTION
cherry-pick  #2292 and #2329 to avoid deprecation warnings. As discussed in #2262.