### PR TITLE
Use the parameter GMRES restart length also for cheap iterations

### DIFF
--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -790,7 +790,7 @@ namespace aspect
             SolverFGMRES<LinearAlgebra::BlockVector>
             solver(solver_control_cheap, mem,
                    SolverFGMRES<LinearAlgebra::BlockVector>::
-                   AdditionalData(50, true));
+                   AdditionalData(parameters.stokes_gmres_restart_length, true));
 
             solver.solve (stokes_block,
                           distributed_stokes_solution,


### PR DESCRIPTION
This modifies the cheap Stokes solver iterations to use the same restart length as the expensive iterations. I see no reason why this parameter should be limited to expensive iterations, and currently, I see no reason to have this as two separate parameters either.
The reason I would iike to have this parameter is that I am trying to reproduce a benchmark that specifies this parameter differently, and I am not able to change this for just a single benchmark in a plugin.