### PR TITLE
Fix parallel viscosity smoothing

### DIFF
--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -286,7 +286,9 @@ namespace aspect
     typename DoFHandler<dim>::active_cell_iterator cell = dof_handler.begin_active();
     for (; cell<dof_handler.end(); ++cell)
       {
-        if (cell->is_artificial())
+        // Skip cells for which we can not / do not need to compute the stabilization
+        if (cell->is_artificial()
+            || (cell->is_ghost() && parameters.use_artificial_viscosity_smoothing == false))
           {
             viscosity_per_cell[cell->active_cell_index()]=-1;
             continue;

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -286,8 +286,8 @@ namespace aspect
     typename DoFHandler<dim>::active_cell_iterator cell = dof_handler.begin_active();
     for (; cell<dof_handler.end(); ++cell)
       {
-        if (!cell->is_locally_owned()
-            || (parameters.use_artificial_viscosity_smoothing  == true  &&  cell->is_artificial()))
+        if (cell->is_artificial()
+            || (parameters.use_artificial_viscosity_smoothing  == false  &&  cell->is_ghost()))
           {
             viscosity_per_cell[cell->active_cell_index()]=-1;
             continue;

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -286,8 +286,7 @@ namespace aspect
     typename DoFHandler<dim>::active_cell_iterator cell = dof_handler.begin_active();
     for (; cell<dof_handler.end(); ++cell)
       {
-        if (cell->is_artificial()
-            || (parameters.use_artificial_viscosity_smoothing  == false  &&  cell->is_ghost()))
+        if (cell->is_artificial())
           {
             viscosity_per_cell[cell->active_cell_index()]=-1;
             continue;


### PR DESCRIPTION
Found this while working on the stabilization. The logic in the old form does not smooth artificial viscosity across processor domains, because for ghost cells `!cell->is_locally_owned()` is true and the cell is skipped no matter what the second condition says. I think the old form missed a parentheses around the two conditions (`!(is_locally_owned || smoothing && is_ghost)`). However, instead of keeping this complicated logic I propose we just always compute the entropy viscosity on ghost cells (whether we need it for smoothing or not). It should not be very expensive, and is much simpler to understand.