### PR TITLE
[bugfix] fix restarting melt models

### DIFF
--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -385,10 +385,7 @@ namespace aspect
     // We have to compute the constraints here because the vector that tells
     // us if a cell is a melt cell is not saved between restarts.
     if (parameters.include_melt_transport)
-      {
-        compute_current_constraints ();
-        melt_handler->add_current_constraints (current_constraints);
-      }
+      compute_current_constraints ();
   }
 
 }

--- a/tests/melt_restart.cc
+++ b/tests/melt_restart.cc
@@ -1,0 +1,76 @@
+#include <aspect/simulator.h>
+#include <iostream>
+
+/*
+ * Launch the following function when this plugin is created. Launch ASPECT
+ * twice to test checkpoint/resume and then terminate the outer ASPECT run.
+ */
+int f()
+{
+  std::cout << "* starting from beginning:" << std::endl;
+
+  // call ASPECT with "--" and pipe an existing input file into it.
+  int ret;
+  std::string command;
+
+  command = ("cd output-melt_restart ; "
+             "(cat " ASPECT_SOURCE_DIR "/tests/melt_restart.prm "
+             " ; "
+             " echo 'set Output directory = output1.tmp' "
+             " ; "
+             " rm -rf output1.tmp ; mkdir output1.tmp "
+             ") "
+             "| ../../aspect -- > /dev/null");
+  std::cout << "Executing the following command:\n"
+            << command
+            << std::endl;
+  ret = system (command.c_str());
+  if (ret!=0)
+    std::cout << "system() returned error " << ret << std::endl;
+
+  command = ("cd output-melt_restart ; "
+             " rm -rf output2.tmp ; mkdir output2.tmp ; "
+             " cp output1.tmp/restart* output2.tmp/");
+  std::cout << "Executing the following command:\n"
+            << command
+            << std::endl;
+  ret = system (command.c_str());
+  if (ret!=0)
+    std::cout << "system() returned error " << ret << std::endl;
+
+
+  std::cout << "* now resuming:" << std::endl;
+  command = ("cd output-melt_restart ; "
+             "(cat " ASPECT_SOURCE_DIR "/tests/melt_restart.prm "
+             " ; "
+             " echo 'set Output directory = output2.tmp' "
+             " ; "
+             " echo 'set Resume computation = true' "
+             ") "
+             "| ../../aspect -- > /dev/null");
+  std::cout << "Executing the following command:\n"
+            << command
+            << std::endl;
+  ret = system (command.c_str());
+  if (ret!=0)
+    std::cout << "system() returned error " << ret << std::endl;
+
+  std::cout << "* now comparing:" << std::endl;
+
+  ret = system ("cd output-melt_restart ; "
+                "cp output1.tmp/log.txt log.txt1;"
+                "cp output2.tmp/log.txt log.txt2;"
+                "cp output1.tmp/statistics statistics1;"
+                "cp output2.tmp/statistics statistics2;"
+                "");
+  if (ret!=0)
+    std::cout << "system() returned error " << ret << std::endl;
+
+  // terminate current process:
+  exit (0);
+  return 42;
+}
+
+
+// run this function by initializing a global variable by it
+int i = f();

--- a/tests/melt_restart.prm
+++ b/tests/melt_restart.prm
@@ -1,0 +1,245 @@
+# test checkpoint/resume.
+
+# This test is controlled via the plugin in melt_restart.cc. The plugin will
+# first execute ASPECT with this .prm and write the output into
+# output1.tmp/. This will generate a snapshot that is then resumed from. The
+# output for this second run will be written into output2.tmp/. Finally,
+# output files will be copied into the main output folder for comparison.
+
+# based on global_melt.prm
+
+set Adiabatic surface temperature          = 1600               # default: 0
+set CFL number                             = 1.0
+set Maximum time step                      = 1e6
+set Nonlinear solver scheme                = iterated Advection and Stokes
+set Output directory                       = melt_restart
+set Max nonlinear iterations               = 20
+set Nonlinear solver tolerance             = 1e-5
+
+# The number of space dimensions you want to run this program in.
+set Dimension                              = 2
+
+# The end time of the simulation. Units: years if the 'Use years in output
+# instead of seconds' parameter is set; seconds otherwise.
+# This end time is chosen in such a way that the solitary wave travels
+# approximately 5 times its wavelength during the model time.
+set End time                               = 1e3
+
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+set Resume computation                     = false
+set Start time                             = 0
+
+set Use years in output instead of seconds = true
+
+subsection Discretization
+  set Stokes velocity polynomial degree    = 2
+  set Composition polynomial degree        = 1
+  subsection Stabilization parameters
+    set beta  = 0.2
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 2
+  set Names of fields = porosity, peridotite
+end
+
+
+subsection Boundary temperature model
+  set List of model names = initial temperature
+
+  subsection Initial temperature
+    set Minimal temperature = 293 # default: 6000
+    set Maximal temperature = 3700  # default: 0
+  end
+end
+
+subsection Boundary composition model
+  set List of model names = initial composition
+end
+
+subsection Boundary velocity model
+  subsection Function
+    set Function constants  = b=100000, c=20000
+    set Variable names      = x,y
+    set Function expression = 0.0; -0.024995 + 0.1 * exp(-((x-b)*(x-b)+y*y)/(2*c*c))
+  end
+end
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 8700000
+    set Y extent = 2900000
+#    set X periodic = true
+    set X repetitions = 3
+  end
+
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 9.81
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = adiabatic
+  subsection Adiabatic
+    set Age bottom boundary layer = 5e8
+    set Age top boundary layer    = 3e8
+    set Amplitude                 = 50
+    set Position                  = center
+    set Radius                    = 350000
+
+    subsection Function
+      set Function expression       = 0;0
+    end
+  end
+
+  subsection Harmonic perturbation
+    set Magnitude = 50
+  end
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Function constants  = pi=3.1415926,a = 0.0, b = 2500000, c = 100000, d=1450000
+    set Function expression = a * exp(-((y-b)*(y-b)+(0.2*(x-d))*(0.2*(x-d)))/(2*c*c)); a * exp(-((y-b)*(y-b)+(0.2*(x-d))*(0.2*(x-d)))/(2*c*c))
+    set Variable names      = x,y
+  end
+end
+
+
+subsection Material model
+
+  set Model name = melt global 
+  subsection Melt global
+    set Thermal conductivity              = 4.7
+    set Reference solid density           = 3400
+    set Reference melt density            = 3000
+    set Thermal expansion coefficient     = 2e-5
+    set Reference permeability            = 1e-8
+    set Reference shear viscosity         = 5e21
+    set Reference bulk viscosity          = 1e19
+    set Exponential melt weakening factor = 10
+    set Thermal viscosity exponent        = 7
+    set Thermal bulk viscosity exponent   = 7
+    set Reference temperature             = 1600
+    set Solid compressibility             = 4.2e-12
+    set Melt compressibility              = 1.25e-11
+    set Reference melt viscosity          = 10
+    set Depletion density change          = -200.0 # -100.0 # 0.0
+  end
+end
+
+
+subsection Mesh refinement
+  set Coarsening fraction                      = 0.05
+  set Refinement fraction                      = 0.8
+
+  set Initial adaptive refinement              = 0                    # default: 2
+  set Initial global refinement                = 3                    # default: 2
+  set Strategy                                 = composition threshold, minimum refinement function #, nonadiabatic temperature
+  set Time steps between mesh refinement       = 0
+
+  subsection Minimum refinement function
+    set Coordinate system   = depth
+    set Function expression = if (depth>1500000,5,4)
+    set Variable names      = depth,phi
+  end
+
+  subsection Composition threshold
+    set Compositional field thresholds = 1e-4,1.0
+  end
+end
+
+
+subsection Boundary fluid pressure model
+  set Plugin name = density
+  subsection Density
+    set Density formulation = solid density
+  end
+end
+
+subsection Heating model
+  set List of model names = adiabatic heating #, latent heat melt, shear heating
+end
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = 2,3
+end
+
+subsection Boundary composition model
+  set Fixed composition boundary indicators   = #2,3
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 0,1,2,3
+end
+
+subsection Nullspace removal
+#  set Remove nullspace                        = net x translation
+
+end
+
+subsection Melt settings
+  set Include melt transport                  = true
+end
+
+
+subsection Postprocess
+
+  set List of postprocessors = visualization,composition statistics,velocity statistics, temperature statistics, depth average
+
+  subsection Visualization
+
+    set List of output variables      = material properties, nonadiabatic temperature, melt fraction, strain rate, melt material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity, reaction terms
+    end
+
+    subsection Melt material properties
+      set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
+    end
+
+    set Number of grouped files       = 0
+    set Interpolate output            = false
+    set Output format                 = vtu
+    set Time between graphical output = 0
+    set Interpolate output            = true
+  end
+
+  subsection Depth average
+    set Number of zones = 12
+    set Time between graphical output = 6e5
+  end
+
+end
+
+subsection Checkpointing
+  set Time between checkpoint = 1
+end
+
+
+subsection Solver parameters
+  set Composition solver tolerance = 1e-14
+  set Temperature solver tolerance = 1e-14
+
+  subsection Stokes solver parameters
+    set Linear solver tolerance = 1e-8
+    set Use direct solver for Stokes system = false
+    set Number of cheap Stokes solver steps = 0
+  end
+end

--- a/tests/melt_restart/log.txt1
+++ b/tests/melt_restart/log.txt1
@@ -1,0 +1,154 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.1.0-pre (master, f534df314)
+--     . using deal.II 9.0.0
+--     . using Trilinos 12.10.1
+--     . using p4est 2.0.0
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-- For information on how to cite ASPECT, see:
+--   https://aspect.geodynamics.org/citing.html?ver=2.1.0-pre&melt=1&sha=f534df314&src=code
+-----------------------------------------------------------------------------
+Number of active cells: 192 (on 4 levels)
+Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+11 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.99932e-16, 0, 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
+
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+11 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.17188e-16, 0, 0, 0.799766
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.799766
+
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+11 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.32692e-16, 0, 0, 0.173272
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.173272
+
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+11 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.31357e-16, 0, 0, 0.0272016
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0272016
+
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+10 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.14372e-16, 0, 0, 0.0032544
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.0032544
+
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+7 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.29571e-16, 0, 0, 0.000312907
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000312907
+
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+6 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.21066e-16, 0, 0, 2.51035e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 2.51035e-05
+
+   Solving temperature system... 0 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+4 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.19363e-16, 0, 0, 1.72283e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.72283e-06
+
+
+   Postprocessing:
+     Writing graphical output:  output1.tmp/solution/solution-00000
+     Compositions min/max/mass: 0/0/0 // 0/0/0
+     RMS, max velocity:         0.00109 m/year, 0.00296 m/year
+     Temperature min/avg/max:   293 K, 2023 K, 3700 K
+     Writing depth average:     output1.tmp/depth_average.gnuplot
+
+*** Snapshot created!
+
+*** Timestep 1:  t=1000 years
+   Solving temperature system... 8 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+4 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.93345e-07, 0, 0, 1.07483e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1.07483e-05
+
+   Solving temperature system... 3 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+4 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.02087e-11, 0, 0, 8.57628e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 8.57628e-07
+
+
+   Postprocessing:
+     Writing graphical output:  output1.tmp/solution/solution-00001
+     Compositions min/max/mass: 0/0/0 // 0/0/0
+     RMS, max velocity:         0.00109 m/year, 0.00296 m/year
+     Temperature min/avg/max:   293 K, 2023 K, 3700 K
+
+Termination requested by criterion: end time
+*** Snapshot created!
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      5.77s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |        10 |     0.684s |        12% |
+| Assemble composition system     |        20 |      1.29s |        22% |
+| Assemble temperature system     |        10 |     0.744s |        13% |
+| Build Stokes preconditioner     |        10 |     0.582s |        10% |
+| Build temperature preconditioner|        10 |   0.00718s |      0.12% |
+| Solve Stokes system             |        10 |       1.1s |        19% |
+| Solve temperature system        |        10 |   0.00358s |         0% |
+| Create snapshot                 |         2 |    0.0311s |      0.54% |
+| Initialization                  |         1 |    0.0156s |      0.27% |
+| Postprocessing                  |         2 |      0.75s |        13% |
+| Setup dof systems               |         1 |   0.00911s |      0.16% |
+| Setup initial conditions        |         1 |     0.032s |      0.55% |
++---------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-- For information on how to cite ASPECT, see:
+--   https://aspect.geodynamics.org/citing.html?ver=2.1.0-pre&melt=1&sha=f534df314&src=code
+-----------------------------------------------------------------------------

--- a/tests/melt_restart/log.txt2
+++ b/tests/melt_restart/log.txt2
@@ -1,0 +1,100 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.1.0-pre (master, f534df314)
+--     . using deal.II 9.0.0
+--     . using Trilinos 12.10.1
+--     . using p4est 2.0.0
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-- For information on how to cite ASPECT, see:
+--   https://aspect.geodynamics.org/citing.html?ver=2.1.0-pre&melt=1&sha=f534df314&src=code
+-----------------------------------------------------------------------------
+*** Resuming from snapshot!
+
+Number of active cells: 192 (on 4 levels)
+Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
+
+*** Timestep 2:  t=1.001e+06 years
+   Solving temperature system... 10 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+10 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.96125e-05, 0, 0, 0.018036
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.018036
+
+   Solving temperature system... 8 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+7 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.62333e-06, 0, 0, 0.000847176
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000847176
+
+   Solving temperature system... 7 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+5 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.56731e-07, 0, 0, 4.65358e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 4.65358e-05
+
+   Solving temperature system... 6 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+4 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.43913e-09, 0, 0, 1.06786e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.06786e-05
+
+   Solving temperature system... 4 iterations.
+   Skipping porosity composition solve because RHS is zero.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+4 iterations.
+   Solving for u_f in 1 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.88827e-10, 0, 0, 1.60715e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.60715e-06
+
+
+   Postprocessing:
+     Writing graphical output:  output2.tmp/solution/solution-00002
+     Compositions min/max/mass: 0/0/0 // 0/0/0
+     RMS, max velocity:         0.00111 m/year, 0.00303 m/year
+     Temperature min/avg/max:   293 K, 2023 K, 3700 K
+     Writing depth average:     output2.tmp/depth_average.gnuplot
+
+Termination requested by criterion: end time
+*** Snapshot created!
+
+
+
++---------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start    |      8.53s |            |
+|                                             |            |            |
+| Section                         | no. calls |  wall time | % of total |
++---------------------------------+-----------+------------+------------+
+| Assemble Stokes system          |         5 |     0.897s |        11% |
+| Assemble composition system     |        10 |      2.28s |        27% |
+| Assemble temperature system     |         5 |      1.21s |        14% |
+| Build Stokes preconditioner     |         5 |      0.71s |       8.3% |
+| Build temperature preconditioner|         5 |   0.00357s |         0% |
+| Solve Stokes system             |         5 |       1.8s |        21% |
+| Solve temperature system        |         5 |   0.00341s |         0% |
+| Create snapshot                 |         1 |     0.022s |      0.26% |
+| Initialization                  |         1 |     0.018s |      0.21% |
+| Postprocessing                  |         1 |     0.868s |        10% |
+| Setup dof systems               |         1 |   0.00945s |      0.11% |
++---------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-- For information on how to cite ASPECT, see:
+--   https://aspect.geodynamics.org/citing.html?ver=2.1.0-pre&melt=1&sha=f534df314&src=code
+-----------------------------------------------------------------------------

--- a/tests/melt_restart/screen-output
+++ b/tests/melt_restart/screen-output
@@ -1,0 +1,11 @@
+
+Loading shared library <./libmelt_restart.so>
+* starting from beginning:
+Executing the following command:
+cd output-melt_restart ; (cat ASPECT_DIR/tests/melt_restart.prm  ;  echo 'set Output directory = output1.tmp'  ;  rm -rf output1.tmp ; mkdir output1.tmp ) | ../../aspect -- > /dev/null
+Executing the following command:
+cd output-melt_restart ;  rm -rf output2.tmp ; mkdir output2.tmp ;  cp output1.tmp/restart* output2.tmp/
+* now resuming:
+Executing the following command:
+cd output-melt_restart ; (cat ASPECT_DIR/tests/melt_restart.prm  ;  echo 'set Output directory = output2.tmp'  ;  echo 'set Resume computation = true' ) | ../../aspect -- > /dev/null
+* now comparing:

--- a/tests/melt_restart/statistics1
+++ b/tests/melt_restart/statistics1
@@ -1,0 +1,29 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Number of nonlinear iterations
+# 9: Iterations for temperature solver
+# 10: Iterations for composition solver 1
+# 11: Iterations for composition solver 2
+# 12: Iterations for Stokes solver
+# 13: Velocity iterations in Stokes preconditioner
+# 14: Schur complement iterations in Stokes preconditioner
+# 15: Visualization file name
+# 16: Minimal value for composition porosity
+# 17: Maximal value for composition porosity
+# 18: Global mass for composition porosity
+# 19: Minimal value for composition peridotite
+# 20: Maximal value for composition peridotite
+# 21: Global mass for composition peridotite
+# 22: RMS velocity (m/year)
+# 23: Max. velocity (m/year)
+# 24: Minimal temperature (K)
+# 25: Average temperature (K)
+# 26: Maximal temperature (K)
+# 27: Average nondimensional temperature (K)
+0 0.000000000000e+00 0.000000000000e+00 192 1891 833 450 8  0 0 0 71 79 544 output1.tmp/solution/solution-00000 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.08902163e-03 2.96202828e-03 2.93000000e+02 2.02282918e+03 3.70000000e+03 5.07727967e-01 
+1 1.000000000000e+03 1.000000000000e+03 192 1891 833 450 2 11 0 0  8 10  68 output1.tmp/solution/solution-00001 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.08903583e-03 2.96208063e-03 2.93000000e+02 2.02282946e+03 3.70000000e+03 5.07728048e-01 

--- a/tests/melt_restart/statistics2
+++ b/tests/melt_restart/statistics2
@@ -1,0 +1,30 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Number of nonlinear iterations
+# 9: Iterations for temperature solver
+# 10: Iterations for composition solver 1
+# 11: Iterations for composition solver 2
+# 12: Iterations for Stokes solver
+# 13: Velocity iterations in Stokes preconditioner
+# 14: Schur complement iterations in Stokes preconditioner
+# 15: Visualization file name
+# 16: Minimal value for composition porosity
+# 17: Maximal value for composition porosity
+# 18: Global mass for composition porosity
+# 19: Minimal value for composition peridotite
+# 20: Maximal value for composition peridotite
+# 21: Global mass for composition peridotite
+# 22: RMS velocity (m/year)
+# 23: Max. velocity (m/year)
+# 24: Minimal temperature (K)
+# 25: Average temperature (K)
+# 26: Maximal temperature (K)
+# 27: Average nondimensional temperature (K)
+0 0.000000000000e+00 0.000000000000e+00 192 1891 833 450 8  0 0 0 71 79 544 output1.tmp/solution/solution-00000 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.08902163e-03 2.96202828e-03 2.93000000e+02 2.02282918e+03 3.70000000e+03 5.07727967e-01 
+1 1.000000000000e+03 1.000000000000e+03 192 1891 833 450 2 11 0 0  8 10  68 output1.tmp/solution/solution-00001 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.08903583e-03 2.96208063e-03 2.93000000e+02 2.02282946e+03 3.70000000e+03 5.07728048e-01 
+2 1.001000000000e+06 1.000000000000e+06 192 1891 833 450 5 35 0 0 30 35 240 output2.tmp/solution/solution-00002 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.10713942e-03 3.03095494e-03 2.93000000e+02 2.02311739e+03 3.70000000e+03 5.07812558e-01 


### PR DESCRIPTION
I just noticed that this was broken and that models with melt transport couldn't be restarted any more. I think we broke it in #2419, where we moved the line 
`melt_handler->add_current_constraints (new_current_constraints);`
into `compute_current_constraints()`, where we then close the constraints, so we can't and shouldn't let the melt handler add its constraints again outside of compute_current_constraints() when we restart the computation. 

I added a test to make sure we don't break this in the future. 