### PR TITLE
Aspect Manual Table of Contents

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -63,6 +63,8 @@
 \newcommand{\petsc}{{\textsc{PETSc}}}
 \newcommand{\aspect}{\textsc{ASPECT}}
 
+\renewcommand{\numberline}[1]{#1~}
+
 \begin{document}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -7,22 +7,9 @@
 \usepackage{subfigure}
 \usepackage{textpos}
 
-% Make more space between the section number and the title in the 
-% table of contents.  
+% This adds space between the Appendix number (e.g., A.101) and the title.
 
-% This uses the package titletoc, which might work, but is quite complex.
-%\usepackage{titletoc}
-
-%\dottedcontents{section}[3.8em]{}{3.3em}{1pc}
-
-% This modifies the internals of the LaTeX TOC internals
-
-% \makeatletter
-% \renewcommand{\l@section}{\@dottedtocline{1}{1.5em}{2.6em}}
-% \renewcommand{\l@subsection}{\@dottedtocline{2}{4.0em}{3.6em}}
-% \renewcommand{\l@subsubsection}{\@dottedtocline{3}{7.4em}{4.5em}}
-% \makeatother
-
+\renewcommand{\numberline}[1]{#1~}
 
 % use a larger page size; otherwise, it is difficult to have complete
 % code listings and output on a single page
@@ -79,8 +66,6 @@
 \newcommand{\trilinos}{{\textsc{Trilinos}}}
 \newcommand{\petsc}{{\textsc{PETSc}}}
 \newcommand{\aspect}{\textsc{ASPECT}}
-
-\renewcommand{\numberline}[1]{#1~}
 
 \begin{document}
 


### PR DESCRIPTION
This resolves (i.e., fixes) Issue #1494 
 
> The Manual's Appendix numbers are overwriting the section titles #1494 

The one line of code

    `\renewcommand{\numberline}[1]{#1~}`

adds a space between the Appendix number (e.g., A.101) and the Appendix title.

There is still one problem with the table of contents; namely, some long titles are not being broken into multiple lines.  For example, see 
    
    > A.10 Parameters in section Boundary composition model/Box with lithosphere ... 271
