### PR TITLE
Update dockerfile to use correct deal.II base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM dealii/dealii:v8.5.0-gcc-mpi-fulldepscandi-debugrelease
+FROM dealii/dealii:v8.5.1-gcc-mpi-fulldepscandi-debugrelease
 
 LABEL maintainer <rene.gassmoeller@mailbox.org>
 


### PR DESCRIPTION
The 8.5.0 image uses an ubuntu that is not longer supported (16.10), which makes it difficult to modify the image. The 8.5.1 image uses ubuntu 16.04, which will be supported for another 2 years.