### PR TITLE
Use nullptr instead of NULL.

### DIFF
--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -222,7 +222,7 @@ namespace aspect
          * the input file (and are consequently currently active) and see if one
          * of them has the desired type specified by the template argument. If so,
          * return a pointer to it. If no boundary composition model is active
-         * that matches the given type, return a NULL pointer.
+         * that matches the given type, return a nullptr.
          *
          * @deprecated Use has_matching_boundary_composition_model() and
          * get_matching_boundary_composition_model() instead.
@@ -324,7 +324,7 @@ namespace aspect
            p != boundary_composition_objects.end(); ++p)
         if (BoundaryCompositionType *x = dynamic_cast<BoundaryCompositionType *> ( (*p).get()) )
           return x;
-      return NULL;
+      return nullptr;
     }
 
 

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -255,7 +255,7 @@ namespace aspect
          * the input file (and are consequently currently active) and see if one
          * of them has the desired type specified by the template argument. If so,
          * return a pointer to it. If no boundary temperature model is active
-         * that matches the given type, return a NULL pointer.
+         * that matches the given type, return a nullptr.
          */
         template <typename BoundaryTemperatureType>
         DEAL_II_DEPRECATED
@@ -354,7 +354,7 @@ namespace aspect
            p != boundary_temperature_objects.end(); ++p)
         if (BoundaryTemperatureType *x = dynamic_cast<BoundaryTemperatureType *> ( (*p).get()) )
           return x;
-      return NULL;
+      return nullptr;
     }
 
 

--- a/include/aspect/boundary_velocity/interface.h
+++ b/include/aspect/boundary_velocity/interface.h
@@ -238,7 +238,7 @@ namespace aspect
          * the input file (and are consequently currently active) and see if one
          * of them has the desired type specified by the template argument. If so,
          * return a pointer to it. If no boundary velocity model is active
-         * that matches the given type, return a NULL pointer.
+         * that matches the given type, return a nullptr.
          */
         template <typename BoundaryVelocityType>
         DEAL_II_DEPRECATED
@@ -335,7 +335,7 @@ namespace aspect
              p != boundary->second.end(); ++p)
           if (BoundaryVelocityType *x = dynamic_cast<BoundaryVelocityType *> ( (*p).get()) )
             return x;
-      return NULL;
+      return nullptr;
     }
 
 

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -341,7 +341,7 @@ namespace aspect
          * the input file (and are consequently currently active) and see if one
          * of them has the desired type specified by the template argument. If so,
          * return a pointer to it. If no heating model is active that matches the
-         * given type, return a NULL pointer.
+         * given type, return a nullptr.
          */
         template <typename HeatingModelType>
         DEAL_II_DEPRECATED
@@ -419,7 +419,7 @@ namespace aspect
            p != heating_model_objects.end(); ++p)
         if (HeatingModelType *x = dynamic_cast<HeatingModelType *> ( (*p).get()) )
           return x;
-      return NULL;
+      return nullptr;
     }
 
 

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -187,7 +187,7 @@ namespace aspect
          * the input file (and are consequently currently active) and see if one
          * of them has the desired type specified by the template argument. If so,
          * return a pointer to it. If no initial composition model is active that matches the
-         * given type, return a NULL pointer.
+         * given type, return a nullptr.
          */
         template <typename InitialCompositionType>
         DEAL_II_DEPRECATED
@@ -282,7 +282,7 @@ namespace aspect
            p != initial_composition_objects.end(); ++p)
         if (InitialCompositionType *x = dynamic_cast<InitialCompositionType *> ( (*p).get()) )
           return x;
-      return NULL;
+      return nullptr;
     }
 
 

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -184,7 +184,7 @@ namespace aspect
          * the input file (and are consequently currently active) and see if one
          * of them has the desired type specified by the template argument. If so,
          * return a pointer to it. If no initial temperature model is active
-         * that matches the given type, return a NULL pointer.
+         * that matches the given type, return a nullptr.
          */
         template <typename InitialTemperatureType>
         DEAL_II_DEPRECATED
@@ -270,7 +270,7 @@ namespace aspect
            p != initial_temperature_objects.end(); ++p)
         if (InitialTemperatureType *x = dynamic_cast<InitialTemperatureType *> ( (*p).get()) )
           return x;
-      return NULL;
+      return nullptr;
     }
 
 

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -296,7 +296,7 @@ namespace aspect
          * and interpolating to the quadrature points, or to query the cell for
          * material ids, neighbors, or other information that is not available
          * solely from the locations. Note that not all calling functions can set
-         * this reference. In these cases it will be a NULL pointer, so make sure
+         * this reference. In these cases it will be a nullptr, so make sure
          * that your material model either fails with a proper error message
          * or provide an alternative calculation for these cases.
          *
@@ -1184,7 +1184,7 @@ namespace aspect
           if (result)
             return result;
         }
-      return NULL;
+      return nullptr;
     }
 
 
@@ -1198,7 +1198,7 @@ namespace aspect
           if (result)
             return result;
         }
-      return NULL;
+      return nullptr;
     }
 
 
@@ -1212,7 +1212,7 @@ namespace aspect
           if (result)
             return result;
         }
-      return NULL;
+      return nullptr;
     }
 
 
@@ -1226,7 +1226,7 @@ namespace aspect
           if (result)
             return result;
         }
-      return NULL;
+      return nullptr;
     }
 
 

--- a/include/aspect/particle/particle.h
+++ b/include/aspect/particle/particle.h
@@ -186,7 +186,7 @@ namespace aspect
          * point to the first element in which the data should be written. This
          * function is meant for serializing all particle properties and
          * afterwards de-serializing the properties by calling the appropriate
-         * constructor Particle(void *&data, PropertyPool *property_pool = NULL);
+         * constructor Particle(void *&data, PropertyPool *property_pool = nullptr);
          *
          * @param [in,out] data The memory location to write particle data
          * into. This pointer points to the begin of the memory, in which the
@@ -355,7 +355,7 @@ namespace aspect
     void Particle<dim,spacedim>::save (Archive &ar, const unsigned int) const
     {
       unsigned int n_properties = 0;
-      if ((property_pool != NULL) && (properties != PropertyPool::invalid_handle))
+      if ((property_pool != nullptr) && (properties != PropertyPool::invalid_handle))
         n_properties = get_properties().size();
 
       ar &location

--- a/include/aspect/particle/particle_accessor.h
+++ b/include/aspect/particle/particle_accessor.h
@@ -46,7 +46,7 @@ namespace aspect
          * point to the first element in which the data should be written. This
          * function is meant for serializing all particle properties and
          * afterwards de-serializing the properties by calling the appropriate
-         * constructor Particle(void *&data, PropertyPool *property_pool = NULL);
+         * constructor Particle(void *&data, PropertyPool *property_pool = nullptr);
          *
          * @param [in,out] data The memory location to write particle data
          * into. This pointer points to the begin of the memory, in which the

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -62,7 +62,7 @@ namespace aspect
     bool
     plugin_type_matches (const PluginType &object)
     {
-      return (dynamic_cast<const TestType *> (&object) != NULL);
+      return (dynamic_cast<const TestType *> (&object) != nullptr);
     }
 
     /**
@@ -562,9 +562,9 @@ namespace aspect
             // finally see if this plugin is derived from
             // SimulatorAccess; if so, draw an arrow from SimulatorAccess
             // also to the plugin's name
-            if (dynamic_cast<const SimulatorAccess<2>*>(instance.get()) != NULL
+            if (dynamic_cast<const SimulatorAccess<2>*>(instance.get()) != nullptr
                 ||
-                dynamic_cast<const SimulatorAccess<3>*>(instance.get()) != NULL)
+                dynamic_cast<const SimulatorAccess<3>*>(instance.get()) != nullptr)
               output_stream << "SimulatorAccess"
                             << " -> "
                             << node_name

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -234,7 +234,7 @@ namespace aspect
          * in the input file (and are consequently currently active) and see
          * if one of them has the desired type specified by the template
          * argument. If so, return a pointer to it. If no postprocessor is
-         * active that matches the given type, return a NULL pointer.
+         * active that matches the given type, return a nullptr.
          *
          * @deprecated Use has_matching_postprocessor() and
          * get_matching_postprocessor() instead.
@@ -405,7 +405,7 @@ namespace aspect
            p != postprocessors.end(); ++p)
         if (PostprocessorType *x = dynamic_cast<PostprocessorType *> ( (*p).get()) )
           return x;
-      return NULL;
+      return nullptr;
     }
 
 

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -580,7 +580,7 @@ namespace aspect
        * <code>source/simulator/solver_schemes.cc</code>.
        */
       double assemble_and_solve_temperature (const bool compute_initial_residual = false,
-                                             double *initial_residual = NULL);
+                                             double *initial_residual = nullptr);
 
       /**
        * Solve the composition equations with whatever method is selected
@@ -595,7 +595,7 @@ namespace aspect
        * <code>source/simulator/solver_schemes.cc</code>.
        */
       std::vector<double> assemble_and_solve_composition (const bool compute_initial_residual = false,
-                                                          std::vector<double> *initial_residual = NULL);
+                                                          std::vector<double> *initial_residual = nullptr);
 
       /**
        * Assemble and solve the Stokes equation.
@@ -615,7 +615,7 @@ namespace aspect
        * <code>source/simulator/solver_schemes.cc</code>.
        */
       double assemble_and_solve_stokes (const bool compute_initial_residual = false,
-                                        double *initial_residual = NULL);
+                                        double *initial_residual = nullptr);
 
       /**
        * Initiate the assembly of one advection matrix and right hand side and

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -830,7 +830,7 @@ namespace aspect
        * no postprocessor of this type has been selected in the input
        * file (or, has been required by another postprocessor using the
        * Postprocess::Interface::required_other_postprocessors()
-       * mechanism), then the function returns a NULL pointer.
+       * mechanism), then the function returns a nullptr.
        *
        * @deprecated Use get_postprocess_manager().has_matching_postprocessor()
        * and get_postprocess_manager().get_matching_postprocessor() instead.
@@ -864,7 +864,7 @@ namespace aspect
     if (get_postprocess_manager().template has_matching_postprocessor<PostprocessorType>())
       return &get_postprocess_manager().template get_matching_postprocessor<PostprocessorType>();
 
-    return NULL;
+    return nullptr;
   }
 }
 

--- a/source/boundary_fluid_pressure/density.cc
+++ b/source/boundary_fluid_pressure/density.cc
@@ -43,7 +43,7 @@ namespace aspect
     ) const
     {
       const MaterialModel::MeltOutputs<dim> *melt_outputs = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
-      Assert(melt_outputs!=NULL, ExcMessage("Error, MeltOutputs are missing in fluid_pressure_gradient()"));
+      Assert(melt_outputs!=nullptr, ExcMessage("Error, MeltOutputs are missing in fluid_pressure_gradient()"));
       for (unsigned int q=0; q<fluid_pressure_gradient_outputs.size(); ++q)
         {
           const Tensor<1,dim> gravity = this->get_gravity_model().gravity_vector(material_model_inputs.position[q]);

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -594,7 +594,7 @@ namespace aspect
 
           const GeometryModel::SphericalShell<dim> *spherical_shell_geometry =
             dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&(this->get_geometry_model()));
-          AssertThrow (spherical_shell_geometry != NULL,
+          AssertThrow (spherical_shell_geometry != nullptr,
                        ExcMessage ("This boundary model is only implemented if the geometry is "
                                    "in fact a spherical shell."));
           Rc=spherical_shell_geometry->inner_radius();

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -78,7 +78,7 @@ namespace aspect
       eccentricity (-1),
       semi_minor_axis_b (-1),
       bottom_depth (-1),
-      topography(NULL)
+      topography(nullptr)
     {}
 
     // Copy constructor
@@ -160,7 +160,7 @@ namespace aspect
       const double rad_to_degree = 180/numbers::PI;
       if (dim == 3)
         phi_theta = Point<dim-1>(phi_theta_d_hat[0] * rad_to_degree,phi_theta_d_hat[1] * rad_to_degree);
-      const double h = topography != NULL ? topography->value(phi_theta) : 0;
+      const double h = topography != nullptr ? topography->value(phi_theta) : 0;
       const double d = d_hat + (d_hat + bottom_depth)/bottom_depth*h;
       const Point<3> phi_theta_d (phi_theta_d_hat[0],
                                   phi_theta_d_hat[1],
@@ -178,7 +178,7 @@ namespace aspect
       Point<dim-1> phi_theta;
       if (dim == 3)
         phi_theta = Point<dim-1>(phi_theta_d[0] * rad_to_degree,phi_theta_d[1] * rad_to_degree);
-      const double h = topography != NULL ? topography->value(phi_theta) : 0;
+      const double h = topography != nullptr ? topography->value(phi_theta) : 0;
       const double d_hat = bottom_depth * (d-h)/(bottom_depth+h);
       const Point<3> phi_theta_d_hat (phi_theta_d[0],
                                       phi_theta_d[1],

--- a/source/heating_model/adiabatic_heating_of_melt.cc
+++ b/source/heating_model/adiabatic_heating_of_melt.cc
@@ -43,7 +43,7 @@ namespace aspect
 
       // get the melt velocity
       const MaterialModel::MeltInputs<dim> *melt_in = material_model_inputs.template get_additional_input<MaterialModel::MeltInputs<dim> >();
-      AssertThrow(melt_in != NULL,
+      AssertThrow(melt_in != nullptr,
                   ExcMessage ("Need MeltInputs from the material model for adiabatic heating with melt!"));
 
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
@@ -58,7 +58,7 @@ namespace aspect
           else
             {
               const MaterialModel::MeltOutputs<dim> *melt_outputs = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
-              Assert(melt_outputs != NULL, ExcMessage("Need MeltOutputs from the material model for adiabatic heating with melt."));
+              Assert(melt_outputs != nullptr, ExcMessage("Need MeltOutputs from the material model for adiabatic heating with melt."));
 
               heating_model_outputs.heating_source_terms[q] = (-porosity * material_model_inputs.velocity[q]
                                                                * this->get_gravity_model().gravity_vector(material_model_inputs.position[q]))
@@ -131,7 +131,7 @@ namespace aspect
     create_additional_material_model_inputs(MaterialModel::MaterialModelInputs<dim> &inputs) const
     {
       // we need the melt inputs for this adiabatic heating of melt
-      if (inputs.template get_additional_input<MaterialModel::MeltInputs<dim> >() != NULL)
+      if (inputs.template get_additional_input<MaterialModel::MeltInputs<dim> >() != nullptr)
         return;
 
       inputs.additional_inputs.push_back(

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -257,7 +257,7 @@ namespace aspect
       // If the heating model does not get the reaction rate outputs, it can not correctly compute
       // the rates of temperature change. To make sure these (incorrect) values are never used anywhere,
       // overwrite them with signaling_NaNs.
-      if (reaction_rate_outputs == NULL)
+      if (reaction_rate_outputs == nullptr)
         for (unsigned int q=0; q<heating_model_outputs.rates_of_temperature_change.size(); ++q)
           heating_model_outputs.rates_of_temperature_change[q] = numbers::signaling_nan<double>();
     }

--- a/source/heating_model/latent_heat_melt.cc
+++ b/source/heating_model/latent_heat_melt.cc
@@ -67,7 +67,7 @@ namespace aspect
                                                                   * melting_rate
                                                                   * material_model_inputs.temperature[q];
                 }
-              else if (use_operator_split && reaction_rate_out != NULL)
+              else if (use_operator_split && reaction_rate_out != nullptr)
                 {
                   // if operator splitting is used in the model, we have to use the reaction rates from the
                   // material model outputs instead of the reaction terms
@@ -89,7 +89,7 @@ namespace aspect
                                                                          * material_model_inputs.temperature[q]
                                                                          / material_model_outputs.specific_heat[q];
                 }
-              else if (use_operator_split && reaction_rate_out == NULL)
+              else if (use_operator_split && reaction_rate_out == nullptr)
                 {
                   // if operator plit is used, but the reaction rate outputs are not there,
                   // fill the rates of temperature change with NaNs, so that an error is thrown

--- a/source/heating_model/shear_heating_with_melt.cc
+++ b/source/heating_model/shear_heating_with_melt.cc
@@ -48,7 +48,7 @@ namespace aspect
 
       // get the melt velocity
       const MaterialModel::MeltInputs<dim> *melt_in = material_model_inputs.template get_additional_input<MaterialModel::MeltInputs<dim> >();
-      AssertThrow(melt_in != NULL,
+      AssertThrow(melt_in != nullptr,
                   ExcMessage ("Need MeltInputs from the material model for shear heating with melt!"));
 
       bool is_melt_cell = false;
@@ -56,7 +56,7 @@ namespace aspect
         is_melt_cell = this->get_melt_handler().is_melt_cell(material_model_inputs.current_cell);
 
       const MaterialModel::MeltOutputs<dim> *melt_outputs = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
-      Assert(melt_outputs != NULL, ExcMessage("Need MeltOutputs from the material model for shear heating with melt."));
+      Assert(melt_outputs != nullptr, ExcMessage("Need MeltOutputs from the material model for shear heating with melt."));
 
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
         {
@@ -98,7 +98,7 @@ namespace aspect
     create_additional_material_model_inputs(MaterialModel::MaterialModelInputs<dim> &inputs) const
     {
       // we need the melt inputs for this shear heating of melt
-      if (inputs.template get_additional_input<MaterialModel::MeltInputs<dim> >() != NULL)
+      if (inputs.template get_additional_input<MaterialModel::MeltInputs<dim> >() != nullptr)
         return;
 
       inputs.additional_inputs.push_back(

--- a/source/initial_composition/porosity.cc
+++ b/source/initial_composition/porosity.cc
@@ -43,7 +43,7 @@ namespace aspect
 
       const MaterialModel::MeltFractionModel<dim> *material_model =
         dynamic_cast<const MaterialModel::MeltFractionModel<dim>* > (&this->get_material_model());
-      AssertThrow(material_model != NULL,
+      AssertThrow(material_model != nullptr,
                   ExcMessage("The used material model is not derived from the 'MeltFractionModel' class, "
                              "and therefore does not support computing equilibrium melt fractions. "
                              "This is incompatible with the `porosity' "

--- a/source/main.cc
+++ b/source/main.cc
@@ -285,7 +285,7 @@ void possibly_load_shared_libs (const std::string &parameters)
                       << ">" << std::endl;
 
           void *handle = dlopen (shared_libs_list[i].c_str(), RTLD_LAZY);
-          AssertThrow (handle != NULL,
+          AssertThrow (handle != nullptr,
                        ExcMessage (std::string("Could not successfully load shared library <")
                                    + shared_libs_list[i] + ">. The operating system reports "
                                    + "that the error is this: <"
@@ -655,7 +655,7 @@ int main (int argc, char *argv[])
   // There might be remaining arguments for PETSc, only hand those over to
   // the MPI initialization, but not the ones we parsed above.
   int n_remaining_arguments = argc - current_argument;
-  char **remaining_arguments = (n_remaining_arguments > 0) ? &argv[current_argument] : NULL;
+  char **remaining_arguments = (n_remaining_arguments > 0) ? &argv[current_argument] : nullptr;
 
   try
     {

--- a/source/material_model/ascii_reference_profile.cc
+++ b/source/material_model/ascii_reference_profile.cc
@@ -233,7 +233,7 @@ namespace aspect
     void
     AsciiReferenceProfile<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<SeismicAdditionalOutputs<dim> >() == NULL
+      if (out.template get_additional_output<SeismicAdditionalOutputs<dim> >() == nullptr
           && seismic_vp_index != numbers::invalid_unsigned_int
           && seismic_vs_index != numbers::invalid_unsigned_int)
         {

--- a/source/material_model/composition_reaction.cc
+++ b/source/material_model/composition_reaction.cc
@@ -97,7 +97,7 @@ namespace aspect
               // (and then set the latter to zero).
               if (this->get_parameters().use_operator_splitting)
                 {
-                  if (reaction_rate_out != NULL)
+                  if (reaction_rate_out != nullptr)
                     reaction_rate_out->reaction_rates[i][c] = (this->get_timestep_number() > 0
                                                                ?
                                                                out.reaction_terms[i][c] / this->get_timestep()
@@ -265,7 +265,7 @@ namespace aspect
     CompositionReaction<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       if (this->get_parameters().use_operator_splitting
-          && out.template get_additional_output<ReactionRateOutputs<dim> >() == NULL)
+          && out.template get_additional_output<ReactionRateOutputs<dim> >() == nullptr)
         {
           const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -92,7 +92,7 @@ namespace aspect
                 {
                   out.viscosities[i] = maximum_viscosity;
 
-                  if (derivatives != NULL)
+                  if (derivatives != nullptr)
                     {
                       derivatives->viscosity_derivative_wrt_strain_rate[i] = 0.0;
                       derivatives->viscosity_derivative_wrt_pressure[i] = 0.0;
@@ -126,7 +126,7 @@ namespace aspect
                   Assert(dealii::numbers::is_finite(out.viscosities[i]),
                          ExcMessage ("Error: Averaged viscosity is not finite."));
 
-                  if (derivatives != NULL)
+                  if (derivatives != nullptr)
                     {
                       const double averaging_factor = maximum_viscosity * maximum_viscosity
                                                       / ((eta_plastic + minimum_viscosity + maximum_viscosity) * (eta_plastic + minimum_viscosity + maximum_viscosity));

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -1976,7 +1976,7 @@ namespace aspect
       // These properties are useful as output, but will also be used by the
       // heating model to reduce shear heating by the amount of work done to
       // reduce grain size.
-      if (out.template get_additional_output<DislocationViscosityOutputs<dim> >() == NULL)
+      if (out.template get_additional_output<DislocationViscosityOutputs<dim> >() == nullptr)
         {
           const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(
@@ -1985,7 +1985,7 @@ namespace aspect
         }
 
       // These properties are only output properties.
-      if (out.template get_additional_output<SeismicAdditionalOutputs<dim> >() == NULL)
+      if (out.template get_additional_output<SeismicAdditionalOutputs<dim> >() == nullptr)
         {
           const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -303,7 +303,7 @@ namespace aspect
       velocity(n_points, numbers::signaling_nan<Tensor<1,dim> >()),
       composition(n_points, std::vector<double>(n_comp, numbers::signaling_nan<double>())),
       strain_rate(n_points, numbers::signaling_nan<SymmetricTensor<2,dim> >()),
-      cell (NULL),
+      cell (nullptr),
       current_cell()
     {}
 
@@ -359,7 +359,7 @@ namespace aspect
       velocity(fe_values.n_quadrature_points, numbers::signaling_nan<Tensor<1,dim> >()),
       composition(fe_values.n_quadrature_points, std::vector<double>(introspection.n_compositional_fields, numbers::signaling_nan<double>())),
       strain_rate(fe_values.n_quadrature_points, numbers::signaling_nan<SymmetricTensor<2,dim> >()),
-      cell(cell_x.state() == IteratorState::valid ? &current_cell : NULL),
+      cell(cell_x.state() == IteratorState::valid ? &current_cell : nullptr),
 #if DEAL_II_VERSION_GTE(9,0,0)
       current_cell (cell_x)
 #else
@@ -419,7 +419,7 @@ namespace aspect
         }
 
       DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-      this->cell = cell_x.state() == IteratorState::valid ? &cell_x : NULL;
+      this->cell = cell_x.state() == IteratorState::valid ? &cell_x : nullptr;
       DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #if DEAL_II_VERSION_GTE(9,0,0)

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -196,7 +196,7 @@ namespace aspect
                   // fill reaction rate outputs if the model uses operator splitting
                   if (this->get_parameters().use_operator_splitting)
                     {
-                      if (reaction_rate_out != NULL)
+                      if (reaction_rate_out != nullptr)
                         {
                           if (c == peridotite_idx && this->get_timestep_number() > 0)
                             reaction_rate_out->reaction_rates[i][c] = porosity_change / melting_time_scale
@@ -222,7 +222,7 @@ namespace aspect
                 {
                   out.reaction_terms[i][c] = 0.0;
 
-                  if (this->get_parameters().use_operator_splitting && reaction_rate_out != NULL)
+                  if (this->get_parameters().use_operator_splitting && reaction_rate_out != nullptr)
                     reaction_rate_out->reaction_rates[i][c] = 0.0;
                 }
             }
@@ -251,7 +251,7 @@ namespace aspect
       // fill melt outputs if they exist
       MeltOutputs<dim> *melt_out = out.template get_additional_output<MeltOutputs<dim> >();
 
-      if (melt_out != NULL)
+      if (melt_out != nullptr)
         {
           const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
@@ -483,7 +483,7 @@ namespace aspect
     MeltGlobal<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       if (this->get_parameters().use_operator_splitting
-          && out.template get_additional_output<ReactionRateOutputs<dim> >() == NULL)
+          && out.template get_additional_output<ReactionRateOutputs<dim> >() == nullptr)
         {
           const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(

--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -310,7 +310,7 @@ namespace aspect
               for (unsigned int c=0; c<in.composition[i].size(); ++c)
                 {
                   // fill reaction rate outputs
-                  if (reaction_rate_out != NULL)
+                  if (reaction_rate_out != nullptr)
                     {
                       if (c == peridotite_idx && this->get_timestep_number() > 0)
                         reaction_rate_out->reaction_rates[i][c] = porosity_change / melting_time_scale
@@ -341,7 +341,7 @@ namespace aspect
                 {
                   out.reaction_terms[i][c] = 0.0;
 
-                  if (reaction_rate_out != NULL)
+                  if (reaction_rate_out != nullptr)
                     reaction_rate_out->reaction_rates[i][c] = 0.0;
                 }
             }
@@ -373,7 +373,7 @@ namespace aspect
       // fill melt outputs if they exist
       MeltOutputs<dim> *melt_out = out.template get_additional_output<MeltOutputs<dim> >();
 
-      if (melt_out != NULL)
+      if (melt_out != nullptr)
         {
           const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
@@ -766,7 +766,7 @@ namespace aspect
     void
     MeltSimple<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (this->get_parameters().use_operator_splitting && out.template get_additional_output<ReactionRateOutputs<dim> >() == NULL)
+      if (this->get_parameters().use_operator_splitting && out.template get_additional_output<ReactionRateOutputs<dim> >() == nullptr)
         {
           const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -698,7 +698,7 @@ namespace aspect
     void
     Steinberger<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<SeismicAdditionalOutputs<dim> >() == NULL)
+      if (out.template get_additional_output<SeismicAdditionalOutputs<dim> >() == nullptr)
         {
           const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -441,7 +441,7 @@ namespace aspect
               // compute derivatives if necessary
               std::vector<SymmetricTensor<2,dim> > composition_viscosities_derivatives(volume_fractions.size());
               std::vector<double> composition_dviscosities_dpressure(volume_fractions.size());
-              if (derivatives != NULL)
+              if (derivatives != nullptr)
                 {
                   const double finite_difference_accuracy = 1e-7;
 
@@ -1141,7 +1141,7 @@ namespace aspect
     void
     ViscoPlastic<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<PlasticAdditionalOutputs<dim> >() == NULL)
+      if (out.template get_additional_output<PlasticAdditionalOutputs<dim> >() == nullptr)
         {
           const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(

--- a/source/material_model/viscoelastic.cc
+++ b/source/material_model/viscoelastic.cc
@@ -564,7 +564,7 @@ namespace aspect
     void
     Viscoelastic<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<ElasticAdditionalOutputs<dim> >() == NULL)
+      if (out.template get_additional_output<ElasticAdditionalOutputs<dim> >() == nullptr)
         {
           const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(

--- a/source/mesh_refinement/compaction_length.cc
+++ b/source/mesh_refinement/compaction_length.cc
@@ -64,7 +64,7 @@ namespace aspect
               this->get_material_model().evaluate(in, out);
 
               MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
-              AssertThrow(melt_out != NULL,
+              AssertThrow(melt_out != nullptr,
                           ExcMessage("Need MeltOutputs from the material model for computing the melt properties."));
 
               // for each composition dof, check if the compaction length exceeds the cell size

--- a/source/particle/output/hdf5.cc
+++ b/source/particle/output/hdf5.cc
@@ -168,8 +168,8 @@ namespace aspect
         H5Pclose(plist_id);
 
         // Write the position data
-        const hid_t position_dataspace = H5Screate_simple(2, global_dataset_size, NULL);
-        const hid_t local_position_dataspace = H5Screate_simple(2, local_dataset_size, NULL);
+        const hid_t position_dataspace = H5Screate_simple(2, global_dataset_size, nullptr);
+        const hid_t local_position_dataspace = H5Screate_simple(2, local_dataset_size, nullptr);
 
 #if H5Dcreate_vers == 1
         hid_t position_dataset = H5Dcreate(h5_file, "nodes", H5T_NATIVE_DOUBLE, position_dataspace, H5P_DEFAULT);
@@ -178,7 +178,7 @@ namespace aspect
 #endif
 
         // Select the local hyperslab from the dataspace
-        H5Sselect_hyperslab(position_dataspace, H5S_SELECT_SET, offset, NULL, local_dataset_size, NULL);
+        H5Sselect_hyperslab(position_dataspace, H5S_SELECT_SET, offset, nullptr, local_dataset_size, nullptr);
 
         // Write position data to the HDF5 file
         H5Dwrite(position_dataset, H5T_NATIVE_DOUBLE, local_position_dataspace, position_dataspace, write_properties, &position_data[0]);
@@ -191,8 +191,8 @@ namespace aspect
 
         global_dataset_size[1] = 1;
         local_dataset_size[1] = 1;
-        const hid_t index_dataspace = H5Screate_simple(1, global_dataset_size, NULL);
-        const hid_t local_index_dataspace = H5Screate_simple(1, local_dataset_size, NULL);
+        const hid_t index_dataspace = H5Screate_simple(1, global_dataset_size, nullptr);
+        const hid_t local_index_dataspace = H5Screate_simple(1, local_dataset_size, nullptr);
 #if H5Dcreate_vers == 1
         const hid_t particle_index_dataset = H5Dcreate(h5_file, "id", HDF5_PARTICLE_INDEX_TYPE, index_dataspace, H5P_DEFAULT);
 #else
@@ -200,7 +200,7 @@ namespace aspect
 #endif
 
         // Select the local hyperslab from the dataspace
-        H5Sselect_hyperslab(index_dataspace, H5S_SELECT_SET, offset, NULL, local_dataset_size, NULL);
+        H5Sselect_hyperslab(index_dataspace, H5S_SELECT_SET, offset, nullptr, local_dataset_size, nullptr);
 
         // Write index data to the HDF5 file
         H5Dwrite(particle_index_dataset, HDF5_PARTICLE_INDEX_TYPE, local_index_dataspace, index_dataspace, write_properties, &index_data[0]);
@@ -233,8 +233,8 @@ namespace aspect
                 if (data_fields > 1)
                   field_name.append('_' + Utilities::to_string(i));
 
-                const hid_t property_dataspace = H5Screate_simple(2, global_dataset_size, NULL);
-                const hid_t local_property_dataspace = H5Screate_simple(2, local_dataset_size, NULL);
+                const hid_t property_dataspace = H5Screate_simple(2, global_dataset_size, nullptr);
+                const hid_t local_property_dataspace = H5Screate_simple(2, local_dataset_size, nullptr);
 #if H5Dcreate_vers == 1
                 const hid_t particle_property_dataset = H5Dcreate(h5_file, field_name.c_str(), H5T_NATIVE_DOUBLE, property_dataspace, H5P_DEFAULT);
 #else
@@ -242,7 +242,7 @@ namespace aspect
 #endif
 
                 // Select the local hyperslab from the dataspace
-                H5Sselect_hyperslab(property_dataspace, H5S_SELECT_SET, offset, NULL, local_dataset_size, NULL);
+                H5Sselect_hyperslab(property_dataspace, H5S_SELECT_SET, offset, nullptr, local_dataset_size, nullptr);
 
                 // Write index data to the HDF5 file
                 H5Dwrite(particle_property_dataset, H5T_NATIVE_DOUBLE, local_property_dataspace, property_dataspace, write_properties, &property_data[output_index][0]);

--- a/source/particle/output/interface.cc
+++ b/source/particle/output/interface.cc
@@ -105,7 +105,7 @@ namespace aspect
           return std::get<dim>(registered_plugins).create_plugin (name,
                                                                   "Particle::Output name");
         else
-          return NULL;
+          return nullptr;
       }
 
 

--- a/source/particle/particle.cc
+++ b/source/particle/particle.cc
@@ -30,7 +30,7 @@ namespace aspect
       location (),
       reference_location(),
       id (0),
-      property_pool(NULL),
+      property_pool(nullptr),
       properties(PropertyPool::invalid_handle)
     {
     }
@@ -44,7 +44,7 @@ namespace aspect
       location (location),
       reference_location (reference_location),
       id (id),
-      property_pool(NULL),
+      property_pool(nullptr),
       properties (PropertyPool::invalid_handle)
     {
     }
@@ -268,7 +268,7 @@ namespace aspect
     const ArrayView<const double>
     Particle<dim,spacedim>::get_properties () const
     {
-      Assert(property_pool != NULL,
+      Assert(property_pool != nullptr,
              ExcInternalError());
 
       return property_pool->get_properties(properties);
@@ -279,7 +279,7 @@ namespace aspect
     const ArrayView<double>
     Particle<dim,spacedim>::get_properties ()
     {
-      Assert(property_pool != NULL,
+      Assert(property_pool != nullptr,
              ExcInternalError());
 
       return property_pool->get_properties(properties);
@@ -289,7 +289,7 @@ namespace aspect
     bool
     Particle<dim,spacedim>::has_properties () const
     {
-      return (property_pool != NULL)
+      return (property_pool != nullptr)
              && (properties != PropertyPool::invalid_handle);
     }
   }

--- a/source/particle/particle_accessor.cc
+++ b/source/particle/particle_accessor.cc
@@ -27,7 +27,7 @@ namespace aspect
     template <int dim, int spacedim>
     ParticleAccessor<dim,spacedim>::ParticleAccessor ()
       :
-      map (NULL),
+      map (nullptr),
       particle ()
     {}
 

--- a/source/particle/property_pool.cc
+++ b/source/particle/property_pool.cc
@@ -25,7 +25,7 @@ namespace aspect
 {
   namespace Particle
   {
-    const PropertyPool::Handle PropertyPool::invalid_handle = NULL;
+    const PropertyPool::Handle PropertyPool::invalid_handle = nullptr;
 
 
     PropertyPool::PropertyPool (const unsigned int n_properties_per_slot)

--- a/source/postprocess/visualization/melt.cc
+++ b/source/postprocess/visualization/melt.cc
@@ -116,7 +116,7 @@ namespace aspect
 
         this->get_material_model().evaluate(in, out);
         MaterialModel::MeltOutputs<dim> *melt_outputs = out.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
-        AssertThrow(melt_outputs != NULL,
+        AssertThrow(melt_outputs != nullptr,
                     ExcMessage("Need MeltOutputs from the material model for computing the melt properties."));
 
         const double p_c_scale = dynamic_cast<const MaterialModel::MeltInterface<dim>*>(&this->get_material_model())->p_c_scale(in,

--- a/source/prescribed_stokes_solution/interface.cc
+++ b/source/prescribed_stokes_solution/interface.cc
@@ -98,7 +98,7 @@ namespace aspect
       prm.leave_subsection ();
 
       if (model_name == "unspecified")
-        return NULL;
+        return nullptr;
 
       Interface<dim> *plugin = std::get<dim>(registered_plugins).create_plugin (model_name,
                                                                                 "Prescribed Stokes solution::Model name");

--- a/source/simulator/assemblers/interface.cc
+++ b/source/simulator/assemblers/interface.cc
@@ -202,21 +202,21 @@ namespace aspect
                                                              finite_element, face_quadrature,
                                                              face_update_flags)
                                       :
-                                      NULL),
+                                      nullptr),
           neighbor_face_finite_element_values (face_quadrature.size() > 0
                                                ?
                                                new FEFaceValues<dim> (mapping,
                                                                       finite_element, face_quadrature,
                                                                       face_update_flags)
                                                :
-                                               NULL),
+                                               nullptr),
           subface_finite_element_values (face_quadrature.size() > 0
                                          ?
                                          new FESubfaceValues<dim> (mapping,
                                                                    finite_element, face_quadrature,
                                                                    face_update_flags)
                                          :
-                                         NULL),
+                                         nullptr),
           local_dof_indices (finite_element.dofs_per_cell),
 
           phi_field (advection_element.dofs_per_cell, numbers::signaling_nan<double>()),
@@ -290,7 +290,7 @@ namespace aspect
                                                              scratch.face_finite_element_values->get_quadrature(),
                                                              scratch.face_finite_element_values->get_update_flags())
                                       :
-                                      NULL),
+                                      nullptr),
           neighbor_face_finite_element_values (scratch.neighbor_face_finite_element_values.get()
                                                ?
                                                new FEFaceValues<dim> (scratch.neighbor_face_finite_element_values->get_mapping(),
@@ -298,7 +298,7 @@ namespace aspect
                                                                       scratch.neighbor_face_finite_element_values->get_quadrature(),
                                                                       scratch.neighbor_face_finite_element_values->get_update_flags())
                                                :
-                                               NULL),
+                                               nullptr),
           subface_finite_element_values (scratch.subface_finite_element_values.get()
                                          ?
                                          new FESubfaceValues<dim> (scratch.subface_finite_element_values->get_mapping(),
@@ -306,7 +306,7 @@ namespace aspect
                                                                    scratch.subface_finite_element_values->get_quadrature(),
                                                                    scratch.subface_finite_element_values->get_update_flags())
                                          :
-                                         NULL),
+                                         nullptr),
           local_dof_indices (scratch.finite_element_values.get_fe().dofs_per_cell),
 
           phi_field (scratch.phi_field),

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -132,7 +132,7 @@ namespace aspect
             {
               const MaterialModel::MaterialModelDerivatives<dim> *derivatives
                 = scratch.material_model_outputs.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim> >();
-              AssertThrow(derivatives != NULL,
+              AssertThrow(derivatives != nullptr,
                           ExcMessage ("Error: The newton method requires derivatives from the material model."));
 
               const SymmetricTensor<2,dim> viscosity_derivative_wrt_strain_rate = derivatives->viscosity_derivative_wrt_strain_rate[q];
@@ -343,7 +343,7 @@ namespace aspect
                   // This one is only available in debug mode, because normally
                   // the AssertTrow in the preconditioner should already have
                   // caught the problem.
-                  Assert(derivatives != NULL,
+                  Assert(derivatives != nullptr,
                          ExcMessage ("Error: The Newton method requires the material to "
                                      "compute derivatives."));
 
@@ -497,7 +497,7 @@ namespace aspect
               // This one is only avaiable in debug mode, because normally
               // the AssertTrow in the preconditioner should already have
               // caught the problem.
-              Assert(derivatives != NULL, ExcMessage ("Error: The newton method requires the derivatives"));
+              Assert(derivatives != nullptr, ExcMessage ("Error: The newton method requires the derivatives"));
 
               const SymmetricTensor<2,dim> viscosity_derivative_wrt_strain_rate = derivatives->viscosity_derivative_wrt_strain_rate[q];
               const double viscosity_derivative_wrt_pressure = derivatives->viscosity_derivative_wrt_pressure[q];

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -233,12 +233,12 @@ namespace aspect
               data.local_rhs(i) += (density * gravity * scratch.phi_u[i])
                                    * JxW;
 
-              if (force != NULL && this->get_parameters().enable_additional_stokes_rhs)
+              if (force != nullptr && this->get_parameters().enable_additional_stokes_rhs)
                 data.local_rhs(i) += (force->rhs_u[q] * scratch.phi_u[i]
                                       + pressure_scaling * force->rhs_p[q] * scratch.phi_p[i])
                                      * JxW;
 
-              if (elastic_outputs != NULL && this->get_parameters().enable_elasticity)
+              if (elastic_outputs != nullptr && this->get_parameters().enable_elasticity)
                 data.local_rhs(i) += (scalar_product(elastic_outputs->elastic_force[q],Tensor<2,dim>(scratch.grads_phi_u[i])))
                                      * JxW;
 
@@ -270,7 +270,7 @@ namespace aspect
       const unsigned int n_points = outputs.viscosities.size();
 
       if (this->get_parameters().enable_additional_stokes_rhs
-          && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >() == NULL)
+          && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::shared_ptr<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >
@@ -283,7 +283,7 @@ namespace aspect
              == n_points, ExcInternalError());
 
       if ((this->get_parameters().enable_elasticity) &&
-          outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim> >() == NULL)
+          outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim> >() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::shared_ptr<MaterialModel::ElasticOutputs<dim> >

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -893,7 +893,7 @@ namespace aspect
         MaterialModel::ReactionRateOutputs<dim> *reaction_rate_outputs
           = scratch.material_model_outputs.template get_additional_output<MaterialModel::ReactionRateOutputs<dim> >();
 
-        Assert(reaction_rate_outputs == NULL,
+        Assert(reaction_rate_outputs == nullptr,
                ExcMessage("You are using a material model where the reaction rate outputs "
                           "are created even though the operator splitting solver option is "
                           "not used in the model, this is not supported! "

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -138,8 +138,8 @@ namespace aspect
     :
     assemblers (new Assemblers::Manager<dim>()),
     parameters (prm, mpi_communicator_),
-    melt_handler (parameters.include_melt_transport ? new MeltHandler<dim> (prm) : NULL),
-    newton_handler (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes ? new NewtonHandler<dim> () : NULL),
+    melt_handler (parameters.include_melt_transport ? new MeltHandler<dim> (prm) : nullptr),
+    newton_handler (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes ? new NewtonHandler<dim> () : nullptr),
     post_signal_creation(
       std::bind (&internals::SimulatorSignals::call_connector_functions<dim>,
                  std::ref(signals))),
@@ -170,7 +170,7 @@ namespace aspect
     prescribed_stokes_solution (PrescribedStokesSolution::create_prescribed_stokes_solution<dim>(prm)),
     adiabatic_conditions (AdiabaticConditions::create_adiabatic_conditions<dim>(prm)),
 #ifdef ASPECT_USE_WORLD_BUILDER
-    world_builder (parameters.world_builder_file != "" ? new WorldBuilder::World (parameters.world_builder_file) : NULL),
+    world_builder (parameters.world_builder_file != "" ? new WorldBuilder::World (parameters.world_builder_file) : nullptr),
 #endif
     boundary_heat_flux (BoundaryHeatFlux::create_boundary_heat_flux<dim>(prm)),
 
@@ -228,7 +228,7 @@ namespace aspect
     // the SimulatorAccess class via multiple inheritance, we need to
     // do a sideways dynamic_cast to this putative sibling of the
     // interface class, and investigate if the dynamic_cast
-    // succeeds. if it succeeds, the dynamic_cast returns a non-NULL
+    // succeeds. if it succeeds, the dynamic_cast returns a non-nullptr
     // result, and we can test this in an if-statement. there is a nice
     // idiom whereby we can write
     //    if (SiblingClass *ptr = dynamic_cast<SiblingClass*>(ptr_to_base))
@@ -292,13 +292,13 @@ namespace aspect
     // Make sure we only have a prescribed Stokes plugin if needed
     if (parameters.nonlinear_solver == NonlinearSolver::single_Advection_no_Stokes)
       {
-        AssertThrow(prescribed_stokes_solution.get()!=NULL,
+        AssertThrow(prescribed_stokes_solution.get()!=nullptr,
                     ExcMessage("For the 'single Advection, no Stokes' solver scheme you need to provide a Stokes plugin!")
                    );
       }
     else
       {
-        AssertThrow(prescribed_stokes_solution.get()==NULL,
+        AssertThrow(prescribed_stokes_solution.get()==nullptr,
                     ExcMessage("The prescribed stokes plugin you selected only works with the solver "
                                "scheme 'single Advection, no Stokes'.")
                    );
@@ -1619,7 +1619,7 @@ namespace aspect
       }
 
     // start the timer for periodic checkpoints after the setup above
-    time_t last_checkpoint_time = std::time(NULL);
+    time_t last_checkpoint_time = std::time(nullptr);
 
   start_time_iteration:
 
@@ -1703,7 +1703,7 @@ namespace aspect
 
         const bool checkpoint_written = maybe_write_checkpoint(last_checkpoint_time,termination);
         if (checkpoint_written)
-          last_checkpoint_time = std::time(NULL);
+          last_checkpoint_time = std::time(nullptr);
 
         // see if we want to terminate
         if (termination.first)

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -451,7 +451,7 @@ namespace aspect
     // This prevents race conditions where some processes will checkpoint and others won't
     if (parameters.checkpoint_time_secs > 0)
       {
-        int global_do_checkpoint = ((std::time(NULL)-last_checkpoint_time) >=
+        int global_do_checkpoint = ((std::time(nullptr)-last_checkpoint_time) >=
                                     parameters.checkpoint_time_secs);
         MPI_Bcast(&global_do_checkpoint, 1, MPI_INT, 0, mpi_communicator);
 
@@ -1562,7 +1562,7 @@ namespace aspect
     MaterialModel::ReactionRateOutputs<dim> *reaction_rate_outputs_T
       = out_T.template get_additional_output<MaterialModel::ReactionRateOutputs<dim> >();
 
-    AssertThrow(reaction_rate_outputs_C != NULL && reaction_rate_outputs_T != NULL,
+    AssertThrow(reaction_rate_outputs_C != nullptr && reaction_rate_outputs_T != nullptr,
                 ExcMessage("You are trying to use the operator splitting solver scheme, "
                            "but the material model you use does not support operator splitting "
                            "(it does not create ReactionRateOutputs, which are required for this "

--- a/source/simulator/lateral_averaging.cc
+++ b/source/simulator/lateral_averaging.cc
@@ -191,7 +191,7 @@ namespace aspect
           const MaterialModel::SeismicAdditionalOutputs<dim> *seismic_outputs
             = out.template get_additional_output<const MaterialModel::SeismicAdditionalOutputs<dim> >();
 
-          Assert(seismic_outputs != NULL,ExcInternalError());
+          Assert(seismic_outputs != nullptr,ExcInternalError());
 
           if (vs_)
             for (unsigned int q=0; q<output.size(); ++q)

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -165,7 +165,7 @@ namespace aspect
       const unsigned int n_points = outputs.viscosities.size();
 
       if (this->get_parameters().enable_additional_stokes_rhs
-          && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >() == NULL)
+          && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::shared_ptr<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >
@@ -202,7 +202,7 @@ namespace aspect
       MaterialModel::MeltOutputs<dim> *melt_outputs = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
 
       Assert(dynamic_cast<const MaterialModel::MeltInterface<dim>*>(&this->get_material_model()) !=
-             NULL, ExcMessage("Error: The current material model needs to be derived from MeltInterface to use melt transport."));
+             nullptr, ExcMessage("Error: The current material model needs to be derived from MeltInterface to use melt transport."));
 
       const FEValuesExtractors::Scalar ex_p_f = introspection.variable("fluid pressure").extractor_scalar();
       const FEValuesExtractors::Scalar ex_p_c = introspection.variable("compaction pressure").extractor_scalar();
@@ -320,7 +320,7 @@ namespace aspect
         const Introspection<dim> &introspection = simulator_access->introspection();
         const MaterialModel::MeltOutputs<dim> *melt_out = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
 
-        Assert(melt_out != NULL, ExcInternalError());
+        Assert(melt_out != nullptr, ExcInternalError());
 
         const unsigned int porosity_index = introspection.compositional_index_for_name("porosity");
         const unsigned int is_compressible = simulator_access->get_material_model().is_compressible();
@@ -384,7 +384,7 @@ namespace aspect
       const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
 
       Assert(dynamic_cast<const MaterialModel::MeltInterface<dim>*>(&this->get_material_model()) !=
-             NULL, ExcMessage("Error: The current material model needs to be derived from MeltInterface to use melt transport."));
+             nullptr, ExcMessage("Error: The current material model needs to be derived from MeltInterface to use melt transport."));
 
       const double p_c_scale = dynamic_cast<const MaterialModel::MeltInterface<dim>*>(&this->get_material_model())->p_c_scale(scratch.material_model_inputs,
                                scratch.material_model_outputs,
@@ -490,7 +490,7 @@ namespace aspect
                                      (bulk_density * gravity * scratch.phi_u[i])
                                      +
                                      // add a force to the RHS if present
-                                     (force!=NULL ?
+                                     (force!=nullptr ?
                                       (force->rhs_u[q] * scratch.phi_u[i]
                                        + pressure_scaling * force->rhs_p[q] * scratch.phi_p[i]
                                        + pressure_scaling * force->rhs_melt_pc[q] * p_c_scale * scratch.phi_p_c[i])
@@ -1198,7 +1198,7 @@ namespace aspect
             const bool is_melt_cell = this->get_melt_handler().is_melt_cell(in.current_cell);
 
             MaterialModel::MeltOutputs<dim> *melt_outputs = out.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
-            Assert(melt_outputs != NULL, ExcMessage("Need MeltOutputs from the material model for computing the melt variables."));
+            Assert(melt_outputs != nullptr, ExcMessage("Need MeltOutputs from the material model for computing the melt variables."));
             const FEValuesExtractors::Vector fluid_velocity_extractor = this->introspection().variable("fluid velocity").extractor_vector();
 
             std::vector<Tensor<1,dim> > phi_u_f(fluid_velocity_dofs_per_cell);
@@ -1535,7 +1535,7 @@ namespace aspect
       MaterialModel::MaterialModelOutputs<dim> material_model_outputs(quadrature_formula.size(), n_compositional_fields);
 
       MeltHandler<dim>::create_material_model_outputs(material_model_outputs);
-      Assert(dynamic_cast<const MaterialModel::MeltInterface<dim>*>(&this->get_material_model()) != NULL,
+      Assert(dynamic_cast<const MaterialModel::MeltInterface<dim>*>(&this->get_material_model()) != nullptr,
              ExcMessage("Your material model does not derive from MaterialModel::MeltInterface, which is required."));
 
       for (auto cell = this->get_dof_handler().begin_active();
@@ -1860,7 +1860,7 @@ namespace aspect
   MeltHandler<dim>::
   create_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &output)
   {
-    if (output.template get_additional_output<MaterialModel::MeltOutputs<dim> >() != NULL)
+    if (output.template get_additional_output<MaterialModel::MeltOutputs<dim> >() != nullptr)
       return;
 
     const unsigned int n_points = output.viscosities.size();

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -135,7 +135,7 @@ namespace aspect
   NewtonHandler<dim>::
   create_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &output)
   {
-    if (output.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim> >() != NULL)
+    if (output.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim> >() != nullptr)
       return;
 
     const unsigned int n_points = output.viscosities.size();

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -27,7 +27,7 @@ namespace aspect
   template <int dim>
   SimulatorAccess<dim>::SimulatorAccess ()
     :
-    simulator (NULL)
+    simulator (nullptr)
   {}
 
 
@@ -693,7 +693,7 @@ namespace aspect
   bool
   SimulatorAccess<dim>::simulator_is_initialized () const
   {
-    return (simulator != NULL);
+    return (simulator != nullptr);
   }
 
   template <int dim>

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -142,7 +142,7 @@ namespace aspect
 
     if (compute_initial_residual)
       {
-        Assert(initial_residual != NULL, ExcInternalError());
+        Assert(initial_residual != nullptr, ExcInternalError());
         *initial_residual = system_rhs.block(introspection.block_indices.temperature).l2_norm();
       }
 
@@ -150,7 +150,7 @@ namespace aspect
     current_linearization_point.block(introspection.block_indices.temperature)
       = solution.block(introspection.block_indices.temperature);
 
-    if ((initial_residual != NULL) && (*initial_residual > 0))
+    if ((initial_residual != nullptr) && (*initial_residual > 0))
       return current_residual / *initial_residual;
 
     return 0.0;
@@ -166,7 +166,7 @@ namespace aspect
 
     if (compute_initial_residual)
       {
-        Assert(initial_residual != NULL, ExcInternalError());
+        Assert(initial_residual != nullptr, ExcInternalError());
         Assert(initial_residual->size() == introspection.n_compositional_fields, ExcInternalError());
       }
 
@@ -221,7 +221,7 @@ namespace aspect
         current_linearization_point.block(introspection.block_indices.compositional_fields[c])
           = solution.block(introspection.block_indices.compositional_fields[c]);
 
-        if ((initial_residual != NULL) && (*initial_residual)[c] > 0)
+        if ((initial_residual != nullptr) && (*initial_residual)[c] > 0)
           current_residual[c] /= (*initial_residual)[c];
         else
           current_residual[c] = 0.0;
@@ -260,7 +260,7 @@ namespace aspect
 
     if (compute_initial_residual)
       {
-        Assert(initial_nonlinear_residual != NULL, ExcInternalError());
+        Assert(initial_nonlinear_residual != nullptr, ExcInternalError());
         *initial_nonlinear_residual = compute_initial_stokes_residual();
       }
 
@@ -283,7 +283,7 @@ namespace aspect
         current_linearization_point.block(fluid_pressure_block) = solution.block(fluid_pressure_block);
       }
 
-    if ((initial_nonlinear_residual != NULL) && (*initial_nonlinear_residual > 0))
+    if ((initial_nonlinear_residual != nullptr) && (*initial_nonlinear_residual > 0))
       return current_nonlinear_residual / *initial_nonlinear_residual;
     else
       return 0.0;

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -936,7 +936,7 @@ namespace aspect
       if ((Utilities::MPI::this_mpi_process(comm) == 0))
         {
           DIR *output_directory = opendir(pathname.c_str());
-          if (output_directory == NULL)
+          if (output_directory == nullptr)
             {
               if (!silent)
                 std::cout << "\n"

--- a/tests/additional_outputs_02.cc
+++ b/tests/additional_outputs_02.cc
@@ -75,7 +75,7 @@ namespace aspect
       {
         std::cout << "* create_additional_material_model_outputs() called" << std::endl;
 
-        if (out.template get_additional_output<MaterialModel::AdditionalOutputs1<dim> >() != NULL)
+        if (out.template get_additional_output<MaterialModel::AdditionalOutputs1<dim> >() != nullptr)
           return;
 
         std::cout << "   creating additional output!" << std::endl;
@@ -91,8 +91,8 @@ namespace aspect
         MaterialModel::AdditionalOutputs1<dim> *additional
           = scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalOutputs1<dim> >();
 
-        std::cout << "* local_assemble_stokes call, have additional? " << (additional!=NULL) << std::endl;
-        if (additional!=NULL)
+        std::cout << "* local_assemble_stokes call, have additional? " << (additional!=nullptr) << std::endl;
+        if (additional!=nullptr)
           std::cout << "   value = " << additional->additional_material_output1[0] << std::endl;
 
 

--- a/tests/additional_outputs_03.cc
+++ b/tests/additional_outputs_03.cc
@@ -89,7 +89,7 @@ namespace aspect
       {
         std::cout << "* create_additional_material_model_outputs() called" << std::endl;
 
-        if (out.template get_additional_output<MaterialModel::AdditionalOutputs1<dim> >() != NULL)
+        if (out.template get_additional_output<MaterialModel::AdditionalOutputs1<dim> >() != nullptr)
           return;
 
         std::cout << "   creating additional output!" << std::endl;
@@ -105,8 +105,8 @@ namespace aspect
         MaterialModel::AdditionalOutputs1<dim> *additional
           = scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalOutputs1<dim> >();
 
-        std::cout << "* local_assemble_stokes call, have additional? " << (additional!=NULL) << std::endl;
-        if (additional!=NULL)
+        std::cout << "* local_assemble_stokes call, have additional? " << (additional!=nullptr) << std::endl;
+        if (additional!=nullptr)
           std::cout << "   value = " << additional->additional_material_output1[0]
                     << " " << additional->additional_material_output1[1] << std::endl;
 

--- a/tests/anisotropic_viscosity.cc
+++ b/tests/anisotropic_viscosity.cc
@@ -180,7 +180,7 @@ namespace aspect
           const double eta = scratch.material_model_outputs.viscosities[q];
           const double one_over_eta = 1. / eta;
 
-          const bool use_tensor = (anisotropic_viscosity != NULL);
+          const bool use_tensor = (anisotropic_viscosity != nullptr);
 
           const SymmetricTensor<4, dim> &stress_strain_director = (use_tensor)
                                                                   ?
@@ -220,7 +220,7 @@ namespace aspect
     {
       const unsigned int n_points = outputs.viscosities.size();
 
-      if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >() == NULL)
+      if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::shared_ptr<MaterialModel::AnisotropicViscosity<dim> >
@@ -277,7 +277,7 @@ namespace aspect
 
           const double eta_two_thirds = scratch.material_model_outputs.viscosities[q] * 2.0 / 3.0;
 
-          const bool use_tensor = (anisotropic_viscosity != NULL);
+          const bool use_tensor = (anisotropic_viscosity != nullptr);
 
           const SymmetricTensor<4, dim> &stress_strain_director = (use_tensor)
                                                                   ?
@@ -349,7 +349,7 @@ namespace aspect
                               :
                               numbers::signaling_nan<double>());
 
-          const bool use_tensor = (anisotropic_viscosity != NULL);
+          const bool use_tensor = (anisotropic_viscosity != nullptr);
 
           const SymmetricTensor<4, dim> &stress_strain_director = (use_tensor)
                                                                   ?
@@ -368,7 +368,7 @@ namespace aspect
               data.local_rhs(i) += (density * gravity * scratch.phi_u[i])
                                    * JxW;
 
-              if (force != NULL)
+              if (force != nullptr)
                 data.local_rhs(i) += (force->rhs_u[q] * scratch.phi_u[i]
                                       + pressure_scaling * force->rhs_p[q] * scratch.phi_p[i])
                                      * JxW;
@@ -403,7 +403,7 @@ namespace aspect
     {
       const unsigned int n_points = outputs.viscosities.size();
 
-      if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >() == NULL)
+      if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::shared_ptr<MaterialModel::AnisotropicViscosity<dim> >
@@ -411,7 +411,7 @@ namespace aspect
         }
 
       if (this->get_parameters().enable_additional_stokes_rhs
-          && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >() == NULL)
+          && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::shared_ptr<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >
@@ -462,7 +462,7 @@ namespace aspect
           // Viscosity scalar
           const double eta_two_thirds = scratch.material_model_outputs.viscosities[q] * 2.0 / 3.0;
 
-          const bool use_tensor = (anisotropic_viscosity != NULL);
+          const bool use_tensor = (anisotropic_viscosity != nullptr);
 
           const SymmetricTensor<4, dim> &stress_strain_director = (use_tensor)
                                                                   ?
@@ -534,7 +534,7 @@ namespace aspect
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
         {
           // If there is an anisotropic viscosity, use it to compute the correct stress
-          const SymmetricTensor<2,dim> &directed_strain_rate = ((anisotropic_viscosity != NULL)
+          const SymmetricTensor<2,dim> &directed_strain_rate = ((anisotropic_viscosity != nullptr)
                                                                 ?
                                                                 anisotropic_viscosity->stress_strain_directors[q]
                                                                 * material_model_inputs.strain_rate[q]
@@ -578,7 +578,7 @@ namespace aspect
     {
       const unsigned int n_points = material_model_outputs.viscosities.size();
 
-      if (material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >() == NULL)
+      if (material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >() == nullptr)
         {
           material_model_outputs.additional_outputs.push_back(
             std::shared_ptr<MaterialModel::AnisotropicViscosity<dim> >
@@ -633,17 +633,17 @@ namespace aspect
     {
       for (unsigned int i=0; i<assemblers.stokes_preconditioner.size(); ++i)
         {
-          if (dynamic_cast<Assemblers::StokesPreconditioner<dim> *>(assemblers.stokes_preconditioner[i].get()) != NULL)
+          if (dynamic_cast<Assemblers::StokesPreconditioner<dim> *>(assemblers.stokes_preconditioner[i].get()) != nullptr)
             assemblers.stokes_preconditioner[i] = std_cxx14::make_unique<Assemblers::StokesPreconditionerAnisotropicViscosity<dim> > ();
-          if (dynamic_cast<Assemblers::StokesCompressiblePreconditioner<dim> *>(assemblers.stokes_preconditioner[i].get()) != NULL)
+          if (dynamic_cast<Assemblers::StokesCompressiblePreconditioner<dim> *>(assemblers.stokes_preconditioner[i].get()) != nullptr)
             assemblers.stokes_preconditioner[i] = std_cxx14::make_unique<Assemblers::StokesCompressiblePreconditionerAnisotropicViscosity<dim> > ();
         }
 
       for (unsigned int i=0; i<assemblers.stokes_system.size(); ++i)
         {
-          if (dynamic_cast<Assemblers::StokesIncompressibleTerms<dim> *>(assemblers.stokes_system[i].get()) != NULL)
+          if (dynamic_cast<Assemblers::StokesIncompressibleTerms<dim> *>(assemblers.stokes_system[i].get()) != nullptr)
             assemblers.stokes_system[i] = std_cxx14::make_unique<Assemblers::StokesIncompressibleTermsAnisotropicViscosity<dim> > ();
-          if (dynamic_cast<Assemblers::StokesCompressibleStrainRateViscosityTerm<dim> *>(assemblers.stokes_system[i].get()) != NULL)
+          if (dynamic_cast<Assemblers::StokesCompressibleStrainRateViscosityTerm<dim> *>(assemblers.stokes_system[i].get()) != nullptr)
             assemblers.stokes_system[i] = std_cxx14::make_unique<Assemblers::StokesCompressibleStrainRateViscosityTermAnisotropicViscosity<dim> > ();
         }
     }
@@ -681,7 +681,7 @@ namespace aspect
           out.compressibilities[i] = 1.0 / (1. + pressure);
           if ((in.position[i]-center).norm() < 0.25)
             {
-              if (anisotropic_viscosity != NULL)
+              if (anisotropic_viscosity != nullptr)
                 anisotropic_viscosity->stress_strain_directors[i] = C;
             }
         }

--- a/tests/composition_active_with_melt.cc
+++ b/tests/composition_active_with_melt.cc
@@ -70,7 +70,7 @@ namespace aspect
         // fill melt outputs if they exist
         aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
-        if (melt_out != NULL)
+        if (melt_out != nullptr)
           {
 
             for (unsigned int i=0; i<in.position.size(); ++i)

--- a/tests/drucker_prager_derivatives.cc
+++ b/tests/drucker_prager_derivatives.cc
@@ -112,7 +112,7 @@ int f()
   MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
   MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
 
-  if (out_base.template get_additional_output<MaterialModelDerivatives<dim> >() != NULL)
+  if (out_base.template get_additional_output<MaterialModelDerivatives<dim> >() != nullptr)
     throw "error";
 
   out_base.additional_outputs.push_back(std::make_shared<MaterialModelDerivatives<dim> > (5));

--- a/tests/free_surface_blob_melt.cc
+++ b/tests/free_surface_blob_melt.cc
@@ -124,7 +124,7 @@ namespace aspect
       // fill melt outputs if they exist
       MeltOutputs<dim> *melt_out = out.template get_additional_output<MeltOutputs<dim> >();
 
-      if (melt_out != NULL)
+      if (melt_out != nullptr)
         {
           const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 

--- a/tests/heat_advection_by_melt.cc
+++ b/tests/heat_advection_by_melt.cc
@@ -23,7 +23,7 @@ namespace aspect
       ) const
       {
         const MaterialModel::MeltOutputs<dim> *melt_outputs = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
-        Assert(melt_outputs != NULL, ExcMessage("Need MeltOutputs from the material model for shear heating with melt."));
+        Assert(melt_outputs != nullptr, ExcMessage("Need MeltOutputs from the material model for shear heating with melt."));
 
         for (unsigned int q=0; q<fluid_pressure_gradient_outputs.size(); ++q)
           {
@@ -67,7 +67,7 @@ namespace aspect
           out.densities[i] = 2.0;
         }
 
-      if (melt_out != NULL)
+      if (melt_out != nullptr)
         {
           for (unsigned int i=0; i < in.position.size(); ++i)
             {

--- a/tests/melt_compressible_advection.cc
+++ b/tests/melt_compressible_advection.cc
@@ -60,7 +60,7 @@ namespace aspect
         // fill melt outputs if they exist
         aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
-        if (melt_out != NULL)
+        if (melt_out != nullptr)
           {
             for (unsigned int i=0; i<in.position.size(); ++i)
               {

--- a/tests/melt_force_vector.cc
+++ b/tests/melt_force_vector.cc
@@ -112,7 +112,7 @@ namespace aspect
         // fill melt outputs if they exist
         aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
-        if (melt_out != NULL)
+        if (melt_out != nullptr)
           for (unsigned int i=0; i<in.position.size(); ++i)
             {
               double porosity = in.composition[i][porosity_idx];

--- a/tests/melt_introspection.cc
+++ b/tests/melt_introspection.cc
@@ -79,7 +79,7 @@ namespace aspect
         // fill melt outputs if they exist
         aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
-        if (melt_out != NULL)
+        if (melt_out != nullptr)
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
             for (unsigned int i=0; i<in.position.size(); ++i)

--- a/tests/melt_material_1.cc
+++ b/tests/melt_material_1.cc
@@ -54,7 +54,7 @@ namespace aspect
         // fill melt outputs if they exist
         aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
-        if (melt_out != NULL)
+        if (melt_out != nullptr)
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
             for (unsigned int i=0; i<in.position.size(); ++i)

--- a/tests/melt_material_2.cc
+++ b/tests/melt_material_2.cc
@@ -54,7 +54,7 @@ namespace aspect
         // fill melt outputs if they exist
         aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
-        if (melt_out != NULL)
+        if (melt_out != nullptr)
           {
             for (unsigned int i=0; i<in.position.size(); ++i)
               {

--- a/tests/melt_material_3.cc
+++ b/tests/melt_material_3.cc
@@ -54,7 +54,7 @@ namespace aspect
         // fill melt outputs if they exist
         aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
-        if (melt_out != NULL)
+        if (melt_out != nullptr)
           {
             for (unsigned int i=0; i<in.position.size(); ++i)
               {

--- a/tests/melt_material_4.cc
+++ b/tests/melt_material_4.cc
@@ -59,7 +59,7 @@ namespace aspect
         // fill melt outputs if they exist
         aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
-        if (melt_out != NULL)
+        if (melt_out != nullptr)
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 

--- a/tests/melt_transport_adaptive.cc
+++ b/tests/melt_transport_adaptive.cc
@@ -114,7 +114,7 @@ namespace aspect
               this->get_material_model().evaluate(in, out);
 
               MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
-              AssertThrow(melt_out != NULL,
+              AssertThrow(melt_out != nullptr,
                           ExcMessage("Need MeltOutputs from the material model for computing the melt properties."));
 
               const double p_c_scale = dynamic_cast<const MaterialModel::MeltInterface<dim>*>(&this->get_material_model())->p_c_scale(in, out, this->get_melt_handler(), true);
@@ -220,7 +220,7 @@ namespace aspect
         // fill melt outputs if they exist
         aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
-        if (melt_out != NULL)
+        if (melt_out != nullptr)
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 

--- a/tests/melt_transport_compressible.cc
+++ b/tests/melt_transport_compressible.cc
@@ -59,7 +59,7 @@ namespace aspect
         // fill melt outputs if they exist
         aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
-        if (melt_out != NULL)
+        if (melt_out != nullptr)
           {
             for (unsigned int i=0; i<in.position.size(); ++i)
               {

--- a/tests/melt_transport_convergence_simple.cc
+++ b/tests/melt_transport_convergence_simple.cc
@@ -66,7 +66,7 @@ namespace aspect
         // fill melt outputs if they exist
         aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
-        if (melt_out != NULL)
+        if (melt_out != nullptr)
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 

--- a/tests/melt_transport_convergence_test.cc
+++ b/tests/melt_transport_convergence_test.cc
@@ -66,7 +66,7 @@ namespace aspect
         // fill melt outputs if they exist
         aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
-        if (melt_out != NULL)
+        if (melt_out != nullptr)
           {
             double c = 1.0;
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");

--- a/tests/melting_rate.cc
+++ b/tests/melting_rate.cc
@@ -78,7 +78,7 @@ namespace aspect
         // fill melt outputs if they exist
         aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
-        if (melt_out != NULL)
+        if (melt_out != nullptr)
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
             for (unsigned int i=0; i<in.position.size(); ++i)

--- a/tests/prescribed_velocity_boundary.cc
+++ b/tests/prescribed_velocity_boundary.cc
@@ -340,7 +340,7 @@ namespace aspect
     InclusionPostprocessor<dim>::execute (TableHandler &statistics)
     {
       std::shared_ptr<Function<dim> > ref_func;
-      if (dynamic_cast<const InclusionMaterial<dim> *>(&this->get_material_model()) != NULL)
+      if (dynamic_cast<const InclusionMaterial<dim> *>(&this->get_material_model()) != nullptr)
         {
           const InclusionMaterial<dim> *
           material_model

--- a/tests/rising_melt_blob.cc
+++ b/tests/rising_melt_blob.cc
@@ -55,7 +55,7 @@ namespace aspect
         // fill melt outputs if they exist
         aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
-        if (melt_out != NULL)
+        if (melt_out != nullptr)
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
             for (unsigned int i=0; i<in.position.size(); ++i)

--- a/tests/segregation_heating.cc
+++ b/tests/segregation_heating.cc
@@ -22,7 +22,7 @@ namespace aspect
       ) const
       {
         const MaterialModel::MeltOutputs<dim> *melt_outputs = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim> >();
-        Assert(melt_outputs != NULL, ExcMessage("Need MeltOutputs from the material model for shear heating with melt."));
+        Assert(melt_outputs != nullptr, ExcMessage("Need MeltOutputs from the material model for shear heating with melt."));
 
         for (unsigned int q=0; q<fluid_pressure_gradient_outputs.size(); ++q)
           {

--- a/tests/simple_nonlinear.cc
+++ b/tests/simple_nonlinear.cc
@@ -115,7 +115,7 @@ int f(double parameter)
   MaterialModelOutputs<dim> out_base(5,3);
   MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
 
-  if (out_base.template get_additional_output<MaterialModelDerivatives<dim> >() != NULL)
+  if (out_base.template get_additional_output<MaterialModelDerivatives<dim> >() != nullptr)
     throw "error";
 
   out_base.additional_outputs.push_back(std::make_shared<MaterialModelDerivatives<dim> > (5));

--- a/tests/spiegelman_fail_test.cc
+++ b/tests/spiegelman_fail_test.cc
@@ -311,7 +311,7 @@ namespace aspect
 
                   Assert(dealii::numbers::is_finite(composition_viscosities[c]),ExcMessage ("Error: Viscosity is not finite."));
 
-                  if (derivatives != NULL)
+                  if (derivatives != nullptr)
                     {
                       if (use_analytical_derivative)
                         {
@@ -400,7 +400,7 @@ namespace aspect
               out.viscosities[i] = Utilities::weighted_p_norm_average(volume_fractions, composition_viscosities, viscosity_averaging_p);
               Assert(dealii::numbers::is_finite(out.viscosities[i]),ExcMessage ("Error: Averaged viscosity is not finite."));
 
-              if (derivatives != NULL)
+              if (derivatives != nullptr)
                 {
                   derivatives->viscosity_derivative_wrt_strain_rate[i] = Utilities::derivative_of_weighted_p_norm_average(out.viscosities[i],volume_fractions, composition_viscosities, composition_viscosities_derivatives, viscosity_averaging_p);
                   derivatives->viscosity_derivative_wrt_pressure[i] = Utilities::derivative_of_weighted_p_norm_average(out.viscosities[i],volume_fractions, composition_viscosities, composition_dviscosities_dpressure, viscosity_averaging_p);

--- a/tests/spiegelman_material.cc
+++ b/tests/spiegelman_material.cc
@@ -129,7 +129,7 @@ int f(double parameter)
   MaterialModelOutputs<dim> out_dviscositydstrainrate_oneone(5,3);
   MaterialModelOutputs<dim> out_dviscositydtemperature(5,3);
 
-  if (out_base.get_additional_output<MaterialModelDerivatives<dim> >() != NULL)
+  if (out_base.get_additional_output<MaterialModelDerivatives<dim> >() != nullptr)
     throw "error";
 
   out_base.additional_outputs.push_back(std::make_shared<MaterialModelDerivatives<dim> > (5));


### PR DESCRIPTION
Since we now use C++11, we can safely do this.

I have not attempted to find places where we compare a pointer again the
integer '0', which should eventually also be fixed to 'nullptr'. But one
step at a time.