### PR TITLE
[WIP] Extending the geoid postprocessor to also calculate gravity anomalies

### DIFF
--- a/include/aspect/postprocess/geoid.h
+++ b/include/aspect/postprocess/geoid.h
@@ -75,6 +75,14 @@ namespace aspect
         double
         evaluate (const Point<dim> &) const;
 
+        /**
+         * Evaluate the gravity anomaly solution at a point. The evaluation point
+         * must be outside of the model domain, and it must be called
+         * after execute().
+         */
+        double
+        evaluate_gravityanomaly (const Point<dim> &) const;
+
       private:
         /**
          * Parameters to set the maximum and minimum degree when computing geoid from spherical harmonics
@@ -128,8 +136,14 @@ namespace aspect
          * The input outer radius is needed to evaluate the density integral contribution of whole model domain at the surface
          * This function returns a pair containing real spherical harmonics of density integral (cos and sin part) from min degree to max degree.
          */
-        std::pair<std::vector<double>,std::vector<double> >
-        density_contribution (const double &outer_radius) const;
+        void
+        density_contribution ();
+
+        /**
+         * Pairs that store the spherical harmonic coefficients for the geoid and gravity anomaly, respectively
+         */
+        std::pair<std::vector<double>,std::vector<double> > SH_density_coes;
+        std::pair<std::vector<double>,std::vector<double> > SH_density_gravity_coes;
 
         /**
          * Function to compute the surface and CMB dynamic topography contribution in spherical harmonic expansion
@@ -150,6 +164,15 @@ namespace aspect
          * A vector to store the sine terms of the geoid anomaly spherical harmonic coefficients.
          */
         std::vector<double> geoid_coesin;
+
+        /**
+         * A vector to store the cosine terms of the gravity anomaly spherical harmonic coefficients.
+         */
+        std::vector<double> gravity_coecos;
+        /**
+         * A vector to store the sine terms of the gravity anomaly spherical harmonic coefficients.
+         */
+        std::vector<double> gravity_coesin;
     };
   }
 }

--- a/include/aspect/postprocess/visualization/geoid.h
+++ b/include/aspect/postprocess/visualization/geoid.h
@@ -79,6 +79,44 @@ namespace aspect
         private:
 
       };
+
+
+      template <int dim>
+      class GravityAnomaly
+        : public CellDataVectorCreator<dim>,
+          public SimulatorAccess<dim>
+      {
+        public:
+          /**
+           * Get the visualization vector for the gravity anomaly.
+           *
+           * @return A pair of values with the following meaning: - The first
+           * element provides the name by which this data should be written to
+           * the output file. - The second element is a pointer to a vector
+           * with one element per active cell on the current processor.
+           * Elements corresponding to active cells that are either artificial
+           * or ghost cells (in deal.II language, see the deal.II glossary)
+           * will be ignored but must nevertheless exist in the returned
+           * vector. While implementations of this function must create this
+           * vector, ownership is taken over by the caller of this function
+           * and the caller will take care of destroying the vector pointed
+           * to.
+           */
+          virtual
+          std::pair<std::string, Vector<float> *>
+          execute () const;
+
+          /**
+           * Let the postprocessor manager know about the other postprocessors
+           * this one depends on. Specifically, the Geoid postprocessor.
+           */
+          virtual
+          std::list<std::string>
+          required_other_postprocessors() const;
+
+        private:
+
+      };
     }
   }
 }


### PR DESCRIPTION
This is work in progress with @LudovicJnnt. This extends the existing geoid postprocessor to also output radial gravity anomalies. This was done by taking the analytical derivative with respect to r. The gravity anomalies are outputted as visualization only, but an extension to write them out into an ascii file is easy to implement if needed. This has not been tested yet (other than some sanity checks). If anyone knows of good analytical benchmarks for this please let me know (@ian-r-rose?). 