### PR TITLE
Add parse input table function

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -120,7 +120,25 @@ namespace aspect
                                const bool has_background_field,
                                const std::string &property_name);
 
-
+    /**
+     * This function takes a string argument that is assumed to represent
+     * an input table, in which each row is separated by
+     * semicolons, and each column separated by commas. The function
+     * returns the parsed entries as a table. In addition this function
+     * utilizes the possibly_extend_from_1_to_N() function to accept
+     * inputs with only a single column/row, which will be extended
+     * to @p n_rows or @p n_columns respectively, to allow abbreviating
+     * the input string (e.g. you can provide a single value instead of
+     * n_rows by n_columns identical values). This function can for example
+     * be used by material models to read densities for different
+     * compositions and different phases for each composition.
+     */
+    template <typename T>
+    Table<2,T>
+    parse_input_table (const std::string &input_string,
+                       const unsigned int n_rows,
+                       const unsigned int n_columns,
+                       const std::string &property_name);
 
     /**
      * Given a vector @p var_declarations expand any entries of the form
@@ -478,7 +496,8 @@ namespace aspect
           // Non-specified behavior
           AssertThrow(false,
                       ExcMessage("Length of " + id_text + " list must be " +
-                                 "either one or " + Utilities::to_string(N)));
+                                 "either one or " + Utilities::to_string(N) +
+                                 ". Currently it is " + Utilities::to_string(values.size()) + "."));
         }
 
       // This should never happen, but return an empty vector so the compiler

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -50,7 +50,6 @@
 
 #include <boost/math/special_functions/spherical_harmonic.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/algorithm/string/trim.hpp>
 
 namespace aspect
 {
@@ -82,7 +81,7 @@ namespace aspect
           for (unsigned int j=0; j<current_columns.size(); ++j)
             {
               // get rid of surrounding whitespace
-              boost::algorithm::trim(current_columns[j]);
+              trim(current_columns[j]);
 
               input_table[i][j] = boost::lexical_cast<T>(current_columns[j]);
             }

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -50,6 +50,7 @@
 
 #include <boost/math/special_functions/spherical_harmonic.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/algorithm/string/trim.hpp>
 
 namespace aspect
 {
@@ -59,6 +60,39 @@ namespace aspect
    */
   namespace Utilities
   {
+    template <typename T>
+    Table<2,T>
+    parse_input_table (const std::string &input_string,
+                       const unsigned int n_rows,
+                       const unsigned int n_columns,
+                       const std::string &property_name)
+    {
+      Table<2,T> input_table(n_rows,n_columns);
+
+      const std::vector<std::string> rows = Utilities::possibly_extend_from_1_to_N(Utilities::split_string_list(input_string,';'),
+                                                                                   n_rows,
+                                                                                   property_name);
+
+      for (unsigned int i=0; i<rows.size(); ++i)
+        {
+          std::vector<std::string> current_columns = Utilities::possibly_extend_from_1_to_N(Utilities::split_string_list(rows[i]),
+                                                     n_columns,
+                                                     property_name);
+
+          for (unsigned int j=0; j<current_columns.size(); ++j)
+            {
+              // get rid of surrounding whitespace
+              boost::algorithm::trim(current_columns[j]);
+
+              input_table[i][j] = boost::lexical_cast<T>(current_columns[j]);
+            }
+        }
+
+      return input_table;
+    }
+
+
+
     std::vector<double> parse_map_to_double_array (const std::string &input_string,
                                                    const std::vector<std::string> &input_field_names,
                                                    const bool has_background_field,
@@ -2993,5 +3027,11 @@ namespace aspect
 
     template class NaturalCoordinate<2>;
     template class NaturalCoordinate<3>;
+
+
+    template Table<2,double> parse_input_table(const std::string &input_string,
+                                               const unsigned int n_rows,
+                                               const unsigned int n_columns,
+                                               const std::string &property_name);
   }
 }

--- a/unit_tests/common.h
+++ b/unit_tests/common.h
@@ -24,6 +24,9 @@
 
 #include <catch.hpp>
 
+#include <deal.II/base/table.h>
+
+
 using Catch::Matchers::Contains;
 using Catch::Matchers::StartsWith;
 
@@ -39,6 +42,25 @@ inline void compare_vectors_approx(
     {
       INFO("array index i=" << i << ": ");
       REQUIRE(computed[i] == Approx(expected[i]));
+    }
+}
+
+/**
+ * Compare the given two table entries with an epsilon (using Catch::Approx)
+ */
+inline void compare_tables_approx(
+  const dealii::Table<2,double> &computed,
+  const dealii::Table<2,double> &expected)
+{
+  REQUIRE(computed.size() == expected.size());
+
+  for (unsigned int i=0; i<computed.n_rows(); ++i)
+    {
+      for (unsigned int j=0; j<computed.n_cols(); ++j)
+        {
+          INFO("array index i,j=" << i << "," << j << ": ");
+          REQUIRE(computed[i][j] == Approx(expected[i][j]));
+        }
     }
 }
 

--- a/unit_tests/parse_map_to_double_array.cc
+++ b/unit_tests/parse_map_to_double_array.cc
@@ -136,3 +136,86 @@ TEST_CASE("Utilities::parse_map_to_double_array FAIL ON PURPOSE")
   true,
   "TestField"), Contains("The keyword `all' is expected but is not found"));
 }
+
+
+TEST_CASE("Utilities::parse_input_table")
+{
+  // Parse multicomponent properties
+  INFO("check 1: ");
+
+  dealii::Table<2,double> expected_result(3,3);
+
+  expected_result[0][0] = 100.0;
+  expected_result[0][1] = 10.0;
+  expected_result[0][2] = 30.0;
+  expected_result[1][0] = 25.0;
+  expected_result[1][1] = 5.0;
+  expected_result[1][2] = 1500.0;
+  expected_result[2][0] = 0.001;
+  expected_result[2][1] = 0.1;
+  expected_result[2][2] = 3.5;
+
+
+  compare_tables_approx(aspect::Utilities::parse_input_table<double> ("100,10,30; 25.0,5.0 ,1.5e3; 0.001,10e-2,3.5",
+                                                                      3, 3, "TestField"),
+                        expected_result);
+
+  expected_result[0][0] = 100.0;
+  expected_result[0][1] = 10.0;
+  expected_result[0][2] = 30.0;
+  expected_result[1][0] = 100.0;
+  expected_result[1][1] = 10.0;
+  expected_result[1][2] = 30.0;
+  expected_result[2][0] = 100.0;
+  expected_result[2][1] = 10.0;
+  expected_result[2][2] = 30.0;
+
+
+  compare_tables_approx(aspect::Utilities::parse_input_table<double> ("100,10,30",
+                                                                      3, 3, "TestField"),
+                        expected_result);
+
+  expected_result[0][0] = 100.0;
+  expected_result[0][1] = 100.0;
+  expected_result[0][2] = 100.0;
+  expected_result[1][0] = 10.0;
+  expected_result[1][1] = 10.0;
+  expected_result[1][2] = 10.0;
+  expected_result[2][0] = 30.0;
+  expected_result[2][1] = 30.0;
+  expected_result[2][2] = 30.0;
+
+
+  compare_tables_approx(aspect::Utilities::parse_input_table<double> ("100;10;30",
+                                                                      3, 3, "TestField"),
+                        expected_result);
+
+  INFO("check complete");
+
+}
+
+using Catch::Matchers::Contains;
+
+TEST_CASE("Utilities::parse_input_table FAIL ON PURPOSE")
+{
+  // Purposefully fail Parse multicomponent properties
+  INFO("check fail 1: ");
+  REQUIRE_THROWS_WITH(
+    aspect::Utilities::parse_input_table<double> ("100,10,30; 25.0,5.0 ,1.5e3",
+                                                  3,3,
+                                                  "TestField"), Contains("Length of TestField"));
+
+  // Purposefully fail Parse multicomponent properties
+  INFO("check fail 2: ");
+  REQUIRE_THROWS_WITH(
+    aspect::Utilities::parse_input_table<double> ("100,10; 25.0,5.0; 5.0,2.5",
+                                                  3,3,
+                                                  "TestField"), Contains("Length of TestField"));
+
+  // Purposefully fail Parse multicomponent properties
+  INFO("check fail 3: ");
+  REQUIRE_THROWS_WITH(
+    aspect::Utilities::parse_input_table<double> ("100,10; a,5.0; 5.0,2.5",
+                                                  3,2,
+                                                  "TestField"), Contains("bad lexical cast"));
+}


### PR DESCRIPTION
This is a function that allows to parse two-dimensional input arrays. One application would be to assign different densities to different compositions, with each composition having different phases (e.g. dependent on the depth). As discussed with @naliboff, I think this can be used to make #2586 more generic. It is not yet used anywhere, I just added tests, and we can discuss about how to integrate it best tomorrow.