### PR TITLE
World builder 3: adding it to the core of asepct

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "contrib/WorldBuilder"]
+	path = contrib/WorldBuilder
+	url = git@github.com:GeodynamicWorldBuilder/WorldBuilder.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ MESSAGE(STATUS "====================================================")
 # Set the name of the project and target:
 SET(TARGET "aspect")
 
-FILE(GLOB_RECURSE TARGET_SRC  "source/*.cc" "unit_tests/*.cc" "include/*.h" "contrib/catch/catch.hpp")
-INCLUDE_DIRECTORIES(include ${CMAKE_BINARY_DIR}/include contrib/catch)
+FILE(GLOB_RECURSE TARGET_SRC  "source/*.cc" "unit_tests/*.cc" "include/*.h" "contrib/catch/catch.hpp" "contrib/WorldBuilder/source/*.cc")
+INCLUDE_DIRECTORIES(include ${CMAKE_BINARY_DIR}/include contrib/catch contrib/WorldBuilder/include/)
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.8)
 
@@ -354,6 +354,19 @@ ELSE()
   SET(ASPECT_WITH_PERPLEX OFF)
 ENDIF()
 
+EXECUTE_PROCESS(COMMAND ls ${CMAKE_SOURCE_DIR}/contrib/WorldBuilder/VERSION RESULT_VARIABLE result OUTPUT_QUIET ERROR_QUIET)
+IF (result)
+	message("-- World Builder not found.")
+	SET(ASPECT_WITH_WORLD_BUILDER OFF CACHE BOOL "" FORCE)
+ELSE()
+	file (STRINGS "${CMAKE_SOURCE_DIR}/contrib/WorldBuilder/VERSION" WorldBuilderVersion)
+	message("-- World Builder version ${WorldBuilderVersion} found.")
+	SET(ASPECT_WITH_WORLD_BUILDER ON CACHE BOOL "If ON the World Builder is compiled togheter with ASPECT.")
+	    FOREACH(_source_file ${TARGET_SRC})
+      SET_PROPERTY(SOURCE ${_source_file}
+	      APPEND PROPERTY COMPILE_DEFINITIONS ASPECT_USE_WORLD_BUILDER=1)
+ENDFOREACH()
+ENDIF()
 
 IF (ASPECT_USE_SHARED_LIBS)
   # some systems need to explicitly link to some libraries to use dlopen

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -341,6 +341,7 @@ namespace aspect
     double                         temperature_solver_tolerance;
     double                         composition_solver_tolerance;
     bool                           use_operator_splitting;
+    std::string                    world_builder_file;
 
     /**
      * @}

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1571,6 +1571,9 @@ namespace aspect
       InitialComposition::Manager<dim>                                        initial_composition_manager;
       InitialTemperature::Manager<dim>                                        initial_temperature_manager;
       const std::unique_ptr<AdiabaticConditions::Interface<dim> >             adiabatic_conditions;
+#ifdef ASPECT_USE_WORLD_BUILDER
+      const std::unique_ptr<WorldBuilder::World>                              world_builder;
+#endif
       BoundaryVelocity::Manager<dim>                                          boundary_velocity_manager;
       std::map<types::boundary_id,std::shared_ptr<BoundaryTraction::Interface<dim> > > boundary_traction;
       const std::unique_ptr<BoundaryHeatFlux::Interface<dim> >                boundary_heat_flux;

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -40,7 +40,12 @@
 #  include <deal.II/lac/affine_constraints.h>
 #endif
 
-
+#ifdef ASPECT_USE_WORLD_BUILDER
+namespace WorldBuilder
+{
+  class World;
+}
+#endif
 
 namespace aspect
 {
@@ -733,6 +738,15 @@ namespace aspect
        */
       const NewtonHandler<dim> &
       get_newton_handler () const;
+
+#ifdef ASPECT_USE_WORLD_BUILDER
+      /**
+       * Return a reference to the world builder that controls the setup of
+       * initial conditions.
+       */
+      const WorldBuilder::World &
+      get_world_builder () const;
+#endif
 
       /**
        * Return a reference to the free surface handler. This function will

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -25,6 +25,9 @@
 #include <aspect/melt.h>
 #include <aspect/newton.h>
 #include <aspect/free_surface.h>
+#ifdef ASPECT_USE_WORLD_BUILDER
+#include <world_builder/world.h>
+#endif
 
 #include <aspect/simulator/assemblers/interface.h>
 #include <aspect/geometry_model/initial_topography_model/zero_topography.h>
@@ -164,6 +167,9 @@ namespace aspect
     gravity_model (GravityModel::create_gravity_model<dim>(prm)),
     prescribed_stokes_solution (PrescribedStokesSolution::create_prescribed_stokes_solution<dim>(prm)),
     adiabatic_conditions (AdiabaticConditions::create_adiabatic_conditions<dim>(prm)),
+#ifdef ASPECT_USE_WORLD_BUILDER
+    world_builder (parameters.world_builder_file != "" ? new WorldBuilder::World (parameters.world_builder_file) : NULL),
+#endif
     boundary_heat_flux (BoundaryHeatFlux::create_boundary_heat_flux<dim>(prm)),
 
     time (numbers::signaling_nan<double>()),

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -281,6 +281,10 @@ namespace aspect
                        "heating\\_reaction\\_rates structures. Operator splitting can be used with any "
                        "existing solver schemes that solve the temperature/composition equations.");
 
+    prm.declare_entry ("World builder file", "",
+                       Patterns::FileName(),
+                       "Name of the world builder file. If empty, the world builder is not initialized.");
+
     prm.enter_subsection ("Solver parameters");
     {
       prm.declare_entry ("Temperature solver tolerance", "1e-12",
@@ -1073,6 +1077,7 @@ namespace aspect
     use_conduction_timestep = prm.get_bool ("Use conduction timestep");
     convert_to_years        = prm.get_bool ("Use years in output instead of seconds");
     timing_output_frequency = prm.get_integer ("Timing output frequency");
+    world_builder_file      = prm.get("World builder file");
 
     maximum_time_step       = prm.get_double("Maximum time step");
     if (convert_to_years == true)

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -626,6 +626,18 @@ namespace aspect
     return *(simulator->newton_handler);
   }
 
+#ifdef ASPECT_USE_WORLD_BUILDER
+  template <int dim>
+  const WorldBuilder::World &
+  SimulatorAccess<dim>::get_world_builder () const
+  {
+    Assert (simulator->world_builder.get() != 0,
+            ExcMessage("You can not call this function if the World Builder is not enabled. "
+                       "Enable it by providing a path to a world builder file."));
+    return *(simulator->world_builder);
+  }
+#endif
+
   template <int dim>
   const FreeSurfaceHandler<dim> &
   SimulatorAccess<dim>::get_free_surface_handler () const


### PR DESCRIPTION
Since it took too long for the review of #2462 to be done, I decided to put the world builder code in a own repository so I could develop the code faster. Now that the basics are done, I thought it would be a good idea (and useful to me) to merge it with aspect in way smaller pieces than I proposed in #2462. I hope this will help the reviewing of the code.

I have added it as a git submodule which is automatically loaded by cmake. This way the version used by aspect can be controlled, and the installation is done automatically with the installation of aspect.