### PR TITLE
Only apply entropy viscosity in streamline direction

### DIFF
--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -446,6 +446,8 @@ namespace aspect
     std::vector<double>            stabilization_c_R;
     std::vector<double>            stabilization_beta;
     double                         stabilization_gamma;
+    bool                           use_streamline_entropy_viscosity;
+
     double                         discontinuous_penalty;
     bool                           use_limiter_for_discontinuous_temperature_solution;
     bool                           use_limiter_for_discontinuous_composition_solution;

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -225,6 +225,12 @@ namespace aspect
                                max_velocity * max_residual /
                                (global_u_infty * global_field_variation));
 
+        // If there is physical conductivity it already stabilizes the equation,
+        // thus reduce the artificial stabilization by this amount.
+        if (entropy_viscosity >= max_conductivity)
+          entropy_viscosity -= max_conductivity;
+        else
+          entropy_viscosity = 0.0;
 
         return std::min (max_viscosity, entropy_viscosity);
       }

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -836,6 +836,15 @@ namespace aspect
                            "If set to true, the maximum of the artificial viscosity in "
                            "the cell as well as the neighbors of the cell is computed and used "
                            "instead.");
+        prm.declare_entry ("Use streamline entropy viscosity", "true",
+                           Patterns::Bool (),
+                           "If set to true (the default), the computed entropy viscosity is"
+                           "only applied in streamline direction, equivalent to an anisotropic "
+                           "stabilizing diffusion in the direction of the flow. If false, the "
+                           "artificial diffusion will be applied isotropically in all directions. "
+                           "While reducing oscillations, setting this option to false can "
+                           "significantly increase the amount of numerical diffusion across "
+                           "boundary layers, and should thus be only used if necessary.");
         prm.declare_entry ("alpha", "2",
                            Patterns::Integer (1, 2),
                            "The exponent $\\alpha$ in the entropy viscosity stabilization. Valid "
@@ -1381,6 +1390,7 @@ namespace aspect
       prm.enter_subsection ("Stabilization parameters");
       {
         use_artificial_viscosity_smoothing  = prm.get_bool ("Use artificial viscosity smoothing");
+        use_streamline_entropy_viscosity    = prm.get_bool ("Use streamline entropy viscosity");
         stabilization_alpha                 = prm.get_integer ("alpha");
 
         stabilization_c_R                   = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("cR"))),

--- a/tests/streamline_entropy_viscosity.prm
+++ b/tests/streamline_entropy_viscosity.prm
@@ -1,0 +1,101 @@
+# A test for the stabilization of the advection equation.
+# Three structures of varying sharpness, and length scales
+# are rotated in a constant spherical flow to check the
+# stabilization scheme for artifical diffusion and oscillations.
+
+set Dimension                              = 2
+
+set Use years in output instead of seconds = false
+set End time                               = 12.5663 #0.1
+set Nonlinear solver scheme                = single Advection, no Stokes
+
+subsection Prescribed Stokes solution  
+  set Model name = circle
+end
+
+subsection Discretization
+  subsection Stabilization parameters
+    set Use artificial viscosity smoothing = true
+  end
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 2
+    set Y extent = 2
+    set Box origin X coordinate = -1
+    set Box origin Y coordinate = -1
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Variable names      = x,y
+    set Function constants  = 
+    set Function expression =  if((sqrt((x-0)^2+(y-0.5)^2)<0.3)&(abs(x)>=0.05|y>=0.7),1,if(sqrt((x-0)^2+(y+0.5)^2)<0.3,1-sqrt((x-0)^2+(y+0.5)^2)/0.3,if(sqrt((x+0.5)^2+(y+0)^2)<0.3,1.0/4.0*(1+cos(pi*min(sqrt((x+0.5)^2+(y+0)^2)/0.3,1))),0)))
+  end
+end
+
+
+subsection Boundary temperature model
+  set List of model names = box
+
+  subsection Box
+    set Bottom temperature = 0
+    set Left temperature   = 0
+    set Right temperature  = 0
+    set Top temperature    = 0
+  end
+end
+
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = top, bottom, left, right
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 0.0
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 0
+    set Thermal conductivity          = 0
+    set Thermal expansion coefficient = 0
+    set Viscosity                     = 0
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 6
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+end
+
+
+subsection Postprocess
+  set List of postprocessors = temperature statistics, visualization
+
+  subsection Visualization
+    set Time between graphical output = 0.1
+    set List of output variables = artificial viscosity
+    set Interpolate output = false
+  end
+end

--- a/tests/streamline_entropy_viscosity/screen-output
+++ b/tests/streamline_entropy_viscosity/screen-output
@@ -1,0 +1,73 @@
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 948 (578+81+289)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.816 m/s, 1.37 m/s
+     Temperature min/avg/max:            0 K, 0.1027 K, 1 K
+     Heat fluxes through boundary parts: -1.881e-07 W, 0 W, -1.466e-06 W, -1.667e-05 W
+     Writing graphical output:           output-supg/solution/solution-00000
+
+*** Timestep 1:  t=0.0883883 seconds
+   Solving temperature system... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.816 m/s, 1.37 m/s
+     Temperature min/avg/max:            -0.07756 K, 0.1026 K, 1.184 K
+     Heat fluxes through boundary parts: -1.237e-07 W, -1.039e-08 W, -1.449e-06 W, -1.713e-05 W
+
+*** Timestep 2:  t=0.176777 seconds
+   Solving temperature system... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.816 m/s, 1.37 m/s
+     Temperature min/avg/max:            -0.1149 K, 0.1024 K, 1.194 K
+     Heat fluxes through boundary parts: -3.842e-07 W, -2.128e-08 W, -1.364e-06 W, -1.737e-05 W
+     Writing graphical output:           output-supg/solution/solution-00001
+
+*** Timestep 3:  t=0.265165 seconds
+   Solving temperature system... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.816 m/s, 1.37 m/s
+     Temperature min/avg/max:            -0.1392 K, 0.1023 K, 1.062 K
+     Heat fluxes through boundary parts: -3.955e-07 W, -5.799e-08 W, -1.264e-06 W, -1.718e-05 W
+     Writing graphical output:           output-supg/solution/solution-00002
+
+*** Timestep 4:  t=0.353553 seconds
+   Solving temperature system... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.816 m/s, 1.37 m/s
+     Temperature min/avg/max:            -0.1428 K, 0.1022 K, 1.044 K
+     Heat fluxes through boundary parts: 3.558e-07 W, -8.041e-08 W, -1.14e-06 W, -1.631e-05 W
+     Writing graphical output:           output-supg/solution/solution-00003
+
+*** Timestep 5:  t=0.441942 seconds
+   Solving temperature system... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.816 m/s, 1.37 m/s
+     Temperature min/avg/max:            -0.1388 K, 0.102 K, 1.017 K
+     Heat fluxes through boundary parts: 1.433e-06 W, -3.743e-08 W, -9.456e-07 W, -1.467e-05 W
+     Writing graphical output:           output-supg/solution/solution-00004
+
+*** Timestep 6:  t=0.5 seconds
+   Solving temperature system... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.816 m/s, 1.37 m/s
+     Temperature min/avg/max:            -0.1352 K, 0.1019 K, 0.9727 K
+     Heat fluxes through boundary parts: 1.917e-06 W, 3.535e-08 W, -7.646e-07 W, -1.317e-05 W
+     Writing graphical output:           output-supg/solution/solution-00005
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/streamline_entropy_viscosity/statistics
+++ b/tests/streamline_entropy_viscosity/statistics
@@ -1,0 +1,24 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: RMS velocity (m/s)
+# 9: Max. velocity (m/s)
+# 10: Minimal temperature (K)
+# 11: Average temperature (K)
+# 12: Maximal temperature (K)
+# 13: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 14: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 15: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 16: Outward heat flux through boundary with indicator 3 ("top") (W)
+# 17: Visualization file name
+0 0.000000000000e+00 0.000000000000e+00 64 659 289 0 8.16496581e-01 1.37436751e+00  0.00000000e+00 1.02664060e-01 1.00000000e+00 -1.88097075e-07  0.00000000e+00 -1.46628901e-06 -1.66666667e-05 output-supg/solution/solution-00000 
+1 8.838834764832e-02 8.838834764832e-02 64 659 289 9 8.16496581e-01 1.37436751e+00 -7.75630536e-02 1.02572181e-01 1.18382664e+00 -1.23688873e-07 -1.03884169e-08 -1.44859069e-06 -1.71334979e-05                                  "" 
+2 1.767766952966e-01 8.838834764832e-02 64 659 289 9 8.16496581e-01 1.37436751e+00 -1.14947437e-01 1.02436588e-01 1.19356988e+00 -3.84236825e-07 -2.12759715e-08 -1.36446992e-06 -1.73737589e-05 output-supg/solution/solution-00001 
+3 2.651650429450e-01 8.838834764832e-02 64 659 289 9 8.16496581e-01 1.37436751e+00 -1.39172719e-01 1.02290906e-01 1.06172277e+00 -3.95520999e-07 -5.79912328e-08 -1.26392378e-06 -1.71760356e-05 output-supg/solution/solution-00002 
+4 3.535533905933e-01 8.838834764832e-02 64 659 289 9 8.16496581e-01 1.37436751e+00 -1.42810166e-01 1.02159149e-01 1.04419089e+00  3.55756266e-07 -8.04087770e-08 -1.14013526e-06 -1.63136280e-05 output-supg/solution/solution-00003 
+5 4.419417382416e-01 8.838834764832e-02 64 659 289 9 8.16496581e-01 1.37436751e+00 -1.38782626e-01 1.02007878e-01 1.01666489e+00  1.43328592e-06 -3.74256555e-08 -9.45587847e-07 -1.46703258e-05 output-supg/solution/solution-00004 
+6 5.000000000000e-01 5.805826175841e-02 64 659 289 9 8.16496581e-01 1.37436751e+00 -1.35228914e-01 1.01879023e-01 9.72696666e-01  1.91743640e-06  3.53484512e-08 -7.64641304e-07 -1.31719399e-05 output-supg/solution/solution-00005 

--- a/tests/streamline_entropy_viscosity_1d.prm
+++ b/tests/streamline_entropy_viscosity_1d.prm
@@ -1,0 +1,110 @@
+# This is a test for the streamline entropy viscosity method that is a setup
+# described in Thieulot, PEPI, 2011, Appendix A. It creates a lateral pipe
+# with a prescribed flow and a temperature jump that moves with the flow.
+# With sufficient stabilization, no oscillations should occur. Since the
+# flow is always parallel to the temperature gradient, in this setup there
+# should be no difference between the entropy viscosity method, and streamline
+# entropy viscosity method.
+
+set CFL number                             = 0.2
+set Dimension                              = 2
+
+set Nonlinear solver scheme                = single Advection, no Stokes
+set Use years in output instead of seconds = false
+set End time                               = 0.5
+
+subsection Prescribed Stokes solution  
+  set Model name = function
+  subsection Pressure function
+    set Function expression = 0.0
+  end
+  subsection Velocity function
+    set Function expression = 1.0;0.0
+  end
+end
+
+
+subsection Discretization
+  subsection Stabilization parameters
+    set Use artificial viscosity smoothing = true
+  end
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+    set Y extent = 0.02
+    set X repetitions = 50
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Variable names      = x,y
+    set Function constants  = 
+    set Function expression = (x<0.25) ? 1.0 : 0.0 
+  end
+end
+
+
+subsection Boundary temperature model
+  set List of model names = box
+
+  subsection Box
+    set Bottom temperature = 0
+    set Left temperature   = 1.0
+    set Right temperature  = 0
+    set Top temperature    = 0
+  end
+end
+
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = left, right
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 0.0
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 0
+    set Thermal conductivity          = 0
+    set Thermal expansion coefficient = 0
+    set Viscosity                     = 0
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 0
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+end
+
+
+subsection Postprocess
+  set List of postprocessors = temperature statistics, visualization
+
+  subsection Visualization
+    set Time between graphical output = .1
+    set List of output variables = artificial viscosity
+  end
+end

--- a/tests/streamline_entropy_viscosity_1d/screen-output
+++ b/tests/streamline_entropy_viscosity_1d/screen-output
@@ -1,0 +1,73 @@
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 948 (578+81+289)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.816 m/s, 1.37 m/s
+     Temperature min/avg/max:            0 K, 0.1027 K, 1 K
+     Heat fluxes through boundary parts: -1.881e-07 W, 0 W, -1.466e-06 W, -1.667e-05 W
+     Writing graphical output:           output-supg/solution/solution-00000
+
+*** Timestep 1:  t=0.0883883 seconds
+   Solving temperature system... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.816 m/s, 1.37 m/s
+     Temperature min/avg/max:            -0.07756 K, 0.1026 K, 1.184 K
+     Heat fluxes through boundary parts: -1.237e-07 W, -1.039e-08 W, -1.449e-06 W, -1.713e-05 W
+
+*** Timestep 2:  t=0.176777 seconds
+   Solving temperature system... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.816 m/s, 1.37 m/s
+     Temperature min/avg/max:            -0.1149 K, 0.1024 K, 1.194 K
+     Heat fluxes through boundary parts: -3.842e-07 W, -2.128e-08 W, -1.364e-06 W, -1.737e-05 W
+     Writing graphical output:           output-supg/solution/solution-00001
+
+*** Timestep 3:  t=0.265165 seconds
+   Solving temperature system... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.816 m/s, 1.37 m/s
+     Temperature min/avg/max:            -0.1392 K, 0.1023 K, 1.062 K
+     Heat fluxes through boundary parts: -3.955e-07 W, -5.799e-08 W, -1.264e-06 W, -1.718e-05 W
+     Writing graphical output:           output-supg/solution/solution-00002
+
+*** Timestep 4:  t=0.353553 seconds
+   Solving temperature system... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.816 m/s, 1.37 m/s
+     Temperature min/avg/max:            -0.1428 K, 0.1022 K, 1.044 K
+     Heat fluxes through boundary parts: 3.558e-07 W, -8.041e-08 W, -1.14e-06 W, -1.631e-05 W
+     Writing graphical output:           output-supg/solution/solution-00003
+
+*** Timestep 5:  t=0.441942 seconds
+   Solving temperature system... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.816 m/s, 1.37 m/s
+     Temperature min/avg/max:            -0.1388 K, 0.102 K, 1.017 K
+     Heat fluxes through boundary parts: 1.433e-06 W, -3.743e-08 W, -9.456e-07 W, -1.467e-05 W
+     Writing graphical output:           output-supg/solution/solution-00004
+
+*** Timestep 6:  t=0.5 seconds
+   Solving temperature system... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.816 m/s, 1.37 m/s
+     Temperature min/avg/max:            -0.1352 K, 0.1019 K, 0.9727 K
+     Heat fluxes through boundary parts: 1.917e-06 W, 3.535e-08 W, -7.646e-07 W, -1.317e-05 W
+     Writing graphical output:           output-supg/solution/solution-00005
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/streamline_entropy_viscosity_1d/statistics
+++ b/tests/streamline_entropy_viscosity_1d/statistics
@@ -1,0 +1,24 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: RMS velocity (m/s)
+# 9: Max. velocity (m/s)
+# 10: Minimal temperature (K)
+# 11: Average temperature (K)
+# 12: Maximal temperature (K)
+# 13: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 14: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 15: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 16: Outward heat flux through boundary with indicator 3 ("top") (W)
+# 17: Visualization file name
+0 0.000000000000e+00 0.000000000000e+00 64 659 289 0 8.16496581e-01 1.37436751e+00  0.00000000e+00 1.02664060e-01 1.00000000e+00 -1.88097075e-07  0.00000000e+00 -1.46628901e-06 -1.66666667e-05 output-supg/solution/solution-00000 
+1 8.838834764832e-02 8.838834764832e-02 64 659 289 9 8.16496581e-01 1.37436751e+00 -7.75630536e-02 1.02572181e-01 1.18382664e+00 -1.23688873e-07 -1.03884169e-08 -1.44859069e-06 -1.71334979e-05                                  "" 
+2 1.767766952966e-01 8.838834764832e-02 64 659 289 9 8.16496581e-01 1.37436751e+00 -1.14947437e-01 1.02436588e-01 1.19356988e+00 -3.84236825e-07 -2.12759715e-08 -1.36446992e-06 -1.73737589e-05 output-supg/solution/solution-00001 
+3 2.651650429450e-01 8.838834764832e-02 64 659 289 9 8.16496581e-01 1.37436751e+00 -1.39172719e-01 1.02290906e-01 1.06172277e+00 -3.95520999e-07 -5.79912328e-08 -1.26392378e-06 -1.71760356e-05 output-supg/solution/solution-00002 
+4 3.535533905933e-01 8.838834764832e-02 64 659 289 9 8.16496581e-01 1.37436751e+00 -1.42810166e-01 1.02159149e-01 1.04419089e+00  3.55756266e-07 -8.04087770e-08 -1.14013526e-06 -1.63136280e-05 output-supg/solution/solution-00003 
+5 4.419417382416e-01 8.838834764832e-02 64 659 289 9 8.16496581e-01 1.37436751e+00 -1.38782626e-01 1.02007878e-01 1.01666489e+00  1.43328592e-06 -3.74256555e-08 -9.45587847e-07 -1.46703258e-05 output-supg/solution/solution-00004 
+6 5.000000000000e-01 5.805826175841e-02 64 659 289 9 8.16496581e-01 1.37436751e+00 -1.35228914e-01 1.01879023e-01 9.72696666e-01  1.91743640e-06  3.53484512e-08 -7.64641304e-07 -1.31719399e-05 output-supg/solution/solution-00005 


### PR DESCRIPTION
This is an experimental change to the entropy viscosity stabilization method that only applies the stabilization along streamlines (by multiplying the velocity with the advected gradient). Compared to SUPG in #2638 it has only a minimal change in the code, and we can keep all the other properties of EV. In first tests by myself and @maxrudolph this seems to fix several of the problems reported in the recent discussion on the mailing list:
- artificial diffusion across boundary layers is much smaller now, resulting in more correct average temperatures for a given Rayleigh number
- the reduced artificial diffusion across boundary layers reduces the inconsistency between top and bottom boundary heat flux (because the artificial diffusion is the part that does not appear in the heat flux postprocessor, and it is cell-size dependent that was the reason for the apparent imbalance)
The attached figure is from Max, and shows how in EV the heat flux does not converge towards the same value (black lines), while without stabilization (red lines) and SEV (green lines) it does.

![image](https://user-images.githubusercontent.com/7582930/45059275-4f5a7280-b050-11e8-9093-06aeeb2ff920.png)

- artificial diffusion of internal structures also is smaller than with EV (because structures are only diffused in one dimension?)

I attach a figure of the same model Ryan used in #412, but with EV, SEV, and SUPG. The bottom left panel shows the initial state, the other three panels the state after one rotation. Note that black and pink colors are over-/undershoots (most prominent in SUPG), and how in EV the structures tend to diffuse in azimuthal and radial direction, while in SEV they primarily diffuse in azimuthal direction. Also note that there are some oscillations in radial direction in SEV that are no longer damped as well as in EV. 

![ev-sev-supg-comparison](https://user-images.githubusercontent.com/7582930/45058318-313f4300-b04d-11e8-9c1c-66a5d5001e3a.png)

There is certainly still room for improvements (currently we do not apply any stabilization perpendicular to streamlines which causes some of the oscillations, and also a high residual does lead to a high stabilization, even if the oscillations are in radial direction, thus the stabilization can not help against it, which leads to overdiffusion in azimuthal direction). Still the current state looks like a big step forward to finally be able to reproduce all the benchmarks multiple groups have been struggling with for so long, and explain the wrong average temperature.

I would appreciate comments, both about the mathematical theory, and how well this works in practice. If you had a benchmark that failed because of weird heat flux / average temperature differences, please give it a try with this change (all tests I have done so far look much better now).

One final remark: Of course if you run a model with sufficiently high resolution all the differences between the methods disappear and you converge towards the correct solution, but in 3D spherical models it is very worthwhile to reduce the *sufficiently* high resolution as much as possible, and with the current EV this means using at least 5 (better 6 or 7) refinements in the boundary layer, which is just absurdly expensive if you want to reproduce a benchmark of say Rayleigh number 7000. SEV should allow much lower resolutions, but how much we would need to test.