### PR TITLE
Added new authors from the 2018 Hackathon to the manual.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -178,14 +178,17 @@ COMPUTATIONAL INFRASTRUCTURE FOR GEODYNAMICS (CIG)
     Martin Kronbichler,
     Marine Lasbleis,
     Shangxin Liu,
+    Hannah Mark,
     Elvira Mulyukova,
     John Naliboff,
+    Bart Niday,
     Jonathan Perry-Houts,
     Elbridge Gerry Puckett,
     Tahiry Rajaonarison,
     Ian Rose,
     D.~Sarah Stamps,
     Cedric Thieulot,
+    Wanying Wang, 
     Iris van Zelst,
     Siqi Zhang \\
 \vspace{1.0em}


### PR DESCRIPTION
Note: There may be new authors after this PR, since there may be open PRs from Hackathon participants which make changes to the manual.