### PR TITLE
add diffusion of prescribed fields

### DIFF
--- a/doc/modules/changes/20181029_jdannberg
+++ b/doc/modules/changes/20181029_jdannberg
@@ -5,10 +5,5 @@ given as an input parameter. This option can be used by selecting the
 'prescribed field with diffusion' compositional field method in the 
 input file, and allows it to smooth quantities that are computed in 
 the material model.
-Changed: If the 'prescribed field' compositional field method is used 
-for a field, this field will now be solved in the order it is listed
-in in the input file (as is done for all compositional fields) instead 
-of being updated after all of the other fields are solved (the 
-previous behaviour). 
 <br>
 (Juliane Dannberg, 2018/10/29)

--- a/doc/modules/changes/20181029_jdannberg
+++ b/doc/modules/changes/20181029_jdannberg
@@ -1,0 +1,14 @@
+New: There is now a new method for compositional fields that allows
+to prescribe them to a value that is computed in the material model 
+and then, in a second step, to diffuse them based on a length scale 
+given as an input parameter. This option can be used by selecting the 
+'prescribed field with diffusion' compositional field method in the 
+input file, and allows it to smooth quantities that are computed in 
+the material model.
+Changed: If the 'prescribed field' compositional field method is used 
+for a field, this field will now be solved in the order it is listed
+in in the input file (as is done for all compositional fields) instead 
+of being updated after all of the other fields are solved (the 
+previous behaviour). 
+<br>
+(Juliane Dannberg, 2018/10/29)

--- a/doc/modules/changes/20181031_jdannberg
+++ b/doc/modules/changes/20181031_jdannberg
@@ -1,0 +1,7 @@
+Changed: If the 'prescribed field' compositional field method is used 
+for a field, this field will now be solved in the order it is listed
+in in the input file (as is done for all compositional fields) instead 
+of being updated after all of the other fields are solved (the 
+previous behaviour). 
+<br>
+(Juliane Dannberg, 2018/10/31)

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -108,7 +108,8 @@ namespace aspect
         particles,
         static_field,
         fem_melt_field,
-        prescribed_field
+        prescribed_field,
+        prescribed_field_with_diffusion
       };
     };
 
@@ -318,6 +319,7 @@ namespace aspect
     double                         maximum_relative_increase_time_step;
     double                         reaction_time_step;
     unsigned int                   reaction_steps_per_advection_step;
+    double                         diffusion_length_scale;
     bool                           use_artificial_viscosity_smoothing;
     bool                           use_conduction_timestep;
     bool                           convert_to_years;

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1149,10 +1149,12 @@ namespace aspect
 
 
       /**
-       * Interpolate material model outputs onto compositional fields in case the
-       * 'prescribed field' compositional field method is used. For every field that
-       * uses this method, this function interpolates additional material model outputs
-       * called 'PrescribedFieldOutputs' and copies these values into the solution vector.
+       * Interpolate material model outputs onto a compositional field. For the field
+       * whose index is given in the input argument compositional_index, this function
+       * interpolates additional material model outputs called 'PrescribedFieldOutputs'
+       * and copies these values into the solution vector.
+       * This is useful for fields that use the 'prescribed field' compositional field
+       * method.
        *
        * This function also updates the old solution vectors with these interpolated
        * values so that this compositional field method can be combined with time-dependent
@@ -1161,7 +1163,7 @@ namespace aspect
        * This function is implemented in
        * <code>source/simulator/helper_functions.cc</code>.
        */
-      void interpolate_material_output_into_fields ();
+      void interpolate_material_output_into_fields (const unsigned int compositional_index);
 
 
       /**

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1150,7 +1150,7 @@ namespace aspect
 
       /**
        * Interpolate material model outputs onto a compositional field. For the field
-       * whose index is given in the input argument compositional_index, this function
+       * whose index is given in the @p compositional_index, this function
        * interpolates additional material model outputs called 'PrescribedFieldOutputs'
        * and copies these values into the solution vector.
        * This is useful for fields that use the 'prescribed field' compositional field
@@ -1163,7 +1163,7 @@ namespace aspect
        * This function is implemented in
        * <code>source/simulator/helper_functions.cc</code>.
        */
-      void interpolate_material_output_into_fields (const unsigned int compositional_index);
+      void interpolate_material_output_into_field (const unsigned int compositional_index);
 
 
       /**

--- a/include/aspect/simulator/assemblers/advection.h
+++ b/include/aspect/simulator/assemblers/advection.h
@@ -49,6 +49,24 @@ namespace aspect
     };
 
     /**
+     * This class assembles the terms for the matrix and right-hand-side equation for the
+     * current cell in case we only want to solve the diffusion equation.
+     */
+    template <int dim>
+    class DiffusionSystem : public Assemblers::Interface<dim>,
+      public SimulatorAccess<dim>
+    {
+      public:
+        virtual
+        void
+        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        virtual
+        std::vector<double>
+        compute_residual(internal::Assembly::Scratch::ScratchBase<dim>  &scratch) const;
+    };
+
+    /**
      * This class assembles the face terms for the right-hand-side of the
      * advection equation for a face at the boundary of the domain where
      * Neumann boundary conditions are used (which allow to prescribe a heat flux).

--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -77,6 +77,10 @@ namespace aspect
 
       const FEValuesExtractors::Scalar solution_field = advection_field.scalar_extractor(introspection);
 
+      if (!advection_field_is_temperature && advection_field.advection_method (introspection)
+          == Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion)
+        return;
+
       for (unsigned int q=0; q<n_q_points; ++q)
         {
           // precompute the values of shape functions and their gradients.
@@ -250,6 +254,84 @@ namespace aspect
               residuals[q] = std::abs(dField_dt + u_grad_field - dreaction_term_dt);
             }
         }
+      return residuals;
+    }
+
+
+
+    template <int dim>
+    void
+    DiffusionSystem<dim>::execute (internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                                   internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const
+    {
+      internal::Assembly::Scratch::AdvectionSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::AdvectionSystem<dim>& > (scratch_base);
+      internal::Assembly::CopyData::AdvectionSystem<dim> &data = dynamic_cast<internal::Assembly::CopyData::AdvectionSystem<dim>& > (data_base);
+
+      const Parameters<dim> &parameters = this->get_parameters();
+      const Introspection<dim> &introspection = this->introspection();
+      const FiniteElement<dim> &fe = this->get_fe();
+
+      const typename Simulator<dim>::AdvectionField advection_field = *scratch.advection_field;
+
+      if (advection_field.is_temperature() || advection_field.advection_method(introspection)
+          != Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion)
+        return;
+
+      const unsigned int n_q_points = scratch.finite_element_values.n_quadrature_points;
+      const unsigned int advection_dofs_per_cell = data.local_dof_indices.size();
+
+      const unsigned int solution_component = advection_field.component_index(introspection);
+      const FEValuesExtractors::Scalar solution_field = advection_field.scalar_extractor(introspection);
+
+      for (unsigned int q=0; q<n_q_points; ++q)
+        {
+          // precompute the values of shape functions and their gradients.
+          // We only need to look up values of shape functions if they
+          // belong to 'our' component. They are zero otherwise anyway.
+          // Note that we later only look at the values that we do set here.
+          for (unsigned int i=0, i_advection=0; i_advection<advection_dofs_per_cell;/*increment at end of loop*/)
+            {
+              if (fe.system_to_component_index(i).first == solution_component)
+                {
+                  scratch.grad_phi_field[i_advection] = scratch.finite_element_values[solution_field].gradient (i,q);
+                  scratch.phi_field[i_advection]      = scratch.finite_element_values[solution_field].value (i,q);
+                  ++i_advection;
+                }
+              ++i;
+            }
+
+          const double JxW = scratch.finite_element_values.JxW(q);
+
+          // do the actual assembly. note that we only need to loop over the advection
+          // shape functions because these are the only contributions we compute here
+          for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
+            {
+              data.local_rhs(i)
+              += scratch.old_field_values[q] * scratch.phi_field[i]
+                 *
+                 JxW;
+
+              for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
+                {
+                  data.local_matrix(i,j)
+                  += (std::pow(parameters.diffusion_length_scale, 2) * (scratch.grad_phi_field[i] * scratch.grad_phi_field[j])
+                      + (scratch.phi_field[i] * scratch.phi_field[j])
+                     )
+                     * JxW;
+                }
+            }
+        }
+    }
+
+
+
+    template <int dim>
+    std::vector<double>
+    DiffusionSystem<dim>::compute_residual(internal::Assembly::Scratch::ScratchBase<dim> &scratch_base) const
+    {
+      internal::Assembly::Scratch::AdvectionSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::AdvectionSystem<dim>& > (scratch_base);
+      std::vector<double> residuals(scratch.finite_element_values.n_quadrature_points, 0.0);
+
       return residuals;
     }
 
@@ -1273,6 +1355,7 @@ namespace aspect
   {
 #define INSTANTIATE(dim) \
   template class AdvectionSystem<dim>; \
+  template class DiffusionSystem<dim>; \
   template class AdvectionSystemBoundaryFace<dim>; \
   template class AdvectionSystemInteriorFace<dim>; \
   template class AdvectionSystemBoundaryHeatFlux<dim>;

--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -314,7 +314,7 @@ namespace aspect
               for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
                 {
                   data.local_matrix(i,j)
-                  += (std::pow(parameters.diffusion_length_scale, 2) * (scratch.grad_phi_field[i] * scratch.grad_phi_field[j])
+                  += (std::pow(parameters.diffusion_length_scale, 2.0) * (scratch.grad_phi_field[i] * scratch.grad_phi_field[j])
                       + (scratch.phi_field[i] * scratch.phi_field[j])
                      )
                      * JxW;

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -187,6 +187,12 @@ namespace aspect
     assemblers->advection_system.push_back(
       std_cxx14::make_unique<aspect::Assemblers::AdvectionSystem<dim> >());
 
+    // add the diffusion assemblers if we have fields that use this method
+    if (std::find(parameters.compositional_field_methods.begin(), parameters.compositional_field_methods.end(),
+                  Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion) != parameters.compositional_field_methods.end())
+      assemblers->advection_system.push_back(
+        std_cxx14::make_unique<aspect::Assemblers::DiffusionSystem<dim> >());
+
     if (parameters.use_discontinuous_temperature_discretization ||
         parameters.use_discontinuous_composition_discretization)
       {

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1726,7 +1726,7 @@ namespace aspect
 
 
   template <int dim>
-  void Simulator<dim>::interpolate_material_output_into_fields (const unsigned int c)
+  void Simulator<dim>::interpolate_material_output_into_field (const unsigned int c)
   {
     // we need some temporary vectors to store our updates to composition in
     // before we copy them over to the solution vector in the end
@@ -2341,7 +2341,7 @@ namespace aspect
   template void Simulator<dim>::interpolate_onto_velocity_system(const TensorFunction<1,dim> &func, LinearAlgebra::Vector &vec);\
   template void Simulator<dim>::apply_limiter_to_dg_solutions(const AdvectionField &advection_field); \
   template void Simulator<dim>::compute_reactions(); \
-  template void Simulator<dim>::interpolate_material_output_into_fields(const unsigned int c); \
+  template void Simulator<dim>::interpolate_material_output_into_field(const unsigned int c); \
   template void Simulator<dim>::check_consistency_of_formulation(); \
   template void Simulator<dim>::replace_outflow_boundary_ids(const unsigned int boundary_id_offset); \
   template void Simulator<dim>::restore_outflow_boundary_ids(const unsigned int boundary_id_offset); \

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1726,21 +1726,16 @@ namespace aspect
 
 
   template <int dim>
-  void Simulator<dim>::interpolate_material_output_into_fields ()
+  void Simulator<dim>::interpolate_material_output_into_fields (const unsigned int c)
   {
-    // find out if we have any prescribed fields
-    if (std::find(parameters.compositional_field_methods.begin(),
-                  parameters.compositional_field_methods.end(),
-                  Parameters<dim>::AdvectionFieldMethod::prescribed_field)
-        == parameters.compositional_field_methods.end())
-      return;
-
     // we need some temporary vectors to store our updates to composition in
     // before we copy them over to the solution vector in the end
     LinearAlgebra::BlockVector distributed_vector (introspection.index_sets.system_partitioning,
                                                    mpi_communicator);
 
-    pcout << "   Copying properties into prescribed compositional fields."
+    const std::string name_of_field = introspection.name_for_compositional_index(c);
+
+    pcout << "   Copying properties into prescribed compositional field " + name_of_field + "."
           << std::endl;
 
     // make an fevalues object that allows us to interpolate onto the solution vector
@@ -1789,38 +1784,33 @@ namespace aspect
 
           // interpolate material properties onto the compositional fields
           for (unsigned int j=0; j<dof_handler.get_fe().base_element(introspection.base_elements.compositional_fields).dofs_per_cell; ++j)
-            for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
-              if (parameters.compositional_field_methods[c] == Parameters<dim>::AdvectionFieldMethod::prescribed_field)
+            {
+              const unsigned int composition_idx
+                = dof_handler.get_fe().component_to_system_index(introspection.component_indices.compositional_fields[c],
+                                                                 /*dof index within component=*/ j);
+
+              // skip entries that are not locally owned:
+              if (dof_handler.locally_owned_dofs().is_element(local_dof_indices[composition_idx]))
                 {
-                  const unsigned int composition_idx
-                    = dof_handler.get_fe().component_to_system_index(introspection.component_indices.compositional_fields[c],
-                                                                     /*dof index within component=*/ j);
+                  Assert(numbers::is_finite(prescribed_field_out->prescribed_field_outputs[j][c]),
+                         ExcMessage("You are trying to use a prescribed advection field, "
+                                    "but the material model you use does not fill the PrescribedFieldOutputs "
+                                    "for your prescribed field, which is required for this method."));
 
-                  // skip entries that are not locally owned:
-                  if (dof_handler.locally_owned_dofs().is_element(local_dof_indices[composition_idx]))
-                    {
-                      Assert(numbers::is_finite(prescribed_field_out->prescribed_field_outputs[j][c]),
-                             ExcMessage("You are trying to use a prescribed advection field, "
-                                        "but the material model you use does not fill the PrescribedFieldOutputs "
-                                        "for your prescribed field, which is required for this method."));
-
-                      distributed_vector(local_dof_indices[composition_idx]) = prescribed_field_out->prescribed_field_outputs[j][c];
-                    }
+                  distributed_vector(local_dof_indices[composition_idx]) = prescribed_field_out->prescribed_field_outputs[j][c];
                 }
+            }
         }
 
     // put the final values into the solution vector
-    for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
-      if (parameters.compositional_field_methods[c] == Parameters<dim>::AdvectionFieldMethod::prescribed_field)
-        {
-          const unsigned int block_c = introspection.block_indices.compositional_fields[c];
-          distributed_vector.block(block_c).compress(VectorOperation::insert);
-          solution.block(block_c) = distributed_vector.block(block_c);
 
-          // We also want to copy the values into the old solution, because it might
-          // be used in other parts of the code
-          old_solution.block(block_c) = distributed_vector.block(block_c);
-        }
+    const unsigned int block_c = introspection.block_indices.compositional_fields[c];
+    distributed_vector.block(block_c).compress(VectorOperation::insert);
+    solution.block(block_c) = distributed_vector.block(block_c);
+
+    // We also want to copy the values into the old solution, because it might
+    // be used in other parts of the code
+    old_solution.block(block_c) = distributed_vector.block(block_c);
   }
 
 
@@ -2351,7 +2341,7 @@ namespace aspect
   template void Simulator<dim>::interpolate_onto_velocity_system(const TensorFunction<1,dim> &func, LinearAlgebra::Vector &vec);\
   template void Simulator<dim>::apply_limiter_to_dg_solutions(const AdvectionField &advection_field); \
   template void Simulator<dim>::compute_reactions(); \
-  template void Simulator<dim>::interpolate_material_output_into_fields(); \
+  template void Simulator<dim>::interpolate_material_output_into_fields(const unsigned int c); \
   template void Simulator<dim>::check_consistency_of_formulation(); \
   template void Simulator<dim>::replace_outflow_boundary_ids(const unsigned int boundary_id_offset); \
   template void Simulator<dim>::restore_outflow_boundary_ids(const unsigned int boundary_id_offset); \

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1028,8 +1028,12 @@ namespace aspect
                          "marked this way, the value of a specific additional material model output, "
                          "called the `PrescribedFieldOutputs' is interpolated onto the field, as in "
                          "the ``prescribed field'' method. Afterwards, the field is diffused based on "
-                         "a solver parameter, the diffusion length scale. The field is not advected "
-                         "with the flow."
+                         "a solver parameter, the diffusion length scale, smoothing the field. "
+                         "Specifically, the field is updated following the equation "
+                         "$C_\\text{smoothed} = C\\text{prescribed} + \\nabla \\cdot l^2 \\nabla C\\text{prescribed}$, "
+                         "where $l$ is the diffusion length scale. Note that this means that the amount "
+                         "of diffusion is independent of the time step size, and that the field is not "
+                         "advected with the flow."
                          "\\end{itemize}");
       prm.declare_entry ("Mapped particle properties", "",
                          Patterns::Map (Patterns::Anything(),

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -178,7 +178,13 @@ namespace aspect
           {
             case Parameters<dim>::AdvectionFieldMethod::fem_field:
             case Parameters<dim>::AdvectionFieldMethod::fem_melt_field:
+            case Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion:
             {
+              // if this is a prescribed field with diffusion, we first have to copy the material model
+              // outputs into the prescribed field before we assemle and solve the equation
+              if (method == Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion)
+                interpolate_material_output_into_fields(c);
+
               assemble_advection_system (adv_field);
 
               if (compute_initial_residual)
@@ -194,11 +200,25 @@ namespace aspect
             }
 
             case Parameters<dim>::AdvectionFieldMethod::particles:
+            {
               interpolate_particle_properties(adv_field);
               break;
+            }
+
+            case Parameters<dim>::AdvectionFieldMethod::prescribed_field:
+            {
+              interpolate_material_output_into_fields(c);
+
+              // Call the signal in case the user wants to do something with the variable:
+              SolverControl dummy;
+              signals.post_advection_solver(*this,
+                                            adv_field.is_temperature(),
+                                            adv_field.compositional_variable,
+                                            dummy);
+              break;
+            }
 
             case Parameters<dim>::AdvectionFieldMethod::static_field:
-            case Parameters<dim>::AdvectionFieldMethod::prescribed_field:
             {
               // Do nothing here, but at least call the signal in case the
               // user wants to do something with the variable:
@@ -214,9 +234,6 @@ namespace aspect
               AssertThrow(false,ExcNotImplemented());
           }
       }
-
-    // Update the prescribed fields *after* we have solved all the other fields
-    interpolate_material_output_into_fields();
 
     // for consistency we update the current linearization point only after we have solved
     // all fields, so that we use the same point in time for every field when solving

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -183,7 +183,7 @@ namespace aspect
               // if this is a prescribed field with diffusion, we first have to copy the material model
               // outputs into the prescribed field before we assemle and solve the equation
               if (method == Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion)
-                interpolate_material_output_into_fields(c);
+                interpolate_material_output_into_field(c);
 
               assemble_advection_system (adv_field);
 
@@ -207,7 +207,7 @@ namespace aspect
 
             case Parameters<dim>::AdvectionFieldMethod::prescribed_field:
             {
-              interpolate_material_output_into_fields(c);
+              interpolate_material_output_into_field(c);
 
               // Call the signal in case the user wants to do something with the variable:
               SolverControl dummy;

--- a/tests/prescribed_field/screen-output
+++ b/tests/prescribed_field/screen-output
@@ -7,7 +7,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
 *** Timestep 0:  t=0 seconds
    Solving temperature system... 0 iterations.
    Skipping normal_field composition solve because RHS is zero.
-   Copying properties into prescribed compositional fields.
+   Copying properties into prescribed compositional field prescribed_field.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
 

--- a/tests/prescribed_field_with_diffusion.cc
+++ b/tests/prescribed_field_with_diffusion.cc
@@ -1,0 +1,76 @@
+#include <aspect/material_model/simple.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    using namespace dealii;
+
+    template <int dim>
+    class PrescribedFieldMaterial : public MaterialModel::Simple<dim>
+    {
+      public:
+
+        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                              MaterialModel::MaterialModelOutputs<dim> &out) const;
+
+        virtual
+        void
+        create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const;
+    };
+
+  }
+}
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+
+    template <int dim>
+    void
+    PrescribedFieldMaterial<dim>::
+    evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+             MaterialModel::MaterialModelOutputs<dim> &out) const
+    {
+      Simple<dim>::evaluate(in, out);
+
+      // set up variable to interpolate prescribed field outputs onto compositional fields
+      PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim> >();
+
+      if (prescribed_field_out != NULL)
+        for (unsigned int i=0; i < in.position.size(); ++i)
+          {
+            const double y = in.position[i](1);
+            prescribed_field_out->prescribed_field_outputs[i][1] = std::exp(-y*y/2.0);
+          }
+    }
+
+
+    template <int dim>
+    void
+    PrescribedFieldMaterial<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
+    {
+      if (out.template get_additional_output<PrescribedFieldOutputs<dim> >() == NULL)
+        {
+          const unsigned int n_points = out.viscosities.size();
+          out.additional_outputs.push_back(
+            std::shared_ptr<MaterialModel::AdditionalMaterialOutputs<dim> >
+            (new MaterialModel::PrescribedFieldOutputs<dim> (n_points, this->n_compositional_fields())));
+        }
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    ASPECT_REGISTER_MATERIAL_MODEL(PrescribedFieldMaterial,
+                                   "prescribed field material",
+                                   "A simple material model that is like the "
+                                   "'Simple' model, but creates prescribed field outputs.")
+  }
+}

--- a/tests/prescribed_field_with_diffusion.prm
+++ b/tests/prescribed_field_with_diffusion.prm
@@ -1,0 +1,115 @@
+# A testcase that demonstrates that interpolating material model
+# outputs into compositional fields and diffusing them works.
+#
+# The property copied into the compositional field 'prescribed field', 
+# is a Gaussian with an amplitude of 1, namely exp(-0.5*x*x). 
+# We choose the diffusion length scale in a way that its amplitude
+# should be reduced to 0.95 when the diffusion equation is solved. 
+#
+# The test also contains another compositional field that does
+# not use this method, so it should remain zero everywhere
+# (which is what the initial condition is).
+
+set Dimension = 2
+set End time                               = 0
+set Start time                             = 0
+set Adiabatic surface temperature          = 0
+set Surface pressure                       = 0
+set Use years in output instead of seconds = false
+
+subsection Solver parameters
+  subsection Diffusion solver parameters
+    set Diffusion length scale = 0.23241476
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+end
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 0.1
+    set Y extent = 10
+    set Y repetitions = 100
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 2
+  set Names of fields  = normal_field, diffused_field
+  set Compositional field methods = field, prescribed field with diffusion
+end
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 0.1
+  end
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Function expression = 0.0; 0.0
+  end
+end
+
+subsection Boundary composition model
+  set Fixed composition boundary indicators = top
+  set Model name = function
+  subsection Function
+    set Function expression = 0; 0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 1.0
+  end
+end
+
+
+subsection Material model
+  set Model name = prescribed field material
+
+  subsection Simple model
+    set Reference density             = 1    # default: 3300
+    set Reference specific heat       = 1250
+    set Reference temperature         = 0    # default: 293
+    set Thermal conductivity          = 1e-6 # default: 4.7
+    set Thermal expansion coefficient = 1
+    set Viscosity                     = 1    # default: 5e24
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 1
+end
+
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 0, 1, 2, 3
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, composition statistics
+
+  subsection Visualization
+
+    set List of output variables      = named additional outputs
+    set Number of grouped files       = 0
+    set Output format                 = vtu
+    set Time between graphical output = 0                                                                                # default: 1e8
+  end
+end

--- a/tests/prescribed_field_with_diffusion/screen-output
+++ b/tests/prescribed_field_with_diffusion/screen-output
@@ -1,0 +1,31 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libprescribed_field_with_diffusion.so>
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 400 (on 2 levels)
+Number of degrees of freedom: 10,628 (4,010+603+2,005+2,005+2,005)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Skipping normal_field composition solve because RHS is zero.
+   Copying properties into prescribed compositional field diffused_field.
+   Solving diffused_field system ... 159 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 37+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-prescribed_field_with_diffusion/solution/solution-00000
+     Compositions min/max/mass: 0/0/0 // 0/0.953/0.1253
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/prescribed_field_with_diffusion/statistics
+++ b/tests/prescribed_field_with_diffusion/statistics
@@ -1,0 +1,21 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for composition solver 2
+# 11: Iterations for Stokes solver
+# 12: Velocity iterations in Stokes preconditioner
+# 13: Schur complement iterations in Stokes preconditioner
+# 14: Visualization file name
+# 15: Minimal value for composition normal_field
+# 16: Maximal value for composition normal_field
+# 17: Global mass for composition normal_field
+# 18: Minimal value for composition diffused_field
+# 19: Maximal value for composition diffused_field
+# 20: Global mass for composition diffused_field
+0 0.000000000000e+00 0.000000000000e+00 400 4613 2005 4010 0 0 159 36 38 37 output-prescribed_field_with_diffusion/solution/solution-00000 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 9.52987448e-01 1.25331414e-01 

--- a/tests/prescribed_field_with_diffusion/statistics
+++ b/tests/prescribed_field_with_diffusion/statistics
@@ -18,4 +18,4 @@
 # 18: Minimal value for composition diffused_field
 # 19: Maximal value for composition diffused_field
 # 20: Global mass for composition diffused_field
-0 0.000000000000e+00 0.000000000000e+00 400 4613 2005 4010 0 0 159 36 38 37 output-prescribed_field_with_diffusion/solution/solution-00000 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 9.52987448e-01 1.25331414e-01 
+0 0.000000000000e+00 0.000000000000e+00 400 4613 2005 4010 0 0 159 37 38 37 output-prescribed_field_with_diffusion/solution/solution-00000 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 9.52987448e-01 1.25331414e-01 


### PR DESCRIPTION
This pull request adds an advection method that allows it to first copy a material model output into a compositional field, and then to diffuse it using a fixed length scale. In order to make this work, I had to change the way the prescribed_field method works: It will not be called after all of the other fields are solved, but instead will be called in the order the fields are listed in (so if the input file lists the prescribed_field last, it would still be solved last). As I just added this functionality two weeks ago, I don't think anyone has started using it yet. 
If we agree that this makes sense, I'll also add a changelog entry explaining this. 