### PR TITLE
Parse map utility

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -73,6 +73,54 @@ namespace aspect
                                  const unsigned int N,
                                  const std::string &id_text);
 
+
+
+    /**
+    * This function takes a string argument that is interpreted as a map
+    * of the form "key1 : value1, key2 : value2, etc", and then parses
+    * it to return a vector of these values where the values are ordered
+    * in the same order as a given set of keys.
+    *
+    * This function also considers a number of special cases:
+    * - If the input string consists of only a comma separated
+    *   set of values "value1, value2, value3, ..." (i.e., without
+    *   the "keyx :" part), then the input string is interpreted
+    *   as if it had had the form "key1 : value1, key2 : value2, ..."
+    *   where "key1", "key2", ... are exactly the keys provided by the
+    *   @p list_of_keys in the same order as provided. In this situation,
+    *   if a background field is required, the background value is
+    *   assigned to the first element of the output vector.
+    * - Whether or not a background field is required depends on
+    *   the parameter being parsed. Requiring a background field
+    *   increases the size of the output vector by 1. For example,
+    *   some Material models require background fields, but input
+    *   files may not.
+    * - Three special keys are recognized:
+    *      all --> Assign the associated value to all fields.
+    *              Only one value is allowed in this case.
+    *      background (or bg) --> Assign associated value to
+    *                             the background.
+    *
+    * @param[in] key_value_map The string representation of the map
+    *   to be parsed.
+    * @param[in] list_of_keys A list of valid key names that are allowed
+    *   to appear in the map. The order of these keys determines the order
+    *   of values that are returned by this function.
+    * @param[in] field_name A name that identifies the type of information
+    *   that is being parsed by this function and that is used in generating
+    *   error messages if the map does not conform to the expected format.
+    *
+    * @return A vector of values that are parsed from the map, provided
+    *   in the order in which the keys appear in the @p list_of_keys argument.
+    */
+    std::vector<double>
+    parse_map_to_double_array (const std::string &key_value_map,
+                               const std::vector<std::string> &list_of_keys,
+                               const bool allow_background_field,
+                               const std::string &field_name);
+
+
+
     /**
      * Given a vector @p var_declarations expand any entries of the form
      * vector(str) or tensor(str) to sublists with component names of the form

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -31,6 +31,12 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/signaling_nan.h>
 
+#if DEAL_II_VERSION_GTE(9,0,0)
+#include <deal.II/base/patterns.h>
+#else
+#include <deal.II/base/parameter_handler.h>
+#endif
+
 #include <aspect/geometry_model/box.h>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/chunk.h>
@@ -53,6 +59,233 @@ namespace aspect
    */
   namespace Utilities
   {
+
+
+
+    std::vector<double> parse_map_to_double_array (const std::string &initial_field_array,
+                                                   const std::vector<std::string> &list_of_field_names,
+                                                   const bool allow_background_field,
+                                                   const std::string &field_name)
+
+    {
+      // Determine the total number of fields. If a background
+      // field is required, then this number equals the
+      // number of given keys plus one for the background
+      // field. Otherwise, the total number of fields is
+      // equal to the number of keys.
+      const unsigned int n_fields = (allow_background_field ?
+                                     list_of_field_names.size() + 1 :
+                                     list_of_field_names.size());
+
+      // Array of field values to be returned.
+      std::vector<double> x_mapped_values (n_fields,std::numeric_limits<double>::quiet_NaN());
+
+      // Split the comma separated values
+      const std::vector<std::string> x_mapped_field_entries = dealii::Utilities::split_string_list(initial_field_array, ',');
+
+
+      // Parse the string depending on what Pattern we are dealing with
+      // ---------------------------------------------------------------
+
+      // Split the list by comma delimited Map components,
+      // then by colon delimited string descriptor and value.
+      if (Patterns::Map(Patterns::Anything(),Patterns::Double(),1,n_fields).match(initial_field_array))
+        {
+
+          // Ensure there are values for all fields
+          AssertThrow ( (x_mapped_field_entries.size() == n_fields)
+                        || (x_mapped_field_entries.size() == 1),
+                        ExcMessage ("The number of "
+                                    + field_name
+                                    + " in the list must equal one of the following values:\n"
+                                    "1 (one value for all fields, including background, using the keyword=`all') \n"
+                                    "or the number of fields plus 1 "
+                                    "(one value for each field plus the background)."));
+
+          // Split each mapped entry into string and value
+          for (std::vector<std::string>::const_iterator p = x_mapped_field_entries.begin();
+               p != x_mapped_field_entries.end(); ++p)
+            {
+              // Look for the two special keyword descriptors:
+              //    all --> assign the associated value to all fields
+              //    background (or bg) --> assign associated value to
+              //                           the background
+              // All other keywords are used to assign the correct
+              // value to the correct position of the property array,
+              // and should match the list of field names, such as,
+              // for example, those found in the Compositional fields
+              // subsection.
+              //
+              // The user must input a background value.
+              //
+              // each entry must have the format:
+              // <id> : <value>
+
+
+              // First, split each mapped entry into string and value
+              const std::vector<std::string> split_parts = Utilities::split_string_list (*p, ':');
+
+              // Ensure that each entry has the correct form.
+              AssertThrow (split_parts.size() == 2,
+                           ExcMessage ("The format for mapped "
+                                       + field_name
+                                       + "requires that each entry has the "
+                                       "form `<id> : <value>' "
+                                       ", but the entry <"
+                                       + *p
+                                       + "> does not appear to follow this pattern."));
+
+              // The easy part: get the field names
+              const std::string keyword = split_parts[0];
+
+              // Handle the case when there is one entry in the list.
+              // The keyword "all" MUST be found.
+              if (x_mapped_field_entries.size() == 1)
+                {
+                  // Check that 'all' was used
+                  AssertThrow (keyword == "all",
+                               ExcMessage ("There is only one "
+                                           + field_name
+                                           + " value given. The keyword `all' is "
+                                           "expected but is not found. Please"
+                                           "check your "
+                                           + field_name
+                                           + " list."));
+
+                  // Assign all the elements to the "all" value
+                  for (unsigned int field_index=0; field_index<n_fields; ++field_index)
+                    {
+                      x_mapped_values[field_index] = Utilities::string_to_double(split_parts[1]);
+                    }
+                }
+
+              // Handle multiple entries
+              else if (x_mapped_field_entries.size()>1)
+                {
+                  // Ensure that the special keyword "all" was not used when multiple entries exist.
+                  AssertThrow (keyword != "all",
+                               ExcMessage ("There are multiple "
+                                           + field_name
+                                           + " values found, the keyword `all' is not "
+                                           "allowed. Please check your "
+                                           + field_name
+                                           + " list."));
+
+                  // Continue with placing values into the correct positions according to
+                  // the order of names passed to this function in the argument list_of_field_names.
+                  if (allow_background_field && (keyword == "background" || keyword == "bg"))
+                    {
+                      // Overwrite the default x_mapped_values to user input.
+                      // Element_0 is reserved for the background.
+                      x_mapped_values[0] = Utilities::string_to_double(split_parts[1]);
+                    }
+                  else
+                    {
+                      // Ensure that each non-special keyword found is also contained in
+                      // the list of field names, and insert the associated
+                      // values to the correct index position.
+                      for (unsigned int field_index=0; field_index<list_of_field_names.size(); ++field_index)
+                        {
+                          if (keyword == list_of_field_names[field_index])
+                            {
+                              const unsigned int map_index = (allow_background_field ?
+                                                              field_index + 1 :
+                                                              field_index);
+
+                              // Throw an error if a match was already found...there can be only one
+                              AssertThrow (std::isnan(x_mapped_values[map_index]) == true,
+                                           ExcMessage ("The keyword <"
+                                                       + keyword
+                                                       + "> in "
+                                                       + field_name
+                                                       + " is listed multiple times. "
+                                                       "Check that you have only one value for "
+                                                       "each field id in your list."
+                                                       "\n\n"
+                                                       "One example of where to check this is if "
+                                                       "Compositional fields are used, "
+                                                       "then check the id list "
+                                                       "from `set Names of fields' in the"
+                                                       "Compositional fields subsection. "
+                                                       "Alternatively, if `set Names of fields' "
+                                                       "is not set, the default names are "
+                                                       "C_1, C_2, ..., C_n."));
+
+                              // We passed the check above, so capture the value
+                              x_mapped_values[map_index] = Utilities::string_to_double(split_parts[1]);
+                            }
+                        }
+                    }
+                }
+            }
+
+          // Go through one more time to make sure everything was set.
+          // If a background is required, start at index one, i.e.,
+          // excluding the background field, because we will treat
+          // that separately below.
+          const unsigned int start_index = (allow_background_field ?
+                                            1 :
+                                            0);
+          const unsigned int list_index_offset = (allow_background_field ?
+                                                  -1 :
+                                                  0);
+
+          for (unsigned int field_index=start_index; field_index<n_fields; ++field_index)
+            {
+              AssertThrow (std::isnan(x_mapped_values[field_index]) == false,
+                           ExcMessage ("The keyword from <"
+                                       + list_of_field_names[field_index+list_index_offset]
+                                       + "> in "
+                                       + field_name
+                                       + " does not match any entries "
+                                       "from the list of field names. "
+                                       "Check that you have a value for "
+                                       "each field id in your list.\n\n"
+                                       "One example of where to check this is if "
+                                       "Compositional fields are used, "
+                                       "then check the id list "
+                                       "from `set Names of fields' in the"
+                                       "Compositional fields subsection. "
+                                       "Alternatively, if `set Names of fields' "
+                                       "is not set, the default names are "
+                                       "C_1, C_2, ..., C_n."));
+
+            }
+          // When required, ensure that the special keyword "background" or "bg" has an
+          // assigned value along with all the other names from list_of_field_names.
+          if (allow_background_field == true)
+            {
+              AssertThrow (std::isnan(x_mapped_values[0]) == false,
+                           ExcMessage ("The background field must be set in "
+                                       + field_name
+                                       + ". Set this value with the keyword id "
+                                       "`background' or `bg' with the format "
+                                       "`<id> : <value>'."));
+            }
+
+        }
+
+      else if (Patterns::List(Patterns::Double(),1,n_fields).match(initial_field_array))
+        {
+          // Handle the older format of a comma separated list of doubles, with no keywords
+          x_mapped_values = possibly_extend_from_1_to_N (dealii::Utilities::string_to_double(dealii::Utilities::split_string_list(initial_field_array)),
+                                                         n_fields,
+                                                         field_name);
+        }
+      else
+        {
+          // No Patterns matches were found!
+          AssertThrow (false,
+                       ExcMessage ("The required format for field <"
+                                   + field_name
+                                   + "> was not found. Specify a comma separated "
+                                   "list of `<double>' or `<id> : <double>'."));
+        }
+      return x_mapped_values;
+    }
+
+
+
     /**
      * Split the set of DoFs (typically locally owned or relevant) in @p whole_set into blocks
      * given by the @p dofs_per_block structure.

--- a/unit_tests/parse_map_to_double_array.cc
+++ b/unit_tests/parse_map_to_double_array.cc
@@ -1,0 +1,157 @@
+/*
+  Copyright (C) 2018 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include "common.h"
+#include <aspect/utilities.h>
+#include <deal.II/base/exceptions.h>
+
+
+TEST_CASE("Utilities::parse_map_to_double_array")
+{
+  // Parse multicomponent properties
+  INFO("check 1: ");
+  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200, C3:300, C4:400, C5:500, bg:0",
+  {"C1","C2","C3","C4","C5"},
+  true,
+  "TestField"),
+  {0.0,100.0,200.0,300.0,400.0,500.0});
+
+  INFO("check 2: ");
+  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("all:100",
+  {"C1","C2","C3","C4","C5"},
+  true,
+  "TestField"),
+  {100.0,100.0,100.0,100.0,100.0,100.0});
+
+  INFO("check 3: ");
+  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("bg:0, C1:100, C2:200, C3:300, C4:400, C5:500",
+  {"C1","C2","C3","C4","C5"},
+  true,
+  "TestField"),
+  {0.0,100.0,200.0,300.0,400.0,500.0});
+
+  INFO("check 4: ");
+  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("bg:0, C2:200, C1:100, C4:400, C5:500, C3:300",
+  {"C1","C2","C3","C4","C5"},
+  true,
+  "TestField"),
+  {0.0,100.0,200.0,300.0,400.0,500.0});
+
+  INFO("check 5: ");
+  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200, bg:0, C3:300, C4:400, C5:500",
+  {"C1","C2","C3","C4","C5"},
+  true,
+  "TestField"),
+  {0.0,100.0,200.0,300.0,400.0,500.0});
+
+  INFO("check 6: ");
+  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("100, 200, 300, 400, 500",
+  {"C1","C2","C3","C4","C5"},
+  false,
+  "TestField"),
+  {100.0,200.0,300.0,400.0,500.0});
+
+  INFO("check 7: ");
+  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200, C3:300, C4:400, C5:500",
+  {"C1","C2","C3","C4","C5"},
+  false,
+  "TestField"),
+  {100.0,200.0,300.0,400.0,500.0});
+
+  INFO("check 8: ");
+  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("background:0, C2:200, C1:100, C4:400, C5:500, C3:300",
+  {"C1","C2","C3","C4","C5"},
+  true,
+  "TestField"),
+  {0.0,100.0,200.0,300.0,400.0,500.0});
+
+  INFO("check complete");
+
+}
+
+using Catch::Matchers::Contains;
+
+TEST_CASE("Utilities::parse_map_to_double_array FAIL ON PURPOSE")
+{
+  // Purposefully fail Parse multicomponent properties
+  INFO("check fail 1: ");
+  REQUIRE_THROWS_WITH(
+    aspect::Utilities::parse_map_to_double_array ("C1:100, C1:200, C3:300, C4:400, C5:500",
+  {"C1","C2","C3","C4","C5"},
+  false,
+  "TestField"), Contains("is listed multiple times"));
+
+
+  INFO("check fail 2: ");
+  REQUIRE_THROWS_WITH(
+    aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200, C3:300, C4:400, C5:500",
+  {"C1","C2","C3","C4","C5"},
+  true,
+  "TestField"), Contains("list must equal one of the following values:"));
+
+
+  INFO("check fail 3: ");
+  REQUIRE_THROWS_WITH(
+    aspect::Utilities::parse_map_to_double_array ("C1:100, C1:200, C3:300, C4;400, C5:500, bg:3",
+  {"C1","C2","C3","C4","C5"},
+  true,
+  "TestField"), Contains("The required format for field"));
+
+
+  INFO("check fail 4: ");
+  REQUIRE_THROWS_WITH(
+    aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200, C3:300, C4:400, C24:500, bg:3",
+  {"C1","C2","C3","C4","C5"},
+  true,
+  "TestField"), Contains("does not match any entries"));
+
+  INFO("check fail 5: ");
+  REQUIRE_THROWS_WITH(
+    aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200, C3:300, all:400, C5:500, bg:3",
+  {"C1","C2","C3","C4","C5"},
+  true,
+  "TestField"), Contains("values found, the keyword `all' is not"));
+
+  INFO("check fail 6: ");
+  REQUIRE_THROWS_WITH(
+    aspect::Utilities::parse_map_to_double_array ("C1:100",
+  {"C1","C2","C3","C4","C5"},
+  true,
+  "TestField"), Contains("The keyword `all' is expected but is not found"));
+
+
+  /*
+    try
+    {
+        aspect::Utilities::parse_map_to_double_array ("C1:100, C1:200, C3:300, C4:400, C5:500",
+    {"C1","C2","C3","C4","C5"},
+    false,
+    "TestField");
+    }
+    catch (dealii::ExceptionBase &e)
+    {
+      e.print_info(std::cerr);
+      std::cerr << "waht=" << e.what() << std::endl;
+      //INFO(e.what());
+      REQUIRE(false);
+    }
+  */
+
+}


### PR DESCRIPTION
This is a new function that parses a comma separated series of maps of keyword_id and doubles. This function addresses issue #1489, to clarify the number of compositional fields in the multicomponent material model and other similar plugins. The current format uses a comma separated list of doubles to assign values to various parameters, such as density, for each compositional field. However, it is unclear which value is assigned to which field. This new function allows for each value to have a label id that matches the labels given to the compositional fields in the parameter file. The current format is also still supported, and the function detects which format is provided. As an example, this function has been implemented in multicomponent material model for the density parameter. This function is based on the change made in pull request #2403.