### PR TITLE
Fix manual references

### DIFF
--- a/doc/manual/cookbooks/gplates/gplates.part.prm
+++ b/doc/manual/cookbooks/gplates/gplates.part.prm
@@ -3,14 +3,14 @@ subsection Boundary temperature model
 end
 
 subsection Boundary velocity model
-  set Prescribed velocity boundary indicators = outer:gplates 
-  set Tangential velocity boundary indicators = inner
+  set Prescribed velocity boundary indicators = top:gplates
+  set Tangential velocity boundary indicators = bottom
   subsection GPlates model
-    set Data directory = $ASPECT_SOURCE_DIR/data/boundary-velocity/gplates/ 
-    set Velocity file name = current_day.gpml 
-    set Time step = 1e6 
-    set Point one = 1.5708,4.87 
-    set Point two = 1.5708,5.24 
-    set Interpolation width = 2000000 
+    set Data directory = $ASPECT_SOURCE_DIR/data/boundary-velocity/gplates/
+    set Velocity file name = current_day.gpml
+    set Data file time step = 1e6
+    set Point one = 1.5708,4.87
+    set Point two = 1.5708,5.24
+    set Lithosphere thickness = 660000
   end
 end

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -7610,10 +7610,6 @@ movements \textit{below} a lithosphere model. All plugin specific options may be
 section~\ref{parameters:Boundary_20velocity_20model}. Possible options include the data directory
 and file name of the velocity file/files, the time step (in model units, mostly seconds or years depending on the 
 ``\texttt{Use years in output instead of seconds}'' flag) and the points that define the 2D plane.
-%The parameter ``\texttt{Interpolation width}'' is used to smooth the provided velocity files by
-%a moving average filter. All velocity data points within this distance are averaged to determine the
-%actual boundary velocity at a certain mesh point. This parameter is usually set to 0 (no interpolation, use
-%nearest velocity point data) and is only needed in case the original setting is unstable or slowly converging.
 
 \paragraph{Comparing and visualizing 2D and 3D models.}
 

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -7610,10 +7610,10 @@ movements \textit{below} a lithosphere model. All plugin specific options may be
 section~\ref{parameters:Boundary_20velocity_20model}. Possible options include the data directory
 and file name of the velocity file/files, the time step (in model units, mostly seconds or years depending on the 
 ``\texttt{Use years in output instead of seconds}'' flag) and the points that define the 2D plane.
-The parameter ``\texttt{Interpolation width}'' is used to smooth the provided velocity files by
-a moving average filter. All velocity data points within this distance are averaged to determine the
-actual boundary velocity at a certain mesh point. This parameter is usually set to 0 (no interpolation, use
-nearest velocity point data) and is only needed in case the original setting is unstable or slowly converging.
+%The parameter ``\texttt{Interpolation width}'' is used to smooth the provided velocity files by
+%a moving average filter. All velocity data points within this distance are averaged to determine the
+%actual boundary velocity at a certain mesh point. This parameter is usually set to 0 (no interpolation, use
+%nearest velocity point data) and is only needed in case the original setting is unstable or slowly converging.
 
 \paragraph{Comparing and visualizing 2D and 3D models.}
 


### PR DESCRIPTION
This PR addresses the issue #2551.
All but one of the warnings for invalid references were for parameters used in benchmarks and cookbooks source files, which I do not know how to fix. I commented a sentence in the manual.tex which refers to an older parameter in Gplates cookbook.