### PR TITLE
Do not assemble stokes boundary assemblers on periodic faces

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -597,7 +597,7 @@ namespace aspect
         // then also work on possible face terms. if necessary, initialize
         // the material model data on faces
         for (unsigned int face_number=0; face_number<GeometryInfo<dim>::faces_per_cell; ++face_number)
-          if (cell->at_boundary(face_number))
+          if (cell->at_boundary(face_number) && !cell->has_periodic_neighbor(face_number))
             {
               scratch.reinit(cell, face_number);
               if (assemblers->stokes_system_assembler_on_boundary_face_properties.need_face_material_model_data)


### PR DESCRIPTION
In the assembly, where we assemble the boundary terms for the stokes assemblers, we do not check for periodic boundaries, so boundary terms are assembled on periodic faces too. This is not a problem for Stokes or traction boundary conditions, because for these terms we have Asserts that make sure no velocity/traction boundary conditions are prescribed on periodic boundaries. However, for other boundary terms from additional assemblers, we probably don't want them to be assembled on periodic faces. Or is there any situation where one might want to do that, and the assemblers should check for that individually?