### PR TITLE
Aspect manual TOC

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -11,6 +11,15 @@
 
 \renewcommand{\numberline}[1]{#1~}
 
+% If your page numbers stick out into the righthand margin but using lengths 
+% appropriate to your document.
+
+\makeatletter
+ \renewcommand{\@pnumwidth}{4em} 
+ \renewcommand{\@tocrmarg}{5em}
+\makeatother
+
+
 % use a larger page size; otherwise, it is difficult to have complete
 % code listings and output on a single page
 \usepackage{fullpage}

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -12,11 +12,12 @@
 \renewcommand{\numberline}[1]{#1~}
 
 % If your page numbers stick out into the righthand margin but using lengths 
-% appropriate to your document.
+% appropriate to your document. See the Introduction to the "The tocloft 
+% package" for additional information.
 
 \makeatletter
- \renewcommand{\@pnumwidth}{4em} 
- \renewcommand{\@tocrmarg}{5em}
+ \renewcommand{\@pnumwidth}{1.75em} 
+ \renewcommand{\@tocrmarg}{3.25em}
 \makeatother
 
 


### PR DESCRIPTION
This PR addresses Issue #2491

The solution was to adjust two internal LaTeX parameters that set the width of the right-hand TOC margin and the size of the box that contains the page numbers, so that now the page numbers in the TOC are aligned in a column.  There is addition documentation in a comment at the top of manual.tex.
