### PR TITLE
Remove unnecessary forward declarations.

### DIFF
--- a/include/aspect/geometry_model/ellipsoidal_chunk.h
+++ b/include/aspect/geometry_model/ellipsoidal_chunk.h
@@ -39,11 +39,6 @@ namespace aspect
   {
     using namespace dealii;
 
-    namespace internal
-    {
-      template <int dim> void set_manifold_ids(Triangulation<dim> &triangulation);
-      template <int dim> void clear_manifold_ids(Triangulation<dim> &triangulation);
-    }
     /**
      * A class that describes a geometry for an ellipsoid such as the WGS84 model of the earth.
      */


### PR DESCRIPTION
#2442 moved these functions out of the class declaration and instead made them
functions in an internal namespace. But it also moved the declaration into the
.h file, which is not necessary since these functions are only used in the
.cc file. So remove the declarations from there.

This finally fixes #2402.