### PR TITLE
Instantiate additional dislocation viscosities output object

### DIFF
--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -2025,5 +2025,10 @@ namespace aspect
                                    "The importance of grain size to mantle dynamics and "
                                    "seismological observations, Geochem. Geophys. Geosyst., "
                                    "18, 3034–3061, doi:10.1002/2017GC006944.")
+
+#define INSTANTIATE(dim) \
+  template class DislocationViscosityOutputs<dim>;
+
+    ASPECT_INSTANTIATE(INSTANTIATE)
   }
 }


### PR DESCRIPTION
The `DislocationViscosityOutputs` are only implicitly used in the grain size material model, but not explicitly instantiated. This can lead to linker errors if they are used in an external plugin (very rare, but happened to me with clang 6.0).