### PR TITLE
Fix viscoelasticity

### DIFF
--- a/include/aspect/material_model/viscoelastic.h
+++ b/include/aspect/material_model/viscoelastic.h
@@ -226,6 +226,14 @@ namespace aspect
 
       private:
         /**
+         * The first 3 (2D) or 6 (3D) compositional fields are assumed
+         * to be components of the viscoelastic stress tensor and
+         * assigned volume fractions of zero.
+         */
+        const std::vector<double> compute_volume_fractions(
+          const std::vector<double> &compositional_fields) const;
+
+        /**
          * Reference temperature for thermal expansion. All components use
          * the same reference_T.
          */

--- a/source/material_model/viscoelastic.cc
+++ b/source/material_model/viscoelastic.cc
@@ -161,13 +161,7 @@ namespace aspect
                               const std::vector<double> &parameter_values,
                               const enum AveragingScheme &average_type) const
     {
-      // Store which components to exclude during volume fraction computation.
-      ComponentMask composition_mask(this->n_compositional_fields(),true);
-      // assign compositional fields associated with viscoelastic stress a value of 0
-      // assume these fields are listed first
-      for (unsigned int i=0; i < SymmetricTensor<2,dim>::n_independent_components; ++i)
-        composition_mask.set(i,false);
-      const std::vector<double> volume_fractions = compute_volume_fractions(composition, composition_mask);
+      const std::vector<double> volume_fractions = compute_volume_fractions(composition);
       const double averaged_vector = average_value(volume_fractions, parameter_values, average_type);
       return averaged_vector;
     }

--- a/source/material_model/viscoelastic.cc
+++ b/source/material_model/viscoelastic.cc
@@ -66,6 +66,41 @@ namespace aspect
       return elastic_shear_moduli;
     }
 
+    template <int dim>
+    const std::vector<double>
+    Viscoelastic<dim>::
+    compute_volume_fractions(const std::vector<double> &compositional_fields) const
+    {
+      std::vector<double> volume_fractions(compositional_fields.size()+1);
+
+      //clip the compositional fields so they are between zero and one
+      std::vector<double> x_comp = compositional_fields;
+      for (unsigned int i=0; i < x_comp.size(); ++i)
+        x_comp[i] = std::min(std::max(x_comp[i], 0.0), 1.0);
+
+      // assign compositional fields associated with viscoelastic stress a value of 0
+      for (unsigned int i=0; i < SymmetricTensor<2,dim>::n_independent_components; ++i)
+        x_comp[i] = 0.0;
+
+      //sum the compositional fields for normalization purposes
+      double sum_composition = 0.0;
+      for (unsigned int i=0; i < x_comp.size(); ++i)
+        sum_composition += x_comp[i];
+
+      if (sum_composition >= 1.0)
+        {
+          volume_fractions[0] = 0.0;  //background mantle
+          for (unsigned int i=1; i <= x_comp.size(); ++i)
+            volume_fractions[i] = x_comp[i-1]/sum_composition;
+        }
+      else
+        {
+          volume_fractions[0] = 1.0 - sum_composition; //background mantle
+          for (unsigned int i=1; i <= x_comp.size(); ++i)
+            volume_fractions[i] = x_comp[i-1];
+        }
+      return volume_fractions;
+    }
 
     template <int dim>
     double
@@ -160,12 +195,6 @@ namespace aspect
       MaterialModel::ElasticOutputs<dim>
       *force_out = out.template get_additional_output<MaterialModel::ElasticOutputs<dim> >();
 
-      // Store which components to exclude during volume fraction computation.
-      ComponentMask composition_mask(this->n_compositional_fields(),true);
-      // assign compositional fields associated with viscoelastic stress a value of 0
-      // assume these fields are listed first
-      for (unsigned int i=0; i < SymmetricTensor<2,dim>::n_independent_components; ++i)
-        composition_mask.set(i,false);
 
       // The elastic time step (dte) is equal to the numerical time step if the time step number
       // is greater than 0 and the parameter 'use_fixed_elastic_time_step' is set to false.
@@ -182,7 +211,7 @@ namespace aspect
         {
           const double temperature = in.temperature[i];
           const std::vector<double> composition = in.composition[i];
-          const std::vector<double> volume_fractions = compute_volume_fractions(composition, composition_mask);
+          const std::vector<double> volume_fractions = compute_volume_fractions(composition);
 
           out.specific_heat[i] = average_value(volume_fractions, specific_heats, arithmetic);
 


### PR DESCRIPTION
This fixes an issue that was introduced in #2356. We thought it was fixed by #2495, but unfortunately it did resolve the issue. 
For safety, I've reverted back to the state in `viscoelastic.cc` and `viscoelastic.h` before #2356. I've checked that the benchmarks now run correctly with the changes in this branch.

At next chance, I'll add a series of tests that should have caught this issue in the first place and use the new `compute_volume_fractions` function.

@gassmoeller - This follows our discussion this evening. Lesson learned about not having a test for the  all the available options.