### PR TITLE
Fix plugin graph generation

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -445,8 +445,6 @@ namespace aspect
     if (parameters.use_discontinuous_temperature_discretization || parameters.use_discontinuous_composition_discretization)
       CitationInfo::add("dg");
 
-    CitationInfo::print_info_block(pcout);
-
     // now that all member variables have been set up, also
     // connect the functions that will actually do the assembly
     set_assemblers();
@@ -1572,6 +1570,8 @@ namespace aspect
   template <int dim>
   void Simulator<dim>::run ()
   {
+    CitationInfo::print_info_block(pcout);
+
     unsigned int max_refinement_level = parameters.initial_global_refinement +
                                         parameters.initial_adaptive_refinement;
     pre_refinement_step = 0;


### PR DESCRIPTION
aspect now happily prints the citation info, which generates a broken
plugin-graph. Fix this by suppressing the output.