### PR TITLE
Clean up get_parameters().convert_to_years in material models and postprocessors

### DIFF
--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -457,7 +457,7 @@ namespace aspect
           if (thermal_viscosity_exponent!=0.0 && reference_T == 0.0)
             AssertThrow(false, ExcMessage("Error: Material model Melt simple with Thermal viscosity exponent can not have reference_T=0."));
 
-          if (this->get_parameters().convert_to_years == true)
+          if (this->convert_output_to_years() == true)
             melting_time_scale *= year_in_seconds;
 
           if (this->get_parameters().use_operator_splitting)

--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -719,7 +719,7 @@ namespace aspect
           if (thermal_viscosity_exponent!=0.0 && reference_T == 0.0)
             AssertThrow(false, ExcMessage("Error: Material model Melt simple with Thermal viscosity exponent can not have reference_T=0."));
 
-          if (this->get_parameters().convert_to_years == true)
+          if (this->convert_output_to_years() == true)
             {
               melting_time_scale *= year_in_seconds;
               freezing_rate /= year_in_seconds;

--- a/source/postprocess/global_statistics.cc
+++ b/source/postprocess/global_statistics.cc
@@ -209,7 +209,7 @@ namespace aspect
       // set global statistics about this time step
       statistics.add_value("Time step number", this->get_timestep_number());
 
-      if (this->get_parameters().convert_to_years == true)
+      if (this->convert_output_to_years() == true)
         {
           statistics.add_value("Time (years)", this->get_time() / year_in_seconds);
           statistics.set_precision("Time (years)", 12);


### PR DESCRIPTION
The flag for converting years to seconds can be checked with the wrapper function convert_output_to_years(), and all but three of the material models and postprocessors use the wrapper. @tjhei suggested cleaning up those three files to make things more consistent/searchable, so I've done that. 