### PR TITLE
Remove usage of deprecated functions

### DIFF
--- a/benchmarks/annulus/annulus.cc
+++ b/benchmarks/annulus/annulus.cc
@@ -430,9 +430,8 @@ namespace aspect
     {
       std::shared_ptr<Function<dim> > ref_func;
       {
-        const AnnulusMaterial<dim> &
-        material_model
-		= Plugins::get_plugin_as_type<const AnnulusMaterial<dim> >(this->get_material_model());
+        const AnnulusMaterial<dim> &material_model
+          = Plugins::get_plugin_as_type<const AnnulusMaterial<dim> >(this->get_material_model());
 
         ref_func.reset (new AnalyticSolutions::FunctionAnnulus<dim>(material_model.get_beta()));
       }

--- a/benchmarks/annulus/annulus.cc
+++ b/benchmarks/annulus/annulus.cc
@@ -56,7 +56,7 @@ namespace aspect
     namespace AnalyticSolutions
     {
       const double A=2.0, B=-3.0/std::log(2.0), C=-1;
-      const double inner_radius = 1, outer_radius = 2.;
+      const double outer_radius = 2.;
       const double rho_0 = 1000.;
       const double gravity = 1.;
 
@@ -346,11 +346,11 @@ namespace aspect
                        const Point<2> &p) const
     {
 
-      const AnnulusMaterial<2> *
+      const AnnulusMaterial<2> &
       material_model
-        = dynamic_cast<const AnnulusMaterial<2> *>(&this->get_material_model());
+        = Plugins::get_plugin_as_type<const AnnulusMaterial<2> >(this->get_material_model());
 
-      return AnalyticSolutions::Annulus_velocity (p, material_model->get_beta());
+      return AnalyticSolutions::Annulus_velocity (p, material_model.get_beta());
     }
 
 
@@ -430,11 +430,11 @@ namespace aspect
     {
       std::shared_ptr<Function<dim> > ref_func;
       {
-        const AnnulusMaterial<dim> *
+        const AnnulusMaterial<dim> &
         material_model
-          = dynamic_cast<const AnnulusMaterial<dim> *>(&this->get_material_model());
+		= Plugins::get_plugin_as_type<const AnnulusMaterial<dim> >(this->get_material_model());
 
-        ref_func.reset (new AnalyticSolutions::FunctionAnnulus<dim>(material_model->get_beta()));
+        ref_func.reset (new AnalyticSolutions::FunctionAnnulus<dim>(material_model.get_beta()));
       }
 
       const QGauss<dim> quadrature_formula (this->introspection().polynomial_degree.velocities+2);
@@ -544,7 +544,7 @@ namespace aspect
                   MaterialModel::MaterialModelInputs<dim> in_face(fe_face_values, cell, this->introspection(), this->get_solution());
                   MaterialModel::MaterialModelOutputs<dim> out_face(fe_face_values.n_quadrature_points, this->n_compositional_fields());
                   fe_face_values[this->introspection().extractors.temperature].get_function_values(topo_vector, topo_values);
-                  this->get_material_model().evaluate(in_face, out_face);
+                  material_model.evaluate(in_face, out_face);
 
                   for (unsigned int q=0; q < quadrature_formula.size(); ++q)
                     {

--- a/benchmarks/shear_bands/shear_bands.cc
+++ b/benchmarks/shear_bands/shear_bands.cc
@@ -775,15 +775,12 @@ namespace aspect
                       ExcMessage("Postprocessor shear bands growth rate only works with the material model shear bands."));
         }
 
-      const PlaneWaveMeltBandsInitialCondition<dim> *
-      initial_composition
-        = this->get_initial_composition_manager().template find_initial_composition_model<PlaneWaveMeltBandsInitialCondition<dim> > ();
+      const PlaneWaveMeltBandsInitialCondition<dim> &initial_composition
+        = this->get_initial_composition_manager().template
+          get_matching_initial_composition_model<PlaneWaveMeltBandsInitialCondition<dim> > ();
 
-      AssertThrow(initial_composition != NULL,
-                  ExcMessage("Postprocessor shear bands growth rate only works with the plane wave melt bands initial composition."));
-
-      amplitude           = initial_composition->get_wave_amplitude();
-      initial_band_angle  = initial_composition->get_initial_band_angle();
+      amplitude           = initial_composition.get_wave_amplitude();
+      initial_band_angle  = initial_composition.get_initial_band_angle();
     }
 
 

--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -227,8 +227,6 @@ namespace aspect
          * @deprecated Use has_matching_boundary_composition_model() and
          * get_matching_boundary_composition_model() instead.
          */
-
-
         template <typename BoundaryCompositionType>
         DEAL_II_DEPRECATED
         BoundaryCompositionType *


### PR DESCRIPTION
Some benchmarks still use the deprecated find_...(plugin) functions. Use the newer `has_...` and `get_...` plugin functions introduced in #2260 and related pull requests.