### PR TITLE
make perplex cmake search quiet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,7 +333,7 @@ ENDIF()
 
 DEAL_II_INVOKE_AUTOPILOT()
 
-FIND_PACKAGE(PerpleX HINTS ./contrib/perplex/install/ ../ ../../ $ENV{PERPLEX_DIR})
+FIND_PACKAGE(PerpleX QUIET HINTS ./contrib/perplex/install/ ../ ../../ $ENV{PERPLEX_DIR})
 IF(${PerpleX_FOUND})
   MESSAGE(STATUS "PerpleX found at ${PerpleX_INCLUDE_DIR}")
   INCLUDE_DIRECTORIES(${PerpleX_INCLUDE_DIR})


### PR DESCRIPTION
otherwise I am getting
```
CMake Warning at CMakeLists.txt:336 (FIND_PACKAGE):
Could not find a package configuration file provided by "PerpleX" with
any
of the following names:
```

related to #2400