### PR TITLE
Avoid creating too many jenkins kubernetes agents

### DIFF
--- a/Jenkinsfile.k8s
+++ b/Jenkinsfile.k8s
@@ -10,6 +10,7 @@ pipeline {
         image 'gassmoeller/aspect-tester:8.5.0'
         ttyEnabled true
         command 'cat'
+        idleMinutes 20
       }
     }
   }


### PR DESCRIPTION
So far this is a test to avoid a deprecation warning and a few issues with the kubernetes jenkins tester. Do not merge, if this works I will add more detailed explanations.