### PR TITLE
Tester check for 'ready to test' label

### DIFF
--- a/Jenkinsfile.k8s
+++ b/Jenkinsfile.k8s
@@ -18,10 +18,6 @@ pipeline {
     timeout(time: 2, unit: 'HOURS') 
   }
 
-  parameters {
-    booleanParam(defaultValue: false, description: 'Is the pull request approved for testing?', name: 'TRUST_BUILD')
-  }
-
   stages {
     stage ("info") {
       steps {
@@ -38,7 +34,6 @@ pipeline {
     stage ("Check permissions") {
       when {
 	allOf {
-            environment name: 'TRUST_BUILD', value: 'false' 
             not {branch 'master'}
             not {changeRequest authorEmail: "rene.gassmoeller@mailbox.org"}
             not {changeRequest authorEmail: "heister@clemson.edu"}
@@ -48,12 +43,14 @@ pipeline {
             not {changeRequest authorEmail: "jbnaliboff@ucdavis.edu"}
             not {changeRequest authorEmail: "menno.fraters@outlook.com"}
             not {changeRequest authorEmail: "a.c.glerum@uu.nl"}
-	    }
+        }
       }
       steps {
         container('dealii'){
-	  echo "Please ask an admin to rerun jenkins with TRUST_BUILD=true"
-	    sh "exit 1"
+          sh '''
+            wget -q -O - https://api.github.com/repos/geodynamics/aspect/issues/${CHANGE_ID}/labels | grep 'ready to test' || \
+            { echo "This commit will only be tested when it has the label 'ready to test'"; exit 1; }
+          '''
         }
       }
     }


### PR DESCRIPTION
Hopefully this lets the tester query a pull request for its labels, and proceed with testing if the 'ready to merge' label has been set.