### PR TITLE
As is usual, make a plugin name lower-case.

### DIFF
--- a/doc/modules/changes/20180620_bangerth-2
+++ b/doc/modules/changes/20180620_bangerth-2
@@ -1,0 +1,8 @@
+Incompatibility: When selecting the 'dynamic core' plugin for the
+boundary temperature, the plugin previously used the "Dynamic core"
+spelling with a leading upper-case letter. However, all other plugins
+use leading lower-case letters. Consequently, the plugin was changed
+to follow the usual convention using all lower-case letters, even
+though this is a change that requires changes to users' input files.
+<br>
+(Wolfgang Bangerth, 2018/06/21)

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -979,7 +979,7 @@ namespace aspect
   namespace BoundaryTemperature
   {
     ASPECT_REGISTER_BOUNDARY_TEMPERATURE_MODEL(DynamicCore,
-                                               "Dynamic core",
+                                               "dynamic core",
                                                "This is a boundary temperature model working only with spherical "
                                                "shell geometry and core statistics postprocessor. The temperature "
                                                "at the top is constant, and the core mantle boundary temperature "

--- a/tests/dynamic_core.prm
+++ b/tests/dynamic_core.prm
@@ -54,7 +54,7 @@ end
 
 
 subsection Boundary temperature model
-  set List of model names = Dynamic core
+  set List of model names = dynamic core
   subsection Dynamic core
     set Inner temperature                 = 4100
     set Outer temperature                 = 300


### PR DESCRIPTION
All plugins use lower-case letters when they are identified in the place
where one selects a plugin, and an initial upper-case letter as a section
name. However, the DynamicCore class uses 'Dynamic core' also as the
plugin name.

Fix this.

This is clearly an incompatible change. I don't know how we usually handle
this: it's a bit of an obscure plugin, so I'd venture the guess that not
many people will actually notice, and maybe we shouldn't be terribly
concerned with backward compatibility. But I still wanted to see what
people think about it first.