### PR TITLE
Fix assert two merged boxes in point_in_domain on free surface.

### DIFF
--- a/source/geometry_model/two_merged_boxes.cc
+++ b/source/geometry_model/two_merged_boxes.cc
@@ -277,8 +277,8 @@ namespace aspect
     bool
     TwoMergedBoxes<dim>::point_is_in_domain(const Point<dim> &point) const
     {
-      AssertThrow(this->get_free_surface_boundary_indicators().size() == 0 ||
-                  this->get_timestep_number() == 0,
+      AssertThrow(this->get_free_surface_boundary_indicators().size() != 0 &&
+                  this->get_timestep_number() != 0,
                   ExcMessage("After displacement of the free surface, this function can no longer be used to determine whether a point lies in the domain or not."));
 
       AssertThrow(dynamic_cast<const InitialTopographyModel::ZeroTopography<dim>*>(&this->get_initial_topography_model()) != nullptr,

--- a/tests/two_merged_boxes_free_surface.prm
+++ b/tests/two_merged_boxes_free_surface.prm
@@ -1,0 +1,89 @@
+set Dimension = 3
+set CFL number                             = 1.0
+set End time                               = 1
+set Start time                             = 0
+set Adiabatic surface temperature          = 0
+set Surface pressure                       = 0
+set Use years in output instead of seconds = false
+set Nonlinear solver scheme                = single Advection, single Stokes
+set Pressure normalization                 = no
+
+
+subsection Boundary temperature model
+  set List of model names = initial temperature
+end
+
+
+
+subsection Gravity model
+  set Model name = vertical
+end
+
+
+subsection Geometry model
+  set Model name = box with lithosphere boundary indicators
+
+  subsection Box with lithosphere boundary indicators
+    set X extent = 1.2
+    set Y extent = 1
+    set Z extent = 1
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 1000
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1250
+    set Reference temperature         = 1
+    set Thermal conductivity          = 1e-6
+    set Thermal expansion coefficient = 2e-5
+    set Viscosity                     = 1
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 1
+  set Initial global refinement          = 2
+end
+
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = 0, 1
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 0,1,2,3,6,7,8,9
+end
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators       = 4
+end
+
+subsection Free surface
+  set Free surface boundary indicators = 5
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization
+  subsection Visualization
+    set List of output variables = depth
+    set Output format = gnuplot
+  end
+end
+

--- a/tests/two_merged_boxes_free_surface/screen-output
+++ b/tests/two_merged_boxes_free_surface/screen-output
@@ -1,0 +1,45 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 128 (on 3 levels)
+Number of degrees of freedom: 5,733 (4,131+225+1,377)
+
+Number of free surface degrees of freedom: 675
+*** Timestep 0:  t=0 seconds
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 63+0 iterations.
+
+Number of active cells: 16 (on 2 levels)
+Number of degrees of freedom: 945 (675+45+225)
+
+Number of free surface degrees of freedom: 135
+*** Timestep 0:  t=0 seconds
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 2+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-two_merged_boxes_free_surface/solution/solution-00000
+
+*** Timestep 1:  t=1 seconds
+   Solving mesh velocity system... 1 iterations.
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 10+0 iterations.
+
+   Postprocessing:
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------


### PR DESCRIPTION
When running a model with this geometry model and a free surface the assert was triggered before the first timestep, which is not consistent with the assert message. I think this should fix it. @anne-glerum Could you look at this?