### PR TITLE
Change default limits for 'uniform radial' particle generator

### DIFF
--- a/doc/modules/changes/20180625_niday
+++ b/doc/modules/changes/20180625_niday
@@ -1,0 +1,4 @@
+Fixed: The default latitude and longitude limits for the 'uniform radial' particle generator were set to (0, pi) even though they are measured in degrees.
+The new default limits correspond to the entire surface of the sphere, and the manual clarifies that latitude is in (0, 180) and not (-90, 90).
+<br>
+(Bart Niday, 2018/06/25)

--- a/source/particle/generator/uniform_radial.cc
+++ b/source/particle/generator/uniform_radial.cc
@@ -171,18 +171,20 @@ namespace aspect
                                    Patterns::Double (0,360),
                                    "Minimum longitude coordinate for the region of particles "
                                    "in degrees. Measured from the center position.");
-                prm.declare_entry ("Maximum longitude", "3.1415",
+                prm.declare_entry ("Maximum longitude", "360",
                                    Patterns::Double (0,360),
                                    "Maximum longitude coordinate for the region of particles "
                                    "in degrees. Measured from the center position.");
                 prm.declare_entry ("Minimum latitude", "0",
                                    Patterns::Double (0,180),
                                    "Minimum latitude coordinate for the region of particles "
-                                   "in degrees. Measured from the center position.");
-                prm.declare_entry ("Maximum latitude", "3.1415",
+                                   "in degrees. Measured from the center position, and from "
+                                   "the north pole.");
+                prm.declare_entry ("Maximum latitude", "180",
                                    Patterns::Double (0,180),
                                    "Maximum latitude coordinate for the region of particles "
-                                   "in degrees. Measured from the center position.");
+                                   "in degrees. Measured from the center position, and from "
+                                   "the north pole.");
                 prm.declare_entry ("Radial layers", "1",
                                    Patterns::Integer(1),
                                    "The number of radial shells of particles that will be generated "


### PR DESCRIPTION
The default maximum longitude and latitude are pi, which does not make sense for angles measured in degrees.