### PR TITLE
cmake: disallow in-source test runs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,13 @@ ADD_CUSTOM_TARGET(setup_tests
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Enabling all tests ...")
 
+# Disable the ability to run all tests in an in-source build:
+IF (("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}") AND ASPECT_RUN_ALL_TESTS)
+  MESSAGE(WARNING "\nEnabling all tests is not supported in in-source builds. Please create a separate build directory!\n")
+  SET(ASPECT_RUN_ALL_TESTS OFF CACHE BOOL "" FORCE)
+ENDIF()
+
+
 SET(ASPECT_TEST_GENERATOR "Unix Makefiles" CACHE STRING 
   "Generator to use for the test cmake project. Using ninja instead of make is not recommended.")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,8 +165,8 @@ ADD_CUSTOM_TARGET(setup_tests
 
 # Disable the ability to run all tests in an in-source build:
 IF (("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}") AND ASPECT_RUN_ALL_TESTS)
-  MESSAGE(WARNING "\nEnabling all tests is not supported in in-source builds. Please create a separate build directory!\n")
   SET(ASPECT_RUN_ALL_TESTS OFF CACHE BOOL "" FORCE)
+  MESSAGE(FATAL_ERROR "\nEnabling all tests is not supported in in-source builds. Please create a separate build directory!\n")
 ENDIF()
 
 


### PR DESCRIPTION
Running the whole testsuite in an in-source build has several problems.
Most importantly, the test build and source directory are not separate,
so the project can not be easily reset.
Rather than trying to fix this, disallow running the "all tests". Of
course running our single "quick test" is still okay.