### PR TITLE
Cleanup citing.html

### DIFF
--- a/citing.html
+++ b/citing.html
@@ -20,31 +20,31 @@
     <script src="js/less-1.4.1.min.js"></script>
 
     <style type="text/css">
-        .box {
-        background: lightgray;
-        font-family: monospace;
-        width: 75%;
-        padding: 10px;
-        word-wrap: break-word;
-        }
+      .box {
+      background: lightgray;
+      font-family: monospace;
+      width: 75%;
+      padding: 10px;
+      word-wrap: break-word;
+      }
 
-        .editbox {
-            background-color: #5f79b8;
-            width: 75%;
-            padding: 10px;
-        }
-        
-        .note {
-            background: #df9f9f;
-            width: 100%;
-            font-size: 150%;
-            margin: auto;
-            border: 1px solid black;
-            padding: 5px;
-            text-align: center;
-        }
+      .editbox {
+      background-color: #5f79b8;
+      width: 75%;
+      padding: 10px;
+      }
+      
+      .note {
+      background: #df9f9f;
+      width: 100%;
+      font-size: 150%;
+      margin: auto;
+      border: 1px solid black;
+      padding: 5px;
+      text-align: center;
+      }
     </style>
-</head>
+  </head>
 
   <body>
 
@@ -52,27 +52,27 @@
 
     <div id="content" class="container">
 
-    <p class="note">NOTE: a link with your selection is available at:<br/>
+      <p class="note">NOTE: a link with your selection is available at:<br/>
         <a style="font-size:75%" id="onlineurl" href="https://aspect.geodynamics.org/citing.html">https://aspect.geodynamics.org/citing.html</a>
-    </p>
+      </p>
 
-<script src="database.js"></script>
-        
-    <script type="text/javascript">
+      <script src="database.js"></script>
+      
+      <script type="text/javascript">
         var checkboxes = ["fs", "melt","particles","dg"];
 
         var intext = "Computations were done using the ASPECT code version <i>VERSION</i>, see \n\\cite{CITEKEYS}.";
 
         var thanks = "We thank the Computational Infrastructure for Geodynamics (geodynamics.org) which is funded by the National Science Foundation under award EAR-0949446 and EAR-1550901 for supporting the development of ASPECT.";
-    </script>
+      </script>
 
-    <br/>
-    <p><b>Please select the following features you used:</b>
-<br/>
-To give credit to the authors of significant pieces contributed to ASPECT, please select the version and check the following checkboxes of features that you feel were important to get your computational results. This will add relevant citations to the list of papers below:
-</p>
+      <br/>
+      <p><b>Please select the following features you used:</b>
+        <br/>
+        To give credit to the authors of significant pieces contributed to ASPECT, please select the version and check the following checkboxes of features that you feel were important to get your computational results. This will add relevant citations to the list of papers below:
+      </p>
 
-    <form action="" class="editbox">
+      <form action="" class="editbox">
         <label>Version: <select id="ver" onchange="update()">
             <option value="dev">dev</option>
             <option value="2.0.1">2.0.1</option>
@@ -88,29 +88,29 @@ To give credit to the authors of significant pieces contributed to ASPECT, pleas
         &nbsp;&nbsp;&nbsp;
         <label><input type="checkbox" id="checkall" onchange="do_checkall()">(check all)</label>
         <br/>
-    </form>
+      </form>
 
-    <br/>
-    <p><b>Please use the following notation to cite ASPECT:</b></p>
-    <div id="intext" class="box"></div>
+      <br/>
+      <p><b>Please use the following notation to cite ASPECT:</b></p>
+      <div id="intext" class="box"></div>
 
-    <br/>
-    <p><b>Please add the following Acknowledgement:</b></p>
-    <div id="thanks" class="box"></div>
+      <br/>
+      <p><b>Please add the following Acknowledgement:</b></p>
+      <div id="thanks" class="box"></div>
 
-    <br/>
-    <p><b>Papers:</b>
-<br>
-The canonical reference for ASPECT is the first publication listed here, but please consider citing
-all the references below:
-</p>
-    <div id="paper" class="box"></div>
+      <br/>
+      <p><b>Papers:</b>
+        <br>
+        The canonical reference for ASPECT is the first publication listed here, but please consider citing
+        all the references below:
+      </p>
+      <div id="paper" class="box"></div>
 
-    <br/>
-    <p><b>Bibtex:</b></p>
-    <div id="bibtex" class="box"></div>
+      <br/>
+      <p><b>Bibtex:</b></p>
+      <div id="bibtex" class="box"></div>
 
-    <script type="text/javascript">
+      <script type="text/javascript">
         function do_checkall() {
             var all = document.getElementById("checkall").checked ? true : false;
             for (var i = 0; i < checkboxes.length; ++i)
@@ -189,8 +189,8 @@ all the references below:
         if (document.addEventListener) document.addEventListener("DOMContentLoaded", autorun, false);
         else if (document.attachEvent) document.attachEvent("onreadystatechange", autorun);
         else window.onload = autorun;
-    </script>
-</body>
+      </script>
+  </body>
 
   <!-- Some JQuery needs to come after the body -->
   <script src="js/jquery.min.js"></script>

--- a/citing.html
+++ b/citing.html
@@ -18,7 +18,6 @@
 
     <!-- LESS needs to come after the stylesheets -->
     <script src="js/less-1.4.1.min.js"></script>
-  </head>
 
     <style type="text/css">
         .box {


### PR DESCRIPTION
The file had a duplicated `</head>` tag, and was awkwardly indented.