### PR TITLE
Make a function unconditionally available and conditionally fail.

### DIFF
--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -40,12 +40,10 @@
 #  include <deal.II/lac/affine_constraints.h>
 #endif
 
-#ifdef ASPECT_USE_WORLD_BUILDER
 namespace WorldBuilder
 {
   class World;
 }
-#endif
 
 namespace aspect
 {
@@ -739,14 +737,15 @@ namespace aspect
       const NewtonHandler<dim> &
       get_newton_handler () const;
 
-#ifdef ASPECT_USE_WORLD_BUILDER
       /**
        * Return a reference to the world builder that controls the setup of
        * initial conditions.
+       *
+       * This call will only succeed if ASPECT was configured to use
+       * the WorldBuilder.
        */
       const WorldBuilder::World &
       get_world_builder () const;
-#endif
 
       /**
        * Return a reference to the free surface handler. This function will

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -26,8 +26,9 @@
 #include <aspect/newton.h>
 #include <aspect/free_surface.h>
 #include <aspect/citation_info.h>
+
 #ifdef ASPECT_USE_WORLD_BUILDER
-#include <world_builder/world.h>
+#  include <world_builder/world.h>
 #endif
 
 #include <aspect/simulator/assemblers/interface.h>

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -626,17 +626,26 @@ namespace aspect
     return *(simulator->newton_handler);
   }
 
-#ifdef ASPECT_USE_WORLD_BUILDER
+
+
   template <int dim>
   const WorldBuilder::World &
   SimulatorAccess<dim>::get_world_builder () const
   {
+#ifdef ASPECT_USE_WORLD_BUILDER
     Assert (simulator->world_builder.get() != 0,
             ExcMessage("You can not call this function if the World Builder is not enabled. "
                        "Enable it by providing a path to a world builder file."));
     return *(simulator->world_builder);
-  }
+#else
+    AssertThrow (false,
+                 ExcMessage ("Configuration of ASPECT did not find a copy of the "
+                             "WorldBuilder library. Consequently, accessing it "
+                             "can not work at runtime."));
 #endif
+  }
+
+
 
   template <int dim>
   const FreeSurfaceHandler<dim> &


### PR DESCRIPTION
This allows writing code that calls SimulatorAccess::get_world_builder()
without having to worry whether the WorldBuilder is actually available.
The check then simply happens at run-time.

This is the follow-up promised in #2571.