### PR TITLE
Fix input check for bound preserving limiter option

### DIFF
--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1480,8 +1480,7 @@ namespace aspect
 
       // global_composition_max_preset.size() and global_composition_min_preset.size() are obtained early than
       // n_compositional_fields. Therefore, we can only check if their sizes are the same here.
-      if (use_limiter_for_discontinuous_temperature_solution
-          || use_limiter_for_discontinuous_composition_solution)
+      if (use_limiter_for_discontinuous_composition_solution)
         AssertThrow ((global_composition_max_preset.size() == (n_compositional_fields)
                       && global_composition_min_preset.size() == (n_compositional_fields)),
                      ExcMessage ("The number of multiple 'Global composition maximum' values "


### PR DESCRIPTION
It makes no sense to check for the correct length of the `global_composition_max_preset` variable if only the temperature limiter is selected. The check is only relevant if the composition limiter is selected.