### PR TITLE
Fix named additional outputs

### DIFF
--- a/doc/modules/changes/20180806_gassmoeller
+++ b/doc/modules/changes/20180806_gassmoeller
@@ -1,0 +1,5 @@
+Fixed: Fixed a bug in the 'Named additional outputs' postprocessor, which
+would cause a segmentation fault if more than one named additional material
+output object was active in the same model.
+<br>
+(Rene Gassmoeller, 2018/08/06)

--- a/source/postprocess/visualization/named_additional_outputs.cc
+++ b/source/postprocess/visualization/named_additional_outputs.cc
@@ -136,7 +136,7 @@ namespace aspect
             if (result)
               {
                 std::vector<double> outputs(n_quadrature_points);
-                for (unsigned int i=0; i<get_names().size(); ++i)
+                for (unsigned int i=0; i<result->get_names().size(); ++i)
                   {
                     outputs = result->get_nth_output(i);
 


### PR DESCRIPTION
Fix an index bug in an inner loop that should only loop over the quantities of the current named additional output object (instead of looping over all of them). The two are the same if only one object is active, but not if there is more than one active.