### PR TITLE
Fix bound preserving limiter in 3d

### DIFF
--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1452,19 +1452,19 @@ namespace aspect
                 if (std::abs(max_solution_local-local_solution_average) > std::numeric_limits<double>::min())
                   {
                     theta = std::min(theta, (max_solution_exact_global-local_solution_average)
-                                                     / (max_solution_local-local_solution_average));
+                                     / (max_solution_local-local_solution_average));
                   }
                 if (std::abs(min_solution_local-local_solution_average) > std::numeric_limits<double>::min())
                   {
                     theta = std::min(theta, (min_solution_exact_global-local_solution_average)
-                                                     / (min_solution_local-local_solution_average));
+                                     / (min_solution_local-local_solution_average));
                   }
 
                 AssertThrow(theta>=0.0,ExcMessage("The bound preserving factor is smaller than zero. "
-                    "This should not happen, please contact the developers. "
-                    "Minimum solution in cell is: " + Utilities::to_string(min_solution_local) +
-                    ". Maximum solution in cell is: " + Utilities::to_string(max_solution_local) +
-                    ". Average solution in cell is: " + Utilities::to_string(local_solution_average)));
+                                                  "This should not happen, please contact the developers. "
+                                                  "Minimum solution in cell is: " + Utilities::to_string(min_solution_local) +
+                                                  ". Maximum solution in cell is: " + Utilities::to_string(max_solution_local) +
+                                                  ". Average solution in cell is: " + Utilities::to_string(local_solution_average)));
 
 
                 /* Modify the advection degrees of freedom of the numerical solution.

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1357,6 +1357,8 @@ namespace aspect
         default:
           Assert (false, ExcNotImplemented());
       }
+
+    Assert (quadrature_points.size() == n_q_points, ExcInternalError());
     Quadrature<dim> quadrature_formula(quadrature_points);
 
     // Quadrature rules only used for the numerical integration for better accuracy
@@ -1440,6 +1442,7 @@ namespace aspect
                     local_solution_average += values_0[q]*fe_values_0.JxW(q);
                   }
                 local_solution_average /= local_area;
+
                 /*
                  * Define theta: a scaling constant used to correct the old solution by the formula
                  *   new_value = theta * (old_value-old_solution_cell_average)+old_solution_cell_average
@@ -1460,12 +1463,12 @@ namespace aspect
                                      / (min_solution_local-local_solution_average));
                   }
 
-                AssertThrow(theta>=0.0,ExcMessage("The bound preserving factor is smaller than zero. "
-                                                  "This should not happen, please contact the developers. "
-                                                  "Minimum solution in cell is: " + Utilities::to_string(min_solution_local) +
-                                                  ". Maximum solution in cell is: " + Utilities::to_string(max_solution_local) +
-                                                  ". Average solution in cell is: " + Utilities::to_string(local_solution_average)));
-
+                Assert(theta >= 0.0,
+                       ExcMessage("The bound preserving factor is smaller than zero. "
+                                  "This should not happen, please contact the developers. "
+                                  "Minimum solution in cell is: " + Utilities::to_string(min_solution_local) +
+                                  ". Maximum solution in cell is: " + Utilities::to_string(max_solution_local) +
+                                  ". Average solution in cell is: " + Utilities::to_string(local_solution_average)));
 
                 /* Modify the advection degrees of freedom of the numerical solution.
                  * Note that we are using DG elements, so every DoF on a locally owned cell is locally owned;

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1277,31 +1277,31 @@ namespace aspect
     const unsigned int n_q_points_2 = quadrature_formula_2.size();
     const unsigned int n_q_points   = dim * n_q_points_2 *std::pow(n_q_points_1, dim-1) ;
 
-    std::vector< Point <dim> > quadrature_points (n_q_points);
+    std::vector< Point <dim> > quadrature_points;
+    quadrature_points.reserve(n_q_points);
 
     switch (dim)
       {
         case 2:
         {
           // append quadrature points combination 12
-          for ( unsigned int i=0; i < n_q_points_1 ; i++)
+          for (unsigned int i=0; i < n_q_points_1 ; ++i)
             {
               const double  x = quadrature_formula_1.point(i)(0);
-              for ( unsigned int j=0; j < n_q_points_2 ; j++)
+              for (unsigned int j=0; j < n_q_points_2 ; ++j)
                 {
-                  const double  y = quadrature_formula_2.point(j)(0);
-                  quadrature_points[i * n_q_points_2+j] = Point<dim>(x,y);
+                  const double y = quadrature_formula_2.point(j)(0);
+                  quadrature_points.push_back(Point<dim>(x,y));
                 }
             }
-          const unsigned int n_q_points_12 = n_q_points_1 * n_q_points_2;
           // append quadrature points combination 21
-          for ( unsigned int i=0; i < n_q_points_2 ; i++)
+          for (unsigned int i=0; i < n_q_points_2 ; ++i)
             {
               const double  x = quadrature_formula_2.point(i)(0);
-              for ( unsigned int j=0; j < n_q_points_1 ; j++)
+              for (unsigned int j=0; j < n_q_points_1 ; ++j)
                 {
-                  const double  y = quadrature_formula_1.point(j)(0);
-                  quadrature_points[n_q_points_12 + i * n_q_points_1+j ] = Point<dim>(x,y);
+                  const double y = quadrature_formula_1.point(j)(0);
+                  quadrature_points.push_back(Point<dim>(x,y));
                 }
             }
           break;
@@ -1310,50 +1310,44 @@ namespace aspect
         case 3:
         {
           // append quadrature points combination 121
-          for ( unsigned int i=0; i < n_q_points_1 ; i++)
+          for ( unsigned int i=0; i < n_q_points_1 ; ++i)
             {
-              const double  x = quadrature_formula_1.point(i)(0);
-              for ( unsigned int j=0; j < n_q_points_2 ; j++)
+              const double x = quadrature_formula_1.point(i)(0);
+              for ( unsigned int j=0; j < n_q_points_2 ; ++j)
                 {
-                  const double  y = quadrature_formula_2.point(j)(0);
-                  for ( unsigned int k=0; k < n_q_points_1 ; k++)
+                  const double y = quadrature_formula_2.point(j)(0);
+                  for ( unsigned int k=0; k < n_q_points_1 ; ++k)
                     {
-                      const unsigned int k_index = i * n_q_points_2 * n_q_points_1 + j * n_q_points_1 + k;
-                      const double  z = quadrature_formula_1.point(k)(0);
-                      quadrature_points[k_index] = Point<dim>(x,y,z);
+                      const double z = quadrature_formula_1.point(k)(0);
+                      quadrature_points.push_back(Point<dim>(x,y,z));
                     }
                 }
             }
-          const unsigned int n_q_points_121 = n_q_points_1 * n_q_points_2 * n_q_points_1;
           // append quadrature points combination 112
-          for ( unsigned int i=0; i < n_q_points_1 ; i++)
+          for (unsigned int i=0; i < n_q_points_1 ; ++i)
             {
-              const double  x = quadrature_formula_1.point(i)(0);
-              for ( unsigned int j=0; j < n_q_points_1 ; j++)
+              const double x = quadrature_formula_1.point(i)(0);
+              for (unsigned int j=0; j < n_q_points_1 ; ++j)
                 {
                   const double y = quadrature_formula_1.point(j)(0);
-                  for ( unsigned int k=0; k < n_q_points_2 ; k++)
+                  for (unsigned int k=0; k < n_q_points_2 ; ++k)
                     {
-                      const unsigned int k_index =
-                        n_q_points_121 + i * n_q_points_1 * n_q_points_2 + j * n_q_points_2 + k;
-                      const double  z = quadrature_formula_2.point(k)(0);
-                      quadrature_points[k_index] = Point<dim>(x,y,z);
+                      const double z = quadrature_formula_2.point(k)(0);
+                      quadrature_points.push_back(Point<dim>(x,y,z));
                     }
                 }
             }
           // append quadrature points combination 211
-          for ( unsigned int i=0; i < n_q_points_2 ; i++)
+          for (unsigned int i=0; i < n_q_points_2 ; ++i)
             {
-              const double  x = quadrature_formula_2.point(i)(0);
-              for ( unsigned int j=0; j < n_q_points_1 ; j++)
+              const double x = quadrature_formula_2.point(i)(0);
+              for ( unsigned int j=0; j < n_q_points_1 ; ++j)
                 {
-                  const double  y = quadrature_formula_1.point(j)(0);
-                  for ( unsigned int k=0; k < n_q_points_1 ; k++)
+                  const double y = quadrature_formula_1.point(j)(0);
+                  for ( unsigned int k=0; k < n_q_points_1 ; ++k)
                     {
-                      const unsigned int k_index =
-                        2 * n_q_points_121 + i * n_q_points_1 * n_q_points_1 + j * n_q_points_1 + k;
-                      const double  z = quadrature_formula_1.point(k)(0);
-                      quadrature_points[k_index] = Point<dim>(x,y,z);
+                      const double z = quadrature_formula_1.point(k)(0);
+                      quadrature_points.push_back(Point<dim>(x,y,z));
                     }
                 }
             }
@@ -1466,11 +1460,11 @@ namespace aspect
                                                      / (min_solution_local-local_solution_average));
                   }
 
-                AssertThrow(theta>0.0,ExcMessage("The bound preserving factor is smaller than zero. "
+                AssertThrow(theta>=0.0,ExcMessage("The bound preserving factor is smaller than zero. "
                     "This should not happen, please contact the developers. "
-                    "Minimum solution in cell is: " + Utilities::int_to_string(min_solution_local) +
-                    ". Maximum solution in cell is: " + Utilities::int_to_string(max_solution_local) +
-                    ". Average solution in cell is: " + Utilities::int_to_string(local_solution_average)));
+                    "Minimum solution in cell is: " + Utilities::to_string(min_solution_local) +
+                    ". Maximum solution in cell is: " + Utilities::to_string(max_solution_local) +
+                    ". Average solution in cell is: " + Utilities::to_string(local_solution_average)));
 
 
                 /* Modify the advection degrees of freedom of the numerical solution.

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1454,21 +1454,14 @@ namespace aspect
                 double theta = 1.0;
                 if (std::abs(max_solution_local-local_solution_average) > std::numeric_limits<double>::min())
                   {
-                    theta = std::min(theta, (max_solution_exact_global-local_solution_average)
-                                     / (max_solution_local-local_solution_average));
+                    theta = std::min(theta, std::abs((max_solution_exact_global-local_solution_average)
+                                                     / (max_solution_local-local_solution_average)));
                   }
                 if (std::abs(min_solution_local-local_solution_average) > std::numeric_limits<double>::min())
                   {
-                    theta = std::min(theta, (min_solution_exact_global-local_solution_average)
-                                     / (min_solution_local-local_solution_average));
+                    theta = std::min(theta, std::abs((min_solution_exact_global-local_solution_average)
+                                                     / (min_solution_local-local_solution_average)));
                   }
-
-                Assert(theta >= 0.0,
-                       ExcMessage("The bound preserving factor is smaller than zero. "
-                                  "This should not happen, please contact the developers. "
-                                  "Minimum solution in cell is: " + Utilities::to_string(min_solution_local) +
-                                  ". Maximum solution in cell is: " + Utilities::to_string(max_solution_local) +
-                                  ". Average solution in cell is: " + Utilities::to_string(local_solution_average)));
 
                 /* Modify the advection degrees of freedom of the numerical solution.
                  * Note that we are using DG elements, so every DoF on a locally owned cell is locally owned;

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1318,7 +1318,7 @@ namespace aspect
                   const double  y = quadrature_formula_2.point(j)(0);
                   for ( unsigned int k=0; k < n_q_points_1 ; k++)
                     {
-                      const unsigned int k_index = i * n_q_points_2 * n_q_points_1 + j * n_q_points_2 + k;
+                      const unsigned int k_index = i * n_q_points_2 * n_q_points_1 + j * n_q_points_1 + k;
                       const double  z = quadrature_formula_1.point(k)(0);
                       quadrature_points[k_index] = Point<dim>(x,y,z);
                     }
@@ -1351,7 +1351,7 @@ namespace aspect
                   for ( unsigned int k=0; k < n_q_points_1 ; k++)
                     {
                       const unsigned int k_index =
-                        2 * n_q_points_121 + i * n_q_points_2 * n_q_points_1 + j * n_q_points_1 + k;
+                        2 * n_q_points_121 + i * n_q_points_1 * n_q_points_1 + j * n_q_points_1 + k;
                       const double  z = quadrature_formula_1.point(k)(0);
                       quadrature_points[k_index] = Point<dim>(x,y,z);
                     }
@@ -1457,19 +1457,26 @@ namespace aspect
                 double theta = 1.0;
                 if (std::abs(max_solution_local-local_solution_average) > std::numeric_limits<double>::min())
                   {
-                    theta = std::min(theta, std::abs((max_solution_exact_global-local_solution_average)
-                                                     / (max_solution_local-local_solution_average)));
+                    theta = std::min(theta, (max_solution_exact_global-local_solution_average)
+                                                     / (max_solution_local-local_solution_average));
                   }
                 if (std::abs(min_solution_local-local_solution_average) > std::numeric_limits<double>::min())
                   {
-                    theta = std::min(theta, std::abs((min_solution_exact_global-local_solution_average)
-                                                     / (min_solution_local-local_solution_average)));
+                    theta = std::min(theta, (min_solution_exact_global-local_solution_average)
+                                                     / (min_solution_local-local_solution_average));
                   }
 
+                AssertThrow(theta>0.0,ExcMessage("The bound preserving factor is smaller than zero. "
+                    "This should not happen, please contact the developers. "
+                    "Minimum solution in cell is: " + Utilities::int_to_string(min_solution_local) +
+                    ". Maximum solution in cell is: " + Utilities::int_to_string(max_solution_local) +
+                    ". Average solution in cell is: " + Utilities::int_to_string(local_solution_average)));
+
+
                 /* Modify the advection degrees of freedom of the numerical solution.
-                 * note that we are using DG elements, so every DoF on a locally owned cell is locally owned;
+                 * Note that we are using DG elements, so every DoF on a locally owned cell is locally owned;
                  * this means that we do not need to check whether the 'distributed_solution' vector actually
-                 *  stores the element we read from/write to here.
+                 * stores the element we read from/write to here.
                  */
                 for (unsigned int j = 0;
                      j < finite_element.base_element(advection_field.base_element(introspection)).dofs_per_cell;


### PR DESCRIPTION
I think there were indexing errors in the bound preserving limiter 3D case that could explain why @maxrudolph sees values outside of the bounds of the limiter in his models. The first commit fixes the indexing errors. The second and third commit of this PR simply refactor the code to avoid the index computation altogether and prevent future mistakes.

I tried to create a testcase, but could not find a model where the bound preserving limiter is actually needed. @egpuckett or @yinghe616 do you maybe have testcases that test the bound preserving limiter?