### PR TITLE
Replace invalid_manifold_id by flat_manifold_id.

### DIFF
--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -354,7 +354,7 @@ namespace aspect
              triangulation.begin_active(); cell != triangulation.end(); ++cell)
         for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
           if (cell->face(f)->at_boundary())
-            cell->face(f)->set_all_manifold_ids (numbers::invalid_manifold_id);
+            cell->face(f)->set_all_manifold_ids (numbers::flat_manifold_id);
     }
 
     template <int dim>

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -60,7 +60,7 @@ namespace aspect
       {
         for (typename Triangulation<dim>::active_cell_iterator cell =
                triangulation.begin_active(); cell != triangulation.end(); ++cell)
-          cell->set_all_manifold_ids (numbers::invalid_manifold_id);
+          cell->set_all_manifold_ids (numbers::flat_manifold_id);
       }
     }
 


### PR DESCRIPTION
types::invalid_manifold_id is deprecated in deal.II post 9.0 and
has been replaced by types::flat_manifold_id. I am pretty sure that
flat_manifold_id already existed in deal.II 9.0, which we require
anyway. So it's safe to use this.

ASPECT cannot currently be compiled with deal.II 9.1-pre because
of #2602, so this does not actually matter in some sense. But it
is a step in the right direction and will have to be addressed
at one point anyway. For me, it also reduces the number of
warnings I get when I want to compile the current state to
the degree this is possible.