### PR TITLE
Also delete manual.aux in 'make clean'.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -104,4 +104,4 @@ manual/manual.tex:
 clean:
 	-rm -f aspect.dox aspect.tag
 	-rm -rf doxygen
-	-rm -rf manual/*.{blg,toc,log,out,bbl}
+	-rm -rf manual/manual.blg manual/manual.toc manual/manual.log manual/manual.out manual/manual.bbl manual/manual.aux


### PR DESCRIPTION
For reasons unclear to me, the wildcard expression previously
used does not actually delete any file on my system. Consequently,
also just spell out the names of the files that are being deleted.