### PR TITLE
Unify heat flux computation

### DIFF
--- a/include/aspect/postprocess/heat_flux_map.h
+++ b/include/aspect/postprocess/heat_flux_map.h
@@ -30,6 +30,12 @@ namespace aspect
 {
   namespace Postprocess
   {
+    namespace internal
+    {
+      template <int dim>
+      std::vector<std::vector<std::pair<double, double> > >
+      compute_heat_flux_through_boundary_faces (const SimulatorAccess<dim> &simulator_access);
+    }
 
     /**
      * A postprocessor that computes the point-wise heat flux density through the boundaries.

--- a/include/aspect/postprocess/heat_flux_map.h
+++ b/include/aspect/postprocess/heat_flux_map.h
@@ -32,6 +32,17 @@ namespace aspect
   {
     namespace internal
     {
+      /**
+       * This function computes for each cell, for each face that is at a
+       * boundary the heat flux normal through this boundary by
+       * integrating
+       *   j =  - k * n . grad T
+       * over the boundary face.
+       * Note that for the inner boundary of the spherical shell geometry,
+       * the normal vector points *into* the core, i.e. we compute the flux
+       * *out* of the mantle, not into it. we fix this when we add the local
+       * contribution to the global flux.
+       */
       template <int dim>
       std::vector<std::vector<std::pair<double, double> > >
       compute_heat_flux_through_boundary_faces (const SimulatorAccess<dim> &simulator_access);

--- a/source/postprocess/heat_flux_map.cc
+++ b/source/postprocess/heat_flux_map.cc
@@ -91,7 +91,6 @@ namespace aspect
     std::pair<std::string,std::string>
     HeatFluxMap<dim>::execute (TableHandler &)
     {
-
       std::vector<std::vector<std::pair<double, double> > > heat_flux_and_area =
         internal::compute_heat_flux_through_boundary_faces (*this);
 
@@ -115,8 +114,8 @@ namespace aspect
                 // evaluate position of heat flow to write into output file
                 const Point<dim> midpoint_at_surface = cell->face(f)->center();
 
-                const double flux_density = heat_flux_and_area[cell->active_cell_index()][f].first
-                                            / heat_flux_and_area[cell->active_cell_index()][f].second;
+                const double flux_density = heat_flux_and_area[cell->active_cell_index()][f].first /
+                                            heat_flux_and_area[cell->active_cell_index()][f].second;
 
                 // store final position and heat flow
                 stored_values.push_back (std::make_pair(midpoint_at_surface, flux_density));

--- a/source/postprocess/heat_flux_map.cc
+++ b/source/postprocess/heat_flux_map.cc
@@ -29,25 +29,71 @@ namespace aspect
 {
   namespace Postprocess
   {
+    namespace internal
+    {
+      template <int dim>
+      std::vector<std::vector<std::pair<double, double> > >
+      compute_heat_flux_through_boundary_faces (const SimulatorAccess<dim> &simulator_access)
+      {
+        std::vector<std::vector<std::pair<double, double> > > heat_flux_and_area(simulator_access.get_triangulation().n_active_cells(),
+                                                                                 std::vector<std::pair<double, double> >(GeometryInfo<dim>::faces_per_cell,
+                                                                                     std::pair<double,double>()));
+
+        // create a quadrature formula based on the temperature element alone.
+        const QGauss<dim-1> quadrature_formula (simulator_access.get_fe().base_element(simulator_access.introspection().base_elements.temperature).degree+1);
+        FEFaceValues<dim> fe_face_values (simulator_access.get_mapping(),
+                                          simulator_access.get_fe(),
+                                          quadrature_formula,
+                                          update_gradients      | update_values |
+                                          update_normal_vectors |
+                                          update_q_points       | update_JxW_values);
+
+        typename MaterialModel::Interface<dim>::MaterialModelInputs in(fe_face_values.n_quadrature_points, simulator_access.n_compositional_fields());
+        typename MaterialModel::Interface<dim>::MaterialModelOutputs out(fe_face_values.n_quadrature_points, simulator_access.n_compositional_fields());
+
+        std::vector<Tensor<1,dim> > temperature_gradients (quadrature_formula.size());
+
+        // loop over all of the surface cells and evaluate the heat flux
+        typename DoFHandler<dim>::active_cell_iterator
+        cell = simulator_access.get_dof_handler().begin_active(),
+        endc = simulator_access.get_dof_handler().end();
+
+        for (; cell!=endc; ++cell)
+          if (cell->is_locally_owned())
+            for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+              if (cell->at_boundary(f))
+                {
+                  fe_face_values.reinit (cell, f);
+                  in.reinit(fe_face_values, cell, simulator_access.introspection(), simulator_access.get_solution(), false);
+                  simulator_access.get_material_model().evaluate(in, out);
+
+                  fe_face_values[simulator_access.introspection().extractors.temperature].get_function_gradients (simulator_access.get_solution(),
+                      temperature_gradients);
+
+                  // Calculate the normal conductive heat flux given by the formula
+                  //   j = - k * n . grad T
+                  for (unsigned int q=0; q<fe_face_values.n_quadrature_points; ++q)
+                    {
+                      const double thermal_conductivity
+                        = out.thermal_conductivities[q];
+
+                      heat_flux_and_area[cell->active_cell_index()][f].first += -thermal_conductivity *
+                                                                                (temperature_gradients[q] * fe_face_values.normal_vector(q)) *
+                                                                                fe_face_values.JxW(q);
+                      heat_flux_and_area[cell->active_cell_index()][f].second += fe_face_values.JxW(q);
+                    }
+                }
+        return heat_flux_and_area;
+      }
+    }
+
     template <int dim>
     std::pair<std::string,std::string>
     HeatFluxMap<dim>::execute (TableHandler &)
     {
-      // create a quadrature formula based on the temperature element alone.
-      const QGauss<dim-1> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.temperature).degree+1);
 
-      FEFaceValues<dim> fe_face_values (this->get_mapping(),
-                                        this->get_fe(),
-                                        quadrature_formula,
-                                        update_gradients      | update_values |
-                                        update_normal_vectors |
-                                        update_q_points       | update_JxW_values);
-
-      typename MaterialModel::Interface<dim>::MaterialModelInputs in(fe_face_values.n_quadrature_points, this->n_compositional_fields());
-      typename MaterialModel::Interface<dim>::MaterialModelOutputs out(fe_face_values.n_quadrature_points, this->n_compositional_fields());
-
-      std::vector<Tensor<1,dim> > temperature_gradients (quadrature_formula.size());
-      std::vector<std::vector<double> > composition_values (this->n_compositional_fields(),std::vector<double> (quadrature_formula.size()));
+      std::vector<std::vector<std::pair<double, double> > > heat_flux_and_area =
+        internal::compute_heat_flux_through_boundary_faces (*this);
 
       // have a stream into which we write the data. the text stream is then
       // later sent to processor 0
@@ -66,62 +112,14 @@ namespace aspect
                 (this->get_geometry_model().translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "top" ||
                  this->get_geometry_model().translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "bottom"))
               {
-                fe_face_values.reinit (cell, f);
-
                 // evaluate position of heat flow to write into output file
                 const Point<dim> midpoint_at_surface = cell->face(f)->center();
 
-                // get the various components of the solution, then
-                // evaluate the material properties there
-                fe_face_values[this->introspection().extractors.temperature].get_function_gradients (this->get_solution(),
-                    temperature_gradients);
-                fe_face_values[this->introspection().extractors.temperature].get_function_values (this->get_solution(), in.temperature);
-                fe_face_values[this->introspection().extractors.pressure].get_function_values (this->get_solution(), in.pressure);
-
-                for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-                  fe_face_values[this->introspection().extractors.compositional_fields[c]].get_function_values(this->get_solution(), composition_values[c]);
-
-                in.position = fe_face_values.get_quadrature_points();
-
-                // since we are not reading the viscosity and the viscosity
-                // is the only coefficient that depends on the strain rate,
-                // we need not compute the strain rate. set the corresponding
-                // array to empty, to prevent accidental use and skip the
-                // evaluation of the strain rate in evaluate().
-                in.strain_rate.resize(0);
-
-
-                for (unsigned int i=0; i<fe_face_values.n_quadrature_points; ++i)
-                  {
-                    for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-                      in.composition[i][c] = composition_values[c][i];
-                  }
-
-                this->get_material_model().evaluate(in, out);
-
-
-                // Calculate the normal conductive heat flux given by the formula
-                //   j = - k * n . grad T
-
-                double normal_flux = 0;
-                double face_area = 0;
-                for (unsigned int q=0; q<fe_face_values.n_quadrature_points; ++q)
-                  {
-                    const double thermal_conductivity
-                      = out.thermal_conductivities[q];
-
-                    normal_flux += -thermal_conductivity *
-                                   (temperature_gradients[q] * fe_face_values.normal_vector(q)) *
-                                   fe_face_values.JxW(q);
-                    face_area += fe_face_values.JxW(q);
-
-                  }
-
-                const double flux_density = normal_flux / face_area;
+                const double flux_density = heat_flux_and_area[cell->active_cell_index()][f].first
+                                            / heat_flux_and_area[cell->active_cell_index()][f].second;
 
                 // store final position and heat flow
                 stored_values.push_back (std::make_pair(midpoint_at_surface, flux_density));
-
               }
 
 

--- a/source/postprocess/heat_flux_statistics.cc
+++ b/source/postprocess/heat_flux_statistics.cc
@@ -20,6 +20,8 @@
 
 
 #include <aspect/postprocess/heat_flux_statistics.h>
+#include <aspect/postprocess/heat_flux_map.h>
+
 #include <aspect/utilities.h>
 #include <aspect/geometry_model/interface.h>
 
@@ -31,23 +33,12 @@ namespace aspect
 {
   namespace Postprocess
   {
-
     template <int dim>
     std::pair<std::string,std::string>
     HeatFluxStatistics<dim>::execute (TableHandler &statistics)
     {
-      // create a quadrature formula based on the temperature element alone.
-      const QGauss<dim-1> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.temperature).degree+1);
-
-      FEFaceValues<dim> fe_face_values (this->get_mapping(),
-                                        this->get_fe(),
-                                        quadrature_formula,
-                                        update_gradients      | update_values |
-                                        update_normal_vectors |
-                                        update_q_points       | update_JxW_values);
-
-      std::vector<Tensor<1,dim> > temperature_gradients (quadrature_formula.size());
-      std::vector<std::vector<double> > composition_values (this->n_compositional_fields(),std::vector<double> (quadrature_formula.size()));
+      std::vector<std::vector<std::pair<double, double> > > heat_flux_and_area =
+        internal::compute_heat_flux_through_boundary_faces (*this);
 
       std::map<types::boundary_id, double> local_boundary_fluxes;
 
@@ -55,49 +46,14 @@ namespace aspect
       cell = this->get_dof_handler().begin_active(),
       endc = this->get_dof_handler().end();
 
-      MaterialModel::MaterialModelInputs<dim> in(fe_face_values.n_quadrature_points, this->n_compositional_fields());
-      MaterialModel::MaterialModelOutputs<dim> out(fe_face_values.n_quadrature_points, this->n_compositional_fields());
-
-      // for every surface face on which it makes sense to compute a
-      // heat flux and that is owned by this processor,
-      // integrate the normal heat flux given by the formula
-      //   j =  - k * n . grad T
-      //
-      // for the spherical shell geometry, note that for the inner boundary,
-      // the normal vector points *into* the core, i.e. we compute the flux
-      // *out* of the mantle, not into it. we fix this when we add the local
-      // contribution to the global flux
       for (; cell!=endc; ++cell)
         if (cell->is_locally_owned())
           for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
             if (cell->at_boundary(f))
               {
-                fe_face_values.reinit (cell, f);
-                // Set use_strain_rates to false since we don't need viscosity
-                in.reinit(fe_face_values, cell, this->introspection(), this->get_solution(), false);
-
-                this->get_material_model().evaluate(in, out);
-
-                // Get the temperature gradients from the solution.
-                fe_face_values[this->introspection().extractors.temperature].get_function_gradients (this->get_solution(), temperature_gradients);
-
-                double local_normal_flux = 0;
-                for (unsigned int q=0; q<fe_face_values.n_quadrature_points; ++q)
-                  {
-                    const double thermal_conductivity
-                      = out.thermal_conductivities[q];
-
-                    local_normal_flux
-                    +=
-                      -thermal_conductivity *
-                      (temperature_gradients[q] *
-                       fe_face_values.normal_vector(q)) *
-                      fe_face_values.JxW(q);
-                  }
-
                 const types::boundary_id boundary_indicator
                   = cell->face(f)->boundary_id();
-                local_boundary_fluxes[boundary_indicator] += local_normal_flux;
+                local_boundary_fluxes[boundary_indicator] += heat_flux_and_area[cell->active_cell_index()][f].first;
               }
 
       // now communicate to get the global values

--- a/source/postprocess/visualization/heat_flux_map.cc
+++ b/source/postprocess/visualization/heat_flux_map.cc
@@ -61,7 +61,7 @@ namespace aspect
                   {
                     // add heatflow for this face
                     (*return_value.second)(cell->active_cell_index()) += heat_flux_and_area[cell->active_cell_index()][f].first /
-                        heat_flux_and_area[cell->active_cell_index()][f].second;
+                                                                         heat_flux_and_area[cell->active_cell_index()][f].second;
                   }
             }
 

--- a/source/postprocess/visualization/heat_flux_map.cc
+++ b/source/postprocess/visualization/heat_flux_map.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/postprocess/visualization/heat_flux_map.h>
+#include <aspect/postprocess/heat_flux_map.h>
 #include <aspect/geometry_model/interface.h>
 
 #include <deal.II/base/quadrature_lib.h>
@@ -40,21 +41,8 @@ namespace aspect
         return_value ("heat_flux_map",
                       new Vector<float>(this->get_triangulation().n_active_cells()));
 
-        // create a quadrature formula based on the temperature element alone.
-        const QGauss<dim-1> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.temperature).degree+1);
-
-        FEFaceValues<dim> fe_face_values (this->get_mapping(),
-                                          this->get_fe(),
-                                          quadrature_formula,
-                                          update_gradients      | update_values |
-                                          update_normal_vectors |
-                                          update_q_points       | update_JxW_values);
-
-        typename MaterialModel::Interface<dim>::MaterialModelInputs in(fe_face_values.n_quadrature_points, this->n_compositional_fields());
-        typename MaterialModel::Interface<dim>::MaterialModelOutputs out(fe_face_values.n_quadrature_points, this->n_compositional_fields());
-
-        std::vector<Tensor<1,dim> > temperature_gradients (quadrature_formula.size());
-        std::vector<std::vector<double> > composition_values (this->n_compositional_fields(),std::vector<double> (quadrature_formula.size()));
+        std::vector<std::vector<std::pair<double, double> > > heat_flux_and_area =
+          internal::compute_heat_flux_through_boundary_faces (*this);
 
         // loop over all of the surface cells and evaluate the heatflux
         typename DoFHandler<dim>::active_cell_iterator
@@ -71,36 +59,9 @@ namespace aspect
                     (this->get_geometry_model().translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "top" ||
                      this->get_geometry_model().translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "bottom"))
                   {
-                    double normal_flux = 0;
-                    double face_area = 0;
-
-                    fe_face_values.reinit (cell, f);
-
-                    // Temperature gradients needed for heat flux.
-                    fe_face_values[this->introspection().extractors.temperature].get_function_gradients (this->get_solution(),
-                        temperature_gradients);
-
-                    // Set use_strain_rate to false since we don't need viscosity.
-                    in.reinit(fe_face_values, cell, this->introspection(), this->get_solution(), false);
-                    this->get_material_model().evaluate(in, out);
-
-
-                    // Calculate the normal conductive heat flux given by the formula
-                    //   j = - k * n . grad T
-
-                    for (unsigned int q=0; q<fe_face_values.n_quadrature_points; ++q)
-                      {
-                        const double thermal_conductivity
-                          = out.thermal_conductivities[q];
-
-                        normal_flux += -thermal_conductivity *
-                                       (temperature_gradients[q] * fe_face_values.normal_vector(q)) *
-                                       fe_face_values.JxW(q);
-                        face_area += fe_face_values.JxW(q);
-                      }
-
                     // add heatflow for this face
-                    (*return_value.second)(cell->active_cell_index()) += normal_flux / face_area;
+                    (*return_value.second)(cell->active_cell_index()) += heat_flux_and_area[cell->active_cell_index()][f].first /
+                        heat_flux_and_area[cell->active_cell_index()][f].second;
                   }
             }
 


### PR DESCRIPTION
We currently have 4 postprocessors that do the same computation of the boundary heat flux, just to process the output in slightly different ways. This PR is a refactoring of that code into a helper function, which ensures we always compute the heat flux in the same way. It also modernizes some of the code with new functionality that was not updated in the postprocessors.