### PR TITLE
fix tests/global_melt_parallel

### DIFF
--- a/tests/global_melt_parallel.prm
+++ b/tests/global_melt_parallel.prm
@@ -224,11 +224,6 @@ subsection Postprocess
 
 end
 
-subsection Checkpointing
-  set Time between checkpoint = 1700
-end
-
-
 subsection Solver parameters
   set Composition solver tolerance = 1e-14
   set Temperature solver tolerance = 1e-14


### PR DESCRIPTION
remove checkpointing that would happen if tester runs slow

fixes #2603