### PR TITLE
Move the check for reasonable parameters earlier in the function.

### DIFF
--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -189,9 +189,8 @@ namespace aspect
 
       // serialize into a stringstream
       aspect::oarchive oa (oss);
-      oa << (*this);
-
       save_critical_parameters (this->parameters, oa);
+      oa << (*this);
 
       // compress with zlib and write to file on the root processor
 #ifdef DEAL_II_WITH_ZLIB
@@ -358,10 +357,10 @@ namespace aspect
         {
           std::istringstream ss;
           ss.str(std::string (&uncompressed[0], uncompressed_size));
-          aspect::iarchive ia (ss);
-          ia >> (*this);
 
+          aspect::iarchive ia (ss);
           load_and_check_critical_parameters(this->parameters, ia);
+          ia >> (*this);
         }
 #else
         AssertThrow (false,


### PR DESCRIPTION
We should check first whether input parameters upon restart are reasonable before
we start to read the rest of the simulation data. That's because the rest may not make
sense to us if the parameters are non-sensical. 

In other words: Try to give error messages as early as possible.

This is a follow-up to #2310, in pursuance of #2090.