### PR TITLE
Replace aspect-devel references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,7 @@ guide on the process of contributing to an open-source project
 [here](https://opensource.guide/how-to-contribute/).
 
 ## Asking and answering questions about ASPECT
-The ASPECT community maintains an active mailing list hosted by CIG
-[here](https://lists.geodynamics.org/cgi-bin/mailman/listinfo/aspect-devel). The
-mailing list is for questions about ASPECT at all levels.
+For questiontions about ASPECT on all levels, please use the [ASPECT](https://community.geodynamics.org/c/aspect) discussion forum. Archived discussions from the inactive aspect-devel mailing list can be downloaded at [aspect-devel archives](http://lists.geodynamics.org/pipermail/aspect-devel).
 
 ## Bug reports
 It is a great help to the community if you report any bugs that you

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For more information see:
  - The official website at https://aspect.geodynamics.org
  - The current [manual](http://www.math.clemson.edu/~heister/manual.pdf)
  - [How to cite ASPECT](https://aspect.geodynamics.org/cite.html)
- - For questions on the source code of ASPECT, portability, installation, etc., use the [aspect-devel](http://lists.geodynamics.org/cgi-bin/mailman/listinfo/aspect-devel) mailing list. This mailing list is where the ASPECT users and developers all hang out.
+ - For questions on the source code of ASPECT, portability, installation, new or existing features, etc., use the [ASPECT](https://community.geodynamics.org/c/aspect) discussion forum. This forum is where the ASPECT users and developers all hang out. Archived discussions from the inactive aspect-devel mailing list can be downloaded at [aspect-devel archives](http://lists.geodynamics.org/pipermail/aspect-devel).
  - ASPECT is primarily based on the deal.II library. If you have particular questions about deal.II, contact the [deal.II discussion groups](https://www.dealii.org/mail.html).
  - In case of more general questions about mantle convection, you can contact the [CIG mantle convection mailing lists](http://lists.geodynamics.org/cgi-bin/mailman/listinfo/cig-MC).
  - ASPECT is being developed by a large, collaborative, and inclusive community. It is currently maintained by the following people:


### PR DESCRIPTION
@gassmoeller - If we are able to import the aspect-devel archives into discus, then we can remove the aspect-devel references or just update that aspect-devel discussions are archived on the forum.