### PR TITLE
Add option to use full A block as preconditioner

### DIFF
--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -327,6 +327,7 @@ namespace aspect
     bool                           use_direct_stokes_solver;
     double                         linear_stokes_solver_tolerance;
     double                         linear_solver_A_block_tolerance;
+    bool                           use_full_A_block_preconditioner;
     double                         linear_solver_S_block_tolerance;
     std::string                    AMG_smoother_type;
     unsigned int                   AMG_smoother_sweeps;

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -99,17 +99,18 @@ namespace aspect
             }
           else
             {
+              const unsigned int pressure_component_index = this->introspection().component_indices.pressure;
               for (unsigned int i = 0; i < stokes_dofs_per_cell; ++i)
-                for (unsigned int j = 0; j < stokes_dofs_per_cell; ++j)
-                  if (scratch.dof_component_indices[i] ==
-                      scratch.dof_component_indices[j])
-                    {
-                      data.local_matrix(i, j) += (one_over_eta * pressure_scaling
-                                                  * pressure_scaling
-                                                  * (scratch.phi_p[i]
-                                                     * scratch.phi_p[j]))
-                                                 * JxW;
-                    }
+                if (scratch.dof_component_indices[i] == pressure_component_index)
+                  for (unsigned int j = 0; j < stokes_dofs_per_cell; ++j)
+                    if (scratch.dof_component_indices[j] == pressure_component_index)
+                      {
+                        data.local_matrix(i, j) += (one_over_eta * pressure_scaling
+                                                    * pressure_scaling
+                                                    * (scratch.phi_p[i]
+                                                       * scratch.phi_p[j]))
+                                                   * JxW;
+                      }
             }
         }
     }

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -42,6 +42,7 @@ namespace aspect
       const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
       const unsigned int n_q_points           = scratch.finite_element_values.n_quadrature_points;
       const double pressure_scaling = this->get_pressure_scaling();
+      const bool assemble_A_approximation = !this->get_parameters().use_full_A_block_preconditioner;
 
       // First loop over all dofs and find those that are in the Stokes system
       // save the component (pressure and dim velocities) each belongs to.
@@ -63,9 +64,10 @@ namespace aspect
             {
               if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
                 {
-                  scratch.grads_phi_u[i_stokes] =
-                    scratch.finite_element_values[introspection.extractors
-                                                  .velocities].symmetric_gradient(i, q);
+                  if (assemble_A_approximation)
+                    scratch.grads_phi_u[i_stokes] =
+                      scratch.finite_element_values[introspection.extractors
+                                                    .velocities].symmetric_gradient(i, q);
                   scratch.phi_p[i_stokes] = scratch.finite_element_values[introspection
                                                                           .extractors.pressure].value(i, q);
                   ++i_stokes;
@@ -78,17 +80,37 @@ namespace aspect
 
           const double JxW = scratch.finite_element_values.JxW(q);
 
-          for (unsigned int i = 0; i < stokes_dofs_per_cell; ++i)
-            for (unsigned int j = 0; j < stokes_dofs_per_cell; ++j)
-              if (scratch.dof_component_indices[i] ==
-                  scratch.dof_component_indices[j])
-                data.local_matrix(i, j) += ((2.0 * eta * (scratch.grads_phi_u[i]
-                                                          * scratch.grads_phi_u[j]))
-                                            + one_over_eta * pressure_scaling
-                                            * pressure_scaling
-                                            * (scratch.phi_p[i]
-                                               * scratch.phi_p[j]))
-                                           * JxW;
+          if (assemble_A_approximation)
+            {
+              for (unsigned int i = 0; i < stokes_dofs_per_cell; ++i)
+                for (unsigned int j = 0; j < stokes_dofs_per_cell; ++j)
+                  if (scratch.dof_component_indices[i] ==
+                      scratch.dof_component_indices[j])
+                    {
+                      data.local_matrix(i, j) += ((2.0 * eta * (scratch.grads_phi_u[i]
+                                                                * scratch.grads_phi_u[j]))
+                                                  + one_over_eta * pressure_scaling
+                                                  * pressure_scaling
+                                                  * (scratch.phi_p[i]
+                                                     * scratch.phi_p[j]))
+                                                 * JxW;
+                    }
+
+            }
+          else
+            {
+              for (unsigned int i = 0; i < stokes_dofs_per_cell; ++i)
+                for (unsigned int j = 0; j < stokes_dofs_per_cell; ++j)
+                  if (scratch.dof_component_indices[i] ==
+                      scratch.dof_component_indices[j])
+                    {
+                      data.local_matrix(i, j) += (one_over_eta * pressure_scaling
+                                                  * pressure_scaling
+                                                  * (scratch.phi_p[i]
+                                                     * scratch.phi_p[j]))
+                                                 * JxW;
+                    }
+            }
         }
     }
 

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -504,7 +504,7 @@ namespace aspect
         Mp_preconditioner_AMG->initialize (system_preconditioner_matrix.block(1,1), Amg_data);
       }
 
-    if (parameters.free_surface_enabled || parameters.include_melt_transport)
+    if (parameters.free_surface_enabled || parameters.include_melt_transport || parameters.use_full_A_block_preconditioner)
       Amg_preconditioner->initialize (system_matrix.block(0,0),
                                       Amg_data);
     else

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -367,6 +367,24 @@ namespace aspect
                            "block preconditioner for the Stokes equation can be found in "
                            "\\cite{KHB12}.");
 
+        prm.declare_entry ("Use full A block as preconditioner", "false",
+                           Patterns::Bool(),
+                           "This parameter determines whether we use an simplified approximation of the"
+                           "$A$ block as preconditioner for the Stokes solver, or the full $A$ block. The "
+                           "simplified approximation only contains the terms that describe the coupling of"
+                           "identical components (plus boundary conditions) as described in "
+                           "\\cite{KHB12}. The full block is closer to the description in "
+                           "\\cite{rudi2017weighted}. There is no clear way to determine, which preconditioner "
+                           "performs better in runtime, the default value (simplified approximation) requires "
+                           "more GMRES iterations, but is faster to apply in each iteration. On the downside it "
+                           "requires storing an additional matrix block, and such requires more memory, although "
+                           "the block is by a factor of 2 or 3 smaller than the original A block (depending on spatial "
+                           "dimension. The full block needs less memory and assembly time (because the block is "
+                           "available anyway), converges in less GMRES iterations, but requires more time per "
+                           "iteration. The default value should be good for relatively simple models, but in "
+                           "particular for very strong viscosity contrasts the full $A$ block can be "
+                           "advantageous.");
+
         prm.declare_entry ("Linear solver S block tolerance", "1e-6",
                            Patterns::Double(0,1),
                            "A relative tolerance up to which the approximate inverse of the $S$ block "
@@ -1091,6 +1109,7 @@ namespace aspect
         n_cheap_stokes_solver_steps     = prm.get_integer ("Number of cheap Stokes solver steps");
         n_expensive_stokes_solver_steps = prm.get_integer ("Maximum number of expensive Stokes solver steps");
         linear_solver_A_block_tolerance = prm.get_double ("Linear solver A block tolerance");
+        use_full_A_block_preconditioner = prm.get_bool ("Use full A block as preconditioner");
         linear_solver_S_block_tolerance = prm.get_double ("Linear solver S block tolerance");
         stokes_gmres_restart_length     = prm.get_integer("GMRES solver restart length");
       }

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -369,17 +369,15 @@ namespace aspect
 
         prm.declare_entry ("Use full A block as preconditioner", "false",
                            Patterns::Bool(),
-                           "This parameter determines whether we use an simplified approximation of the"
+                           "This parameter determines whether we use an simplified approximation of the "
                            "$A$ block as preconditioner for the Stokes solver, or the full $A$ block. The "
-                           "simplified approximation only contains the terms that describe the coupling of"
+                           "simplified approximation only contains the terms that describe the coupling of "
                            "identical components (plus boundary conditions) as described in "
                            "\\cite{KHB12}. The full block is closer to the description in "
                            "\\cite{rudi2017weighted}. There is no clear way to determine, which preconditioner "
                            "performs better in runtime, the default value (simplified approximation) requires "
-                           "more GMRES iterations, but is faster to apply in each iteration. On the downside it "
-                           "requires storing an additional matrix block, and such requires more memory, although "
-                           "the block is by a factor of 2 or 3 smaller than the original A block (depending on spatial "
-                           "dimension. The full block needs less memory and assembly time (because the block is "
+                           "more outer GMRES iterations, but is faster to apply in each iteration. The full block "
+                           "needs less assembly time (because the block is "
                            "available anyway), converges in less GMRES iterations, but requires more time per "
                            "iteration. The default value should be good for relatively simple models, but in "
                            "particular for very strong viscosity contrasts the full $A$ block can be "

--- a/tests/use_full_A_block_preconditioner.prm
+++ b/tests/use_full_A_block_preconditioner.prm
@@ -1,0 +1,106 @@
+# This is a relatively realistic compressible model setup.
+# There is no simple analytical solution to it, it is rather
+# intended to serve as a comparison for more complicated
+# models. This variation is particulary made to test using
+# the full A block as preconditioner for the Stokes system
+# instead of the simplified approximation described in the
+# first ASPECT paper.
+
+set CFL number                             = 1.0
+set End time                               = 1e5
+set Adiabatic surface temperature          = 1600.0
+set Use years in output instead of seconds = true
+
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Use full A block as preconditioner = true
+  end
+end
+
+subsection Boundary temperature model
+  set List of model names = spherical constant
+  subsection Spherical constant
+    set Inner temperature = 4250
+    set Outer temperature = 273
+  end
+end
+
+subsection Geometry model
+  set Model name = spherical shell
+
+  subsection Spherical shell
+    set Inner radius  = 3481000
+    set Opening angle = 90
+    set Outer radius  = 6371000
+  end
+end
+
+subsection Gravity model
+  set Model name = radial constant
+
+  subsection Radial constant
+    set Magnitude = 9.81
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = harmonic perturbation
+  subsection Harmonic perturbation
+    set Magnitude = 200.0
+  end
+end
+
+subsection Material model
+  set Model name = simple compressible
+
+  subsection Simple compressible model
+    set Reference density = 3340
+    set Reference specific heat = 1200
+    set Thermal expansion coefficient = 3e-5
+    set Viscosity = 1e21
+    set Reference compressibility = 2.5e-12
+  end
+
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+
+  set Initial global refinement          = 3
+
+  set Refinement fraction                = 0.0
+  set Coarsening fraction                = 0.0
+
+  set Strategy                           = velocity
+
+  set Time steps between mesh refinement = 0
+end
+
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = 0,1
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 0,2,3
+end
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators       = 1
+end
+
+
+subsection Postprocess
+  set List of postprocessors =
+end
+
+subsection Heating model
+  set List of model names = adiabatic heating, shear heating
+end

--- a/tests/use_full_A_block_preconditioner/screen-output
+++ b/tests/use_full_A_block_preconditioner/screen-output
@@ -1,0 +1,26 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Number of active cells: 192 (on 4 levels)
+Number of degrees of freedom: 2,724 (1,666+225+833)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 11+0 iterations.
+
+   Postprocessing:
+
+*** Timestep 1:  t=100000 years
+   Solving temperature system... 11 iterations.
+   Solving Stokes system... 9+0 iterations.
+
+   Postprocessing:
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/use_full_A_block_preconditioner/statistics
+++ b/tests/use_full_A_block_preconditioner/statistics
@@ -1,0 +1,12 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+0 0.000000000000e+00 0.000000000000e+00 192 1891 833  0 11 12 16 
+1 1.000000000000e+05 1.000000000000e+05 192 1891 833 11  9 10 14 


### PR DESCRIPTION
In order to finish #2498 I would like to be able to use the same solver setup as the paper Rudi et al (2017), "Weighted BFBT Preconditioner for Stokes Flow Problems with Highly Heterogeneous Viscosity". However, they use the full A block for the preconditioner, instead of our simplified version. This PR adds a parameter that allows changing this behavior, which might also be of interest for other models that struggle with convergence issues in the linear solver. I also tried to avoid some unnecessary work in that case (there is not much use in assembling a preconditioner matrix block that will never be used). 
In theory there is more potential for savings, we could even think about not allocating the preconditioner A block at all, but that would require more changes to the constraints, so i skipped it for now. 
Also we could remove the arbitrary `if (parameters.free_surface_enabled || parameters.include_melt_transport)` conditions and simply set `use_full_A_block_preconditioner` if we have a free surface or melt. Would that be useful?
