### PR TITLE
Make installation FAQ more visible.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2869,7 +2869,7 @@ in the configuration file \texttt{candi.cfg}, or by providing platform specific 
 In case you encounter problems during the installation, please consult our wiki
 (\url{https://github.com/geodynamics/aspect/wiki}) for frequently asked
 questions and special instructions for MacOS users, before posting your
-questions on the mailing list.
+questions on the forum (\url{https://community.geodynamics.org/c/aspect}).
 
 \subsubsection{System prerequisites}
 
@@ -2939,7 +2939,10 @@ version at any time, and we usually support several older versions of
     This step might take a long time, but can be parallelized by adding 
     \texttt{-jN}, where 
     \texttt{N} is the number of CPU cores available on your computer. Further configuration options 
-    and parameters are listed at \url{https://github.com/dealii/candi}.
+    and parameters are listed at \url{https://github.com/dealii/candi}. In case you encounter
+    problems during this step, please read the error message, and consult our wiki
+    (\url{https://github.com/geodynamics/aspect/wiki}) for common installation problems,
+    before asking on the forum (\url{https://community.geodynamics.org/c/aspect}).
 
 \item You may now want to configure your environment to make it aware of the newly installed
     packages. This can be achieved by adding the line 


### PR DESCRIPTION
The current link to the installation FAQ is not really visible inside the instructions if someone gets stuck at a particular point (because it is in the introductory text of the section). Put another reference to the point where it is most likely needed (when running candi). This was suggested by Björn Heyn.
Also update the reference to the mailing list by the forum address.
