### PR TITLE
Remove link to legal notice of deal.ii on website

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,19 +236,6 @@
 	    </p>
 
 	  </div>
-
-
-
-	  <div class="well">
-	    <p>
-	      <b>Legal Notice:</b>
-	      Some countries' laws require us to post this
-	      <a href="http://www.dealii.org/blabla.html">legal
-	      notice</a>. Please write to the responsible 
-	      federal judges if you find this silly.
-	    </p>
-
-          </div>
         </div>
 
         <div class="hidden-xs col-sm-3">


### PR DESCRIPTION
I think this was appropriate when our website was still hosted at dealii.org, but now it is outdated (and confusing).