### PR TITLE
Replace find_plugin function

### DIFF
--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -30,6 +30,9 @@
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/distributed/tria.h>
 
+#include <boost/core/demangle.hpp>
+#include <typeinfo>
+
 
 namespace aspect
 {
@@ -255,8 +258,25 @@ namespace aspect
          * that matches the given type, return a NULL pointer.
          */
         template <typename BoundaryTemperatureType>
+        DEAL_II_DEPRECATED
         BoundaryTemperatureType *
         find_boundary_temperature_model () const;
+
+        template <typename BoundaryTemperatureType>
+        bool
+        has_matching_boundary_temperature_model () const;
+
+        /**
+         * Go through the list of all boundary temperature models that have been selected
+         * in the input file (and are consequently currently active) and see
+         * if one of them has the type specified by the template
+         * argument or can be casted to that type. If so, return a reference
+         * to it. If no boundary temperature model is active that matches the given type,
+         * throw an exception.
+         */
+        template <typename BoundaryTemperatureType>
+        const BoundaryTemperatureType &
+        get_matching_boundary_temperature_model () const;
 
         /*
          * Return a set of boundary indicators for which boundary
@@ -329,6 +349,45 @@ namespace aspect
         if (BoundaryTemperatureType *x = dynamic_cast<BoundaryTemperatureType *> ( (*p).get()) )
           return x;
       return NULL;
+    }
+
+
+    template <int dim>
+    template <typename BoundaryTemperatureType>
+    inline
+    bool
+    Manager<dim>::has_matching_boundary_temperature_model () const
+    {
+      for (typename std::vector<std::shared_ptr<Interface<dim> > >::const_iterator
+           p = boundary_temperature_objects.begin();
+           p != boundary_temperature_objects.end(); ++p)
+        if (Plugins::plugin_type_matches<BoundaryTemperatureType>(*(*p)))
+          return true;
+      return false;
+    }
+
+
+    template <int dim>
+    template <typename BoundaryTemperatureType>
+    inline
+    const BoundaryTemperatureType &
+    Manager<dim>::get_matching_boundary_temperature_model () const
+    {
+      AssertThrow(has_matching_boundary_temperature_model<BoundaryTemperatureType> (),
+                  ExcMessage("You asked BoundaryTemperature:Manager::get_boundary_temperature_model() for a "
+                             "boundary temperature model of type <" + boost::core::demangle(typeid(BoundaryTemperatureType).name()) + "> "
+                             "that could not be found in the current model. Activate this "
+                             "boundary temperature model in the input file."));
+
+      typename std::vector<std::shared_ptr<Interface<dim> > >::const_iterator boundary_temperature_model;
+      for (typename std::vector<std::shared_ptr<Interface<dim> > >::const_iterator
+           p = boundary_temperature_objects.begin();
+           p != boundary_temperature_objects.end(); ++p)
+        if (Plugins::plugin_type_matches<BoundaryTemperatureType>(*(*p)))
+          return Plugins::get_plugin_as_type<BoundaryTemperatureType>(*(*p));
+
+      // We will never get here, because we had the Assert above. Just to avoid warnings.
+      return Plugins::get_plugin_as_type<BoundaryTemperatureType>(*(*boundary_temperature_model));
     }
 
 

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -262,6 +262,12 @@ namespace aspect
         BoundaryTemperatureType *
         find_boundary_temperature_model () const;
 
+        /**
+         * Go through the list of all boundary temperature models that have been selected
+         * in the input file (and are consequently currently active) and return
+         * true if one of them has the desired type specified by the template
+         * argument.
+         */
         template <typename BoundaryTemperatureType>
         bool
         has_matching_boundary_temperature_model () const;

--- a/include/aspect/boundary_velocity/interface.h
+++ b/include/aspect/boundary_velocity/interface.h
@@ -245,6 +245,12 @@ namespace aspect
         BoundaryVelocityType *
         find_boundary_velocity_model () const;
 
+        /**
+         * Go through the list of all boundary velocity models that have been selected
+         * in the input file (and are consequently currently active) and return
+         * true if one of them has the desired type specified by the template
+         * argument.
+         */
         template <typename BoundaryVelocityType>
         bool
         has_matching_boundary_velocity_model () const;

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -333,10 +333,16 @@ namespace aspect
          * given type, return a NULL pointer.
          */
         template <typename HeatingModelType>
-	DEAL_II_DEPRECATED
+        DEAL_II_DEPRECATED
         HeatingModelType *
         find_heating_model () const;
 
+        /**
+         * Go through the list of all heating models that have been selected
+         * in the input file (and are consequently currently active) and return
+         * true if one of them has the desired type specified by the template
+         * argument.
+         */
         template <typename HeatingModelType>
         bool
         has_matching_heating_model () const;

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -194,6 +194,12 @@ namespace aspect
         InitialCompositionType *
         find_initial_composition_model () const;
 
+        /**
+         * Go through the list of all initial composition models that have been selected
+         * in the input file (and are consequently currently active) and return
+         * true if one of them has the desired type specified by the template
+         * argument.
+         */
         template <typename InitialCompositionType>
         bool
         has_matching_initial_composition_model () const;

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -191,6 +191,12 @@ namespace aspect
         InitialTemperatureType *
         find_initial_temperature_model () const;
 
+        /**
+         * Go through the list of all initial temperature models that have been selected
+         * in the input file (and are consequently currently active) and return
+         * true if one of them has the desired type specified by the template
+         * argument.
+         */
         template <typename InitialTemperatureType>
         bool
         has_matching_initial_temperature_model () const;

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -122,7 +122,7 @@ namespace aspect
     bool
     Manager<dim>::adiabatic_heating_enabled() const
     {
-      return find_heating_model<HeatingModel::AdiabaticHeating<dim> >() != NULL;
+      return has_matching_heating_model<HeatingModel::AdiabaticHeating<dim> >() ;
     }
 
 
@@ -131,7 +131,7 @@ namespace aspect
     bool
     Manager<dim>::shear_heating_enabled() const
     {
-      return find_heating_model<HeatingModel::ShearHeating<dim> >() != NULL;
+      return has_matching_heating_model<HeatingModel::ShearHeating<dim> >() ;
     }
 
 

--- a/source/postprocess/core_statistics.cc
+++ b/source/postprocess/core_statistics.cc
@@ -46,14 +46,10 @@ namespace aspect
       // and create a single string that can be output to the screen
       std::ostringstream screen_text;
 
-      const BoundaryTemperature::DynamicCore<dim> *dynamic_core =
-        this->get_boundary_temperature_manager().template find_boundary_temperature_model<BoundaryTemperature::DynamicCore<dim> >();
+      const BoundaryTemperature::DynamicCore<dim> &dynamic_core =
+        this->get_boundary_temperature_manager().template get_matching_boundary_temperature_model<BoundaryTemperature::DynamicCore<dim> >();
 
-      AssertThrow(dynamic_core != NULL,
-                  ExcMessage("Could not find the dynamic core temperature boundary conditions. "
-                             "Perhaps you forgot to include it?"));
-
-      core_data = dynamic_core->get_core_data();
+      core_data = dynamic_core.get_core_data();
 
       // now add core mantle boundary heat flux to the statistics object
       // and create a single string that can be output to the screen
@@ -136,7 +132,7 @@ namespace aspect
           statistics.set_scientific (name10, true);
         }
 
-      if (dynamic_core->is_OES_used())
+      if (dynamic_core.is_OES_used())
         {
           const std::string name11 = "Other energy source (W)";
           statistics.add_value (name11, core_data.Q_OES);

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1806,8 +1806,8 @@ namespace aspect
                                "Please check the consistency of your input file."));
 
         const bool use_simplified_adiabatic_heating =
-          heating_model_manager.template find_heating_model<HeatingModel::AdiabaticHeating<dim> >()
-          ->use_simplified_adiabatic_heating();
+          heating_model_manager.template get_matching_heating_model<HeatingModel::AdiabaticHeating<dim> >()
+          .use_simplified_adiabatic_heating();
 
         AssertThrow(use_simplified_adiabatic_heating == true,
                     ExcMessage("ASPECT detected an inconsistency in the provided input file. "


### PR DESCRIPTION
This pull request addresses #2260. The deal.ii deprecated find_plugin functions for the following interfaces are replaced by has_matching and get_matching.

- [ ] boundary temperature
- [ ] boundary velocity 
- [ ] heating model 
- [ ] initial composition 
- [ ] initial temperature
