### PR TITLE
Jenkinsfile.k8s whitespace and step names

### DIFF
--- a/Jenkinsfile.k8s
+++ b/Jenkinsfile.k8s
@@ -19,7 +19,7 @@ pipeline {
   }
 
   stages {
-    stage ("info") {
+    stage ("Info") {
       steps {
         container('dealii') {
           echo "PR: ${env.CHANGE_ID} - ${env.CHANGE_TITLE}"
@@ -31,7 +31,7 @@ pipeline {
       }
     }
 
-    stage ("Check permissions") {
+    stage ("Check Permissions") {
       when {
         allOf {
           not {branch 'master'}
@@ -55,7 +55,7 @@ pipeline {
       }
     }
 
-    stage('Check indentation') {
+    stage('Check Indentation') {
       steps {
         container('dealii') {
           sh './doc/indent'
@@ -100,7 +100,7 @@ pipeline {
       }
     }
 
-    stage('Run tests') {
+    stage('Test') {
       options {
         timeout(time: 90, unit: 'MINUTES')
       }

--- a/Jenkinsfile.k8s
+++ b/Jenkinsfile.k8s
@@ -21,7 +21,7 @@ pipeline {
   stages {
     stage ("info") {
       steps {
-        container('dealii'){
+        container('dealii') {
           echo "PR: ${env.CHANGE_ID} - ${env.CHANGE_TITLE}"
           echo "CHANGE_AUTHOR_EMAIL: ${env.CHANGE_AUTHOR_EMAIL}"
           echo "CHANGE_AUTHOR: ${env.CHANGE_AUTHOR}"
@@ -33,20 +33,20 @@ pipeline {
 
     stage ("Check permissions") {
       when {
-	allOf {
-            not {branch 'master'}
-            not {changeRequest authorEmail: "rene.gassmoeller@mailbox.org"}
-            not {changeRequest authorEmail: "heister@clemson.edu"}
-            not {changeRequest authorEmail: "bangerth@colostate.edu"}
-            not {changeRequest authorEmail: "judannberg@gmail.com"}
-            not {changeRequest authorEmail: "ja3170@columbia.edu"}
-            not {changeRequest authorEmail: "jbnaliboff@ucdavis.edu"}
-            not {changeRequest authorEmail: "menno.fraters@outlook.com"}
-            not {changeRequest authorEmail: "a.c.glerum@uu.nl"}
+        allOf {
+          not {branch 'master'}
+          not {changeRequest authorEmail: "rene.gassmoeller@mailbox.org"}
+          not {changeRequest authorEmail: "heister@clemson.edu"}
+          not {changeRequest authorEmail: "bangerth@colostate.edu"}
+          not {changeRequest authorEmail: "judannberg@gmail.com"}
+          not {changeRequest authorEmail: "ja3170@columbia.edu"}
+          not {changeRequest authorEmail: "jbnaliboff@ucdavis.edu"}
+          not {changeRequest authorEmail: "menno.fraters@outlook.com"}
+          not {changeRequest authorEmail: "a.c.glerum@uu.nl"}
         }
       }
       steps {
-        container('dealii'){
+        container('dealii') {
           sh '''
             wget -q -O - https://api.github.com/repos/geodynamics/aspect/issues/${CHANGE_ID}/labels | grep 'ready to test' || \
             { echo "This commit will only be tested when it has the label 'ready to test'"; exit 1; }
@@ -57,22 +57,24 @@ pipeline {
 
     stage('Check indentation') {
       steps {
-        container('dealii'){
+        container('dealii') {
           sh './doc/indent'
           sh 'git diff > changes-astyle.diff'
           archiveArtifacts artifacts: 'changes-astyle.diff', fingerprint: true
           sh '''
-	    git diff --exit-code || \
-	    { echo "Please check indentation, see artifacts in the top right corner!"; exit 1; }
-	    '''
-          }
+            git diff --exit-code || \
+            { echo "Please check indentation, see artifacts in the top right corner!"; exit 1; }
+          '''
         }
+      }
     }
 
     stage('Build') {
-      options {timeout(time: 15, unit: 'MINUTES')}
+      options {
+        timeout(time: 15, unit: 'MINUTES')
+      }
       steps {
-        container('dealii'){
+        container('dealii') {
           sh '''
             export NP=`grep -c ^processor /proc/cpuinfo`
             mkdir -p /home/dealii/build-gcc-fast
@@ -86,12 +88,12 @@ pipeline {
 
             # Set up build system and compile ASPECT
             cmake -G "Ninja" \
-	    	-D DEAL_II_CXX_FLAGS='-Werror' \
-	    	-D ASPECT_TEST_GENERATOR=Ninja \
-	  	-D ASPECT_USE_PETSC=OFF \
-  		-D ASPECT_RUN_ALL_TESTS=ON \
-  		-D ASPECT_PRECOMPILE_HEADERS=ON \
-  		$WORKSPACE/
+              -D DEAL_II_CXX_FLAGS='-Werror' \
+              -D ASPECT_TEST_GENERATOR=Ninja \
+              -D ASPECT_USE_PETSC=OFF \
+              -D ASPECT_RUN_ALL_TESTS=ON \
+              -D ASPECT_PRECOMPILE_HEADERS=ON \
+              $WORKSPACE/
             ninja -j $NP
           '''
         }
@@ -99,9 +101,11 @@ pipeline {
     }
 
     stage('Run tests') {
-      options {timeout(time: 90, unit: 'MINUTES')}
+      options {
+        timeout(time: 90, unit: 'MINUTES')
+      }
       steps {
-        container('dealii'){
+        container('dealii') {
           sh '''
             # This export avoids a warning about
             # a discovered, but unconnected infiniband network.
@@ -121,13 +125,13 @@ pipeline {
             # Avoid the warning described above
             export OMPI_MCA_btl=self,tcp
 
-           cd /home/dealii/build-gcc-fast
+            cd /home/dealii/build-gcc-fast
 
             # Output the test results using ctest. Since
             # the tests were prebuild in the previous shell
             # command, this will be fast although it is not
             # running in parallel.
-	    ctest \
+            ctest \
               --no-compress-output \
               --test-action Test
           '''


### PR DESCRIPTION
This is just some cleanup that I didn't want to add to #2604. Replacing tabs with spaces, making sure indentation is correct, and capitalizing step names.