### PR TITLE
Let initial conditions use thermal expansivity from material model

### DIFF
--- a/include/aspect/initial_temperature/S40RTS_perturbation.h
+++ b/include/aspect/initial_temperature/S40RTS_perturbation.h
@@ -186,6 +186,11 @@ namespace aspect
          */
         unsigned int vs_to_density_index;
 
+        /**
+         * Whether to use the thermal expansion coefficient from the material model
+         */
+        bool use_material_model_thermal_alpha;
+
     };
 
   }

--- a/include/aspect/initial_temperature/SAVANI_perturbation.h
+++ b/include/aspect/initial_temperature/SAVANI_perturbation.h
@@ -177,6 +177,12 @@ namespace aspect
          * The column index of the vs to density scaling in the data file
          */
         unsigned int vs_to_density_index;
+
+        /**
+         * Whether to use the thermal expansion coefficient from the material model
+         */
+        bool use_material_model_thermal_alpha;
+
     };
 
   }

--- a/source/initial_temperature/SAVANI_perturbation.cc
+++ b/source/initial_temperature/SAVANI_perturbation.cc
@@ -22,6 +22,9 @@
 #include <aspect/initial_temperature/SAVANI_perturbation.h>
 #include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/utilities.h>
+#include <aspect/simulator_access.h>
+#include <aspect/initial_composition/interface.h>
+#include <aspect/material_model/interface.h>
 #include <fstream>
 #include <iostream>
 #include <deal.II/base/std_cxx11/array.h>
@@ -297,8 +300,28 @@ namespace aspect
 
       double temperature_perturbation;
       if (depth > no_perturbation_depth)
-        // scale the density perturbation into a temperature perturbation
-        temperature_perturbation =  -1./thermal_alpha * density_perturbation;
+        {
+          // scale the density perturbation into a temperature perturbation
+          // see if we need to ask material model for the thermal expansion coefficient
+          if (use_material_model_thermal_alpha)
+            {
+              MaterialModel::MaterialModelInputs<3> in(1, this->n_compositional_fields());
+              MaterialModel::MaterialModelOutputs<3> out(1, this->n_compositional_fields());
+              in.position[0] = position;
+              in.temperature[0] = background_temperature;
+              in.pressure[0] = this->get_adiabatic_conditions().pressure(position);
+              in.velocity[0] = Tensor<1,3> ();
+              for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
+                in.composition[0][c] = this->get_initial_composition_manager().initial_composition(position, c);
+              in.strain_rate.resize(0);
+
+              this->get_material_model().evaluate(in, out);
+
+              temperature_perturbation = -1./(out.thermal_expansion_coefficients[0]) * density_perturbation;
+            }
+          else
+            temperature_perturbation = -1./thermal_alpha * density_perturbation;
+        }
       else
         // set heterogeneity to zero down to a specified depth
         temperature_perturbation = 0.0;
@@ -316,9 +339,9 @@ namespace aspect
       {
         prm.enter_subsection("SAVANI perturbation");
         {
-          prm.declare_entry("Data directory", "$ASPECT_SOURCE_DIR/data/initial-temperature/SAVANI/",
-                            Patterns::DirectoryName (),
-                            "The path to the model data.");
+          prm.declare_entry ("Data directory", "$ASPECT_SOURCE_DIR/data/initial-temperature/SAVANI/",
+                             Patterns::DirectoryName (),
+                             "The path to the model data.");
           prm.declare_entry ("Initial condition file name", "savani.dlnvs.60.m.ab",
                              Patterns::Anything(),
                              "The file name of the spherical harmonics coefficients "
@@ -340,6 +363,11 @@ namespace aspect
                              Patterns::Double (0),
                              "The value of the thermal expansion coefficient $\\beta$. "
                              "Units: $1/K$.");
+          prm.declare_entry ("Use thermal expansion coefficient from material model", "false",
+                             Patterns::Bool (),
+                             "Option to take the thermal expansion coefficient from the "
+                             "material model instead of from what is specified in this "
+                             "section.");
           prm.declare_entry ("Remove degree 0 from perturbation","true",
                              Patterns::Bool (),
                              "Option to remove the degree zero component from the perturbation, "
@@ -397,6 +425,7 @@ namespace aspect
           spline_depth_file_name  = prm.get ("Spline knots depth file name");
           vs_to_density_constant           = prm.get_double ("Vs to density scaling");
           thermal_alpha           = prm.get_double ("Thermal expansion coefficient in initial temperature scaling");
+          use_material_model_thermal_alpha = prm.get_bool ("Use thermal expansion coefficient from material model");
           zero_out_degree_0       = prm.get_bool ("Remove degree 0 from perturbation");
           reference_temperature   = prm.get_double ("Reference temperature");
           no_perturbation_depth   = prm.get_double ("Remove temperature heterogeneity down to specified depth");

--- a/tests/thermal_alpha_s40rts.prm
+++ b/tests/thermal_alpha_s40rts.prm
@@ -1,0 +1,80 @@
+# Test for S40RTS initial condition using thermal expansion from the material model
+
+set Dimension                              = 3
+set Use years in output instead of seconds = true
+set End time                               = 0
+set Adiabatic surface temperature          = 1600
+
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Viscosity                     = 1e22
+    set Thermal viscosity exponent    = 5.0
+    set Reference temperature         = 1600
+  end
+end
+
+
+subsection Geometry model
+  set Model name = spherical shell
+
+  subsection Spherical shell
+    set Inner radius  = 3481000
+    set Outer radius  = 6336000
+  end
+end
+
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 0,1
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = 0,1
+  set List of model names = initial temperature
+end
+
+subsection Boundary temperature model
+  set List of model names = spherical constant
+  subsection Spherical constant
+    set Inner temperature = 2600 
+    set Outer temperature = 273 
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = S40RTS perturbation
+
+  subsection S40RTS perturbation
+    set Use thermal expansion coefficient from material model = true
+    set Thermal expansion coefficient in initial temperature scaling = 1 # large value since this shouldn't be used
+  end
+end
+
+
+subsection Gravity model
+  set Model name = radial constant
+
+  subsection Radial constant
+    set Magnitude = 10
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 1
+  set Time steps between mesh refinement = 0
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics
+end

--- a/tests/thermal_alpha_s40rts/screen-output
+++ b/tests/thermal_alpha_s40rts/screen-output
@@ -1,0 +1,21 @@
+
+Number of active cells: 768 (on 2 levels)
+Number of degrees of freedom: 28,690 (20,790+970+6,930)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+33 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.0277 m/year, 0.096 m/year
+     Temperature min/avg/max:            273 K, 1499 K, 2600 K
+     Heat fluxes through boundary parts: -4.242e+12 W, 1.026e+13 W
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+


### PR DESCRIPTION
This adds an option so that S40RTS or SAVANI initial conditions can read in thermal expansivity from the material model, instead of inputing a constant value in the parameter file. By default the option is off.