### PR TITLE
update Timo's affiliation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
 	allOf {
             not {branch 'master'}
             not {changeRequest authorEmail: "rene.gassmoeller@mailbox.org"}
-            not {changeRequest authorEmail: "heister@clemson.edu"}
+            not {changeRequest authorEmail: "timo.heister@gmail.com"}
             not {changeRequest authorEmail: "bangerth@colostate.edu"}
             not {changeRequest authorEmail: "judannberg@gmail.com"}
             not {changeRequest authorEmail: "ja3170@columbia.edu"}

--- a/Jenkinsfile.k8s
+++ b/Jenkinsfile.k8s
@@ -36,7 +36,7 @@ pipeline {
         allOf {
           not {branch 'master'}
           not {changeRequest authorEmail: "rene.gassmoeller@mailbox.org"}
-          not {changeRequest authorEmail: "heister@clemson.edu"}
+          not {changeRequest authorEmail: "timo.heister@gmail.com"}
           not {changeRequest authorEmail: "bangerth@colostate.edu"}
           not {changeRequest authorEmail: "judannberg@gmail.com"}
           not {changeRequest authorEmail: "ja3170@columbia.edu"}

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For more information see:
      - Wolfgang Bangerth: bangerth@math.colostate.edu
      - Juliane Dannberg: judannberg@gmail.com
      - Rene Gassmoeller: rene.gassmoeller@mailbox.org
-     - Timo Heister: heister@clemson.edu
+     - Timo Heister: heister@sci.utah.edu
 
  - The following people have significantly contributed and furthered ASPECT's goals and are therefore Principal Developers:
 

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -12791,7 +12791,7 @@ resources:
   \item Rene
     Gassm{\"o}ller: \url{rene.gassmoeller@mailbox.org},
   \item Timo
-    Heister: \url{heister@clemson.edu}.
+    Heister: \url{heister@sci.utah.edu}.
   \end{itemize}
 \end{itemize}
 


### PR DESCRIPTION
The github default email address should be my gmail now.