### PR TITLE
Fixed a typo in the comment of a header file.

### DIFF
--- a/include/aspect/material_model/simple_compressible.h
+++ b/include/aspect/material_model/simple_compressible.h
@@ -100,7 +100,7 @@ namespace aspect
 
       private:
         /**
-         * The reference surface temperature
+         * The reference density
          */
         double reference_rho;
 


### PR DESCRIPTION
"reference_rho" variable was mistakenly commented as reference surface temperature.