### PR TITLE
Implement maximum first timestep parameter.

### DIFF
--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -315,6 +315,7 @@ namespace aspect
     double                         CFL_number;
     double                         maximum_time_step;
     double                         maximum_relative_increase_time_step;
+    double                         maximum_first_time_step;
     double                         reaction_time_step;
     unsigned int                   reaction_steps_per_advection_step;
     bool                           use_artificial_viscosity_smoothing;

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -613,6 +613,8 @@ namespace aspect
     // make sure that the timestep doesn't increase too fast
     if (time_step != 0)
       new_time_step = std::min(new_time_step, time_step + time_step * parameters.maximum_relative_increase_time_step);
+    else
+      new_time_step = std::min(new_time_step, parameters.maximum_first_time_step);
 
     new_time_step = termination_manager.check_for_last_time_step(std::min(new_time_step,
                                                                           parameters.maximum_time_step));

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -155,7 +155,7 @@ namespace aspect
                        "``Maximum relative increase in time step''."
                        "The default value is a value so that when converted from years into seconds "
                        "it equals the largest number representable by a floating "
-                       "point number, implying an unlimited time step."
+                       "point number, implying an unlimited time step. "
                        "Units: Years or seconds, depending on the ``Use years "
                        "in output instead of seconds'' parameter.");
 

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -143,6 +143,22 @@ namespace aspect
                        "Units: Years or seconds, depending on the ``Use years "
                        "in output instead of seconds'' parameter.");
 
+    prm.declare_entry ("Maximum first time step",
+                       /* boost::lexical_cast<std::string>(std::numeric_limits<double>::max() /
+                                                           year_in_seconds) = */ "5.69e+300",
+                       Patterns::Double (0),
+                       "Set a maximum time step size for only the first timestep. Generally the time step "
+                       "based on the CFL number should be sufficient, but for complicated models "
+                       "or benchmarking it may be useful to limit the first time step to some value, "
+                       "especially when using the free surface, which needs to settle to prevent "
+                       "instabilities. This should in that case be combined with a value set for "
+                       "``Maximum relative increase in time step''."
+                       "The default value is a value so that when converted from years into seconds "
+                       "it equals the largest number representable by a floating "
+                       "point number, implying an unlimited time step."
+                       "Units: Years or seconds, depending on the ``Use years "
+                       "in output instead of seconds'' parameter.");
+
     prm.declare_entry ("Maximum relative increase in time step", boost::lexical_cast<std::string>(std::numeric_limits<int>::max()),
                        Patterns::Double (0),
                        "Set a percentage with which the the time step is limited to increase. Generally the "
@@ -1096,6 +1112,9 @@ namespace aspect
       maximum_time_step *= year_in_seconds;
 
     maximum_relative_increase_time_step = prm.get_double("Maximum relative increase in time step") * 0.01;
+    maximum_first_time_step = prm.get_double("Maximum first time step");
+    if (convert_to_years == true)
+      maximum_first_time_step *= year_in_seconds;
 
     {
       const std::string solver_scheme = prm.get ("Nonlinear solver scheme");

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -152,7 +152,7 @@ namespace aspect
                        "or benchmarking it may be useful to limit the first time step to some value, "
                        "especially when using the free surface, which needs to settle to prevent "
                        "instabilities. This should in that case be combined with a value set for "
-                       "``Maximum relative increase in time step''."
+                       "``Maximum relative increase in time step''. "
                        "The default value is a value so that when converted from years into seconds "
                        "it equals the largest number representable by a floating "
                        "point number, implying an unlimited time step. "


### PR DESCRIPTION
I noticed that in models with a free surface and open boundaries all around, it can help a lot if the first timestep can be capped manually. I thought it might also be useful to others.