### PR TITLE
Fix update source file script

### DIFF
--- a/doc/update_source_files.sh
+++ b/doc/update_source_files.sh
@@ -31,10 +31,7 @@ done
 
 for script in `ls ${SCRIPT_FOLDER}/*.pl`; do
   for file in $@ ; do
-    cat "$file.bak" | perl $script > "$file"
+    cat "$file" | perl $script > "$file.tmp"
+    mv "$file.tmp" "$file"
   done
-done
-
-for source_file in "$@"; do
-  rm ${source_file}.tmp
 done


### PR DESCRIPTION
This was broken since #2460. By starting from the backup file $file.bak the first changes that were made by the sed script were always ignored. Instead the perl scripts need to be applied to the already partially upgraded file $file.