### PR TITLE
Remove ConstraintMatrix in global.h

### DIFF
--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -36,9 +36,6 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <deal.II/lac/trilinos_precondition.h>
 #endif
 
-#if DEAL_II_VERSION_GTE(9,1,0)
-#  include <deal.II/lac/affine_constraints.h>
-#endif
 #include <deal.II/lac/generic_linear_algebra.h>
 
 #include <boost/archive/binary_oarchive.hpp>
@@ -51,18 +48,6 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 namespace aspect
 {
-#if DEAL_II_VERSION_GTE(9,1,0)
-  /**
-   * The ConstraintMatrix class was deprecated in deal.II 9.1 in favor
-   * of AffineConstraints. To make the name available for ASPECT
-   * nonetheless, use a `using` declaration. This injects the name
-   * into the `aspect` namespace, where it is visible before the
-   * deprecated name in the `dealii` namespace, thereby suppressing
-   * the deprecation message.
-   */
-  using ConstraintMatrix = class dealii::AffineConstraints<double>;
-#endif
-
   /**
    * The following are a set of global constants which may be used by ASPECT:
    * (for sources of data and values used by ASPECT, see source/global.cc)

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -39,6 +39,12 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
+#if !DEAL_II_VERSION_GTE(9,1,0)
+#  include <deal.II/lac/constraint_matrix.h>
+#else
+#  include <deal.II/lac/affine_constraints.h>
+#endif
+
 #include <aspect/global.h>
 #include <aspect/simulator_access.h>
 #include <aspect/lateral_averaging.h>
@@ -68,6 +74,18 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 namespace aspect
 {
   using namespace dealii;
+
+#if DEAL_II_VERSION_GTE(9,1,0)
+  /**
+   * The ConstraintMatrix class was deprecated in deal.II 9.1 in favor
+   * of AffineConstraints. To make the name available for ASPECT
+   * nonetheless, use a `using` declaration. This injects the name
+   * into the `aspect` namespace, where it is visible before the
+   * deprecated name in the `dealii` namespace, thereby suppressing
+   * the deprecation message.
+   */
+  using ConstraintMatrix = class dealii::AffineConstraints<double>;
+#endif
 
   template <int dim>
   class MeltHandler;

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -34,11 +34,29 @@
 #include <deal.II/fe/fe.h>
 #include <deal.II/fe/mapping_q.h>
 
+#if !DEAL_II_VERSION_GTE(9,1,0)
+#  include <deal.II/lac/constraint_matrix.h>
+#else
+#  include <deal.II/lac/affine_constraints.h>
+#endif
+
 
 
 namespace aspect
 {
   using namespace dealii;
+
+#if DEAL_II_VERSION_GTE(9,1,0)
+  /**
+   * The ConstraintMatrix class was deprecated in deal.II 9.1 in favor
+   * of AffineConstraints. To make the name available for ASPECT
+   * nonetheless, use a `using` declaration. This injects the name
+   * into the `aspect` namespace, where it is visible before the
+   * deprecated name in the `dealii` namespace, thereby suppressing
+   * the deprecation message.
+   */
+  using ConstraintMatrix = class dealii::AffineConstraints<double>;
+#endif
 
   // forward declarations:
   template <int dim> class Simulator;

--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -27,9 +27,6 @@
 #include <aspect/parameters.h>
 
 #include <deal.II/base/parameter_handler.h>
-#if !DEAL_II_VERSION_GTE(9,1,0)
-#  include <deal.II/lac/constraint_matrix.h>
-#endif
 
 #include <boost/signals2.hpp>
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -33,9 +33,6 @@
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/signaling_nan.h>
-#if !DEAL_II_VERSION_GTE(9,1,0)
-#  include <deal.II/lac/constraint_matrix.h>
-#endif
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/sparsity_tools.h>
 #include <deal.II/grid/grid_tools.h>

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -38,9 +38,6 @@
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/signaling_nan.h>
-#if !DEAL_II_VERSION_GTE(9,1,0)
-#  include <deal.II/lac/constraint_matrix.h>
-#endif
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/grid/grid_tools.h>
 

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -29,9 +29,6 @@
 #include <deal.II/base/function.h>
 
 #include <deal.II/lac/full_matrix.h>
-#if !DEAL_II_VERSION_GTE(9,1,0)
-#  include <deal.II/lac/constraint_matrix.h>
-#endif
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/fe/fe_values.h>

--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -23,9 +23,6 @@
 #include <aspect/global.h>
 
 #include <deal.II/lac/solver_gmres.h>
-#if !DEAL_II_VERSION_GTE(9,1,0)
-#  include <deal.II/lac/constraint_matrix.h>
-#endif
 
 #ifdef ASPECT_USE_PETSC
 #include <deal.II/lac/solver_cg.h>

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -25,9 +25,6 @@
 
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/lac/solver_gmres.h>
-#if !DEAL_II_VERSION_GTE(9,1,0)
-#  include <deal.II/lac/constraint_matrix.h>
-#endif
 
 #ifdef ASPECT_USE_PETSC
 #include <deal.II/lac/solver_cg.h>


### PR DESCRIPTION
This is a fixup to #2329. I do not like to include more things into global.h, we should only include what is necessary. In practice this will not make a big difference, because most plugins include simulator_access.h, but when we require deal.II 9.1 we can replace the include in the simulator_access.h by a forward declaration and probably save some compile time. For the moment I think this is a cleaner solution than just putting `ConstraintMatrix` into global.h.