### PR TITLE
Remove experimental setting that did not help

### DIFF
--- a/Jenkinsfile.k8s
+++ b/Jenkinsfile.k8s
@@ -10,7 +10,6 @@ pipeline {
         image 'gassmoeller/aspect-tester:8.5.0'
         ttyEnabled true
         command 'cat'
-        idleMinutes 20
       }
     }
   }


### PR DESCRIPTION
This essentially reverts #2554. This setting was only an experiment, and it did not solve the issue at hand. Moreover @tjesser-ucdavis-edu suspects it is responsible for some other issues we have seen, so we decided to remove it. No test changes expected.