### PR TITLE
Jenkinsfile.k8s : Build in Jenkins workspace instead of /home/dealii and other build step cleanup

### DIFF
--- a/Jenkinsfile.k8s
+++ b/Jenkinsfile.k8s
@@ -97,9 +97,8 @@ pipeline {
               ..
           '''
           sh '''
-            export NP=`grep -c ^processor /proc/cpuinfo`
             cd build-gcc-fast
-            ninja -j "${NP}"
+            ninja
           '''
         }
       }

--- a/Jenkinsfile.k8s
+++ b/Jenkinsfile.k8s
@@ -83,24 +83,25 @@ pipeline {
             # openmpi complains about running as root. We need
             # to run as root, because the surrounding Jenkins container
             # assumes we have root access.
-            sed -i 's/mpirun/mpirun --allow-run-as-root/' $WORKSPACE/tests/CMakeLists.txt
+            sed -i 's/mpirun/mpirun --allow-run-as-root/' "${WORKSPACE}/tests/CMakeLists.txt"
           '''
           sh '''
             cd /home/dealii/build-gcc-fast
-            
+
             # Set up build system and compile ASPECT
-            cmake -G "Ninja" \
+            cmake \
+              -G 'Ninja' \
               -D DEAL_II_CXX_FLAGS='-Werror' \
-              -D ASPECT_TEST_GENERATOR=Ninja \
-              -D ASPECT_USE_PETSC=OFF \
-              -D ASPECT_RUN_ALL_TESTS=ON \
-              -D ASPECT_PRECOMPILE_HEADERS=ON \
-              $WORKSPACE/
+              -D ASPECT_TEST_GENERATOR='Ninja' \
+              -D ASPECT_USE_PETSC='OFF' \
+              -D ASPECT_RUN_ALL_TESTS='ON' \
+              -D ASPECT_PRECOMPILE_HEADERS='ON' \
+              "${WORKSPACE}/"
           '''
           sh '''
             export NP=`grep -c ^processor /proc/cpuinfo`
             cd /home/dealii/build-gcc-fast
-            ninja -j $NP
+            ninja -j "${NP}"
           '''
         }
       }

--- a/Jenkinsfile.k8s
+++ b/Jenkinsfile.k8s
@@ -75,9 +75,7 @@ pipeline {
       }
       steps {
         container('dealii') {
-          sh '''
-            mkdir -p /home/dealii/build-gcc-fast
-          '''
+          sh 'mkdir -p /home/dealii/build-gcc-fast'
           sh '''
             # We need to add this option to mpirun, otherwise
             # openmpi complains about running as root. We need

--- a/Jenkinsfile.k8s
+++ b/Jenkinsfile.k8s
@@ -76,13 +76,13 @@ pipeline {
       steps {
         container('dealii') {
           sh 'mkdir build-gcc-fast'
-          sh '''
-            # We need to add this option to mpirun, otherwise
-            # openmpi complains about running as root. We need
-            # to run as root, because the surrounding Jenkins container
-            # assumes we have root access.
-            sed -i 's/mpirun/mpirun --allow-run-as-root/' 'tests/CMakeLists.txt'
-          '''
+
+          // We need to add this option to mpirun, otherwise
+          // openmpi complains about running as root. We need
+          // to run as root, because the surrounding Jenkins container
+          // assumes we have root access.
+          sh 'sed -i "s/mpirun/mpirun --allow-run-as-root/" "tests/CMakeLists.txt"'
+
           sh '''
             cd build-gcc-fast
 
@@ -96,6 +96,7 @@ pipeline {
               -D ASPECT_PRECOMPILE_HEADERS='ON' \
               ..
           '''
+
           sh '''
             cd build-gcc-fast
             ninja
@@ -125,6 +126,7 @@ pipeline {
             # most efficient way to build the tests).
             ninja -k 0 tests || true
           '''
+
           sh '''
             # Avoid the warning described above
             export OMPI_MCA_btl=self,tcp

--- a/Jenkinsfile.k8s
+++ b/Jenkinsfile.k8s
@@ -75,16 +75,16 @@ pipeline {
       }
       steps {
         container('dealii') {
-          sh 'mkdir -p /home/dealii/build-gcc-fast'
+          sh 'mkdir build-gcc-fast'
           sh '''
             # We need to add this option to mpirun, otherwise
             # openmpi complains about running as root. We need
             # to run as root, because the surrounding Jenkins container
             # assumes we have root access.
-            sed -i 's/mpirun/mpirun --allow-run-as-root/' "${WORKSPACE}/tests/CMakeLists.txt"
+            sed -i 's/mpirun/mpirun --allow-run-as-root/' 'tests/CMakeLists.txt'
           '''
           sh '''
-            cd /home/dealii/build-gcc-fast
+            cd build-gcc-fast
 
             # Set up build system and compile ASPECT
             cmake \
@@ -94,11 +94,11 @@ pipeline {
               -D ASPECT_USE_PETSC='OFF' \
               -D ASPECT_RUN_ALL_TESTS='ON' \
               -D ASPECT_PRECOMPILE_HEADERS='ON' \
-              "${WORKSPACE}/"
+              ..
           '''
           sh '''
             export NP=`grep -c ^processor /proc/cpuinfo`
-            cd /home/dealii/build-gcc-fast
+            cd build-gcc-fast
             ninja -j "${NP}"
           '''
         }
@@ -116,7 +116,7 @@ pipeline {
             # a discovered, but unconnected infiniband network.
             export OMPI_MCA_btl=self,tcp
 
-            cd /home/dealii/build-gcc-fast/tests
+            cd build-gcc-fast/tests
 
             # Let ninja prebuild the test libraries and run
             # the tests to create the output files in parallel. We
@@ -130,7 +130,7 @@ pipeline {
             # Avoid the warning described above
             export OMPI_MCA_btl=self,tcp
 
-            cd /home/dealii/build-gcc-fast
+            cd build-gcc-fast
 
             # Output the test results using ctest. Since
             # the tests were prebuild in the previous shell
@@ -145,18 +145,16 @@ pipeline {
       post {
         always {
           container('dealii') {
-            sh 'mv /home/dealii/build-gcc-fast/Testing .'
-
             // Generate the 'Tests' output page in Jenkins
             xunit testTimeMargin: '3000',
               thresholdMode: 1,
               thresholds: [failed(), skipped()],
-              tools: [CTest(pattern: 'Testing/**/*.xml')]
+              tools: [CTest(pattern: 'build-gcc-fast/Testing/**/*.xml')]
 
             // Update the reference test output with the new test results
             sh '''
               export OMPI_MCA_btl=self,tcp
-              cd /home/dealii/build-gcc-fast
+              cd build-gcc-fast
               ninja generate_reference_output
             '''
 

--- a/Jenkinsfile.k8s
+++ b/Jenkinsfile.k8s
@@ -76,16 +76,18 @@ pipeline {
       steps {
         container('dealii') {
           sh '''
-            export NP=`grep -c ^processor /proc/cpuinfo`
             mkdir -p /home/dealii/build-gcc-fast
-            cd /home/dealii/build-gcc-fast
-
+          '''
+          sh '''
             # We need to add this option to mpirun, otherwise
             # openmpi complains about running as root. We need
             # to run as root, because the surrounding Jenkins container
             # assumes we have root access.
             sed -i 's/mpirun/mpirun --allow-run-as-root/' $WORKSPACE/tests/CMakeLists.txt
-
+          '''
+          sh '''
+            cd /home/dealii/build-gcc-fast
+            
             # Set up build system and compile ASPECT
             cmake -G "Ninja" \
               -D DEAL_II_CXX_FLAGS='-Werror' \
@@ -94,6 +96,10 @@ pipeline {
               -D ASPECT_RUN_ALL_TESTS=ON \
               -D ASPECT_PRECOMPILE_HEADERS=ON \
               $WORKSPACE/
+          '''
+          sh '''
+            export NP=`grep -c ^processor /proc/cpuinfo`
+            cd /home/dealii/build-gcc-fast
             ninja -j $NP
           '''
         }


### PR DESCRIPTION
Some more refactoring to remove complexity.

Regarding https://github.com/geodynamics/aspect/commit/bbe3c56225d3e1b3178c3fc78a6dee0626376be5, I'm not sure how Aspect detects the Deal.ii installation in the container, so that change may need to be reverted.