### PR TITLE
jenkins: clean workspace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,4 +106,6 @@ pipeline {
       }
     }
   }
+
+  post { cleanup { cleanWs() } }
 }


### PR DESCRIPTION
Each build generates about 250MB on the slave (source checkout) that is
never removed. Clean this in a post-build step.