### PR TITLE
Fix multiple additional named outputs postprocessor

### DIFF
--- a/doc/modules/changes/20181004_gassmoeller
+++ b/doc/modules/changes/20181004_gassmoeller
@@ -1,0 +1,5 @@
+Fixed: The 'named additional outputs' postprocessor used to only support
+a single named output from the material model due to an indexing bug. This
+is fixed now.
+<br>
+(Rene Gassmoeller, 2018/10/04)

--- a/source/postprocess/visualization/named_additional_outputs.cc
+++ b/source/postprocess/visualization/named_additional_outputs.cc
@@ -128,6 +128,7 @@ namespace aspect
         this->get_material_model().create_additional_named_outputs(out);
         this->get_material_model().evaluate(in, out);
 
+        unsigned int field_index = 0;
         for (unsigned int k=0; k<out.additional_outputs.size(); ++k)
           {
             const MaterialModel::NamedAdditionalMaterialOutputs<dim> *result
@@ -136,12 +137,12 @@ namespace aspect
             if (result)
               {
                 std::vector<double> outputs(n_quadrature_points);
-                for (unsigned int i=0; i<result->get_names().size(); ++i)
+                for (unsigned int i=0; i<result->get_names().size(); ++i, ++field_index)
                   {
                     outputs = result->get_nth_output(i);
 
                     for (unsigned int q=0; q<n_quadrature_points; ++q)
-                      computed_quantities[q][i] = outputs[q];
+                      computed_quantities[q][field_index] = outputs[q];
                   }
               }
           }


### PR DESCRIPTION
As described in the changelog. This was only a problem if a material model creates multiple named additional outputs and only if this postprocessor is active.