### PR TITLE
Add basic parameter file validation mode.

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -511,6 +511,7 @@ void print_help()
             << "       -j, --threads          (to use multi-threading)\n"
             << "       --output-xml           (print parameters in xml format to standard output and exit)\n"
             << "       --output-plugin-graph  (write a representation of all plugins to standard output and exit)\n"
+            << "       --validate             (parse parameter file and exit)\n"
             << "       --test                 (run the unit tests from unit_tests/, run --test -h for more info)\n"
             << std::endl;
 }
@@ -550,13 +551,30 @@ template<int dim>
 void
 run_simulator(const std::string &input_as_string,
               const bool output_xml,
-              const bool output_plugin_graph)
+              const bool output_plugin_graph,
+              const bool validate_only)
 {
   using namespace dealii;
 
   ParameterHandler prm;
   const bool i_am_proc_0 = (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0);
   aspect::Simulator<dim>::declare_parameters(prm);
+
+  if (validate_only)
+    {
+      try
+        {
+          parse_parameters (input_as_string, prm);
+        }
+      catch (...)
+        {
+          throw aspect::QuietException();
+        }
+      if (i_am_proc_0)
+        std::cout << "Valid parameter file." << std::endl;
+      return;
+    }
+
   parse_parameters (input_as_string, prm);
 
   if (output_xml)
@@ -601,6 +619,7 @@ int main (int argc, char *argv[])
   bool output_help         = false;
   bool use_threads         = false;
   bool run_unittests       = false;
+  bool validate_only       = false;
   int current_argument = 1;
 
   // Loop over all command line arguments. Handle a number of special ones
@@ -641,6 +660,10 @@ int main (int argc, char *argv[])
         {
           run_unittests = true;
           break;
+        }
+      else if (arg == "--validate")
+        {
+          validate_only = true;
         }
       else
         {
@@ -690,7 +713,7 @@ int main (int argc, char *argv[])
       if (i_am_proc_0)
         {
           // Output header, except for a clean output for xml or plugin graph
-          if (!output_xml && !output_plugin_graph)
+          if (!output_xml && !output_plugin_graph && !validate_only)
             print_aspect_header(std::cout);
 
           if (output_help)
@@ -754,12 +777,12 @@ int main (int argc, char *argv[])
         {
           case 2:
           {
-            run_simulator<2>(input_as_string,output_xml,output_plugin_graph);
+            run_simulator<2>(input_as_string,output_xml,output_plugin_graph,validate_only);
             break;
           }
           case 3:
           {
-            run_simulator<3>(input_as_string,output_xml,output_plugin_graph);
+            run_simulator<3>(input_as_string,output_xml,output_plugin_graph,validate_only);
             break;
           }
           default:

--- a/source/main.cc
+++ b/source/main.cc
@@ -571,7 +571,7 @@ run_simulator(const std::string &input_as_string,
           throw aspect::QuietException();
         }
       if (i_am_proc_0)
-        std::cerr << "The provided parameter file is valid.\n\n"
+        std::cout << "The provided parameter file is valid.\n\n"
                   << "Note: This validation only checks high level "
                   << "parameter file errors, like typos in keywords or "
                   << "parameter names. It may miss more nuanced errors "

--- a/source/main.cc
+++ b/source/main.cc
@@ -511,7 +511,7 @@ void print_help()
             << "       -j, --threads          (to use multi-threading)\n"
             << "       --output-xml           (print parameters in xml format to standard output and exit)\n"
             << "       --output-plugin-graph  (write a representation of all plugins to standard output and exit)\n"
-            << "       --validate             (parse parameter file and exit)\n"
+            << "       --validate             (parse parameter file and exit or report errors)\n"
             << "       --test                 (run the unit tests from unit_tests/, run --test -h for more info)\n"
             << std::endl;
 }
@@ -571,7 +571,13 @@ run_simulator(const std::string &input_as_string,
           throw aspect::QuietException();
         }
       if (i_am_proc_0)
-        std::cout << "Valid parameter file." << std::endl;
+        std::cerr << "The provided parameter file is valid.\n\n"
+                  << "Note: This validation only checks high level "
+                  << "parameter file errors, like typos in keywords or "
+                  << "parameter names. It may miss more nuanced errors "
+                  << "that aren't encountered until the model actually "
+                  << "begins running."
+                  << std::endl;
       return;
     }
 


### PR DESCRIPTION
This idea could definitely be improved upon, but is of useful as is. This PR adds a `--validate` flag that exits after parsing the parameter file. I typically do the same thing by just starting a model and ctrl-c'ing it after the parameter file is parsed. This is very slightly more straightforward, and possible to automate in a script later on if needed.