### PR TITLE
design a structure for interpolating material model outputs onto comp…

### DIFF
--- a/doc/modules/changes/20181001_jdannberg
+++ b/doc/modules/changes/20181001_jdannberg
@@ -1,0 +1,8 @@
+New: Compositional fields can now be prescribed to a value that is 
+computed in the material model as an additional output at every time 
+step and then interpolated and copied into the solution vector (as 
+opposed to advecting the compositional field). This option can be 
+used by selecting the 'prescribed field' compositional field method 
+in the input file.
+<br>
+(Juliane Dannberg, 2018/10/01)

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -798,6 +798,35 @@ namespace aspect
 
 
     /**
+     * Additional output fields for prescribed field outputs to be added to
+     * the MaterialModel::MaterialModelOutputs structure and filled in the
+     * MaterialModel::Interface::evaluate() function.
+     *
+     * If the advection scheme "prescribed field" is selected, then these
+     * material model outputs will be interpolated onto the corresponding
+     * compositional field.
+     */
+    template <int dim>
+    class PrescribedFieldOutputs : public NamedAdditionalMaterialOutputs<dim>
+    {
+      public:
+        PrescribedFieldOutputs (const unsigned int n_points,
+                                const unsigned int n_comp);
+
+        virtual std::vector<double> get_nth_output(const unsigned int idx) const;
+
+        /**
+         * Prescribed field outputs for all compositional fields at the evaluation points
+         * that are passed to the instance of MaterialModel::Interface::evaluate()
+         * that fills the current object.
+         * copy_properties[q][c] is the prescribed field output at the evaluation point q
+         * for the compositional field with the index c.
+         */
+        std::vector<std::vector<double> > copy_properties;
+    };
+
+
+    /**
      * A class for additional output fields to be added to the RHS of the
      * Stokes system, which can be attached to the
      * MaterialModel::MaterialModelOutputs structure and filled in the

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -822,7 +822,7 @@ namespace aspect
          * copy_properties[q][c] is the prescribed field output at the evaluation point q
          * for the compositional field with the index c.
          */
-        std::vector<std::vector<double> > copy_properties;
+        std::vector<std::vector<double> > prescribed_field_outputs;
     };
 
 

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -805,6 +805,11 @@ namespace aspect
      * If the advection scheme "prescribed field" is selected, then these
      * material model outputs will be interpolated onto the corresponding
      * compositional field.
+     *
+     * However, note that this structure always has as many prescribed field
+     * outputs as there are compositional fields, even if not all of them
+     * are using the "prescribed field" method. It is the responsibility
+     * of the individual material models to fill the correct entries.
      */
     template <int dim>
     class PrescribedFieldOutputs : public NamedAdditionalMaterialOutputs<dim>

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -819,7 +819,7 @@ namespace aspect
          * Prescribed field outputs for all compositional fields at the evaluation points
          * that are passed to the instance of MaterialModel::Interface::evaluate()
          * that fills the current object.
-         * copy_properties[q][c] is the prescribed field output at the evaluation point q
+         * prescribed_field_outputs[q][c] is the prescribed field output at the evaluation point q
          * for the compositional field with the index c.
          */
         std::vector<std::vector<double> > prescribed_field_outputs;

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -107,7 +107,8 @@ namespace aspect
         fem_field,
         particles,
         static_field,
-        fem_melt_field
+        fem_melt_field,
+        prescribed_field
       };
     };
 

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1161,7 +1161,7 @@ namespace aspect
        * This function is implemented in
        * <code>source/simulator/helper_functions.cc</code>.
        */
-      void interpolate_material_output_into_field ();
+      void interpolate_material_output_into_fields ();
 
 
       /**

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1149,6 +1149,22 @@ namespace aspect
 
 
       /**
+       * Interpolate material model outputs onto compositional fields in case the
+       * 'prescribed field' compositional field method is used. For every field that
+       * uses this method, this function interpolates additional material model outputs
+       * called 'PrescribedFieldOutputs' and copies these values into the solution vector.
+       *
+       * This function also updates the old solution vectors with these interpolated
+       * values so that this compositional field method can be combined with time-dependent
+       * problems like advection or diffusion of the field.
+       *
+       * This function is implemented in
+       * <code>source/simulator/helper_functions.cc</code>.
+       */
+      void interpolate_material_output_into_field ();
+
+
+      /**
        * Interpolate the given function onto the velocity FE space and write
        * it into the given vector.
        *

--- a/include/aspect/simulator/assemblers/advection.h
+++ b/include/aspect/simulator/assemblers/advection.h
@@ -48,6 +48,8 @@ namespace aspect
         compute_residual(internal::Assembly::Scratch::ScratchBase<dim>  &scratch) const;
     };
 
+
+
     /**
      * This class assembles the face terms for the right-hand-side of the
      * advection equation for a face at the boundary of the domain where

--- a/include/aspect/simulator/assemblers/advection.h
+++ b/include/aspect/simulator/assemblers/advection.h
@@ -48,8 +48,6 @@ namespace aspect
         compute_residual(internal::Assembly::Scratch::ScratchBase<dim>  &scratch) const;
     };
 
-
-
     /**
      * This class assembles the face terms for the right-hand-side of the
      * advection equation for a face at the boundary of the domain where

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -854,6 +854,15 @@ namespace aspect
 
         return names;
       }
+
+
+      std::vector<std::string> make_prescribed_field_output_names(const unsigned int n_comp)
+      {
+        std::vector<std::string> names;
+        for (unsigned int c=0; c<n_comp; ++c)
+          names.push_back("prescribed_field_output_C" + Utilities::int_to_string(c));
+        return names;
+      }
     }
 
 
@@ -881,6 +890,32 @@ namespace aspect
         cth_reaction_rates[q] = reaction_rates[q][idx];
 
       return cth_reaction_rates;
+    }
+
+
+
+    template<int dim>
+    PrescribedFieldOutputs<dim>::PrescribedFieldOutputs (const unsigned int n_points,
+                                                         const unsigned int n_comp)
+      :
+      NamedAdditionalMaterialOutputs<dim>(make_prescribed_field_output_names(n_comp)),
+      copy_properties(n_points, std::vector<double>(n_comp, std::numeric_limits<double>::quiet_NaN()))
+    {}
+
+
+
+    template<int dim>
+    std::vector<double>
+    PrescribedFieldOutputs<dim>::get_nth_output(const unsigned int idx) const
+    {
+      // we have to extract the prescribed field outputs for one particular compositional
+      // field, but the vector in the material model outputs is sorted so that the
+      // number of evaluation points (and not the compositional fields) is the outer
+      // vector
+      std::vector<double> prescribed_field_outputs(copy_properties.size());
+      for (unsigned int q=0; q<copy_properties.size(); ++q)
+        prescribed_field_outputs[q] = copy_properties[q][idx];
+      return prescribed_field_outputs;
     }
   }
 }
@@ -945,6 +980,8 @@ namespace aspect
   template class SeismicAdditionalOutputs<dim>; \
   \
   template class ReactionRateOutputs<dim>; \
+  \
+  template class PrescribedFieldOutputs<dim>; \
   \
   namespace MaterialAveraging \
   { \

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -856,6 +856,7 @@ namespace aspect
       }
 
 
+
       std::vector<std::string> make_prescribed_field_output_names(const unsigned int n_comp)
       {
         std::vector<std::string> names;
@@ -899,7 +900,7 @@ namespace aspect
                                                          const unsigned int n_comp)
       :
       NamedAdditionalMaterialOutputs<dim>(make_prescribed_field_output_names(n_comp)),
-      copy_properties(n_points, std::vector<double>(n_comp, std::numeric_limits<double>::quiet_NaN()))
+      prescribed_field_outputs(n_points, std::vector<double>(n_comp, std::numeric_limits<double>::quiet_NaN()))
     {}
 
 
@@ -912,10 +913,10 @@ namespace aspect
       // field, but the vector in the material model outputs is sorted so that the
       // number of evaluation points (and not the compositional fields) is the outer
       // vector
-      std::vector<double> prescribed_field_outputs(copy_properties.size());
-      for (unsigned int q=0; q<copy_properties.size(); ++q)
-        prescribed_field_outputs[q] = copy_properties[q][idx];
-      return prescribed_field_outputs;
+      std::vector<double> nth_prescribed_field_output(prescribed_field_outputs.size());
+      for (unsigned int q=0; q<prescribed_field_outputs.size(); ++q)
+        nth_prescribed_field_output[q] = prescribed_field_outputs[q][idx];
+      return nth_prescribed_field_output;
     }
   }
 }

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1726,6 +1726,93 @@ namespace aspect
 
 
   template <int dim>
+  void Simulator<dim>::interpolate_material_output_into_field ()
+  {
+    // we need some temporary vectors to store our updates to composition in
+    // before we copy them over to the solution vector in the end
+    LinearAlgebra::BlockVector distributed_vector (introspection.index_sets.system_partitioning,
+                                                   mpi_communicator);
+
+    pcout << "   Copying material properties into prescribed compositional fields."
+          << std::endl;
+
+    // make an fevalues object that allows us to interpolate onto the solution vector
+    const Quadrature<dim> quadrature(dof_handler.get_fe().base_element(introspection.base_elements.compositional_fields).get_unit_support_points());
+
+    FEValues<dim> fe_values (*mapping,
+                             dof_handler.get_fe(),
+                             quadrature,
+                             update_quadrature_points | update_values | update_gradients);
+
+    std::vector<types::global_dof_index> local_dof_indices (dof_handler.get_fe().dofs_per_cell);
+    MaterialModel::MaterialModelInputs<dim> in(quadrature.size(), introspection.n_compositional_fields);
+    MaterialModel::MaterialModelOutputs<dim> out(quadrature.size(), introspection.n_compositional_fields);
+
+    // add the prescribed field outputs that will be used for interpolating
+    material_model->create_additional_named_outputs(out);
+
+    MaterialModel::PrescribedFieldOutputs<dim> *prescribed_field_outputs
+      = out.template get_additional_output<MaterialModel::PrescribedFieldOutputs<dim> >();
+
+    // check if the material model computes prescribed field outputs
+    AssertThrow(prescribed_field_outputs != NULL,
+                ExcMessage("You are trying to use the a prescribed advection field, "
+                           "but the material model you use does not support interpolating material properties "
+                           "(it does not create PrescribedFieldOutputs, which are required for this "
+                           "advection field type)."));
+
+    // Make a loop first over all cells, and then over all degrees of freedom in each element
+    // to interpolate material properties onto a solution vector.
+
+    // Note that the values for some degrees of freedom are set more than once in the loop
+    // below where we assign the new values to distributed_vector (if they are located on the
+    // interface between cells), as we loop over all cells, and then over all degrees of freedom
+    // on each cell. But even though we touch some DoF twice, we always compute the same value,
+    // and then overwrite the same value in distributed_vector.
+    typename DoFHandler<dim>::active_cell_iterator cell = dof_handler.begin_active(),
+                                                   endc = dof_handler.end();
+    for (; cell!=endc; ++cell)
+      if (cell->is_locally_owned())
+        {
+          fe_values.reinit (cell);
+          cell->get_dof_indices (local_dof_indices);
+          in.reinit(fe_values, cell, introspection, solution);
+
+          material_model->evaluate(in, out);
+
+          // interpolate material properties onto the compositional fields
+          for (unsigned int j=0; j<dof_handler.get_fe().base_element(introspection.base_elements.compositional_fields).dofs_per_cell; ++j)
+            for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
+              if (parameters.compositional_field_methods[c] == Parameters<dim>::AdvectionFieldMethod::prescribed_field)
+                {
+                  const unsigned int composition_idx
+                    = dof_handler.get_fe().component_to_system_index(introspection.component_indices.compositional_fields[c],
+                                                                     /*dof index within component=*/ j);
+
+                  // skip entries that are not locally owned:
+                  if (dof_handler.locally_owned_dofs().is_element(local_dof_indices[composition_idx]))
+                    {
+                      distributed_vector(local_dof_indices[composition_idx]) = prescribed_field_outputs->copy_properties[j][c];;
+                    }
+                }
+        }
+
+    // put the final values into the solution vector
+    for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
+      if (parameters.compositional_field_methods[c] == Parameters<dim>::AdvectionFieldMethod::prescribed_field)
+        {
+          const unsigned int block_c = introspection.block_indices.compositional_fields[c];
+          distributed_vector.block(block_c).compress(VectorOperation::insert);
+          solution.block(block_c) = distributed_vector.block(block_c);
+
+          // We also want to copy the values into the old solution, because it might
+          // be used in other parts of the code
+          old_solution.block(block_c) = distributed_vector.block(block_c);
+        }
+  }
+
+
+  template <int dim>
   void
   Simulator<dim>::check_consistency_of_formulation()
   {
@@ -2178,6 +2265,7 @@ namespace aspect
   template void Simulator<dim>::interpolate_onto_velocity_system(const TensorFunction<1,dim> &func, LinearAlgebra::Vector &vec);\
   template void Simulator<dim>::apply_limiter_to_dg_solutions(const AdvectionField &advection_field); \
   template void Simulator<dim>::compute_reactions(); \
+  template void Simulator<dim>::interpolate_material_output_into_field(); \
   template void Simulator<dim>::check_consistency_of_formulation(); \
   template void Simulator<dim>::check_consistency_of_boundary_conditions() const; \
   template double Simulator<dim>::compute_initial_newton_residual(const LinearAlgebra::BlockVector &linearized_stokes_initial_guess); \

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1733,7 +1733,7 @@ namespace aspect
     LinearAlgebra::BlockVector distributed_vector (introspection.index_sets.system_partitioning,
                                                    mpi_communicator);
 
-    pcout << "   Copying material properties into prescribed compositional fields."
+    pcout << "   Copying properties into prescribed compositional fields."
           << std::endl;
 
     // make an fevalues object that allows us to interpolate onto the solution vector
@@ -1751,13 +1751,13 @@ namespace aspect
     // add the prescribed field outputs that will be used for interpolating
     material_model->create_additional_named_outputs(out);
 
-    MaterialModel::PrescribedFieldOutputs<dim> *prescribed_field_outputs
+    MaterialModel::PrescribedFieldOutputs<dim> *prescribed_field_out
       = out.template get_additional_output<MaterialModel::PrescribedFieldOutputs<dim> >();
 
     // check if the material model computes prescribed field outputs
-    AssertThrow(prescribed_field_outputs != NULL,
+    AssertThrow(prescribed_field_out != NULL,
                 ExcMessage("You are trying to use the a prescribed advection field, "
-                           "but the material model you use does not support interpolating material properties "
+                           "but the material model you use does not support interpolating properties "
                            "(it does not create PrescribedFieldOutputs, which are required for this "
                            "advection field type)."));
 
@@ -1792,7 +1792,7 @@ namespace aspect
                   // skip entries that are not locally owned:
                   if (dof_handler.locally_owned_dofs().is_element(local_dof_indices[composition_idx]))
                     {
-                      distributed_vector(local_dof_indices[composition_idx]) = prescribed_field_outputs->copy_properties[j][c];;
+                      distributed_vector(local_dof_indices[composition_idx]) = prescribed_field_out->prescribed_field_outputs[j][c];;
                     }
                 }
         }

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1763,7 +1763,7 @@ namespace aspect
 
     // check if the material model computes prescribed field outputs
     AssertThrow(prescribed_field_out != NULL,
-                ExcMessage("You are trying to use the a prescribed advection field, "
+                ExcMessage("You are trying to use a prescribed advection field, "
                            "but the material model you use does not support interpolating properties "
                            "(it does not create PrescribedFieldOutputs, which is required for this "
                            "advection field type)."));
@@ -1799,6 +1799,11 @@ namespace aspect
                   // skip entries that are not locally owned:
                   if (dof_handler.locally_owned_dofs().is_element(local_dof_indices[composition_idx]))
                     {
+                      Assert(numbers::is_finite(prescribed_field_out->prescribed_field_outputs[j][c]),
+                             ExcMessage("You are trying to use a prescribed advection field, "
+                                        "but the material model you use does not fill the PrescribedFieldOutputs "
+                                        "for your prescribed field, which is required for this method."));
+
                       distributed_vector(local_dof_indices[composition_idx]) = prescribed_field_out->prescribed_field_outputs[j][c];
                     }
                 }

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -965,7 +965,7 @@ namespace aspect
                          Patterns::List(Patterns::Anything()),
                          "A user-defined name for each of the compositional fields requested.");
       prm.declare_entry ("Compositional field methods", "",
-                         Patterns::List (Patterns::Selection("field|particles|static|melt field")),
+                         Patterns::List (Patterns::Selection("field|particles|static|melt field|prescribed field")),
                          "A comma separated list denoting the solution method of each "
                          "compositional field. Each entry of the list must be "
                          "one of the currently implemented field types: "
@@ -1004,6 +1004,12 @@ namespace aspect
                          "advected with the melt velocity instead of the solid velocity. "
                          "This method can only be chosen if melt transport is active in the "
                          "model."
+                         "\n"
+                         "\\item ``prescribed field'': If a compositional field is marked "
+                         "with this method, then the value of a specific additional material "
+                         "model output, called the `PrescribedFieldOutputs' is interpolated "
+                         "onto the field. This field does not change otherwise, it is not "
+                         "advected with the flow."
                          "\\end{itemize}");
       prm.declare_entry ("Mapped particle properties", "",
                          Patterns::Map (Patterns::Anything(),
@@ -1522,6 +1528,8 @@ namespace aspect
             compositional_field_methods[i] = AdvectionFieldMethod::static_field;
           else if (x_compositional_field_methods[i] == "melt field")
             compositional_field_methods[i] = AdvectionFieldMethod::fem_melt_field;
+          else if (x_compositional_field_methods[i] == "prescribed field")
+            compositional_field_methods[i] = AdvectionFieldMethod::prescribed_field;
           else
             AssertThrow(false,ExcNotImplemented());
         }

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1005,8 +1005,9 @@ namespace aspect
                          "This method can only be chosen if melt transport is active in the "
                          "model."
                          "\n"
-                         "\\item ``prescribed field'': If a compositional field is marked "
-                         "with this method, then the value of a specific additional material "
+                         "\\item ``prescribed field'': The value of these fields is determined "
+                         "in each time step from the material model. If a compositional field is "
+                         "marked with this method, then the value of a specific additional material "
                          "model output, called the `PrescribedFieldOutputs' is interpolated "
                          "onto the field. This field does not change otherwise, it is not "
                          "advected with the flow."
@@ -1539,6 +1540,12 @@ namespace aspect
         AssertThrow (this->include_melt_transport,
                      ExcMessage ("The advection method 'melt field' can only be selected if melt "
                                  "transport is used in the simulation."));
+
+      if (std::find(compositional_field_methods.begin(), compositional_field_methods.end(), AdvectionFieldMethod::prescribed_field)
+          != compositional_field_methods.end())
+        AssertThrow (!this->use_discontinuous_composition_discretization,
+                     ExcMessage ("The advection method 'prescribed field' has not yet been tested with "
+                                 "a discontinuous composition discretization."));
 
       const std::vector<std::string> x_mapped_particle_properties
         = Utilities::split_string_list

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -215,13 +215,8 @@ namespace aspect
           }
       }
 
-    // Update the copy fields *after* we have solved all the other fields
-    for (unsigned int c=0; c < introspection.n_compositional_fields; ++c)
-      {
-        const AdvectionField adv_field (AdvectionField::composition(c));
-        if (adv_field.advection_method(introspection) == Parameters<dim>::AdvectionFieldMethod::prescribed_field)
-          interpolate_material_output_into_field();
-      }
+    // Update the prescribed fields *after* we have solved all the other fields
+    interpolate_material_output_into_fields();
 
     // for consistency we update the current linearization point only after we have solved
     // all fields, so that we use the same point in time for every field when solving

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -198,6 +198,7 @@ namespace aspect
               break;
 
             case Parameters<dim>::AdvectionFieldMethod::static_field:
+            case Parameters<dim>::AdvectionFieldMethod::prescribed_field:
             {
               // Do nothing here, but at least call the signal in case the
               // user wants to do something with the variable:
@@ -212,6 +213,14 @@ namespace aspect
             default:
               AssertThrow(false,ExcNotImplemented());
           }
+      }
+
+    // Update the copy fields *after* we have solved all the other fields
+    for (unsigned int c=0; c < introspection.n_compositional_fields; ++c)
+      {
+        const AdvectionField adv_field (AdvectionField::composition(c));
+        if (adv_field.advection_method(introspection) == Parameters<dim>::AdvectionFieldMethod::prescribed_field)
+          interpolate_material_output_into_field();
       }
 
     // for consistency we update the current linearization point only after we have solved

--- a/tests/prescribed_field.cc
+++ b/tests/prescribed_field.cc
@@ -1,0 +1,73 @@
+#include <aspect/material_model/simple.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    using namespace dealii;
+
+    template <int dim>
+    class PrescribedFieldMaterial : public MaterialModel::Simple<dim>
+    {
+      public:
+
+        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                              MaterialModel::MaterialModelOutputs<dim> &out) const;
+
+        virtual
+        void
+        create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const;
+    };
+
+  }
+}
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+
+    template <int dim>
+    void
+    PrescribedFieldMaterial<dim>::
+    evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+             MaterialModel::MaterialModelOutputs<dim> &out) const
+    {
+      Simple<dim>::evaluate(in, out);
+
+      // set up variable to copy outputs
+      PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim> >();
+
+      if (prescribed_field_out != NULL)
+        for (unsigned int i=0; i < in.position.size(); ++i)
+          prescribed_field_out->copy_properties[i][1] = out.densities[i];
+    }
+
+
+    template <int dim>
+    void
+    PrescribedFieldMaterial<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
+    {
+      if (out.template get_additional_output<PrescribedFieldOutputs<dim> >() == NULL)
+        {
+          const unsigned int n_points = out.viscosities.size();
+          out.additional_outputs.push_back(
+            std::shared_ptr<MaterialModel::AdditionalMaterialOutputs<dim> >
+            (new MaterialModel::PrescribedFieldOutputs<dim> (n_points, this->n_compositional_fields())));
+        }
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    ASPECT_REGISTER_MATERIAL_MODEL(PrescribedFieldMaterial,
+                                   "prescribed field material",
+                                   "A simple material model that is like the "
+                                   "'Simple' model, but creates prescribed field outputs.")
+  }
+}

--- a/tests/prescribed_field.cc
+++ b/tests/prescribed_field.cc
@@ -36,12 +36,12 @@ namespace aspect
     {
       Simple<dim>::evaluate(in, out);
 
-      // set up variable to copy outputs
+      // set up variable to interpolate prescribed field outputs onto compositional fields
       PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim> >();
 
       if (prescribed_field_out != NULL)
         for (unsigned int i=0; i < in.position.size(); ++i)
-          prescribed_field_out->copy_properties[i][1] = out.densities[i];
+          prescribed_field_out->prescribed_field_outputs[i][1] = out.densities[i];
     }
 
 

--- a/tests/prescribed_field.prm
+++ b/tests/prescribed_field.prm
@@ -1,0 +1,103 @@
+# A testcase that demonstrates that interpolating material model
+# outputs into compositional fields works.
+#
+# The density is chosen as rho = 1 + 0.1*sin(2*pi*x)*sin(2*pi*y) 
+# and is copied into the compositional field 'prescribed field', 
+# so the minimum and maximum composition should be 0.9 at 1.1, 
+# respecively.
+# The test also contains another compositional field that does
+# not use this method, so it should remain zero everywhere
+# (which is what the initial condition is).
+
+set Dimension = 2
+set End time                               = 0
+set Start time                             = 0
+set Adiabatic surface temperature          = 0
+set Surface pressure                       = 0
+set Use years in output instead of seconds = false
+
+subsection Boundary temperature model
+  set List of model names = box
+end
+
+subsection Gravity model
+  set Model name = vertical
+end
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+    set Y extent = 1
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 2
+  set Names of fields  = normal_field, prescribed_field
+  set Compositional field methods = field, prescribed field
+end
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 0.1 * sin(2*3.1416*x) * sin(2*3.1416*y)
+  end
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Function expression = 0.0; 0.0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 1.0
+  end
+end
+
+
+subsection Material model
+  set Model name = prescribed field material
+
+  subsection Simple model
+    set Reference density             = 1    # default: 3300
+    set Reference specific heat       = 1250
+    set Reference temperature         = 0    # default: 293
+    set Thermal conductivity          = 1e-6 # default: 4.7
+    set Thermal expansion coefficient = 1
+    set Viscosity                     = 1    # default: 5e24
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 4
+end
+
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 0, 1, 2, 3
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, composition statistics
+
+  subsection Visualization
+
+    set List of output variables      = density
+    set Number of grouped files       = 0
+    set Output format                 = vtu
+    set Time between graphical output = 0                                                                                # default: 1e8
+  end
+end

--- a/tests/prescribed_field/screen-output
+++ b/tests/prescribed_field/screen-output
@@ -1,0 +1,30 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libprescribed_field.so>
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Skipping normal_field composition solve because RHS is zero.
+   Copying material properties into prescribed compositional fields.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 33+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-prescribed_field/solution/solution-00000
+     Compositions min/max/mass: 0/0/0 // 0.9/1.1/1
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/prescribed_field/screen-output
+++ b/tests/prescribed_field/screen-output
@@ -1,17 +1,13 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 
 Loading shared library <./libprescribed_field.so>
 
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
 
 *** Timestep 0:  t=0 seconds
    Solving temperature system... 0 iterations.
    Skipping normal_field composition solve because RHS is zero.
-   Copying material properties into prescribed compositional fields.
+   Copying properties into prescribed compositional fields.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
 
@@ -26,5 +22,3 @@ Termination requested by criterion: end time
 +---------------------------------+-----------+------------+------------+
 +---------------------------------+-----------+------------+------------+
 
------------------------------------------------------------------------------
------------------------------------------------------------------------------

--- a/tests/prescribed_field/statistics
+++ b/tests/prescribed_field/statistics
@@ -1,0 +1,21 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for composition solver 2
+# 11: Iterations for Stokes solver
+# 12: Velocity iterations in Stokes preconditioner
+# 13: Schur complement iterations in Stokes preconditioner
+# 14: Visualization file name
+# 15: Minimal value for composition normal_field
+# 16: Maximal value for composition normal_field
+# 17: Global mass for composition normal_field
+# 18: Minimal value for composition prescribed_field
+# 19: Maximal value for composition prescribed_field
+# 20: Global mass for composition prescribed_field
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 2178 0 0 0 33 34 33 output-prescribed_field/solution/solution-00000 0.00000000e+00 0.00000000e+00 0.00000000e+00 9.00000000e-01 1.10000000e+00 1.00000000e+00 


### PR DESCRIPTION
…ositional fields

This is something I started to work on during the hackathon together with @alarshi because she wanted to copy something from the material model outputs into compositional fields and then solve a diffusion problem for this field, but it turned out that interpolating properties onto compositional fields is also useful for a number of other things. In this case, we wanted to compute something expensive in the material model that will be used in several different places (the equilibrium grain size), so it is convenient to store it in a compositional field so that it can be accessed easily. 

In the future, I see this as a method that could be combined with other compositional field advection/diffusion methods, and it is a first step to getting part of the changes suggested in #2532 back into the main version of ASPECT. 