### PR TITLE
Add new function to return the full list of compositional fields

### DIFF
--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -349,7 +349,6 @@ namespace aspect
 
       /**
        * A function that returns the full list of compositional field names.
-       * No arguments needed.
        */
       const std::vector<std::string>&
       get_composition_names () const;

--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -348,6 +348,13 @@ namespace aspect
       name_for_compositional_index (const unsigned int index) const;
 
       /**
+       * A function that returns the full list of compositional field names.
+       * No arguments needed.
+       */
+      const std::vector<std::string>&
+      get_composition_names () const;
+
+      /**
        * A function that gets the name of a compositional field as an input
        * parameter and returns if the compositional field is used in this
        * simulation.

--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -350,7 +350,7 @@ namespace aspect
       /**
        * A function that returns the full list of compositional field names.
        */
-      const std::vector<std::string>&
+      const std::vector<std::string> &
       get_composition_names () const;
 
       /**

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -264,6 +264,14 @@ namespace aspect
   }
 
   template <int dim>
+  const std::vector<std::string>&
+  Introspection<dim>::get_composition_names () const
+  {
+    // Simply return the full list of composition names
+    return composition_names;
+  }
+
+  template <int dim>
   bool
   Introspection<dim>::compositional_name_exists (const std::string &name) const
   {

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -264,7 +264,7 @@ namespace aspect
   }
 
   template <int dim>
-  const std::vector<std::string>&
+  const std::vector<std::string> &
   Introspection<dim>::get_composition_names () const
   {
     // Simply return the full list of composition names


### PR DESCRIPTION
The change allows the full list of compositional fields to be returned in a vector. This change was needed for adding a different new function in utilities.cc to parse maps. The reference for this related function will be added soon.