### PR TITLE
Provide formulas for the material-statistics postprocessor.

### DIFF
--- a/doc/modules/changes/20180822_gassmoeller
+++ b/doc/modules/changes/20180822_gassmoeller
@@ -1,5 +1,5 @@
 New: There is now a 'material statistics' postprocessor that computes the
-averaged density, averaged viscosity, and total mass in a
+average density, average viscosity, and total mass in a
 model.
 <br>
 (Rene Gassmoeller, 2018/08/22)

--- a/source/postprocess/material_statistics.cc
+++ b/source/postprocess/material_statistics.cc
@@ -120,8 +120,12 @@ namespace aspect
                                   "material statistics",
                                   "A postprocessor that computes some statistics about "
                                   "the material properties. In particular, it computes the "
-                                  "volume-averaged density, volume-averaged viscosity, and "
-                                  "total mass in the model. Currently, only arithmetic "
-                                  "averaging is supported.")
+                                  "volume-averages of the density and viscosity, and the "
+                                  "total mass in the model. Specifically, it implements "
+                                  "the following formulas in each time step: "
+                                  "$\\left<\\rho\\right> = \\frac{1}{|\\Omega|} \\int_\\Omega \\rho(\\mathbf x) \\, \\text{d}x$, "
+                                  "$\\left<\\eta\\right> = \\frac{1}{|\\Omega|} \\int_\\Omega \\eta(\\mathbf x) \\, \\text{d}x$, "
+                                  "$M = \\int_\\Omega \\rho(\\mathbf x) \\, \\text{d}x$, "
+                                  "where $|\\Omega|$ is the volume of the domain.")
   }
 }


### PR DESCRIPTION
Better be specific with formulas than rely on a reader's understanding of
a text description.

I'm not sure there is a reason why one would ever want to use anything
other than the usual arithmetic averaging for the density and mass,
given that these have physical interpretations, so I dropped that remark.

I'm tacking on a change in wording in @gassmoeller's original changelog
to make it clear that the postprocessor computes 'the average density',
(passive) rather than 'averages the density' (an action).

Follow-up to #2630.