### PR TITLE
[bugfix] fix additional material model outputs on face assemblers

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -962,12 +962,12 @@ namespace aspect
                                                      scratch.face_material_model_inputs);
 
                 for (unsigned int i=0; i<assemblers->advection_system_on_boundary_face.size(); ++i)
-                  assemblers->advection_system_on_boundary_face[i]->create_additional_material_model_outputs(scratch.material_model_outputs);
+                  assemblers->advection_system_on_boundary_face[i]->create_additional_material_model_outputs(scratch.face_material_model_outputs);
 
                 for (unsigned int i=0; i<assemblers->advection_system_on_interior_face.size(); ++i)
-                  assemblers->advection_system_on_interior_face[i]->create_additional_material_model_outputs(scratch.material_model_outputs);
+                  assemblers->advection_system_on_interior_face[i]->create_additional_material_model_outputs(scratch.face_material_model_outputs);
 
-                heating_model_manager.create_additional_material_model_outputs(scratch.material_model_outputs);
+                heating_model_manager.create_additional_material_model_outputs(scratch.face_material_model_outputs);
 
                 material_model->evaluate(scratch.face_material_model_inputs,
                                          scratch.face_material_model_outputs);


### PR DESCRIPTION
In the assembly of the advection system for boundary faces, where we attach the additional outputs to the material model outputs, we used to attach the additional outputs to the "normal" material model outputs instead of the face material model outputs. I don't think anyone noticed this, probably because so far we haven't used additional outputs with the face assemblers. 

This pull request fixes this. 