### PR TITLE
Fix warnings when compiling a test.

### DIFF
--- a/tests/edit_parameters.cc
+++ b/tests/edit_parameters.cc
@@ -8,7 +8,7 @@ namespace aspect
   using namespace dealii;
 
   // Global variables (to be set by parameters)
-  int switch_step;
+  unsigned int switch_step;
   bool switched;
 
   /**
@@ -35,8 +35,6 @@ namespace aspect
   void change_boundary_condition (const SimulatorAccess<dim> &simulator_access,
                                   Parameters<dim> &parameters)
   {
-    types::boundary_id bottom = 2; // bottom boundary indicator for 2D box
-
     if ( simulator_access.get_timestep_number() >= switch_step && !switched )
       {
         simulator_access.get_pcout()<<"Reducing CFL number!"<<std::endl;


### PR DESCRIPTION
Specifically, a warning about an unused variable, and a warning about comparison
between signed and unsigned.