### PR TITLE
move average_value function to material model interface

### DIFF
--- a/include/aspect/material_model/diffusion_dislocation.h
+++ b/include/aspect/material_model/diffusion_dislocation.h
@@ -130,26 +130,7 @@ namespace aspect
         std::vector<double> densities;
         std::vector<double> thermal_expansivities;
 
-        /**
-         * Enumeration for selecting which viscosity averaging scheme to use.
-         * Select between harmonic, arithmetic, geometric, and
-         * maximum_composition. The max composition scheme simply uses the
-         * viscosity of whichever field has the highest volume fraction. For
-         * each quadrature point, averaging is conducted over the N
-         * compositional fields plus the background field.
-         */
-        enum averaging_scheme
-        {
-          harmonic,
-          arithmetic,
-          geometric,
-          maximum_composition
-        } viscosity_averaging;
-
-
-        double average_value (const std::vector<double> &composition,
-                              const std::vector<double> &parameter_values,
-                              const enum averaging_scheme &average_type) const;
+        CompositionalAveragingOperation viscosity_averaging;
 
         std::vector<double>
         calculate_isostrain_viscosities ( const std::vector<double> &volume_fractions,

--- a/include/aspect/material_model/dynamic_friction.h
+++ b/include/aspect/material_model/dynamic_friction.h
@@ -135,27 +135,7 @@ namespace aspect
          */
         double reference_T;
 
-        /**
-         * Enumeration for selecting which averaging scheme to use. Select
-         * between harmonic, arithmetic, geometric, and maximum_composition.
-         * The max composition scheme simply uses the parameter of whichever
-         * field has the highest volume fraction.
-         */
-        enum AveragingScheme
-        {
-          harmonic,
-          arithmetic,
-          geometric,
-          maximum_composition
-        };
-
-
-        AveragingScheme viscosity_averaging;
-
-        double average_value (const std::vector<double> &composition,
-                              const std::vector<double> &parameter_values,
-                              const enum AveragingScheme &average_type) const;
-
+        CompositionalAveragingOperation viscosity_averaging;
 
         /**
          * Vector for field densities, read from parameter file .

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -952,12 +952,17 @@ namespace aspect
      * composition, and more than one compositional field might have nonzero
      * values at a given quadrature point. This means that properties have to
      * be averaged based on the fractions of each compositional field present.
-     * This function performs this type of averaging, and allows it to choose
-     * between harmonic, arithmetic and geometric averaging or simply selecting
-     * the material property of the compositional field with the largest volume
-     * fraction. For each quadrature point, averaging is conducted over the
-     * compositional fields given in @p volume_fractions, plus an additional
-     * background field in case the composition does not add up to 1.
+     * This function performs this type of averaging. The averaging is based
+     * on the choice in @p average_type. Averaging is conducted over the
+     * compositional fields given in @p volume_fractions. This means that
+     * @p volume_fractions and @p parameter_values have to have the same size,
+     * which would typically be the number of compositional fields used in the
+     * simulation (with the potential addition of a background field, in case
+     * the composition does not add up to 1). However, one might not want to
+     * average over all fields, as in some cases compositional fields do not
+     * represent a rock type, but other tracked quantities like the finite
+     * strain, so the implementation is independent of the number of entries in
+     * @p volume_fractions.
      */
     double average_value (const std::vector<double> &volume_fractions,
                           const std::vector<double> &parameter_values,

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -928,6 +928,42 @@ namespace aspect
     compute_volume_fractions(const std::vector<double> &compositional_fields,
                              const ComponentMask &field_mask = ComponentMask());
 
+
+    /**
+     * For multicomponent material models:
+     * Enumeration for selecting which averaging scheme to use when
+     * averaging the properties of different compositional fields.
+     * Select between harmonic, arithmetic, geometric, and
+     * maximum_composition. The max composition scheme simply uses the
+     * viscosity of whichever field has the highest volume fraction.
+     */
+    enum CompositionalAveragingOperation
+    {
+      harmonic,
+      arithmetic,
+      geometric,
+      maximum_composition
+    };
+
+    /**
+     * For multicomponent material models:
+     * Material models compute output quantities such as the viscosity, the
+     * density, etc. For some models, these values depend strongly on the
+     * composition, and more than one compositional field might have nonzero
+     * values at a given quadrature point. This means that properties have to
+     * be averaged based on the fractions of each compositional field present.
+     * This function performs this type of averaging, and allows it to choose
+     * between harmonic, arithmetic and geometric averaging or simply selecting
+     * the material property of the compositional field with the largest volume
+     * fraction. For each quadrature point, averaging is conducted over the
+     * compositional fields given in @p volume_fractions, plus an additional
+     * background field in case the composition does not add up to 1.
+     */
+    double average_value (const std::vector<double> &volume_fractions,
+                          const std::vector<double> &parameter_values,
+                          const CompositionalAveragingOperation &average_type);
+
+
     /**
      * A base class for parameterizations of material models. Classes derived
      * from this class will need to implement functions that provide material

--- a/include/aspect/material_model/multicomponent.h
+++ b/include/aspect/material_model/multicomponent.h
@@ -124,26 +124,9 @@ namespace aspect
         double reference_T;
 
         /**
-         * Enumeration for selecting which averaging scheme to use. Select
-         * between harmonic, arithmetic, geometric, and maximum_composition.
-         * The max composition scheme simply uses the parameter of whichever
-         * field has the highest volume fraction.
+         * Enumeration for selecting which viscosity averaging scheme to use.
          */
-        enum AveragingScheme
-        {
-          harmonic,
-          arithmetic,
-          geometric,
-          maximum_composition
-        };
-
-
-        AveragingScheme viscosity_averaging;
-
-        double average_value (const std::vector<double> &composition,
-                              const std::vector<double> &parameter_values,
-                              const enum AveragingScheme &average_type) const;
-
+        CompositionalAveragingOperation viscosity_averaging;
 
         /**
          * Vector for field densities, read from parameter file .

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -175,19 +175,8 @@ namespace aspect
 
         /**
          * Enumeration for selecting which viscosity averaging scheme to use.
-         * Select between harmonic, arithmetic, geometric, and
-         * maximum_composition. The max composition scheme simply uses the
-         * viscosity of whichever field has the highest volume fraction.
-         * For each quadrature point, averaging is conducted over the
-         * N compositional fields plus the background field.
          */
-        enum averaging_scheme
-        {
-          harmonic,
-          arithmetic,
-          geometric,
-          maximum_composition
-        } viscosity_averaging;
+        CompositionalAveragingOperation viscosity_averaging;
 
         /**
          * Enumeration for selecting which type of viscous flow law to use.
@@ -210,9 +199,6 @@ namespace aspect
           drucker_prager
         } yield_mechanism;
 
-        double average_value (const std::vector<double> &volume_fractions,
-                              const std::vector<double> &parameter_values,
-                              const averaging_scheme &average_type) const;
 
         std::pair<std::vector<double>, std::vector<bool> >
         calculate_isostrain_viscosities ( const std::vector<double> &volume_fractions,

--- a/include/aspect/material_model/viscoelastic.h
+++ b/include/aspect/material_model/viscoelastic.h
@@ -232,33 +232,16 @@ namespace aspect
         double reference_T;
 
         /**
-         * Enumeration for selecting which averaging scheme to use. Select
-         * between harmonic, arithmetic, geometric, and maximum_composition.
-         * The max composition scheme simply uses the parameter of whichever
-         * field has the highest volume fraction.
+         * Enumeration for selecting which viscosity averaging scheme to use.
          */
-        enum AveragingScheme
-        {
-          harmonic,
-          arithmetic,
-          geometric,
-          maximum_composition
-        };
-
-
-        AveragingScheme viscosity_averaging;
-
-        double average_value (const std::vector<double> &composition,
-                              const std::vector<double> &parameter_values,
-                              const enum AveragingScheme &average_type) const;
-
+        CompositionalAveragingOperation viscosity_averaging;
 
         /**
          * Used for calculating average elastic shear modulus and viscosity
          */
         double calculate_average_vector (const std::vector<double> &composition,
                                          const std::vector<double> &parameter_values,
-                                         const enum AveragingScheme &average_type) const;
+                                         const CompositionalAveragingOperation &average_type) const;
 
 
         double calculate_average_viscoelastic_viscosity (const double average_viscosity,

--- a/source/material_model/diffusion_dislocation.cc
+++ b/source/material_model/diffusion_dislocation.cc
@@ -27,56 +27,6 @@ namespace aspect
   namespace MaterialModel
   {
     template <int dim>
-    double
-    DiffusionDislocation<dim>::
-    average_value ( const std::vector<double> &composition,
-                    const std::vector<double> &parameter_values,
-                    const enum averaging_scheme &average_type) const
-    {
-      double averaged_parameter = 0.0;
-      const std::vector<double> volume_fractions = compute_volume_fractions(composition);
-
-      switch (average_type)
-        {
-          case arithmetic:
-          {
-            for (unsigned int i=0; i< volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]*parameter_values[i];
-            break;
-          }
-          case harmonic:
-          {
-            for (unsigned int i=0; i< volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]/(parameter_values[i]);
-            averaged_parameter = 1.0/averaged_parameter;
-            break;
-          }
-          case geometric:
-          {
-            for (unsigned int i=0; i < volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]*std::log(parameter_values[i]);
-            averaged_parameter = std::exp(averaged_parameter);
-            break;
-          }
-          case maximum_composition:
-          {
-            const unsigned int i = (unsigned int)(std::max_element( volume_fractions.begin(),
-                                                                    volume_fractions.end() )
-                                                  - volume_fractions.begin());
-            averaged_parameter = parameter_values[i];
-            break;
-          }
-          default:
-          {
-            AssertThrow( false, ExcNotImplemented() );
-            break;
-          }
-        }
-      return averaged_parameter;
-    }
-
-
-    template <int dim>
     std::vector<double>
     DiffusionDislocation<dim>::
     calculate_isostrain_viscosities ( const std::vector<double> &volume_fractions,
@@ -265,7 +215,7 @@ namespace aspect
               // We have given the user freedom to apply alternative bounds, because in diffusion-dominated
               // creep (where n_diff=1) viscosities are stress and strain-rate independent, so the calculation
               // of compositional field viscosities is consistent with any averaging scheme.
-              out.viscosities[i] = average_value(composition, composition_viscosities, viscosity_averaging);
+              out.viscosities[i] = average_value(volume_fractions, composition_viscosities, viscosity_averaging);
             }
 
           out.densities[i] = density;

--- a/source/material_model/dynamic_friction.cc
+++ b/source/material_model/dynamic_friction.cc
@@ -33,9 +33,8 @@ namespace aspect
     template <int dim>
     const std::vector<double>
     DynamicFriction<dim>::
-    compute_viscosities(
-      const double pressure,
-      const SymmetricTensor<2,dim> &strain_rate) const
+    compute_viscosities(const double pressure,
+                        const SymmetricTensor<2,dim> &strain_rate) const
     {
 
       std::vector<double> viscosities( mu_s.size());
@@ -97,53 +96,6 @@ namespace aspect
       return viscosities;
     }
 
-    template <int dim>
-    double
-    DynamicFriction<dim>::
-    average_value ( const std::vector<double> &volume_fractions,
-                    const std::vector<double> &parameter_values,
-                    const enum AveragingScheme &average_type) const
-    {
-      double averaged_parameter = 0.0;
-
-      switch (average_type)
-        {
-          case arithmetic:
-          {
-            for (unsigned int i=0; i< volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]*parameter_values[i];
-            break;
-          }
-          case harmonic:
-          {
-            for (unsigned int i=0; i< volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]/(parameter_values[i]);
-            averaged_parameter = 1.0/averaged_parameter;
-            break;
-          }
-          case geometric:
-          {
-            for (unsigned int i=0; i < volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]*std::log(parameter_values[i]);
-            averaged_parameter = std::exp(averaged_parameter);
-            break;
-          }
-          case maximum_composition:
-          {
-            const unsigned int i = (unsigned int)(std::max_element( volume_fractions.begin(),
-                                                                    volume_fractions.end() )
-                                                  - volume_fractions.begin());
-            averaged_parameter = parameter_values[i];
-            break;
-          }
-          default:
-          {
-            AssertThrow( false, ExcNotImplemented() );
-            break;
-          }
-        }
-      return averaged_parameter;
-    }
 
 
     template <int dim>
@@ -161,15 +113,15 @@ namespace aspect
           if (in.strain_rate.size() > 0)
             {
               const std::vector<double> viscosities = compute_viscosities(in.pressure[i], in.strain_rate[i]);
-              out.viscosities[i] = average_value ( volume_fractions, viscosities, viscosity_averaging);
+              out.viscosities[i] = average_value (volume_fractions, viscosities, viscosity_averaging);
             }
-          out.specific_heat[i] = average_value ( volume_fractions, specific_heats, arithmetic);
+          out.specific_heat[i] = average_value (volume_fractions, specific_heats, arithmetic);
 
 
           // Arithmetic averaging of thermal conductivities
           // This may not be strictly the most reasonable thing, but for most Earth materials we hope
           // that they do not vary so much that it is a big problem.
-          out.thermal_conductivities[i] = average_value ( volume_fractions, thermal_conductivities, arithmetic);
+          out.thermal_conductivities[i] = average_value (volume_fractions, thermal_conductivities, arithmetic);
 
           double density = 0.0;
           for (unsigned int j=0; j < volume_fractions.size(); ++j)
@@ -182,7 +134,7 @@ namespace aspect
           out.densities[i] = density;
 
 
-          out.thermal_expansion_coefficients[i] = average_value ( volume_fractions, thermal_expansivities, arithmetic);
+          out.thermal_expansion_coefficients[i] = average_value (volume_fractions, thermal_expansivities, arithmetic);
 
 
           // Compressibility at the given positions.

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -110,22 +110,26 @@ namespace aspect
                    const std::vector<double> &parameter_values,
                    const enum CompositionalAveragingOperation &average_type)
     {
+      Assert(volume_fractions.size() == parameter_values.size(),
+             ExcMessage ("The volume fractions and parameter values vectors used for averaging "
+                         "have to have the same length!"));
+
       double averaged_parameter = 0.0;
 
       switch (average_type)
         {
           case arithmetic:
           {
-            for (unsigned int i=0; i< volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]*parameter_values[i];
+            for (unsigned int i=0; i<volume_fractions.size(); ++i)
+              averaged_parameter += volume_fractions[i] * parameter_values[i];
             break;
           }
           case harmonic:
           {
-            for (unsigned int i=0; i< volume_fractions.size(); ++i)
+            for (unsigned int i=0; i<volume_fractions.size(); ++i)
               {
-                AssertThrow(parameter_values[i] != 0,
-                            ExcMessage ("All values must be greater than 0 during harmonic averaging"));
+                AssertThrow(parameter_values[i] > 0,
+                            ExcMessage ("All parameter values must be greater than 0 for harmonic averaging!"));
                 averaged_parameter += volume_fractions[i]/(parameter_values[i]);
               }
             averaged_parameter = 1.0/averaged_parameter;
@@ -133,8 +137,12 @@ namespace aspect
           }
           case geometric:
           {
-            for (unsigned int i=0; i < volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]*std::log(parameter_values[i]);
+            for (unsigned int i=0; i<volume_fractions.size(); ++i)
+              {
+                AssertThrow(parameter_values[i] > 0,
+                            ExcMessage ("All parameter values must be greater than 0 for geometric averaging!"));
+                averaged_parameter += volume_fractions[i] * std::log(parameter_values[i]);
+              }
             averaged_parameter = std::exp(averaged_parameter);
             break;
           }
@@ -148,7 +156,7 @@ namespace aspect
           }
           default:
           {
-            AssertThrow( false, ExcNotImplemented() );
+            AssertThrow(false, ExcNotImplemented());
             break;
           }
         }

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -105,6 +105,58 @@ namespace aspect
 
 
 
+    double
+    average_value (const std::vector<double> &volume_fractions,
+                   const std::vector<double> &parameter_values,
+                   const enum CompositionalAveragingOperation &average_type)
+    {
+      double averaged_parameter = 0.0;
+
+      switch (average_type)
+        {
+          case arithmetic:
+          {
+            for (unsigned int i=0; i< volume_fractions.size(); ++i)
+              averaged_parameter += volume_fractions[i]*parameter_values[i];
+            break;
+          }
+          case harmonic:
+          {
+            for (unsigned int i=0; i< volume_fractions.size(); ++i)
+              {
+                AssertThrow(parameter_values[i] != 0,
+                            ExcMessage ("All values must be greater than 0 during harmonic averaging"));
+                averaged_parameter += volume_fractions[i]/(parameter_values[i]);
+              }
+            averaged_parameter = 1.0/averaged_parameter;
+            break;
+          }
+          case geometric:
+          {
+            for (unsigned int i=0; i < volume_fractions.size(); ++i)
+              averaged_parameter += volume_fractions[i]*std::log(parameter_values[i]);
+            averaged_parameter = std::exp(averaged_parameter);
+            break;
+          }
+          case maximum_composition:
+          {
+            const unsigned int i = (unsigned int)(std::max_element( volume_fractions.begin(),
+                                                                    volume_fractions.end() )
+                                                  - volume_fractions.begin());
+            averaged_parameter = parameter_values[i];
+            break;
+          }
+          default:
+          {
+            AssertThrow( false, ExcNotImplemented() );
+            break;
+          }
+        }
+      return averaged_parameter;
+    }
+
+
+
     template <int dim>
     Interface<dim>::~Interface ()
     {}

--- a/source/material_model/multicomponent.cc
+++ b/source/material_model/multicomponent.cc
@@ -31,55 +31,6 @@ namespace aspect
   namespace MaterialModel
   {
     template <int dim>
-    double
-    Multicomponent<dim>::
-    average_value ( const std::vector<double> &volume_fractions,
-                    const std::vector<double> &parameter_values,
-                    const enum AveragingScheme &average_type) const
-    {
-      double averaged_parameter = 0.0;
-
-      switch (average_type)
-        {
-          case arithmetic:
-          {
-            for (unsigned int i=0; i< volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]*parameter_values[i];
-            break;
-          }
-          case harmonic:
-          {
-            for (unsigned int i=0; i< volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]/(parameter_values[i]);
-            averaged_parameter = 1.0/averaged_parameter;
-            break;
-          }
-          case geometric:
-          {
-            for (unsigned int i=0; i < volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]*std::log(parameter_values[i]);
-            averaged_parameter = std::exp(averaged_parameter);
-            break;
-          }
-          case maximum_composition:
-          {
-            const unsigned int i = (unsigned int)(std::max_element( volume_fractions.begin(),
-                                                                    volume_fractions.end() )
-                                                  - volume_fractions.begin());
-            averaged_parameter = parameter_values[i];
-            break;
-          }
-          default:
-          {
-            AssertThrow( false, ExcNotImplemented() );
-            break;
-          }
-        }
-      return averaged_parameter;
-    }
-
-
-    template <int dim>
     void
     Multicomponent<dim>::
     evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
@@ -91,14 +42,14 @@ namespace aspect
           const std::vector<double> composition = in.composition[i];
           const std::vector<double> volume_fractions = compute_volume_fractions(composition);
 
-          out.viscosities[i] = average_value ( volume_fractions, viscosities, viscosity_averaging);
-          out.specific_heat[i] = average_value ( volume_fractions, specific_heats, arithmetic);
+          out.viscosities[i] = average_value (volume_fractions, viscosities, viscosity_averaging);
+          out.specific_heat[i] = average_value (volume_fractions, specific_heats, arithmetic);
 
 
           // Arithmetic averaging of thermal conductivities
           // This may not be strictly the most reasonable thing, but for most Earth materials we hope
           // that they do not vary so much that it is a big problem.
-          out.thermal_conductivities[i] = average_value ( volume_fractions, thermal_conductivities, arithmetic);
+          out.thermal_conductivities[i] = average_value (volume_fractions, thermal_conductivities, arithmetic);
 
           double density = 0.0;
           for (unsigned int j=0; j < volume_fractions.size(); ++j)
@@ -111,7 +62,7 @@ namespace aspect
           out.densities[i] = density;
 
 
-          out.thermal_expansion_coefficients[i] = average_value ( volume_fractions, thermal_expansivities, arithmetic);
+          out.thermal_expansion_coefficients[i] = average_value (volume_fractions, thermal_expansivities, arithmetic);
 
 
           // Compressibility at the given positions.

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -75,54 +75,6 @@ namespace aspect
     }
 
 
-    template <int dim>
-    double
-    ViscoPlastic<dim>::
-    average_value ( const std::vector<double> &volume_fractions,
-                    const std::vector<double> &parameter_values,
-                    const enum averaging_scheme &average_type) const
-    {
-      double averaged_parameter = 0.0;
-
-      switch (average_type)
-        {
-          case arithmetic:
-          {
-            for (unsigned int i=0; i< volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]*parameter_values[i];
-            break;
-          }
-          case harmonic:
-          {
-            for (unsigned int i=0; i< volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]/(parameter_values[i]);
-            averaged_parameter = 1.0/averaged_parameter;
-            break;
-          }
-          case geometric:
-          {
-            for (unsigned int i=0; i < volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]*std::log(parameter_values[i]);
-            averaged_parameter = std::exp(averaged_parameter);
-            break;
-          }
-          case maximum_composition:
-          {
-            const unsigned int i = (unsigned int)(std::max_element( volume_fractions.begin(),
-                                                                    volume_fractions.end() )
-                                                  - volume_fractions.begin());
-            averaged_parameter = parameter_values[i];
-            break;
-          }
-          default:
-          {
-            AssertThrow( false, ExcNotImplemented() );
-            break;
-          }
-        }
-      return averaged_parameter;
-    }
-
 
     template <int dim>
     std::pair<std::vector<double>, std::vector<bool> >

--- a/source/material_model/viscoelastic.cc
+++ b/source/material_model/viscoelastic.cc
@@ -67,71 +67,20 @@ namespace aspect
     }
 
 
-    template <int dim>
-    double
-    Viscoelastic<dim>::
-    average_value (const std::vector<double> &volume_fractions,
-                   const std::vector<double> &parameter_values,
-                   const enum AveragingScheme &average_type) const
-    {
-      double averaged_parameter = 0.0;
-
-      switch (average_type)
-        {
-          case arithmetic:
-          {
-            for (unsigned int i=0; i< volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]*parameter_values[i];
-            break;
-          }
-          case harmonic:
-          {
-            for (unsigned int i=0; i< volume_fractions.size(); ++i)
-              {
-                AssertThrow(parameter_values[i] != 0,
-                            ExcMessage ("All values must be greater than 0 during harmonic averaging"));
-                averaged_parameter += volume_fractions[i]/(parameter_values[i]);
-              }
-            averaged_parameter = 1.0/averaged_parameter;
-            break;
-          }
-          case geometric:
-          {
-            for (unsigned int i=0; i < volume_fractions.size(); ++i)
-              averaged_parameter += volume_fractions[i]*std::log(parameter_values[i]);
-            averaged_parameter = std::exp(averaged_parameter);
-            break;
-          }
-          case maximum_composition:
-          {
-            const unsigned int i = (unsigned int)(std::max_element( volume_fractions.begin(),
-                                                                    volume_fractions.end() )
-                                                  - volume_fractions.begin());
-            averaged_parameter = parameter_values[i];
-            break;
-          }
-          default:
-          {
-            AssertThrow( false, ExcNotImplemented() );
-            break;
-          }
-        }
-      return averaged_parameter;
-    }
 
     template <int dim>
     double
     Viscoelastic<dim>::
     calculate_average_vector (const std::vector<double> &composition,
                               const std::vector<double> &parameter_values,
-                              const enum AveragingScheme &average_type) const
+                              const CompositionalAveragingOperation &average_type) const
     {
       // Store which components to exclude during volume fraction computation.
-      ComponentMask composition_mask(this->n_compositional_fields(),true);
+      ComponentMask composition_mask(this->n_compositional_fields(), true);
       // assign compositional fields associated with viscoelastic stress a value of 0
       // assume these fields are listed first
       for (unsigned int i=0; i < SymmetricTensor<2,dim>::n_independent_components; ++i)
-        composition_mask.set(i,false);
+        composition_mask.set(i, false);
       const std::vector<double> volume_fractions = compute_volume_fractions(composition, composition_mask);
       const double averaged_vector = average_value(volume_fractions, parameter_values, average_type);
       return averaged_vector;


### PR DESCRIPTION
I am trying to clean up the material models a bit by moving functions into the interface. I started with the average_value function (which was used in 5 different material models, with bugfixes only being included in some of them), but there are more candidates. 

The interface already had a similar function that is used in a number of material models (the `compute_volume_fractions` function), and at the moment, these functions are just normal functions in the interface. As I plan to add more, a question:

Does it make sense to just add all of them in the place they are at the moment, or do we want to start a new file (interface.cc already has more than 1000 lines!) or a new namespace for these functions? We could call it something like material helper functions. 