### PR TITLE
Possibility to turn off the solvers and initial conditions setup during the initial refinement

### DIFF
--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -412,6 +412,7 @@ namespace aspect
     unsigned int                   min_grid_level;
     std::vector<double>            additional_refinement_times;
     unsigned int                   adaptive_refinement_interval;
+    bool                           solvers_off_on_initial_refinement;
     bool                           run_postprocessors_on_initial_refinement;
     bool                           run_postprocessors_on_nonlinear_iterations;
     /**

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -412,7 +412,8 @@ namespace aspect
     unsigned int                   min_grid_level;
     std::vector<double>            additional_refinement_times;
     unsigned int                   adaptive_refinement_interval;
-    bool                           solvers_off_on_initial_refinement;
+    bool                           skip_solvers_on_initial_refinement;
+    bool                           skip_setup_initial_conditions_on_initial_refinement;
     bool                           run_postprocessors_on_initial_refinement;
     bool                           run_postprocessors_on_nonlinear_iterations;
     /**

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1639,7 +1639,7 @@ namespace aspect
               {
                 const bool initial_refinement_done = maybe_do_initial_refinement(max_refinement_level);
                 if (initial_refinement_done)
-                goto start_time_iteration;
+                  goto start_time_iteration;
               }
           }
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1591,6 +1591,13 @@ namespace aspect
 
     if (parameters.resume_computation == false)
       {
+        if (parameters.solvers_off_on_initial_refinement)
+          {
+            const bool initial_refinement_done = maybe_do_initial_refinement(max_refinement_level);
+            if (initial_refinement_done) 
+              goto start_time_iteration;
+          }
+
         TimerOutput::Scope timer (computing_timer, "Setup initial conditions");
 
         // Add topography to box models after all initial refinement
@@ -1614,7 +1621,7 @@ namespace aspect
 
         // see if we have to start over with a new adaptive refinement cycle
         // at the beginning of the simulation
-        if (timestep_number == 0)
+        if (timestep_number == 0 && !parameters.solvers_off_on_initial_refinement)
           {
             const bool initial_refinement_done = maybe_do_initial_refinement(max_refinement_level);
             if (initial_refinement_done)

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1592,8 +1592,7 @@ namespace aspect
     if (parameters.resume_computation == false)
       {
         // See if we want to skip the initial conditions setup during the pre-
-        // refinement phase. If set true, the solvers won't be executed. An
-        // assertThrow will pop if the user tries to set solvers ON.
+        // refinement phase. If set to true, the solvers will not be executed.
         if (parameters.skip_setup_initial_conditions_on_initial_refinement)
           {
             const bool initial_refinement_done = maybe_do_initial_refinement(max_refinement_level);
@@ -1640,7 +1639,7 @@ namespace aspect
               {
                 const bool initial_refinement_done = maybe_do_initial_refinement(max_refinement_level);
                 if (initial_refinement_done)
-                  goto start_time_iteration;
+                goto start_time_iteration;
               }
           }
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1592,12 +1592,12 @@ namespace aspect
     if (parameters.resume_computation == false)
       {
         // See if we want to skip the initial conditions setup during the pre-
-        // refinement phase. If set true, the solvers won't be executed. An 
+        // refinement phase. If set true, the solvers won't be executed. An
         // assertThrow will pop if the user tries to set solvers ON.
         if (parameters.skip_setup_initial_conditions_on_initial_refinement)
           {
             const bool initial_refinement_done = maybe_do_initial_refinement(max_refinement_level);
-            if (initial_refinement_done) 
+            if (initial_refinement_done)
               goto start_time_iteration;
           }
 
@@ -1612,12 +1612,12 @@ namespace aspect
         compute_initial_pressure_field ();
 
         signals.post_set_initial_state (*this);
-        
-        // See if we want to skip the solvers during the pre-refinement phase. 
+
+        // See if we want to skip the solvers during the pre-refinement phase.
         if (parameters.skip_solvers_on_initial_refinement)
           {
             const bool initial_refinement_done = maybe_do_initial_refinement(max_refinement_level);
-            if (initial_refinement_done) 
+            if (initial_refinement_done)
               goto start_time_iteration;
           }
       }
@@ -1631,11 +1631,11 @@ namespace aspect
         solve_timestep ();
 
         // see if we have to start over with a new adaptive refinement cycle
-        // at the beginning of the simulation.  
+        // at the beginning of the simulation.
         if (timestep_number == 0)
           {
-            // Starting a new cycle only occurs if we do not want to skip the 
-            // initial conditions setup and the solvers. 
+            // Starting a new cycle only occurs if we do not want to skip the
+            // initial conditions setup and the solvers.
             if (!parameters.skip_setup_initial_conditions_on_initial_refinement && !parameters.skip_solvers_on_initial_refinement)
               {
                 const bool initial_refinement_done = maybe_do_initial_refinement(max_refinement_level);

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -638,10 +638,15 @@ namespace aspect
                          "Whether or not the postprocessors should be executed after "
                          "each of the initial adaptive refinement cycles that are run at "
                          "the start of the simulation.");
-      prm.declare_entry ("Solvers off on initial refinement", "false",
+      prm.declare_entry ("Skip solvers on initial refinement", "false",
                          Patterns::Bool (),
-                         "Whether or not solvers should be executed after the initial "
+                         "Whether or not solvers should be executed during the initial "
                          "adaptive refinement cycles that are run at the start of the "
+                         "simulation.");
+      prm.declare_entry ("Skip setup initial conditions on initial refinement", "false",
+                         Patterns::Bool (),
+                         "Whether or not the initial conditions should be set up during the "
+                         "the adaptive refinement cycles that are run at the start of the "
                          "simulation.");
     }
     prm.leave_subsection();
@@ -1126,8 +1131,18 @@ namespace aspect
         for (unsigned int i=0; i<additional_refinement_times.size(); ++i)
           additional_refinement_times[i] *= year_in_seconds;
 
-      solvers_off_on_initial_refinement = prm.get_bool("Solvers off on initial refinement");
+      skip_solvers_on_initial_refinement = prm.get_bool("Skip solvers on initial refinement");
+      skip_setup_initial_conditions_on_initial_refinement = prm.get_bool("Skip setup initial conditions on initial refinement");
+      
+      //AssertThrow(skip_setup_initial_conditions_on_initial_refinement == true && skip_solvers_on_initial_refinement == false,  
+      //            ExcMessage("Cannot execute solvers if no initial conditions are set up. "
+      //                       "You must set skip_solvers_on_initial_refinement to true."));
+      
       run_postprocessors_on_initial_refinement = prm.get_bool("Run postprocessors on initial refinement");
+       
+      //AssertThrow(skip_setup_initial_conditions_on_initial_refinement == true && run_postprocessors_on_initial_refinement == true,  
+      //            ExcMessage("Cannot run postprocessors if no initial conditions are set up. "
+      //                       "You must set run_postprocessors_on_initial_refinement to false."));
     }
     prm.leave_subsection ();
 

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -638,6 +638,11 @@ namespace aspect
                          "Whether or not the postprocessors should be executed after "
                          "each of the initial adaptive refinement cycles that are run at "
                          "the start of the simulation.");
+      prm.declare_entry ("Solvers off during initial refinement", "false",
+                         Patterns::Bool (),
+                         "Whether or not solvers should be executed after the initial "
+                         "adaptive refinement cycles that are run at the start of the "
+                         "simulation.");
     }
     prm.leave_subsection();
 

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1133,8 +1133,8 @@ namespace aspect
 
       skip_solvers_on_initial_refinement = prm.get_bool("Skip solvers on initial refinement");
       skip_setup_initial_conditions_on_initial_refinement = prm.get_bool("Skip setup initial conditions on initial refinement");
-     
-      if (skip_setup_initial_conditions_on_initial_refinement == true && skip_solvers_on_initial_refinement == false) 
+
+      if (skip_setup_initial_conditions_on_initial_refinement == true && skip_solvers_on_initial_refinement == false)
         AssertThrow(false, ExcMessage("Cannot execute solvers if no initial conditions are set up. "
                                       "You must set skip_solvers_on_initial_refinement to true."));
 

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1133,16 +1133,16 @@ namespace aspect
 
       skip_solvers_on_initial_refinement = prm.get_bool("Skip solvers on initial refinement");
       skip_setup_initial_conditions_on_initial_refinement = prm.get_bool("Skip setup initial conditions on initial refinement");
-      
-      //AssertThrow(skip_setup_initial_conditions_on_initial_refinement == true && skip_solvers_on_initial_refinement == false,  
-      //            ExcMessage("Cannot execute solvers if no initial conditions are set up. "
-      //                       "You must set skip_solvers_on_initial_refinement to true."));
-      
+     
+      if (skip_setup_initial_conditions_on_initial_refinement == true && skip_solvers_on_initial_refinement == false) 
+        AssertThrow(false, ExcMessage("Cannot execute solvers if no initial conditions are set up. "
+                                      "You must set skip_solvers_on_initial_refinement to true."));
+
       run_postprocessors_on_initial_refinement = prm.get_bool("Run postprocessors on initial refinement");
-       
-      //AssertThrow(skip_setup_initial_conditions_on_initial_refinement == true && run_postprocessors_on_initial_refinement == true,  
-      //            ExcMessage("Cannot run postprocessors if no initial conditions are set up. "
-      //                       "You must set run_postprocessors_on_initial_refinement to false."));
+
+      if (skip_setup_initial_conditions_on_initial_refinement == true && run_postprocessors_on_initial_refinement == true)
+        AssertThrow(false, ExcMessage("Cannot run postprocessors if no initial conditions are set up. "
+                                      "You must set run_postprocessors_on_initial_refinement to false."));
     }
     prm.leave_subsection ();
 

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -638,7 +638,7 @@ namespace aspect
                          "Whether or not the postprocessors should be executed after "
                          "each of the initial adaptive refinement cycles that are run at "
                          "the start of the simulation.");
-      prm.declare_entry ("Solvers off during initial refinement", "false",
+      prm.declare_entry ("Solvers off on initial refinement", "false",
                          Patterns::Bool (),
                          "Whether or not solvers should be executed after the initial "
                          "adaptive refinement cycles that are run at the start of the "
@@ -1126,6 +1126,7 @@ namespace aspect
         for (unsigned int i=0; i<additional_refinement_times.size(); ++i)
           additional_refinement_times[i] *= year_in_seconds;
 
+      solvers_off_on_initial_refinement = prm.get_bool("Solvers off on initial refinement");
       run_postprocessors_on_initial_refinement = prm.get_bool("Run postprocessors on initial refinement");
     }
     prm.leave_subsection ();

--- a/tests/skip_initial_conditions_setup_on_initial_refinement.prm
+++ b/tests/skip_initial_conditions_setup_on_initial_refinement.prm
@@ -1,0 +1,82 @@
+##### simple test for ascii data initial temperature
+
+set Dimension                              = 2
+
+set Use years in output instead of seconds = true
+set End time                               = 1
+set Output directory                       = output-test
+#set Adiabatic surface temperature          = 1613.0
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 660000
+    set Y extent = 660000
+  end
+end
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 273
+  end
+end
+
+
+subsection Boundary temperature model
+  set List of model names = box
+end
+
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = bottom:function,left:function,right:function,top:function
+end
+
+
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = 1;0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Viscosity = 1e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 1
+  set Initial adaptive refinement              = 2
+  set Time steps between mesh refinement       = 0
+  set Skip solvers on initial refinement       = true
+  set Skip setup initial conditions on initial refinement = true
+  set Strategy                                 = minimum refinement function
+  subsection Minimum refinement function
+    set Variable names        = x, y
+    set Function expression   = if(x>330000, 3 ,1)
+  end
+end
+
+
+subsection Postprocess
+  set List of postprocessors = heat flux statistics
+end
+

--- a/tests/skip_initial_conditions_setup_on_initial_refinement.prm
+++ b/tests/skip_initial_conditions_setup_on_initial_refinement.prm
@@ -1,20 +1,20 @@
-##### simple test for ascii data initial temperature
+##### simple test for skipping initial conditions setup
+##### on initial refinement.
 
 set Dimension                              = 2
-
 set Use years in output instead of seconds = true
 set End time                               = 1
 set Output directory                       = output-test
-#set Adiabatic surface temperature          = 1613.0
+
 
 subsection Geometry model
   set Model name = box
-
   subsection Box
     set X extent = 660000
     set Y extent = 660000
   end
 end
+
 
 subsection Initial temperature model
   set Model name = function
@@ -28,10 +28,6 @@ subsection Boundary temperature model
   set List of model names = box
 end
 
-
-# The parameters below this comment were created by the update script
-# as replacement for the old 'Model settings' subsection. They can be
-# safely merged with any existing subsections with the same name.
 
 subsection Boundary velocity model
   set Prescribed velocity boundary indicators = bottom:function,left:function,right:function,top:function
@@ -47,7 +43,6 @@ end
 
 subsection Gravity model
   set Model name = vertical
-
   subsection Vertical
     set Magnitude = 10
   end

--- a/tests/skip_initial_conditions_setup_on_initial_refinement/screen-output
+++ b/tests/skip_initial_conditions_setup_on_initial_refinement/screen-output
@@ -1,0 +1,58 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (solvers_off, 1a1603d53)
+--     . using deal.II 8.5.1
+--     . using Trilinos 12.12.1
+--     . using p4est 1.1.0
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+-- How to cite ASPECT: https://aspect.geodynamics.org/cite.html
+-----------------------------------------------------------------------------
+
+Number of active cells: 4 (on 2 levels)
+Number of degrees of freedom: 84 (50+9+25)
+
+Number of active cells: 10 (on 3 levels)
+Number of degrees of freedom: 189 (114+18+57)
+
+Number of active cells: 40 (on 4 levels)
+Number of degrees of freedom: 634 (386+55+193)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 21+0 iterations.
+
+   Postprocessing:
+     Heat fluxes through boundary parts: -1.121e-12 W, -1.121e-12 W, -1.495e-12 W, -3.737e-13 W
+
+*** Timestep 1:  t=1 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+
+   Postprocessing:
+     Heat fluxes through boundary parts: -1.121e-12 W, -1.121e-12 W, -1.495e-12 W, -3.737e-13 W
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.123s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |   0.00839s |       6.8% |
+| Assemble temperature system     |         2 |   0.00591s |       4.8% |
+| Build Stokes preconditioner     |         2 |    0.0109s |       8.9% |
+| Build temperature preconditioner|         2 |  0.000636s |      0.52% |
+| Solve Stokes system             |         2 |   0.00476s |       3.9% |
+| Solve temperature system        |         2 |   0.00107s |      0.87% |
+| Initialization                  |         1 |     0.069s |        56% |
+| Postprocessing                  |         2 |   0.00187s |       1.5% |
+| Refine mesh structure, part 1   |         2 |   0.00115s |      0.93% |
+| Refine mesh structure, part 2   |         2 |  0.000787s |      0.64% |
+| Setup dof systems               |         3 |   0.00462s |       3.8% |
+| Setup initial conditions        |         3 |    0.0107s |       8.7% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/skip_initial_conditions_setup_on_initial_refinement/statistics
+++ b/tests/skip_initial_conditions_setup_on_initial_refinement/statistics
@@ -1,0 +1,16 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 12: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 13: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 14: Outward heat flux through boundary with indicator 3 ("top") (W)
+0 0.000000000000e+00 0.000000000000e+00 40 441 193 0 21 22 66 -1.12106505e-12 -1.12106505e-12 -1.49475340e-12 -3.73688349e-13 
+1 1.000000000000e+00 1.000000000000e+00 40 441 193 0  0  0  0 -1.12106505e-12 -1.12106505e-12 -1.49475340e-12 -3.73688349e-13 

--- a/tests/skip_solvers_on_initial_refinement.prm
+++ b/tests/skip_solvers_on_initial_refinement.prm
@@ -1,15 +1,13 @@
-##### simple test for ascii data initial temperature
+##### simple test for skipping solvers on initial refinement
 
 set Dimension                              = 2
-
 set Use years in output instead of seconds = true
 set End time                               = 1
 set Output directory                       = output-test
-#set Adiabatic surface temperature          = 1613.0
+
 
 subsection Geometry model
   set Model name = box
-
   subsection Box
     set X extent = 660000
     set Y extent = 660000
@@ -30,10 +28,6 @@ subsection Boundary temperature model
 end
 
 
-# The parameters below this comment were created by the update script
-# as replacement for the old 'Model settings' subsection. They can be
-# safely merged with any existing subsections with the same name.
-
 subsection Boundary velocity model
   set Prescribed velocity boundary indicators = bottom:function,left:function,right:function,top:function
 end
@@ -48,7 +42,6 @@ end
 
 subsection Gravity model
   set Model name = vertical
-
   subsection Vertical
     set Magnitude = 10
   end

--- a/tests/skip_solvers_on_initial_refinement.prm
+++ b/tests/skip_solvers_on_initial_refinement.prm
@@ -1,0 +1,83 @@
+##### simple test for ascii data initial temperature
+
+set Dimension                              = 2
+
+set Use years in output instead of seconds = true
+set End time                               = 1
+set Output directory                       = output-test
+#set Adiabatic surface temperature          = 1613.0
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 660000
+    set Y extent = 660000
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 273
+  end
+end
+
+
+subsection Boundary temperature model
+  set List of model names = box
+end
+
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = bottom:function,left:function,right:function,top:function
+end
+
+
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = 1;0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Viscosity = 1e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 1
+  set Initial adaptive refinement              = 2
+  set Time steps between mesh refinement       = 0
+  set Skip solvers on initial refinement       = true
+  set Skip setup initial conditions on initial refinement = false
+  set Strategy                                 = minimum refinement function
+  subsection Minimum refinement function
+    set Variable names        = x, y
+    set Function expression   = if(x>330000, 3 ,1)
+  end
+end
+
+
+subsection Postprocess
+  set List of postprocessors = heat flux statistics
+end
+

--- a/tests/skip_solvers_on_initial_refinement/screen-output
+++ b/tests/skip_solvers_on_initial_refinement/screen-output
@@ -1,0 +1,58 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.0.0-pre (solvers_off, 1a1603d53)
+--     . using deal.II 8.5.1
+--     . using Trilinos 12.12.1
+--     . using p4est 1.1.0
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+-- How to cite ASPECT: https://aspect.geodynamics.org/cite.html
+-----------------------------------------------------------------------------
+
+Number of active cells: 4 (on 2 levels)
+Number of degrees of freedom: 84 (50+9+25)
+
+Number of active cells: 10 (on 3 levels)
+Number of degrees of freedom: 189 (114+18+57)
+
+Number of active cells: 40 (on 4 levels)
+Number of degrees of freedom: 634 (386+55+193)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 21+0 iterations.
+
+   Postprocessing:
+     Heat fluxes through boundary parts: -1.121e-12 W, -1.121e-12 W, -1.495e-12 W, -3.737e-13 W
+
+*** Timestep 1:  t=1 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+
+   Postprocessing:
+     Heat fluxes through boundary parts: -1.121e-12 W, -1.121e-12 W, -1.495e-12 W, -3.737e-13 W
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |     0.123s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         2 |   0.00839s |       6.8% |
+| Assemble temperature system     |         2 |   0.00591s |       4.8% |
+| Build Stokes preconditioner     |         2 |    0.0109s |       8.9% |
+| Build temperature preconditioner|         2 |  0.000636s |      0.52% |
+| Solve Stokes system             |         2 |   0.00476s |       3.9% |
+| Solve temperature system        |         2 |   0.00107s |      0.87% |
+| Initialization                  |         1 |     0.069s |        56% |
+| Postprocessing                  |         2 |   0.00187s |       1.5% |
+| Refine mesh structure, part 1   |         2 |   0.00115s |      0.93% |
+| Refine mesh structure, part 2   |         2 |  0.000787s |      0.64% |
+| Setup dof systems               |         3 |   0.00462s |       3.8% |
+| Setup initial conditions        |         3 |    0.0107s |       8.7% |
++---------------------------------+-----------+------------+------------+
+

--- a/tests/skip_solvers_on_initial_refinement/statistics
+++ b/tests/skip_solvers_on_initial_refinement/statistics
@@ -1,0 +1,16 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 12: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 13: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 14: Outward heat flux through boundary with indicator 3 ("top") (W)
+0 0.000000000000e+00 0.000000000000e+00 40 441 193 0 21 22 66 -1.12106505e-12 -1.12106505e-12 -1.49475340e-12 -3.73688349e-13 
+1 1.000000000000e+00 1.000000000000e+00 40 441 193 0  0  0  0 -1.12106505e-12 -1.12106505e-12 -1.49475340e-12 -3.73688349e-13 


### PR DESCRIPTION
For those who want to skip solvers and the initial conditions setup, this pull request adds 2 parameters for the subsection mesh refinement.

AssertThrow for solvers ON while setup initial conditions OFF does not work for some reason.
AssertThrow for skipping setup initial conditions while running postprocessors on initial refinement does not work either.

