### PR TITLE
Add a termination criteria based on wall time.

### DIFF
--- a/include/aspect/termination_criteria/end_walltime.h
+++ b/include/aspect/termination_criteria/end_walltime.h
@@ -1,0 +1,86 @@
+/*
+  Copyright (C) 2011- 2018 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef __aspect__termination_criteria_end_walltime_h
+#define __aspect__termination_criteria_end_walltime_h
+
+#include <aspect/termination_criteria/interface.h>
+#include <aspect/simulator.h>
+
+namespace aspect
+{
+  namespace TerminationCriteria
+  {
+
+    /**
+     * A class that terminates the simulation when a specified end time is
+     * reached.
+     *
+     * @ingroup TerminationCriteria
+     */
+    template <int dim>
+    class EndWalltime : public Interface<dim>, public SimulatorAccess<dim>
+    {
+      public:
+
+        /**
+         * Evaluate this termination criterion.
+         *
+         * @return Whether to terminate the simulation (true) or continue
+         * (false).
+         */
+        virtual
+        bool
+        execute (void);
+
+        /**
+         * Declare the parameters this class takes through input files.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         */
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
+
+      private:
+        /**
+         * The maximum walltime duration in seconds. The program will be terminated
+         * once this value is reached.
+         */
+        unsigned int walltime_duration;
+
+        /**
+         * The start_walltime is not stored into checkpoint, so it will get reset at restart.
+         * Make start_walltime as a static variable that it gets initialized pretty much
+         * right away as the program starts, rather than several seconds in once we get
+         * to creating the plugin. It gives better estimate of the actual start time.
+         */
+        static std::time_t start_walltime;
+    };
+  }
+}
+
+#endif

--- a/source/termination_criteria/end_walltime.cc
+++ b/source/termination_criteria/end_walltime.cc
@@ -1,0 +1,80 @@
+/*
+  Copyright (C) 2011 - 2018 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/termination_criteria/end_walltime.h>
+
+namespace aspect
+{
+  namespace TerminationCriteria
+  {
+    // The start_walltime is made as static and initialized here to
+    // make sure it is initialized right way as the programe starts.
+    template <int dim>
+    std::time_t
+    EndWalltime<dim>::start_walltime = std::time(NULL);
+
+    template <int dim>
+    bool
+    EndWalltime<dim>::execute()
+    {
+      return ( (std::time(NULL)-start_walltime) >= (int)walltime_duration);
+    }
+
+
+    template <int dim>
+    void
+    EndWalltime<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Termination criteria");
+      {
+        prm.declare_entry ("Wall time",
+                           "0",
+                           Patterns::Double (0),
+                           "The wall time of the simulation. The default value is zero, "
+                           "which disabled this termination criteria. Unit: hours.");
+      }
+      prm.leave_subsection ();
+    }
+
+
+    template <int dim>
+    void
+    EndWalltime<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Termination criteria");
+      {
+        walltime_duration = prm.get_double ("Wall time") * 3600; // Change from hours to seconds.
+      }
+      prm.leave_subsection ();
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace TerminationCriteria
+  {
+    ASPECT_REGISTER_TERMINATION_CRITERION(EndWalltime,
+                                          "wall time",
+                                          "Terminate the simulation once the wall time limit has reached.");
+  }
+}

--- a/source/termination_criteria/end_walltime.cc
+++ b/source/termination_criteria/end_walltime.cc
@@ -74,6 +74,6 @@ namespace aspect
   {
     ASPECT_REGISTER_TERMINATION_CRITERION(EndWalltime,
                                           "wall time",
-                                          "Terminate the simulation once the wall time limit has reached.");
+                                          "Terminate the simulation once the wall time limit has reached.")
   }
 }

--- a/source/termination_criteria/end_walltime.cc
+++ b/source/termination_criteria/end_walltime.cc
@@ -29,13 +29,13 @@ namespace aspect
     // make sure it is initialized right way as the programe starts.
     template <int dim>
     std::time_t
-    EndWalltime<dim>::start_walltime = std::time(NULL);
+    EndWalltime<dim>::start_walltime = std::time(nullptr);
 
     template <int dim>
     bool
     EndWalltime<dim>::execute()
     {
-      return ( (std::time(NULL)-start_walltime) >= (int)walltime_duration);
+      return ( (std::time(nullptr)-start_walltime) >= (int)walltime_duration);
     }
 
 

--- a/source/termination_criteria/end_walltime.cc
+++ b/source/termination_criteria/end_walltime.cc
@@ -46,10 +46,9 @@ namespace aspect
       prm.enter_subsection("Termination criteria");
       {
         prm.declare_entry ("Wall time",
-                           "0",
+                           "24",
                            Patterns::Double (0),
-                           "The wall time of the simulation. The default value is zero, "
-                           "which disabled this termination criteria. Unit: hours.");
+                           "The wall time of the simulation. Unit: hours.");
       }
       prm.leave_subsection ();
     }

--- a/tests/walltime.prm
+++ b/tests/walltime.prm
@@ -1,0 +1,83 @@
+# Tests whether the 'wall time' termination criteria work OK on a
+# minimal problem
+set Dimension = 2
+set CFL number                             = 1.0
+set End time                               = 1e9
+set Start time                             = 0
+set Adiabatic surface temperature          = 0
+set Surface pressure                       = 0
+set Use years in output instead of seconds = false  # default: true
+set Nonlinear solver scheme                = single Advection, single Stokes
+
+
+subsection Boundary temperature model
+  set List of model names = box
+end
+
+
+
+subsection Gravity model
+  set Model name = vertical
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 3.3 # default: 1
+    set Y extent = 2.2
+    set Z extent = 1.1
+
+    set Box origin X coordinate = -1.9
+    set Box origin Y coordinate = 2.5
+    set Box origin Z coordinate = 3.1
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = perturbed box
+end
+
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1    # default: 3300
+    set Reference specific heat       = 1250
+    set Reference temperature         = 1    # default: 293
+    set Thermal conductivity          = 1e-6 # default: 4.7
+    set Thermal expansion coefficient = 2e-5
+    set Viscosity                     = 1    # default: 5e24
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 1
+end
+
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = 0, 1
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 1
+end
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators       = 0, 2, 3
+end
+
+subsection Termination criteria
+  set Termination criteria      = wall time
+  set Wall time                 = 0
+end

--- a/tests/walltime/screen-output
+++ b/tests/walltime/screen-output
@@ -1,0 +1,18 @@
+
+Number of active cells: 4 (on 2 levels)
+Number of degrees of freedom: 84 (50+9+25)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 10+0 iterations.
+
+   Postprocessing:
+
+Termination requested by criterion: wall time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+


### PR DESCRIPTION
Many HPCs have wall time limitations for jobs (e.g. 24 hours). I created a termination criteria base on the wall time used. I thought it would be useful for those running long jobs on those HPCs have limited wall time.