### PR TITLE
Micro-language-fix for the manual.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -4457,8 +4457,9 @@ Section~\ref{sec:extending}.}
 Basically, these are just regular text files you can edit with programs like
 \texttt{gedit}, \texttt{kwrite} or \texttt{kate} when working on Linux, or
 something as simple as \texttt{NotePad} on Windows. When setting up these input
-files, you basically have to describe everything that characterizes the
-computation you want to do. In particular, this includes the following:
+files for a model you have in mind, you have to describe everything
+that characterizes the situation you are considering. In particular,
+this includes the following:
 \begin{itemize}
   \item What internal forces act on the medium (the equation)?
   \item What external forces do we have (the right hand side)


### PR DESCRIPTION
I seem to have had this sitting around in my working directory for a while
already. I believe I thought that the term 'basically' is informal. It's
also incorrect: You really do have to describe 'everything', not just
'basically everything'.