### PR TITLE
Updates to the code for copying material model data into compositional fields.

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -804,11 +804,15 @@ namespace aspect
      * the MaterialModel::MaterialModelOutputs structure and filled in the
      * MaterialModel::Interface::evaluate() function.
      *
-     * If the advection scheme "prescribed field" is selected, then these
-     * material model outputs will be interpolated onto the corresponding
+     * This structure is used if for one of the compositional fields employed
+     * by a simulation, the advection scheme "prescribed field" is selected.
+     * (See Parameters::AdvectionFieldMethod for more information.)
+     * Then, while updating the compositional field, a structure of this
+     * type is created, given to the material model, and the material model
+     * outputs will finally be interpolated onto the corresponding
      * compositional field.
      *
-     * However, note that this structure always has as many prescribed field
+     * @note This structure always has as many prescribed field
      * outputs as there are compositional fields, even if not all of them
      * are using the "prescribed field" method. It is the responsibility
      * of the individual material models to fill the correct entries.

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -98,7 +98,12 @@ namespace aspect
     /**
      * A struct that describes the available methods to solve
      * advected fields. This type is at the moment only used to determine how
-     * to advect each compositional field.
+     * to advect each compositional field -- or what else to do with it if
+     * it doesn't satisfy an advection equation, for example if the
+     * compositional field just contains data interpolated from
+     * particles in each time step (`particles`) or if it contains
+     * data interpolated from other sources such as material outputs
+     * (`prescribed_field`), neither of which is further advected.
      */
     struct AdvectionFieldMethod
     {

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1151,19 +1151,26 @@ namespace aspect
       /**
        * Interpolate material model outputs onto a compositional field. For the field
        * whose index is given in the @p compositional_index, this function
-       * interpolates additional material model outputs called 'PrescribedFieldOutputs'
-       * and copies these values into the solution vector.
-       * This is useful for fields that use the 'prescribed field' compositional field
-       * method.
+       * asks the material model to fill a MaterialModel::MaterialModelOutputs
+       * object that has an attached MaterialModel::PrescribedFieldOutputs
+       * "additional outputs" object. The MaterialModel::MaterialModelInputs
+       * object passed to the material model then contains the support points of
+       * the compositional field, thereby allowing the outputs to be
+       * interpolated to the finite element space and consequently into the
+       * solution vector.
+       * This is useful for compositional fields whose advection mode is set
+       * to Parameters::AdvectionFieldMethod::prescribed_field.
        *
-       * This function also updates the old solution vectors with these interpolated
-       * values so that this compositional field method can be combined with time-dependent
-       * problems like advection or diffusion of the field.
+       * This function also sets the previous solution vectors (corresponding to the
+       * solution from previous time steps) to the same interpolated
+       * values. This implies that the compositional field method can then be
+       * combined with time-dependent problems like advection or diffusion of
+       * the field.
        *
        * This function is implemented in
        * <code>source/simulator/helper_functions.cc</code>.
        */
-      void interpolate_material_output_into_field (const unsigned int compositional_index);
+      void interpolate_material_output_into_compositional_field (const unsigned int compositional_index);
 
 
       /**

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -183,7 +183,7 @@ namespace aspect
               // if this is a prescribed field with diffusion, we first have to copy the material model
               // outputs into the prescribed field before we assemle and solve the equation
               if (method == Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion)
-                interpolate_material_output_into_field(c);
+                interpolate_material_output_into_compositional_field(c);
 
               assemble_advection_system (adv_field);
 
@@ -207,7 +207,7 @@ namespace aspect
 
             case Parameters<dim>::AdvectionFieldMethod::prescribed_field:
             {
-              interpolate_material_output_into_field(c);
+              interpolate_material_output_into_compositional_field(c);
 
               // Call the signal in case the user wants to do something with the variable:
               SolverControl dummy;


### PR DESCRIPTION
These are all updates for code introduced mostly in #2677. The only functional
change is to rename interpolate_material_output_into_field() to
interpolate_material_output_into_compositional_field() to make clear
where the data goes.

I have some more questions about this code, but will ask that separately
once these cleanups are merged.

Related also to #2715, #2716, #2718, #2719.