### PR TITLE
fixed attribute ignored warning

### DIFF
--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -230,8 +230,8 @@ namespace aspect
 
 
         template <typename BoundaryCompositionType>
-        BoundaryCompositionType *
         DEAL_II_DEPRECATED
+        BoundaryCompositionType *
         find_boundary_composition_model () const;
 
         /**


### PR DESCRIPTION
The deal II deprecation PR resulted in an error during compilation of ASPECT:
... aspect/include/aspect/boundary_composition/interface.h:235:44: warning: attribute ignored [-Wattributes]
         find_boundary_composition_model () const;

This PR fixes that warning.
