### PR TITLE
Update initial topography documentation

### DIFF
--- a/source/geometry_model/initial_topography_model/ascii_data.cc
+++ b/source/geometry_model/initial_topography_model/ascii_data.cc
@@ -149,7 +149,7 @@ namespace aspect
                                              "Implementation of a model in which the surface "
                                              "topography is derived from a file containing data "
                                              "in ascii format. The following geometry models "
-                                             "are currently supported: box, chunk, shperical shell. "
+                                             "are currently supported: box. "
                                              "Note the required format of the "
                                              "input data: The first lines may contain any number of comments "
                                              "if they begin with `#', but one of these lines needs to "


### PR DESCRIPTION
The documentation for the 'ascii data' option of the 'Initial topography' model currently states that box, chunk and spherical shell geometries are supported. It appears that only the box geometry is currently supported, but #1705 will add support for the Chunk geometry.

I have not explicitly tried a test model, but I believe the 'prm_polygon' option will only work with the box geometry as well.

In addition to adding documentation, would it be worth adding Asserts so that one cannot use the Chunk or Spherical shell geometry with the unsupported Initial topography options?

