### PR TITLE
switching output of solcx, solkz to MKS again

### DIFF
--- a/benchmarks/solcx/solcx.prm
+++ b/benchmarks/solcx/solcx.prm
@@ -15,6 +15,7 @@ set Output directory                       = output
 set Pressure normalization                 = volume
 set Nonlinear solver scheme                = no Advection, iterated Stokes
 
+set Use years in output instead of seconds = false
 
 ############### Parameters describing the model
 

--- a/benchmarks/solkz/solkz.prm
+++ b/benchmarks/solkz/solkz.prm
@@ -15,6 +15,7 @@ set Output directory                       = output
 set Pressure normalization                 = volume
 set Nonlinear solver scheme                = no Advection, iterated Stokes
 
+set Use years in output instead of seconds = false
 
 ############### Parameters describing the model
 


### PR DESCRIPTION
As they are now the two parameter files for SOLCX and SOLKZ generate velocity outputs in m/year which is a) nonsensical b) different than what is shown in the manual.