### PR TITLE
Update find syntax in update script

### DIFF
--- a/doc/update_all_files.sh
+++ b/doc/update_all_files.sh
@@ -9,7 +9,7 @@ DOC_DIR=`dirname $0`
 BASE_DIR=`pwd $DOC_DIR/..`
 
 # Update source files
-SOURCE_FILES=`find $BASE_DIR -type f -name *.cc -or -name *.h -not -name *.bak -path doc/ -prune`
+SOURCE_FILES=`find $BASE_DIR -type f \( -name *.cc -or -name *.h \) -and -not -name *.bak | grep -v doc`
 bash ${DOC_DIR}/update_source_files.sh $SOURCE_FILES
 
 # Update prm files


### PR DESCRIPTION
While working on #2460 I found that apparently the syntax for the `find` command has changed, as the old version that worked on ubuntu 14.04 does not work anymore for 18.04, instead I need the attached changes that work on 18.04 and 14.04.