### PR TITLE
Add necessary #include file to make things compile again.

### DIFF
--- a/source/boundary_heat_flux/function.cc
+++ b/source/boundary_heat_flux/function.cc
@@ -21,6 +21,7 @@
 
 #include <aspect/boundary_heat_flux/function.h>
 #include <aspect/global.h>
+#include <aspect/geometry_model/interface.h>
 #include <deal.II/base/signaling_nan.h>
 
 namespace aspect


### PR DESCRIPTION
I think the problem came in through an unfortunate combination of #2343 and #2337 -- each might have compiled successfully individually, but not in combination.