### PR TITLE
Introduce parameters.xml

### DIFF
--- a/doc/parameter_view/parameters.css
+++ b/doc/parameter_view/parameters.css
@@ -1,0 +1,47 @@
+ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+}
+
+/* Style the button that is used to open and close the collapsible content */
+.collapsible {
+  background-color: #ddd;
+  color: #444;
+  cursor: pointer;
+  padding: 3px;
+  width: auto;
+  border: none;
+  border-radius: 5px;
+  margin: 10px;
+  text-align: left;
+  outline: none;
+}
+
+/* Style parameters that are no subsections */
+.parameter {
+  background-color: #eee;
+  color: #444;
+  cursor: pointer;
+  padding: 3px;
+  width: auto;
+  border: none;
+  border-radius: 5px;
+  margin: 10px;
+  text-align: left;
+  outline: none;
+}
+/* Add a background color to the button if it is clicked on (add the .active class with JS), and when you move the mouse over it (hover) */
+.active, .collapsible:hover {
+  background-color: #ccc;
+}
+
+/* Style the collapsible content. Note: hidden by default */
+.content {
+  padding: 5px;
+  margin: 0 18px;
+  border-radius: 5px;
+  display: none;
+  overflow: hidden;
+  background-color: #f1f1f1;
+} 

--- a/doc/parameter_view/parameters.js
+++ b/doc/parameter_view/parameters.js
@@ -1,13 +1,34 @@
+/*
+  Copyright (C) 2018 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
 demangleStrings();
 
 function demangleStrings() {
-mangledStrings = document.getElementsByClassName("mangled");
-var j;
-for (j = 0; j < mangledStrings.length; j++) {
-mangledStrings[j].innerHTML = mangledStrings[j].innerHTML.replace(/_20/g," ");
-mangledStrings[j].innerHTML = mangledStrings[j].innerHTML.replace(/_2d/g,"-");
-}
-return;
+  mangledStrings = document.getElementsByClassName("mangled");
+  var j;
+  for (j = 0; j < mangledStrings.length; j++) {
+    mangledStrings[j].innerHTML = mangledStrings[j].innerHTML.replace(/_20/g," ");
+    mangledStrings[j].innerHTML = mangledStrings[j].innerHTML.replace(/_2d/g,"-");
+  }
+  return;
 }
 
 

--- a/doc/parameter_view/parameters.js
+++ b/doc/parameter_view/parameters.js
@@ -1,0 +1,27 @@
+demangleStrings();
+
+function demangleStrings() {
+mangledStrings = document.getElementsByClassName("mangled");
+var j;
+for (j = 0; j < mangledStrings.length; j++) {
+mangledStrings[j].innerHTML = mangledStrings[j].innerHTML.replace(/_20/g," ");
+mangledStrings[j].innerHTML = mangledStrings[j].innerHTML.replace(/_2d/g,"-");
+}
+return;
+}
+
+
+var coll = document.getElementsByClassName("collapsible");
+var i;
+
+for (i = 0; i < coll.length; i++) {
+  coll[i].addEventListener("click", function() {
+    this.classList.toggle("active");
+    var content = this.nextElementSibling;
+    if (content.style.display === "block") {
+      content.style.display = "none";
+    } else {
+      content.style.display = "block";
+    }
+  });
+}

--- a/doc/parameter_view/parameters.xml
+++ b/doc/parameter_view/parameters.xml
@@ -1,0 +1,17525 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="application/xml" href="parameters.xsl"?>
+
+<ParameterHandler>
+<Dimension>
+<value>
+2
+</value>
+<default_value>
+2
+</default_value>
+<documentation>
+The number of space dimensions you want to run this program in. ASPECT can run in 2 and 3 space dimensions.
+</documentation>
+<pattern>
+0
+</pattern>
+<pattern_description>
+[Integer range 2...3 (inclusive)]
+</pattern_description>
+</Dimension>
+<Additional_20shared_20libraries>
+<value/>
+<default_value/>
+<documentation>
+A list of names of additional shared libraries that should be loaded upon starting up the program. The names of these files can contain absolute or relative paths (relative to the directory in which you call ASPECT). In fact, file names that do not contain any directory information (i.e., only the name of a file such as &lt;myplugin.so&gt; will not be found if they are not located in one of the directories listed in the \texttt{LD_LIBRARY_PATH} environment variable. In order to load a library in the current directory, use &lt;./myplugin.so&gt; instead.
+
+The typical use of this parameter is so that you can implement additional plugins in your own directories, rather than in the ASPECT source directories. You can then simply compile these plugins into a shared library without having to re-compile all of ASPECT. See the section of the manual discussing writing extensions for more information on how to compile additional files into a shared library.
+</documentation>
+<pattern>
+1
+</pattern>
+<pattern_description>
+[List of &lt;[FileName (Type: input)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Additional_20shared_20libraries>
+<Resume_20computation>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+A flag indicating whether the computation should be resumed from a previously saved state (if true) or start from scratch (if false). If auto is selected, models will be resumed if there is an existing checkpoint file, otherwise started from scratch.
+</documentation>
+<pattern>
+2
+</pattern>
+<pattern_description>
+[Selection true|false|auto ]
+</pattern_description>
+</Resume_20computation>
+<Max_20nonlinear_20iterations>
+<value>
+10
+</value>
+<default_value>
+10
+</default_value>
+<documentation>
+The maximal number of nonlinear iterations to be performed.
+</documentation>
+<pattern>
+3
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Max_20nonlinear_20iterations>
+<Max_20nonlinear_20iterations_20in_20pre_2drefinement>
+<value>
+2147483647
+</value>
+<default_value>
+2147483647
+</default_value>
+<documentation>
+The maximal number of nonlinear iterations to be performed in the pre-refinement steps. This does not include the last refinement step before moving to timestep 1. When this parameter has a larger value than max nonlinear iterations, the latter is used.
+</documentation>
+<pattern>
+4
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Max_20nonlinear_20iterations_20in_20pre_2drefinement>
+<Start_20time>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The start time of the simulation. Units: Years if the &apos;Use years in output instead of seconds&apos; parameter is set; seconds otherwise.
+</documentation>
+<pattern>
+5
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Start_20time>
+<Timing_20output_20frequency>
+<value>
+100
+</value>
+<default_value>
+100
+</default_value>
+<documentation>
+How frequently in timesteps to output timing information. This is generally adjusted only for debugging and timing purposes. If the value is set to zero it will also output timing information at the initiation timesteps.
+</documentation>
+<pattern>
+6
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Timing_20output_20frequency>
+<Use_20years_20in_20output_20instead_20of_20seconds>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+When computing results for mantle convection simulations, it is often difficult to judge the order of magnitude of results when they are stated in MKS units involving seconds. Rather, some kinds of results such as velocities are often stated in terms of meters per year (or, sometimes, centimeters per year). On the other hand, for non-dimensional computations, one wants results in their natural unit system as used inside the code. If this flag is set to `true&apos; conversion to years happens; if it is `false&apos;, no such conversion happens. Note that when `true&apos;, some input such as prescribed velocities should also use years instead of seconds.
+</documentation>
+<pattern>
+7
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20years_20in_20output_20instead_20of_20seconds>
+<CFL_20number>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+In computations, the time step $k$ is chosen according to $k = c \min_K \frac {h_K} {\|u\|_{\infty,K} p_T}$ where $h_K$ is the diameter of cell $K$, and the denominator is the maximal magnitude of the velocity on cell $K$ times the polynomial degree $p_T$ of the temperature discretization. The dimensionless constant $c$ is called the CFL number in this program. For time discretizations that have explicit components, $c$ must be less than a constant that depends on the details of the time discretization and that is no larger than one. On the other hand, for implicit discretizations such as the one chosen here, one can choose the time step as large as one wants (in particular, one can choose $c&gt;1$) though a CFL number significantly larger than one will yield rather diffusive solutions. Units: None.
+</documentation>
+<pattern>
+8
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</CFL_20number>
+<Maximum_20time_20step>
+<value>
+5.69e+300
+</value>
+<default_value>
+5.69e+300
+</default_value>
+<documentation>
+Set a maximum time step size for the solver to use. Generally the time step based on the CFL number should be sufficient, but for complicated models or benchmarking it may be useful to limit the time step to some value. The default value is a value so that when converted from years into seconds it equals the largest number representable by a floating point number, implying an unlimited time step.Units: Years or seconds, depending on the ``Use years in output instead of seconds&apos;&apos; parameter.
+</documentation>
+<pattern>
+9
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20time_20step>
+<Maximum_20first_20time_20step>
+<value>
+5.69e+300
+</value>
+<default_value>
+5.69e+300
+</default_value>
+<documentation>
+Set a maximum time step size for only the first timestep. Generally the time step based on the CFL number should be sufficient, but for complicated models or benchmarking it may be useful to limit the first time step to some value, especially when using the free surface, which needs to settle to prevent instabilities. This should in that case be combined with a value set for ``Maximum relative increase in time step&apos;&apos;. The default value is a value so that when converted from years into seconds it equals the largest number representable by a floating point number, implying an unlimited time step. Units: Years or seconds, depending on the ``Use years in output instead of seconds&apos;&apos; parameter.
+</documentation>
+<pattern>
+10
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20first_20time_20step>
+<Maximum_20relative_20increase_20in_20time_20step>
+<value>
+2147483647
+</value>
+<default_value>
+2147483647
+</default_value>
+<documentation>
+Set a percentage with which the the time step is limited to increase. Generally the time step based on the CFL number should be sufficient, but for complicated models which may suddenly drastically change behavior, it may be useful to limit the increase in the time step, without limiting the time step size of the whole simulation to a particular number. For example, if this parameter is set to $50$, then that means that the time step can at most increase by 50\% from one time step to the next, or by a factor of 1.5. Units: \%
+</documentation>
+<pattern>
+11
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20relative_20increase_20in_20time_20step>
+<Use_20conduction_20timestep>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Mantle convection simulations are often focused on convection dominated systems. However, these codes can also be used to investigate systems where heat conduction plays a dominant role. This parameter indicates whether the simulator should also use heat conduction in determining the length of each time step.
+</documentation>
+<pattern>
+12
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20conduction_20timestep>
+<Nonlinear_20solver_20scheme>
+<value>
+single Advection, single Stokes
+</value>
+<default_value>
+single Advection, single Stokes
+</default_value>
+<documentation>
+The kind of scheme used to resolve the nonlinearity in the system. `single Advection, single Stokes&apos; means that no nonlinear iterations are done, and the temperature, compositional fields and Stokes equations are solved exactly once per time step, one after the other. The `iterated Advection and Stokes&apos; scheme iterates this decoupled approach by alternating the solution of the temperature, composition and Stokes systems. The `single Advection, iterated Stokes&apos; scheme solves the temperature and composition equation once at the beginning of each time step and then iterates out the solution of the Stokes equation. The `no Advection, iterated Stokes&apos; scheme only solves the Stokes system, iterating out the solution, and ignores compositions and the temperature equation (careful, the material model must not depend on the temperature or composition; this is mostly useful for Stokes benchmarks). The `single Advection, no Stokes&apos; scheme only solves the temperature and other advection systems once, and instead of solving for the Stokes system, a prescribed velocity and pressure is used. The `iterated Advection and Newton Stokes&apos; scheme iterates by alternating the solution of the temperature, composition and Stokes equations, using Picard iterations for the temperature and composition, and Newton iterations for the Stokes system. The `first timestep only, single Stokes&apos; scheme solves the Stokes equations exactly once, at the first time step. No nonlinear iterations are done, and the temperature and composition systems are not solved. The `IMPES&apos; scheme is deprecated and only allowed for reasons of backwards compatibility. It is the same as `single Advection, single Stokes&apos; .The `iterated IMPES&apos; scheme is deprecated and only allowed for reasons of backwards compatibility. It is the same as `iterated Advection and Stokes&apos;. The `iterated Stokes&apos; scheme is deprecated and only allowed for reasons of backwards compatibility. It is the same as `single Advection, iterated Stokes&apos;. The `Stokes only&apos; scheme is deprecated and only allowed for reasons of backwards compatibility. It is the same as `no Advection, iterated Stokes&apos;. The `Advection only&apos; scheme is deprecated and only allowed for reasons of backwards compatibility. It is the same as `single Advection, no Stokes&apos;. The `Newton Stokes&apos; scheme is deprecated and only allowed for reasons of backwards compatibility. It is the same as `iterated Advection and Newton Stokes&apos;.
+</documentation>
+<pattern>
+13
+</pattern>
+<pattern_description>
+[Selection single Advection, single Stokes|iterated Advection and Stokes|single Advection, iterated Stokes|no Advection, iterated Stokes|iterated Advection and Newton Stokes|single Advection, no Stokes|IMPES|iterated IMPES|iterated Stokes|Newton Stokes|Stokes only|Advection only|first timestep only, single Stokes ]
+</pattern_description>
+</Nonlinear_20solver_20scheme>
+<Nonlinear_20solver_20tolerance>
+<value>
+1e-5
+</value>
+<default_value>
+1e-5
+</default_value>
+<documentation>
+A relative tolerance up to which the nonlinear solver will iterate. This parameter is only relevant if the `Nonlinear solver scheme&apos; does nonlinear iterations, in other words, if it is set to something other than `single Advection, single Stokes&apos; or `single Advection, no Stokes&apos;.
+</documentation>
+<pattern>
+14
+</pattern>
+<pattern_description>
+[Double 0...1 (inclusive)]
+</pattern_description>
+</Nonlinear_20solver_20tolerance>
+<Pressure_20normalization>
+<value>
+surface
+</value>
+<default_value>
+surface
+</default_value>
+<documentation>
+If and how to normalize the pressure after the solution step. This is necessary because depending on boundary conditions, in many cases the pressure is only determined by the model up to a constant. On the other hand, we often would like to have a well-determined pressure, for example for table lookups of material properties in models or for comparing solutions. If the given value is `surface&apos;, then normalization at the end of each time steps adds a constant value to the pressure in such a way that the average pressure at the surface of the domain is what is set in the `Surface pressure&apos; parameter; the surface of the domain is determined by asking the geometry model whether a particular face of the geometry has a zero or small `depth&apos;. If the value of this parameter is `volume&apos; then the pressure is normalized so that the domain average is zero. If `no&apos; is given, the no pressure normalization is performed.
+</documentation>
+<pattern>
+15
+</pattern>
+<pattern_description>
+[Selection surface|volume|no ]
+</pattern_description>
+</Pressure_20normalization>
+<Surface_20pressure>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The value the pressure is normalized to in each time step when `Pressure normalization&apos; is set to `surface&apos; with default value 0. This setting is ignored in all other cases.
+
+The mathematical equations that describe thermal convection only determine the pressure up to an arbitrary constant. On the other hand, for comparison and for looking up material parameters it is important that the pressure be normalized somehow. We do this by enforcing a particular average pressure value at the surface of the domain, where the geometry model determines where the surface is. This parameter describes what this average surface pressure value is supposed to be. By default, it is set to zero, but one may want to choose a different value for example for simulating only the volume of the mantle below the lithosphere, in which case the surface pressure should be the lithostatic pressure at the bottom of the lithosphere.
+
+For more information, see the section in the manual that discusses the general mathematical model.
+</documentation>
+<pattern>
+16
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Surface_20pressure>
+<Adiabatic_20surface_20temperature>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+In order to make the problem in the first time step easier to solve, we need a reasonable guess for the temperature and pressure. To obtain it, we use an adiabatic pressure and temperature field. This parameter describes what the `adiabatic&apos; temperature would be at the surface of the domain (i.e. at depth zero). Note that this value need not coincide with the boundary condition posed at this point. Rather, the boundary condition may differ significantly from the adiabatic value, and then typically induce a thermal boundary layer.
+
+For more information, see the section in the manual that discusses the general mathematical model.
+</documentation>
+<pattern>
+17
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Adiabatic_20surface_20temperature>
+<Output_20directory>
+<value>
+output
+</value>
+<default_value>
+output
+</default_value>
+<documentation>
+The name of the directory into which all output files should be placed. This may be an absolute or a relative path.
+</documentation>
+<pattern>
+18
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Output_20directory>
+<Use_20operator_20splitting>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+If set to true, the advection and reactions of compositional fields and temperature are solved separately, and can use different time steps. Note that this will only work if the material/heating model fills the reaction\_rates/heating\_reaction\_rates structures. Operator splitting can be used with any existing solver schemes that solve the temperature/composition equations.
+</documentation>
+<pattern>
+19
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20operator_20splitting>
+<World_20builder_20file>
+<value/>
+<default_value/>
+<documentation>
+Name of the world builder file. If empty, the world builder is not initialized.
+</documentation>
+<pattern>
+20
+</pattern>
+<pattern_description>
+[FileName (Type: input)]
+</pattern_description>
+</World_20builder_20file>
+<Solver_20parameters>
+<Temperature_20solver_20tolerance>
+<value>
+1e-12
+</value>
+<default_value>
+1e-12
+</default_value>
+<documentation>
+The relative tolerance up to which the linear system for the temperature system gets solved. See `Stokes solver parameters/Linear solver tolerance&apos; for more details.
+</documentation>
+<pattern>
+21
+</pattern>
+<pattern_description>
+[Double 0...1 (inclusive)]
+</pattern_description>
+</Temperature_20solver_20tolerance>
+<Composition_20solver_20tolerance>
+<value>
+1e-12
+</value>
+<default_value>
+1e-12
+</default_value>
+<documentation>
+The relative tolerance up to which the linear system for the composition system gets solved. See `Stokes solver parameters/Linear solver tolerance&apos; for more details.
+</documentation>
+<pattern>
+22
+</pattern>
+<pattern_description>
+[Double 0...1 (inclusive)]
+</pattern_description>
+</Composition_20solver_20tolerance>
+<Stokes_20solver_20parameters>
+<Use_20direct_20solver_20for_20Stokes_20system>
+<value>
+true
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+If set to true the linear system for the Stokes equation will be solved using Trilinos klu, otherwise an iterative Schur complement solver is used. The direct solver is only efficient for small problems.
+</documentation>
+<pattern>
+23
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20direct_20solver_20for_20Stokes_20system>
+<Linear_20solver_20tolerance>
+<value>
+1e-7
+</value>
+<default_value>
+1e-7
+</default_value>
+<documentation>
+A relative tolerance up to which the linear Stokes systems in each time or nonlinear step should be solved. The absolute tolerance will then be $\| M x_0 - F \| \cdot \text{tol}$, where $x_0 = (0,p_0)$ is the initial guess of the pressure, $M$ is the system matrix, $F$ is the right-hand side, and tol is the parameter specified here. We include the initial guess of the pressure to remove the dependency of the tolerance on the static pressure. A given tolerance value of 1 would mean that a zero solution vector is an acceptable solution since in that case the norm of the residual of the linear system equals the norm of the right hand side. A given tolerance of 0 would mean that the linear system has to be solved exactly, since this is the only way to obtain a zero residual.
+
+In practice, you should choose the value of this parameter to be so that if you make it smaller the results of your simulation do not change any more (qualitatively) whereas if you make it larger, they do. For most cases, the default value should be sufficient. In fact, a tolerance of 1e-4 might be accurate enough.
+</documentation>
+<pattern>
+24
+</pattern>
+<pattern_description>
+[Double 0...1 (inclusive)]
+</pattern_description>
+</Linear_20solver_20tolerance>
+<Number_20of_20cheap_20Stokes_20solver_20steps>
+<value>
+200
+</value>
+<default_value>
+200
+</default_value>
+<documentation>
+As explained in the paper that describes ASPECT (Kronbichler, Heister, and Bangerth, 2012, see \cite{KHB12}) we first try to solve the Stokes system in every time step using a GMRES iteration with a poor but cheap preconditioner. By default, we try whether we can converge the GMRES solver in 200 such iterations before deciding that we need a better preconditioner. This is sufficient for simple problems with variable viscosity and we never need the second phase with the more expensive preconditioner. On the other hand, for more complex problems, and in particular for problems with strongly nonlinear viscosity, the 200 cheap iterations don&apos;t actually do very much good and one might skip this part right away. In that case, this parameter can be set to zero, i.e., we immediately start with the better but more expensive preconditioner.
+</documentation>
+<pattern>
+25
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Number_20of_20cheap_20Stokes_20solver_20steps>
+<Maximum_20number_20of_20expensive_20Stokes_20solver_20steps>
+<value>
+1000
+</value>
+<default_value>
+1000
+</default_value>
+<documentation>
+This sets the maximum number of iterations used in the expensive Stokes solver. If this value is set too low for the size of the problem, the Stokes solver will not converge and return an error message pointing out that the user didn&apos;t allow a sufficiently large number of iterations for the iterative solver to converge.
+</documentation>
+<pattern>
+26
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Maximum_20number_20of_20expensive_20Stokes_20solver_20steps>
+<GMRES_20solver_20restart_20length>
+<value>
+50
+</value>
+<default_value>
+50
+</default_value>
+<documentation>
+This is the number of iterations that define the GMRES solver restart length. Increasing this parameter helps with convergence issues arising from high localized viscosity jumps in the domain. Be aware that increasing this number increases the memory usage of the Stokes solver, and makes individual Stokes iterations more expensive.
+</documentation>
+<pattern>
+27
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</GMRES_20solver_20restart_20length>
+<Linear_20solver_20A_20block_20tolerance>
+<value>
+1e-2
+</value>
+<default_value>
+1e-2
+</default_value>
+<documentation>
+A relative tolerance up to which the approximate inverse of the $A$ block of the Stokes system is computed. This approximate $A$ is used in the preconditioning used in the GMRES solver. The exact definition of this block preconditioner for the Stokes equation can be found in \cite{KHB12}.
+</documentation>
+<pattern>
+28
+</pattern>
+<pattern_description>
+[Double 0...1 (inclusive)]
+</pattern_description>
+</Linear_20solver_20A_20block_20tolerance>
+<Use_20full_20A_20block_20as_20preconditioner>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+This parameter determines whether we use an simplified approximation of the $A$ block as preconditioner for the Stokes solver, or the full $A$ block. The simplified approximation only contains the terms that describe the coupling of identical components (plus boundary conditions) as described in \cite{KHB12}. The full block is closer to the description in \cite{rudi2017weighted}.
+
+There is no clear way to determine which preconditioner performs better. The default value (simplified approximation) requires more outer GMRES iterations, but is faster to apply in each iteration. The full block needs less assembly time (because the block is available anyway), converges in less GMRES iterations, but requires more time per iteration. There are also differences in the amount of memory consumption between the two approaches.
+
+The default value should be good for relatively simple models, but in particular for very strong viscosity contrasts the full $A$ block can be advantageous.
+</documentation>
+<pattern>
+29
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20full_20A_20block_20as_20preconditioner>
+<Linear_20solver_20S_20block_20tolerance>
+<value>
+1e-6
+</value>
+<default_value>
+1e-6
+</default_value>
+<documentation>
+A relative tolerance up to which the approximate inverse of the $S$ block (i.e., the Schur complement matrix $S = BA^{-1}B^{T}$) of the Stokes system is computed. This approximate inverse of the $S$ block is used in the preconditioning used in the GMRES solver. The exact definition of this block preconditioner for the Stokes equation can be found in \cite{KHB12}.
+</documentation>
+<pattern>
+30
+</pattern>
+<pattern_description>
+[Double 0...1 (inclusive)]
+</pattern_description>
+</Linear_20solver_20S_20block_20tolerance>
+</Stokes_20solver_20parameters>
+<AMG_20parameters>
+<AMG_20smoother_20type>
+<value>
+Chebyshev
+</value>
+<default_value>
+Chebyshev
+</default_value>
+<documentation>
+This parameter sets the type of smoother for the AMG. The default is strongly recommended for any normal runs with ASPECT. There are some indications that the symmetric Gauss-Seidel might be better and more stable for the Newton solver. For extensive benchmarking of various settings of the AMG parameters in this section for the Stokes problem and others, see https://github.com/geodynamics/aspect/pull/234.
+</documentation>
+<pattern>
+31
+</pattern>
+<pattern_description>
+[Selection Chebyshev|symmetric Gauss-Seidel ]
+</pattern_description>
+</AMG_20smoother_20type>
+<AMG_20smoother_20sweeps>
+<value>
+2
+</value>
+<default_value>
+2
+</default_value>
+<documentation>
+Determines how many sweeps of the smoother should be performed. When the flag elliptic is set to true, (which is true for ASPECT), the polynomial degree of the Chebyshev smoother is set to this value. The term sweeps refers to the number of matrix-vector products performed in the Chebyshev case. In the non-elliptic case, this parameter sets the number of SSOR relaxation sweeps for post-smoothing to be performed. The default is strongly recommended. There are indications that for the Newton solver a different value might be better. For extensive benchmarking of various settings of the AMG parameters in this section for the Stokes problem and others, see https://github.com/geodynamics/aspect/pull/234.
+</documentation>
+<pattern>
+32
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</AMG_20smoother_20sweeps>
+<AMG_20aggregation_20threshold>
+<value>
+0.001
+</value>
+<default_value>
+0.001
+</default_value>
+<documentation>
+This threshold tells the AMG setup how the coarsening should be performed. In the AMG used by ML, all points that strongly couple with the tentative coarse-level point form one aggregate. The term strong coupling is controlled by the variable aggregation\_threshold, meaning that all elements that are not smaller than aggregation\_threshold times the diagonal element do couple strongly. The default is strongly recommended. There are indications that for the Newton solver a different value might be better. For extensive benchmarking of various settings of the AMG parameters in this section for the Stokes problem and others, see https://github.com/geodynamics/aspect/pull/234.
+</documentation>
+<pattern>
+33
+</pattern>
+<pattern_description>
+[Double 0...1 (inclusive)]
+</pattern_description>
+</AMG_20aggregation_20threshold>
+<AMG_20output_20details>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Turns on extra information on the AMG solver. Note that this will generate much more output.
+</documentation>
+<pattern>
+34
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</AMG_20output_20details>
+</AMG_20parameters>
+<Operator_20splitting_20parameters>
+<Reaction_20time_20step>
+<value>
+1000.0
+</value>
+<default_value>
+1000.0
+</default_value>
+<documentation>
+Set a time step size for computing reactions of compositional fields and the temperature field in case operator splitting is used. This is only used when the nonlinear solver scheme ``operator splitting&apos;&apos; is selected. The reaction time step must be greater than 0. If you want to prescribe the reaction time step only as a relative value compared to the advection time step as opposed to as an absolute value, you should use the parameter ``Reaction time steps per advection step&apos;&apos; and set this parameter to the same (or larger) value as the ``Maximum time step&apos;&apos; (which is 5.69e+300 by default). Units: Years or seconds, depending on the ``Use years in output instead of seconds&apos;&apos; parameter.
+</documentation>
+<pattern>
+35
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reaction_20time_20step>
+<Reaction_20time_20steps_20per_20advection_20step>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The number of reaction time steps done within one advection time step in case operator splitting is used. This is only used if the nonlinear solver scheme ``operator splitting&apos;&apos; is selected. If set to zero, this parameter is ignored. Otherwise, the reaction time step size is chosen according to this criterion and the ``Reaction time step&apos;&apos;, whichever yields the smaller time step. Units: none.
+</documentation>
+<pattern>
+36
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Reaction_20time_20steps_20per_20advection_20step>
+</Operator_20splitting_20parameters>
+<Newton_20solver_20parameters>
+<Nonlinear_20Newton_20solver_20switch_20tolerance>
+<value>
+1e-5
+</value>
+<default_value>
+1e-5
+</default_value>
+<documentation>
+A relative tolerance with respect to the residual of the first iteration, up to which the nonlinear Picard solver will iterate, before changing to the Newton solver.
+</documentation>
+<pattern>
+94
+</pattern>
+<pattern_description>
+[Double 0...1 (inclusive)]
+</pattern_description>
+</Nonlinear_20Newton_20solver_20switch_20tolerance>
+<Max_20pre_2dNewton_20nonlinear_20iterations>
+<value>
+10
+</value>
+<default_value>
+10
+</default_value>
+<documentation>
+If the &apos;Nonlinear Newton solver switch tolerance&apos; is reached before the maximal number of Picard iteration, then the solver switches to Newton solves anyway.
+</documentation>
+<pattern>
+95
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Max_20pre_2dNewton_20nonlinear_20iterations>
+<Max_20Newton_20line_20search_20iterations>
+<value>
+5
+</value>
+<default_value>
+5
+</default_value>
+<documentation>
+The maximum number of line search iterations allowed. If the criterion is not reached after this number of iteration, we apply the scaled increment even though it does not satisfy the necessary criteria and simply continue with the next Newton iteration.
+</documentation>
+<pattern>
+96
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Max_20Newton_20line_20search_20iterations>
+<Use_20Newton_20residual_20scaling_20method>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+This method allows to slowly introduce the derivatives based on the improvement of the residual. If set to false, the scaling factor for the Newton derivatives is set to one immediately when switching on the Newton solver. When this is set to true, the derivatives are slowly introduced by the following equation: $\max(0.0, (1.0-(residual/switch\_initial\_residual)))$, where switch\_initial\_residual is the residual at the time when the Newton solver is switched on.
+</documentation>
+<pattern>
+97
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20Newton_20residual_20scaling_20method>
+<Maximum_20linear_20Stokes_20solver_20tolerance>
+<value>
+0.9
+</value>
+<default_value>
+0.9
+</default_value>
+<documentation>
+The linear Stokes solver tolerance is dynamically chosen for the Newton solver, based on the Eisenstat walker 1994 paper (https://doi.org/10.1137/0917003), equation 2.2. Because this value can become larger then one, we limit this value by this parameter.
+</documentation>
+<pattern>
+98
+</pattern>
+<pattern_description>
+[Double 0...1 (inclusive)]
+</pattern_description>
+</Maximum_20linear_20Stokes_20solver_20tolerance>
+<Stabilization_20preconditioner>
+<value>
+SPD
+</value>
+<default_value>
+SPD
+</default_value>
+<documentation>
+This parameters allows for the stabilization of the preconditioner. If one derives the Newton method without any modifications, the matrix created for the preconditioning is not necessarily Symmetric Positive Definite. This is problematic (see Fraters et al., in prep). When `none&apos; is chosen, the preconditioner is not stabilized. The `symmetric&apos; parameters symmetrizes the matrix, and `PD&apos; makes the matrix Positive Definite. `SPD&apos; is the full stabilization, where the matrix is guaranteed Symmetric Positive Definite.
+</documentation>
+<pattern>
+99
+</pattern>
+<pattern_description>
+[Selection SPD|PD|symmetric|none ]
+</pattern_description>
+</Stabilization_20preconditioner>
+<Stabilization_20velocity_20block>
+<value>
+SPD
+</value>
+<default_value>
+SPD
+</default_value>
+<documentation>
+This parameters allows for the stabilization of the velocity block. If one derives the Newton method without any modifications, the matrix created for the velocity block is not necessarily Symmetric Positive Definite. This is problematic (see Fraters et al., in prep). When `none&apos; is chosen, the velocity block is not stabilized. The `symmetric&apos; parameters symmetrizes the matrix, and `PD&apos; makes the matrix Positive Definite. `SPD&apos; is the full stabilization, where the matrix is guaranteed Symmetric Positive Definite.
+</documentation>
+<pattern>
+100
+</pattern>
+<pattern_description>
+[Selection SPD|PD|symmetric|none ]
+</pattern_description>
+</Stabilization_20velocity_20block>
+<Use_20Newton_20failsafe>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+When this parameter is true and the linear solver fails, we try again, but now with SPD stabilization for both the preconditioner and the velocity block. The SPD stabilization will remain active untill the next timestep, when the default values are restored.
+</documentation>
+<pattern>
+101
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20Newton_20failsafe>
+<SPD_20safety_20factor>
+<value>
+0.9
+</value>
+<default_value>
+0.9
+</default_value>
+<documentation>
+When stabilizing the Newton matrix, we can encounter situations where the coefficient inside the elliptic (top-left) block becomes negative or zero. This coefficient has the form $1+x$ where $x$ can sometimes be smaller than $-1$. In this case, the top-left block of the matrix is no longer positive definite, and both preconditioners and iterative solvers may fail. To prevent this, the stabilization computes an $\alpha$ so that $1+\alpha x$ is never negative. This $\alpha$ is chosen as $1$ if $x\ge -1$, and $\alpha=-\frac 1x$ otherwise. (Note that this always leads to $0\le \alpha \le 1$.)  On the other hand, we also want to stay away from $1+\alpha x=0$, and so modify the choice of $\alpha$ to be $1$ if $x\ge -c$, and $\alpha=-\frac cx$ with a $c$ between zero and one. This way, if $c&lt;1$, we are assured that $1-\alpha x&gt;c$, i.e., bounded away from zero.
+</documentation>
+<pattern>
+102
+</pattern>
+<pattern_description>
+[Double 0...1 (inclusive)]
+</pattern_description>
+</SPD_20safety_20factor>
+<Use_20Eisenstat_20Walker_20method_20for_20Picard_20iterations>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+If set to true, the Picard iteration uses the Eisenstat Walker method to determine how accurately linear systems need to be solved. The Picard iteration is used, for example, in the first few iterations of the Newton method before the matrix is built including derivatives of the model, since the Picard iteration generally converges even from points where Newton&apos;s method does not. 
+
+Once derivatives are used in a Newton method, \aspect{} always uses the Eisenstat Walker method.
+</documentation>
+<pattern>
+103
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20Eisenstat_20Walker_20method_20for_20Picard_20iterations>
+</Newton_20solver_20parameters>
+</Solver_20parameters>
+<Formulation>
+<Formulation>
+<value>
+custom
+</value>
+<default_value>
+custom
+</default_value>
+<documentation>
+Select a formulation for the basic equations. Different published formulations are available in ASPECT (see the list of possible values for this parameter in the manual for available options). Two ASPECT specific options are
+\begin{enumerate}
+  \item `isothermal compression&apos;: ASPECT&apos;s original formulation, using the explicit compressible mass equation, and the full density for the temperature equation.
+  \item `custom&apos;: A custom selection of `Mass conservation&apos; and `Temperature equation&apos;.
+\end{enumerate}
+
+\note{Warning: The `custom&apos; option is implemented for advanced users that want full control over the equations solved. It is possible to choose inconsistent formulations and no error checking is performed on the consistency of the resulting equations.}
+
+\note{The `anelastic liquid approximation&apos; option here can also be used to set up the `truncated anelastic liquid approximation&apos; as long as this option is chosen together with a material model that defines a density that depends on temperature and depth and not on the pressure.}
+</documentation>
+<pattern>
+37
+</pattern>
+<pattern_description>
+[Selection isothermal compression|custom|anelastic liquid approximation|Boussinesq approximation ]
+</pattern_description>
+</Formulation>
+<Mass_20conservation>
+<value>
+ask material model
+</value>
+<default_value>
+ask material model
+</default_value>
+<documentation>
+Possible approximations for the density derivatives in the mass conservation equation. Note that this parameter is only evaluated if `Formulation&apos; is set to `custom&apos;. Other formulations ignore the value of this parameter.
+</documentation>
+<pattern>
+38
+</pattern>
+<pattern_description>
+[Selection incompressible|isothermal compression|hydrostatic compression|reference density profile|implicit reference density profile|ask material model ]
+</pattern_description>
+</Mass_20conservation>
+<Temperature_20equation>
+<value>
+real density
+</value>
+<default_value>
+real density
+</default_value>
+<documentation>
+Possible approximations for the density in the temperature equation. Possible approximations are `real density&apos; and `reference density profile&apos;. Note that this parameter is only evaluated if `Formulation&apos; is set to `custom&apos;. Other formulations ignore the value of this parameter.
+</documentation>
+<pattern>
+39
+</pattern>
+<pattern_description>
+[Selection real density|reference density profile ]
+</pattern_description>
+</Temperature_20equation>
+<Enable_20additional_20Stokes_20RHS>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to ask the material model for additional terms for the right-hand side of the Stokes equation. This feature is likely only used when implementing force vectors for manufactured solution problems and requires filling additional outputs of type AdditionalMaterialOutputsStokesRHS.
+</documentation>
+<pattern>
+40
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Enable_20additional_20Stokes_20RHS>
+<Enable_20elasticity>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to include the additional elastic terms on the right-hand side of the Stokes equation.
+</documentation>
+<pattern>
+41
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Enable_20elasticity>
+</Formulation>
+<Melt_20settings>
+<Include_20melt_20transport>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to include the transport of melt into the model or not. If this is set to true, two additional pressures (the fluid pressure and the compaction pressure) will be added to the finite element. Including melt transport in the simulation also requires that there is one compositional field that has the name `porosity&apos;. This field will be used for computing the additional pressures and the melt velocity, and has a different advection equation than other compositional fields, as it is effectively advected with the melt velocity.
+</documentation>
+<pattern>
+42
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Include_20melt_20transport>
+<Melt_20scaling_20factor_20threshold>
+<value>
+1e-3
+</value>
+<default_value>
+1e-3
+</default_value>
+<documentation>
+The factor by how much the Darcy coefficient K\_D in a cell can be smaller than the reference Darcy coefficient for this cell still to be considered a melt cell (for which the melt transport equations are solved). For smaller Darcy coefficients, the Stokes equations (without melt) are solved instead. Only used if ``Include melt transport&apos;&apos; is true. 
+</documentation>
+<pattern>
+88
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Melt_20scaling_20factor_20threshold>
+<Heat_20advection_20by_20melt>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to use a porosity weighted average of the melt and solid velocity to advect heat in the temperature equation or not. If this is set to true, additional terms are assembled on the left-hand side of the temperature advection equation. Only used if Include melt transport is true. If this is set to false, only the solid velocity is used (as in models without melt migration).
+</documentation>
+<pattern>
+89
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Heat_20advection_20by_20melt>
+<Use_20discontinuous_20compaction_20pressure>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+Whether to use a discontinuous element for the compaction pressure or not. From our preliminary tests, continuous elements seem to work better in models where the porosity is &gt; 0 everywhere in the domain, and discontinuous elements work better in models where in parts of the domain the porosity = 0.
+</documentation>
+<pattern>
+90
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20discontinuous_20compaction_20pressure>
+<Average_20melt_20velocity>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+Whether to cell-wise average the material properties that are used to compute the melt velocity or not. The melt velocity is computed as the sum of the solid velocity and the phase separation flux $ - K_D / \phi (\nabla p_f - \rho_f \mathbf g)$. If this parameter is set to true, $K_D$ and $\phi$ will be averaged cell-wise in the computation of the phase separation flux. This is useful because in some models the melt velocity can have spikes close to the interface between regions of melt and no melt, as both $K_D$ and $\phi$ go to zero for vanishing melt fraction. As the melt velocity is used for computing the time step size, and in models that use heat transport by melt or shear heating of melt, setting this parameter to true can speed up the model and make it mode stable. In computations where accuracy and convergence behavior of the melt velocity is important (like in benchmark cases with an analytical solution), this parameter should probably be set to &apos;false&apos;.
+</documentation>
+<pattern>
+91
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Average_20melt_20velocity>
+</Melt_20settings>
+<Free_20surface>
+<Free_20surface_20boundary_20indicators>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of names denoting those boundaries where there is a free surface. Set to nothing to disable all free surface computations.
+
+The names of the boundaries listed here can either by numbers (in which case they correspond to the numerical boundary indicators assigned by the geometry object), or they can correspond to any of the symbolic names the geometry object may have provided for each part of the boundary. You may want to compare this with the documentation of the geometry model you use in your model.
+</documentation>
+<pattern>
+43
+</pattern>
+<pattern_description>
+[List of &lt;[Anything]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Free_20surface_20boundary_20indicators>
+<Free_20surface_20stabilization_20theta>
+<value>
+0.5
+</value>
+<default_value>
+0.5
+</default_value>
+<documentation>
+Theta parameter described in Kaus et. al. 2010. An unstabilized free surface can overshoot its equilibrium position quite easily and generate unphysical results.  One solution is to use a quasi-implicit correction term to the forces near the free surface.  This parameter describes how much the free surface is stabilized with this term, where zero is no stabilization, and one is fully implicit.
+</documentation>
+<pattern>
+85
+</pattern>
+<pattern_description>
+[Double 0...1 (inclusive)]
+</pattern_description>
+</Free_20surface_20stabilization_20theta>
+<Surface_20velocity_20projection>
+<value>
+normal
+</value>
+<default_value>
+normal
+</default_value>
+<documentation>
+After each time step the free surface must be advected in the direction of the velocity field. Mass conservation requires that the mesh velocity is in the normal direction of the surface. However, for steep topography or large curvature, advection in the normal direction can become ill-conditioned, and instabilities in the mesh can form. Projection of the mesh velocity onto the local vertical direction can preserve the mesh quality better, but at the cost of slightly poorer mass conservation of the domain.
+</documentation>
+<pattern>
+86
+</pattern>
+<pattern_description>
+[Selection normal|vertical ]
+</pattern_description>
+</Surface_20velocity_20projection>
+<Additional_20tangential_20mesh_20velocity_20boundary_20indicators>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of names denoting those boundaries where there the mesh is allowed to move tangential to the boundary. All tangential mesh movements along those boundaries that have tangential material velocity boundary conditions are allowed by default, this parameters allows to generate mesh movements along other boundaries that are open, or have prescribed material velocities or tractions.
+
+The names of the boundaries listed here can either be numbers (in which case they correspond to the numerical boundary indicators assigned by the geometry object), or they can correspond to any of the symbolic names the geometry object may have provided for each part of the boundary. You may want to compare this with the documentation of the geometry model you use in your model.
+</documentation>
+<pattern>
+87
+</pattern>
+<pattern_description>
+[List of &lt;[Anything]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Additional_20tangential_20mesh_20velocity_20boundary_20indicators>
+</Free_20surface>
+<Boundary_20traction_20model>
+<Prescribed_20traction_20boundary_20indicators>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list denoting those boundaries on which a traction force is prescribed, i.e., where known external forces act, resulting in an unknown velocity. This is often used to model ``open&apos;&apos; boundaries where we only know the pressure. This pressure then produces a force that is normal to the boundary and proportional to the pressure.
+
+The format of valid entries for this parameter is that of a map given as ``key1 [selector]: value1, key2 [selector]: value2, key3: value3, ...&apos;&apos; where each key must be a valid boundary indicator (which is either an integer or the symbolic name the geometry model in use may have provided for this part of the boundary) and each value must be one of the currently implemented boundary traction models. ``selector&apos;&apos; is an optional string given as a subset of the letters `xyz&apos; that allows you to apply the boundary conditions only to the components listed. As an example, &apos;1 y: function&apos; applies the type `function&apos; to the y component on boundary 1. Without a selector it will affect all components of the traction.
+</documentation>
+<pattern>
+44
+</pattern>
+<pattern_description>
+[Map of &lt;[Anything]&gt;:&lt;[Selection ascii data|function|initial lithostatic pressure|zero traction ]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Prescribed_20traction_20boundary_20indicators>
+<Ascii_20data_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/boundary-traction/ascii-data/test/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/boundary-traction/ascii-data/test/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a `/&apos;) or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+969
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value>
+box_2d_%s.%d.txt
+</value>
+<default_value>
+box_2d_%s.%d.txt
+</default_value>
+<documentation>
+The file name of the model data. Provide file in format: (Velocity file name).\%s\%d where \%s is a string specifying the boundary of the model according to the names of the boundary indicators (of the chosen geometry model).\%d is any sprintf integer qualifier, specifying the format of the current file number. 
+</documentation>
+<pattern>
+970
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+</documentation>
+<pattern>
+971
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+<Data_20file_20time_20step>
+<value>
+1e6
+</value>
+<default_value>
+1e6
+</default_value>
+<documentation>
+Time step between following data files. Depending on the setting of the global `Use years in output instead of seconds&apos; flag in the input file, this number is either interpreted as seconds or as years. The default is one million, i.e., either one million seconds or one million years.
+</documentation>
+<pattern>
+972
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Data_20file_20time_20step>
+<First_20data_20file_20model_20time>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Time from which on the data file with number `First data file number&apos; is used as boundary condition. Until this time, a boundary condition equal to zero everywhere is assumed. Depending on the setting of the global `Use years in output instead of seconds&apos; flag in the input file, this number is either interpreted as seconds or as years.
+</documentation>
+<pattern>
+973
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</First_20data_20file_20model_20time>
+<First_20data_20file_20number>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Number of the first velocity file to be loaded when the model time is larger than `First velocity file model time&apos;.
+</documentation>
+<pattern>
+974
+</pattern>
+<pattern_description>
+[Integer range -2147483648...2147483647 (inclusive)]
+</pattern_description>
+</First_20data_20file_20number>
+<Decreasing_20file_20order>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+In some cases the boundary files are not numbered in increasing but in decreasing order (e.g. `Ma BP&apos;). If this flag is set to `True&apos; the plugin will first load the file with the number `First data file number&apos; and decrease the file number during the model run.
+</documentation>
+<pattern>
+975
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Decreasing_20file_20order>
+</Ascii_20data_20model>
+<Function>
+<Coordinate_20system>
+<value>
+cartesian
+</value>
+<default_value>
+cartesian
+</default_value>
+<documentation>
+A selection that determines the assumed coordinate system for the function variables. Allowed values are `cartesian&apos;, `spherical&apos;, and `depth&apos;. `spherical&apos; coordinates are interpreted as r,phi or r,phi,theta in 2D/3D respectively with theta being the polar angle. `depth&apos; will create a function, in which only the first parameter is non-zero, which is interpreted to be the depth of the point.
+</documentation>
+<pattern>
+976
+</pattern>
+<pattern_description>
+[Selection cartesian|spherical|depth ]
+</pattern_description>
+</Coordinate_20system>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+977
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0; 0
+</value>
+<default_value>
+0; 0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+978
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+979
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Function>
+<Initial_20lithostatic_20pressure>
+<Representative_20point>
+<value/>
+<default_value/>
+<documentation>
+The point where the pressure profile will be calculated. Cartesian coordinates when geometry is a box, otherwise enter radius, longitude, and in 3D latitude.Units: m or degrees.
+</documentation>
+<pattern>
+980
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Representative_20point>
+<Number_20of_20integration_20points>
+<value>
+1000
+</value>
+<default_value>
+1000
+</default_value>
+<documentation>
+The number of integration points over which we integrate the lithostatic pressure downwards. 
+</documentation>
+<pattern>
+981
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Number_20of_20integration_20points>
+</Initial_20lithostatic_20pressure>
+</Boundary_20traction_20model>
+<Boundary_20heat_20flux_20model>
+<Fixed_20heat_20flux_20boundary_20indicators>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of names denoting those boundaries on which the heat flux is fixed and described by the boundary heat flux object selected in the &apos;Model name&apos; parameter. All boundary indicators used by the geometry but not explicitly listed here or in the list of &apos;Fixed temperature boundary indicators&apos; in the &apos;Boundary temperature model&apos; will end up with no-flux (insulating) boundary conditions.
+
+The names of the boundaries listed here can either be numbers (in which case they correspond to the numerical boundary indicators assigned by the geometry object), or they can correspond to any of the symbolic names the geometry object may have provided for each part of the boundary. You may want to compare this with the documentation of the geometry model you use in your model.
+
+This parameter only describes which boundaries have a fixed heat flux, but not what heat flux should hold on these boundaries. The latter piece of information needs to be implemented in a plugin in the BoundaryHeatFlux group, unless an existing implementation in this group already provides what you want.
+</documentation>
+<pattern>
+45
+</pattern>
+<pattern_description>
+[List of &lt;[Anything]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Fixed_20heat_20flux_20boundary_20indicators>
+<Model_20name>
+<value>
+function
+</value>
+<default_value>
+function
+</default_value>
+<documentation>
+Select one of the following plugins:
+
+`function&apos;: Implementation of a model in which the boundary heat flux is given in terms of an explicit formula that is elaborated in the parameters in section ``Boundary heat flux model|Function&apos;&apos;. The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
+The formula you describe in the mentioned section is a scalar value for the heat flux that is assumed to be the flux normal to the boundary, and that has the unit W/(m$^2$) (in 3d) or W/m (in 2d). Negative fluxes are interpreted as the flow of heat into the domain, and positive fluxes are interpreted as heat flowing out of the domain.
+
+The symbol $t$ indicating time that may appear in the formulas for the prescribed heat flux is interpreted as having units seconds unless the global parameter ``Use years in output instead of seconds&apos;&apos; has been set.
+</documentation>
+<pattern>
+982
+</pattern>
+<pattern_description>
+[Selection function ]
+</pattern_description>
+</Model_20name>
+<Function>
+<Coordinate_20system>
+<value>
+cartesian
+</value>
+<default_value>
+cartesian
+</default_value>
+<documentation>
+A selection that determines the assumed coordinate system for the function variables. Allowed values are `cartesian&apos;, `spherical&apos;, and `depth&apos;. `spherical&apos; coordinates are interpreted as r,phi or r,phi,theta in 2D/3D respectively with theta being the polar angle. `depth&apos; will create a function, in which only the first parameter is non-zero, which is interpreted to be the depth of the point.
+</documentation>
+<pattern>
+983
+</pattern>
+<pattern_description>
+[Selection cartesian|spherical|depth ]
+</pattern_description>
+</Coordinate_20system>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+984
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+985
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+986
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Function>
+</Boundary_20heat_20flux_20model>
+<Nullspace_20removal>
+<Remove_20nullspace>
+<value/>
+<default_value/>
+<documentation>
+Choose none, one or several from 
+
+\begin{itemize} \item net rotation \item angular momentum \item net translation \item linear momentum \item net x translation \item net y translation \item net z translation \item linear x momentum \item linear y momentum \item linear z momentum \end{itemize}
+
+These are a selection of operations to remove certain parts of the nullspace from the velocity after solving. For some geometries and certain boundary conditions the velocity field is not uniquely determined but contains free translations and/or rotations. Depending on what you specify here, these non-determined modes will be removed from the velocity field at the end of the Stokes solve step.
+
+
+The ``angular momentum&apos;&apos; option removes a rotation such that the net angular momentum is zero. The ``linear * momentum&apos;&apos; options remove translations such that the net momentum in the relevant direction is zero.  The ``net rotation&apos;&apos; option removes the net rotation of the domain, and the ``net * translation&apos;&apos; options remove the net translations in the relevant directions.  For most problems there should not be a significant difference between the momentum and rotation/translation versions of nullspace removal, although the momentum versions are more physically motivated. They are equivalent for constant density simulations, and approximately equivalent when the density variations are small.
+
+Note that while more than one operation can be selected it only makes sense to pick one rotational and one translational operation.
+</documentation>
+<pattern>
+46
+</pattern>
+<pattern_description>
+[MultipleSelection net rotation|angular momentum|net translation|linear momentum|net x translation|net y translation|net z translation|linear x momentum|linear y momentum|linear z momentum ]
+</pattern_description>
+</Remove_20nullspace>
+</Nullspace_20removal>
+<Mesh_20refinement>
+<Initial_20global_20refinement>
+<value>
+2
+</value>
+<default_value>
+2
+</default_value>
+<documentation>
+The number of global refinement steps performed on the initial coarse mesh, before the problem is first solved there.
+</documentation>
+<pattern>
+47
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Initial_20global_20refinement>
+<Initial_20adaptive_20refinement>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The number of adaptive refinement steps performed after initial global refinement but while still within the first time step.
+</documentation>
+<pattern>
+48
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Initial_20adaptive_20refinement>
+<Time_20steps_20between_20mesh_20refinement>
+<value>
+10
+</value>
+<default_value>
+10
+</default_value>
+<documentation>
+The number of time steps after which the mesh is to be adapted again based on computed error indicators. If 0 then the mesh will never be changed.
+</documentation>
+<pattern>
+49
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Time_20steps_20between_20mesh_20refinement>
+<Refinement_20fraction>
+<value>
+0.3
+</value>
+<default_value>
+0.3
+</default_value>
+<documentation>
+The fraction of cells with the largest error that should be flagged for refinement.
+</documentation>
+<pattern>
+50
+</pattern>
+<pattern_description>
+[Double 0...1 (inclusive)]
+</pattern_description>
+</Refinement_20fraction>
+<Coarsening_20fraction>
+<value>
+0.05
+</value>
+<default_value>
+0.05
+</default_value>
+<documentation>
+The fraction of cells with the smallest error that should be flagged for coarsening.
+</documentation>
+<pattern>
+51
+</pattern>
+<pattern_description>
+[Double 0...1 (inclusive)]
+</pattern_description>
+</Coarsening_20fraction>
+<Adapt_20by_20fraction_20of_20cells>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Use fraction of the total number of cells instead of fraction of the total error as the limit for refinement and coarsening.
+</documentation>
+<pattern>
+52
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Adapt_20by_20fraction_20of_20cells>
+<Minimum_20refinement_20level>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The minimum refinement level each cell should have, and that can not be exceeded by coarsening. Should not be higher than the &apos;Initial global refinement&apos; parameter.
+</documentation>
+<pattern>
+53
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Minimum_20refinement_20level>
+<Additional_20refinement_20times>
+<value/>
+<default_value/>
+<documentation>
+A list of times so that if the end time of a time step is beyond this time, an additional round of mesh refinement is triggered. This is mostly useful to make sure we can get through the initial transient phase of a simulation on a relatively coarse mesh, and then refine again when we are in a time range that we are interested in and where we would like to use a finer mesh. Units: Each element of the list has units years if the &apos;Use years in output instead of seconds&apos; parameter is set; seconds otherwise.
+</documentation>
+<pattern>
+54
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Additional_20refinement_20times>
+<Run_20postprocessors_20on_20initial_20refinement>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether or not the postprocessors should be executed after each of the initial adaptive refinement cycles that are run at the start of the simulation.
+</documentation>
+<pattern>
+55
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Run_20postprocessors_20on_20initial_20refinement>
+<Skip_20solvers_20on_20initial_20refinement>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether or not solvers should be executed during the initial adaptive refinement cycles that are run at the start of the simulation.
+</documentation>
+<pattern>
+56
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Skip_20solvers_20on_20initial_20refinement>
+<Skip_20setup_20initial_20conditions_20on_20initial_20refinement>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether or not the initial conditions should be set up during the the adaptive refinement cycles that are run at the start of the simulation.
+</documentation>
+<pattern>
+57
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Skip_20setup_20initial_20conditions_20on_20initial_20refinement>
+<Strategy>
+<value>
+thermal energy density
+</value>
+<default_value>
+thermal energy density
+</default_value>
+<documentation>
+A comma separated list of mesh refinement criteria that will be run whenever mesh refinement is required. The results of each of these criteria, i.e., the refinement indicators they produce for all the cells of the mesh will then be normalized to a range between zero and one and the results of different criteria will then be merged through the operation selected in this section.
+
+The following criteria are available:
+
+`artificial viscosity&apos;: A mesh refinement criterion that computes refinement indicators from the artificial viscosity of the temperature or compositional fields based on user specified weights.
+
+`boundary&apos;: A class that implements a mesh refinement criterion which always flags all cells on specified boundaries for refinement. This is useful to provide high accuracy for processes at or close to the edge of the model domain.
+
+To use this refinement criterion, you may want to combine it with other refinement criteria, setting the &apos;Normalize individual refinement criteria&apos; flag and using the `max&apos; setting for &apos;Refinement criteria merge operation&apos;.
+
+`compaction length&apos;: A mesh refinement criterion for models with melt transport that computes refinement indicators based on the compaction length, defined as $\delta = \sqrt{\frac{(\xi + 4 \eta/3) k}{\eta_f}}$. $\xi$ is the bulk viscosity, $\eta$ is the shear viscosity, $k$ is the permeability and $\eta_f$ is the melt viscosity. If the cell width or height exceeds a multiple (which is specified as an input parameter) of this compaction length, the cell is marked for refinement.
+
+`composition&apos;: A mesh refinement criterion that computes refinement indicators from the compositional fields. If there is more than one compositional field, then it simply takes the sum of the indicators computed from each of the compositional field.
+
+The way these indicators are computed is by evaluating the `Kelly error indicator&apos; on each compositional field. This error indicator takes the finite element approximation of the compositional field and uses it to compute an approximation of the second derivatives of the composition for each cell. This approximation is then multiplied by an appropriate power of the cell&apos;s diameter to yield an indicator for how large the error is likely going to be on this cell. This construction rests on the observation that for many partial differential equations, the error on each cell is proportional to some power of the cell&apos;s diameter times the second derivatives of the solution on that cell.
+
+For complex equations such as those we solve here, this observation may not be strictly true in the mathematical sense, but it often yields meshes that are surprisingly good.
+
+`composition approximate gradient&apos;: A mesh refinement criterion that computes refinement indicators from the gradients of compositional fields. If there is more than one compositional field, then it simply takes the sum of the indicators times a user-specified weight for each field.
+
+In contrast to the `composition gradient&apos; refinement criterion, the current criterion does not compute the gradient at quadrature points on each cell, but by a finite difference approximation between the centers of cells. Consequently, it also works if the compositional fields are computed using discontinuous finite elements.
+
+`composition gradient&apos;: A mesh refinement criterion that computes refinement indicators from the gradients of compositional fields. If there is more than one compositional field, then it simply takes the sum of the indicators times a user-specified weight for each field.
+
+This refinement criterion computes the gradient of the compositional field at quadrature points on each cell, and then averages them in some way to obtain a refinement indicator for each cell. This will give a reasonable approximation of the true gradient of the compositional field if you are using a continuous finite element.
+
+On the other hand, for discontinuous finite elements (see the `Use discontinuous composition discretization&apos; parameter in the `Discretization&apos; section), the gradient at quadrature points does not include the contribution of jumps in the compositional field between cells, and consequently will not be an accurate approximation of the true gradient. As an extreme example, consider the case of using piecewise constant finite elements for compositional fields; in that case, the gradient of the solution at quadrature points inside each cell will always be exactly zero, even if the finite element solution is different from each cell to the next. Consequently, the current refinement criterion will likely not be useful in this situation. That said, the `composition approximate gradient&apos; refinement criterion exists for exactly this purpose.
+
+`composition threshold&apos;: A mesh refinement criterion that computes refinement indicators from the compositional fields. If any field exceeds the threshold given in the input file, the cell is marked for refinement.
+
+`density&apos;: A mesh refinement criterion that computes refinement indicators from a field that describes the spatial variability of the density, $\rho$. Because this quantity may not be a continuous function ($\rho$ and $C_p$ may be discontinuous functions along discontinuities in the medium, for example due to phase changes), we approximate the gradient of this quantity to refine the mesh. The error indicator defined here takes the magnitude of the approximate gradient and scales it by $h_K^{1+d/2}$ where $h_K$ is the diameter of each cell and $d$ is the dimension. This scaling ensures that the error indicators converge to zero as $h_K\rightarrow 0$ even if the energy density is discontinuous, since the gradient of a discontinuous function grows like $1/h_K$.
+
+`maximum refinement function&apos;: A mesh refinement criterion that ensures a maximum refinement level described by an explicit formula with the depth or position as argument. Which coordinate representation is used is determined by an input parameter. Whatever the coordinate system chosen, the function you provide in the input file will by default depend on variables `x&apos;, `y&apos; and `z&apos; (if in 3d). However, the meaning of these symbols depends on the coordinate system. In the Cartesian coordinate system, they simply refer to their natural meaning. If you have selected `depth&apos; for the coordinate system, then `x&apos; refers to the depth variable and `y&apos; and `z&apos; will simply always be zero. If you have selected a spherical coordinate system, then `x&apos; will refer to the radial distance of the point to the origin, `y&apos; to the azimuth angle and `z&apos; to the polar angle measured positive from the north pole. Note that the order of spherical coordinates is r,phi,theta and not r,theta,phi, since this allows for dimension independent expressions. Each coordinate system also includes a final `t&apos; variable which represents the model time, evaluated in years if the &apos;Use years in output instead of seconds&apos; parameter is set, otherwise evaluated in seconds. After evaluating the function, its values are rounded to the nearest integer.
+
+The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
+`minimum refinement function&apos;: A mesh refinement criterion that ensures a minimum refinement level described by an explicit formula with the depth or position as argument. Which coordinate representation is used is determined by an input parameter. Whatever the coordinate system chosen, the function you provide in the input file will by default depend on variables `x&apos;, `y&apos; and `z&apos; (if in 3d). However, the meaning of these symbols depends on the coordinate system. In the Cartesian coordinate system, they simply refer to their natural meaning. If you have selected `depth&apos; for the coordinate system, then `x&apos; refers to the depth variable and `y&apos; and `z&apos; will simply always be zero. If you have selected a spherical coordinate system, then `x&apos; will refer to the radial distance of the point to the origin, `y&apos; to the azimuth angle and `z&apos; to the polar angle measured positive from the north pole. Note that the order of spherical coordinates is r,phi,theta and not r,theta,phi, since this allows for dimension independent expressions. Each coordinate system also includes a final `t&apos; variable which represents the model time, evaluated in years if the &apos;Use years in output instead of seconds&apos; parameter is set, otherwise evaluated in seconds. After evaluating the function, its values are rounded to the nearest integer.
+
+The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
+`nonadiabatic temperature&apos;: A mesh refinement criterion that computes refinement indicators from the excess temperature(difference between temperature and adiabatic temperature.
+
+`particle density&apos;: A mesh refinement criterion that computes refinement indicators based on the density of particles. In practice this plugin equilibrates the number of particles per cell, leading to fine cells in high particle density regions and coarse cells in low particle density regions. This plugin is mostly useful for models with inhomogeneous particle density, e.g. when tracking an initial interface with a high particle density, or when the spatial particle density denotes the region of interest. Additionally, this plugin tends to balance the computational load between processes in parallel computations, because the particle and mesh density is more aligned.
+
+`slope&apos;: A class that implements a mesh refinement criterion intended for use with a free surface. It calculates a local slope based on the angle between the surface normal and the local gravity vector. Cells with larger angles are marked for refinement.
+
+To use this refinement criterion, you may want to combine it with other refinement criteria, setting the &apos;Normalize individual refinement criteria&apos; flag and using the `max&apos; setting for &apos;Refinement criteria merge operation&apos;.
+
+`strain rate&apos;: A mesh refinement criterion that computes the refinement indicators equal to the strain rate norm computed at the center of the elements.
+
+`temperature&apos;: A mesh refinement criterion that computes refinement indicators from the temperature field.
+
+The way these indicators are computed is by evaluating the `Kelly error indicator&apos; on the temperature field. This error indicator takes the finite element approximation of the temperature field and uses it to compute an approximation of the second derivatives of the temperature for each cell. This approximation is then multiplied by an appropriate power of the cell&apos;s diameter to yield an indicator for how large the error is likely going to be on this cell. This construction rests on the observation that for many partial differential equations, the error on each cell is proportional to some power of the cell&apos;s diameter times the second derivatives of the solution on that cell.
+
+For complex equations such as those we solve here, this observation may not be strictly true in the mathematical sense, but it often yields meshes that are surprisingly good.
+
+`thermal energy density&apos;: A mesh refinement criterion that computes refinement indicators from a field that describes the spatial variability of the thermal energy density, $\rho C_p T$. Because this quantity may not be a continuous function ($\rho$ and $C_p$ may be discontinuous functions along discontinuities in the medium, for example due to phase changes), we approximate the gradient of this quantity to refine the mesh. The error indicator defined here takes the magnitude of the approximate gradient and scales it by $h_K^{1.5}$ where $h_K$ is the diameter of each cell. This scaling ensures that the error indicators converge to zero as $h_K\rightarrow 0$ even if the energy density is discontinuous, since the gradient of a discontinuous function grows like $1/h_K$.
+
+`topography&apos;: A class that implements a mesh refinement criterion, which always flags all cells in the uppermost layer for refinement. This is useful to provide high accuracy for processes at or close to the surface.
+
+To use this refinement criterion, you may want to combine it with other refinement criteria, setting the &apos;Normalize individual refinement criteria&apos; flag and using the `max&apos; setting for &apos;Refinement criteria merge operation&apos;.
+
+`velocity&apos;: A mesh refinement criterion that computes refinement indicators from the velocity field.
+
+The way these indicators are computed is by evaluating the `Kelly error indicator&apos; on the velocity field. This error indicator takes the finite element approximation of the velocity field and uses it to compute an approximation of the second derivatives of the velocity for each cell. This approximation is then multiplied by an appropriate power of the cell&apos;s diameter to yield an indicator for how large the error is likely going to be on this cell. This construction rests on the observation that for many partial differential equations, the error on each cell is proportional to some power of the cell&apos;s diameter times the second derivatives of the solution on that cell.
+
+For complex equations such as those we solve here, this observation may not be strictly true in the mathematical sense, but it often yields meshes that are surprisingly good.
+
+`viscosity&apos;: A mesh refinement criterion that computes refinement indicators from a field that describes the spatial variability of the logarithm of the viscosity, $\log\eta$. (We choose the logarithm of the viscosity because it can vary by orders of magnitude.)Because this quantity may not be a continuous function ($\eta$ may be a discontinuous function along discontinuities in the medium, for example due to phase changes), we approximate the gradient of this quantity to refine the mesh. The error indicator defined here takes the magnitude of the approximate gradient and scales it by $h_K^{1+d/2}$ where $h_K$ is the diameter of each cell and $d$ is the dimension. This scaling ensures that the error indicators converge to zero as $h_K\rightarrow 0$ even if the energy density is discontinuous, since the gradient of a discontinuous function grows like $1/h_K$.
+</documentation>
+<pattern>
+239
+</pattern>
+<pattern_description>
+[MultipleSelection artificial viscosity|boundary|compaction length|composition|composition approximate gradient|composition gradient|composition threshold|density|maximum refinement function|minimum refinement function|nonadiabatic temperature|particle density|slope|strain rate|temperature|thermal energy density|topography|velocity|viscosity ]
+</pattern_description>
+</Strategy>
+<Normalize_20individual_20refinement_20criteria>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+If multiple refinement criteria are specified in the ``Strategy&apos;&apos; parameter, then they need to be combined somehow to form the final refinement indicators. This is done using the method described by the ``Refinement criteria merge operation&apos;&apos; parameter which can either operate on the raw refinement indicators returned by each strategy (i.e., dimensional quantities) or using normalized values where the indicators of each strategy are first normalized to the interval $[0,1]$ (which also makes them non-dimensional). This parameter determines whether this normalization will happen.
+</documentation>
+<pattern>
+240
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Normalize_20individual_20refinement_20criteria>
+<Refinement_20criteria_20scaling_20factors>
+<value/>
+<default_value/>
+<documentation>
+A list of scaling factors by which every individual refinement criterion will be multiplied by. If only a single refinement criterion is selected (using the ``Strategy&apos;&apos; parameter, then this parameter has no particular meaning. On the other hand, if multiple criteria are chosen, then these factors are used to weigh the various indicators relative to each other. 
+
+If ``Normalize individual refinement criteria&apos;&apos; is set to true, then the criteria will first be normalized to the interval $[0,1]$ and then multiplied by the factors specified here. You will likely want to choose the factors to be not too far from 1 in that case, say between 1 and 10, to avoid essentially disabling those criteria with small weights. On the other hand, if the criteria are not normalized to $[0,1]$ using the parameter mentioned above, then the factors you specify here need to take into account the relative numerical size of refinement indicators (which in that case carry physical units).
+
+You can experimentally play with these scaling factors by choosing to output the refinement indicators into the graphical output of a run.
+
+If the list of indicators given in this parameter is empty, then this indicates that they should all be chosen equal to one. If the list is not empty then it needs to have as many entries as there are indicators chosen in the ``Strategy&apos;&apos; parameter.
+</documentation>
+<pattern>
+241
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Refinement_20criteria_20scaling_20factors>
+<Refinement_20criteria_20merge_20operation>
+<value>
+max
+</value>
+<default_value>
+max
+</default_value>
+<documentation>
+If multiple mesh refinement criteria are computed for each cell (by passing a list of more than element to the \texttt{Strategy} parameter in this section of the input file) then one will have to decide which one should win when deciding which cell to refine. The operation that selects from these competing criteria is the one that is selected here. The options are:
+
+\begin{itemize}
+\item \texttt{plus}: Add the various error indicators together and refine those cells on which the sum of indicators is largest.
+\item \texttt{max}: Take the maximum of the various error indicators and refine those cells on which the maximal indicators is largest.
+\end{itemize}The refinement indicators computed by each strategy are modified by the ``Normalize individual refinement criteria&apos;&apos; and ``Refinement criteria scale factors&apos;&apos; parameters.
+</documentation>
+<pattern>
+242
+</pattern>
+<pattern_description>
+[Selection plus|max ]
+</pattern_description>
+</Refinement_20criteria_20merge_20operation>
+<Artificial_20viscosity>
+<Temperature_20scaling_20factor>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+A scaling factor for the artificial viscosity  of the temperature equation. Use 0.0 to disable.
+</documentation>
+<pattern>
+243
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Temperature_20scaling_20factor>
+<Compositional_20field_20scaling_20factors>
+<value/>
+<default_value/>
+<documentation>
+A list of scaling factors by which every individual compositional field will be multiplied. These factors are used to weigh the various indicators relative to each other and to the temperature. 
+
+If the list of scaling factors given in this parameter is empty, then this indicates that they should all be chosen equal to 0. If the list is not empty then it needs to have as many entries as there are compositional fields.
+</documentation>
+<pattern>
+244
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Compositional_20field_20scaling_20factors>
+</Artificial_20viscosity>
+<Boundary>
+<Boundary_20refinement_20indicators>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of names denoting those boundaries where there should be mesh refinement.
+
+The names of the boundaries listed here can either be numbers (in which case they correspond to the numerical boundary indicators assigned by the geometry object), or they can correspond to any of the symbolic names the geometry object may have provided for each part of the boundary. You may want to compare this with the documentation of the geometry model you use in your model.
+</documentation>
+<pattern>
+245
+</pattern>
+<pattern_description>
+[List of &lt;[Anything]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Boundary_20refinement_20indicators>
+</Boundary>
+<Compaction_20length>
+<Mesh_20cells_20per_20compaction_20length>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+The desired ratio between compaction length and size of the mesh cells, or, in other words, how many cells the mesh should (at least) have per compaction length. Every cell where this ratio is smaller than the value specified by this parameter (in places with fewer mesh cells per compaction length) is marked for refinement.
+</documentation>
+<pattern>
+246
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Mesh_20cells_20per_20compaction_20length>
+</Compaction_20length>
+<Composition>
+<Compositional_20field_20scaling_20factors>
+<value/>
+<default_value/>
+<documentation>
+A list of scaling factors by which every individual compositional field will be multiplied. If only a single compositional field exists, then this parameter has no particular meaning. On the other hand, if multiple criteria are chosen, then these factors are used to weigh the various indicators relative to each other. 
+
+If the list of scaling factors given in this parameter is empty, then this indicates that they should all be chosen equal to one. If the list is not empty then it needs to have as many entries as there are compositional fields.
+</documentation>
+<pattern>
+247
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Compositional_20field_20scaling_20factors>
+</Composition>
+<Composition_20approximate_20gradient>
+<Compositional_20field_20scaling_20factors>
+<value/>
+<default_value/>
+<documentation>
+A list of scaling factors by which every individual compositional field gradient will be multiplied. If only a single compositional field exists, then this parameter has no particular meaning. On the other hand, if multiple criteria are chosen, then these factors are used to weigh the various indicators relative to each other. 
+
+If the list of scaling factors given in this parameter is empty, then this indicates that they should all be chosen equal to one. If the list is not empty then it needs to have as many entries as there are compositional fields.
+</documentation>
+<pattern>
+248
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Compositional_20field_20scaling_20factors>
+</Composition_20approximate_20gradient>
+<Composition_20gradient>
+<Compositional_20field_20scaling_20factors>
+<value/>
+<default_value/>
+<documentation>
+A list of scaling factors by which every individual compositional field gradient will be multiplied. If only a single compositional field exists, then this parameter has no particular meaning. On the other hand, if multiple criteria are chosen, then these factors are used to weigh the various indicators relative to each other. 
+
+If the list of scaling factors given in this parameter is empty, then this indicates that they should all be chosen equal to one. If the list is not empty then it needs to have as many entries as there are compositional fields.
+</documentation>
+<pattern>
+249
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Compositional_20field_20scaling_20factors>
+</Composition_20gradient>
+<Composition_20threshold>
+<Compositional_20field_20thresholds>
+<value/>
+<default_value/>
+<documentation>
+A list of thresholds that every individual compositional field will be evaluated against.
+</documentation>
+<pattern>
+250
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Compositional_20field_20thresholds>
+</Composition_20threshold>
+<Maximum_20refinement_20function>
+<Coordinate_20system>
+<value>
+depth
+</value>
+<default_value>
+depth
+</default_value>
+<documentation>
+A selection that determines the assumed coordinate system for the function variables. Allowed values are `depth&apos;, `cartesian&apos; and `spherical&apos;. `depth&apos; will create a function, in which only the first variable is non-zero, which is interpreted to be the depth of the point. `spherical&apos; coordinates are interpreted as r,phi or r,phi,theta in 2D/3D respectively with theta being the polar angle.
+</documentation>
+<pattern>
+251
+</pattern>
+<pattern_description>
+[Selection depth|cartesian|spherical ]
+</pattern_description>
+</Coordinate_20system>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+252
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+253
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+254
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Maximum_20refinement_20function>
+<Minimum_20refinement_20function>
+<Coordinate_20system>
+<value>
+depth
+</value>
+<default_value>
+depth
+</default_value>
+<documentation>
+A selection that determines the assumed coordinate system for the function variables. Allowed values are `depth&apos;, `cartesian&apos; and `spherical&apos;. `depth&apos; will create a function, in which only the first variable is non-zero, which is interpreted to be the depth of the point. `spherical&apos; coordinates are interpreted as r,phi or r,phi,theta in 2D/3D respectively with theta being the polar angle.
+</documentation>
+<pattern>
+255
+</pattern>
+<pattern_description>
+[Selection depth|cartesian|spherical ]
+</pattern_description>
+</Coordinate_20system>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+256
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+257
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+258
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Minimum_20refinement_20function>
+</Mesh_20refinement>
+<Postprocess>
+<Run_20postprocessors_20on_20nonlinear_20iterations>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether or not the postprocessors should be executed after each of the nonlinear iterations done within one time step. As this is mainly an option for the purposes of debugging, it is not supported when the &apos;Time between graphical output&apos; is larger than zero, or when the postprocessor is not intended to be run more than once per timestep.
+</documentation>
+<pattern>
+58
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Run_20postprocessors_20on_20nonlinear_20iterations>
+<List_20of_20postprocessors>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of postprocessor objects that should be run at the end of each time step. Some of these postprocessors will declare their own parameters which may, for example, include that they will actually do something only every so many time steps or years. Alternatively, the text `all&apos; indicates that all available postprocessors should be run after each time step.
+
+The following postprocessors are available:
+
+`Stokes residual&apos;: A postprocessor that outputs the Stokes residuals during the iterative solver algorithm into a file stokes_residuals.txt in the output directory.
+
+`basic statistics&apos;: A postprocessor that outputs some simplified statistics like the Rayleigh number and other quantities that only make sense in certain model setups. The output is written after completing initial adaptive refinement steps. The postprocessor assumes a point at the surface at the adiabatic surface temperature and pressure is a reasonable reference condition for computing these properties. Furthermore, the Rayleigh number is computed using the model depth (i.e. not the radius of the Earth), as we need a definition that is geometry independent. Take care when comparing these values to published studies and make sure they use the same definitions.
+
+`boundary densities&apos;: A postprocessor that computes the laterally averaged density at the top and bottom of the domain.
+
+`boundary pressures&apos;: A postprocessor that computes the laterally averaged pressure at the top and bottom of the domain.
+
+`command&apos;: A postprocessor that executes a command line process.
+
+`composition statistics&apos;: A postprocessor that computes some statistics about the compositional fields, if present in this simulation. In particular, it computes maximal and minimal values of each field, as well as the total mass contained in this field as defined by the integral $m_i(t) = \int_\Omega c_i(\mathbf x,t) \; \text{d}x$.
+
+`core statistics&apos;: A postprocessor that computes some statistics about the core evolution. (Working only with dynamic core boundary temperature plugin)
+
+`depth average&apos;: A postprocessor that computes depth averaged quantities and writes them into a file &lt;depth_average.ext&gt; in the output directory, where the extension of the file is determined by the output format you select. In addition to the output format, a number of other parameters also influence this postprocessor, and they can be set in the section \texttt{Postprocess/Depth average} in the input file.
+
+In the output files, the $x$-value of each data point corresponds to the depth, whereas the $y$-value corresponds to the simulation time. The time is provided in seconds or, if the global ``Use years in output instead of seconds&apos;&apos; parameter is set, in years.
+
+`dynamic topography&apos;: A postprocessor that computes a measure of dynamic topography based on the stress at the surface and bottom. The data is written into text files named `dynamic\_topography.NNNNN&apos; in the output directory, where NNNNN is the number of the time step.
+
+The exact approach works as follows: At the centers of all cells that sit along the top surface, we evaluate the stress and evaluate the component of it in the direction in which gravity acts. In other words, we compute $\sigma_{rr}={\hat g}^T(2 \eta \varepsilon(\mathbf u)- \frac 13 (\textrm{div}\;\mathbf u)I)\hat g - p_d$ where $\hat g = \mathbf g/\|\mathbf g\|$ is the direction of the gravity vector $\mathbf g$ and $p_d=p-p_a$ is the dynamic pressure computed by subtracting the adiabatic pressure $p_a$ from the total pressure $p$ computed as part of the Stokes solve. From this, the dynamic topography is computed using the formula $h=\frac{\sigma_{rr}}{(\mathbf g \cdot \mathbf n)  \rho}$ where $\rho$ is the density at the cell center. For the bottom surface we chose the convection that positive values are up (out) and negative values are in (down), analogous to the deformation of the upper surface. Note that this implementation takes the direction of gravity into account, which means that reversing the flow in backward advection calculations will not reverse the instantaneous topography because the reverse flow will be divided by the reverse surface gravity.  
+The file format then consists of lines with Euclidean coordinates followed by the corresponding topography value.
+
+(As a side note, the postprocessor chooses the cell center instead of the center of the cell face at the surface, where we really are interested in the quantity, since this often gives better accuracy. The results should in essence be the same, though.)
+
+`geoid&apos;: A postprocessor that computes a representation of the geoid based on the density structure in the mantle, as well as the dynamic topography at the surface and core mantle boundary (CMB). The geoid is computed from a spherical harmonic expansion, so the geometry of the domain must be a 3D spherical shell.
+
+`global statistics&apos;: A postprocessor that outputs all the global statistics information, e.g. the time of the simulation, the timestep number, number of degrees of freedom and solver iterations for each timestep. The postprocessor can output different formats, the first printing one line in the statistics file per nonlinear solver iteration (if a nonlinear solver scheme is selected). The second prints one line per timestep, summing the information about all nonlinear iterations in this line. Note that this postprocessor is always active independent on whether or not it is selected in the parameter file.
+
+`gravity calculation&apos;: A postprocessor that computes gravity and gravity potential for a set of points (e.g. satellites) in or above the model surface for a user-defined range of latitudes, longitudes and radius.
+
+`heat flux densities&apos;: A postprocessor that computes some statistics about the heat flux density for each boundary id.  The heat flux density across each boundary  is computed in outward direction, i.e., from the domain to the outside. The heat flux is computed as sum of advective heat flux and conductive heat flux through Neumann boundaries, both computed as integral over the boundary area, and conductive heat flux through Dirichlet boundaries, which is computed using the consistent boundary flux method as described in ``Gresho, P. M., Lee, R. L., Sani, R. L., Maslanik, M. K., &amp; Eaton, B. E. (1987). The consistent Galerkin FEM for computing derived boundary quantities in thermal and or fluids problems. International Journal for Numerical Methods in Fluids, 7(4), 371-394.&apos;&apos;
+
+Note that the ``heat flux statistics&apos;&apos; postprocessor computes the same quantity as the one here, but not divided by the area of the surface. In other words, it computes the \textit{total} heat flux through each boundary.
+
+`heat flux map&apos;: A postprocessor that computes the heat flux density across each boundary in outward direction, i.e., from the domain to the outside. The heat flux is computed as sum of advective heat flux and conductive heat flux through Neumann boundaries, both computed as integral over the boundary area, and conductive heat flux through Dirichlet boundaries, which is computed using the consistent boundary flux method as described in ``Gresho, P. M., Lee, R. L., Sani, R. L., Maslanik, M. K., &amp; Eaton, B. E. (1987). The consistent Galerkin FEM for computing derived boundary quantities in thermal and or fluids problems. International Journal for Numerical Methods in Fluids, 7(4), 371-394.&apos;&apos;
+
+`heat flux statistics&apos;: A postprocessor that computes some statistics about the heat flux density across each boundary in outward direction, i.e., from the domain to the outside. The heat flux is computed as sum of advective heat flux and conductive heat flux through Neumann boundaries, both computed as integral over the boundary area, and conductive heat flux through Dirichlet boundaries, which is computed using the consistent boundary flux method as described in ``Gresho, P. M., Lee, R. L., Sani, R. L., Maslanik, M. K., &amp; Eaton, B. E. (1987). The consistent Galerkin FEM for computing derived boundary quantities in thermal and or fluids problems. International Journal for Numerical Methods in Fluids, 7(4), 371-394.&apos;&apos;The point-wise heat flux can be obtained from the heat flux map postprocessor, which outputs the heat flux to a file, or the heat flux map visualization postprocessor, which outputs the heat flux for visualization. 
+
+As stated, this postprocessor computes the \textit{outbound} heat flux. If you are interested in the opposite direction, for example from the core into the mantle when the domain describes the mantle, then you need to multiply the result by -1.
+
+\note{In geodynamics, the term ``heat flux&apos;&apos; is often understood to be the quantity $- k \nabla T$, which is really a heat flux \textit{density}, i.e., a vector-valued field. In contrast to this, the current postprocessor only computes the integrated flux over each part of the boundary. Consequently, the units of the quantity computed here are $W=\frac{J}{s}$.}
+
+The ``heat flux densities&apos;&apos; postprocessor computes the same quantity as the one here, but divided by the area of the surface.
+
+`heating statistics&apos;: A postprocessor that computes some statistics about heating, averaged by volume. 
+
+`mass flux statistics&apos;: A postprocessor that computes some statistics about the mass flux across boundaries. For each boundary indicator (see your geometry description for which boundary indicators are used), the mass flux is computed in outward direction, i.e., from the domain to the outside, using the formula $\int_{\Gamma_i} \rho \mathbf v \cdot \mathbf n$ where $\Gamma_i$ is the part of the boundary with indicator $i$, $\rho$ is the density as reported by the material model, $\mathbf v$ is the velocity, and $\mathbf n$ is the outward normal. 
+
+As stated, this postprocessor computes the \textit{outbound} mass flux. If you are interested in the opposite direction, for example from the core into the mantle when the domain describes the mantle, then you need to multiply the result by -1.
+
+\note{In geodynamics, the term ``mass flux&apos;&apos; is often understand to be the quantity $\rho \mathbf v$, which is really a mass flux \textit{density}, i.e., a vector-valued field. In contrast to this, the current postprocessor only computes the integrated flux over each part of the boundary. Consequently, the units of the quantity computed here are $\frac{kg}{s}$.}
+
+`material statistics&apos;: A postprocessor that computes some statistics about the material properties. In particular, it computes the volume-averages of the density and viscosity, and the total mass in the model. Specifically, it implements the following formulas in each time step: $\left&lt;\rho\right&gt; = \frac{1}{|\Omega|} \int_\Omega \rho(\mathbf x) \, \text{d}x$, $\left&lt;\eta\right&gt; = \frac{1}{|\Omega|} \int_\Omega \eta(\mathbf x) \, \text{d}x$, $M = \int_\Omega \rho(\mathbf x) \, \text{d}x$, where $|\Omega|$ is the volume of the domain.
+
+`matrix statistics&apos;: A postprocessor that computes some statistics about the matrices. In particular, it outputs total memory consumption, total non-zero elements, and non-zero elements per block, for system matrix and system preconditioner matrix.
+
+`melt statistics&apos;: A postprocessor that computes some statistics about the melt (volume) fraction. If the material model does not implement a melt fraction function, the output is set to zero.
+
+`memory statistics&apos;: A postprocessor that computes some statistics about the memory consumption. In particular, it computes the memory usage of the system matrix, triangulation, p4est, DoFHandler, current constraints, and solution vector, all in MB. It also outputs the memory usage of the system matrix to the screen.
+
+`particle count statistics&apos;: A postprocessor that computes some statistics about the particle distribution, if present in this simulation. In particular, it computes minimal, average and maximal values of particles per cell in the global domain.
+
+`particles&apos;: A Postprocessor that creates particles that follow the velocity field of the simulation. The particles can be generated and propagated in various ways and they can carry a number of constant or time-varying properties. The postprocessor can write output positions and properties of all particles at chosen intervals, although this is not mandatory. It also allows other parts of the code to query the particles for information.
+
+`point values&apos;: A postprocessor that evaluates the solution (i.e., velocity, pressure, temperature, and compositional fields along with other fields that are treated as primary variables) at the end of every time step or after a user-specified time interval at a given set of points and then writes this data into the file &lt;point\_values.txt&gt; in the output directory. The points at which the solution should be evaluated are specified in the section \texttt{Postprocess/Point values} in the input file.
+
+In the output file, data is organized as (i) time, (ii) the 2 or 3 coordinates of the evaluation points, and (iii) followed by the values of the solution vector at this point. The time is provided in seconds or, if the global ``Use years in output instead of seconds&apos;&apos; parameter is set, in years. In the latter case, the velocity is also converted to meters/year, instead of meters/second.
+
+\note{Evaluating the solution of a finite element field at arbitrarily chosen points is an expensive process. Using this postprocessor will only be efficient if the number of evaluation points or output times is relatively small. If you need a very large number of evaluation points, you should consider extracting this information from the visualization program you use to display the output of the `visualization&apos; postprocessor.}
+
+`pressure statistics&apos;: A postprocessor that computes some statistics about the pressure field.
+
+`rotation statistics&apos;: A postprocessor that computes some statistics about the rotational velocity of the model (i.e. integrated net rotation and angular momentum). In 2D we assume the model to be a cross-section through an infinite domain in z direction, with a zero z-velocity. Thus, the z-axis is the only possible rotation axis and both moment of inertia and angular momentum are scalar instead of tensor quantities.
+
+`spherical velocity statistics&apos;: A postprocessor that computes radial, tangential and total RMS velocity.
+
+`temperature statistics&apos;: A postprocessor that computes some statistics about the temperature field.
+
+`topography&apos;: A postprocessor intended for use with a free surface.  After every step it loops over all the vertices on the top surface and determines the maximum and minimum topography relative to a reference datum (initial box height for a box geometry model or initial radius for a sphere/spherical shell geometry model). If &apos;Topography.Output to file&apos; is set to true, also outputs topography into text files named `topography.NNNNN&apos; in the output directory, where NNNNN is the number of the time step.
+The file format then consists of lines with Euclidean coordinates followed by the corresponding topography value.Topography is printed/written in meters.
+
+`velocity boundary statistics&apos;: A postprocessor that computes some statistics about the velocity along the boundaries. For each boundary indicator (see your geometry description for which boundary indicators are used), the min and max velocity magnitude is computed.
+
+`velocity statistics&apos;: A postprocessor that computes some statistics about the velocity field.
+
+`visualization&apos;: A postprocessor that takes the solution and writes it into files that can be read by a graphical visualization program. Additional run time parameters are read from the parameter subsection &apos;Visualization&apos;.
+</documentation>
+<pattern>
+104
+</pattern>
+<pattern_description>
+[MultipleSelection Stokes residual|basic statistics|boundary densities|boundary pressures|command|composition statistics|core statistics|depth average|dynamic topography|geoid|global statistics|gravity calculation|heat flux densities|heat flux map|heat flux statistics|heating statistics|mass flux statistics|material statistics|matrix statistics|melt statistics|memory statistics|particle count statistics|particles|point values|pressure statistics|rotation statistics|spherical velocity statistics|temperature statistics|topography|velocity boundary statistics|velocity statistics|visualization ]
+</pattern_description>
+</List_20of_20postprocessors>
+<Command>
+<Terminate_20on_20failure>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Select whether \aspect{} should terminate if the command returns a non-zero exit status.
+</documentation>
+<pattern>
+105
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Terminate_20on_20failure>
+<Run_20on_20all_20processes>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to run command from all processes (true), or only on process 0 (false).
+</documentation>
+<pattern>
+106
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Run_20on_20all_20processes>
+<Command>
+<value/>
+<default_value/>
+<documentation>
+Command to execute.
+</documentation>
+<pattern>
+107
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Command>
+</Command>
+<Dynamic_20core_20statistics>
+<Excess_20entropy_20only>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Output the excess entropy only instead the each entropy terms.
+</documentation>
+<pattern>
+108
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Excess_20entropy_20only>
+</Dynamic_20core_20statistics>
+<Depth_20average>
+<Time_20between_20graphical_20output>
+<value>
+1e8
+</value>
+<default_value>
+1e8
+</default_value>
+<documentation>
+The time interval between each generation of graphical output files. A value of zero indicates that output should be generated in each time step. Units: years if the &apos;Use years in output instead of seconds&apos; parameter is set; seconds otherwise.
+</documentation>
+<pattern>
+109
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Time_20between_20graphical_20output>
+<Number_20of_20zones>
+<value>
+10
+</value>
+<default_value>
+10
+</default_value>
+<documentation>
+The number of zones in depth direction within which we are to compute averages. By default, we subdivide the entire domain into 10 depth zones and compute temperature and other averages within each of these zones. However, if you have a very coarse mesh, it may not make much sense to subdivide the domain into so many zones and you may wish to choose less than this default. It may also make computations slightly faster. On the other hand, if you have an extremely highly resolved mesh, choosing more zones might also make sense.
+</documentation>
+<pattern>
+110
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Number_20of_20zones>
+<Output_20format>
+<value>
+gnuplot
+</value>
+<default_value>
+gnuplot
+</default_value>
+<documentation>
+The format in which the output shall be produced. The format in which the output is generated also determines the extension of the file into which data is written. The list of possible output formats that can be given here is documented in the appendix of the manual where the current parameter is described.
+</documentation>
+<pattern>
+111
+</pattern>
+<pattern_description>
+[Selection none|dx|ucd|gnuplot|povray|eps|gmv|tecplot|tecplot_binary|vtk|vtu|hdf5|svg|deal.II intermediate|txt ]
+</pattern_description>
+</Output_20format>
+<List_20of_20output_20variables>
+<value>
+all
+</value>
+<default_value>
+all
+</default_value>
+<documentation>
+A comma separated list which specifies which quantities to average in each depth slice. It defaults to averaging all available quantities, but this can be an expensive operation, so you may want to select only a few.
+
+List of options:
+all|temperature|composition|adiabatic temperature|adiabatic pressure|adiabatic density|adiabatic density derivative|velocity magnitude|sinking velocity|Vs|Vp|viscosity|vertical heat flux
+</documentation>
+<pattern>
+112
+</pattern>
+<pattern_description>
+[MultipleSelection all|temperature|composition|adiabatic temperature|adiabatic pressure|adiabatic density|adiabatic density derivative|velocity magnitude|sinking velocity|Vs|Vp|viscosity|vertical heat flux ]
+</pattern_description>
+</List_20of_20output_20variables>
+</Depth_20average>
+<Dynamic_20topography>
+<Density_20above>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Dynamic topography is calculated as the excess or lack of mass that is supported by mantle flow. This value depends on the density of material that is moved up or down, i.e. crustal rock, and the density of the material that is displaced (generally water or air). While the density of crustal rock is part of the material model, this parameter `Density above&apos; allows the user to specify the density value of material that is displaced above the solid surface. By default this material is assumed to be air, with a density of 0. Units: $kg/m^3$.
+</documentation>
+<pattern>
+113
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Density_20above>
+<Density_20below>
+<value>
+9900
+</value>
+<default_value>
+9900
+</default_value>
+<documentation>
+Dynamic topography is calculated as the excess or lack of mass that is supported by mantle flow. This value depends on the density of material that is moved up or down, i.e. mantle above CMB, and the density of the material that is displaced (generally outer core material). While the density of mantle rock is part of the material model, this parameter `Density below&apos; allows the user to specify the density value of material that is displaced below the solid surface. By default this material is assumed to be outer core material with a density of 9900. Units: $kg/m^3$.
+</documentation>
+<pattern>
+114
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Density_20below>
+<Output_20surface>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+Whether to output a file containing the surface dynamic topography.
+</documentation>
+<pattern>
+115
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Output_20surface>
+<Output_20bottom>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+Whether to output a file containing the bottom (i.e., CMB) dynamic topography.
+</documentation>
+<pattern>
+116
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Output_20bottom>
+</Dynamic_20topography>
+<Geoid>
+<Maximum_20degree>
+<value>
+20
+</value>
+<default_value>
+20
+</default_value>
+<documentation>
+This parameter can be a random positive integer. However, the value normally should not exceed the maximum degree of the initial perturbed temperature field. For example, if the initial temperature uses S40RTS, the maximum degree should not be larger than 40.
+</documentation>
+<pattern>
+117
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Maximum_20degree>
+<Minimum_20degree>
+<value>
+2
+</value>
+<default_value>
+2
+</default_value>
+<documentation>
+This parameter normally is set to 2 since the perturbed gravitational potential at degree 1 always vanishes in a reference frame with the planetary center of mass same as the center of figure.
+</documentation>
+<pattern>
+118
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Minimum_20degree>
+<Output_20data_20in_20geographical_20coordinates>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Option to output the geoid anomaly in geographical coordinates (latitude and longitude). The default is false, so postprocess will output the data in geocentric coordinates (x,y,z) as normally.
+</documentation>
+<pattern>
+119
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Output_20data_20in_20geographical_20coordinates>
+<Density_20above>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The density value above the surface boundary.
+</documentation>
+<pattern>
+120
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Density_20above>
+<Density_20below>
+<value>
+9900
+</value>
+<default_value>
+9900
+</default_value>
+<documentation>
+The density value below the CMB boundary.
+</documentation>
+<pattern>
+121
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Density_20below>
+<Also_20output_20the_20spherical_20harmonic_20coefficients_20of_20geoid_20anomaly>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Option to also output the spherical harmonic coefficients of the geoid anomaly up to the maximum degree. The default is false, so postprocess will only output the geoid anomaly in grid format. 
+</documentation>
+<pattern>
+122
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Also_20output_20the_20spherical_20harmonic_20coefficients_20of_20geoid_20anomaly>
+<Also_20output_20the_20spherical_20harmonic_20coefficients_20of_20surface_20dynamic_20topography_20contribution>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Option to also output the spherical harmonic coefficients of the surface dynamic topography contribution to the maximum degree. The default is false. 
+</documentation>
+<pattern>
+123
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Also_20output_20the_20spherical_20harmonic_20coefficients_20of_20surface_20dynamic_20topography_20contribution>
+<Also_20output_20the_20spherical_20harmonic_20coefficients_20of_20CMB_20dynamic_20topography_20contribution>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Option to also output the spherical harmonic coefficients of the CMB dynamic topography contribution to the maximum degree. The default is false. 
+</documentation>
+<pattern>
+124
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Also_20output_20the_20spherical_20harmonic_20coefficients_20of_20CMB_20dynamic_20topography_20contribution>
+<Also_20output_20the_20spherical_20harmonic_20coefficients_20of_20density_20anomaly_20contribution>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Option to also output the spherical harmonic coefficients of the density anomaly contribution to the maximum degree. The default is false. 
+</documentation>
+<pattern>
+125
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Also_20output_20the_20spherical_20harmonic_20coefficients_20of_20density_20anomaly_20contribution>
+</Geoid>
+<Global_20statistics>
+<Write_20statistics_20for_20each_20nonlinear_20iteration>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to put every nonlinear iteration into a separate line in the statistics file (if true), or to output only one line per time step that contains the total number of iterations of the Stokes and advection linear system solver.
+</documentation>
+<pattern>
+126
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Write_20statistics_20for_20each_20nonlinear_20iteration>
+</Global_20statistics>
+<Gravity_20calculation>
+<Quadrature_20degree_20increase>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Quadrature degree increase over the velocity element degree may be required when gravity is calculated near the surface or inside the model. An increase in the quadrature element adds accuracy to the gravity solution from noise due to the model grid.
+</documentation>
+<pattern>
+127
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Quadrature_20degree_20increase>
+<Number_20points_20radius>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Gravity may be calculated for a set of points along the radius (e.g. depth profile) between a minimum and maximum radius.
+</documentation>
+<pattern>
+128
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Number_20points_20radius>
+<Number_20points_20longitude>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Gravity may be calculated for a sets of points along the longitude (e.g. gravity map) between a minimum and maximum longitude.
+</documentation>
+<pattern>
+129
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Number_20points_20longitude>
+<Number_20points_20latitude>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Gravity may be calculated for a sets of points along the latitude (e.g. gravity map) between a minimum and maximum latitude.
+</documentation>
+<pattern>
+130
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Number_20points_20latitude>
+<Minimum_20radius>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Minimum radius may be defined in or outside the model.
+</documentation>
+<pattern>
+131
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20radius>
+<Maximum_20radius>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Maximum radius can be defined in or outside the model.
+</documentation>
+<pattern>
+132
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20radius>
+<Minimum_20longitude>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Gravity may be calculated for a sets of points along the longitude between a minimum and maximum longitude.
+</documentation>
+<pattern>
+133
+</pattern>
+<pattern_description>
+[Double 0...360 (inclusive)]
+</pattern_description>
+</Minimum_20longitude>
+<Minimum_20latitude>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Gravity may be calculated for a sets of points along the latitude between a minimum and maximum latitude.
+</documentation>
+<pattern>
+134
+</pattern>
+<pattern_description>
+[Double 0...180 (inclusive)]
+</pattern_description>
+</Minimum_20latitude>
+<Maximum_20longitude>
+<value>
+360
+</value>
+<default_value>
+360
+</default_value>
+<documentation>
+Gravity may be calculated for a sets of points along the longitude between a minimum and maximum longitude.
+</documentation>
+<pattern>
+135
+</pattern>
+<pattern_description>
+[Double 0...360 (inclusive)]
+</pattern_description>
+</Maximum_20longitude>
+<Maximum_20latitude>
+<value>
+180
+</value>
+<default_value>
+180
+</default_value>
+<documentation>
+Gravity may be calculated for a sets of points along the latitude between a minimum and maximum latitude.
+</documentation>
+<pattern>
+136
+</pattern>
+<pattern_description>
+[Double 0...180 (inclusive)]
+</pattern_description>
+</Maximum_20latitude>
+</Gravity_20calculation>
+<Particles>
+<Time_20between_20data_20output>
+<value>
+1e8
+</value>
+<default_value>
+1e8
+</default_value>
+<documentation>
+The time interval between each generation of output files. A value of zero indicates that output should be generated every time step.
+
+Units: years if the &apos;Use years in output instead of seconds&apos; parameter is set; seconds otherwise.
+</documentation>
+<pattern>
+137
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Time_20between_20data_20output>
+<Data_20output_20format>
+<value>
+vtu
+</value>
+<default_value>
+vtu
+</default_value>
+<documentation>
+A comma separated list of file formats to be used for graphical output. The list of possible output formats that can be given here is documented in the appendix of the manual where the current parameter is described.
+</documentation>
+<pattern>
+138
+</pattern>
+<pattern_description>
+[MultipleSelection none|dx|ucd|gnuplot|povray|eps|gmv|tecplot|tecplot_binary|vtk|vtu|hdf5|svg|deal.II intermediate|ascii ]
+</pattern_description>
+</Data_20output_20format>
+<Number_20of_20grouped_20files>
+<value>
+16
+</value>
+<default_value>
+16
+</default_value>
+<documentation>
+VTU file output supports grouping files from several CPUs into a given number of files using MPI I/O when writing on a parallel filesystem. Select 0 for no grouping. This will disable parallel file output and instead write one file per processor. A value of 1 will generate one big file containing the whole solution, while a larger value will create that many files (at most as many as there are MPI ranks).
+</documentation>
+<pattern>
+139
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Number_20of_20grouped_20files>
+<Write_20in_20background_20thread>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+File operations can potentially take a long time, blocking the progress of the rest of the model run. Setting this variable to `true&apos; moves this process into a background thread, while the rest of the model continues.
+</documentation>
+<pattern>
+140
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Write_20in_20background_20thread>
+<Temporary_20output_20location>
+<value/>
+<default_value/>
+<documentation>
+On large clusters it can be advantageous to first write the output to a temporary file on a local file system and later move this file to a network file system. If this variable is set to a non-empty string it will be interpreted as a temporary storage location.
+</documentation>
+<pattern>
+141
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Temporary_20output_20location>
+<Load_20balancing_20strategy>
+<value>
+repartition
+</value>
+<default_value>
+repartition
+</default_value>
+<documentation>
+Strategy that is used to balance the computational load across processors for adaptive meshes.
+</documentation>
+<pattern>
+142
+</pattern>
+<pattern_description>
+[MultipleSelection none|remove particles|add particles|remove and add particles|repartition ]
+</pattern_description>
+</Load_20balancing_20strategy>
+<Minimum_20particles_20per_20cell>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Lower limit for particle number per cell. This limit is useful for adaptive meshes to prevent fine cells from being empty of particles. It will be checked and enforced after mesh refinement and after particle movement. If there are \texttt{n\_number\_of\_particles} $&lt;$ \texttt{min\_particles\_per\_cell} particles in one cell then \texttt{min\_particles\_per\_cell} - \texttt{n\_number\_of\_particles} particles are generated and randomly placed in this cell. If the particles carry properties the individual property plugins control how the properties of the new particles are initialized.
+</documentation>
+<pattern>
+143
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Minimum_20particles_20per_20cell>
+<Maximum_20particles_20per_20cell>
+<value>
+100
+</value>
+<default_value>
+100
+</default_value>
+<documentation>
+Upper limit for particle number per cell. This limit is useful for adaptive meshes to prevent coarse cells from slowing down the whole model. It will be checked and enforced after mesh refinement, after MPI transfer of particles and after particle movement. If there are \texttt{n\_number\_of\_particles} $&gt;$ \texttt{max\_particles\_per\_cell} particles in one cell then \texttt{n\_number\_of\_particles} - \texttt{max\_particles\_per\_cell} particles in this cell are randomly chosen and destroyed.
+</documentation>
+<pattern>
+144
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Maximum_20particles_20per_20cell>
+<Particle_20weight>
+<value>
+10
+</value>
+<default_value>
+10
+</default_value>
+<documentation>
+Weight that is associated with the computational load of a single particle. The sum of particle weights will be added to the sum of cell weights to determine the partitioning of the mesh if the `repartition&apos; particle load balancing strategy is selected. The optimal weight depends on the used integrator and particle properties. In general for a more expensive integrator and more expensive properties a larger particle weight is recommended. Before adding the weights of particles, each cell already carries a weight of 1000 to account for the cost of field-based computations.
+</documentation>
+<pattern>
+145
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Particle_20weight>
+<Update_20ghost_20particles>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Some particle interpolation algorithms require knowledge about particles in neighboring cells. To allow this, particles in ghost cells need to be exchanged between the processes neighboring this cell. This parameter determines whether this transport is happening.
+</documentation>
+<pattern>
+146
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Update_20ghost_20particles>
+<Particle_20generator_20name>
+<value>
+random uniform
+</value>
+<default_value>
+random uniform
+</default_value>
+<documentation>
+Select one of the following models:
+
+`ascii file&apos;: Generates a distribution of particles from coordinates specified in an Ascii data file. The file format is a simple text file, with as many columns as spatial dimensions and as many lines as particles to be generated. Initial comment lines starting with `#&apos; will be discarded. Note that this plugin always generates as many particles as there are coordinates in the data file, the ``Postprocess/Particles/Number of particles&apos;&apos; parameter has no effect on this plugin. All of the values that define this generator are read from a section ``Postprocess/Particles/Generator/Ascii file&apos;&apos; in the input file, see Section~\ref{parameters:Postprocess/Particles/Generator/Ascii_20file}.
+
+`probability density function&apos;: Generate a random distribution of particles over the entire simulation domain. The probability density is prescribed in the form of a user-prescribed function. The format of this function follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}. The return value of the function is always checked to be a non-negative probability density but it can be zero in parts of the domain.
+
+`quadrature points&apos;: Generates particles at the quadrature points of each active cell of the triangulation. Here, Gauss quadrature of degree (velocity\_degree + 1), is used similarly to the assembly of Stokes matrix.
+
+`random uniform&apos;: Generates a random uniform distribution of particles over the entire simulation domain.
+
+`reference cell&apos;: Generates a uniform distribution of particles per cell and spatial direction in the unit cell and transforms each of the particles back to real region in the model domain. Uniform here means the particles will be generated with an equal spacing in each spatial dimension
+
+`uniform box&apos;: Generate a uniform distribution of particles over a rectangular domain in 2D or 3D. Uniform here means the particles will be generated with an equal spacing in each spatial dimension. Note that in order to produce a regular distribution the number of generated particles might not exactly match the one specified in the input file.
+
+`uniform radial&apos;: Generate a uniform distribution of particles over a spherical domain in 2D or 3D. Uniform here means the particles will be generated with an equal spacing in each spherical spatial dimension, i.e., the particles are created at positions that increase linearly with equal spacing in radius, colatitude and longitude around a certain center point. Note that in order to produce a regular distribution the number of generated particles might not exactly match the one specified in the input file.
+</documentation>
+<pattern>
+147
+</pattern>
+<pattern_description>
+[Selection ascii file|probability density function|quadrature points|random uniform|reference cell|uniform box|uniform radial ]
+</pattern_description>
+</Particle_20generator_20name>
+<Generator>
+<Ascii_20file>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/particle/generator/ascii/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/particle/generator/ascii/
+</default_value>
+<documentation>
+The name of a directory that contains the particle data. This path may either be absolute (if starting with a &apos;/&apos;) or relative to the current directory. The path may also include the special text &apos;$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+148
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value>
+particle.dat
+</value>
+<default_value>
+particle.dat
+</default_value>
+<documentation>
+The name of the particle file.
+</documentation>
+<pattern>
+149
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+</Ascii_20file>
+<Probability_20density_20function>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+157
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+158
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+159
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+<Random_20cell_20selection>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+If true, particle numbers per cell are calculated randomly according to their respective probability density. This means particle numbers per cell can deviate statistically from the integral of the probability density. If false, first determine how many particles each cell should have based on the integral of the density over each of the cells, and then once we know how many particles we want on each cell, choose their locations randomly within each cell.
+</documentation>
+<pattern>
+160
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Random_20cell_20selection>
+<Random_20number_20seed>
+<value>
+5432
+</value>
+<default_value>
+5432
+</default_value>
+<documentation>
+The seed for the random number generator that controls the particle generation. Keep constant to generate identical particle distributions in subsequent model runs. Change to get a different distribution. In parallel computations the seed is further modified on each process to ensure different particle patterns on different processes.
+</documentation>
+<pattern>
+161
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Random_20number_20seed>
+</Probability_20density_20function>
+<Reference_20cell>
+<Number_20of_20particles_20per_20cell_20per_20direction>
+<value>
+2
+</value>
+<default_value>
+2
+</default_value>
+<documentation>
+List of number of particles to create per cell and spatial dimension. The size of the list is the number of spatial dimensions. If only one value is given, then each spatial dimension is set to the same value. The list of numbers are parsed as a floating point number (so that one can specify, for example, &apos;1e4&apos; particles) but it is interpreted as an integer, of course.
+</documentation>
+<pattern>
+162
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Number_20of_20particles_20per_20cell_20per_20direction>
+</Reference_20cell>
+<Uniform_20box>
+<Minimum_20x>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Minimum x coordinate for the region of particles.
+</documentation>
+<pattern>
+164
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20x>
+<Maximum_20x>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Maximum x coordinate for the region of particles.
+</documentation>
+<pattern>
+165
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20x>
+<Minimum_20y>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Minimum y coordinate for the region of particles.
+</documentation>
+<pattern>
+166
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20y>
+<Maximum_20y>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Maximum y coordinate for the region of particles.
+</documentation>
+<pattern>
+167
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20y>
+<Minimum_20z>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Minimum z coordinate for the region of particles.
+</documentation>
+<pattern>
+168
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20z>
+<Maximum_20z>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Maximum z coordinate for the region of particles.
+</documentation>
+<pattern>
+169
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20z>
+</Uniform_20box>
+<Uniform_20radial>
+<Center_20x>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+x coordinate for the center of the spherical region, where particles are generated.
+</documentation>
+<pattern>
+171
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Center_20x>
+<Center_20y>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+y coordinate for the center of the spherical region, where particles are generated.
+</documentation>
+<pattern>
+172
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Center_20y>
+<Center_20z>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+z coordinate for the center of the spherical region, where particles are generated.
+</documentation>
+<pattern>
+173
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Center_20z>
+<Minimum_20radius>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Minimum radial coordinate for the region of particles. Measured from the center position.
+</documentation>
+<pattern>
+174
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20radius>
+<Maximum_20radius>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Maximum radial coordinate for the region of particles. Measured from the center position.
+</documentation>
+<pattern>
+175
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20radius>
+<Minimum_20longitude>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Minimum longitude coordinate for the region of particles in degrees. Measured from the center position.
+</documentation>
+<pattern>
+176
+</pattern>
+<pattern_description>
+[Double -180...360 (inclusive)]
+</pattern_description>
+</Minimum_20longitude>
+<Maximum_20longitude>
+<value>
+360
+</value>
+<default_value>
+360
+</default_value>
+<documentation>
+Maximum longitude coordinate for the region of particles in degrees. Measured from the center position.
+</documentation>
+<pattern>
+177
+</pattern>
+<pattern_description>
+[Double -180...360 (inclusive)]
+</pattern_description>
+</Maximum_20longitude>
+<Minimum_20latitude>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Minimum latitude coordinate for the region of particles in degrees. Measured from the center position, and from the north pole.
+</documentation>
+<pattern>
+178
+</pattern>
+<pattern_description>
+[Double 0...180 (inclusive)]
+</pattern_description>
+</Minimum_20latitude>
+<Maximum_20latitude>
+<value>
+180
+</value>
+<default_value>
+180
+</default_value>
+<documentation>
+Maximum latitude coordinate for the region of particles in degrees. Measured from the center position, and from the north pole.
+</documentation>
+<pattern>
+179
+</pattern>
+<pattern_description>
+[Double 0...180 (inclusive)]
+</pattern_description>
+</Maximum_20latitude>
+<Radial_20layers>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+The number of radial shells of particles that will be generated around the central point.
+</documentation>
+<pattern>
+180
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Radial_20layers>
+</Uniform_20radial>
+</Generator>
+<Number_20of_20particles>
+<value>
+1000
+</value>
+<default_value>
+1000
+</default_value>
+<documentation>
+Total number of particles to create (not per processor or per element). The number is parsed as a floating point number (so that one can specify, for example, &apos;1e4&apos; particles) but it is interpreted as an integer, of course.
+</documentation>
+<pattern>
+170
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Number_20of_20particles>
+<Integration_20scheme>
+<value>
+rk2
+</value>
+<default_value>
+rk2
+</default_value>
+<documentation>
+This parameter is used to decide which method to use to solve the equation that describes the position of particles, i.e., $\frac{d}{dt}\mathbf x_k(t) = \mathbf u(\mathbf x_k(t),t)$, where $k$ is an index that runs over all particles, and $\mathbf u(\mathbf x,t)$ is the velocity field that results from the Stokes equations.
+
+In practice, the exact velocity $\mathbf u(\mathbf x,t)$ is of course not available, but only a numerical approximation $\mathbf u_h(\mathbf x,t)$. Furthermore, this approximation is only available at discrete time steps, $\mathbf u^n(\mathbf x)=\mathbf u(\mathbf x,t^n)$, and these need to be interpolated between time steps if the integrator for the equation above requires an evaluation at time points between the discrete time steps. If we denote this interpolation in time by $\tilde{\mathbf u}_h(\mathbf x,t)$ where $\tilde{\mathbf u}_h(\mathbf x,t^n)=\mathbf u^n(\mathbf x)$, then the equation the differential equation solver really tries to solve is $\frac{d}{dt}\tilde{\mathbf x}_k(t) =  \tilde{\mathbf u}_h(\mathbf x_k(t),t)$.
+
+As a consequence of these considerations, if you try to assess convergence properties of an ODE integrator -- for example to verify that the RK4 integrator converges with fourth order --, it is important to recall that the integrator may not solve the equation you think it solves. If, for example, we call the numerical solution of the ODE $\tilde{\mathbf x}_{k,h}(t)$, then the error will typically satisfy a relationship like $$  \| \tilde{\mathbf x}_k(T) - \tilde{\mathbf x}_{k,h}(T) \|  \le  C(T) \Delta t^p$$ where $\Delta t$ is the time step and $p$ the convergence order of the method, and $C(T)$ is a (generally unknown) constant that depends on the end time $T$ at which one compares the solutions. On the other hand, an analytically computed trajectory would likely use the \textit{exact} velocity, and one may be tempted to compute $\| \mathbf x_k(T) - \tilde{\mathbf x}_{k,h}(T) \|$, but this quantity will, in the best case, only satisfy an estimate of the form $$  \| \mathbf x_k(T) - \tilde{\mathbf x}_{k,h}(T) \|  \le  C_1(T) \Delta t^p  + C_2(T) \| \mathbf u-\mathbf u_h \|  + C_3(T) \| \mathbf u_h-\tilde{\mathbf u}_h \|$$ with appropriately chosen norms for the second and third term. These second and third terms typically converge to zero at relatively low rates (compared to the order $p$ of the integrator, which can often be chosen relatively high) in the mesh size $h$ and the time step size $\\Delta t$, limiting the overall accuracy of the ODE integrator.
+
+Select one of the following models:
+
+`euler&apos;: Explicit Euler scheme integrator, where $y_{n+1} = y_n + \Delta t \, v(y_n)$. This requires only one integration substep per timestep.
+
+`rk2&apos;: Second Order Runge Kutta integrator $y_{n+1} = y_n + \Delta t\, v(t_{n+1/2}, y_{n} + \frac{1}{2} k_1)$ where $k_1 = \Delta t\, v(t_{n}, y_{n})$
+
+`rk4&apos;: Runge Kutta fourth order integrator, where $y_{n+1} = y_n + \frac{1}{6} k_1 + \frac{1}{3} k_2 + \frac{1}{3} k_3 + \frac{1}{6} k_4$ and $k_1$, $k_2$, $k_3$, $k_4$ are defined as usual.
+</documentation>
+<pattern>
+181
+</pattern>
+<pattern_description>
+[Selection euler|rk2|rk4 ]
+</pattern_description>
+</Integration_20scheme>
+<Interpolation_20scheme>
+<value>
+cell average
+</value>
+<default_value>
+cell average
+</default_value>
+<documentation>
+Select one of the following models:
+
+`bilinear least squares&apos;: Interpolates particle properties onto a vector of points using a bilinear least squares method. Currently only 2D models are supported. Note that deal.II must be configured with BLAS/LAPACK.
+
+`cell average&apos;: Return the average of all particle properties in the given cell.
+
+`harmonic average&apos;: Return the harmonic average of all particle properties in the given cell. If the cell contains no particles, return the harmonic average of the properties in the neighboring cells.
+
+`nearest neighbor&apos;: Return the properties of the nearest neighboring particle in the current cell, or nearest particle in nearest neighboring cell if current cell is empty.
+</documentation>
+<pattern>
+182
+</pattern>
+<pattern_description>
+[Selection bilinear least squares|cell average|harmonic average|nearest neighbor ]
+</pattern_description>
+</Interpolation_20scheme>
+<Interpolator>
+<Bilinear_20least_20squares>
+<Global_20particle_20property_20maximum>
+<value>
+1.7976931348623157e+308
+</value>
+<default_value>
+1.7976931348623157e+308
+</default_value>
+<documentation>
+The maximum global particle property values that will be used as a limiter for the bilinear least squares interpolation. The number of the input &apos;Global particle property maximum&apos; values separated by &apos;,&apos; has to be the same as the number of particle properties.
+</documentation>
+<pattern>
+183
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Global_20particle_20property_20maximum>
+<Global_20particle_20property_20minimum>
+<value>
+-1.7976931348623157e+308
+</value>
+<default_value>
+-1.7976931348623157e+308
+</default_value>
+<documentation>
+The minimum global particle property that will be used as a limiter for the bilinear least squares interpolation. The number of the input &apos;Global particle property minimum&apos; values separated by &apos;,&apos; has to be the same as the number of particle properties.
+</documentation>
+<pattern>
+184
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Global_20particle_20property_20minimum>
+<Use_20limiter>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to apply a global particle property limiting scheme to the interpolated particle properties.
+</documentation>
+<pattern>
+185
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20limiter>
+</Bilinear_20least_20squares>
+</Interpolator>
+<List_20of_20particle_20properties>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of particle properties that should be tracked. By default none is selected, which means only position, velocity and id of the particles are output. 
+
+The following properties are available:
+
+`composition&apos;: Implementation of a plugin in which the particle property is defined by the compositional fields in the model. This can be used to track solid compositionevolution over time.
+
+`function&apos;: Implementation of a model in which the particle property is set by evaluating an explicit function at the initial position of each particle. The function is defined in the parameters in section ``Particles|Function&apos;&apos;. The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
+`initial composition&apos;: Implementation of a plugin in which the particle property is given as the initial composition at the particle&apos;s initial position. The particle gets as many properties as there are compositional fields.
+
+`initial position&apos;: Implementation of a plugin in which the particle property is given as the initial position of the particle. This property is vector-valued with as many components as there are space dimensions. In practice, it is often most useful to only visualize one of the components of this vector, or the magnitude of the vector. For example, in a spherical mantle simulation, the magnitude of this property equals the starting radius of a particle, and is thereby indicative of which part of the mantle a particle comes from.
+
+`integrated strain&apos;: A plugin in which the particle property tensor is defined as the deformation gradient tensor $\mathbf F$ this particle has experienced. $\mathbf F$ can be polar-decomposed into the left stretching tensor $\mathbf L$ (the finite strain we are interested in), and the rotation tensor $\mathbf Q$. See the corresponding cookbook in the manual for more detailed information.
+
+`integrated strain invariant&apos;: A plugin in which the particle property is defined as the finite strain invariant ($\varepsilon_{ii}$). This property is calculated with the timestep ($dt$) and the second invariant of the deviatoric strain rate tensor ($\dot{\varepsilon}_{ii}$), where the value at time step $n$ is $\varepsilon_{ii}^{n} = \varepsilon_{ii}^{n-1} + dt\dot{\varepsilon}_{ii}$.
+
+`melt particle&apos;: Implementation of a plugin in which the particle property is defined as presence of melt above a threshold, which can be set as an input parameter. This property is set to 0 if melt is not present and set to 1 if melt is present.
+
+`pT path&apos;: Implementation of a plugin in which the particle property is defined as the current pressure and temperature at this position. This can be used to generate pressure-temperature paths of material points over time.
+
+`position&apos;: Implementation of a plugin in which the particle property is defined as the current position.
+
+`velocity&apos;: Implementation of a plugin in which the particle property is defined as the recent velocity at this position.
+</documentation>
+<pattern>
+186
+</pattern>
+<pattern_description>
+[MultipleSelection composition|function|initial composition|initial position|integrated strain|integrated strain invariant|melt particle|pT path|position|velocity ]
+</pattern_description>
+</List_20of_20particle_20properties>
+<Function>
+<Number_20of_20components>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+The number of function components where each component is described by a function expression delimited by a &apos;;&apos;.
+</documentation>
+<pattern>
+187
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Number_20of_20components>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+188
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+189
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+190
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Function>
+<Melt_20particle>
+<Threshold_20for_20melt_20presence>
+<value>
+1e-3
+</value>
+<default_value>
+1e-3
+</default_value>
+<documentation>
+The minimum porosity that has to be present at the position of a particle for it to be considered a melt particle (in the sense that the melt presence property is set to 1).
+</documentation>
+<pattern>
+191
+</pattern>
+<pattern_description>
+[Double 0...1 (inclusive)]
+</pattern_description>
+</Threshold_20for_20melt_20presence>
+</Melt_20particle>
+</Particles>
+<Point_20values>
+<Time_20between_20point_20values_20output>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The time interval between each generation of point values output. A value of zero indicates that output should be generated in each time step. Units: years if the &apos;Use years in output instead of seconds&apos; parameter is set; seconds otherwise.
+</documentation>
+<pattern>
+192
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Time_20between_20point_20values_20output>
+<Evaluation_20points>
+<value/>
+<default_value/>
+<documentation>
+The list of points at which the solution should be evaluated. Points need to be separated by semicolons, and coordinates of each point need to be separated by commas.
+</documentation>
+<pattern>
+193
+</pattern>
+<pattern_description>
+[List of &lt;[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 2...2 (inclusive)]&gt; of length 0...4294967295 (inclusive) separated by &lt;;&gt;]
+</pattern_description>
+</Evaluation_20points>
+<Use_20natural_20coordinates>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether or not the Evaluation points are specified in the natural coordinates of the geometry model, e.g. radius, lon, lat for the chunk model. Currently, natural coordinates for the spherical shell and sphere geometries are not supported. 
+</documentation>
+<pattern>
+194
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20natural_20coordinates>
+</Point_20values>
+<Rotation_20statistics>
+<Use_20constant_20density_20of_20one>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to use a constant density of one for the computation of the angular momentum and moment of inertia. This is an approximation that assumes that the &apos;volumetric&apos; rotation is equal to the &apos;mass&apos; rotation. If this parameter is true this postprocessor computes &apos;net rotation&apos; instead of &apos;angular momentum&apos;.
+</documentation>
+<pattern>
+195
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20constant_20density_20of_20one>
+<Output_20full_20moment_20of_20inertia_20tensor>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to write the full moment of inertia tensor into the statistics output instead of its norm for the current rotation axis. This is a second-order symmetric tensor with 6 components in 3D. In 2D this option has no effect, because the rotation axis is fixed and thus the moment of inertia is always a scalar.
+</documentation>
+<pattern>
+196
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Output_20full_20moment_20of_20inertia_20tensor>
+</Rotation_20statistics>
+<Topography>
+<Output_20to_20file>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether or not to write topography to a text file named named &apos;topography.NNNNN&apos; in the output directory
+</documentation>
+<pattern>
+197
+</pattern>
+<pattern_description>
+[List of &lt;[Bool]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Output_20to_20file>
+<Time_20between_20text_20output>
+<value>
+0.
+</value>
+<default_value>
+0.
+</default_value>
+<documentation>
+The time interval between each generation of text output files. A value of zero indicates that output should be generated in each time step. Units: years if the &apos;Use years in output instead of seconds&apos; parameter is set; seconds otherwise.
+</documentation>
+<pattern>
+198
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Time_20between_20text_20output>
+</Topography>
+<Visualization>
+<Time_20between_20graphical_20output>
+<value>
+1e8
+</value>
+<default_value>
+1e8
+</default_value>
+<documentation>
+The time interval between each generation of graphical output files. A value of zero indicates that output should be generated in each time step. Units: years if the &apos;Use years in output instead of seconds&apos; parameter is set; seconds otherwise.
+</documentation>
+<pattern>
+199
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Time_20between_20graphical_20output>
+<Time_20steps_20between_20graphical_20output>
+<value>
+2147483647
+</value>
+<default_value>
+2147483647
+</default_value>
+<documentation>
+The maximum number of time steps between each generation of graphical output files.
+</documentation>
+<pattern>
+200
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Time_20steps_20between_20graphical_20output>
+<Output_20format>
+<value>
+vtu
+</value>
+<default_value>
+vtu
+</default_value>
+<documentation>
+The file format to be used for graphical output. The list of possible output formats that can be given here is documented in the appendix of the manual where the current parameter is described.
+</documentation>
+<pattern>
+201
+</pattern>
+<pattern_description>
+[Selection none|dx|ucd|gnuplot|povray|eps|gmv|tecplot|tecplot_binary|vtk|vtu|hdf5|svg|deal.II intermediate ]
+</pattern_description>
+</Output_20format>
+<Number_20of_20grouped_20files>
+<value>
+16
+</value>
+<default_value>
+16
+</default_value>
+<documentation>
+VTU file output supports grouping files from several CPUs into a given number of files using MPI I/O when writing on a parallel filesystem. Select 0 for no grouping. This will disable parallel file output and instead write one file per processor. A value of 1 will generate one big file containing the whole solution, while a larger value will create that many files (at most as many as there are MPI ranks).
+</documentation>
+<pattern>
+202
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Number_20of_20grouped_20files>
+<Write_20in_20background_20thread>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+File operations can potentially take a long time, blocking the progress of the rest of the model run. Setting this variable to `true&apos; moves this process into a background thread, while the rest of the model continues.
+</documentation>
+<pattern>
+203
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Write_20in_20background_20thread>
+<Temporary_20output_20location>
+<value/>
+<default_value/>
+<documentation>
+On large clusters it can be advantageous to first write the output to a temporary file on a local file system and later move this file to a network file system. If this variable is set to a non-empty string it will be interpreted as a temporary storage location.
+</documentation>
+<pattern>
+204
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Temporary_20output_20location>
+<Interpolate_20output>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+deal.II offers the possibility to linearly interpolate output fields of higher order elements to a finer resolution. This somewhat compensates the fact that most visualization software only offers linear interpolation between grid points and therefore the output file is a very coarse representation of the actual solution field. Activating this option increases the spatial resolution in each dimension by a factor equal to the polynomial degree used for the velocity finite element (usually 2). In other words, instead of showing one quadrilateral or hexahedron in the visualization per cell on which \aspect{} computes, it shows multiple (for quadratic elements, it will describe each cell of the mesh on which we compute as $2\times 2$ or $2\times 2\times 2$ cells in 2d and 3d, respectively; correspondingly more subdivisions are used if you use cubic, quartic, or even higher order elements for the velocity).
+
+The effect of using this option can be seen in the following picture showing a variation of the output produced with the input files from Section~\ref{sec:shell-simple-2d}:
+
+\begin{center}  \includegraphics[width=0.5\textwidth]{viz/parameters/build-patches}\end{center}Here, the left picture shows one visualization cell per computational cell (i.e., the option is switch off, as is the default), and the right picture shows the same simulation with the option switched on. The images show the same data, demonstrating that interpolating the solution onto bilinear shape functions as is commonly done in visualizing data loses information.
+
+Of course, activating this option also greatly increases the amount of data \aspect{} will write to disk: approximately by a factor of 4 in 2d, and a factor of 8 in 3d, when using quadratic elements for the velocity, and correspondingly more for even higher order elements.
+</documentation>
+<pattern>
+205
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Interpolate_20output>
+<Filter_20output>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+deal.II offers the possibility to filter duplicate vertices for HDF5 output files. This merges the vertices of adjacent cells and therefore saves disk space, but misrepresents discontinuous output properties. Activating this function reduces the disk space by about a factor of $2^{dim}$ for HDF5 output, and currently has no effect on other output formats. \note{\textbf{Warning:} Setting this flag to true will result in visualization output that does not accurately represent discontinuous fields. This may be because you are using a discontinuous finite element for the pressure, temperature, or compositional variables, or because you use a visualization postprocessor that outputs quantities as discontinuous fields (e.g., the strain rate, viscosity, etc.). These will then all be visualized as \textit{continuous} quantities even though, internally, \aspect{} considers them as discontinuous fields.}
+</documentation>
+<pattern>
+206
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Filter_20output>
+<Output_20mesh_20velocity>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+For free surface computations Aspect uses an Arbitrary-Lagrangian-Eulerian formulation to handle deforming the domain, so the mesh has its own velocity field.  This may be written as an output field by setting this parameter to true.
+</documentation>
+<pattern>
+207
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Output_20mesh_20velocity>
+<List_20of_20output_20variables>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of visualization objects that should be run whenever writing graphical output. By default, the graphical output files will always contain the primary variables velocity, pressure, and temperature. However, one frequently wants to also visualize derived quantities, such as the thermodynamic phase that corresponds to a given temperature-pressure value, or the corresponding seismic wave speeds. The visualization objects do exactly this: they compute such derived quantities and place them into the output file. The current parameter is the place where you decide which of these additional output variables you want to have in your output file.
+
+The following postprocessors are available:
+
+`ISA rotation timescale&apos;: A visualization output object that generates output showing the timescale for the rotation of grains toward the infinite strain axis. Kaminski and Ribe (2002, Gcubed) call this quantity $\tau_{ISA}$ and define it as $\tau_{ISA} \approx \frac{1}{\dot{\epsilon}}$ where $\dot{\epsilon}$ is the largest eigenvalue of the strain rate tensor. It can be used, along with the grain lag angle $\Theta$, to calculate the grain orientation lag parameter.
+
+`Vp anomaly&apos;: A visualization output object that generates output showing the percentage anomaly in the seismic compressional wave speed $V_p$ as a spatially variable function with one value per cell. This anomaly is either shown as a percentage anomaly relative to the reference profile given by adiabatic conditions (with the compositions given by the current composition, such that the reference could potentially change through time), or as a percentage change relative to the laterally averaged velocity at the depth of the cell. This velocity is calculated by linear interpolation between average values calculated within equally thick depth slices. The number of depth slices in the domain is user-defined. Typically, the best results will be obtained if the number of depth slices is balanced between being large enough to capture step changes in velocities, but small enough to maintain a reasonable number of evaluation points per slice. Bear in mind that lateral averaging subsamples the finite element mesh. Note that this plugin requires a material model that provides seismic velocities.
+
+`Vs anomaly&apos;: A visualization output object that generates output showing the percentage anomaly in the seismic shear wave speed $V_s$ as a spatially variable function with one value per cell. This anomaly is either shown as a percentage anomaly relative to the reference profile given by adiabatic conditions (with the compositions given by the current composition, such that the reference could potentially change through time), or as a percentage change relative to the laterally averaged velocity at the depth of the cell. This velocity is calculated by linear interpolation between average values calculated within equally thick depth slices. The number of depth slices in the domain is user-defined. Typically, the best results will be obtained if the number of depth slices is balanced between being large enough to capture step changes in velocities, but small enough to maintain a reasonable number of evaluation points per slice. Bear in mind that lateral averaging subsamples the finite element mesh. Note that this plugin requires a material model that provides seismic velocities.
+
+`adiabat&apos;: A visualization output object that generates adiabatic temperature, pressure, density, and density derivative as produced by AdiabaticConditions.
+
+`artificial viscosity&apos;: A visualization output object that generates output showing the value of the artificial viscosity on each cell.
+
+`artificial viscosity composition&apos;: A visualization output object that generates output showing the value of the artificial viscosity for a compositional field on each cell.
+
+`boundary indicators&apos;: A visualization output object that generates output about the used boundary indicators. In a loop over the active cells, if a cell lies at a domain boundary, the boundary indicator of the face along the boundary is requested. In case the cell does not lie along any domain boundary, the cell is assigned the value of the largest used boundary indicator plus one. When a cell is situated in one of the corners of the domain, multiple faces will have a boundary indicator. This postprocessor returns the value of the first face along a boundary that is encountered in a loop over all the faces. 
+
+`compositional vector&apos;: A visualization output object that outputs vectors whose components are derived from compositional fields. Input parameters for this postprocessor are defined in section Postprocess/Visualization/Compositional fields as vectors
+
+`density&apos;: A visualization output object that generates output for the density.
+
+`depth&apos;: A visualization output postprocessor that outputs the depth for all points inside the domain, as determined by the geometry model.
+
+`dynamic topography&apos;: A visualization output object that generates output for the dynamic topography at the top and bottom of the model space. The approach to determine the dynamic topography requires us to compute the stress tensor and evaluate the component of it in the direction in which gravity acts. In other words, we compute $\sigma_{rr}={\hat g}^T(2 \eta \varepsilon(\mathbf u)-\frac 13 (\textrm{div}\;\mathbf u)I)\hat g - p_d$ where $\hat g = \mathbf g/\|\mathbf g\|$ is the direction of the gravity vector $\mathbf g$ and $p_d=p-p_a$ is the dynamic pressure computed by subtracting the adiabatic pressure $p_a$ from the total pressure $p$ computed as part of the Stokes solve. From this, the dynamic topography is computed using the formula $h=\frac{\sigma_{rr}}{(\mathbf g \cdot \mathbf n)  \rho}$ where $\rho$ is the density at the cell center. For the bottom surface we chose the convection that positive values are up (out) and negative values are in (down), analogous to the deformation of the upper surface. Note that this implementation takes the direction of gravity into account, which means that reversing the flow in backward advection calculations will not reverse the instantaneous topography because the reverse flow will be divided by the reverse surface gravity.
+
+Strictly speaking, the dynamic topography is of course a quantity that is only of interest at the surface. However, we compute it everywhere to make things fit into the framework within which we produce data for visualization. You probably only want to visualize whatever data this postprocessor generates at the surface of your domain and simply ignore the rest of the data generated.
+
+`error indicator&apos;: A visualization output object that generates output showing the estimated error or other mesh refinement indicator as a spatially variable function with one value per cell.
+
+`geoid&apos;: Visualization for the geoid solution. The geoid is given by the equivalent water column height due to a gravity perturbation. (Units: m)
+
+`grain lag angle&apos;: A visualization output object that generates output showing the angle between the ~infinite strain axis and the flow velocity. Kaminski and Ribe (2002, Gcubed) call this quantity $\Theta$ and define it as $\Theta = \cos^{-1}(\hat{u}\cdot\hat{e})$  where $\hat{u}=\vec{u}/|{u}|$, $\vec{u}$ is the local flow velocity, and $\hat{e}$ is the local infinite strain axis, which we calculate as the first eigenvector of the &apos;left stretch&apos; tensor. $\Theta$ can be used to calculate the grain orientation lag parameter.
+
+`gravity&apos;: A visualization output object that outputs the gravity vector.
+
+`heat flux map&apos;: A visualization output object that generates output for the heat flux density across the top and bottom boundary in outward direction. The heat flux is computed as sum of advective heat flux and conductive heat flux through Neumann boundaries, both computed as integral over the boundary area, and conductive heat flux through Dirichlet boundaries, which is computed using the consistent boundary flux method as described in ``Gresho, P. M., Lee, R. L., Sani, R. L., Maslanik, M. K., &amp; Eaton, B. E. (1987). The consistent Galerkin FEM for computing derived boundary quantities in thermal and or fluids problems. International Journal for Numerical Methods in Fluids, 7(4), 371-394.&apos;&apos;
+
+`heating&apos;: A visualization output object that generates output for all the heating terms used in the energy equation.
+
+`material properties&apos;: A visualization output object that generates output for the material properties given by the material model.There are a number of other visualization postprocessors that offer to write individual material properties. However, they all individually have to evaluate the material model. This is inefficient if one wants to output more than just one or two of the fields provided by the material model. The current postprocessor allows to output a (potentially large) subset of all of the information provided by material models at once, with just a single material model evaluation per output point.
+
+`maximum horizontal compressive stress&apos;: A plugin that computes the direction and magnitude of the maximum horizontal component of the compressive stress as a vector field. The direction of this vector can often be used to visualize the principal mode of deformation (e.g., at normal faults or extensional margins) and can be correlated with seismic anisotropy. Recall that the \textit{compressive} stress is simply the negative stress, $\sigma_c=-\sigma=-\left[     2\eta (\varepsilon(\mathbf u)             - \frac 13 (\nabla \cdot \mathbf u) I)     + pI\right]$.
+
+Following \cite{LundTownend07}, we define the maximum horizontal stress direction as that \textit{horizontal} direction $\mathbf n$ that maximizes $\mathbf n^T \sigma_c \mathbf n$. We call a vector \textit{horizontal} if it is perpendicular to the gravity vector $\mathbf g$.
+
+In two space dimensions, $\mathbf n$ is simply a vector that is horizontal (we choose one of the two possible choices). This direction is then scaled by the size of the horizontal stress in this direction, i.e., the plugin outputs the vector $\mathbf w = (\mathbf n^T \sigma_c \mathbf n) \; \mathbf n$.
+
+In three space dimensions, given two horizontal, perpendicular, unit length, but otherwise arbitrarily chosen vectors $\mathbf u,\mathbf v$, we can express $\mathbf n = (\cos \alpha)\mathbf u + (\sin\alpha)\mathbf v$ where $\alpha$ maximizes the expression \begin{align*}  f(\alpha) = \mathbf n^T \sigma_c \mathbf n  = (\mathbf u^T \sigma_c \mathbf u)(\cos\alpha)^2    +2(\mathbf u^T \sigma_c \mathbf v)(\cos\alpha)(\sin\alpha)    +(\mathbf v^T \sigma_c \mathbf v)(\sin\alpha)^2.\end{align*}
+
+The maximum of $f(\alpha)$ is attained where $f&apos;(\alpha)=0$. Evaluating the derivative and using trigonometric identities, one finds that $\alpha$ has to satisfy the equation \begin{align*}  \tan(2\alpha) = \frac{\mathbf u^T \sigma_c \mathbf v}                          {\mathbf u^T \sigma_c \mathbf u                            - \mathbf v^T \sigma_c \mathbf v}.\end{align*}Since the transform $\alpha\mapsto\alpha+\pi$ flips the direction of $\mathbf n$, we only need to seek a solution to this equation in the interval $\alpha\in[0,\pi)$. These are given by $\alpha_1=\frac 12 \arctan \frac{\mathbf u^T \sigma_c \mathbf v}{\mathbf u^T \sigma_c \mathbf u - \mathbf v^T \sigma_c \mathbf v}$ and $\alpha_2=\alpha_1+\frac{\pi}{2}$, one of which will correspond to a minimum and the other to a maximum of $f(\alpha)$. One checks the sign of $f&apos;&apos;(\alpha)=-2(\mathbf u^T \sigma_c \mathbf u - \mathbf v^T \sigma_c \mathbf v)\cos(2\alpha) - 2 (\mathbf u^T \sigma_c \mathbf v) \sin(2\alpha)$ for each of these to determine the $\alpha$ that maximizes $f(\alpha)$, and from this immediately arrives at the correct form for the maximum horizontal stress $\mathbf n$.
+
+The description above computes a 3d \textit{direction} vector $\mathbf n$. If one were to scale this vector the same way as done in 2d, i.e., with the magnitude of the stress in this direction, one will typically get vectors whose length is principally determined by the hydrostatic pressure at a given location simply because the hydrostatic pressure is the largest component of the overall stress. On the other hand, the hydrostatic pressure does not determine any principal direction because it is an isotropic, anti-compressive force. As a consequence, there are often points in simulations (e.g., at the center of convection rolls) where the stress has no dominant horizontal direction, and the algorithm above will then in essence choose a random direction because the stress is approximately equal in all horizontal directions. If one scaled the output by the magnitude of the stress in this direction (i.e., approximately equal to the hydrostatic pressure at this point), one would get randomly oriented vectors at these locations with significant lengths.
+
+To avoid this problem, we scale the maximal horizontal compressive stress direction $\mathbf n$ by the \textit{difference} between the stress in the maximal and minimal horizontal stress directions. In other words, let $\mathbf n_\perp=(\sin \alpha)\mathbf u - (\cos\alpha)\mathbf v$ be the horizontal direction perpendicular to $\mathbf n$, then this plugin outputs the vector quantity $\mathbf w = (\mathbf n^T \sigma_c \mathbf n                -\mathbf n^T_\perp \sigma_c \mathbf n_\perp)               \; \mathbf n$. In other words, the length of the vector produced indicates \textit{how dominant} the direction of maximal horizontal compressive strength is.
+
+Fig.~\ref{fig:max-horizontal-compressive-stress} shows a simple example for this kind of visualization in 3d.
+
+\begin{figure}  \includegraphics[width=0.3\textwidth]    {viz/plugins/maximum_horizontal_compressive_stress/temperature.png}  \hfill  \includegraphics[width=0.3\textwidth]    {viz/plugins/maximum_horizontal_compressive_stress/velocity.png}  \hfill  \includegraphics[width=0.3\textwidth]    {viz/plugins/maximum_horizontal_compressive_stress/horizontal-stress.png}  \caption{\it Illustration of the `maximum horizontal     compressive stress&apos; visualization plugin. The left     figure shows a ridge-like temperature anomaly. Together     with no-slip boundary along all six boundaries, this     results in two convection rolls (center). The maximal     horizontal compressive strength at the bottom center     of the domain is perpendicular to the ridge because     the flow comes together there from the left and right,     yielding a compressive force in left-right direction.     At the top of the model, the flow separates outward,     leading to a \textit{negative} compressive stress     in left-right direction; because there is no flow     in front-back direction, the compressive strength     in front-back direction is zero, making the along-ridge     direction the dominant one. At the center of the     convection rolls, both horizontal directions yield     the same stress; the plugin therefore chooses an     essentially arbitrary horizontal vector, but then     uses a zero magnitude given that the difference     between the maximal and minimal horizontal stress     is zero at these points.}  \label{fig:max-horizontal-compressive-stress}\end{figure}
+
+`melt fraction&apos;: A visualization output object that generates output for the melt fraction at the temperature and pressure of the current point. If the material model computes a melt fraction, this is the quantity that will be visualized. Otherwise, a specific parametrization for batch melting (as described in the following) will be used. It does not take into account latent heat. If there are no compositional fields, this postprocessor will visualize the melt fraction of peridotite (calculated using the anhydrous model of Katz, 2003). If there is at least one compositional field, the postprocessor assumes that the  first compositional field is the content of pyroxenite, and will visualize the melt fraction for a mixture of peridotite and pyroxenite (using the melting model of Sobolev, 2011 for pyroxenite). All the parameters that were used in these calculations can be changed in the input file, the most relevant maybe being the mass fraction of Cpx in peridotite in the Katz melting model (Mass fraction cpx), which right now has a default of 15\%. The corresponding p-T-diagrams can be generated by running the tests melt\_postprocessor\_peridotite and melt\_postprocessor\_pyroxenite.
+
+`melt material properties&apos;: A visualization output object that generates output for melt related properties of the material model. Note that this postprocessor always outputs the compaction pressure, but can output a large range of additional properties, as selected in the ``List of properties&apos;&apos; parameter.
+
+`named additional outputs&apos;: Some material models can compute quantities other than those that typically appear in the equations that \aspect{} solves (such as the viscosity, density, etc). Examples of quantities material models may be able to compute are seismic velocities, or other quantities that can be derived from the state variables and the material coefficients such as the stress or stress anisotropies. These quantities are generically referred to as `named outputs&apos; because they are given an explicit name different from the usual outputs of material models.
+
+This visualization postprocessor outputs whatever quantities the material model can compute. What quantities these are is specific to the material model in use for a simulation, and for many models in fact does not contain any named outputs at all.
+
+`nonadiabatic pressure&apos;: A visualization output object that generates output for the non-adiabatic component of the pressure.
+
+The variable that is outputted this way is computed by taking the pressure at each point and subtracting from it the adiabatic pressure computed at the beginning of the simulation. Because the adiabatic pressure is one way of defining a static pressure background field, what this visualization postprocessor therefore produces is \textit{one} way to compute a \textit{dynamic pressure}. There are, however, other ways as well, depending on the choice of the ``background pressure&apos;&apos;.
+
+`nonadiabatic temperature&apos;: A visualization output object that generates output for the non-adiabatic component of the temperature.
+
+`particle count&apos;: A visualization output object that generates output about the number of particles per cell.
+
+`partition&apos;: A visualization output object that generates output for the parallel partition that every cell of the mesh is associated with.
+
+`shear stress&apos;: A visualization output object that generates output for the 3 (in 2d) or 6 (in 3d) components of the shear stress tensor, i.e., for the components of the tensor $2\eta\varepsilon(\mathbf u)$ in the incompressible case and $2\eta\left[\varepsilon(\mathbf u)-\tfrac 13(\textrm{tr}\;\varepsilon(\mathbf u))\mathbf I\right]$ in the compressible case. The shear stress differs from the full stress tensor by the absence of the pressure.
+
+`spd factor&apos;: A visualization output object that generates output for the spd factor. The spd factor is a factor which scales a part of the Jacobian used for the Newton solver to make sure that the Jacobian remains positive definite.
+
+`specific heat&apos;: A visualization output object that generates output for the specific heat $C_p$.
+
+`strain rate&apos;: A visualization output object that generates output for the norm of the strain rate, i.e., for the quantity $\sqrt{\varepsilon(\mathbf u):\varepsilon(\mathbf u)}$ in the incompressible case and $\sqrt{[\varepsilon(\mathbf u)-\tfrac 13(\textrm{tr}\;\varepsilon(\mathbf u))\mathbf I]:[\varepsilon(\mathbf u)-\tfrac 13(\textrm{tr}\;\varepsilon(\mathbf u))\mathbf I]}$ in the compressible case.
+
+`strain rate tensor&apos;: A visualization output object that generates output for the 4 (in 2d) or 9 (in 3d) components of the strain rate tensor, i.e., for the components of the tensor $\varepsilon(\mathbf u)$ in the incompressible case and $\varepsilon(\mathbf u)-\tfrac 13(\textrm{tr}\;\varepsilon(\mathbf u))\mathbf I$ in the compressible case.
+
+`stress&apos;: A visualization output object that generates output for the 3 (in 2d) or 6 (in 3d) components of the stress tensor, i.e., for the components of the tensor $2\eta\varepsilon(\mathbf u)+pI$ in the incompressible case and $2\eta\left[\varepsilon(\mathbf u)-\tfrac 13(\textrm{tr}\;\varepsilon(\mathbf u))\mathbf I\right]+pI$ in the compressible case.
+
+`temperature anomaly&apos;: A visualization output postprocessor that outputs the temperature minus the depth-average of the temperature.The average temperature is calculated using the lateral averaging function from the ``depth average&apos;&apos; postprocessor and interpolated linearly between the layers specified through ``Number of depth slices&apos;&apos;
+
+`thermal conductivity&apos;: A visualization output object that generates output for the thermal conductivity $k$.
+
+`thermal diffusivity&apos;: A visualization output object that generates output for the thermal diffusivity $\kappa$=$\frac{k}{\rho C_p}$, with $k$ the thermal conductivity.
+
+`thermal expansivity&apos;: A visualization output object that generates output for the thermal expansivity.
+
+`vertical heat flux&apos;: A visualization output object that generates output for the heat flux in the vertical direction, which is the sum of the advective and the conductive heat flux, with the sign convention of positive flux upwards.
+
+`viscosity&apos;: A visualization output object that generates output for the viscosity.
+
+`volumetric strain rate&apos;: A visualization output object that generates output for the volumetric strain rate, i.e., for the quantity $\nabla\cdot\mathbf u = \textrm{div}\; \mathbf u = \textrm{trace}\; \varepsilon(\mathbf u)$. This should be zero (in some average sense) in incompressible convection models, but can be non-zero in compressible models and models with melt transport.
+</documentation>
+<pattern>
+208
+</pattern>
+<pattern_description>
+[MultipleSelection ISA rotation timescale|Vp anomaly|Vs anomaly|adiabat|artificial viscosity|artificial viscosity composition|boundary indicators|compositional vector|density|depth|dynamic topography|error indicator|geoid|grain lag angle|gravity|heat flux map|heating|material properties|maximum horizontal compressive stress|melt fraction|melt material properties|named additional outputs|nonadiabatic pressure|nonadiabatic temperature|particle count|partition|shear stress|spd factor|specific heat|strain rate|strain rate tensor|stress|temperature anomaly|thermal conductivity|thermal diffusivity|thermal expansivity|vertical heat flux|viscosity|volumetric strain rate ]
+</pattern_description>
+</List_20of_20output_20variables>
+<Artificial_20viscosity_20composition>
+<Name_20of_20compositional_20field>
+<value/>
+<default_value/>
+<documentation>
+The name of the compositional field whose output should be visualized. 
+</documentation>
+<pattern>
+209
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Name_20of_20compositional_20field>
+</Artificial_20viscosity_20composition>
+<Compositional_20fields_20as_20vectors>
+<Names_20of_20vectors>
+<value/>
+<default_value/>
+<documentation>
+Names of vectors as they will appear in the output.
+</documentation>
+<pattern>
+210
+</pattern>
+<pattern_description>
+[List of &lt;[Anything]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Names_20of_20vectors>
+<Names_20of_20fields>
+<value/>
+<default_value/>
+<documentation>
+A list of sets of compositional fields which should be output as vectors. Sets are separated from each other by semicolons and vector components within each set are separated by commas (e.g. $vec1_x$, $vec1_y$ ; $vec2_x$, $vec2_y$) where each name must be a defined named compositional field. If only one name is given in a set, it is interpreted as the first in a sequence of dim consecutive compositional fields.
+</documentation>
+<pattern>
+211
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Names_20of_20fields>
+</Compositional_20fields_20as_20vectors>
+<Material_20properties>
+<List_20of_20material_20properties>
+<value>
+density,thermal expansivity,specific heat,viscosity
+</value>
+<default_value>
+density,thermal expansivity,specific heat,viscosity
+</default_value>
+<documentation>
+A comma separated list of material properties that should be written whenever writing graphical output. By default, the material properties will always contain the density, thermal expansivity, specific heat and viscosity. The following material properties are available:
+
+viscosity|density|thermal expansivity|specific heat|thermal conductivity|thermal diffusivity|compressibility|entropy derivative temperature|entropy derivative pressure|reaction terms|melt fraction
+</documentation>
+<pattern>
+212
+</pattern>
+<pattern_description>
+[MultipleSelection viscosity|density|thermal expansivity|specific heat|thermal conductivity|thermal diffusivity|compressibility|entropy derivative temperature|entropy derivative pressure|reaction terms|melt fraction ]
+</pattern_description>
+</List_20of_20material_20properties>
+</Material_20properties>
+<Melt_20material_20properties>
+<List_20of_20properties>
+<value>
+compaction viscosity,permeability
+</value>
+<default_value>
+compaction viscosity,permeability
+</default_value>
+<documentation>
+A comma separated list of melt properties that should be written whenever writing graphical output. The following material properties are available:
+
+compaction viscosity|fluid viscosity|permeability|fluid density|fluid density gradient|is melt cell|darcy coefficient|darcy coefficient no cutoff|compaction length
+</documentation>
+<pattern>
+213
+</pattern>
+<pattern_description>
+[MultipleSelection compaction viscosity|fluid viscosity|permeability|fluid density|fluid density gradient|is melt cell|darcy coefficient|darcy coefficient no cutoff|compaction length ]
+</pattern_description>
+</List_20of_20properties>
+</Melt_20material_20properties>
+<Melt_20fraction>
+<A1>
+<value>
+1085.7
+</value>
+<default_value>
+1085.7
+</default_value>
+<documentation>
+Constant parameter in the quadratic function that approximates the solidus of peridotite. Units: $°C$.
+</documentation>
+<pattern>
+214
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</A1>
+<A2>
+<value>
+1.329e-7
+</value>
+<default_value>
+1.329e-7
+</default_value>
+<documentation>
+Prefactor of the linear pressure term in the quadratic function that approximates the solidus of peridotite. Units: $°C/Pa$.
+</documentation>
+<pattern>
+215
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</A2>
+<A3>
+<value>
+-5.1e-18
+</value>
+<default_value>
+-5.1e-18
+</default_value>
+<documentation>
+Prefactor of the quadratic pressure term in the quadratic function that approximates the solidus of peridotite. Units: $°C/(Pa^2)$.
+</documentation>
+<pattern>
+216
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</A3>
+<B1>
+<value>
+1475.0
+</value>
+<default_value>
+1475.0
+</default_value>
+<documentation>
+Constant parameter in the quadratic function that approximates the lherzolite liquidus used for calculating the fraction of peridotite-derived melt. Units: $°C$.
+</documentation>
+<pattern>
+217
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</B1>
+<B2>
+<value>
+8.0e-8
+</value>
+<default_value>
+8.0e-8
+</default_value>
+<documentation>
+Prefactor of the linear pressure term in the quadratic function that approximates the  lherzolite liquidus used for calculating the fraction of peridotite-derived melt. Units: $°C/Pa$.
+</documentation>
+<pattern>
+218
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</B2>
+<B3>
+<value>
+-3.2e-18
+</value>
+<default_value>
+-3.2e-18
+</default_value>
+<documentation>
+Prefactor of the quadratic pressure term in the quadratic function that approximates the  lherzolite liquidus used for calculating the fraction of peridotite-derived melt. Units: $°C/(Pa^2)$.
+</documentation>
+<pattern>
+219
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</B3>
+<C1>
+<value>
+1780.0
+</value>
+<default_value>
+1780.0
+</default_value>
+<documentation>
+Constant parameter in the quadratic function that approximates the liquidus of peridotite. Units: $°C$.
+</documentation>
+<pattern>
+220
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</C1>
+<C2>
+<value>
+4.50e-8
+</value>
+<default_value>
+4.50e-8
+</default_value>
+<documentation>
+Prefactor of the linear pressure term in the quadratic function that approximates the liquidus of peridotite. Units: $°C/Pa$.
+</documentation>
+<pattern>
+221
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</C2>
+<C3>
+<value>
+-2.0e-18
+</value>
+<default_value>
+-2.0e-18
+</default_value>
+<documentation>
+Prefactor of the quadratic pressure term in the quadratic function that approximates the liquidus of peridotite. Units: $°C/(Pa^2)$.
+</documentation>
+<pattern>
+222
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</C3>
+<r1>
+<value>
+0.5
+</value>
+<default_value>
+0.5
+</default_value>
+<documentation>
+Constant in the linear function that approximates the clinopyroxene reaction coefficient. Units: non-dimensional.
+</documentation>
+<pattern>
+223
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</r1>
+<r2>
+<value>
+8e-11
+</value>
+<default_value>
+8e-11
+</default_value>
+<documentation>
+Prefactor of the linear pressure term in the linear function that approximates the clinopyroxene reaction coefficient. Units: $1/Pa$.
+</documentation>
+<pattern>
+224
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</r2>
+<beta>
+<value>
+1.5
+</value>
+<default_value>
+1.5
+</default_value>
+<documentation>
+Exponent of the melting temperature in the melt fraction calculation. Units: non-dimensional.
+</documentation>
+<pattern>
+225
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</beta>
+<Mass_20fraction_20cpx>
+<value>
+0.15
+</value>
+<default_value>
+0.15
+</default_value>
+<documentation>
+Mass fraction of clinopyroxene in the peridotite to be molten. Units: non-dimensional.
+</documentation>
+<pattern>
+226
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Mass_20fraction_20cpx>
+<D1>
+<value>
+976.0
+</value>
+<default_value>
+976.0
+</default_value>
+<documentation>
+Constant parameter in the quadratic function that approximates the solidus of pyroxenite. Units: $°C$.
+</documentation>
+<pattern>
+227
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</D1>
+<D2>
+<value>
+1.329e-7
+</value>
+<default_value>
+1.329e-7
+</default_value>
+<documentation>
+Prefactor of the linear pressure term in the quadratic function that approximates the solidus of pyroxenite. Note that this factor is different from the value given in Sobolev, 2011, because they use the potential temperature whereas we use the absolute temperature. Units: $°C/Pa$.
+</documentation>
+<pattern>
+228
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</D2>
+<D3>
+<value>
+-5.1e-18
+</value>
+<default_value>
+-5.1e-18
+</default_value>
+<documentation>
+Prefactor of the quadratic pressure term in the quadratic function that approximates the solidus of pyroxenite. Units: $°C/(Pa^2)$.
+</documentation>
+<pattern>
+229
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</D3>
+<E1>
+<value>
+663.8
+</value>
+<default_value>
+663.8
+</default_value>
+<documentation>
+Prefactor of the linear depletion term in the quadratic function that approximates the melt fraction of pyroxenite. Units: $°C/Pa$.
+</documentation>
+<pattern>
+230
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</E1>
+<E2>
+<value>
+-611.4
+</value>
+<default_value>
+-611.4
+</default_value>
+<documentation>
+Prefactor of the quadratic depletion term in the quadratic function that approximates the melt fraction of pyroxenite. Units: $°C/(Pa^2)$.
+</documentation>
+<pattern>
+231
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</E2>
+</Melt_20fraction>
+<Vs_20anomaly>
+<Average_20velocity_20scheme>
+<value>
+reference profile
+</value>
+<default_value>
+reference profile
+</default_value>
+<documentation>
+Scheme to compute the average velocity-depth profile. The reference profile option evaluates the conditions along the reference adiabat according to the material model. The lateral average option instead calculates a lateral average from subdivision of the mesh. The lateral average option may produce spurious results where there are sharp velocity changes.
+</documentation>
+<pattern>
+232
+</pattern>
+<pattern_description>
+[Selection reference profile|lateral average ]
+</pattern_description>
+</Average_20velocity_20scheme>
+<Number_20of_20depth_20slices>
+<value>
+50
+</value>
+<default_value>
+50
+</default_value>
+<documentation>
+Number of depth slices used to define average seismic shear wave velocities from which anomalies are calculated. Units: non-dimensional.
+</documentation>
+<pattern>
+233
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Number_20of_20depth_20slices>
+</Vs_20anomaly>
+<Vp_20anomaly>
+<Average_20velocity_20scheme>
+<value>
+reference profile
+</value>
+<default_value>
+reference profile
+</default_value>
+<documentation>
+Scheme to compute the average velocity-depth profile. The reference profile option evaluates the conditions along the reference adiabat according to the material model. The lateral average option instead calculates a lateral average from subdivision of the mesh. The lateral average option may produce spurious results where there are sharp velocity changes.
+</documentation>
+<pattern>
+234
+</pattern>
+<pattern_description>
+[Selection reference profile|lateral average ]
+</pattern_description>
+</Average_20velocity_20scheme>
+<Number_20of_20depth_20slices>
+<value>
+50
+</value>
+<default_value>
+50
+</default_value>
+<documentation>
+Number of depth slices used to define average seismic compressional wave velocities from which anomalies are calculated. Units: non-dimensional.
+</documentation>
+<pattern>
+235
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Number_20of_20depth_20slices>
+</Vp_20anomaly>
+<Temperature_20anomaly>
+<Number_20of_20depth_20slices>
+<value>
+20
+</value>
+<default_value>
+20
+</default_value>
+<documentation>
+Number of depth slices used to define average temperature.
+</documentation>
+<pattern>
+236
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Number_20of_20depth_20slices>
+<Use_20maximal_20temperature_20for_20bottom>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+If true, use the specified boundary temepratures as average temperatures at the surface. If false, extrapolate the temperature gradient between the first and second cells to the surface. This option will only work for models with a fixed surface temperature. 
+</documentation>
+<pattern>
+237
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20maximal_20temperature_20for_20bottom>
+<Use_20minimal_20temperature_20for_20surface>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+Whether to use the minimal speficied boundary temperature as the bottom boundary temperature. This option will only work for models with a fixed bottom boundary temperature. 
+</documentation>
+<pattern>
+238
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20minimal_20temperature_20for_20surface>
+</Temperature_20anomaly>
+</Visualization>
+</Postprocess>
+<Checkpointing>
+<Time_20between_20checkpoint>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The wall time between performing checkpoints. If 0, will use the checkpoint step frequency instead. Units: Seconds.
+</documentation>
+<pattern>
+59
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Time_20between_20checkpoint>
+<Steps_20between_20checkpoint>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The number of timesteps between performing checkpoints. If 0 and time between checkpoint is not specified, checkpointing will not be performed. Units: None.
+</documentation>
+<pattern>
+60
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Steps_20between_20checkpoint>
+</Checkpointing>
+<Discretization>
+<Stokes_20velocity_20polynomial_20degree>
+<value>
+2
+</value>
+<default_value>
+2
+</default_value>
+<documentation>
+The polynomial degree to use for the velocity variables in the Stokes system. The polynomial degree for the pressure variable will then be one less in order to make the velocity/pressure pair conform with the usual LBB (Babuska-Brezzi) condition. In other words, we are using a Taylor-Hood element for the Stokes equations and this parameter indicates the polynomial degree of it. As an example, a value of 2 for this parameter will yield the element $Q_2^d \times Q_1$ for the $d$ velocity components and the pressure, respectively (unless the `Use locally conservative discretization&apos; parameter is set, which modifies the pressure element). Units: None.
+</documentation>
+<pattern>
+61
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Stokes_20velocity_20polynomial_20degree>
+<Temperature_20polynomial_20degree>
+<value>
+2
+</value>
+<default_value>
+2
+</default_value>
+<documentation>
+The polynomial degree to use for the temperature variable. As an example, a value of 2 for this parameter will yield either the element $Q_2$ or $DGQ_2$ for the temperature field, depending on whether we use a continuous or discontinuous field. Units: None.
+</documentation>
+<pattern>
+62
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Temperature_20polynomial_20degree>
+<Composition_20polynomial_20degree>
+<value>
+2
+</value>
+<default_value>
+2
+</default_value>
+<documentation>
+The polynomial degree to use for the composition variable(s). As an example, a value of 2 for this parameter will yield either the element $Q_2$ or $DGQ_2$ for the compositional field(s), depending on whether we use continuous or discontinuous field(s). Units: None.
+</documentation>
+<pattern>
+63
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Composition_20polynomial_20degree>
+<Use_20locally_20conservative_20discretization>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to use a Stokes discretization that is locally conservative at the expense of a larger number of degrees of freedom (true), or to go with a cheaper discretization that does not locally conserve mass, although it is globally conservative (false).
+
+When using a locally conservative discretization, the finite element space for the pressure is discontinuous between cells and is the polynomial space $P_ {-q}$ of polynomials of degree $q$ in each variable separately. Here, $q$ is one less than the value given in the parameter ``Stokes velocity polynomial degree&apos;&apos;. As a consequence of choosing this element, it can be shown if the medium is considered incompressible that the computed discrete velocity field $\mathbf u_h$ satisfies the property $\int_ {\partial K} \mathbf u_h \cdot \mathbf n = 0$ for every cell $K$, i.e., for each cell inflow and outflow exactly balance each other as one would expect for an incompressible medium. In other words, the velocity field is locally conservative.
+
+On the other hand, if this parameter is set to ``false&apos;&apos;, then the finite element space is chosen as $Q_q$. This choice does not yield the local conservation property but has the advantage of requiring fewer degrees of freedom. Furthermore, the error is generally smaller with this choice.
+
+For an in-depth discussion of these issues and a quantitative evaluation of the different choices, see \cite {KHB12} .
+</documentation>
+<pattern>
+64
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20locally_20conservative_20discretization>
+<Use_20discontinuous_20temperature_20discretization>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to use a temperature discretization that is discontinuous as opposed to continuous. This then requires the assembly of face terms between cells, and weak imposition of boundary terms for the temperature field via the interior-penalty discontinuous Galerkin method.
+</documentation>
+<pattern>
+65
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20discontinuous_20temperature_20discretization>
+<Use_20discontinuous_20composition_20discretization>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to use a composition discretization that is discontinuous as opposed to continuous. This then requires the assembly of face terms between cells, and weak imposition of boundary terms for the composition field via the discontinuous Galerkin method.
+</documentation>
+<pattern>
+66
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20discontinuous_20composition_20discretization>
+<Stabilization_20parameters>
+<Use_20artificial_20viscosity_20smoothing>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+If set to false, the artificial viscosity of a cell is computed and is computed on every cell separately as discussed in \cite{KHB12}. If set to true, the maximum of the artificial viscosity in the cell as well as the neighbors of the cell is computed and used instead.
+</documentation>
+<pattern>
+67
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20artificial_20viscosity_20smoothing>
+<alpha>
+<value>
+2
+</value>
+<default_value>
+2
+</default_value>
+<documentation>
+The exponent $\alpha$ in the entropy viscosity stabilization. Valid options are 1 or 2. The recommended setting is 2. (This parameter does not correspond to any variable in the 2012 paper by Kronbichler, Heister and Bangerth that describes ASPECT, see \cite{KHB12}. Rather, the paper always uses 2 as the exponent in the definition of the entropy, following equation (15) of the paper. The full approach is discussed in \cite{GPP11}.) Note that this is not the thermal expansion coefficient, also commonly referred to as $\alpha$.Units: None.
+</documentation>
+<pattern>
+68
+</pattern>
+<pattern_description>
+[Integer range 1...2 (inclusive)]
+</pattern_description>
+</alpha>
+<cR>
+<value>
+0.33
+</value>
+<default_value>
+0.33
+</default_value>
+<documentation>
+The $c_R$ factor in the entropy viscosity stabilization. This parameter controls the part of the entropy viscosity that depends on the solution field itself and its residual in addition to the cell diameter and the maximum velocity in the cell. This parameter can be given as a single value or as a list with as many entries as one plus the number of compositional fields. In the former case all advection fields use the same stabilization parameters, in the latter case each field (temperature first, then all compositions) use individual parameters. This can be useful to reduce the stabilization for the temperature, which already has some physical diffusion. (For historical reasons, the name used here is different from the one used in the 2012 paper by Kronbichler, Heister and Bangerth that describes ASPECT, see \cite{KHB12}. This parameter corresponds to the factor $\alpha_E$ in the formulas following equation (15) of the paper. After further experiments, we have also chosen to use a different value than described there.) Units: None.
+</documentation>
+<pattern>
+69
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</cR>
+<beta>
+<value>
+0.078
+</value>
+<default_value>
+0.078
+</default_value>
+<documentation>
+The $\beta$ factor in the artificial viscosity stabilization. This parameter controls the maximum dissipation of the entropy viscosity, which is the part that only scales with the cell diameter and the maximum velocity in the cell, but does not depend on the solution field itself or its residual. An appropriate value for 2d is 0.078 and 0.117 for 3d. (For historical reasons, the name used here is different from the one used in the 2012 paper by Kronbichler, Heister and Bangerth that describes ASPECT, see \cite{KHB12}. This parameter can be given as a single value or as a list with as many entries as one plus the number of compositional fields. In the former case all advection fields use the same stabilization parameters, in the latter case each field (temperature first, then all compositions) use individual parameters. This can be useful to reduce the stabilization for the temperature, which already has some physical diffusion. This parameter corresponds to the factor $\alpha_{\text{max}}$ in the formulas following equation (15) of the paper. After further experiments, we have also chosen to use a different value than described there: It can be chosen as stated there for uniformly refined meshes, but it needs to be chosen larger if the mesh has cells that are not squares or cubes.) Units: None.
+</documentation>
+<pattern>
+70
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</beta>
+<gamma>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The strain rate scaling factor in the artificial viscosity stabilization. This parameter determines how much the strain rate (in addition to the velocity) should influence the stabilization. (This parameter does not correspond to any variable in the 2012 paper by Kronbichler, Heister and Bangerth that describes ASPECT, see \cite{KHB12}. Rather, the paper always uses 0, i.e. they specify the maximum dissipation $\nu_h^\text{max}$ as $\nu_h^\text{max}\vert_K = \alpha_{\text{max}} h_K \|\mathbf u\|_{\infty,K}$. Here, we use $\|\lvert\mathbf u\rvert + \gamma h_K \lvert\varepsilon (\mathbf u)\rvert\|_{\infty,K}$ instead of $\|\mathbf u\|_{\infty,K}$. Units: None.
+</documentation>
+<pattern>
+71
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</gamma>
+<Discontinuous_20penalty>
+<value>
+10
+</value>
+<default_value>
+10
+</default_value>
+<documentation>
+The value used to penalize discontinuities in the discontinuous Galerkin method. This is used only for the temperature field, and not for the composition field, as pure advection does not use the interior penalty method. This is largely empirically decided -- it must be large enough to ensure the bilinear form is coercive, but not so large as to penalize discontinuity at all costs.
+</documentation>
+<pattern>
+72
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Discontinuous_20penalty>
+<Use_20limiter_20for_20discontinuous_20temperature_20solution>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to apply the bound preserving limiter as a correction after computing the discontinuous temperature solution. Currently we apply this only to the temperature solution if the &apos;Global temperature maximum&apos; and &apos;Global temperature minimum&apos; are already defined in the .prm file. This limiter keeps the discontinuous solution in the range given by &apos;Global temperature maximum&apos; and &apos;Global temperature minimum&apos;.
+</documentation>
+<pattern>
+73
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20limiter_20for_20discontinuous_20temperature_20solution>
+<Use_20limiter_20for_20discontinuous_20composition_20solution>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to apply the bound preserving limiter as a correction after having the discontinuous composition solution. Currently we apply this only to the compositional solution if the &apos;Global composition maximum&apos; and &apos;Global composition minimum&apos; are already defined in the .prm file. This limiter keeps the discontinuous solution in the range given by Global composition maximum&apos; and &apos;Global composition minimum&apos;.
+</documentation>
+<pattern>
+74
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20limiter_20for_20discontinuous_20composition_20solution>
+<Global_20temperature_20maximum>
+<value>
+1.7976931348623157e+308
+</value>
+<default_value>
+1.7976931348623157e+308
+</default_value>
+<documentation>
+The maximum global temperature value that will be used in the bound preserving limiter for the discontinuous solutions from temperature advection fields.
+</documentation>
+<pattern>
+75
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Global_20temperature_20maximum>
+<Global_20temperature_20minimum>
+<value>
+-1.7976931348623157e+308
+</value>
+<default_value>
+-1.7976931348623157e+308
+</default_value>
+<documentation>
+The minimum global temperature value that will be used in the bound preserving limiter for the discontinuous solutions from temperature advection fields.
+</documentation>
+<pattern>
+76
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Global_20temperature_20minimum>
+<Global_20composition_20maximum>
+<value>
+1.7976931348623157e+308
+</value>
+<default_value>
+1.7976931348623157e+308
+</default_value>
+<documentation>
+The maximum global composition values that will be used in the bound preserving limiter for the discontinuous solutions from composition advection fields. The number of the input &apos;Global composition maximum&apos; values separated by &apos;,&apos; has to be the same as the number of the compositional fields
+</documentation>
+<pattern>
+77
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Global_20composition_20maximum>
+<Global_20composition_20minimum>
+<value>
+-1.7976931348623157e+308
+</value>
+<default_value>
+-1.7976931348623157e+308
+</default_value>
+<documentation>
+The minimum global composition value that will be used in the bound preserving limiter for the discontinuous solutions from composition advection fields. The number of the input &apos;Global composition minimum&apos; values separated by &apos;,&apos; has to be the same as the number of the compositional fields
+</documentation>
+<pattern>
+78
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Global_20composition_20minimum>
+</Stabilization_20parameters>
+</Discretization>
+<Compositional_20fields>
+<Number_20of_20fields>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The number of fields that will be advected along with the flow field, excluding velocity, pressure and temperature.
+</documentation>
+<pattern>
+79
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Number_20of_20fields>
+<Names_20of_20fields>
+<value/>
+<default_value/>
+<documentation>
+A user-defined name for each of the compositional fields requested.
+</documentation>
+<pattern>
+80
+</pattern>
+<pattern_description>
+[List of &lt;[Anything]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Names_20of_20fields>
+<Compositional_20field_20methods>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list denoting the solution method of each compositional field. Each entry of the list must be one of the currently implemented field types: ``field&apos;&apos;, ``particles&apos;&apos;, or ``static&apos;&apos;.
+
+These choices correspond to the following methods by which compositional fields gain their values:\begin{itemize}\item ``field&apos;&apos;: If a compositional field is marked with this method, then its values are computed in each time step by advecting along the values of the previous time step using the velocity field, and applying reaction rates to it. In other words, this corresponds to the usual notion of a composition field as mentioned in Section~\ref{sec:compositional}. 
+\item ``particles&apos;&apos;: If a compositional field is marked with this method, then its values are obtained in each time step by interpolating the corresponding properties from the particles located on each cell. The time evolution therefore happens because particles move along with the velocity field, and particle properties can react with each other as well. See Section~\ref{sec:particles} for more information about how particles behave.
+\item ``static&apos;&apos;: If a compositional field is marked this way, then it does not evolve at all. Its values are simply set to the initial conditions, and will then never change.
+\item ``melt field&apos;&apos;: If a compositional field is marked with this method, then its values are computed in each time step by advecting along the values of the previous time step using the melt velocity, and applying reaction rates to it. In other words, this corresponds to the usual notion of a composition field as mentioned in Section~\ref{sec:compositional}, except that it is advected with the melt velocity instead of the solid velocity. This method can only be chosen if melt transport is active in the model.
+\item ``prescribed field&apos;&apos;: The value of these fields is determined in each time step from the material model. If a compositional field is marked with this method, then the value of a specific additional material model output, called the `PrescribedFieldOutputs&apos; is interpolated onto the field. This field does not change otherwise, it is not advected with the flow.\end{itemize}
+</documentation>
+<pattern>
+81
+</pattern>
+<pattern_description>
+[List of &lt;[Selection field|particles|static|melt field|prescribed field ]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Compositional_20field_20methods>
+<Mapped_20particle_20properties>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list denoting the particle properties that will be projected to those compositional fields that are of the ``particles&apos;&apos; field type.
+
+The format of valid entries for this parameter is that of a map given as ``key1: value1, key2: value2 [component2], key3: value3 [component4], ...&apos;&apos; where each key must be a valid field name of the ``particles&apos;&apos; type, and each value must be one of the currently selected particle properties. Component is a component index of the particle property that is 0 by default, but can be set up to n-1, where n is the number of vector components of this particle property. The component indicator only needs to be set if not the first component of the particle property should be mapped (e.g. the $y$-component of the velocity at the particle positions).
+</documentation>
+<pattern>
+82
+</pattern>
+<pattern_description>
+[Map of &lt;[Anything]&gt;:&lt;[Anything]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Mapped_20particle_20properties>
+<List_20of_20normalized_20fields>
+<value/>
+<default_value/>
+<documentation>
+A list of integers smaller than or equal to the number of compositional fields. All compositional fields in this list will be normalized before the first timestep. The normalization is implemented in the following way: First, the sum of the fields to be normalized is calculated at every point and the global maximum is determined. Second, the compositional fields to be normalized are divided by this maximum.
+</documentation>
+<pattern>
+83
+</pattern>
+<pattern_description>
+[List of &lt;[Integer range 0...2147483647 (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</List_20of_20normalized_20fields>
+</Compositional_20fields>
+<Material_20model>
+<Material_20averaging>
+<value>
+none
+</value>
+<default_value>
+none
+</default_value>
+<documentation>
+Whether or not (and in the first case, how) to do any averaging of material model output data when constructing the linear systems for velocity/pressure, temperature, and compositions in each time step, as well as their corresponding preconditioners.
+
+Possible choices: none|arithmetic average|harmonic average|geometric average|pick largest|project to Q1|log average
+
+The process of averaging, and where it may be used, is discussed in more detail in Section~\ref{sec:sinker-with-averaging}.
+
+More averaging schemes are available in the averaging material model. This material model is a ``compositing material model&apos;&apos; which can be used in combination with other material models.
+</documentation>
+<pattern>
+84
+</pattern>
+<pattern_description>
+[Selection none|arithmetic average|harmonic average|geometric average|pick largest|project to Q1|log average ]
+</pattern_description>
+</Material_20averaging>
+<Model_20name>
+<value>
+simple
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+The name of the material model to be used in this simulation. There are many material models you can choose from, as listed below. They generally fall into two category: (i) models that implement a particular case of material behavior, (ii) models that modify other models in some way. We sometimes call the latter ``compositing models&apos;&apos;. An example of a compositing model is the ``depth dependent&apos;&apos; model below in that it takes another, freely choosable model as its base and then modifies that model&apos;s output in some way.
+
+You can select one of the following models:
+
+`Steinberger&apos;: This material model looks up the viscosity from the tables that correspond to the paper of Steinberger and Calderwood 2006 (``Models of large-scale viscous flow in the Earth&apos;s mantle with constraints from mineral physics and surface observations&apos;&apos;, Geophys. J. Int., 167, 1461-1481, \url{http://dx.doi.org/10.1111/j.1365-246X.2006.03131.x}) and material data from a database generated by the thermodynamics code \texttt{Perplex}, see \url{http://www.perplex.ethz.ch/}. The default example data builds upon the thermodynamic database by Stixrude 2011 and assumes a pyrolitic composition by Ringwood 1988 but is easily replaceable by other data files. 
+
+`ascii reference profile&apos;: A material model that reads in a reference state for density, thermal expansivity, compressibility and specific heat from a text file. 
+Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of points in the reference state as for example `# POINTS: 3&apos;. Following the comment lines there has to be a single line containing the names of all data columns, separated by arbitrarily many spaces. Column names are not allowed to contain spaces. The file can contain unnecessary columns, but for this plugin it needs to at least provide the columns named `density&apos;, `thermal\_expansivity&apos;, `specific\_heat&apos;, and `compressibility&apos;. Note that the data lines in the file need to be sorted in order of increasing depth from 0 to the maximal depth in the model domain. Points in the model that are outside of the provided depth range will be assigned the maximum or minimum depth values, respectively. Points do not need to be equidistant, but the computation of properties is optimized in speed if they are.
+
+The viscosity $\eta$ is computed as \begin{equation}\eta(z,T) = \eta_r(z) \eta_0 \exp\left(-A \frac{T - T_{\text{adi}}}{T_{\text{adi}}}\right),\end{equation}where $\eta_r(z)$ is the depth-dependence, which is a piecewise constant function computed according to the list of ``Viscosity prefactors&apos;&apos; and ``Transition depths&apos;&apos;, $\eta_0$ is the reference viscosity specified by the parameter ``Viscosity&apos;&apos; and $A$ describes the dependence on temperature and corresponds to the parameter ``Thermal viscosity exponent&apos;&apos;.
+
+`averaging&apos;: The ``averaging&apos;&apos; Material model applies an averaging of the quadrature points within a cell. The values to average are supplied by any of the other available material models. In other words, it is a ``compositing material model&apos;&apos;. Parameters related to the average model are read from a subsection ``Material model/Averaging&apos;&apos;.
+
+The user must specify a ``Base model&apos;&apos; from which material properties are derived. Furthermore an averaging operation must be selected, where the Choice should be from the list none|arithmetic average|harmonic average|geometric average|pick largest|log average|NWD arithmetic average|NWD harmonic average|NWD geometric average.
+
+NWD stands for Normalized Weighed Distance. The models with this in front of their name work with a weighed average, which means each quadrature point requires an individual weight. The weight is determined by the distance, where the exact relation is determined by a bell shaped curve. A bell shaped curve is a continuous function which is one at its maximum and exactly zero at and beyond its limit. This bell shaped curve is spanned around each quadrature point to determine the weighting map for each quadrature point. The used bell shape comes from Lucy (1977). The distance is normalized so the largest distance becomes one. This means that if variable &apos;&apos;Bell shape limit&apos;&apos; is exactly one, the farthest quadrature point is just on the limit and its weight will be exactly zero. In this plugin it is not implemented as larger and equal than the limit, but larger than, to ensure the quadrature point at distance zero is always included.
+
+`compositing&apos;: The ``compositing&apos;&apos; Material model selects material model properties from a given set of other material models, and is intended to make mixing different material models easier.
+
+Specifically, this material model works by allowing to specify the name of another material model for each coefficient that material models are asked for (such as the viscosity, density, etc.). Whenever the material model is asked for the values of coefficients, it then evaluates all of the ``base models&apos;&apos; that were listed for the various coefficients, and copies the values returned by these base models into the output structure.
+
+The implementation of this material model is somewhat expensive because it has to evaluate all material coefficients of all underlying material models. Consequently, if performance of assembly and postprocessing is important, then implementing a separate material model is a better choice than using this material model.
+
+`composition reaction&apos;: A material model that behaves in the same way as the simple material model, but includes two compositional fields and a reaction between them. Above a depth given in the input file, the first fields gets converted to the second field. 
+
+`depth dependent&apos;: The ``depth dependent&apos;&apos; Material model applies a depth-dependent scaling to any of the other available material models. In other words, it is a ``compositing material model&apos;&apos;.
+
+Parameters related to the depth dependent model are read from a subsection ``Material model/Depth dependent model&apos;&apos;. The user must specify a ``Base model&apos;&apos; from which material properties are derived. Currently the depth dependent model only allows depth dependence of viscosity - other material properties are taken from the ``Base model&apos;&apos;. Viscosity $\eta$ at depth $z$ is calculated according to:\begin{equation}\eta(z,p,T,X,...) = \eta(z) \eta_b(p,T,X,..)/\eta_{rb}\end{equation}where $\eta(z)$ is the depth-dependence specified by the depth dependent model, $\eta_b(p,T,X,...)$ is the viscosity calculated from the base model, and $\eta_{rb}$ is the reference viscosity of the ``Base model&apos;&apos;. In addition to the specification of the ``Base model&apos;&apos;, the user must specify the method to be used to calculate the depth-dependent viscosity $\eta(z)$ as ``Material model/Depth dependent model/Depth dependence method&apos;&apos;, which can be chosen among ``None|Function|File|List&apos;&apos;. Each method and the associated parameters are as follows:
+
+``Function&apos;&apos;: read a user-specified parsed function from the input file in a subsection ``Material model/Depth dependent model/Viscosity depth function&apos;&apos;. By default, this function is uniformly equal to 1.0e21. Specifying a function that returns a value less than or equal to 0.0 anywhere in the model domain will produce an error. 
+
+``File&apos;&apos;: read a user-specified file containing viscosity values at specified depths. The file containing depth-dependent viscosities is read from a directory specified by the user as ``Material model/Depth dependent model/Data directory&apos;&apos;, from a file with name specified as ``Material model/Depth dependent model/Viscosity depth file&apos;&apos;. The format of this file is ascii text and contains two columns with one header line:
+
+example Viscosity depth file:\\Depth (m)    Viscosity (Pa-s)\\0.0000000e+00     1.0000000e+21\\6.7000000e+05     1.0000000e+22\\
+
+Viscosity is interpolated from this file using linear interpolation. ``None&apos;&apos;: no depth-dependence. Viscosity is taken directly from ``Base model&apos;&apos;
+
+``List:&apos;&apos;: read a comma-separated list of depth values corresponding to the maximum depths of layers having constant depth-dependence $\eta(z)$. The layers must be specified in order of increasing depth, and the last layer in the list must have a depth greater than or equal to the maximal depth of the model. The list of layer depths is specified as ``Material model/Depth dependent model/Depth list&apos;&apos; and the corresponding list of layer viscosities is specified as ``Material model/Depth dependent model/Viscosity list&apos;&apos;
+
+`diffusion dislocation&apos;: An implementation of a viscous rheology including diffusion and dislocation creep. Compositional fields can each be assigned individual activation energies, reference densities, thermal expansivities, and stress exponents. The effective viscosity is defined as 
+
+\[\eta_{\text{eff}} = \left(\frac{1}{\eta_{\text{eff}}^\text{diff}}+ \frac{1}{\eta_{\text{eff}}^\text{dis}}\right)^{-1}\] where \[\eta_{\text{i}} = \frac{1}{2} A^{-\frac{1}{n_i}} d^\frac{m_i}{n_i} \dot{\varepsilon_i}^{\frac{1-n_i}{n_i}} \exp\left(\frac{E_i^\ast + PV_i^\ast}{n_iRT}\right)\] 
+
+where $d$ is grain size, $i$ corresponds to diffusion or dislocation creep, $\dot{\varepsilon}$ is the square root of the second invariant of the strain rate tensor, $R$ is the gas constant, $T$ is temperature, and $P$ is pressure. $A_i$ are prefactors, $n_i$ and $m_i$ are stress and grain size exponents $E_i$ are the activation energies and $V_i$ are the activation volumes. 
+
+This form of the viscosity equation is commonly used in geodynamic simulatons See, for example, Billen and Hirth (2007), G3, 8, Q08012. Significantly, other studies may use slightly different forms of the viscosity equation leading to variations in how specific terms are defined or combined. For example, the grain size exponent should always be positive in the diffusion viscosity equation used here, while other studies place the grain size term in the denominator and invert the sign of the grain size exponent. When examining previous work, one should carefully check how the viscous prefactor and grain size terms are defined.  
+
+The ratio of diffusion to dislocation strain rate is found by Newton&apos;s method, iterating to find the stress which satisfies the above equations. The value for the components of this formula and additional parameters are read from the parameter file in subsection &apos;Material model/DiffusionDislocation&apos;.
+
+`drucker prager&apos;: A material model that has constant values for all coefficients but the density and viscosity. The defaults for all coefficients are chosen to be similar to what is believed to be correct for Earth&apos;s mantle. All of the values that define this model are read from a section ``Material model/Drucker Prager&apos;&apos; in the input file, see Section~\ref{parameters:Material_20model/Drucker_20Prager}. Note that the model does not take into account any dependencies of material properties on compositional fields. 
+
+The viscosity is computed according to the Drucker Prager frictional plasticity criterion (non-associative) based on a user-defined internal friction angle $\phi$ and cohesion $C$. In 3D:  $\sigma_y = \frac{6 C \cos(\phi)}{\sqrt(3) (3+\sin(\phi))} + \frac{2 P \sin(\phi)}{\sqrt(3) (3+\sin(\phi))}$, where $P$ is the pressure. See for example Zienkiewicz, O. C., Humpheson, C. and Lewis, R. W. (1975), G\&apos;{e}otechnique 25, No. 4, 671-689. With this formulation we circumscribe instead of inscribe the Mohr Coulomb yield surface. In 2D the Drucker Prager yield surface is the same as the Mohr Coulomb surface:  $\sigma_y = P \sin(\phi) + C \cos(\phi)$. Note that in 2D for $\phi=0$, these criteria revert to the von Mises criterion (no pressure dependence). See for example Thieulot, C. (2011), PEPI 188, 47-68. 
+
+Note that we enforce the pressure to be positive to prevent negative yield strengths and viscosities. 
+
+We then use the computed yield strength to scale back the viscosity on to the yield surface using the Viscosity Rescaling Method described in Kachanov, L. M. (2004), Fundamentals of the Theory of Plasticity, Dover Publications, Inc. (Not Radial Return.)A similar implementation can be found in GALE (https://geodynamics.org/cig/software/gale/gale-manual.pdf). 
+
+To avoid numerically unfavourably large (or even negative) viscosity ranges, we cut off the viscosity with a user-defined minimum and maximum viscosity: $\eta_eff = \frac{1}{\frac{1}{\eta_min + \eta}+ \frac{1}{\eta_max}}$. 
+
+Note that this model uses the formulation that assumes an incompressible medium despite the fact that the density follows the law $\rho(T)=\rho_0(1-\beta(T-T_{\text{ref}}))$. 
+
+`dynamic friction&apos;: This model is for use with an arbitrary number of compositional fields, where each field represents a rock type which can have completely different properties from the others.Each rock type itself has constant material properties, with the exception of viscosity which is modified according to a Drucker-Prager yield criterion. Unlike the drucker prager or visco plastic material models, the angle of internal friction is a function of velocity. This relationship is similar to rate-and-state friction constitutive relationships, which are applicable to the strength of rocks during earthquakes. The formulation used here is derived from van Dinther et al. 2013, JGR. Each compositional field is interpreed as a volume fraction. If the sum of the fields is greater than one, they are renormalized. If it is less than one, material properties for ``background material&apos;&apos; make up the rest. When more than one field is present, the material properties are averaged arithmetically. An exception is the viscosity, where the averaging should make more of a difference. For this, the user selectsbetween arithmetic, harmonic, geometric, or maximum composition averaging. 
+
+`grain size&apos;: A material model that relies on compositional fields that correspond to the average grain sizes of a mineral phase and source terms that determine the grain size evolution in terms of the strain rate, temperature, phase transitions, and the creep regime. This material model only works if a compositional field named &apos;grain_size&apos; is present. In the diffusion creep regime, the viscosity depends on this grain size field. We use the grain size evolution laws described in Behn et al., 2009. Implications of grain size evolution on the seismic structure of the oceanic upper mantle, Earth Planet. Sci. Letters, 282, 178–189. Other material parameters are either prescribed similar to the &apos;simple&apos; material model, or read from data files that were generated by the Perplex or Hefesto software. This material model is described in more detail in Dannberg, J., Z. Eilon, U. Faul, R. Gassmoeller, P. Moulik, and R. Myhill (2017), The importance of grain size to mantle dynamics and seismological observations, Geochem. Geophys. Geosyst., 18, 3034–3061, doi:10.1002/2017GC006944.
+
+`latent heat&apos;: A material model that includes phase transitions and the possibility that latent heat is released or absorbed when material crosses one of the phase transitions of up to two different materials (compositional fields). This model implements a standard approximation of the latent heat terms following Christensen \&amp; Yuen, 1985. The change of entropy is calculated as $Delta S = \gamma \frac{\Delta\rho}{\rho^2}$ with the Clapeyron slope $\gamma$ and the density change $\Delta\rho$ of the phase transition being input parameters. The model employs an analytic phase function in the form $X=\frac{1}{2} \left( 1 + \tanh \left( \frac{\Delta p}{\Delta p_0} \right) \right)$ with $\Delta p = p - p_{\text{transition}} - \gamma \left( T - T_{\text{transition}} \right)$ and $\Delta p_0$ being the pressure difference over the width of the phase transition (specified as input parameter).
+
+`latent heat melt&apos;: A material model that includes the latent heat of melting for two materials: peridotite and pyroxenite. The melting model for peridotite is taken from Katz et al., 2003 (A new parameterization of hydrous mantle melting) and the one for pyroxenite from Sobolev et al., 2011 (Linking mantle plumes, large igneous provinces and environmental catastrophes). The model assumes a constant entropy change for melting 100\% of the material, which can be specified in the input file. The partial derivatives of entropy with respect to temperature and pressure required for calculating the latent heat consumption are then calculated as product of this constant entropy change, and the respective derivative of the function the describes the melt fraction. This is linearly averaged with respect to the fractions of the two materials present. If no compositional fields are specified in the input file, the model assumes that the material is peridotite. If compositional fields are specified, the model assumes that the first compositional field is the fraction of pyroxenite and the rest of the material is peridotite. 
+
+Otherwise, this material model has a temperature- and pressure-dependent density and viscosity and the density and thermal expansivity depend on the melt fraction present. It is possible to extent this model to include a melt fraction dependence of all the material parameters by calling the function melt_fraction in the calculation of the respective parameter. However, melt and solid move with the same velocity and melt extraction is not taken into account (batch melting). 
+
+`melt global&apos;: A material model that implements a simple formulation of the material parameters required for the modelling of melt transport, including a source term for the porosity according to a simplified linear melting model similar to \cite{schmeling2006}:
+$\phi_{\text{equilibrium}} = \frac{T-T_{\text{sol}}}{T_{\text{liq}}-T_{\text{sol}}}$
+with $T_{\text{sol}} = T_{\text{sol,0}} + \Delta T_p \, p + \Delta T_c \, C$ 
+$T_{\text{liq}} = T_{\text{sol}}  + \Delta T_{\text{sol-liq}}$.
+
+`melt simple&apos;: A material model that implements a simple formulation of the material parameters required for the modelling of melt transport, including a source term for the porosity according to the melting model for dry peridotite of \cite{KSL2003}. This also includes a computation of the latent heat of melting (if the `latent heat&apos; heating model is active).
+
+Most of the material properties are constant, except for the shear, viscosity $\eta$, the compaction viscosity $\xi$, and the permeability $k$, which depend on the porosity; and the solid and melt densities, which depend on temperature and pressure:
+ $\eta(\phi,T) = \eta_0 e^{\alpha(\phi-\phi_0)} e^{-\beta(T-T_0)/T_0}$, $\xi(\phi,T) = \xi_0 \frac{\phi_0}{\phi} e^{-\beta(T-T_0)/T_0}$, $k=k_0 \phi^n (1-\phi)^m$, $\rho=\rho_0 (1 - \alpha (T - T_{\text{adi}})) e^{\kappa p}$.
+
+The model is compressible only if this is specified in the input file, and contains compressibility for both solid and melt.
+
+`multicomponent&apos;: This model is for use with an arbitrary number of compositional fields, where each field represents a rock type which can have completely different properties from the others. However, each rock type itself has constant material properties.  The value of the  compositional field is interpreted as a volume fraction. If the sum of the fields is greater than one, they are renormalized.  If it is less than one, material properties  for ``background mantle&apos;&apos; make up the rest. When more than one field is present, the material properties are averaged arithmetically.  An exception is the viscosity, where the averaging should make more of a difference.  For this, the user selects between arithmetic, harmonic, geometric, or maximum composition averaging.
+
+`nondimensional&apos;: A material model for nondimensionalized computations for compressible or incompressible computations defined through Rayleigh number 	ext{Ra} and Dissipation number Di. This model is made to be used with the Boussinesq, ALA, or TALA formulation.
+
+The viscosity is defined as \[\eta = \text{Di} / \text{Ra} \cdot \exp(-b T&apos; + c z)\] where $T&apos;$ is the temperature variation from the adiabatic temperature, $z$ is the depth, $b$ is given by ``Viscosity temperature prefactor&apos;&apos;, and $c$ by ``Viscosity depth prefactor&apos;&apos;. If $\text{Di}$ is zero, it will be replaced by 1.0 in $\eta$.
+
+The density is defined as \[\rho = \exp(\text{Di}/\gamma \cdot z)  (1.0 - \alpha T&apos; + \text{Di} \gamma p&apos;),\] where $\alpha=\text{Di}$ is the thermal expansion coefficient, $\gamma$ is the Grueneisen parameter, and $p&apos;$ is the pressure variation from the adiabatic pressure. The pressure dependent term is not present if ``TALA&apos;&apos; is enabled.
+
+`perplex lookup&apos;: A material model that has constant values for viscosity and thermal conductivity, and calculates other properties on-the-fly using PerpleX meemum. Compositional fields correspond to the individual components in the order given in the PerpleX file.
+
+`simple&apos;: A material model that has constant values for all coefficients but the density and viscosity. The defaults for all coefficients are chosen to be similar to what is believed to be correct for Earth&apos;s mantle. All of the values that define this model are read from a section ``Material model/Simple model&apos;&apos; in the input file, see Section~\ref{parameters:Material_20model/Simple_20model}.
+
+This model uses the following set of equations for the two coefficients that are non-constant: \begin{align}  \eta(p,T,\mathfrak c) &amp;= \tau(T) \zeta(\mathfrak c) \eta_0, \\  \rho(p,T,\mathfrak c) &amp;= \left(1-\alpha (T-T_0)\right)\rho_0 + \Delta\rho \; c_0,\end{align}where $c_0$ is the first component of the compositional vector $\mathfrak c$ if the model uses compositional fields, or zero otherwise. 
+
+The temperature pre-factor for the viscosity formula above is defined as \begin{align}  \tau(T) &amp;= H\left(e^{-\beta (T-T_0)/T_0}\right),\intertext{with}   \qquad\qquad H(x) &amp;= \begin{cases}                            \tau_{\text{min}} &amp; \text{if}\; x&lt;\tau_{\text{min}}, \\                            x &amp; \text{if}\; 10^{-2}\le x \le 10^2, \\                            \tau_{\text{max}} &amp; \text{if}\; x&gt;\tau_{\text{max}}, \\                         \end{cases}\end{align} where $x=e^{-\beta (T-T_0)/T_0}$, $\beta$ corresponds to the input parameter ``Thermal viscosity exponent&apos;&apos;, and $T_0$ to the parameter ``Reference temperature&apos;&apos;. If you set $T_0=0$ in the input file, the thermal pre-factor $\tau(T)=1$. The parameters $\tau_{\text{min}}$ and $\tau_{\text{max}}$ set the minimum and maximum values of the temperature pre-factor and are set using ``Maximum thermal prefactor&apos;&apos; and ``Minimum thermal prefactor&apos;&apos;. Specifying a value of 0.0 for the minimum or maximum values will disable pre-factor limiting.
+
+The compositional pre-factor for the viscosity is defined as \begin{align}  \zeta(\mathfrak c) &amp;= \xi^{c_0}\end{align} if the model has compositional fields and equals one otherwise. $\xi$ corresponds to the parameter ``Composition viscosity prefactor&apos;&apos; in the input file.
+
+Finally, in the formula for the density, $\alpha$ corresponds to the ``Thermal expansion coefficient&apos;&apos; and $\Delta\rho$ corresponds to the parameter ``Density differential for compositional field 1&apos;&apos;.
+
+Note that this model uses the formulation that assumes an incompressible medium despite the fact that the density follows the law $\rho(T)=\rho_0(1-\alpha(T-T_{\text{ref}}))$. 
+
+\note{Despite its name, this material model is not exactly ``simple&apos;&apos;, as indicated by the formulas above. While it was originally intended to be simple, it has over time acquired all sorts of temperature and compositional dependencies that weren&apos;t initially intended. Consequently, there is now a ``simpler&apos;&apos; material model that now fills the role the current model was originally intended to fill.}
+
+`simple compressible&apos;: A material model that has constant values for all coefficients but the density. The defaults for all coefficients are chosen to be similar to what is believed to be correct for Earth&apos;s mantle. All of the values that define this model are read from a section ``Material model/Simple compressible model&apos;&apos; in the input file, see Section~\ref{parameters:Material_20model/Simple_20compressible_20model}.
+
+This model uses the following equations for the density: \begin{align}  \rho(p,T) = \rho_0              \left(1-\alpha (T-T_a)\right)               \exp{\beta (P-P_0))}\end{align}This formulation for the density assumes that the compressibility provided by the user is the adiabatic compressibility ($\beta_S$). The thermal expansivity and isentropic compressibility implied by the pressure and temperature dependence are equal to the user-defined constant values only along the reference isentrope, and there is also an implicit pressure dependence to the heat capacity $C_p$ via Maxwell&apos;s relations.
+
+`simpler&apos;: A material model that has constant values except for density, which depends linearly on temperature: \begin{align}  \rho(p,T) &amp;= \left(1-\alpha (T-T_0)\right)\rho_0.\end{align}
+
+\note{This material model fills the role the ``simple&apos;&apos; material model was originally intended to fill, before the latter acquired all sorts of complicated temperature and compositional dependencies.}
+
+`visco plastic&apos;: An implementation of a visco-plastic rheology with options for selecting dislocation creep, diffusion creep or composite viscous flow laws.  Plasticity limits viscous stresses through a Drucker Prager yield criterion. The model is incompressible. Note that this material model is based heavily on the DiffusionDislocation (Bob Myhill) and DruckerPrager (Anne Glerum) material models. 
+
+ The viscosity for dislocation or diffusion creep is defined as \[v = \frac 12 A^{-\frac{1}{n}} d^{\frac{m}{n}} \dot{\varepsilon}_{ii}^{\frac{1-n}{n}} \exp\left(\frac{E + PV}{nRT}\right)\] where $A$ is the prefactor, $n$ is the stress exponent, $\dot{\varepsilon}_{ii}$ is the square root of the deviatoric strain rate tensor second invariant, $d$ is grain size, $m$ is the grain size exponent, $E$ is activation energy, $V$ is activation volume, $P$ is pressure, $R$ is the gas exponent and $T$ is temperature. This form of the viscosity equation is commonly used in geodynamic simulations. See, for example, Billen and Hirth (2007), G3, 8, Q08012. Significantly, other studies may use slightly different forms of the viscosity equation leading to variations in how specific terms are defined or combined. For example, the grain size exponent should always be positive in the diffusion viscosity equation used here, while other studies place the grain size term in the denominator and invert the sign of the grain size exponent. When examining previous work, one should carefully check how the viscous prefactor and grain size terms are defined. 
+
+ One may select to use the diffusion ($v_{\text{diff}}$; $n=1$, $m!=0$), dislocation ($v_{\text{disl}}$, $n&gt;1$, $m=0$) or composite $\frac{v_{\text{diff}} v_{\text{disl}}}{v_{\text{diff}}+v_{\text{disl}}}$ equation form. 
+
+ The diffusion and dislocation prefactors can be weakened with a factor between 0 and 1 according to the total or the viscous strain only. 
+
+ Viscosity is limited through one of two different `yielding&apos; mechanisms. 
+
+Plasticity limits viscous stress through a Drucker Prager yield criterion, where the yield stress in 3D is  $\sigma_y = \frac{6C\cos(\phi) + 2P\sin(\phi)} {\sqrt(3)(3+\sin(\phi))}$ and $\sigma_y = C\cos(\phi) + P\sin(\phi)$ in 2D. Above, $C$ is cohesion and $\phi$  is the angle of internal friction.  Note that the 2D form is equivalent to the Mohr Coulomb yield surface.  If $\phi$ is 0, the yield stress is fixed and equal to the cohesion (Von Mises yield criterion). When the viscous stress ($2v{\varepsilon}_{ii}$) exceeds the yield stress, the viscosity is rescaled back to the yield surface: $v_{y}=\sigma_{y}/(2{\varepsilon}_{ii})$. This form of plasticity is commonly used in geodynamic models. See, for example, Thieulot, C. (2011), PEPI 188, pp. 47-68. 
+
+The user has the option to linearly reduce the cohesion and internal friction angle as a function of the finite strain magnitude. The finite strain invariant or full strain tensor is calculated through compositional fields within the material model. This implementation is identical to the compositional field finite strain plugin and cookbook described in the manual (author: Gassmoeller, Dannberg). If the user selects to track the finite strain invariant ($e_{ii}$), a single compositional field tracks the value derived from $e_{ii}^t = (e_{ii})^{(t-1)} + \dot{e}_{ii}\; dt$, where $t$ and $t-1$ are the current and prior time steps, $\dot{e}_{ii}$ is the second invariant of the strain rate tensor and $dt$ is the time step size. In the case of the full strain tensor $F$, the finite strain magnitude is derived from the second invariant of the symmetric stretching tensor $L$, where $L = F [F]^T$. The user must specify a single compositional field for the finite strain invariant or multiple fields (4 in 2D, 9 in 3D) for the finite strain tensor. These field(s) must be the first listed compositional fields in the parameter file. Note that one or more of the finite strain tensor components must be assigned a non-zero value initially. This value can be be quite small (e.g., 1.e-8), but still non-zero. While the option to track and use the full finite strain tensor exists, tracking the associated compositional fields is computationally expensive in 3D. Similarly, the finite strain magnitudes may in fact decrease if the orientation of the deformation field switches through time. Consequently, the ideal solution is track the finite strain invariant (single compositional) field within the material and track the full finite strain tensor through particles.When only the second invariant of the strain is tracked, one has the option to track the full strain or only the plastic strain. In the latter case, strain is only tracked in case the material is plastically yielding, i.e. the viscous stess &gt; yield strength. 
+
+Viscous stress may also be limited by a non-linear stress limiter that has a form similar to the Peierls creep mechanism. This stress limiter assigns an effective viscosity $\sigma_{\text{eff}} = \frac{\tau_y}{2\varepsilon_y} {\frac{\varepsilon_{ii}}{\varepsilon_y}}^{\frac{1}{n_y}-1}$ Above $\tau_y$ is a yield stress, $\varepsilon_y$ is the reference strain rate, $\varepsilon_{ii}$ is the strain rate and $n_y$ is the stress limiter exponent.  The yield stress, $\tau_y$, is defined through the Drucker Prager yield criterion formulation. This method of limiting viscous stress has been used in various forms within the geodynamic literature, including Christensen (1992), JGR, 97(B2), pp. 2015-2036; Cizkova and Bina (2013), EPSL, 379, pp. 95-103; Cizkova and Bina (2015), EPSL, 430, pp. 408-415. When $n_y$ is 1, it essentially becomes a linear viscosity model, and in the limit $n_y\rightarrow \infty$ it converges to the standard viscosity rescaling method (concretely, values $n_y&gt;20$ are large enough).
+
+ Compositional fields can each be assigned individual values of thermal diffusivity, heat capacity, density, thermal expansivity and rheological parameters. 
+
+ If more than one compositional field is present at a given point, viscosities are averaged with an arithmetic, geometric harmonic (default) or maximum composition scheme. 
+
+ The value for the components of this formula and additional parameters are read from the parameter file in subsection  &apos;Material model/Visco Plastic&apos;.
+
+`viscoelastic&apos;: An implementation of a simple linear viscoelastic rheology that only includes the deviatoric components of elasticity. Specifically, the viscoelastic rheology only takes into account the elastic shear strength (e.g., shear modulus), while the tensile and volumetric strength (e.g., Young&apos;s and bulk modulus) are not considered. The model is incompressible and allows specifying an arbitrary number of compositional fields, where each field represents a different rock type or component of the viscoelastic stress tensor. The stress tensor in 2D and 3D, respectively, contains 3 or 6 components. The compositional fields representing these components must be named and listed in a very specific format, which is designed to minimize mislabeling stress tensor components as distinct &apos;compositional rock types&apos; (or vice versa). For 2D models, the first three compositional fields must be labeled &apos;stress\_xx&apos;, &apos;stress\_yy&apos; and &apos;stress\_xy&apos;. In 3D, the first six compositional fields must be labeled &apos;stress\_xx&apos;, &apos;stress\_yy&apos;, &apos;stress\_zz&apos;, &apos;stress\_xy&apos;, &apos;stress\_xz&apos;, &apos;stress\_yz&apos;. 
+
+ Expanding the model to include non-linear viscous flow (e.g., diffusion/dislocation creep) and plasticity would produce a constitutive relationship commonly referred to as partial elastoviscoplastic (e.g., pEVP) in the geodynamics community. While extensively discussed and applied within the geodynamics literature, notable references include: Moresi et al. (2003), J. Comp. Phys., v. 184, p. 476-497. Gerya and Yuen (2007), Phys. Earth. Planet. Inter., v. 163, p. 83-105. Gerya (2010), Introduction to Numerical Geodynamic Modeling. Kaus (2010), Tectonophysics, v. 484, p. 36-47. Choi et al. (2013), J. Geophys. Res., v. 118, p. 2429-2444. Keller et al. (2013), Geophys. J. Int., v. 195, p. 1406-1442. 
+
+ The overview below directly follows Moresi et al. (2003) eqns. 23-32. However, an important distinction between this material model and the studies above is the use of compositional fields, rather than tracers, to track individual components of the viscoelastic stress tensor. The material model will be updated when an option to track and calculate viscoelastic stresses with tracers is implemented. 
+
+ Moresi et al. (2003) begins (eqn. 23) by writing the deviatoric rate of deformation ($\hat{D}$) as the sum of elastic ($\hat{D_{e}}$) and viscous ($\hat{D_{v}}$) components: $\hat{D} = \hat{D_{e}} + \hat{D_{v}}$.  These terms further decompose into $\hat{D_{v}} = \frac{\tau}{2\eta}$ and $\hat{D_{e}} = \frac{\overset{\nabla}{\tau}}{2\mu}$, where $\tau$ is the viscous deviatoric stress, $\eta$ is the shear viscosity, $\mu$ is the shear modulus and $\overset{\nabla}{\tau}$ is the Jaumann corotational stress rate. This later term (eqn. 24) contains the time derivative of the deviatoric stress ($\dot{\tau}$) and terms that account for material spin (e.g., rotation) due to advection: $\overset{\nabla}{\tau} = \dot{\tau} + {\tau}W -W\tau$. Above, $W$ is the material spin tensor (eqn. 25): $W_{ij} = \frac{1}{2} \left (\frac{\partial V_{i}}{\partial x_{j}} - \frac{\partial V_{j}}{\partial x_{i}} \right )$. 
+
+ The Jaumann stress-rate can also be approximated using terms from the time at the previous time step ($t$) and current time step ($t + \Delta t^{e}$): $\smash[t]{\overset{\nabla}{\tau}}^{t + \Delta t^{e}} \approx \frac{\tau^{t + \Delta t^{e} - \tau^{t}}}{\Delta t^{e}} - W^{t}\tau^{t} + \tau^{t}W^{t}$. In this material model, the size of the time step above ($\Delta t^{e}$) can be specified as the numerical time step size or an independent fixed time step. If the latter case is a selected, the user has an option to apply a stress averaging scheme to account for the differences between the numerical and fixed elastic time step (eqn. 32). If one selects to use a fixed elastic time step throughout the model run, this can still be achieved by using CFL and maximum time step values that restrict the numerical time step to a specific time.
+
+ The formulation above allows rewriting the total rate of deformation (eqn. 29) as $\tau^{t + \Delta t^{e}} = \eta_{eff} \left ( 2\hat{D}^{t + \triangle t^{e}} + \frac{\tau^{t}}{\mu \Delta t^{e}} + \frac{W^{t}\tau^{t} - \tau^{t}W^{t}}{\mu}  \right )$. 
+
+ The effective viscosity (eqn. 28) is a function of the viscosity ($\eta$), elastic time step size ($\Delta t^{e}$) and shear relaxation time ($ \alpha = \frac{\eta}{\mu} $): $\eta_{eff} = \eta \frac{\Delta t^{e}}{\Delta t^{e} + \alpha}$ The magnitude of the shear modulus thus controls how much the effective viscosity is reduced relative to the initial viscosity. 
+
+ Elastic effects are introduced into the governing Stokes equations through an elastic force term (eqn. 30) using stresses from the previous time step: $F^{e,t} = -\frac{\eta_{eff}}{\mu \Delta t^{e}} \tau^{t}$. This force term is added onto the right-hand side force vector in the system of equations. 
+
+ The value of each compositional field representing distinct rock types at a point is interpreted to be a volume fraction of that rock type. If the sum of the compositional field volume fractions is less than one, then the remainder of the volume is assumed to be &apos;background material&apos;.
+
+ Several model parameters (densities, elastic shear moduli, thermal expansivities, thermal conductivies, specific heats) can be defined per-compositional field. For each material parameter the user supplies a comma delimited list of length N+1, where N is the number of compositional fields. The additional field corresponds to the value for background material. They should be ordered &apos;&apos;background, composition1, composition2...&apos;&apos;. However, the first 3 (2D) or 6 (3D) composition fields correspond to components of the elastic stress tensor and their material values will not contribute to the volume fractions. If a single value is given, then all the compositional fields are given that value. Other lengths of lists are not allowed. For a given compositional field the material parameters are treated as constant, except density, which varies linearly with temperature according to the thermal expansivity. 
+
+ When more than one compositional field is present at a point, they are averaged arithmetically. An exception is viscosity, which may be averaged arithmetically, harmonically, geometrically, or by selecting the viscosity of the composition field with the greatest volume fraction.
+</documentation>
+<pattern>
+267
+</pattern>
+<pattern_description>
+[Selection Steinberger|ascii reference profile|averaging|compositing|composition reaction|depth dependent|diffusion dislocation|drucker prager|dynamic friction|grain size|latent heat|latent heat melt|melt global|melt simple|multicomponent|nondimensional|perplex lookup|simple|simple compressible|simpler|visco plastic|viscoelastic|unspecified ]
+</pattern_description>
+</Model_20name>
+<Ascii_20reference_20profile>
+<Thermal_20conductivity>
+<value>
+4.0
+</value>
+<default_value>
+4.0
+</default_value>
+<documentation>
+Reference conductivity
+</documentation>
+<pattern>
+268
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20conductivity>
+<Viscosity>
+<value>
+1e21
+</value>
+<default_value>
+1e21
+</default_value>
+<documentation>
+Viscosity
+</documentation>
+<pattern>
+269
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Viscosity>
+<Use_20TALA>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to use the TALA instead of the ALA approximation.
+</documentation>
+<pattern>
+270
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20TALA>
+<Thermal_20viscosity_20exponent>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The temperature dependence of viscosity. Dimensionless exponent.
+</documentation>
+<pattern>
+271
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20viscosity_20exponent>
+<Transition_20depths>
+<value>
+1.5e5, 4.1e5, 6.6e5
+</value>
+<default_value>
+1.5e5, 4.1e5, 6.6e5
+</default_value>
+<documentation>
+A list of depths where the viscosity changes. Values must monotonically increase. Units: $m$.
+</documentation>
+<pattern>
+272
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Transition_20depths>
+<Viscosity_20prefactors>
+<value>
+10, 0.1, 1, 10
+</value>
+<default_value>
+10, 0.1, 1, 10
+</default_value>
+<documentation>
+A list of prefactors for the viscosity that determine the viscosity profile. Each prefactor is applied in a depth range specified by the list of `Transition depths&apos;, i.e. the first prefactor is applied above the first transition depth, the second one between the first and second transition depth, and so on. To compute the viscosity profile, this prefactor is multiplied by the reference viscosity specified through the parameter `Viscosity&apos;. List must have one more entry than Transition depths. Units: non-dimensional.
+</documentation>
+<pattern>
+273
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Viscosity_20prefactors>
+<Ascii_20data_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/adiabatic-conditions/ascii-data/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/adiabatic-conditions/ascii-data/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a `/&apos;) or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+274
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value/>
+<default_value/>
+<documentation>
+The file name of the model data. Provide file in format: (Velocity file name).\%s\%d where \%s is a string specifying the boundary of the model according to the names of the boundary indicators (of the chosen geometry model).\%d is any sprintf integer qualifier, specifying the format of the current file number. 
+</documentation>
+<pattern>
+275
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+</documentation>
+<pattern>
+276
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+</Ascii_20data_20model>
+</Ascii_20reference_20profile>
+<Averaging>
+<Base_20model>
+<value>
+simple
+</value>
+<default_value>
+simple
+</default_value>
+<documentation>
+The name of a material model that will be modified by an averaging operation. Valid values for this parameter are the names of models that are also valid for the ``Material models/Model name&apos;&apos; parameter. See the documentation for that for more information.
+</documentation>
+<pattern>
+277
+</pattern>
+<pattern_description>
+[Selection Steinberger|ascii reference profile|averaging|compositing|composition reaction|depth dependent|diffusion dislocation|drucker prager|dynamic friction|grain size|latent heat|latent heat melt|melt global|melt simple|multicomponent|nondimensional|perplex lookup|simple|simple compressible|simpler|visco plastic|viscoelastic ]
+</pattern_description>
+</Base_20model>
+<Averaging_20operation>
+<value>
+none
+</value>
+<default_value>
+none
+</default_value>
+<documentation>
+Choose the averaging operation to use.
+</documentation>
+<pattern>
+278
+</pattern>
+<pattern_description>
+[Selection none|arithmetic average|harmonic average|geometric average|pick largest|log average|nwd arithmetic average|nwd harmonic average|nwd geometric average ]
+</pattern_description>
+</Averaging_20operation>
+<Bell_20shape_20limit>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+The limit normalized distance between 0 and 1 where the bell shape becomes zero. See the manual for a more information.
+</documentation>
+<pattern>
+279
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Bell_20shape_20limit>
+</Averaging>
+<Compositing>
+<Compressibility>
+<value>
+unspecified
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Material model to use for Compressibility. Valid values for this parameter are the names of models that are also valid for the ``Material models/Model name&apos;&apos; parameter. See the documentation for that for more information.
+</documentation>
+<pattern>
+280
+</pattern>
+<pattern_description>
+[Selection Steinberger|ascii reference profile|averaging|compositing|composition reaction|depth dependent|diffusion dislocation|drucker prager|dynamic friction|grain size|latent heat|latent heat melt|melt global|melt simple|multicomponent|nondimensional|perplex lookup|simple|simple compressible|simpler|visco plastic|viscoelastic|unspecified ]
+</pattern_description>
+</Compressibility>
+<Density>
+<value>
+unspecified
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Material model to use for Density. Valid values for this parameter are the names of models that are also valid for the ``Material models/Model name&apos;&apos; parameter. See the documentation for that for more information.
+</documentation>
+<pattern>
+281
+</pattern>
+<pattern_description>
+[Selection Steinberger|ascii reference profile|averaging|compositing|composition reaction|depth dependent|diffusion dislocation|drucker prager|dynamic friction|grain size|latent heat|latent heat melt|melt global|melt simple|multicomponent|nondimensional|perplex lookup|simple|simple compressible|simpler|visco plastic|viscoelastic|unspecified ]
+</pattern_description>
+</Density>
+<Entropy_20derivative_20pressure>
+<value>
+unspecified
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Material model to use for Entropy derivative pressure. Valid values for this parameter are the names of models that are also valid for the ``Material models/Model name&apos;&apos; parameter. See the documentation for that for more information.
+</documentation>
+<pattern>
+282
+</pattern>
+<pattern_description>
+[Selection Steinberger|ascii reference profile|averaging|compositing|composition reaction|depth dependent|diffusion dislocation|drucker prager|dynamic friction|grain size|latent heat|latent heat melt|melt global|melt simple|multicomponent|nondimensional|perplex lookup|simple|simple compressible|simpler|visco plastic|viscoelastic|unspecified ]
+</pattern_description>
+</Entropy_20derivative_20pressure>
+<Entropy_20derivative_20temperature>
+<value>
+unspecified
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Material model to use for Entropy derivative temperature. Valid values for this parameter are the names of models that are also valid for the ``Material models/Model name&apos;&apos; parameter. See the documentation for that for more information.
+</documentation>
+<pattern>
+283
+</pattern>
+<pattern_description>
+[Selection Steinberger|ascii reference profile|averaging|compositing|composition reaction|depth dependent|diffusion dislocation|drucker prager|dynamic friction|grain size|latent heat|latent heat melt|melt global|melt simple|multicomponent|nondimensional|perplex lookup|simple|simple compressible|simpler|visco plastic|viscoelastic|unspecified ]
+</pattern_description>
+</Entropy_20derivative_20temperature>
+<Reaction_20terms>
+<value>
+unspecified
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Material model to use for Reaction terms. Valid values for this parameter are the names of models that are also valid for the ``Material models/Model name&apos;&apos; parameter. See the documentation for that for more information.
+</documentation>
+<pattern>
+284
+</pattern>
+<pattern_description>
+[Selection Steinberger|ascii reference profile|averaging|compositing|composition reaction|depth dependent|diffusion dislocation|drucker prager|dynamic friction|grain size|latent heat|latent heat melt|melt global|melt simple|multicomponent|nondimensional|perplex lookup|simple|simple compressible|simpler|visco plastic|viscoelastic|unspecified ]
+</pattern_description>
+</Reaction_20terms>
+<Specific_20heat>
+<value>
+unspecified
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Material model to use for Specific heat. Valid values for this parameter are the names of models that are also valid for the ``Material models/Model name&apos;&apos; parameter. See the documentation for that for more information.
+</documentation>
+<pattern>
+285
+</pattern>
+<pattern_description>
+[Selection Steinberger|ascii reference profile|averaging|compositing|composition reaction|depth dependent|diffusion dislocation|drucker prager|dynamic friction|grain size|latent heat|latent heat melt|melt global|melt simple|multicomponent|nondimensional|perplex lookup|simple|simple compressible|simpler|visco plastic|viscoelastic|unspecified ]
+</pattern_description>
+</Specific_20heat>
+<Thermal_20conductivity>
+<value>
+unspecified
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Material model to use for Thermal conductivity. Valid values for this parameter are the names of models that are also valid for the ``Material models/Model name&apos;&apos; parameter. See the documentation for that for more information.
+</documentation>
+<pattern>
+286
+</pattern>
+<pattern_description>
+[Selection Steinberger|ascii reference profile|averaging|compositing|composition reaction|depth dependent|diffusion dislocation|drucker prager|dynamic friction|grain size|latent heat|latent heat melt|melt global|melt simple|multicomponent|nondimensional|perplex lookup|simple|simple compressible|simpler|visco plastic|viscoelastic|unspecified ]
+</pattern_description>
+</Thermal_20conductivity>
+<Thermal_20expansion_20coefficient>
+<value>
+unspecified
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Material model to use for Thermal expansion coefficient. Valid values for this parameter are the names of models that are also valid for the ``Material models/Model name&apos;&apos; parameter. See the documentation for that for more information.
+</documentation>
+<pattern>
+287
+</pattern>
+<pattern_description>
+[Selection Steinberger|ascii reference profile|averaging|compositing|composition reaction|depth dependent|diffusion dislocation|drucker prager|dynamic friction|grain size|latent heat|latent heat melt|melt global|melt simple|multicomponent|nondimensional|perplex lookup|simple|simple compressible|simpler|visco plastic|viscoelastic|unspecified ]
+</pattern_description>
+</Thermal_20expansion_20coefficient>
+<Viscosity>
+<value>
+unspecified
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Material model to use for Viscosity. Valid values for this parameter are the names of models that are also valid for the ``Material models/Model name&apos;&apos; parameter. See the documentation for that for more information.
+</documentation>
+<pattern>
+288
+</pattern>
+<pattern_description>
+[Selection Steinberger|ascii reference profile|averaging|compositing|composition reaction|depth dependent|diffusion dislocation|drucker prager|dynamic friction|grain size|latent heat|latent heat melt|melt global|melt simple|multicomponent|nondimensional|perplex lookup|simple|simple compressible|simpler|visco plastic|viscoelastic|unspecified ]
+</pattern_description>
+</Viscosity>
+</Compositing>
+<Composition_20reaction_20model>
+<Reference_20density>
+<value>
+3300
+</value>
+<default_value>
+3300
+</default_value>
+<documentation>
+Reference density $\rho_0$. Units: $kg/m^3$.
+</documentation>
+<pattern>
+289
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20density>
+<Reference_20temperature>
+<value>
+293
+</value>
+<default_value>
+293
+</default_value>
+<documentation>
+The reference temperature $T_0$. Units: $K$.
+</documentation>
+<pattern>
+290
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Viscosity>
+<value>
+5e24
+</value>
+<default_value>
+5e24
+</default_value>
+<documentation>
+The value of the constant viscosity. Units: $kg/m/s$.
+</documentation>
+<pattern>
+291
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Viscosity>
+<Composition_20viscosity_20prefactor_201>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+A linear dependency of viscosity on the first compositional field. Dimensionless prefactor. With a value of 1.0 (the default) the viscosity does not depend on the composition.
+</documentation>
+<pattern>
+292
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Composition_20viscosity_20prefactor_201>
+<Composition_20viscosity_20prefactor_202>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+A linear dependency of viscosity on the second compositional field. Dimensionless prefactor. With a value of 1.0 (the default) the viscosity does not depend on the composition.
+</documentation>
+<pattern>
+293
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Composition_20viscosity_20prefactor_202>
+<Thermal_20viscosity_20exponent>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The temperature dependence of viscosity. Dimensionless exponent.
+</documentation>
+<pattern>
+294
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20viscosity_20exponent>
+<Thermal_20conductivity>
+<value>
+4.7
+</value>
+<default_value>
+4.7
+</default_value>
+<documentation>
+The value of the thermal conductivity $k$. Units: $W/m/K$.
+</documentation>
+<pattern>
+295
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20conductivity>
+<Reference_20specific_20heat>
+<value>
+1250
+</value>
+<default_value>
+1250
+</default_value>
+<documentation>
+The value of the specific heat $C_p$. Units: $J/kg/K$.
+</documentation>
+<pattern>
+296
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20specific_20heat>
+<Thermal_20expansion_20coefficient>
+<value>
+2e-5
+</value>
+<default_value>
+2e-5
+</default_value>
+<documentation>
+The value of the thermal expansion coefficient $\beta$. Units: $1/K$.
+</documentation>
+<pattern>
+297
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20expansion_20coefficient>
+<Density_20differential_20for_20compositional_20field_201>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+If compositional fields are used, then one would frequently want to make the density depend on these fields. In this simple material model, we make the following assumptions: if no compositional fields are used in the current simulation, then the density is simply the usual one with its linear dependence on the temperature. If there are compositional fields, then the density only depends on the first and the second one in such a way that the density has an additional term of the kind $+\Delta \rho \; c_1(\mathbf x)$. This parameter describes the value of $\Delta \rho$ for the first field. Units: $kg/m^3/\textrm{unit change in composition}$.
+</documentation>
+<pattern>
+298
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Density_20differential_20for_20compositional_20field_201>
+<Density_20differential_20for_20compositional_20field_202>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+If compositional fields are used, then one would frequently want to make the density depend on these fields. In this simple material model, we make the following assumptions: if no compositional fields are used in the current simulation, then the density is simply the usual one with its linear dependence on the temperature. If there are compositional fields, then the density only depends on the first and the second one in such a way that the density has an additional term of the kind $+\Delta \rho \; c_1(\mathbf x)$. This parameter describes the value of $\Delta \rho$ for the second field. Units: $kg/m^3/\textrm{unit change in composition}$.
+</documentation>
+<pattern>
+299
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Density_20differential_20for_20compositional_20field_202>
+<Reaction_20depth>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Above this depth the compositional fields react: The first field gets converted to the second field. Units: $m$.
+</documentation>
+<pattern>
+300
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reaction_20depth>
+</Composition_20reaction_20model>
+<Depth_20dependent_20model>
+<Base_20model>
+<value>
+simple
+</value>
+<default_value>
+simple
+</default_value>
+<documentation>
+The name of a material model that will be modified by a depth dependent viscosity. Valid values for this parameter are the names of models that are also valid for the ``Material models/Model name&apos;&apos; parameter. See the documentation for that for more information.
+</documentation>
+<pattern>
+301
+</pattern>
+<pattern_description>
+[Selection Steinberger|ascii reference profile|averaging|compositing|composition reaction|depth dependent|diffusion dislocation|drucker prager|dynamic friction|grain size|latent heat|latent heat melt|melt global|melt simple|multicomponent|nondimensional|perplex lookup|simple|simple compressible|simpler|visco plastic|viscoelastic ]
+</pattern_description>
+</Base_20model>
+<Depth_20dependence_20method>
+<value>
+None
+</value>
+<default_value>
+None
+</default_value>
+<documentation>
+Method that is used to specify how the viscosity should vary with depth. 
+</documentation>
+<pattern>
+302
+</pattern>
+<pattern_description>
+[Selection Function|File|List|None ]
+</pattern_description>
+</Depth_20dependence_20method>
+<Data_20directory>
+<value>
+./
+</value>
+<default_value>
+./
+</default_value>
+<documentation>
+The path to the model data. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+303
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Viscosity_20depth_20file>
+<value>
+visc-depth.txt
+</value>
+<default_value>
+visc-depth.txt
+</default_value>
+<documentation>
+The name of the file containing depth-dependent viscosity data. 
+</documentation>
+<pattern>
+304
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Viscosity_20depth_20file>
+<Depth_20list>
+<value/>
+<default_value/>
+<documentation>
+A comma-separated list of depth values for use with the ``List&apos;&apos; ``Depth dependence method&apos;&apos;. The list must be provided in order of increasing depth, and the last value must be greater than or equal to the maximal depth of the model. The depth list is interpreted as a layered viscosity structure and the depth values specify the maximum depths of each layer. 
+</documentation>
+<pattern>
+305
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Depth_20list>
+<Viscosity_20list>
+<value/>
+<default_value/>
+<documentation>
+A comma-separated list of viscosity values, corresponding to the depth values provided in ``Depth list&apos;&apos;. The number of viscosity values specified here must be the same as the number of depths provided in ``Depth list&apos;&apos; 
+</documentation>
+<pattern>
+306
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Viscosity_20list>
+<Viscosity_20depth_20function>
+<Variable_20names>
+<value>
+x,t
+</value>
+<default_value>
+x,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+307
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+1.0e21
+</value>
+<default_value>
+1.0e21
+</default_value>
+<documentation/>
+<pattern>
+310
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+309
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Viscosity_20depth_20function>
+</Depth_20dependent_20model>
+<Diffusion_20dislocation>
+<Reference_20temperature>
+<value>
+293
+</value>
+<default_value>
+293
+</default_value>
+<documentation>
+For calculating density by thermal expansivity. Units: $K$
+</documentation>
+<pattern>
+311
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Minimum_20strain_20rate>
+<value>
+1.4e-20
+</value>
+<default_value>
+1.4e-20
+</default_value>
+<documentation>
+Stabilizes strain dependent viscosity. Units: $1 / s$
+</documentation>
+<pattern>
+312
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20strain_20rate>
+<Minimum_20viscosity>
+<value>
+1e17
+</value>
+<default_value>
+1e17
+</default_value>
+<documentation>
+Lower cutoff for effective viscosity. Units: $Pa \, s$
+</documentation>
+<pattern>
+313
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20viscosity>
+<Maximum_20viscosity>
+<value>
+1e28
+</value>
+<default_value>
+1e28
+</default_value>
+<documentation>
+Upper cutoff for effective viscosity. Units: $Pa \, s$
+</documentation>
+<pattern>
+314
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20viscosity>
+<Effective_20viscosity_20coefficient>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+Scaling coefficient for effective viscosity.
+</documentation>
+<pattern>
+315
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Effective_20viscosity_20coefficient>
+<Reference_20viscosity>
+<value>
+1e22
+</value>
+<default_value>
+1e22
+</default_value>
+<documentation>
+The reference viscosity that is used for pressure scaling. To understand how pressure scaling works, take a look at \cite{KHB12}. In particular, the value of this parameter would not affect the solution computed by \aspect{} if we could do arithmetic exactly; however, computers do arithmetic in finite precision, and consequently we need to scale quantities in ways so that their magnitudes are roughly the same. As explained in \cite{KHB12}, we scale the pressure during some computations (never visible by users) by a factor that involves a reference viscosity. This parameter describes this reference viscosity.
+
+For problems with a constant viscosity, you will generally want to choose the reference viscosity equal to the actual viscosity. For problems with a variable viscosity, the reference viscosity should be a value that adequately represents the order of magnitude of the viscosities that appear, such as an average value or the value one would use to compute a Rayleigh number.
+
+Units: $Pa \, s$
+</documentation>
+<pattern>
+316
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20viscosity>
+<Strain_20rate_20residual_20tolerance>
+<value>
+1e-22
+</value>
+<default_value>
+1e-22
+</default_value>
+<documentation>
+Tolerance for correct diffusion/dislocation strain rate ratio.
+</documentation>
+<pattern>
+317
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Strain_20rate_20residual_20tolerance>
+<Maximum_20strain_20rate_20ratio_20iterations>
+<value>
+40
+</value>
+<default_value>
+40
+</default_value>
+<documentation>
+Maximum number of iterations to find the correct diffusion/dislocation strain rate ratio.
+</documentation>
+<pattern>
+318
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Maximum_20strain_20rate_20ratio_20iterations>
+<Thermal_20diffusivity>
+<value>
+0.8e-6
+</value>
+<default_value>
+0.8e-6
+</default_value>
+<documentation>
+Units: $m^2/s$
+</documentation>
+<pattern>
+319
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20diffusivity>
+<Heat_20capacity>
+<value>
+1.25e3
+</value>
+<default_value>
+1.25e3
+</default_value>
+<documentation>
+The value of the specific heat $C_p$. Units: $J/kg/K$
+</documentation>
+<pattern>
+320
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Heat_20capacity>
+<Densities>
+<value>
+3300.
+</value>
+<default_value>
+3300.
+</default_value>
+<documentation>
+List of densities, $\rho$, for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: $kg / m^3$
+</documentation>
+<pattern>
+321
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Densities>
+<Thermal_20expansivities>
+<value>
+3.5e-5
+</value>
+<default_value>
+3.5e-5
+</default_value>
+<documentation>
+List of thermal expansivities for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: $1 / K$
+</documentation>
+<pattern>
+322
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Thermal_20expansivities>
+<Grain_20size>
+<value>
+1e-3
+</value>
+<default_value>
+1e-3
+</default_value>
+<documentation>
+Units: $m$
+</documentation>
+<pattern>
+323
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Grain_20size>
+<Viscosity_20averaging_20scheme>
+<value>
+harmonic
+</value>
+<default_value>
+harmonic
+</default_value>
+<documentation>
+When more than one compositional field is present at a point with different viscosities, we need to come up with an average viscosity at that point.  Select a weighted harmonic, arithmetic, geometric, or maximum composition.
+</documentation>
+<pattern>
+324
+</pattern>
+<pattern_description>
+[Selection arithmetic|harmonic|geometric|maximum composition ]
+</pattern_description>
+</Viscosity_20averaging_20scheme>
+<Prefactors_20for_20diffusion_20creep>
+<value>
+1.5e-15
+</value>
+<default_value>
+1.5e-15
+</default_value>
+<documentation>
+List of viscosity prefactors, $A$, for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value. Units: $Pa^{-1} m^{m_{\text{diffusion}}} s^{-1}$
+</documentation>
+<pattern>
+325
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Prefactors_20for_20diffusion_20creep>
+<Stress_20exponents_20for_20diffusion_20creep>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+List of stress exponents, $n_{\text{diffusion}}$, for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: None
+</documentation>
+<pattern>
+326
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Stress_20exponents_20for_20diffusion_20creep>
+<Grain_20size_20exponents_20for_20diffusion_20creep>
+<value>
+3
+</value>
+<default_value>
+3
+</default_value>
+<documentation>
+List of grain size exponents, $m_{\text{diffusion}}$, for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: None
+</documentation>
+<pattern>
+327
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Grain_20size_20exponents_20for_20diffusion_20creep>
+<Activation_20energies_20for_20diffusion_20creep>
+<value>
+375e3
+</value>
+<default_value>
+375e3
+</default_value>
+<documentation>
+List of activation energies, $E_a$, for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: $J / mol$
+</documentation>
+<pattern>
+328
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Activation_20energies_20for_20diffusion_20creep>
+<Activation_20volumes_20for_20diffusion_20creep>
+<value>
+6e-6
+</value>
+<default_value>
+6e-6
+</default_value>
+<documentation>
+List of activation volumes, $V_a$, for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: $m^3 / mol$
+</documentation>
+<pattern>
+329
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Activation_20volumes_20for_20diffusion_20creep>
+<Prefactors_20for_20dislocation_20creep>
+<value>
+1.1e-16
+</value>
+<default_value>
+1.1e-16
+</default_value>
+<documentation>
+List of viscosity prefactors, $A$, for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value. Units: $Pa^{-n_{\text{dislocation}}} s^{-1}$
+</documentation>
+<pattern>
+330
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Prefactors_20for_20dislocation_20creep>
+<Stress_20exponents_20for_20dislocation_20creep>
+<value>
+3.5
+</value>
+<default_value>
+3.5
+</default_value>
+<documentation>
+List of stress exponents, $n_{\text{dislocation}}$, for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: None
+</documentation>
+<pattern>
+331
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Stress_20exponents_20for_20dislocation_20creep>
+<Activation_20energies_20for_20dislocation_20creep>
+<value>
+530e3
+</value>
+<default_value>
+530e3
+</default_value>
+<documentation>
+List of activation energies, $E_a$, for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: $J / mol$
+</documentation>
+<pattern>
+332
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Activation_20energies_20for_20dislocation_20creep>
+<Activation_20volumes_20for_20dislocation_20creep>
+<value>
+1.4e-5
+</value>
+<default_value>
+1.4e-5
+</default_value>
+<documentation>
+List of activation volumes, $V_a$, for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: $m^3 / mol$
+</documentation>
+<pattern>
+333
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Activation_20volumes_20for_20dislocation_20creep>
+</Diffusion_20dislocation>
+<Drucker_20Prager>
+<Reference_20density>
+<value>
+3300
+</value>
+<default_value>
+3300
+</default_value>
+<documentation>
+The reference density $\rho_0$. Units: $kg/m^3$.
+</documentation>
+<pattern>
+334
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20density>
+<Reference_20temperature>
+<value>
+293
+</value>
+<default_value>
+293
+</default_value>
+<documentation>
+The reference temperature $T_0$. The reference temperature is used in the density calculation. Units: $K$.
+</documentation>
+<pattern>
+335
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Reference_20viscosity>
+<value>
+1e22
+</value>
+<default_value>
+1e22
+</default_value>
+<documentation>
+The reference viscosity that is used for pressure scaling. To understand how pressure scaling works, take a look at \cite{KHB12}. In particular, the value of this parameter would not affect the solution computed by \aspect{} if we could do arithmetic exactly; however, computers do arithmetic in finite precision, and consequently we need to scale quantities in ways so that their magnitudes are roughly the same. As explained in \cite{KHB12}, we scale the pressure during some computations (never visible by users) by a factor that involves a reference viscosity. This parameter describes this reference viscosity.
+
+For problems with a constant viscosity, you will generally want to choose the reference viscosity equal to the actual viscosity. For problems with a variable viscosity, the reference viscosity should be a value that adequately represents the order of magnitude of the viscosities that appear, such as an average value or the value one would use to compute a Rayleigh number.
+
+Units: $Pa \, s$
+</documentation>
+<pattern>
+336
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20viscosity>
+<Thermal_20conductivity>
+<value>
+4.7
+</value>
+<default_value>
+4.7
+</default_value>
+<documentation>
+The value of the thermal conductivity $k$. Units: $W/m/K$.
+</documentation>
+<pattern>
+337
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20conductivity>
+<Reference_20specific_20heat>
+<value>
+1250
+</value>
+<default_value>
+1250
+</default_value>
+<documentation>
+The value of the specific heat $C_p$. Units: $J/kg/K$.
+</documentation>
+<pattern>
+338
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20specific_20heat>
+<Thermal_20expansion_20coefficient>
+<value>
+2e-5
+</value>
+<default_value>
+2e-5
+</default_value>
+<documentation>
+The value of the thermal expansion coefficient $\beta$. Units: $1/K$.
+</documentation>
+<pattern>
+339
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20expansion_20coefficient>
+<Viscosity>
+<Minimum_20viscosity>
+<value>
+1e19
+</value>
+<default_value>
+1e19
+</default_value>
+<documentation>
+The value of the minimum viscosity cutoff $\eta_min$. Units: $Pa\;s$.
+</documentation>
+<pattern>
+340
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20viscosity>
+<Maximum_20viscosity>
+<value>
+1e24
+</value>
+<default_value>
+1e24
+</default_value>
+<documentation>
+The value of the maximum viscosity cutoff $\eta_max$. Units: $Pa\;s$.
+</documentation>
+<pattern>
+341
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20viscosity>
+<Reference_20strain_20rate>
+<value>
+1e-15
+</value>
+<default_value>
+1e-15
+</default_value>
+<documentation>
+The value of the initial strain rate prescribed during the first nonlinear iteration $\dot{\epsilon}_ref$. Units: $1/s$.
+</documentation>
+<pattern>
+342
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20strain_20rate>
+<Angle_20of_20internal_20friction>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The value of the angle of internal friction $\phi$. For a value of zero, in 2D the von Mises criterion is retrieved. Angles higher than 30 degrees are harder to solve numerically. Units: degrees.
+</documentation>
+<pattern>
+343
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Angle_20of_20internal_20friction>
+<Cohesion>
+<value>
+2e7
+</value>
+<default_value>
+2e7
+</default_value>
+<documentation>
+The value of the cohesion $C$. Units: $Pa$.
+</documentation>
+<pattern>
+344
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Cohesion>
+</Viscosity>
+</Drucker_20Prager>
+<Dynamic_20Friction>
+<Reference_20temperature>
+<value>
+293
+</value>
+<default_value>
+293
+</default_value>
+<documentation>
+The reference temperature $T_0$. Units: $K$.
+</documentation>
+<pattern>
+345
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Densities>
+<value>
+3300.
+</value>
+<default_value>
+3300.
+</default_value>
+<documentation>
+List of densities for background mantle and compositional fields,for a total of N+1 values, where N is the number of compositional fields.If only one value is given, then all use the same value.  Units: $kg / m^3$
+</documentation>
+<pattern>
+346
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Densities>
+<Thermal_20expansivities>
+<value>
+4.e-5
+</value>
+<default_value>
+4.e-5
+</default_value>
+<documentation>
+List of thermal expansivities for background mantle and compositional fields,for a total of N+1 values, where N is the number of compositional fields.If only one value is given, then all use the same value. Units: $1/K$
+</documentation>
+<pattern>
+347
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Thermal_20expansivities>
+<Specific_20heats>
+<value>
+1250.
+</value>
+<default_value>
+1250.
+</default_value>
+<documentation>
+List of specific heats $C_p$ for background mantle and compositional fields,for a total of N+1 values, where N is the number of compositional fields.If only one value is given, then all use the same value. Units: $J /kg /K$
+</documentation>
+<pattern>
+348
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Specific_20heats>
+<Thermal_20conductivities>
+<value>
+4.7
+</value>
+<default_value>
+4.7
+</default_value>
+<documentation>
+List of thermal conductivities for background mantle and compositional fields,for a total of N+1 values, where N is the number of compositional fields.If only one value is given, then all use the same value. Units: $W/m/K$.
+</documentation>
+<pattern>
+349
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Thermal_20conductivities>
+<Viscosity_20averaging_20scheme>
+<value>
+harmonic
+</value>
+<default_value>
+harmonic
+</default_value>
+<documentation>
+When more than one compositional field is present at a point with different viscosities, we need to come up with an average viscosity at that point.  Select a weighted harmonic, arithmetic, geometric, or maximum composition.
+</documentation>
+<pattern>
+350
+</pattern>
+<pattern_description>
+[Selection arithmetic|harmonic|geometric|maximum composition ]
+</pattern_description>
+</Viscosity_20averaging_20scheme>
+<Viscosities>
+<Minimum_20viscosity>
+<value>
+1e19
+</value>
+<default_value>
+1e19
+</default_value>
+<documentation>
+The value of the minimum viscosity cutoff $\eta_min$. Units: $Pa\;s$.
+</documentation>
+<pattern>
+351
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20viscosity>
+<Maximum_20viscosity>
+<value>
+1e24
+</value>
+<default_value>
+1e24
+</default_value>
+<documentation>
+The value of the maximum viscosity cutoff $\eta_max$. Units: $Pa\;s$.
+</documentation>
+<pattern>
+352
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20viscosity>
+<Reference_20strain_20rate>
+<value>
+1e-15
+</value>
+<default_value>
+1e-15
+</default_value>
+<documentation>
+The value of the initial strain rate prescribed during the first nonlinear iteration $\dot{\epsilon}_ref$. Units: $1/s$.
+</documentation>
+<pattern>
+353
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20strain_20rate>
+<Coefficients_20of_20static_20friction>
+<value>
+0.5
+</value>
+<default_value>
+0.5
+</default_value>
+<documentation>
+List of coefficients of static friction for background mantle and compositional fields,for a total of N+1 values, where N is the number of compositional fields.If only one value is given, then all use the same value. Units: $dimensionless$
+</documentation>
+<pattern>
+354
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Coefficients_20of_20static_20friction>
+<Coefficients_20of_20dynamic_20friction>
+<value>
+0.4
+</value>
+<default_value>
+0.4
+</default_value>
+<documentation>
+List of coefficients of dynamic friction for background mantle and compositional fields,for a total of N+1 values, where N is the number of compositional fields.If only one value is given, then all use the same value. Units: $dimensionless$
+</documentation>
+<pattern>
+355
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Coefficients_20of_20dynamic_20friction>
+<Cohesions>
+<value>
+4.e6
+</value>
+<default_value>
+4.e6
+</default_value>
+<documentation>
+List of cohesions for background mantle and compositional fields,for a total of N+1 values, where N is the number of compositional fields.If only one value is given, then all use the same value. Units: $Pa$
+</documentation>
+<pattern>
+356
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Cohesions>
+<Background_20Viscosities>
+<value>
+1.e20
+</value>
+<default_value>
+1.e20
+</default_value>
+<documentation>
+List of background viscosities for mantle and compositional fields,for a total of N+1 values, where N is the number of compositional fields.If only one value is given, then all use the same value. Units: $Pa \, s $
+</documentation>
+<pattern>
+357
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Background_20Viscosities>
+</Viscosities>
+</Dynamic_20Friction>
+<Grain_20size_20model>
+<Reference_20density>
+<value>
+3300
+</value>
+<default_value>
+3300
+</default_value>
+<documentation>
+The reference density $\rho_0$. Units: $kg/m^3$.
+</documentation>
+<pattern>
+358
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20density>
+<Reference_20temperature>
+<value>
+293
+</value>
+<default_value>
+293
+</default_value>
+<documentation>
+The reference temperature $T_0$. Units: $K$.
+</documentation>
+<pattern>
+359
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Viscosity>
+<value>
+5e24
+</value>
+<default_value>
+5e24
+</default_value>
+<documentation>
+The value of the constant viscosity. Units: $kg/m/s$.
+</documentation>
+<pattern>
+360
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Viscosity>
+<Thermal_20conductivity>
+<value>
+4.7
+</value>
+<default_value>
+4.7
+</default_value>
+<documentation>
+The value of the thermal conductivity $k$. Units: $W/m/K$.
+</documentation>
+<pattern>
+361
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20conductivity>
+<Reference_20specific_20heat>
+<value>
+1250
+</value>
+<default_value>
+1250
+</default_value>
+<documentation>
+The value of the specific heat $cp$. Units: $J/kg/K$.
+</documentation>
+<pattern>
+362
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20specific_20heat>
+<Thermal_20expansion_20coefficient>
+<value>
+2e-5
+</value>
+<default_value>
+2e-5
+</default_value>
+<documentation>
+The value of the thermal expansion coefficient $\alpha$. Units: $1/K$.
+</documentation>
+<pattern>
+363
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20expansion_20coefficient>
+<Reference_20compressibility>
+<value>
+4e-12
+</value>
+<default_value>
+4e-12
+</default_value>
+<documentation>
+The value of the reference compressibility. Units: $1/Pa$.
+</documentation>
+<pattern>
+364
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20compressibility>
+<Phase_20transition_20depths>
+<value/>
+<default_value/>
+<documentation>
+A list of depths where phase transitions occur. Values must monotonically increase. Units: $m$.
+</documentation>
+<pattern>
+365
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Phase_20transition_20depths>
+<Phase_20transition_20temperatures>
+<value/>
+<default_value/>
+<documentation>
+A list of temperatures where phase transitions occur. Higher or lower temperatures lead to phase transition ocurring in smaller or greater depths than given in Phase transition depths, depending on the Clapeyron slope given in Phase transition Clapeyron slopes. List must have the same number of entries as Phase transition depths. Units: $K$.
+</documentation>
+<pattern>
+366
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Phase_20transition_20temperatures>
+<Phase_20transition_20widths>
+<value/>
+<default_value/>
+<documentation>
+A list of widths for each phase transition. This is only use to specify the region where the recrystallized grain size is assigned after material has crossed a phase transition and should accordingly be chosen similar to the maximum cell width expected at the phase transition.List must have the same number of entries as Phase transition depths. Units: $m$.
+</documentation>
+<pattern>
+367
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Phase_20transition_20widths>
+<Phase_20transition_20Clapeyron_20slopes>
+<value/>
+<default_value/>
+<documentation>
+A list of Clapeyron slopes for each phase transition. A positive Clapeyron slope indicates that the phase transition will occur in a greater depth, if the temperature is higher than the one given in Phase transition temperatures and in a smaller depth, if the temperature is smaller than the one given in Phase transition temperatures. For negative slopes the other way round. List must have the same number of entries as Phase transition depths. Units: $Pa/K$.
+</documentation>
+<pattern>
+368
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Phase_20transition_20Clapeyron_20slopes>
+<Grain_20growth_20activation_20energy>
+<value>
+3.5e5
+</value>
+<default_value>
+3.5e5
+</default_value>
+<documentation>
+The activation energy for grain growth $E_g$. Units: $J/mol$.
+</documentation>
+<pattern>
+369
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Grain_20growth_20activation_20energy>
+<Grain_20growth_20activation_20volume>
+<value>
+8e-6
+</value>
+<default_value>
+8e-6
+</default_value>
+<documentation>
+The activation volume for grain growth $V_g$. Units: $m^3/mol$.
+</documentation>
+<pattern>
+370
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Grain_20growth_20activation_20volume>
+<Grain_20growth_20exponent>
+<value>
+3
+</value>
+<default_value>
+3
+</default_value>
+<documentation>
+The exponent of the grain growth law $p_g$. This is an experimentally determined grain growth constant. Units: none.
+</documentation>
+<pattern>
+371
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Grain_20growth_20exponent>
+<Grain_20growth_20rate_20constant>
+<value>
+1.5e-5
+</value>
+<default_value>
+1.5e-5
+</default_value>
+<documentation>
+The prefactor for the Ostwald ripening grain growth law $G_0$. This is dependent on water content, which is assumed to be 50 H/$10^6$ Si for the default value. Units: $m^{p_g}/s$.
+</documentation>
+<pattern>
+372
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Grain_20growth_20rate_20constant>
+<Minimum_20grain_20size>
+<value>
+1e-5
+</value>
+<default_value>
+1e-5
+</default_value>
+<documentation>
+The minimum grain size that is used for the material model. This parameter is introduced to limit local viscosity contrasts, but still allows for a widely varying viscosity over the whole mantle range. Units: m.
+</documentation>
+<pattern>
+399
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20grain_20size>
+<Reciprocal_20required_20strain>
+<value>
+10
+</value>
+<default_value>
+10
+</default_value>
+<documentation>
+This parameter ($\lambda$) gives an estimate of the strain necessary to achieve a new grain size. 
+</documentation>
+<pattern>
+374
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Reciprocal_20required_20strain>
+<Recrystallized_20grain_20size>
+<value/>
+<default_value/>
+<documentation>
+The grain size $d_{ph}$ to that a phase will be reduced to when crossing a phase transition. When set to zero, grain size will not be reduced. Units: m.
+</documentation>
+<pattern>
+375
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Recrystallized_20grain_20size>
+<Use_20paleowattmeter>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+A flag indicating whether the computation should be use the paleowattmeter approach of Austin and Evans (2007) for grain size reduction in the dislocation creep regime (if true) or the paleopiezometer approach from Hall and Parmetier (2003) (if false).
+</documentation>
+<pattern>
+376
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20paleowattmeter>
+<Average_20specific_20grain_20boundary_20energy>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+The average specific grain boundary energy $\gamma$. Units: $J/m^2$.
+</documentation>
+<pattern>
+377
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Average_20specific_20grain_20boundary_20energy>
+<Work_20fraction_20for_20boundary_20area_20change>
+<value>
+0.1
+</value>
+<default_value>
+0.1
+</default_value>
+<documentation>
+The fraction $\chi$ of work done by dislocation creep to change the grain boundary area. Units: $J/m^2$.
+</documentation>
+<pattern>
+378
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Work_20fraction_20for_20boundary_20area_20change>
+<Geometric_20constant>
+<value>
+3
+</value>
+<default_value>
+3
+</default_value>
+<documentation>
+The geometric constant $c$ used in the paleowattmeter grain size reduction law. Units: none.
+</documentation>
+<pattern>
+379
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Geometric_20constant>
+<Dislocation_20viscosity_20iteration_20threshold>
+<value>
+1e-3
+</value>
+<default_value>
+1e-3
+</default_value>
+<documentation>
+We need to perform an iteration inside the computation of the dislocation viscosity, because it depends on the dislocation strain rate, which depends on the dislocation viscosity itself. This number determines the termination accuracy, i.e. if the dislocation viscosity changes by less than this factor we terminate the iteration.
+</documentation>
+<pattern>
+380
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Dislocation_20viscosity_20iteration_20threshold>
+<Dislocation_20viscosity_20iteration_20number>
+<value>
+100
+</value>
+<default_value>
+100
+</default_value>
+<documentation>
+We need to perform an iteration inside the computation of the dislocation viscosity, because it depends on the dislocation strain rate, which depends on the dislocation viscosity itself. This number determines the maximum number of iterations that are performed. 
+</documentation>
+<pattern>
+381
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Dislocation_20viscosity_20iteration_20number>
+<Dislocation_20creep_20exponent>
+<value>
+3.5
+</value>
+<default_value>
+3.5
+</default_value>
+<documentation>
+The power-law exponent $n_{dis}$ for dislocation creep. Units: none.
+</documentation>
+<pattern>
+382
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Dislocation_20creep_20exponent>
+<Dislocation_20activation_20energy>
+<value>
+4.8e5
+</value>
+<default_value>
+4.8e5
+</default_value>
+<documentation>
+The activation energy for dislocation creep $E_{dis}$. Units: $J/mol$.
+</documentation>
+<pattern>
+383
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Dislocation_20activation_20energy>
+<Dislocation_20activation_20volume>
+<value>
+1.1e-5
+</value>
+<default_value>
+1.1e-5
+</default_value>
+<documentation>
+The activation volume for dislocation creep $V_{dis}$. Units: $m^3/mol$.
+</documentation>
+<pattern>
+384
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Dislocation_20activation_20volume>
+<Dislocation_20creep_20prefactor>
+<value>
+4.5e-15
+</value>
+<default_value>
+4.5e-15
+</default_value>
+<documentation>
+The prefactor for the dislocation creep law $A_{dis}$. Units: $Pa^{-n_{dis}}/s$.
+</documentation>
+<pattern>
+385
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Dislocation_20creep_20prefactor>
+<Diffusion_20creep_20exponent>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+The power-law exponent $n_{diff}$ for diffusion creep. Units: none.
+</documentation>
+<pattern>
+386
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Diffusion_20creep_20exponent>
+<Diffusion_20activation_20energy>
+<value>
+3.35e5
+</value>
+<default_value>
+3.35e5
+</default_value>
+<documentation>
+The activation energy for diffusion creep $E_{diff}$. Units: $J/mol$.
+</documentation>
+<pattern>
+387
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Diffusion_20activation_20energy>
+<Diffusion_20activation_20volume>
+<value>
+4e-6
+</value>
+<default_value>
+4e-6
+</default_value>
+<documentation>
+The activation volume for diffusion creep $V_{diff}$. Units: $m^3/mol$.
+</documentation>
+<pattern>
+388
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Diffusion_20activation_20volume>
+<Diffusion_20creep_20prefactor>
+<value>
+7.4e-15
+</value>
+<default_value>
+7.4e-15
+</default_value>
+<documentation>
+The prefactor for the diffusion creep law $A_{diff}$. Units: $m^{p_{diff}} Pa^{-n_{diff}}/s$.
+</documentation>
+<pattern>
+389
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Diffusion_20creep_20prefactor>
+<Diffusion_20creep_20grain_20size_20exponent>
+<value>
+3
+</value>
+<default_value>
+3
+</default_value>
+<documentation>
+The diffusion creep grain size exponent $p_{diff}$ that determines the dependence of vescosity on grain size. Units: none.
+</documentation>
+<pattern>
+390
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Diffusion_20creep_20grain_20size_20exponent>
+<Maximum_20temperature_20dependence_20of_20viscosity>
+<value>
+100
+</value>
+<default_value>
+100
+</default_value>
+<documentation>
+The factor by which viscosity at adiabatic temperature and ambient temperature are allowed to differ (a value of x means that the viscosity can be x times higher or x times lower compared to the value at adiabatic temperature. This parameter is introduced to limit local viscosity contrasts, but still allow for a widely varying viscosity over the whole mantle range. Units: none.
+</documentation>
+<pattern>
+391
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20temperature_20dependence_20of_20viscosity>
+<Minimum_20viscosity>
+<value>
+1e18
+</value>
+<default_value>
+1e18
+</default_value>
+<documentation>
+The minimum viscosity that is allowed in the whole model domain. Units: Pa \, s.
+</documentation>
+<pattern>
+392
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20viscosity>
+<Maximum_20viscosity>
+<value>
+1e26
+</value>
+<default_value>
+1e26
+</default_value>
+<documentation>
+The maximum viscosity that is allowed in the whole model domain. Units: Pa \, s.
+</documentation>
+<pattern>
+393
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20viscosity>
+<Minimum_20specific_20heat>
+<value>
+500
+</value>
+<default_value>
+500
+</default_value>
+<documentation>
+The minimum specific heat that is allowed in the whole model domain. Units: J/kg/K.
+</documentation>
+<pattern>
+394
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20specific_20heat>
+<Maximum_20specific_20heat>
+<value>
+6000
+</value>
+<default_value>
+6000
+</default_value>
+<documentation>
+The maximum specific heat that is allowed in the whole model domain. Units: J/kg/K.
+</documentation>
+<pattern>
+395
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20specific_20heat>
+<Minimum_20thermal_20expansivity>
+<value>
+1e-5
+</value>
+<default_value>
+1e-5
+</default_value>
+<documentation>
+The minimum thermal expansivity that is allowed in the whole model domain. Units: 1/K.
+</documentation>
+<pattern>
+396
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20thermal_20expansivity>
+<Maximum_20thermal_20expansivity>
+<value>
+1e-3
+</value>
+<default_value>
+1e-3
+</default_value>
+<documentation>
+The maximum thermal expansivity that is allowed in the whole model domain. Units: 1/K.
+</documentation>
+<pattern>
+397
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20thermal_20expansivity>
+<Maximum_20latent_20heat_20substeps>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+The maximum number of substeps over the temperature pressure range to calculate the averaged enthalpy gradient over a cell.
+</documentation>
+<pattern>
+398
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Maximum_20latent_20heat_20substeps>
+<Lower_20mantle_20grain_20size_20scaling>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+A scaling factor for the grain size in the lower mantle. In models where the high grain size contrast between the upper and lower mantle causes numerical problems, the grain size in the lower mantle can be scaled to a larger value, simultaneously scaling the viscosity prefactors and grain growth parameters to keep the same physical behavior. Differences to the original formulation only occur when material with a smaller grain size than the recrystallization grain size cross the upper-lower mantle boundary. The real grain size can be obtained by dividing the model grain size by this value. Units: none.
+</documentation>
+<pattern>
+400
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Lower_20mantle_20grain_20size_20scaling>
+<Advect_20logarithm_20of_20grain_20size>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+This parameter determines whether to advect the logarithm of the grain size or the grain size itself. The equation and the physics are the same, but for problems with high grain size gradients it might be preferable to advect the logarithm. 
+</documentation>
+<pattern>
+401
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Advect_20logarithm_20of_20grain_20size>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/material-model/steinberger/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/material-model/steinberger/
+</default_value>
+<documentation>
+The path to the model data. The path may also include the special text &apos;$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the &apos;data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+402
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Material_20file_20names>
+<value>
+pyr-ringwood88.txt
+</value>
+<default_value>
+pyr-ringwood88.txt
+</default_value>
+<documentation>
+The file names of the material data. List with as many components as active compositional fields (material data is assumed to be in order with the ordering of the fields). 
+</documentation>
+<pattern>
+403
+</pattern>
+<pattern_description>
+[List of &lt;[Anything]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Material_20file_20names>
+<Derivatives_20file_20names>
+<value/>
+<default_value/>
+<documentation>
+The file names of the enthalpy derivatives data. List with as many components as active compositional fields (material data is assumed to be in order with the ordering of the fields). 
+</documentation>
+<pattern>
+404
+</pattern>
+<pattern_description>
+[List of &lt;[Anything]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Derivatives_20file_20names>
+<Use_20table_20properties>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+This parameter determines whether to use the table properties also for density, thermal expansivity and specific heat. If false the properties are generated as in the simple compressible plugin.
+</documentation>
+<pattern>
+405
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20table_20properties>
+<Material_20file_20format>
+<value>
+perplex
+</value>
+<default_value>
+perplex
+</default_value>
+<documentation>
+The material file format to be read in the property tables.
+</documentation>
+<pattern>
+406
+</pattern>
+<pattern_description>
+[Selection perplex|hefesto ]
+</pattern_description>
+</Material_20file_20format>
+<Use_20enthalpy_20for_20material_20properties>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+This parameter determines whether to use the enthalpy to calculate the thermal expansivity and specific heat (if true) or use the thermal expansivity and specific heat values from the material properties table directly (if false).
+</documentation>
+<pattern>
+407
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20enthalpy_20for_20material_20properties>
+<Bilinear_20interpolation>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+This parameter determines whether to use bilinear interpolation to compute material properties (slower but more accurate).
+</documentation>
+<pattern>
+408
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Bilinear_20interpolation>
+</Grain_20size_20model>
+<Latent_20heat>
+<Reference_20density>
+<value>
+3300
+</value>
+<default_value>
+3300
+</default_value>
+<documentation>
+Reference density $\rho_0$. Units: $kg/m^3$.
+</documentation>
+<pattern>
+409
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20density>
+<Reference_20temperature>
+<value>
+293
+</value>
+<default_value>
+293
+</default_value>
+<documentation>
+The reference temperature $T_0$. Units: $K$.
+</documentation>
+<pattern>
+410
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Viscosity>
+<value>
+5e24
+</value>
+<default_value>
+5e24
+</default_value>
+<documentation>
+The value of the constant viscosity. Units: $kg/m/s$.
+</documentation>
+<pattern>
+411
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Viscosity>
+<Composition_20viscosity_20prefactor>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+A linear dependency of viscosity on composition. Dimensionless prefactor.
+</documentation>
+<pattern>
+412
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Composition_20viscosity_20prefactor>
+<Thermal_20viscosity_20exponent>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The temperature dependence of viscosity. Dimensionless exponent.
+</documentation>
+<pattern>
+413
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20viscosity_20exponent>
+<Thermal_20conductivity>
+<value>
+2.38
+</value>
+<default_value>
+2.38
+</default_value>
+<documentation>
+The value of the thermal conductivity $k$. Units: $W/m/K$.
+</documentation>
+<pattern>
+414
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20conductivity>
+<Reference_20specific_20heat>
+<value>
+1250
+</value>
+<default_value>
+1250
+</default_value>
+<documentation>
+The value of the specific heat $C_p$. Units: $J/kg/K$.
+</documentation>
+<pattern>
+415
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20specific_20heat>
+<Thermal_20expansion_20coefficient>
+<value>
+4e-5
+</value>
+<default_value>
+4e-5
+</default_value>
+<documentation>
+The value of the thermal expansion coefficient $\beta$. Units: $1/K$.
+</documentation>
+<pattern>
+416
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20expansion_20coefficient>
+<Compressibility>
+<value>
+5.124e-12
+</value>
+<default_value>
+5.124e-12
+</default_value>
+<documentation>
+The value of the compressibility $\kappa$. Units: $1/Pa$.
+</documentation>
+<pattern>
+417
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Compressibility>
+<Density_20differential_20for_20compositional_20field_201>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+If compositional fields are used, then one would frequently want to make the density depend on these fields. In this simple material model, we make the following assumptions: if no compositional fields are used in the current simulation, then the density is simply the usual one with its linear dependence on the temperature. If there are compositional fields, then the density only depends on the first one in such a way that the density has an additional term of the kind $+\Delta \rho \; c_1(\mathbf x)$. This parameter describes the value of $\Delta \rho$. Units: $kg/m^3/\textrm{unit change in composition}$.
+</documentation>
+<pattern>
+418
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Density_20differential_20for_20compositional_20field_201>
+<Phase_20transition_20depths>
+<value/>
+<default_value/>
+<documentation>
+A list of depths where phase transitions occur. Values must monotonically increase. Units: $m$.
+</documentation>
+<pattern>
+419
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Phase_20transition_20depths>
+<Phase_20transition_20widths>
+<value/>
+<default_value/>
+<documentation>
+A list of widths for each phase transition, in terms of depth. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition depths. Units: $m$.
+</documentation>
+<pattern>
+420
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Phase_20transition_20widths>
+<Phase_20transition_20pressures>
+<value/>
+<default_value/>
+<documentation>
+A list of pressures where phase transitions occur. Values must monotonically increase. Define transition by depth instead of pressure must be set to false to use this parameter. Units: $Pa$.
+</documentation>
+<pattern>
+421
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Phase_20transition_20pressures>
+<Phase_20transition_20pressure_20widths>
+<value/>
+<default_value/>
+<documentation>
+A list of widths for each phase transition, in terms of pressure. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition pressures. Define transition by depth instead of pressure must be set to false to use this parameter. Units: $Pa$.
+</documentation>
+<pattern>
+422
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Phase_20transition_20pressure_20widths>
+<Define_20transition_20by_20depth_20instead_20of_20pressure>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+Whether to list phase transitions by depth or pressure. If this parameter is true, then the input file will use Phase transitions depths and Phase transition widths to define the phase transition. If it is false, the parameter file will read in phase transition data from Phase transition pressures and Phase transition pressure widths.
+</documentation>
+<pattern>
+423
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Define_20transition_20by_20depth_20instead_20of_20pressure>
+<Phase_20transition_20temperatures>
+<value/>
+<default_value/>
+<documentation>
+A list of temperatures where phase transitions occur. Higher or lower temperatures lead to phase transition occurring in smaller or greater depths than given in Phase transition depths, depending on the Clapeyron slope given in Phase transition Clapeyron slopes. List must have the same number of entries as Phase transition depths. Units: $K$.
+</documentation>
+<pattern>
+424
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Phase_20transition_20temperatures>
+<Phase_20transition_20Clapeyron_20slopes>
+<value/>
+<default_value/>
+<documentation>
+A list of Clapeyron slopes for each phase transition. A positive Clapeyron slope indicates that the phase transition will occur in a greater depth, if the temperature is higher than the one given in Phase transition temperatures and in a smaller depth, if the temperature is smaller than the one given in Phase transition temperatures. For negative slopes the other way round. List must have the same number of entries as Phase transition depths. Units: $Pa/K$.
+</documentation>
+<pattern>
+425
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Phase_20transition_20Clapeyron_20slopes>
+<Phase_20transition_20density_20jumps>
+<value/>
+<default_value/>
+<documentation>
+A list of density jumps at each phase transition. A positive value means that the density increases with depth. The corresponding entry in Corresponding phase for density jump determines if the density jump occurs in peridotite, eclogite or none of them.List must have the same number of entries as Phase transition depths. Units: $kg/m^3$.
+</documentation>
+<pattern>
+426
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Phase_20transition_20density_20jumps>
+<Corresponding_20phase_20for_20density_20jump>
+<value/>
+<default_value/>
+<documentation>
+A list of phases, which correspond to the Phase transition density jumps. The density jumps occur only in the phase that is given by this phase value. 0 stands for the 1st compositional fields, 1 for the second compositional field and -1 for none of them. List must have the same number of entries as Phase transition depths. Units: $Pa/K$.
+</documentation>
+<pattern>
+427
+</pattern>
+<pattern_description>
+[List of &lt;[Integer range 0...2147483647 (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Corresponding_20phase_20for_20density_20jump>
+<Viscosity_20prefactors>
+<value/>
+<default_value/>
+<documentation>
+A list of prefactors for the viscosity for each phase. The reference viscosity will be multiplied by this factor to get the corresponding viscosity for each phase. List must have one more entry than Phase transition depths. Units: non-dimensional.
+</documentation>
+<pattern>
+428
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Viscosity_20prefactors>
+<Minimum_20viscosity>
+<value>
+1e19
+</value>
+<default_value>
+1e19
+</default_value>
+<documentation>
+Limit for the minimum viscosity in the model. Units: Pa \, s.
+</documentation>
+<pattern>
+429
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20viscosity>
+<Maximum_20viscosity>
+<value>
+1e24
+</value>
+<default_value>
+1e24
+</default_value>
+<documentation>
+Limit for the maximum viscosity in the model. Units: Pa \, s.
+</documentation>
+<pattern>
+430
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20viscosity>
+</Latent_20heat>
+<Latent_20heat_20melt>
+<Reference_20density>
+<value>
+3300
+</value>
+<default_value>
+3300
+</default_value>
+<documentation>
+Reference density $\rho_0$. Units: $kg/m^3$.
+</documentation>
+<pattern>
+431
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20density>
+<Reference_20temperature>
+<value>
+293
+</value>
+<default_value>
+293
+</default_value>
+<documentation>
+The reference temperature $T_0$. Units: $K$.
+</documentation>
+<pattern>
+432
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Viscosity>
+<value>
+5e24
+</value>
+<default_value>
+5e24
+</default_value>
+<documentation>
+The value of the constant viscosity. Units: $kg/m/s$.
+</documentation>
+<pattern>
+433
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Viscosity>
+<Composition_20viscosity_20prefactor>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+A linear dependency of viscosity on composition. Dimensionless prefactor.
+</documentation>
+<pattern>
+434
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Composition_20viscosity_20prefactor>
+<Thermal_20viscosity_20exponent>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The temperature dependence of viscosity. Dimensionless exponent.
+</documentation>
+<pattern>
+435
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20viscosity_20exponent>
+<Thermal_20conductivity>
+<value>
+2.38
+</value>
+<default_value>
+2.38
+</default_value>
+<documentation>
+The value of the thermal conductivity $k$. Units: $W/m/K$.
+</documentation>
+<pattern>
+436
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20conductivity>
+<Reference_20specific_20heat>
+<value>
+1250
+</value>
+<default_value>
+1250
+</default_value>
+<documentation>
+The value of the specific heat $C_p$. Units: $J/kg/K$.
+</documentation>
+<pattern>
+437
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20specific_20heat>
+<Thermal_20expansion_20coefficient>
+<value>
+4e-5
+</value>
+<default_value>
+4e-5
+</default_value>
+<documentation>
+The value of the thermal expansion coefficient $\alpha_s$. Units: $1/K$.
+</documentation>
+<pattern>
+438
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20expansion_20coefficient>
+<Thermal_20expansion_20coefficient_20of_20melt>
+<value>
+6.8e-5
+</value>
+<default_value>
+6.8e-5
+</default_value>
+<documentation>
+The value of the thermal expansion coefficient $\alpha_f$. Units: $1/K$.
+</documentation>
+<pattern>
+439
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20expansion_20coefficient_20of_20melt>
+<Compressibility>
+<value>
+5.124e-12
+</value>
+<default_value>
+5.124e-12
+</default_value>
+<documentation>
+The value of the compressibility $\kappa$. Units: $1/Pa$.
+</documentation>
+<pattern>
+440
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Compressibility>
+<Density_20differential_20for_20compositional_20field_201>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+If compositional fields are used, then one would frequently want to make the density depend on these fields. In this simple material model, we make the following assumptions: if no compositional fields are used in the current simulation, then the density is simply the usual one with its linear dependence on the temperature. If there are compositional fields, then the density only depends on the first one in such a way that the density has an additional term of the kind $+\Delta \rho \; c_1(\mathbf x)$. This parameter describes the value of $\Delta \rho$. Units: $kg/m^3/\textrm{unit change in composition}$.
+</documentation>
+<pattern>
+441
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Density_20differential_20for_20compositional_20field_201>
+<A1>
+<value>
+1085.7
+</value>
+<default_value>
+1085.7
+</default_value>
+<documentation>
+Constant parameter in the quadratic function that approximates the solidus of peridotite. Units: $°C$.
+</documentation>
+<pattern>
+442
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</A1>
+<A2>
+<value>
+1.329e-7
+</value>
+<default_value>
+1.329e-7
+</default_value>
+<documentation>
+Prefactor of the linear pressure term in the quadratic function that approximates the solidus of peridotite. Units: $°C/Pa$.
+</documentation>
+<pattern>
+443
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</A2>
+<A3>
+<value>
+-5.1e-18
+</value>
+<default_value>
+-5.1e-18
+</default_value>
+<documentation>
+Prefactor of the quadratic pressure term in the quadratic function that approximates the solidus of peridotite. Units: $°C/(Pa^2)$.
+</documentation>
+<pattern>
+444
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</A3>
+<B1>
+<value>
+1475.0
+</value>
+<default_value>
+1475.0
+</default_value>
+<documentation>
+Constant parameter in the quadratic function that approximates the lherzolite liquidus used for calculating the fraction of peridotite-derived melt. Units: $°C$.
+</documentation>
+<pattern>
+445
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</B1>
+<B2>
+<value>
+8.0e-8
+</value>
+<default_value>
+8.0e-8
+</default_value>
+<documentation>
+Prefactor of the linear pressure term in the quadratic function that approximates the  lherzolite liquidus used for calculating the fraction of peridotite-derived melt. Units: $°C/Pa$.
+</documentation>
+<pattern>
+446
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</B2>
+<B3>
+<value>
+-3.2e-18
+</value>
+<default_value>
+-3.2e-18
+</default_value>
+<documentation>
+Prefactor of the quadratic pressure term in the quadratic function that approximates the  lherzolite liquidus used for calculating the fraction of peridotite-derived melt. Units: $°C/(Pa^2)$.
+</documentation>
+<pattern>
+447
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</B3>
+<C1>
+<value>
+1780.0
+</value>
+<default_value>
+1780.0
+</default_value>
+<documentation>
+Constant parameter in the quadratic function that approximates the liquidus of peridotite. Units: $°C$.
+</documentation>
+<pattern>
+448
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</C1>
+<C2>
+<value>
+4.50e-8
+</value>
+<default_value>
+4.50e-8
+</default_value>
+<documentation>
+Prefactor of the linear pressure term in the quadratic function that approximates the liquidus of peridotite. Units: $°C/Pa$.
+</documentation>
+<pattern>
+449
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</C2>
+<C3>
+<value>
+-2.0e-18
+</value>
+<default_value>
+-2.0e-18
+</default_value>
+<documentation>
+Prefactor of the quadratic pressure term in the quadratic function that approximates the liquidus of peridotite. Units: $°C/(Pa^2)$.
+</documentation>
+<pattern>
+450
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</C3>
+<r1>
+<value>
+0.5
+</value>
+<default_value>
+0.5
+</default_value>
+<documentation>
+Constant in the linear function that approximates the clinopyroxene reaction coefficient. Units: non-dimensional.
+</documentation>
+<pattern>
+451
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</r1>
+<r2>
+<value>
+8e-11
+</value>
+<default_value>
+8e-11
+</default_value>
+<documentation>
+Prefactor of the linear pressure term in the linear function that approximates the clinopyroxene reaction coefficient. Units: $1/Pa$.
+</documentation>
+<pattern>
+452
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</r2>
+<beta>
+<value>
+1.5
+</value>
+<default_value>
+1.5
+</default_value>
+<documentation>
+Exponent of the melting temperature in the melt fraction calculation. Units: non-dimensional.
+</documentation>
+<pattern>
+453
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</beta>
+<Peridotite_20melting_20entropy_20change>
+<value>
+-300
+</value>
+<default_value>
+-300
+</default_value>
+<documentation>
+The entropy change for the phase transition from solid to melt of peridotite. Units: $J/(kg K)$.
+</documentation>
+<pattern>
+454
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Peridotite_20melting_20entropy_20change>
+<Mass_20fraction_20cpx>
+<value>
+0.15
+</value>
+<default_value>
+0.15
+</default_value>
+<documentation>
+Mass fraction of clinopyroxene in the peridotite to be molten. Units: non-dimensional.
+</documentation>
+<pattern>
+455
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Mass_20fraction_20cpx>
+<D1>
+<value>
+976.0
+</value>
+<default_value>
+976.0
+</default_value>
+<documentation>
+Constant parameter in the quadratic function that approximates the solidus of pyroxenite. Units: $°C$.
+</documentation>
+<pattern>
+456
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</D1>
+<D2>
+<value>
+1.329e-7
+</value>
+<default_value>
+1.329e-7
+</default_value>
+<documentation>
+Prefactor of the linear pressure term in the quadratic function that approximates the solidus of pyroxenite. Note that this factor is different from the value given in Sobolev, 2011, because they use the potential temperature whereas we use the absolute temperature. Units: $°C/Pa$.
+</documentation>
+<pattern>
+457
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</D2>
+<D3>
+<value>
+-5.1e-18
+</value>
+<default_value>
+-5.1e-18
+</default_value>
+<documentation>
+Prefactor of the quadratic pressure term in the quadratic function that approximates the solidus of pyroxenite. Units: $°C/(Pa^2)$.
+</documentation>
+<pattern>
+458
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</D3>
+<E1>
+<value>
+663.8
+</value>
+<default_value>
+663.8
+</default_value>
+<documentation>
+Prefactor of the linear depletion term in the quadratic function that approximates the melt fraction of pyroxenite. Units: $°C/Pa$.
+</documentation>
+<pattern>
+459
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</E1>
+<E2>
+<value>
+-611.4
+</value>
+<default_value>
+-611.4
+</default_value>
+<documentation>
+Prefactor of the quadratic depletion term in the quadratic function that approximates the melt fraction of pyroxenite. Units: $°C/(Pa^2)$.
+</documentation>
+<pattern>
+460
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</E2>
+<Pyroxenite_20melting_20entropy_20change>
+<value>
+-400
+</value>
+<default_value>
+-400
+</default_value>
+<documentation>
+The entropy change for the phase transition from solid to melt of pyroxenite. Units: $J/(kg K)$.
+</documentation>
+<pattern>
+461
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Pyroxenite_20melting_20entropy_20change>
+<Maximum_20pyroxenite_20melt_20fraction>
+<value>
+0.5429
+</value>
+<default_value>
+0.5429
+</default_value>
+<documentation>
+Maximum melt fraction of pyroxenite in this parameterization. At higher temperatures peridotite begins to melt.
+</documentation>
+<pattern>
+462
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20pyroxenite_20melt_20fraction>
+<Relative_20density_20of_20melt>
+<value>
+0.9
+</value>
+<default_value>
+0.9
+</default_value>
+<documentation>
+The relative density of melt compared to the solid material. This means, the density change upon melting is this parameter times the density of solid material.Units: non-dimensional.
+</documentation>
+<pattern>
+463
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Relative_20density_20of_20melt>
+</Latent_20heat_20melt>
+<Melt_20global>
+<Reference_20solid_20density>
+<value>
+3000
+</value>
+<default_value>
+3000
+</default_value>
+<documentation>
+Reference density of the solid $\rho_{s,0}$. Units: $kg/m^3$.
+</documentation>
+<pattern>
+464
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20solid_20density>
+<Reference_20melt_20density>
+<value>
+2500
+</value>
+<default_value>
+2500
+</default_value>
+<documentation>
+Reference density of the melt/fluid$\rho_{f,0}$. Units: $kg/m^3$.
+</documentation>
+<pattern>
+465
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20melt_20density>
+<Reference_20temperature>
+<value>
+293
+</value>
+<default_value>
+293
+</default_value>
+<documentation>
+The reference temperature $T_0$. The reference temperature is used in both the density and viscosity formulas. Units: $K$.
+</documentation>
+<pattern>
+466
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Reference_20shear_20viscosity>
+<value>
+5e20
+</value>
+<default_value>
+5e20
+</default_value>
+<documentation>
+The value of the constant viscosity $\eta_0$ of the solid matrix. This viscosity may be modified by both temperature and porosity dependencies. Units: $Pa \, s$.
+</documentation>
+<pattern>
+467
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20shear_20viscosity>
+<Reference_20bulk_20viscosity>
+<value>
+1e22
+</value>
+<default_value>
+1e22
+</default_value>
+<documentation>
+The value of the constant bulk viscosity $\xi_0$ of the solid matrix. This viscosity may be modified by both temperature and porosity dependencies. Units: $Pa \, s$.
+</documentation>
+<pattern>
+468
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20bulk_20viscosity>
+<Reference_20melt_20viscosity>
+<value>
+10
+</value>
+<default_value>
+10
+</default_value>
+<documentation>
+The value of the constant melt viscosity $\eta_f$. Units: $Pa \, s$.
+</documentation>
+<pattern>
+469
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20melt_20viscosity>
+<Exponential_20melt_20weakening_20factor>
+<value>
+27
+</value>
+<default_value>
+27
+</default_value>
+<documentation>
+The porosity dependence of the viscosity. Units: dimensionless.
+</documentation>
+<pattern>
+470
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Exponential_20melt_20weakening_20factor>
+<Thermal_20viscosity_20exponent>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The temperature dependence of the shear viscosity. Dimensionless exponent. See the general documentation of this model for a formula that states the dependence of the viscosity on this factor, which is called $\beta$ there.
+</documentation>
+<pattern>
+471
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20viscosity_20exponent>
+<Thermal_20bulk_20viscosity_20exponent>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The temperature dependence of the bulk viscosity. Dimensionless exponent. See the general documentation of this model for a formula that states the dependence of the viscosity on this factor, which is called $\beta$ there.
+</documentation>
+<pattern>
+472
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20bulk_20viscosity_20exponent>
+<Thermal_20conductivity>
+<value>
+4.7
+</value>
+<default_value>
+4.7
+</default_value>
+<documentation>
+The value of the thermal conductivity $k$. Units: $W/m/K$.
+</documentation>
+<pattern>
+473
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20conductivity>
+<Reference_20specific_20heat>
+<value>
+1250
+</value>
+<default_value>
+1250
+</default_value>
+<documentation>
+The value of the specific heat $C_p$. Units: $J/kg/K$.
+</documentation>
+<pattern>
+474
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20specific_20heat>
+<Thermal_20expansion_20coefficient>
+<value>
+2e-5
+</value>
+<default_value>
+2e-5
+</default_value>
+<documentation>
+The value of the thermal expansion coefficient $\beta$. Units: $1/K$.
+</documentation>
+<pattern>
+475
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20expansion_20coefficient>
+<Reference_20permeability>
+<value>
+1e-8
+</value>
+<default_value>
+1e-8
+</default_value>
+<documentation>
+Reference permeability of the solid host rock.Units: $m^2$.
+</documentation>
+<pattern>
+476
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20permeability>
+<Depletion_20density_20change>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The density contrast between material with a depletion of 1 and a depletion of zero. Negative values indicate lower densities of depleted material. Depletion is indicated by the compositional field with the name peridotite. Not used if this field does not exist in the model. Units: $kg/m^3$.
+</documentation>
+<pattern>
+477
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Depletion_20density_20change>
+<Surface_20solidus>
+<value>
+1300
+</value>
+<default_value>
+1300
+</default_value>
+<documentation>
+Solidus for a pressure of zero. Units: $K$.
+</documentation>
+<pattern>
+478
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Surface_20solidus>
+<Depletion_20solidus_20change>
+<value>
+200.0
+</value>
+<default_value>
+200.0
+</default_value>
+<documentation>
+The solidus temperature change for a depletion of 100\%. For positive values, the solidus gets increased for a positive peridotite field (depletion) and lowered for a negative peridotite field (enrichment). Scaling with depletion is linear. Only active when fractional melting is used. Units: $K$.
+</documentation>
+<pattern>
+479
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Depletion_20solidus_20change>
+<Pressure_20solidus_20change>
+<value>
+6e-8
+</value>
+<default_value>
+6e-8
+</default_value>
+<documentation>
+The linear solidus temperature change with pressure. For positive values, the solidus gets increased for positive pressures. Units: $1/Pa$.
+</documentation>
+<pattern>
+480
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Pressure_20solidus_20change>
+<Solid_20compressibility>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The value of the compressibility of the solid matrix. Units: $1/Pa$.
+</documentation>
+<pattern>
+481
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Solid_20compressibility>
+<Melt_20compressibility>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The value of the compressibility of the melt. Units: $1/Pa$.
+</documentation>
+<pattern>
+482
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Melt_20compressibility>
+<Melt_20bulk_20modulus_20derivative>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The value of the pressure derivative of the melt bulk modulus. Units: None.
+</documentation>
+<pattern>
+483
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Melt_20bulk_20modulus_20derivative>
+<Include_20melting_20and_20freezing>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+Whether to include melting and freezing (according to a simplified linear melting approximation in the model (if true), or not (if false).
+</documentation>
+<pattern>
+484
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Include_20melting_20and_20freezing>
+<Melting_20time_20scale_20for_20operator_20splitting>
+<value>
+1e3
+</value>
+<default_value>
+1e3
+</default_value>
+<documentation>
+In case the operator splitting scheme is used, the porosity field can not be set to a new equilibrium melt fraction instantly, but the model has to provide a melting time scale instead. This time scale defines how fast melting happens, or more specifically, the parameter defines the time after which the deviation of the porosity from the equilibrium melt fraction will be reduced to a fraction of $1/e$. So if the melting time scale is small compared to the time step size, the reaction will be so fast that the porosity is very close to the equilibrium melt fraction after reactions are computed. Conversely, if the melting time scale is large compared to the time step size, almost no melting and freezing will occur.
+
+Also note that the melting time scale has to be larger than or equal to the reaction time step used in the operator splitting scheme, otherwise reactions can not be computed. If the model does not use operator splitting, this parameter is not used. Units: yr or s, depending on the ``Use years in output instead of seconds&apos;&apos; parameter.
+</documentation>
+<pattern>
+485
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Melting_20time_20scale_20for_20operator_20splitting>
+</Melt_20global>
+<Melt_20simple>
+<Reference_20solid_20density>
+<value>
+3000
+</value>
+<default_value>
+3000
+</default_value>
+<documentation>
+Reference density of the solid $\rho_{s,0}$. Units: $kg/m^3$.
+</documentation>
+<pattern>
+486
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20solid_20density>
+<Reference_20melt_20density>
+<value>
+2500
+</value>
+<default_value>
+2500
+</default_value>
+<documentation>
+Reference density of the melt/fluid$\rho_{f,0}$. Units: $kg/m^3$.
+</documentation>
+<pattern>
+487
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20melt_20density>
+<Reference_20temperature>
+<value>
+293
+</value>
+<default_value>
+293
+</default_value>
+<documentation>
+The reference temperature $T_0$. The reference temperature is used in both the density and viscosity formulas. Units: $K$.
+</documentation>
+<pattern>
+488
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Reference_20shear_20viscosity>
+<value>
+5e20
+</value>
+<default_value>
+5e20
+</default_value>
+<documentation>
+The value of the constant viscosity $\eta_0$ of the solid matrix. This viscosity may be modified by both temperature and porosity dependencies. Units: $Pa \, s$.
+</documentation>
+<pattern>
+489
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20shear_20viscosity>
+<Reference_20bulk_20viscosity>
+<value>
+1e22
+</value>
+<default_value>
+1e22
+</default_value>
+<documentation>
+The value of the constant bulk viscosity $\xi_0$ of the solid matrix. This viscosity may be modified by both temperature and porosity dependencies. Units: $Pa \, s$.
+</documentation>
+<pattern>
+490
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20bulk_20viscosity>
+<Reference_20melt_20viscosity>
+<value>
+10
+</value>
+<default_value>
+10
+</default_value>
+<documentation>
+The value of the constant melt viscosity $\eta_f$. Units: $Pa \, s$.
+</documentation>
+<pattern>
+491
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20melt_20viscosity>
+<Exponential_20melt_20weakening_20factor>
+<value>
+27
+</value>
+<default_value>
+27
+</default_value>
+<documentation>
+The porosity dependence of the viscosity. Units: dimensionless.
+</documentation>
+<pattern>
+492
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Exponential_20melt_20weakening_20factor>
+<Thermal_20viscosity_20exponent>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The temperature dependence of the shear viscosity. Dimensionless exponent. See the general documentation of this model for a formula that states the dependence of the viscosity on this factor, which is called $\beta$ there.
+</documentation>
+<pattern>
+493
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20viscosity_20exponent>
+<Thermal_20bulk_20viscosity_20exponent>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The temperature dependence of the bulk viscosity. Dimensionless exponent. See the general documentation of this model for a formula that states the dependence of the viscosity on this factor, which is called $\beta$ there.
+</documentation>
+<pattern>
+494
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20bulk_20viscosity_20exponent>
+<Thermal_20conductivity>
+<value>
+4.7
+</value>
+<default_value>
+4.7
+</default_value>
+<documentation>
+The value of the thermal conductivity $k$. Units: $W/m/K$.
+</documentation>
+<pattern>
+495
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20conductivity>
+<Reference_20specific_20heat>
+<value>
+1250
+</value>
+<default_value>
+1250
+</default_value>
+<documentation>
+The value of the specific heat $C_p$. Units: $J/kg/K$.
+</documentation>
+<pattern>
+496
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20specific_20heat>
+<Thermal_20expansion_20coefficient>
+<value>
+2e-5
+</value>
+<default_value>
+2e-5
+</default_value>
+<documentation>
+The value of the thermal expansion coefficient $\beta$. Units: $1/K$.
+</documentation>
+<pattern>
+497
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20expansion_20coefficient>
+<Reference_20permeability>
+<value>
+1e-8
+</value>
+<default_value>
+1e-8
+</default_value>
+<documentation>
+Reference permeability of the solid host rock.Units: $m^2$.
+</documentation>
+<pattern>
+498
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20permeability>
+<Melt_20extraction_20depth>
+<value>
+1000.0
+</value>
+<default_value>
+1000.0
+</default_value>
+<documentation>
+Depth above that melt will be extracted from the model, which is done by a negative reaction term proportional to the porosity field. Units: $m$.
+</documentation>
+<pattern>
+499
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Melt_20extraction_20depth>
+<Solid_20compressibility>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The value of the compressibility of the solid matrix. Units: $1/Pa$.
+</documentation>
+<pattern>
+500
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Solid_20compressibility>
+<Melt_20compressibility>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The value of the compressibility of the melt. Units: $1/Pa$.
+</documentation>
+<pattern>
+501
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Melt_20compressibility>
+<Melt_20bulk_20modulus_20derivative>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The value of the pressure derivative of the melt bulk modulus. Units: None.
+</documentation>
+<pattern>
+502
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Melt_20bulk_20modulus_20derivative>
+<Use_20full_20compressibility>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+If the compressibility should be used everywhere in the code (if true), changing the volume of material when the density changes, or only in the momentum conservation and advection equations (if false).
+</documentation>
+<pattern>
+503
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20full_20compressibility>
+<Use_20fractional_20melting>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+If fractional melting should be used (if true), including a solidus change based on depletion (in this case, the amount of melt that has migrated away from its origin), and freezing of melt when it has moved to a region with temperatures lower than the solidus; or if batch melting should be used (if false), assuming that the melt fraction only depends on temperature and pressure, and how much melt has already been generated at a given point, but not considering movement of melt in the melting parameterization.
+
+Note that melt does not freeze unless the &apos;Freezing rate&apos; parameter is set to a value larger than 0.
+</documentation>
+<pattern>
+504
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20fractional_20melting>
+<Freezing_20rate>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+Freezing rate of melt when in subsolidus regions. If this parameter is set to a number larger than 0.0, it specifies the fraction of melt that will freeze per year (or per second, depending on the ``Use years in output instead of seconds&apos;&apos; parameter), as soon as the porosity exceeds the equilibrium melt fraction, and the equilibrium melt fraction falls below the depletion. In this case, melt will freeze according to the given rate until one of those conditions is not fulfilled anymore. The reasoning behind this is that there should not be more melt present than the equilibrium melt fraction, as melt production decreases with increasing depletion, but the freezing process of melt also reduces the depletion by the same amount, and as soon as the depletion falls below the equilibrium melt fraction, we expect that material should melt again (no matter how much melt is present). This is quite a simplification and not a realistic freezing parameterization, but without tracking the melt composition, there is no way to compute freezing rates accurately. If this parameter is set to zero, no freezing will occur. Note that freezing can never be faster than determined by the ``Melting time scale for operator splitting&apos;&apos;. The product of the ``Freezing rate&apos;&apos; and the ``Melting time scale for operator splitting&apos;&apos; defines how fast freezing occurs with respect to melting (if the product is 0.5, melting will occur twice as fast as freezing). Units: 1/yr or 1/s, depending on the ``Use years in output instead of seconds&apos;&apos; parameter.
+</documentation>
+<pattern>
+505
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Freezing_20rate>
+<Melting_20time_20scale_20for_20operator_20splitting>
+<value>
+1e3
+</value>
+<default_value>
+1e3
+</default_value>
+<documentation>
+Because the operator splitting scheme is used, the porosity field can not be set to a new equilibrium melt fraction instantly, but the model has to provide a melting time scale instead. This time scale defines how fast melting happens, or more specifically, the parameter defines the time after which the deviation of the porosity from the equilibrium melt fraction will be reduced to a fraction of $1/e$. So if the melting time scale is small compared to the time step size, the reaction will be so fast that the porosity is very close to the equilibrium melt fraction after reactions are computed. Conversely, if the melting time scale is large compared to the time step size, almost no melting and freezing will occur.
+
+Also note that the melting time scale has to be larger than or equal to the reaction time step used in the operator splitting scheme, otherwise reactions can not be computed. Units: yr or s, depending on the ``Use years in output instead of seconds&apos;&apos; parameter.
+</documentation>
+<pattern>
+506
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Melting_20time_20scale_20for_20operator_20splitting>
+<Depletion_20density_20change>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The density contrast between material with a depletion of 1 and a depletion of zero. Negative values indicate lower densities of depleted material. Depletion is indicated by the compositional field with the name peridotite. Not used if this field does not exist in the model. Units: $kg/m^3$.
+</documentation>
+<pattern>
+507
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Depletion_20density_20change>
+<Depletion_20solidus_20change>
+<value>
+200.0
+</value>
+<default_value>
+200.0
+</default_value>
+<documentation>
+The solidus temperature change for a depletion of 100\%. For positive values, the solidus gets increased for a positive peridotite field (depletion) and lowered for a negative peridotite field (enrichment). Scaling with depletion is linear. Only active when fractional melting is used. Units: $K$.
+</documentation>
+<pattern>
+508
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Depletion_20solidus_20change>
+<A1>
+<value>
+1085.7
+</value>
+<default_value>
+1085.7
+</default_value>
+<documentation>
+Constant parameter in the quadratic function that approximates the solidus of peridotite. Units: ${}^\circ C$.
+</documentation>
+<pattern>
+509
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</A1>
+<A2>
+<value>
+1.329e-7
+</value>
+<default_value>
+1.329e-7
+</default_value>
+<documentation>
+Prefactor of the linear pressure term in the quadratic function that approximates the solidus of peridotite. Units: ${}^\circ C/Pa$.
+</documentation>
+<pattern>
+510
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</A2>
+<A3>
+<value>
+-5.1e-18
+</value>
+<default_value>
+-5.1e-18
+</default_value>
+<documentation>
+Prefactor of the quadratic pressure term in the quadratic function that approximates the solidus of peridotite. Units: ${}^\circ C/(Pa^2)$.
+</documentation>
+<pattern>
+511
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</A3>
+<B1>
+<value>
+1475.0
+</value>
+<default_value>
+1475.0
+</default_value>
+<documentation>
+Constant parameter in the quadratic function that approximates the lherzolite liquidus used for calculating the fraction of peridotite-derived melt. Units: ${}^\circ C$.
+</documentation>
+<pattern>
+512
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</B1>
+<B2>
+<value>
+8.0e-8
+</value>
+<default_value>
+8.0e-8
+</default_value>
+<documentation>
+Prefactor of the linear pressure term in the quadratic function that approximates the  lherzolite liquidus used for calculating the fraction of peridotite-derived melt. Units: ${}^\circ C/Pa$.
+</documentation>
+<pattern>
+513
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</B2>
+<B3>
+<value>
+-3.2e-18
+</value>
+<default_value>
+-3.2e-18
+</default_value>
+<documentation>
+Prefactor of the quadratic pressure term in the quadratic function that approximates the  lherzolite liquidus used for calculating the fraction of peridotite-derived melt. Units: ${}^\circ C/(Pa^2)$.
+</documentation>
+<pattern>
+514
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</B3>
+<C1>
+<value>
+1780.0
+</value>
+<default_value>
+1780.0
+</default_value>
+<documentation>
+Constant parameter in the quadratic function that approximates the liquidus of peridotite. Units: ${}^\circ C$.
+</documentation>
+<pattern>
+515
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</C1>
+<C2>
+<value>
+4.50e-8
+</value>
+<default_value>
+4.50e-8
+</default_value>
+<documentation>
+Prefactor of the linear pressure term in the quadratic function that approximates the liquidus of peridotite. Units: ${}^\circ C/Pa$.
+</documentation>
+<pattern>
+516
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</C2>
+<C3>
+<value>
+-2.0e-18
+</value>
+<default_value>
+-2.0e-18
+</default_value>
+<documentation>
+Prefactor of the quadratic pressure term in the quadratic function that approximates the liquidus of peridotite. Units: ${}^\circ C/(Pa^2)$.
+</documentation>
+<pattern>
+517
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</C3>
+<r1>
+<value>
+0.5
+</value>
+<default_value>
+0.5
+</default_value>
+<documentation>
+Constant in the linear function that approximates the clinopyroxene reaction coefficient. Units: non-dimensional.
+</documentation>
+<pattern>
+518
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</r1>
+<r2>
+<value>
+8e-11
+</value>
+<default_value>
+8e-11
+</default_value>
+<documentation>
+Prefactor of the linear pressure term in the linear function that approximates the clinopyroxene reaction coefficient. Units: $1/Pa$.
+</documentation>
+<pattern>
+519
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</r2>
+<beta>
+<value>
+1.5
+</value>
+<default_value>
+1.5
+</default_value>
+<documentation>
+Exponent of the melting temperature in the melt fraction calculation. Units: non-dimensional.
+</documentation>
+<pattern>
+520
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</beta>
+<Peridotite_20melting_20entropy_20change>
+<value>
+-300
+</value>
+<default_value>
+-300
+</default_value>
+<documentation>
+The entropy change for the phase transition from solid to melt of peridotite. Units: $J/(kg K)$.
+</documentation>
+<pattern>
+521
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Peridotite_20melting_20entropy_20change>
+<Mass_20fraction_20cpx>
+<value>
+0.15
+</value>
+<default_value>
+0.15
+</default_value>
+<documentation>
+Mass fraction of clinopyroxene in the peridotite to be molten. Units: non-dimensional.
+</documentation>
+<pattern>
+522
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Mass_20fraction_20cpx>
+</Melt_20simple>
+<Multicomponent>
+<Reference_20temperature>
+<value>
+293
+</value>
+<default_value>
+293
+</default_value>
+<documentation>
+The reference temperature $T_0$. Units: $K$.
+</documentation>
+<pattern>
+523
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Densities>
+<value>
+3300.
+</value>
+<default_value>
+3300.
+</default_value>
+<documentation>
+List of densities for background mantle and compositional fields,for a total of N+1 values, where N is the number of compositional fields.If only one value is given, then all use the same value.  Units: $kg / m^3$
+</documentation>
+<pattern>
+524
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Densities>
+<Viscosities>
+<value>
+1.e21
+</value>
+<default_value>
+1.e21
+</default_value>
+<documentation>
+List of viscosities for background mantle and compositional fields,for a total of N+1 values, where N is the number of compositional fields.If only one value is given, then all use the same value. Units: $Pa \, s$
+</documentation>
+<pattern>
+525
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Viscosities>
+<Thermal_20expansivities>
+<value>
+4.e-5
+</value>
+<default_value>
+4.e-5
+</default_value>
+<documentation>
+List of thermal expansivities for background mantle and compositional fields,for a total of N+1 values, where N is the number of compositional fields.If only one value is given, then all use the same value. Units: $1/K$
+</documentation>
+<pattern>
+526
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Thermal_20expansivities>
+<Specific_20heats>
+<value>
+1250.
+</value>
+<default_value>
+1250.
+</default_value>
+<documentation>
+List of specific heats $C_p$ for background mantle and compositional fields,for a total of N+1 values, where N is the number of compositional fields.If only one value is given, then all use the same value. Units: $J /kg /K$
+</documentation>
+<pattern>
+527
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Specific_20heats>
+<Thermal_20conductivities>
+<value>
+4.7
+</value>
+<default_value>
+4.7
+</default_value>
+<documentation>
+List of thermal conductivities for background mantle and compositional fields,for a total of N+1 values, where N is the number of compositional fields.If only one value is given, then all use the same value. Units: $W/m/K$.
+</documentation>
+<pattern>
+528
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Thermal_20conductivities>
+<Viscosity_20averaging_20scheme>
+<value>
+harmonic
+</value>
+<default_value>
+harmonic
+</default_value>
+<documentation>
+When more than one compositional field is present at a point with different viscosities, we need to come up with an average viscosity at that point.  Select a weighted harmonic, arithmetic, geometric, or maximum composition.
+</documentation>
+<pattern>
+529
+</pattern>
+<pattern_description>
+[Selection arithmetic|harmonic|geometric|maximum composition ]
+</pattern_description>
+</Viscosity_20averaging_20scheme>
+</Multicomponent>
+<Nondimensional_20model>
+<Reference_20density>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+Reference density $\rho_0$. Units: $kg/m^3$.
+</documentation>
+<pattern>
+530
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20density>
+<Ra>
+<value>
+1e4
+</value>
+<default_value>
+1e4
+</default_value>
+<documentation>
+Rayleigh number Ra
+</documentation>
+<pattern>
+531
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Ra>
+<Di>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+Dissipation number. Pick 0.0 for incompressible computations.
+</documentation>
+<pattern>
+532
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Di>
+<gamma>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+Grueneisen parameter
+</documentation>
+<pattern>
+533
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</gamma>
+<Reference_20specific_20heat>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+The value of the specific heat $C_p$. Units: $J/kg/K$.
+</documentation>
+<pattern>
+534
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20specific_20heat>
+<Viscosity_20temperature_20prefactor>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+Exponential temperature prefactor for viscosity.
+</documentation>
+<pattern>
+535
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Viscosity_20temperature_20prefactor>
+<Viscosity_20depth_20prefactor>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+Exponential depth prefactor for viscosity.
+</documentation>
+<pattern>
+536
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Viscosity_20depth_20prefactor>
+<Use_20TALA>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to use the TALA instead of the ALA approximation.
+</documentation>
+<pattern>
+537
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20TALA>
+</Nondimensional_20model>
+<PerpleX_20lookup_20model>
+<PerpleX_20input_20file_20name>
+<value>
+rock.dat
+</value>
+<default_value>
+rock.dat
+</default_value>
+<documentation>
+The name of the PerpleX input file (should end with .dat).
+</documentation>
+<pattern>
+538
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</PerpleX_20input_20file_20name>
+<Viscosity>
+<value>
+5e24
+</value>
+<default_value>
+5e24
+</default_value>
+<documentation>
+The value of the viscosity $\eta$. Units: $kg/m/s$.
+</documentation>
+<pattern>
+539
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Viscosity>
+<Thermal_20conductivity>
+<value>
+4.7
+</value>
+<default_value>
+4.7
+</default_value>
+<documentation>
+The value of the thermal conductivity $k$. Units: $W/m/K$.
+</documentation>
+<pattern>
+540
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20conductivity>
+<Minimum_20material_20temperature>
+<value>
+0.
+</value>
+<default_value>
+0.
+</default_value>
+<documentation>
+The value of the minimum temperature used to query PerpleX. Units: $K$.
+</documentation>
+<pattern>
+541
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20material_20temperature>
+<Maximum_20material_20temperature>
+<value>
+6000.
+</value>
+<default_value>
+6000.
+</default_value>
+<documentation>
+The value of the maximum temperature used to query PerpleX. Units: $K$.
+</documentation>
+<pattern>
+542
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20material_20temperature>
+<Minimum_20material_20pressure>
+<value>
+1.e5
+</value>
+<default_value>
+1.e5
+</default_value>
+<documentation>
+The value of the minimum pressure used to query PerpleX. Units: $Pa$.
+</documentation>
+<pattern>
+543
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20material_20pressure>
+<Maximum_20material_20pressure>
+<value>
+1.e12
+</value>
+<default_value>
+1.e12
+</default_value>
+<documentation>
+The value of the maximum pressure used to query PerpleX. Units: $Pa$.
+</documentation>
+<pattern>
+544
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20material_20pressure>
+</PerpleX_20lookup_20model>
+<Simple_20model>
+<Reference_20density>
+<value>
+3300
+</value>
+<default_value>
+3300
+</default_value>
+<documentation>
+Reference density $\rho_0$. Units: $kg/m^3$.
+</documentation>
+<pattern>
+545
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20density>
+<Reference_20temperature>
+<value>
+293
+</value>
+<default_value>
+293
+</default_value>
+<documentation>
+The reference temperature $T_0$. The reference temperature is used in both the density and viscosity formulas. Units: $K$.
+</documentation>
+<pattern>
+546
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Viscosity>
+<value>
+5e24
+</value>
+<default_value>
+5e24
+</default_value>
+<documentation>
+The value of the constant viscosity $\eta_0$. This viscosity may be modified by both temperature and compositional dependencies. Units: $kg/m/s$.
+</documentation>
+<pattern>
+547
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Viscosity>
+<Composition_20viscosity_20prefactor>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+A linear dependency of viscosity on the first compositional field. Dimensionless prefactor. With a value of 1.0 (the default) the viscosity does not depend on the composition. See the general documentation of this model for a formula that states the dependence of the viscosity on this factor, which is called $\xi$ there.
+</documentation>
+<pattern>
+548
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Composition_20viscosity_20prefactor>
+<Thermal_20viscosity_20exponent>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The temperature dependence of viscosity. Dimensionless exponent. See the general documentation of this model for a formula that states the dependence of the viscosity on this factor, which is called $\beta$ there.
+</documentation>
+<pattern>
+549
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20viscosity_20exponent>
+<Maximum_20thermal_20prefactor>
+<value>
+1.0e2
+</value>
+<default_value>
+1.0e2
+</default_value>
+<documentation>
+The maximum value of the viscosity prefactor associated with temperature dependence.
+</documentation>
+<pattern>
+550
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20thermal_20prefactor>
+<Minimum_20thermal_20prefactor>
+<value>
+1.0e-2
+</value>
+<default_value>
+1.0e-2
+</default_value>
+<documentation>
+The minimum value of the viscosity prefactor associated with temperature dependence.
+</documentation>
+<pattern>
+551
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20thermal_20prefactor>
+<Thermal_20conductivity>
+<value>
+4.7
+</value>
+<default_value>
+4.7
+</default_value>
+<documentation>
+The value of the thermal conductivity $k$. Units: $W/m/K$.
+</documentation>
+<pattern>
+552
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20conductivity>
+<Reference_20specific_20heat>
+<value>
+1250
+</value>
+<default_value>
+1250
+</default_value>
+<documentation>
+The value of the specific heat $C_p$. Units: $J/kg/K$.
+</documentation>
+<pattern>
+553
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20specific_20heat>
+<Thermal_20expansion_20coefficient>
+<value>
+2e-5
+</value>
+<default_value>
+2e-5
+</default_value>
+<documentation>
+The value of the thermal expansion coefficient $\alpha$. Units: $1/K$.
+</documentation>
+<pattern>
+554
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20expansion_20coefficient>
+<Density_20differential_20for_20compositional_20field_201>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+If compositional fields are used, then one would frequently want to make the density depend on these fields. In this simple material model, we make the following assumptions: if no compositional fields are used in the current simulation, then the density is simply the usual one with its linear dependence on the temperature. If there are compositional fields, then the density only depends on the first one in such a way that the density has an additional term of the kind $+\Delta \rho \; c_1(\mathbf x)$. This parameter describes the value of $\Delta \rho$. Units: $kg/m^3/\textrm{unit change in composition}$.
+</documentation>
+<pattern>
+555
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Density_20differential_20for_20compositional_20field_201>
+</Simple_20model>
+<Simple_20compressible_20model>
+<Reference_20density>
+<value>
+3300
+</value>
+<default_value>
+3300
+</default_value>
+<documentation>
+Reference density $\rho_0$. Units: $kg/m^3$.
+</documentation>
+<pattern>
+556
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20density>
+<Viscosity>
+<value>
+1e21
+</value>
+<default_value>
+1e21
+</default_value>
+<documentation>
+The value of the constant viscosity $\eta_0$. Units: $kg/m/s$.
+</documentation>
+<pattern>
+557
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Viscosity>
+<Thermal_20conductivity>
+<value>
+4.7
+</value>
+<default_value>
+4.7
+</default_value>
+<documentation>
+The value of the thermal conductivity $k$. Units: $W/m/K$.
+</documentation>
+<pattern>
+558
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20conductivity>
+<Reference_20specific_20heat>
+<value>
+1250
+</value>
+<default_value>
+1250
+</default_value>
+<documentation>
+The value of the specific heat $C_p$. Units: $J/kg/K$.
+</documentation>
+<pattern>
+559
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20specific_20heat>
+<Thermal_20expansion_20coefficient>
+<value>
+2e-5
+</value>
+<default_value>
+2e-5
+</default_value>
+<documentation>
+The value of the thermal expansion coefficient $\alpha$. Units: $1/K$.
+</documentation>
+<pattern>
+560
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20expansion_20coefficient>
+<Reference_20compressibility>
+<value>
+4e-12
+</value>
+<default_value>
+4e-12
+</default_value>
+<documentation>
+The value of the reference compressibility. Units: $1/Pa$.
+</documentation>
+<pattern>
+561
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20compressibility>
+</Simple_20compressible_20model>
+<Simpler_20model>
+<Reference_20density>
+<value>
+3300
+</value>
+<default_value>
+3300
+</default_value>
+<documentation>
+Reference density $\rho_0$. Units: $kg/m^3$.
+</documentation>
+<pattern>
+562
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20density>
+<Reference_20temperature>
+<value>
+293
+</value>
+<default_value>
+293
+</default_value>
+<documentation>
+The reference temperature $T_0$. The reference temperature is used in the density formula. Units: $K$.
+</documentation>
+<pattern>
+563
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Viscosity>
+<value>
+5e24
+</value>
+<default_value>
+5e24
+</default_value>
+<documentation>
+The value of the viscosity $\eta$. Units: $kg/m/s$.
+</documentation>
+<pattern>
+564
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Viscosity>
+<Thermal_20conductivity>
+<value>
+4.7
+</value>
+<default_value>
+4.7
+</default_value>
+<documentation>
+The value of the thermal conductivity $k$. Units: $W/m/K$.
+</documentation>
+<pattern>
+565
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20conductivity>
+<Reference_20specific_20heat>
+<value>
+1250
+</value>
+<default_value>
+1250
+</default_value>
+<documentation>
+The value of the specific heat $C_p$. Units: $J/kg/K$.
+</documentation>
+<pattern>
+566
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20specific_20heat>
+<Thermal_20expansion_20coefficient>
+<value>
+2e-5
+</value>
+<default_value>
+2e-5
+</default_value>
+<documentation>
+The value of the thermal expansion coefficient $\beta$. Units: $1/K$.
+</documentation>
+<pattern>
+567
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20expansion_20coefficient>
+</Simpler_20model>
+<Steinberger_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/material-model/steinberger/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/material-model/steinberger/
+</default_value>
+<documentation>
+The path to the model data. The path may also include the special text &apos;$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+568
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Material_20file_20names>
+<value>
+pyr-ringwood88.txt
+</value>
+<default_value>
+pyr-ringwood88.txt
+</default_value>
+<documentation>
+The file names of the material data (material data is assumed to be in order with the ordering of the compositional fields). Note that there are three options on how many files need to be listed here: 1. If only one file is provided, it is used for the whole model domain, and compositional fields are ignored. 2. If there is one more file name than the number of compositional fields, then the first file is assumed to define a `background composition&apos; that is modified by the compositional fields. If there are exactly as many files as compositional fields, the fields are assumed to represent the fractions of different materials and the average property is computed as a sum of the value of the compositional field times the material property of that field.
+</documentation>
+<pattern>
+569
+</pattern>
+<pattern_description>
+[List of &lt;[Anything]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Material_20file_20names>
+<Radial_20viscosity_20file_20name>
+<value>
+radial-visc.txt
+</value>
+<default_value>
+radial-visc.txt
+</default_value>
+<documentation>
+The file name of the radial viscosity data. 
+</documentation>
+<pattern>
+570
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Radial_20viscosity_20file_20name>
+<Lateral_20viscosity_20file_20name>
+<value>
+temp-viscosity-prefactor.txt
+</value>
+<default_value>
+temp-viscosity-prefactor.txt
+</default_value>
+<documentation>
+The file name of the lateral viscosity data. 
+</documentation>
+<pattern>
+571
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Lateral_20viscosity_20file_20name>
+<Use_20lateral_20average_20temperature_20for_20viscosity>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+Whether to use to use the laterally averaged temperature instead of the adiabatic temperature as reference for the viscosity calculation. This ensures that the laterally averaged viscosities remain more or less constant over the model runtime. This behaviour might or might not be desired.
+</documentation>
+<pattern>
+572
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20lateral_20average_20temperature_20for_20viscosity>
+<Number_20lateral_20average_20bands>
+<value>
+10
+</value>
+<default_value>
+10
+</default_value>
+<documentation>
+Number of bands to compute laterally averaged temperature within.
+</documentation>
+<pattern>
+573
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Number_20lateral_20average_20bands>
+<Bilinear_20interpolation>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+Whether to use bilinear interpolation to compute material properties (slower but more accurate). 
+</documentation>
+<pattern>
+574
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Bilinear_20interpolation>
+<Latent_20heat>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to include latent heat effects in the calculation of thermal expansivity and specific heat. Following the approach of Nakagawa et al. 2009. 
+</documentation>
+<pattern>
+575
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Latent_20heat>
+<Reference_20viscosity>
+<value>
+1e23
+</value>
+<default_value>
+1e23
+</default_value>
+<documentation>
+The reference viscosity that is used for pressure scaling. To understand how pressure scaling works, take a look at \cite{KHB12}. In particular, the value of this parameter would not affect the solution computed by \aspect{} if we could do arithmetic exactly; however, computers do arithmetic in finite precision, and consequently we need to scale quantities in ways so that their magnitudes are roughly the same. As explained in \cite{KHB12}, we scale the pressure during some computations (never visible by users) by a factor that involves a reference viscosity. This parameter describes this reference viscosity.
+
+For problems with a constant viscosity, you will generally want to choose the reference viscosity equal to the actual viscosity. For problems with a variable viscosity, the reference viscosity should be a value that adequately represents the order of magnitude of the viscosities that appear, such as an average value or the value one would use to compute a Rayleigh number.
+
+Units: $Pa \, s$
+</documentation>
+<pattern>
+576
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20viscosity>
+<Minimum_20viscosity>
+<value>
+1e19
+</value>
+<default_value>
+1e19
+</default_value>
+<documentation>
+The minimum viscosity that is allowed in the viscosity calculation. Smaller values will be cut off.
+</documentation>
+<pattern>
+577
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20viscosity>
+<Maximum_20viscosity>
+<value>
+1e23
+</value>
+<default_value>
+1e23
+</default_value>
+<documentation>
+The maximum viscosity that is allowed in the viscosity calculation. Larger values will be cut off.
+</documentation>
+<pattern>
+578
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20viscosity>
+<Maximum_20lateral_20viscosity_20variation>
+<value>
+1e2
+</value>
+<default_value>
+1e2
+</default_value>
+<documentation>
+The relative cutoff value for lateral viscosity variations caused by temperature deviations. The viscosity may vary laterally by this factor squared.
+</documentation>
+<pattern>
+579
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20lateral_20viscosity_20variation>
+<Thermal_20conductivity>
+<value>
+4.7
+</value>
+<default_value>
+4.7
+</default_value>
+<documentation>
+The value of the thermal conductivity $k$. Units: $W/m/K$.
+</documentation>
+<pattern>
+580
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20conductivity>
+</Steinberger_20model>
+<Visco_20Plastic>
+<Reference_20temperature>
+<value>
+293
+</value>
+<default_value>
+293
+</default_value>
+<documentation>
+For calculating density by thermal expansivity. Units: $K$
+</documentation>
+<pattern>
+581
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Minimum_20strain_20rate>
+<value>
+1.0e-20
+</value>
+<default_value>
+1.0e-20
+</default_value>
+<documentation>
+Stabilizes strain dependent viscosity. Units: $1 / s$
+</documentation>
+<pattern>
+582
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20strain_20rate>
+<Reference_20strain_20rate>
+<value>
+1.0e-15
+</value>
+<default_value>
+1.0e-15
+</default_value>
+<documentation>
+Reference strain rate for first time step. Units: $1 / s$
+</documentation>
+<pattern>
+583
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20strain_20rate>
+<Minimum_20viscosity>
+<value>
+1e17
+</value>
+<default_value>
+1e17
+</default_value>
+<documentation>
+Lower cutoff for effective viscosity. Units: $Pa \, s$
+</documentation>
+<pattern>
+584
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimum_20viscosity>
+<Maximum_20viscosity>
+<value>
+1e28
+</value>
+<default_value>
+1e28
+</default_value>
+<documentation>
+Upper cutoff for effective viscosity. Units: $Pa \, s$
+</documentation>
+<pattern>
+585
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20viscosity>
+<Reference_20viscosity>
+<value>
+1e22
+</value>
+<default_value>
+1e22
+</default_value>
+<documentation>
+Reference viscosity for nondimensionalization. To understand how pressure scaling works, take a look at \cite{KHB12}. In particular, the value of this parameter would not affect the solution computed by \aspect{} if we could do arithmetic exactly; however, computers do arithmetic in finite precision, and consequently we need to scale quantities in ways so that their magnitudes are roughly the same. As explained in \cite{KHB12}, we scale the pressure during some computations (never visible by users) by a factor that involves a reference viscosity. This parameter describes this reference viscosity.
+
+For problems with a constant viscosity, you will generally want to choose the reference viscosity equal to the actual viscosity. For problems with a variable viscosity, the reference viscosity should be a value that adequately represents the order of magnitude of the viscosities that appear, such as an average value or the value one would use to compute a Rayleigh number.
+
+Units: $Pa \, s$
+</documentation>
+<pattern>
+586
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20viscosity>
+<Thermal_20diffusivities>
+<value>
+0.8e-6
+</value>
+<default_value>
+0.8e-6
+</default_value>
+<documentation>
+List of thermal diffusivities, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: $m^2/s$
+</documentation>
+<pattern>
+587
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Thermal_20diffusivities>
+<Heat_20capacities>
+<value>
+1.25e3
+</value>
+<default_value>
+1.25e3
+</default_value>
+<documentation>
+List of heat capacities $C_p$, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: $J/kg/K$
+</documentation>
+<pattern>
+588
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Heat_20capacities>
+<Densities>
+<value>
+3300.
+</value>
+<default_value>
+3300.
+</default_value>
+<documentation>
+List of densities, $\rho$, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: $kg / m^3$
+</documentation>
+<pattern>
+589
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Densities>
+<Thermal_20expansivities>
+<value>
+3.5e-5
+</value>
+<default_value>
+3.5e-5
+</default_value>
+<documentation>
+List of thermal expansivities for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: $1 / K$
+</documentation>
+<pattern>
+590
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Thermal_20expansivities>
+<Use_20strain_20weakening>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Apply strain weakening to viscosity, cohesion and internal angle of friction based on accumulated finite strain.  Units: None
+</documentation>
+<pattern>
+591
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20strain_20weakening>
+<Use_20plastic_20strain_20weakening>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Apply strain weakening to cohesion and internal angle of friction based on accumulated finite plastic strain only.  Units: None
+</documentation>
+<pattern>
+592
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20plastic_20strain_20weakening>
+<Use_20viscous_20strain_20weakening>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Apply strain weakening to diffusion and dislocation viscosity prefactors based on accumulated finite viscous strain only.  Units: None
+</documentation>
+<pattern>
+593
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20viscous_20strain_20weakening>
+<Use_20finite_20strain_20tensor>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Track and use the full finite strain tensor for strain weakening. Units: None
+</documentation>
+<pattern>
+594
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20finite_20strain_20tensor>
+<Start_20plasticity_20strain_20weakening_20intervals>
+<value>
+0.
+</value>
+<default_value>
+0.
+</default_value>
+<documentation>
+List of strain weakening interval initial strains for the cohesion and friction angle parameters of the background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: None
+</documentation>
+<pattern>
+595
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Start_20plasticity_20strain_20weakening_20intervals>
+<End_20plasticity_20strain_20weakening_20intervals>
+<value>
+1.
+</value>
+<default_value>
+1.
+</default_value>
+<documentation>
+List of strain weakening interval final strains for the cohesion and friction angle parameters of the background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: None
+</documentation>
+<pattern>
+596
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</End_20plasticity_20strain_20weakening_20intervals>
+<Start_20prefactor_20strain_20weakening_20intervals>
+<value>
+0.
+</value>
+<default_value>
+0.
+</default_value>
+<documentation>
+List of strain weakening interval initial strains for the diffusion and dislocation prefactor parameters of the background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: None
+</documentation>
+<pattern>
+597
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Start_20prefactor_20strain_20weakening_20intervals>
+<End_20prefactor_20strain_20weakening_20intervals>
+<value>
+1.
+</value>
+<default_value>
+1.
+</default_value>
+<documentation>
+List of strain weakening interval final strains for the diffusion and dislocation prefactor parameters of the background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: None
+</documentation>
+<pattern>
+598
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</End_20prefactor_20strain_20weakening_20intervals>
+<Prefactor_20strain_20weakening_20factors>
+<value>
+1.
+</value>
+<default_value>
+1.
+</default_value>
+<documentation>
+List of viscous strain weakening factors for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: None
+</documentation>
+<pattern>
+599
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...1 (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Prefactor_20strain_20weakening_20factors>
+<Cohesion_20strain_20weakening_20factors>
+<value>
+1.
+</value>
+<default_value>
+1.
+</default_value>
+<documentation>
+List of cohesion strain weakening factors for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: None
+</documentation>
+<pattern>
+600
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Cohesion_20strain_20weakening_20factors>
+<Friction_20strain_20weakening_20factors>
+<value>
+1.
+</value>
+<default_value>
+1.
+</default_value>
+<documentation>
+List of friction strain weakening factors for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: None
+</documentation>
+<pattern>
+601
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Friction_20strain_20weakening_20factors>
+<Grain_20size>
+<value>
+1e-3
+</value>
+<default_value>
+1e-3
+</default_value>
+<documentation>
+Units: $m$
+</documentation>
+<pattern>
+602
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Grain_20size>
+<Viscosity_20averaging_20scheme>
+<value>
+harmonic
+</value>
+<default_value>
+harmonic
+</default_value>
+<documentation>
+When more than one compositional field is present at a point with different viscosities, we need to come up with an average viscosity at that point.  Select a weighted harmonic, arithmetic, geometric, or maximum composition.
+</documentation>
+<pattern>
+603
+</pattern>
+<pattern_description>
+[Selection arithmetic|harmonic|geometric|maximum composition ]
+</pattern_description>
+</Viscosity_20averaging_20scheme>
+<Viscous_20flow_20law>
+<value>
+composite
+</value>
+<default_value>
+composite
+</default_value>
+<documentation>
+Select what type of viscosity law to use between diffusion, dislocation and composite options. Soon there will be an option to select a specific flow law for each assigned composition 
+</documentation>
+<pattern>
+604
+</pattern>
+<pattern_description>
+[Selection diffusion|dislocation|composite ]
+</pattern_description>
+</Viscous_20flow_20law>
+<Yield_20mechanism>
+<value>
+drucker
+</value>
+<default_value>
+drucker
+</default_value>
+<documentation>
+Select what type of yield mechanism to use between Drucker Prager and stress limiter options.
+</documentation>
+<pattern>
+605
+</pattern>
+<pattern_description>
+[Selection drucker|limiter ]
+</pattern_description>
+</Yield_20mechanism>
+<Prefactors_20for_20diffusion_20creep>
+<value>
+1.5e-15
+</value>
+<default_value>
+1.5e-15
+</default_value>
+<documentation>
+List of viscosity prefactors, $A$, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value. Units: $Pa^{-1} m^{m_{\text{diffusion}}} s^{-1}$
+</documentation>
+<pattern>
+606
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Prefactors_20for_20diffusion_20creep>
+<Stress_20exponents_20for_20diffusion_20creep>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+List of stress exponents, $n_{\text{diffusion}}$, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: None
+</documentation>
+<pattern>
+607
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Stress_20exponents_20for_20diffusion_20creep>
+<Grain_20size_20exponents_20for_20diffusion_20creep>
+<value>
+3
+</value>
+<default_value>
+3
+</default_value>
+<documentation>
+List of grain size exponents, $m_{\text{diffusion}}$, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value. Units: None
+</documentation>
+<pattern>
+608
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Grain_20size_20exponents_20for_20diffusion_20creep>
+<Activation_20energies_20for_20diffusion_20creep>
+<value>
+375e3
+</value>
+<default_value>
+375e3
+</default_value>
+<documentation>
+List of activation energies, $E_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: $J / mol$
+</documentation>
+<pattern>
+609
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Activation_20energies_20for_20diffusion_20creep>
+<Activation_20volumes_20for_20diffusion_20creep>
+<value>
+6e-6
+</value>
+<default_value>
+6e-6
+</default_value>
+<documentation>
+List of activation volumes, $V_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: $m^3 / mol$
+</documentation>
+<pattern>
+610
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Activation_20volumes_20for_20diffusion_20creep>
+<Prefactors_20for_20dislocation_20creep>
+<value>
+1.1e-16
+</value>
+<default_value>
+1.1e-16
+</default_value>
+<documentation>
+List of viscosity prefactors, $A$, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value. Units: $Pa^{-n_{\text{dislocation}}} s^{-1}$
+</documentation>
+<pattern>
+611
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Prefactors_20for_20dislocation_20creep>
+<Stress_20exponents_20for_20dislocation_20creep>
+<value>
+3.5
+</value>
+<default_value>
+3.5
+</default_value>
+<documentation>
+List of stress exponents, $n_{\text{dislocation}}$, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: None
+</documentation>
+<pattern>
+612
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Stress_20exponents_20for_20dislocation_20creep>
+<Activation_20energies_20for_20dislocation_20creep>
+<value>
+530e3
+</value>
+<default_value>
+530e3
+</default_value>
+<documentation>
+List of activation energies, $E_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: $J / mol$
+</documentation>
+<pattern>
+613
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Activation_20energies_20for_20dislocation_20creep>
+<Activation_20volumes_20for_20dislocation_20creep>
+<value>
+1.4e-5
+</value>
+<default_value>
+1.4e-5
+</default_value>
+<documentation>
+List of activation volumes, $V_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: $m^3 / mol$
+</documentation>
+<pattern>
+614
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Activation_20volumes_20for_20dislocation_20creep>
+<Angles_20of_20internal_20friction>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+List of angles of internal friction, $\phi$, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. For a value of zero, in 2D the von Mises criterion is retrieved. Angles higher than 30 degrees are harder to solve numerically. Units: degrees.
+</documentation>
+<pattern>
+615
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Angles_20of_20internal_20friction>
+<Cohesions>
+<value>
+1e20
+</value>
+<default_value>
+1e20
+</default_value>
+<documentation>
+List of cohesions, $C$, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. The extremely large default cohesion value (1e20 Pa) prevents the viscous stress from exceeding the yield stress. Units: $Pa$.
+</documentation>
+<pattern>
+616
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Cohesions>
+<Stress_20limiter_20exponents>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+List of stress limiter exponents, $n_{\text{lim}}$, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. Units: none.
+</documentation>
+<pattern>
+617
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Stress_20limiter_20exponents>
+<Maximum_20yield_20stress>
+<value>
+1e12
+</value>
+<default_value>
+1e12
+</default_value>
+<documentation>
+Limits the maximum value of the yield stress determined by the drucker-prager plasticity parameters. Default value is chosen so this is not automatically used. Values of 100e6--1000e6 $Pa$ have been used in previous models. Units: $Pa$
+</documentation>
+<pattern>
+618
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20yield_20stress>
+<Adiabat_20temperature_20gradient_20for_20viscosity>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+Add an adiabatic temperature gradient to the temperature used in the flow law so that the activation volume is consistent with what one would use in a earth-like (compressible) model. Default is set so this is off. Note that this is a linear approximation of the real adiabatic gradient, which is okay for the upper mantle, but is not really accurate for the lower mantle. Using a pressure gradient of 32436 Pa/m, then a value of 0.3 $K/km$ = 0.0003 $K/m$ = 9.24e-09 $K/Pa$ gives an earth-like adiabat.Units: $K/Pa$
+</documentation>
+<pattern>
+619
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Adiabat_20temperature_20gradient_20for_20viscosity>
+</Visco_20Plastic>
+<Viscoelastic>
+<Reference_20temperature>
+<value>
+293
+</value>
+<default_value>
+293
+</default_value>
+<documentation>
+The reference temperature $T_0$. Units: $K$.
+</documentation>
+<pattern>
+620
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Densities>
+<value>
+3300.
+</value>
+<default_value>
+3300.
+</default_value>
+<documentation>
+List of densities for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value.  Units: $kg / m^3$
+</documentation>
+<pattern>
+621
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Densities>
+<Viscosities>
+<value>
+1.e21
+</value>
+<default_value>
+1.e21
+</default_value>
+<documentation>
+List of viscosities for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value. Units: $Pa s$
+</documentation>
+<pattern>
+622
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Viscosities>
+<Thermal_20expansivities>
+<value>
+4.e-5
+</value>
+<default_value>
+4.e-5
+</default_value>
+<documentation>
+List of thermal expansivities for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value. Units: $1/K$
+</documentation>
+<pattern>
+623
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Thermal_20expansivities>
+<Specific_20heats>
+<value>
+1250.
+</value>
+<default_value>
+1250.
+</default_value>
+<documentation>
+List of specific heats $C_p$ for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value. Units: $J /kg /K$
+</documentation>
+<pattern>
+624
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Specific_20heats>
+<Thermal_20conductivities>
+<value>
+4.7
+</value>
+<default_value>
+4.7
+</default_value>
+<documentation>
+List of thermal conductivities for background mantle and compositional fields, for a total of N+1 values, where N is the number of compositional fields. If only one value is given, then all use the same value. Units: $W/m/K$ 
+</documentation>
+<pattern>
+625
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Thermal_20conductivities>
+<Viscosity_20averaging_20scheme>
+<value>
+harmonic
+</value>
+<default_value>
+harmonic
+</default_value>
+<documentation>
+When more than one compositional field is present at a point with different viscosities, we need to come up with an average viscosity at that point.  Select a weighted harmonic, arithmetic, geometric, or maximum composition.
+</documentation>
+<pattern>
+626
+</pattern>
+<pattern_description>
+[Selection arithmetic|harmonic|geometric|maximum composition  ]
+</pattern_description>
+</Viscosity_20averaging_20scheme>
+<Elastic_20shear_20moduli>
+<value>
+75.0e9
+</value>
+<default_value>
+75.0e9
+</default_value>
+<documentation>
+List of elastic shear moduli, $G$, for background material and compositional fields, for a total of N+1 values, where N is the number of compositional fields. The default value of 75 GPa is representative of mantle rocks. Units: Pa.
+</documentation>
+<pattern>
+627
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Elastic_20shear_20moduli>
+<Use_20fixed_20elastic_20time_20step>
+<value>
+unspecified
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Select whether the material time scale in the viscoelastic constitutive relationship uses the regular numerical time step or a separate fixed elastic time step throughout the model run. The fixed elastic time step is always used during the initial time step. If a fixed elastic time step is used throughout the model run, a stress averaging scheme can be applied to account for differences with the numerical time step. An alternative approach is to limit the maximum time step size so that it is equal to the elastic time step. The default value of this parameter is &apos;unspecified&apos;, which throws an exception during runtime. In order for the model to run the user must select &apos;true&apos; or &apos;false&apos;.
+</documentation>
+<pattern>
+628
+</pattern>
+<pattern_description>
+[Selection true|false|unspecified ]
+</pattern_description>
+</Use_20fixed_20elastic_20time_20step>
+<Fixed_20elastic_20time_20step>
+<value>
+1.e3
+</value>
+<default_value>
+1.e3
+</default_value>
+<documentation>
+The fixed elastic time step $dte$. Units: years if the &apos;Use years in output instead of seconds&apos; parameter is set; seconds otherwise.
+</documentation>
+<pattern>
+629
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Fixed_20elastic_20time_20step>
+<Use_20stress_20averaging>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to apply a stress averaging scheme to account for differences between the fixed elastic time step and numerical time step. 
+</documentation>
+<pattern>
+630
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20stress_20averaging>
+</Viscoelastic>
+</Material_20model>
+<Boundary_20fluid_20pressure_20model>
+<Plugin_20name>
+<value>
+density
+</value>
+<default_value>
+density
+</default_value>
+<documentation>
+Select one of the following plugins:
+
+`density&apos;: A plugin that prescribes the fluid pressure gradient at the boundary based on fluid/solid density from the material model.
+</documentation>
+<pattern>
+92
+</pattern>
+<pattern_description>
+[Selection density ]
+</pattern_description>
+</Plugin_20name>
+<Density>
+<Density_20formulation>
+<value>
+solid density
+</value>
+<default_value>
+solid density
+</default_value>
+<documentation>
+The density formulation used to compute the fluid pressure gradient at the model boundary.
+
+`solid density&apos; prescribes the gradient of the fluid pressure as solid density times gravity (which is the lithostatic pressure) and leads to approximately the same pressure in the melt as in the solid, so that fluid is only flowing in or out due to differences in dynamic pressure.
+
+`fluid density&apos; prescribes the gradient of the fluid pressure as fluid density times gravity and causes melt to flow in with the same velocity as inflowing solid material, or no melt flowing in or out if the solid velocity normal to the boundary is zero.
+
+&apos;average density&apos; prescribes the gradient of the fluid pressure as the averaged fluid and solid density times gravity (which is a better approximation for the lithostatic pressure than just the solid density) and leads to approximately the same pressure in the melt as in the solid, so that fluid is only flowing in or out due to differences in dynamic pressure.
+</documentation>
+<pattern>
+93
+</pattern>
+<pattern_description>
+[Selection solid density|fluid density|average density ]
+</pattern_description>
+</Density_20formulation>
+</Density>
+</Boundary_20fluid_20pressure_20model>
+<Termination_20criteria>
+<Checkpoint_20on_20termination>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to checkpoint the simulation right before termination.
+</documentation>
+<pattern>
+259
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Checkpoint_20on_20termination>
+<Termination_20criteria>
+<value>
+end time
+</value>
+<default_value>
+end time
+</default_value>
+<documentation>
+A comma separated list of termination criteria that will determine when the simulation should end. Whether explicitly stated or not, the ``end time&apos;&apos; termination criterion will always be used.The following termination criteria are available:
+
+`end step&apos;: Terminate the simulation once the specified timestep has been reached. 
+
+`end time&apos;: Terminate the simulation once the end time specified in the input file has been reached. Unlike all other termination criteria, this criterion is \textit{always} active, whether it has been explicitly selected or not in the input file (this is done to preserve historical behavior of \aspect{}, but it also likely does not inconvenience anyone since it is what would be selected in most cases anyway).
+
+`steady state velocity&apos;: A criterion that terminates the simulation when the RMS of the velocity field stays within a certain range for a specified period of time.
+
+`user request&apos;: Terminate the simulation gracefully when a file with a specified name appears in the output directory. This allows the user to gracefully exit the simulation at any time by simply creating such a file using, for example, \texttt{touch output/terminate}. The file&apos;s location is chosen to be in the output directory, rather than in a generic location such as the Aspect directory, so that one can run multiple simulations at the same time (which presumably write to different output directories) and can selectively terminate a particular one.
+
+`wall time&apos;: Terminate the simulation once the wall time limit has reached.
+</documentation>
+<pattern>
+260
+</pattern>
+<pattern_description>
+[MultipleSelection end step|end time|steady state velocity|user request|wall time ]
+</pattern_description>
+</Termination_20criteria>
+<End_20step>
+<value>
+100
+</value>
+<default_value>
+100
+</default_value>
+<documentation>
+Terminate the simulation once the specified timestep has been reached.
+</documentation>
+<pattern>
+261
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</End_20step>
+<Wall_20time>
+<value>
+24
+</value>
+<default_value>
+24
+</default_value>
+<documentation>
+The wall time of the simulation. Unit: hours.
+</documentation>
+<pattern>
+263
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Wall_20time>
+<Steady_20state_20velocity>
+<Maximum_20relative_20deviation>
+<value>
+0.05
+</value>
+<default_value>
+0.05
+</default_value>
+<documentation>
+The maximum relative deviation of the RMS in recent simulation time for the system to be considered in steady state. If the actual deviation is smaller than this number, then the simulation will be terminated.
+</documentation>
+<pattern>
+264
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20relative_20deviation>
+<Time_20in_20steady_20state>
+<value>
+1e7
+</value>
+<default_value>
+1e7
+</default_value>
+<documentation>
+The minimum length of simulation time that the system should be in steady state before termination.Units: years if the &apos;Use years in output instead of seconds&apos; parameter is set; seconds otherwise.
+</documentation>
+<pattern>
+265
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Time_20in_20steady_20state>
+</Steady_20state_20velocity>
+<User_20request>
+<File_20name>
+<value>
+terminate-aspect
+</value>
+<default_value>
+terminate-aspect
+</default_value>
+<documentation>
+The name of a file that, if it exists in the output directory (whose name is also specified in the input file) will lead to termination of the simulation. The file&apos;s location is chosen to be in the output directory, rather than in a generic location such as the Aspect directory, so that one can run multiple simulations at the same time (which presumably write to different output directories) and can selectively terminate a particular one.
+</documentation>
+<pattern>
+266
+</pattern>
+<pattern_description>
+[FileName (Type: input)]
+</pattern_description>
+</File_20name>
+</User_20request>
+</Termination_20criteria>
+<End_20time>
+<value>
+0.0
+</value>
+<default_value>
+5.69e+300
+</default_value>
+<documentation>
+The end time of the simulation. The default value is a number so that when converted from years to seconds it is approximately equal to the largest number representable in floating point arithmetic. For all practical purposes, this equals infinity. Units: Years if the &apos;Use years in output instead of seconds&apos; parameter is set; seconds otherwise.
+</documentation>
+<pattern>
+262
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</End_20time>
+<Heating_20model>
+<List_20of_20model_20names>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of heating models that will be used to calculate the heating terms in the energy equation. The results of each of these criteria, i.e., the heating source terms and the latent heat terms for the left hand side will be added.
+
+The following heating models are available:
+
+`adiabatic heating&apos;: Implementation of a standard and a simplified model of adiabatic heating.
+
+`adiabatic heating of melt&apos;: Implementation of a standard and a simplified model of adiabatic heating of melt. The full model implements the heating term 
+$\alpha T (-\phi \mathbf u_s \cdot \nabla p) + \alpha T (\phi \mathbf u_f \cdot 
+abla p)$.
+For full adiabatic heating, this has to be used in combination with the heating model `adiabatic heating&apos; to also include adiabatic heating for the solid part, and the full heating term is then $\alpha T ((1-\phi) \mathbf u_s \cdot \nabla p) + \alpha T (\phi \mathbf u_f \cdot \nabla p)$.
+
+`compositional heating&apos;: Implementation of a model in which magnitude of internal heat production is determined from fixed values assigned to each compositional field. These values are interpreted as having units $W/m^3$.
+
+`constant heating&apos;: Implementation of a model in which the heating rate is constant.
+
+`function&apos;: Implementation of a model in which the heating rate is given in terms of an explicit formula that is elaborated in the parameters in section ``Heating model|Function&apos;&apos;. The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
+The formula is interpreted as having units W/kg.
+
+Since the symbol $t$ indicating time may appear in the formulas for the heating rate, it is interpreted as having units seconds unless the global parameter ``Use years in output instead of seconds&apos;&apos; is set.
+
+`latent heat&apos;: Implementation of a standard model for latent heat.
+
+`latent heat melt&apos;: Implementation of a standard model for latent heat of melting. This assumes that there is a compositional field called porosity, and it uses the reaction term of this field (the fraction of material that melted in the current time step) multiplied by a constant entropy change for melting all of the material as source term of the heating model.
+If there is no field called porosity, the heating terms are 0.
+
+`radioactive decay&apos;: Implementation of a model in which the internal heating rate is radioactive decaying in the following rule:
+\[(\text{initial concentration})\cdot 0.5^{\text{time}/(\text{half life})}\]
+The crust and mantle can have different concentrations, and the crust can be defined either by depth or by a certain compositional field.
+The formula is interpreted as having units W/kg.
+
+`shear heating&apos;: Implementation of a standard model for shear heating. Adds the term: $  2 \eta \left( \varepsilon - \frac{1}{3} \text{tr} \varepsilon \mathbf 1 \right) : \left( \varepsilon - \frac{1}{3} \text{tr} \varepsilon \mathbf 1 \right)$ to the right-hand side of the temperature equation.
+
+`shear heating with melt&apos;: Implementation of a standard model for shear heating of migrating melt, including bulk (compression) heating $\xi \left( \nabla \cdot \mathbf u_s \right)^2 $ and heating due to melt segregation $\frac{\eta_f \phi^2}{k} \left( \mathbf u_f - \mathbf u_s \right)^2 $. For full shear heating, this has to be used in combination with the heating model shear heating to also include shear heating for the solid part.
+</documentation>
+<pattern>
+631
+</pattern>
+<pattern_description>
+[MultipleSelection adiabatic heating|adiabatic heating of melt|compositional heating|constant heating|function|latent heat|latent heat melt|radioactive decay|shear heating|shear heating with melt ]
+</pattern_description>
+</List_20of_20model_20names>
+<Adiabatic_20heating>
+<Use_20simplified_20adiabatic_20heating>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+A flag indicating whether the adiabatic heating should be simplified from $\alpha T (\mathbf u \cdot \nabla p)$ to $ \alpha \rho T (\mathbf u \cdot \mathbf g) $.
+</documentation>
+<pattern>
+632
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20simplified_20adiabatic_20heating>
+</Adiabatic_20heating>
+<Adiabatic_20heating_20of_20melt>
+<Use_20simplified_20adiabatic_20heating>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+A flag indicating whether the adiabatic heating should be simplified from $\alpha T (\mathbf u \cdot \nabla p)$ to $ \alpha \rho T (\mathbf u \cdot \mathbf g) $.
+</documentation>
+<pattern>
+633
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20simplified_20adiabatic_20heating>
+</Adiabatic_20heating_20of_20melt>
+<Compositional_20heating>
+<Compositional_20heating_20values>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+List of heat production per unit volume values for background and compositional fields, for a total of N+1 values, where the first value correponds to the background material, and N is the number of compositional fields. Units: $W/m^3$.
+</documentation>
+<pattern>
+634
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Compositional_20heating_20values>
+<Use_20compositional_20field_20for_20heat_20production_20averaging>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+A list of integers with as many entries as compositional fields plus one. The first entry corresponds to the background material, each following entry corresponds to a particular compositional field. If the entry for a field is &apos;1&apos; this field is considered during the computation of volume fractions, if it is &apos;0&apos; the field is ignored. This is useful if some compositional fields are used to track properties like finite strain that should not contribute to heat production. The first entry determines whether the background field contributes to heat production or not (essentially similar to setting its &apos;Compositional heating values&apos; to zero, but included for consistency in the length of the input lists).
+</documentation>
+<pattern>
+635
+</pattern>
+<pattern_description>
+[List of &lt;[Integer range 0...1 (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Use_20compositional_20field_20for_20heat_20production_20averaging>
+</Compositional_20heating>
+<Constant_20heating>
+<Radiogenic_20heating_20rate>
+<value>
+0e0
+</value>
+<default_value>
+0e0
+</default_value>
+<documentation>
+The specific rate of heating due to radioactive decay (or other bulk sources you may want to describe). This parameter corresponds to the variable $H$ in the temperature equation stated in the manual, and the heating term is $ho H$. Units: W/kg.
+</documentation>
+<pattern>
+636
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Radiogenic_20heating_20rate>
+</Constant_20heating>
+<Function>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+637
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+638
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+639
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Function>
+<Latent_20heat_20melt>
+<Melting_20entropy_20change>
+<value>
+-300
+</value>
+<default_value>
+-300
+</default_value>
+<documentation>
+The entropy change for the phase transition from solid to melt. Units: $J/(kg K)$.
+</documentation>
+<pattern>
+640
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Melting_20entropy_20change>
+</Latent_20heat_20melt>
+<Radioactive_20decay>
+<Number_20of_20elements>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Number of radioactive elements
+</documentation>
+<pattern>
+641
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Number_20of_20elements>
+<Heating_20rates>
+<value/>
+<default_value/>
+<documentation>
+Heating rates of different elements (W/kg)
+</documentation>
+<pattern>
+642
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Heating_20rates>
+<Half_20decay_20times>
+<value/>
+<default_value/>
+<documentation>
+Half decay times. Units: (Seconds), or (Years) if set `use years instead of seconds&apos;.
+</documentation>
+<pattern>
+643
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Half_20decay_20times>
+<Initial_20concentrations_20crust>
+<value/>
+<default_value/>
+<documentation>
+Initial concentrations of different elements (ppm)
+</documentation>
+<pattern>
+644
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Initial_20concentrations_20crust>
+<Initial_20concentrations_20mantle>
+<value/>
+<default_value/>
+<documentation>
+Initial concentrations of different elements (ppm)
+</documentation>
+<pattern>
+645
+</pattern>
+<pattern_description>
+[List of &lt;[Double 0...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Initial_20concentrations_20mantle>
+<Crust_20defined_20by_20composition>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether crust defined by composition or depth
+</documentation>
+<pattern>
+646
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Crust_20defined_20by_20composition>
+<Crust_20depth>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Depth of the crust when crust if defined by depth. Units: m
+</documentation>
+<pattern>
+647
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Crust_20depth>
+<Crust_20composition_20number>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Which composition field should be treated as crust
+</documentation>
+<pattern>
+648
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Crust_20composition_20number>
+</Radioactive_20decay>
+</Heating_20model>
+<Geometry_20model>
+<Model_20name>
+<value>
+box
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Select one of the following models:
+
+`box&apos;: A box geometry parallel to the coordinate directions. The extent of the box in each coordinate direction is set in the parameter file. The box geometry labels its 2*dim sides as follows: in 2d, boundary indicators 0 through 3 denote the left, right, bottom and top boundaries; in 3d, boundary indicators 0 through 5 indicate left, right, front, back, bottom and top boundaries (see also the documentation of the deal.II class ``GeometryInfo&apos;&apos;). You can also use symbolic names ``left&apos;&apos;, ``right&apos;&apos;, etc., to refer to these boundaries in input files. It is also possible to add initial topography to the box model. Note however that this is done after the last initial adaptive refinement cycle. Also, initial topography is supposed to be small, as it is not taken into account when depth or a representative point is computed. 
+
+`box with lithosphere boundary indicators&apos;: A box geometry parallel to the coordinate directions. The extent of the box in each coordinate direction is set in the parameter file. This geometry model labels its sides with 2*dim+2*(dim-1) boundary indicators: in 2d, boundary indicators 0 through 3 denote the left, right, bottom and top boundaries, while indicators4 and 5 denote the upper part of the left and right vertical boundary, respectively. In 3d, boundary indicators 0 through 5 indicate left, right, front, back, bottom and top boundaries (see also the documentation of the deal.II class ``GeometryInfo&apos;&apos;), while indicators 6, 7, 8 and 9 denote the left, right, front and back upper parts of the vertical boundaries, respectively. You can also use symbolic names ``left&apos;&apos;, ``right&apos;&apos;, ``left lithosphere&apos;&apos;, etc., to refer to these boundaries in input files.
+
+Note that for a given ``Global refinement level&apos;&apos; and no user-specified ``Repetitions&apos;&apos;, the lithosphere part of the mesh will be more refined. 
+
+The additional boundary indicators for the lithosphere allow for selecting boundary conditions for the lithosphere different from those for the underlying mantle. An example application of this geometry is to prescribe a velocity on the lithospheric plates, but use open boundary conditions underneath. 
+
+`chunk&apos;: A geometry which can be described as a chunk of a spherical shell, bounded by lines of longitude, latitude and radius. The minimum and maximum longitude, latitude (if in 3d) and depth of the chunk is set in the parameter file. The chunk geometry labels its 2*dim sides as follows: ``west&apos;&apos; and ``east&apos;&apos;: minimum and maximum longitude, ``south&apos;&apos; and ``north&apos;&apos;: minimum and maximum latitude, ``inner&apos;&apos; and ``outer&apos;&apos;: minimum and maximum radii. 
+
+The dimensions of the model are specified by parameters of the following form: Chunk (minimum || maximum) (longitude || latitude): edges of geographical quadrangle (in degrees)Chunk (inner || outer) radius: Radii at bottom and top of chunk(Longitude || Latitude || Radius) repetitions: number of cells in each coordinate direction.
+
+When used in 2d, this geometry does not imply the use of a spherical coordinate system. Indeed, in 2d the geometry is simply a sector of an annulus in a Cartesian coordinate system and consequently would correspond to a sector of a cross section of the fluid filled space between two infinite cylinders where one has made the assumption that the velocity in direction of the cylinder axes is zero. This is consistent with the definition of what we consider the two-dimension case given in Section~\ref{sec:meaning-of-2d}.
+
+`ellipsoidal chunk&apos;: A 3D chunk geometry that accounts for Earth&apos;s ellipticity (default assuming the WGS84 ellipsoid definition) which can be defined in non-coordinate directions. In the description of the ellipsoidal chunk, two of the ellipsoidal axes have the same length so that there is only a semi-major axis and a semi-minor axis. The user has two options for creating an ellipsoidal chunk geometry: 1) by defining two opposing points (SW and NE or NW and SE) a coordinate parallel ellipsoidal chunk geometry will be created. 2) by defining three points a non-coordinate parallel ellipsoidal chunk will be created. The points are defined in the input file by longitude:latitude. It is also possible to define additional subdivisions of the mesh in each direction. Faces of the model are defined as 0, west; 1,east; 2, south; 3, north; 4, inner; 5, outer.
+
+This geometry model supports initial topography for deforming the initial mesh.
+
+`sphere&apos;: A geometry model for a sphere with a user specified radius. This geometry has only a single boundary, so the only valid boundary indicator to specify in input files is ``0&apos;&apos;. It can also be referenced by the symbolic name ``surface&apos;&apos; in input files.
+
+Despite the name, this geometry does not imply the use of a spherical coordinate system when used in 2d. Indeed, in 2d the geometry is simply a circle in a Cartesian coordinate system and consequently would correspond to a cross section of the fluid filled interior of an infinite cylinder where one has made the assumption that the velocity in direction of the cylinder axes is zero. This is consistent with the definition of what we consider the two-dimension case given in Section~\ref{sec:meaning-of-2d}.
+
+`spherical shell&apos;: A geometry representing a spherical shell or a piece of it. Inner and outer radii are read from the parameter file in subsection &apos;Spherical shell&apos;.
+
+Despite the name, this geometry does not imply the use of a spherical coordinate system when used in 2d. Indeed, in 2d the geometry is simply an annulus in a Cartesian coordinate system and consequently would correspond to a cross section of the fluid filled space between two infinite cylinders where one has made the assumption that the velocity in direction of the cylinder axes is zero. This is consistent with the definition of what we consider the two-dimension case given in Section~\ref{sec:meaning-of-2d}.
+
+The model assigns boundary indicators as follows: In 2d, inner and outer boundaries get boundary indicators zero and one, and if the opening angle set in the input file is less than 360, then left and right boundaries are assigned indicators two and three. These boundaries can also be referenced using the symbolic names `inner&apos;, `outer&apos; and (if applicable) `left&apos;, `right&apos;.
+
+In 3d, inner and outer indicators are treated as in 2d. If the opening angle is chosen as 90 degrees, i.e., the domain is the intersection of a spherical shell and the first octant, then indicator 2 is at the face $x=0$, 3 at $y=0$, and 4 at $z=0$. These last three boundaries can then also be referred to as `east&apos;, `west&apos; and `south&apos; symbolically in input files.
+</documentation>
+<pattern>
+649
+</pattern>
+<pattern_description>
+[Selection box|box with lithosphere boundary indicators|chunk|ellipsoidal chunk|sphere|spherical shell|unspecified ]
+</pattern_description>
+</Model_20name>
+<Box>
+<X_20extent>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Extent of the box in x-direction. Units: m.
+</documentation>
+<pattern>
+650
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</X_20extent>
+<Y_20extent>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Extent of the box in y-direction. Units: m.
+</documentation>
+<pattern>
+651
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Y_20extent>
+<Z_20extent>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Extent of the box in z-direction. This value is ignored if the simulation is in 2d. Units: m.
+</documentation>
+<pattern>
+652
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Z_20extent>
+<Box_20origin_20X_20coordinate>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+X coordinate of box origin. Units: m.
+</documentation>
+<pattern>
+653
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Box_20origin_20X_20coordinate>
+<Box_20origin_20Y_20coordinate>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Y coordinate of box origin. Units: m.
+</documentation>
+<pattern>
+654
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Box_20origin_20Y_20coordinate>
+<Box_20origin_20Z_20coordinate>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Z coordinate of box origin. This value is ignored if the simulation is in 2d. Units: m.
+</documentation>
+<pattern>
+655
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Box_20origin_20Z_20coordinate>
+<X_20repetitions>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Number of cells in X direction.
+</documentation>
+<pattern>
+656
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</X_20repetitions>
+<Y_20repetitions>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Number of cells in Y direction.
+</documentation>
+<pattern>
+657
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Y_20repetitions>
+<Z_20repetitions>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Number of cells in Z direction.
+</documentation>
+<pattern>
+658
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Z_20repetitions>
+<X_20periodic>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether the box should be periodic in X direction
+</documentation>
+<pattern>
+659
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</X_20periodic>
+<Y_20periodic>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether the box should be periodic in Y direction
+</documentation>
+<pattern>
+660
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Y_20periodic>
+<Z_20periodic>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether the box should be periodic in Z direction
+</documentation>
+<pattern>
+661
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Z_20periodic>
+</Box>
+<Chunk>
+<Chunk_20inner_20radius>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Radius at the bottom surface of the chunk. Units: m.
+</documentation>
+<pattern>
+662
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Chunk_20inner_20radius>
+<Chunk_20outer_20radius>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Radius at the top surface of the chunk. Units: m.
+</documentation>
+<pattern>
+663
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Chunk_20outer_20radius>
+<Chunk_20minimum_20longitude>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Minimum longitude of the chunk. Units: degrees.
+</documentation>
+<pattern>
+664
+</pattern>
+<pattern_description>
+[Double -180...360 (inclusive)]
+</pattern_description>
+</Chunk_20minimum_20longitude>
+<Chunk_20maximum_20longitude>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Maximum longitude of the chunk. Units: degrees.
+</documentation>
+<pattern>
+665
+</pattern>
+<pattern_description>
+[Double -180...360 (inclusive)]
+</pattern_description>
+</Chunk_20maximum_20longitude>
+<Chunk_20minimum_20latitude>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Minimum latitude of the chunk. This value is ignored if the simulation is in 2d. Units: degrees.
+</documentation>
+<pattern>
+666
+</pattern>
+<pattern_description>
+[Double -90...90 (inclusive)]
+</pattern_description>
+</Chunk_20minimum_20latitude>
+<Chunk_20maximum_20latitude>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Maximum latitude of the chunk. This value is ignored if the simulation is in 2d. Units: degrees.
+</documentation>
+<pattern>
+667
+</pattern>
+<pattern_description>
+[Double -90...90 (inclusive)]
+</pattern_description>
+</Chunk_20maximum_20latitude>
+<Radius_20repetitions>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Number of cells in radius.
+</documentation>
+<pattern>
+668
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Radius_20repetitions>
+<Longitude_20repetitions>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Number of cells in longitude.
+</documentation>
+<pattern>
+669
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Longitude_20repetitions>
+<Latitude_20repetitions>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Number of cells in latitude. This value is ignored if the simulation is in 2d
+</documentation>
+<pattern>
+670
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Latitude_20repetitions>
+</Chunk>
+<Ellipsoidal_20chunk>
+<NE_20corner>
+<value/>
+<default_value/>
+<documentation>
+Longitude:latitude in degrees of the North-East corner point of model region.The North-East direction is positive. If one of the three corners is not provided the missing corner value will be calculated so all faces are parallel.
+</documentation>
+<pattern>
+671
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</NE_20corner>
+<NW_20corner>
+<value/>
+<default_value/>
+<documentation>
+Longitude:latitude in degrees of the North-West corner point of model region. The North-East direction is positive. If one of the three corners is not provided the missing corner value will be calculated so all faces are parallel.
+</documentation>
+<pattern>
+672
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</NW_20corner>
+<SW_20corner>
+<value/>
+<default_value/>
+<documentation>
+Longitude:latitude in degrees of the South-West corner point of model region. The North-East direction is positive. If one of the three corners is not provided the missing corner value will be calculated so all faces are parallel.
+</documentation>
+<pattern>
+673
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</SW_20corner>
+<SE_20corner>
+<value/>
+<default_value/>
+<documentation>
+Longitude:latitude in degrees of the South-East corner point of model region. The North-East direction is positive. If one of the three corners is not provided the missing corner value will be calculated so all faces are parallel.
+</documentation>
+<pattern>
+674
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</SE_20corner>
+<Depth>
+<value>
+500000.0
+</value>
+<default_value>
+500000.0
+</default_value>
+<documentation>
+Bottom depth of model region.
+</documentation>
+<pattern>
+675
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Depth>
+<Semi_2dmajor_20axis>
+<value>
+6378137.0
+</value>
+<default_value>
+6378137.0
+</default_value>
+<documentation>
+The semi-major axis (a) of an ellipsoid. This is the radius for a sphere (eccentricity=0). Default WGS84 semi-major axis.
+</documentation>
+<pattern>
+676
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Semi_2dmajor_20axis>
+<Eccentricity>
+<value>
+8.1819190842622e-2
+</value>
+<default_value>
+8.1819190842622e-2
+</default_value>
+<documentation>
+Eccentricity of the ellipsoid. Zero is a perfect sphere, default (8.1819190842622e-2) is WGS84.
+</documentation>
+<pattern>
+677
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Eccentricity>
+<East_2dWest_20subdivisions>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+The number of subdivisions of the coarse (initial) mesh in the East-West direction.
+</documentation>
+<pattern>
+678
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</East_2dWest_20subdivisions>
+<North_2dSouth_20subdivisions>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+The number of subdivisions of the coarse (initial) mesh in the North-South direction.
+</documentation>
+<pattern>
+679
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</North_2dSouth_20subdivisions>
+<Depth_20subdivisions>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+The number of subdivisions of the coarse (initial) mesh in depth.
+</documentation>
+<pattern>
+680
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Depth_20subdivisions>
+</Ellipsoidal_20chunk>
+<Sphere>
+<Radius>
+<value>
+6371000
+</value>
+<default_value>
+6371000
+</default_value>
+<documentation>
+Radius of the sphere. Units: m.
+</documentation>
+<pattern>
+681
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Radius>
+</Sphere>
+<Spherical_20shell>
+<Inner_20radius>
+<value>
+3481000
+</value>
+<default_value>
+3481000
+</default_value>
+<documentation>
+Inner radius of the spherical shell. Units: m. 
+
+\note{The default value of 3,481,000 m equals the radius of a sphere with equal volume as Earth (i.e., 6371 km) minus the average depth of the core-mantle boundary (i.e., 2890 km).}
+</documentation>
+<pattern>
+682
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Inner_20radius>
+<Outer_20radius>
+<value>
+6336000
+</value>
+<default_value>
+6336000
+</default_value>
+<documentation>
+Outer radius of the spherical shell. Units: m. 
+
+\note{The default value of 6,336,000 m equals the radius of a sphere with equal volume as Earth (i.e., 6371 km) minus the average depth of the mantle-crust interface (i.e., 35 km).}
+</documentation>
+<pattern>
+683
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Outer_20radius>
+<Opening_20angle>
+<value>
+360
+</value>
+<default_value>
+360
+</default_value>
+<documentation>
+Opening angle in degrees of the section of the shell that we want to build. The only opening angles that are allowed for this geometry are 90, 180, and 360 in 2d; and 90 and 360 in 3d. Units: degrees.
+</documentation>
+<pattern>
+684
+</pattern>
+<pattern_description>
+[Double 0...360 (inclusive)]
+</pattern_description>
+</Opening_20angle>
+<Cells_20along_20circumference>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The number of cells in circumferential direction that are created in the coarse mesh in 2d. If zero, this number is chosen automatically in a way that produces meshes in which cells have a reasonable aspect ratio for models in which the depth of the mantle is roughly that of the Earth. For planets with much shallower mantles and larger cores, you may want to chose a larger number to avoid cells that are elongated in tangential and compressed in radial direction.
+
+In 3d, the number of cells is computed differently and does not have an easy interpretation. Valid values for this parameter in 3d are 0 (let this class choose), 6, 12 and 96. Other possible values may be discussed in the documentation of the deal.II function GridGenerator::hyper_shell. The parameter is best left at its default in 3d.
+
+In either case, this parameter is ignored unless the opening angle of the domain is 360 degrees.
+</documentation>
+<pattern>
+685
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Cells_20along_20circumference>
+</Spherical_20shell>
+<Box_20with_20lithosphere_20boundary_20indicators>
+<Lithospheric_20thickness>
+<value>
+0.2
+</value>
+<default_value>
+0.2
+</default_value>
+<documentation>
+The thickness of the lithosphere used to create additional boundary indicators to set specific boundary conditions for the lithosphere. 
+</documentation>
+<pattern>
+686
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Lithospheric_20thickness>
+<X_20extent>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Extent of the box in x-direction. Units: m.
+</documentation>
+<pattern>
+687
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</X_20extent>
+<Y_20extent>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Extent of the box in y-direction. Units: m.
+</documentation>
+<pattern>
+688
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Y_20extent>
+<Z_20extent>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Extent of the box in z-direction. This value is ignored if the simulation is in 2d. Units: m.
+</documentation>
+<pattern>
+689
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Z_20extent>
+<Box_20origin_20X_20coordinate>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+X coordinate of box origin. Units: m.
+</documentation>
+<pattern>
+690
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Box_20origin_20X_20coordinate>
+<Box_20origin_20Y_20coordinate>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Y coordinate of box origin. Units: m.
+</documentation>
+<pattern>
+691
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Box_20origin_20Y_20coordinate>
+<Box_20origin_20Z_20coordinate>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Z coordinate of box origin. This value is ignored if the simulation is in 2d. Units: m.
+</documentation>
+<pattern>
+692
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Box_20origin_20Z_20coordinate>
+<X_20repetitions>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Number of cells in X direction of the lower box. The same number of repetitions will be used in the upper box.
+</documentation>
+<pattern>
+693
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</X_20repetitions>
+<Y_20repetitions>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Number of cells in Y direction of the lower box. If the simulation is in 3d, the same number of repetitions will be used in the upper box.
+</documentation>
+<pattern>
+694
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Y_20repetitions>
+<Z_20repetitions>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Number of cells in Z direction of the lower box. This value is ignored if the simulation is in 2d.
+</documentation>
+<pattern>
+695
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Z_20repetitions>
+<Y_20repetitions_20lithosphere>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Number of cells in Y direction in the lithosphere. This value is ignored if the simulation is in 3d.
+</documentation>
+<pattern>
+696
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Y_20repetitions_20lithosphere>
+<Z_20repetitions_20lithosphere>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Number of cells in Z direction in the lithosphere. This value is ignored if the simulation is in 2d.
+</documentation>
+<pattern>
+697
+</pattern>
+<pattern_description>
+[Integer range 1...2147483647 (inclusive)]
+</pattern_description>
+</Z_20repetitions_20lithosphere>
+<X_20periodic>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether the box should be periodic in X direction.
+</documentation>
+<pattern>
+698
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</X_20periodic>
+<Y_20periodic>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether the box should be periodic in Y direction.
+</documentation>
+<pattern>
+699
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Y_20periodic>
+<Z_20periodic>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether the box should be periodic in Z direction. This value is ignored if the simulation is in 2d.
+</documentation>
+<pattern>
+700
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Z_20periodic>
+<X_20periodic_20lithosphere>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether the box should be periodic in X direction in the lithosphere.
+</documentation>
+<pattern>
+701
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</X_20periodic_20lithosphere>
+<Y_20periodic_20lithosphere>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether the box should be periodic in Y direction in the lithosphere. This value is ignored if the simulation is in 2d. 
+</documentation>
+<pattern>
+702
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Y_20periodic_20lithosphere>
+</Box_20with_20lithosphere_20boundary_20indicators>
+<Initial_20topography_20model>
+<Model_20name>
+<value>
+zero topography
+</value>
+<default_value>
+zero topography
+</default_value>
+<documentation>
+Select one of the following models:
+
+`ascii data&apos;: Implementation of a model in which the surface topography is derived from a file containing data in ascii format. The following geometry models are currently supported: box, chunk, shperical shell. Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of grid points in each dimension as for example `# POINTS: 3 3&apos;. The order of the data columns has to be `x&apos;, `Topography [m]&apos; in a 2d model and  `x&apos;, `y&apos;, `Topography [m]&apos; in a 3d model, which means that there has to be a single column containing the topography. Note that the data in the input file needs to be sorted in a specific order: the first coordinate needs to ascend first, followed by the second in order to assign the correct data to the prescribed coordinates. If you use a spherical model, then the assumed grid changes. `x&apos; will be replaced by the azimuth angle in radians  and `y&apos; by the polar angle in radians measured positive from the north pole. The grid will be assumed to be a longitude-colatitude grid. Note that the order of spherical coordinates is `phi&apos;, `theta&apos; and not `theta&apos;, `phi&apos;, since this allows for dimension independent expressions.
+
+`prm polygon&apos;: An initial topography model that defines the initial topography as constant inside each of a set of polygonal parts of the surface. The polygons, and their associated surface elevation, are defined in the `Geometry model/Initial topography/Prm polygon&apos; section.
+
+`zero topography&apos;: Implementation of a model in which the initial topography is zero. 
+</documentation>
+<pattern>
+703
+</pattern>
+<pattern_description>
+[Selection ascii data|prm polygon|zero topography ]
+</pattern_description>
+</Model_20name>
+<Ascii_20data_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/geometry-model/initial-topography-model/ascii-data/test/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/geometry-model/initial-topography-model/ascii-data/test/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a `/&apos;) or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+704
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value>
+box_2d_%s.0.txt
+</value>
+<default_value>
+box_2d_%s.0.txt
+</default_value>
+<documentation>
+The file name of the model data. Provide file in format: (Velocity file name).\%s\%d where \%s is a string specifying the boundary of the model according to the names of the boundary indicators (of the chosen geometry model).\%d is any sprintf integer qualifier, specifying the format of the current file number. 
+</documentation>
+<pattern>
+705
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+</documentation>
+<pattern>
+706
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+</Ascii_20data_20model>
+<Prm_20polygon>
+<Topography_20parameters>
+<value/>
+<default_value/>
+<documentation>
+Set the topography height and the polygon which should be set to that height. The format is : &quot;The topography height 	extgreater The point list describing a polygon \&amp; The next topography height 	extgreater the next point list describing a polygon.&quot; The format for the point list describing the polygon is &quot;x1,y1;x2,y2&quot;. For example for two triangular areas of 100 and -100 meters high set: &apos;100 	extgreater 0,0;5,5;0,10 \&amp; -100 	extgreater 10,10;10,15;20,15&apos;. Units of the height are always in meters. The units of the coordinates are dependent on the geometry model. In the box model they are in meters, in the chunks they are in degrees, etc. Please refer to the manual of the individual geometry model to so see how the topography is implemented.
+</documentation>
+<pattern>
+707
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Topography_20parameters>
+</Prm_20polygon>
+</Initial_20topography_20model>
+</Geometry_20model>
+<Gravity_20model>
+<Model_20name>
+<value>
+vertical
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Select one of the following models:
+
+`ascii data&apos;: Gravity is read from a file that describes the reference state. The default profile follows the preliminary reference Earth model (PREM, Dziewonski and Anderson, 1981). Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of points in the reference state as for example `# POINTS: 3&apos;. Following the comment lines there has to be a single line containing the names of all data columns, separated by arbitrarily many spaces. Column names are not allowed to contain spaces. The file can contain unnecessary columns, but for this plugin it needs to at least provide a column named `gravity&apos;. Note that the data lines in the file need to be sorted in order of increasing depth from 0 to the maximal depth in the model domain. Points in the model that are outside of the provided depth range will be assigned the maximum or minimum depth values, respectively. Points do not need to be equidistant, but the computation of properties is optimized in speed if they are.
+
+`function&apos;: Gravity is given in terms of an explicit formula that is elaborated in the parameters in section ``Gravity model|Function&apos;&apos;. The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
+`radial constant&apos;: A gravity model in which the gravity has a constant magnitude and the direction is radial (pointing inward if the value is positive). The magnitude is read from the parameter file in subsection &apos;Radial constant&apos;.
+
+`radial earth-like&apos;: This plugin has been removed due to its misleading name. The included profile was hard-coded and was less earth-like than the `ascii data&apos; plugin, which uses the profile of the Preliminary Reference Earth Model (PREM). Use `ascii data&apos; instead of `radial earth-like&apos;.
+
+`radial linear&apos;: A gravity model which is radial (pointing inward if the gravity is positive) and the magnitude changes linearly with depth. The magnitude of gravity at the surface and bottom is read from the input file in a section ``Gravity model/Radial linear&apos;&apos;.
+
+`vertical&apos;: A gravity model in which the gravity direction is vertical (pointing downward for positive values) and at a constant magnitude by default equal to one.
+</documentation>
+<pattern>
+708
+</pattern>
+<pattern_description>
+[Selection ascii data|function|radial constant|radial earth-like|radial linear|vertical|unspecified ]
+</pattern_description>
+</Model_20name>
+<Ascii_20data_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/gravity-model/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/gravity-model/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a `/&apos;) or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+709
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value>
+prem.txt
+</value>
+<default_value>
+prem.txt
+</default_value>
+<documentation>
+The file name of the model data. Provide file in format: (Velocity file name).\%s\%d where \%s is a string specifying the boundary of the model according to the names of the boundary indicators (of the chosen geometry model).\%d is any sprintf integer qualifier, specifying the format of the current file number. 
+</documentation>
+<pattern>
+710
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+</documentation>
+<pattern>
+711
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+</Ascii_20data_20model>
+<Function>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+712
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0; 0
+</value>
+<default_value>
+0; 0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+713
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+714
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Function>
+<Radial_20constant>
+<Magnitude>
+<value>
+9.81
+</value>
+<default_value>
+9.81
+</default_value>
+<documentation>
+Magnitude of the gravity vector in $m/s^2$. For positive values the direction is radially inward towards the center of the earth.
+</documentation>
+<pattern>
+715
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Magnitude>
+</Radial_20constant>
+<Radial_20linear>
+<Magnitude_20at_20surface>
+<value>
+9.8
+</value>
+<default_value>
+9.8
+</default_value>
+<documentation>
+Magnitude of the radial gravity vector at the surface of the domain. Units: $m/s^2$
+</documentation>
+<pattern>
+716
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Magnitude_20at_20surface>
+<Magnitude_20at_20bottom>
+<value>
+10.7
+</value>
+<default_value>
+10.7
+</default_value>
+<documentation>
+Magnitude of the radial gravity vector at the bottom of the domain. `Bottom&apos; means themaximum depth in the chosen geometry, and for example represents the core-mantle boundary in the case of the `spherical shell&apos; geometry model, and the center in the case of the `sphere&apos; geometry model. Units: $m/s^2$
+</documentation>
+<pattern>
+717
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Magnitude_20at_20bottom>
+</Radial_20linear>
+<Vertical>
+<Magnitude>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Value of the gravity vector in $m/s^2$ directed along negative y (2D) or z (3D) axis (if the magnitude is positive.
+</documentation>
+<pattern>
+718
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Magnitude>
+</Vertical>
+</Gravity_20model>
+<Initial_20temperature_20model>
+<List_20of_20model_20names>
+<value/>
+<default_value/>
+<documentation>
+A comma-separated list of initial temperature models that will be used to initialize the temperature. These plugins are loaded in the order given, and modify the existing temperature field via the operators listed in &apos;List of model operators&apos;.
+
+The following initial temperature models are available:
+
+`S40RTS perturbation&apos;: An initial temperature field in which the temperature is perturbed following the S20RTS or S40RTS shear wave velocity model by Ritsema and others, which can be downloaded here \url{http://www.earth.lsa.umich.edu/~jritsema/research.html}. Information on the vs model can be found in Ritsema, J., Deuss, A., van Heijst, H.J. \&amp; Woodhouse, J.H., 2011. S40RTS: a degree-40 shear-velocity model for the mantle from new Rayleigh wave dispersion, teleseismic traveltime and normal-mode splitting function measurements, Geophys. J. Int. 184, 1223-1236. The scaling between the shear wave perturbation and the density perturbation can be constant and set by the user with the &apos;Vs to density scaling&apos; parameter or depth-dependent and read in from a file. To convert density the user can specify the &apos;Thermal expansion coefficient in initial temperature scaling&apos; parameter. The scaling is as follows: $\delta ln \rho (r,\theta,\phi) = \xi \cdot \delta ln v_s(r,\theta, \phi)$ and $\delta T(r,\theta,\phi) = - \frac{1}{\alpha} \delta ln \rho(r,\theta,\phi)$. $\xi$ is the `vs to density scaling&apos; parameter and $\alpha$ is the &apos;Thermal expansion coefficient in initial temperature scaling&apos; parameter. The temperature perturbation is added to an otherwise constant temperature (incompressible model) or adiabatic reference profile (compressible model). If a depth is specified in &apos;Remove temperature heterogeneity down to specified depth&apos;, there is no temperature perturbation prescribed down to that depth.
+Note the required file format if the vs to density scaling is read in from a file: The first lines may contain any number of comments if they begin with &apos;#&apos;, but one of these lines needs to contain the number of points in the reference state as for example &apos;# POINTS: 3&apos;. Following the comment lines there has to be a single line containing the names of all data columns, separated by arbitrarily many spaces. Column names are not allowed to contain spaces. The file can contain unnecessary columns, but for this plugin it needs to at least provide the columns named `depth&apos; and `vs\_to\_density&apos;. Note that the data lines in the file need to be sorted in order of increasing depth from 0 to the maximal depth in the model domain. Points in the model that are outside of the provided depth range will be assigned the maximum or minimum depth values, respectively. Points do not need to be equidistant, but the computation of properties is optimized in speed if they are.
+
+`SAVANI perturbation&apos;: An initial temperature field in which the temperature is perturbed following the SAVANI shear wave velocity model by Auer and others, which can be downloaded here \url{http://n.ethz.ch/~auerl/savani.tar.bz2}. Information on the vs model can be found in Auer, L., Boschi, L., Becker, T.W., Nissen-Meyer, T. \&amp; Giardini, D., 2014. Savani: A variable resolution whole-mantle model of anisotropic shear velocity variations based on multiple data sets. Journal of Geophysical Research: Solid Earth 119.4 (2014): 3006-3034. The scaling between the shear wave perturbation and the density perturbation can be constant and set by the user with the &apos;Vs to density scaling&apos; parameter or depth-dependent and read in from a file. To convert density the user can specify the &apos;Thermal expansion coefficient in initial temperature scaling&apos; parameter. The scaling is as follows: $\delta ln \rho (r,\theta,\phi) = \xi \cdot \delta ln v_s(r,\theta, \phi)$ and $\delta T(r,\theta,\phi) = - \frac{1}{\alpha} \delta ln \rho(r,\theta,\phi)$. $\xi$ is the `vs to density scaling&apos; parameter and $\alpha$ is the &apos;Thermal expansion coefficient in initial temperature scaling&apos; parameter. The temperature perturbation is added to an otherwise constant temperature (incompressible model) or adiabatic reference profile (compressible model).If a depth is specified in &apos;Remove temperature heterogeneity down to specified depth&apos;, there is no temperature perturbation prescribed down to that depth.
+Note the required file format if the vs to density scaling is read in from a file: The first lines may contain any number of comments if they begin with &apos;#&apos;, but one of these lines needs to contain the number of points in the reference state as for example &apos;# POINTS: 3&apos;. Following the comment lines there has to be a single line containing the names of all data columns, separated by arbitrarily many spaces. Column names are not allowed to contain spaces. The file can contain unnecessary columns, but for this plugin it needs to at least provide the columns named `depth&apos; and `vs\_to\_density&apos;. Note that the data lines in the file need to be sorted in order of increasing depth from 0 to the maximal depth in the model domain. Points in the model that are outside of the provided depth range will be assigned the maximum or minimum depth values, respectively. Points do not need to be equidistant, but the computation of properties is optimized in speed if they are.
+
+`adiabatic&apos;: Temperature is prescribed as an adiabatic profile with upper and lower thermal boundary layers, whose ages are given as input parameters.
+
+`adiabatic boundary&apos;: An initial temperature condition that allows for discretizing the model domain into two layers separated by a user-defined isothermal boundary using a table look-up approach. The user includes an input ascii data file that is formatted as 3 columns of `latitude&apos;, `longitude&apos;, and `depth&apos;, where `depth&apos; is in kilometers and represents the depth of an initial temperature of 1673.15 K (by default). The temperature is defined from the surface (273.15 K) to the isotherm as a linear gradient. Below the isotherm the temperature increases approximately adiabatically (0.0005 K per meter). This initial temperature condition is designed specifically for the ellipsoidal chunk geometry model.
+
+`ascii data&apos;: Implementation of a model in which the initial temperature is derived from files containing data in ascii format. Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of grid points in each dimension as for example `# POINTS: 3 3&apos;. The order of the data columns has to be `x&apos;, `y&apos;, `Temperature [K]&apos; in a 2d model and  `x&apos;, `y&apos;, `z&apos;, `Temperature [K]&apos; in a 3d model, which means that there has to be a single column containing the temperature. Note that the data in the input files need to be sorted in a specific order: the first coordinate needs to ascend first, followed by the second and the third at last in order to assign the correct data to the prescribed coordinates. If you use a spherical model, then the assumed grid changes. `x&apos; will be replaced by the radial distance of the point to the bottom of the model, `y&apos; by the azimuth angle and `z&apos; by the polar angle measured positive from the north pole. The grid will be assumed to be a latitude-longitude grid. Note that the order of spherical coordinates is `r&apos;, `phi&apos;, `theta&apos; and not `r&apos;, `theta&apos;, `phi&apos;, since this allows for dimension independent expressions.
+
+`ascii profile&apos;: Implementation of a model in which the initial temperature is read from a file that provides these values as a function of depth. Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of points in the temperature profile, for example `# POINTS: 10&apos;. Following the comment lines, there has to be a single line containing the names of all data columns, separated by arbitrarily many spaces. Column names are not allowed to contain spaces. The file can contain unnecessary columns, but for this plugin it needs to at least provide columns named `depth&apos; and`temperature&apos;.Note that the data lines in the file need to be sorted in order of increasing depth from 0 to the maximal depth in the model domain. Points in the model that are outside of the provided depth range will be assigned the maximum or minimum depth values, respectively. Points do not need to be equidistant, but the computation of properties is optimized in speed if they are.
+
+`function&apos;: Specify the initial temperature in terms of an explicit formula. The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
+`harmonic perturbation&apos;: An initial temperature field in which the temperature is perturbed following a harmonic function (spherical harmonic or sine depending on geometry and dimension) in lateral and radial direction from an otherwise constant temperature (incompressible model) or adiabatic reference profile (compressible model).
+
+`inclusion shape perturbation&apos;: An initial temperature field in which there is an inclusion in a constant-temperature box field. The size, shape, gradient, position, and temperature of the inclusion are defined by parameters.
+
+`mandelbox&apos;: Fractal-shaped temperature field.
+
+`patch on S40RTS&apos;: Implementation of a model in which the initial temperature is derived from a file containing shear wave velocity perturbations in ascii format (e.g. a high resolution upper mantle tomography) combined with S40RTS. Note the required format of the input ascii input data: The first lines may contain any number of comments if they begin with &apos;#&apos;, but one of these lines needs to contain the number of grid points in each dimension as for example &apos;# POINTS: 3 3 3&apos;. The order of the data columns has to be  `x&apos;, `y&apos;, `z&apos;, &apos;Vs Perturbation&apos; in a 3d model, which means that there has to be a single column containing the temperature. Note that the data in the input files need to be sorted in a specific order: the first coordinate needs to ascend first, followed by the second and the third at last in order to assign the correct data to the prescribed coordinates. In the spherical model data will be handled as Cartesian, however, `x&apos; will be replaced by the radial distance of the point to the bottom of the model, `y&apos; by the azimuth angle and `z&apos; by the polar angle measured positive from the north pole. The grid will be assumed to be a latitude-longitude grid. Note that the order of spherical coordinates is `r&apos;, `phi&apos;, `theta&apos; and not `r&apos;, `theta&apos;, `phi&apos;, since this allows for dimension independent expressions. See S40RTS documentation for details on input parameters in the S40RTS perturbation subsection. The boundary between the two tomography models is smoothed using a depth weighted combination of Vs values within the region of smoothing. 
+
+`perturbed box&apos;: An initial temperature field in which the temperature is perturbed slightly from an otherwise constant value equal to one. The perturbation is chosen in such a way that the initial temperature is constant to one along the entire boundary.
+
+`polar box&apos;: An initial temperature field in which the temperature is perturbed slightly from an otherwise constant value equal to one. The perturbation is such that there are two poles on opposing corners of the box. 
+
+`spherical gaussian perturbation&apos;: An initial temperature field in which the temperature is perturbed by a single Gaussian added to an otherwise spherically symmetric state. Additional parameters are read from the parameter file in subsection &apos;Spherical gaussian perturbation&apos;.
+
+`spherical hexagonal perturbation&apos;: An initial temperature field in which the temperature is perturbed following an $N$-fold pattern in a specified direction from an otherwise spherically symmetric state. The class&apos;s name comes from previous versions when the only option was $N=6$.
+
+`world builder&apos;: Specify the initial temperature through the World Builder. More information on the World Builder can be found at \url{https://geodynamicworldbuilder.github.io}. Make sure to specify the location of the World Builder file in the parameter &apos;World builder file&apos;.
+</documentation>
+<pattern>
+719
+</pattern>
+<pattern_description>
+[MultipleSelection S40RTS perturbation|SAVANI perturbation|adiabatic|adiabatic boundary|ascii data|ascii profile|function|harmonic perturbation|inclusion shape perturbation|mandelbox|patch on S40RTS|perturbed box|polar box|spherical gaussian perturbation|spherical hexagonal perturbation|world builder ]
+</pattern_description>
+</List_20of_20model_20names>
+<List_20of_20model_20operators>
+<value>
+add
+</value>
+<default_value>
+add
+</default_value>
+<documentation>
+A comma-separated list of operators that will be used to append the listed temperature models onto the previous models. If only one operator is given, the same operator is applied to all models.
+</documentation>
+<pattern>
+720
+</pattern>
+<pattern_description>
+[MultipleSelection add|subtract|minimum|maximum ]
+</pattern_description>
+</List_20of_20model_20operators>
+<Model_20name>
+<value>
+adiabatic
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Select one of the following models:
+
+`S40RTS perturbation&apos;: An initial temperature field in which the temperature is perturbed following the S20RTS or S40RTS shear wave velocity model by Ritsema and others, which can be downloaded here \url{http://www.earth.lsa.umich.edu/~jritsema/research.html}. Information on the vs model can be found in Ritsema, J., Deuss, A., van Heijst, H.J. \&amp; Woodhouse, J.H., 2011. S40RTS: a degree-40 shear-velocity model for the mantle from new Rayleigh wave dispersion, teleseismic traveltime and normal-mode splitting function measurements, Geophys. J. Int. 184, 1223-1236. The scaling between the shear wave perturbation and the density perturbation can be constant and set by the user with the &apos;Vs to density scaling&apos; parameter or depth-dependent and read in from a file. To convert density the user can specify the &apos;Thermal expansion coefficient in initial temperature scaling&apos; parameter. The scaling is as follows: $\delta ln \rho (r,\theta,\phi) = \xi \cdot \delta ln v_s(r,\theta, \phi)$ and $\delta T(r,\theta,\phi) = - \frac{1}{\alpha} \delta ln \rho(r,\theta,\phi)$. $\xi$ is the `vs to density scaling&apos; parameter and $\alpha$ is the &apos;Thermal expansion coefficient in initial temperature scaling&apos; parameter. The temperature perturbation is added to an otherwise constant temperature (incompressible model) or adiabatic reference profile (compressible model). If a depth is specified in &apos;Remove temperature heterogeneity down to specified depth&apos;, there is no temperature perturbation prescribed down to that depth.
+Note the required file format if the vs to density scaling is read in from a file: The first lines may contain any number of comments if they begin with &apos;#&apos;, but one of these lines needs to contain the number of points in the reference state as for example &apos;# POINTS: 3&apos;. Following the comment lines there has to be a single line containing the names of all data columns, separated by arbitrarily many spaces. Column names are not allowed to contain spaces. The file can contain unnecessary columns, but for this plugin it needs to at least provide the columns named `depth&apos; and `vs\_to\_density&apos;. Note that the data lines in the file need to be sorted in order of increasing depth from 0 to the maximal depth in the model domain. Points in the model that are outside of the provided depth range will be assigned the maximum or minimum depth values, respectively. Points do not need to be equidistant, but the computation of properties is optimized in speed if they are.
+
+`SAVANI perturbation&apos;: An initial temperature field in which the temperature is perturbed following the SAVANI shear wave velocity model by Auer and others, which can be downloaded here \url{http://n.ethz.ch/~auerl/savani.tar.bz2}. Information on the vs model can be found in Auer, L., Boschi, L., Becker, T.W., Nissen-Meyer, T. \&amp; Giardini, D., 2014. Savani: A variable resolution whole-mantle model of anisotropic shear velocity variations based on multiple data sets. Journal of Geophysical Research: Solid Earth 119.4 (2014): 3006-3034. The scaling between the shear wave perturbation and the density perturbation can be constant and set by the user with the &apos;Vs to density scaling&apos; parameter or depth-dependent and read in from a file. To convert density the user can specify the &apos;Thermal expansion coefficient in initial temperature scaling&apos; parameter. The scaling is as follows: $\delta ln \rho (r,\theta,\phi) = \xi \cdot \delta ln v_s(r,\theta, \phi)$ and $\delta T(r,\theta,\phi) = - \frac{1}{\alpha} \delta ln \rho(r,\theta,\phi)$. $\xi$ is the `vs to density scaling&apos; parameter and $\alpha$ is the &apos;Thermal expansion coefficient in initial temperature scaling&apos; parameter. The temperature perturbation is added to an otherwise constant temperature (incompressible model) or adiabatic reference profile (compressible model).If a depth is specified in &apos;Remove temperature heterogeneity down to specified depth&apos;, there is no temperature perturbation prescribed down to that depth.
+Note the required file format if the vs to density scaling is read in from a file: The first lines may contain any number of comments if they begin with &apos;#&apos;, but one of these lines needs to contain the number of points in the reference state as for example &apos;# POINTS: 3&apos;. Following the comment lines there has to be a single line containing the names of all data columns, separated by arbitrarily many spaces. Column names are not allowed to contain spaces. The file can contain unnecessary columns, but for this plugin it needs to at least provide the columns named `depth&apos; and `vs\_to\_density&apos;. Note that the data lines in the file need to be sorted in order of increasing depth from 0 to the maximal depth in the model domain. Points in the model that are outside of the provided depth range will be assigned the maximum or minimum depth values, respectively. Points do not need to be equidistant, but the computation of properties is optimized in speed if they are.
+
+`adiabatic&apos;: Temperature is prescribed as an adiabatic profile with upper and lower thermal boundary layers, whose ages are given as input parameters.
+
+`adiabatic boundary&apos;: An initial temperature condition that allows for discretizing the model domain into two layers separated by a user-defined isothermal boundary using a table look-up approach. The user includes an input ascii data file that is formatted as 3 columns of `latitude&apos;, `longitude&apos;, and `depth&apos;, where `depth&apos; is in kilometers and represents the depth of an initial temperature of 1673.15 K (by default). The temperature is defined from the surface (273.15 K) to the isotherm as a linear gradient. Below the isotherm the temperature increases approximately adiabatically (0.0005 K per meter). This initial temperature condition is designed specifically for the ellipsoidal chunk geometry model.
+
+`ascii data&apos;: Implementation of a model in which the initial temperature is derived from files containing data in ascii format. Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of grid points in each dimension as for example `# POINTS: 3 3&apos;. The order of the data columns has to be `x&apos;, `y&apos;, `Temperature [K]&apos; in a 2d model and  `x&apos;, `y&apos;, `z&apos;, `Temperature [K]&apos; in a 3d model, which means that there has to be a single column containing the temperature. Note that the data in the input files need to be sorted in a specific order: the first coordinate needs to ascend first, followed by the second and the third at last in order to assign the correct data to the prescribed coordinates. If you use a spherical model, then the assumed grid changes. `x&apos; will be replaced by the radial distance of the point to the bottom of the model, `y&apos; by the azimuth angle and `z&apos; by the polar angle measured positive from the north pole. The grid will be assumed to be a latitude-longitude grid. Note that the order of spherical coordinates is `r&apos;, `phi&apos;, `theta&apos; and not `r&apos;, `theta&apos;, `phi&apos;, since this allows for dimension independent expressions.
+
+`ascii profile&apos;: Implementation of a model in which the initial temperature is read from a file that provides these values as a function of depth. Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of points in the temperature profile, for example `# POINTS: 10&apos;. Following the comment lines, there has to be a single line containing the names of all data columns, separated by arbitrarily many spaces. Column names are not allowed to contain spaces. The file can contain unnecessary columns, but for this plugin it needs to at least provide columns named `depth&apos; and`temperature&apos;.Note that the data lines in the file need to be sorted in order of increasing depth from 0 to the maximal depth in the model domain. Points in the model that are outside of the provided depth range will be assigned the maximum or minimum depth values, respectively. Points do not need to be equidistant, but the computation of properties is optimized in speed if they are.
+
+`function&apos;: Specify the initial temperature in terms of an explicit formula. The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
+`harmonic perturbation&apos;: An initial temperature field in which the temperature is perturbed following a harmonic function (spherical harmonic or sine depending on geometry and dimension) in lateral and radial direction from an otherwise constant temperature (incompressible model) or adiabatic reference profile (compressible model).
+
+`inclusion shape perturbation&apos;: An initial temperature field in which there is an inclusion in a constant-temperature box field. The size, shape, gradient, position, and temperature of the inclusion are defined by parameters.
+
+`mandelbox&apos;: Fractal-shaped temperature field.
+
+`patch on S40RTS&apos;: Implementation of a model in which the initial temperature is derived from a file containing shear wave velocity perturbations in ascii format (e.g. a high resolution upper mantle tomography) combined with S40RTS. Note the required format of the input ascii input data: The first lines may contain any number of comments if they begin with &apos;#&apos;, but one of these lines needs to contain the number of grid points in each dimension as for example &apos;# POINTS: 3 3 3&apos;. The order of the data columns has to be  `x&apos;, `y&apos;, `z&apos;, &apos;Vs Perturbation&apos; in a 3d model, which means that there has to be a single column containing the temperature. Note that the data in the input files need to be sorted in a specific order: the first coordinate needs to ascend first, followed by the second and the third at last in order to assign the correct data to the prescribed coordinates. In the spherical model data will be handled as Cartesian, however, `x&apos; will be replaced by the radial distance of the point to the bottom of the model, `y&apos; by the azimuth angle and `z&apos; by the polar angle measured positive from the north pole. The grid will be assumed to be a latitude-longitude grid. Note that the order of spherical coordinates is `r&apos;, `phi&apos;, `theta&apos; and not `r&apos;, `theta&apos;, `phi&apos;, since this allows for dimension independent expressions. See S40RTS documentation for details on input parameters in the S40RTS perturbation subsection. The boundary between the two tomography models is smoothed using a depth weighted combination of Vs values within the region of smoothing. 
+
+`perturbed box&apos;: An initial temperature field in which the temperature is perturbed slightly from an otherwise constant value equal to one. The perturbation is chosen in such a way that the initial temperature is constant to one along the entire boundary.
+
+`polar box&apos;: An initial temperature field in which the temperature is perturbed slightly from an otherwise constant value equal to one. The perturbation is such that there are two poles on opposing corners of the box. 
+
+`spherical gaussian perturbation&apos;: An initial temperature field in which the temperature is perturbed by a single Gaussian added to an otherwise spherically symmetric state. Additional parameters are read from the parameter file in subsection &apos;Spherical gaussian perturbation&apos;.
+
+`spherical hexagonal perturbation&apos;: An initial temperature field in which the temperature is perturbed following an $N$-fold pattern in a specified direction from an otherwise spherically symmetric state. The class&apos;s name comes from previous versions when the only option was $N=6$.
+
+`world builder&apos;: Specify the initial temperature through the World Builder. More information on the World Builder can be found at \url{https://geodynamicworldbuilder.github.io}. Make sure to specify the location of the World Builder file in the parameter &apos;World builder file&apos;.
+
+\textbf{Warning}: This parameter provides an old and deprecated way of specifying initial temperature models and shouldn&apos;t be used. Please use &apos;List of model names&apos; instead.
+</documentation>
+<pattern>
+721
+</pattern>
+<pattern_description>
+[Selection S40RTS perturbation|SAVANI perturbation|adiabatic|adiabatic boundary|ascii data|ascii profile|function|harmonic perturbation|inclusion shape perturbation|mandelbox|patch on S40RTS|perturbed box|polar box|spherical gaussian perturbation|spherical hexagonal perturbation|world builder|unspecified ]
+</pattern_description>
+</Model_20name>
+<S40RTS_20perturbation>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/S40RTS/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/S40RTS/
+</default_value>
+<documentation>
+The path to the model data. 
+</documentation>
+<pattern>
+722
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Initial_20condition_20file_20name>
+<value>
+S40RTS.sph
+</value>
+<default_value>
+S40RTS.sph
+</default_value>
+<documentation>
+The file name of the spherical harmonics coefficients from Ritsema et al.
+</documentation>
+<pattern>
+723
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Initial_20condition_20file_20name>
+<Spline_20knots_20depth_20file_20name>
+<value>
+Spline_knots.txt
+</value>
+<default_value>
+Spline_knots.txt
+</default_value>
+<documentation>
+The file name of the spline knot locations from Ritsema et al.
+</documentation>
+<pattern>
+724
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Spline_20knots_20depth_20file_20name>
+<Vs_20to_20density_20scaling_20method>
+<value>
+constant
+</value>
+<default_value>
+constant
+</default_value>
+<documentation>
+Method that is used to specify how the vs-to-density scaling varies with depth.
+</documentation>
+<pattern>
+725
+</pattern>
+<pattern_description>
+[Selection file|constant ]
+</pattern_description>
+</Vs_20to_20density_20scaling_20method>
+<Vs_20to_20density_20scaling>
+<value>
+0.25
+</value>
+<default_value>
+0.25
+</default_value>
+<documentation>
+This parameter specifies how the perturbation in shear wave velocity as prescribed by S20RTS or S40RTS is scaled into a density perturbation. See the general description of this model for more detailed information.
+</documentation>
+<pattern>
+726
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Vs_20to_20density_20scaling>
+<Thermal_20expansion_20coefficient_20in_20initial_20temperature_20scaling>
+<value>
+2e-5
+</value>
+<default_value>
+2e-5
+</default_value>
+<documentation>
+The value of the thermal expansion coefficient $\beta$. Units: $1/K$.
+</documentation>
+<pattern>
+727
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20expansion_20coefficient_20in_20initial_20temperature_20scaling>
+<Use_20thermal_20expansion_20coefficient_20from_20material_20model>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Option to take the thermal expansion coefficient from the material model instead of from what is specified in this section.
+</documentation>
+<pattern>
+728
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20thermal_20expansion_20coefficient_20from_20material_20model>
+<Remove_20degree_200_20from_20perturbation>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+Option to remove the degree zero component from the perturbation, which will ensure that the laterally averaged temperature for a fixed depth is equal to the background temperature.
+</documentation>
+<pattern>
+729
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Remove_20degree_200_20from_20perturbation>
+<Reference_20temperature>
+<value>
+1600.0
+</value>
+<default_value>
+1600.0
+</default_value>
+<documentation>
+The reference temperature that is perturbed by the spherical harmonic functions. Only used in incompressible models.
+</documentation>
+<pattern>
+730
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Remove_20temperature_20heterogeneity_20down_20to_20specified_20depth>
+<value>
+-1.7976931348623157e+308
+</value>
+<default_value>
+-1.7976931348623157e+308
+</default_value>
+<documentation>
+This will set the heterogeneity prescribed by S20RTS or S40RTS to zero down to the specified depth (in meters). Note that your resolution has to be adequate to capture this cutoff. For example if you specify a depth of 660km, but your closest spherical depth layers are only at 500km and 750km (due to a coarse resolution) it will only zero out heterogeneities down to 500km. Similar caution has to be taken when using adaptive meshing.
+</documentation>
+<pattern>
+731
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Remove_20temperature_20heterogeneity_20down_20to_20specified_20depth>
+<Specify_20a_20lower_20maximum_20order>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Option to use a lower maximum order when reading the data file of spherical harmonic coefficients. This is probably used for the faster tests or when the users only want to see the spherical harmonic pattern up to a certain order.
+</documentation>
+<pattern>
+732
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Specify_20a_20lower_20maximum_20order>
+<Maximum_20order>
+<value>
+20
+</value>
+<default_value>
+20
+</default_value>
+<documentation>
+The maximum order the users specify when reading the data file of spherical harmonic coefficients, which must be smaller than the maximum order the data file stored. This parameter will be used only if &apos;Specify a lower maximum order&apos; is set to true.
+</documentation>
+<pattern>
+733
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Maximum_20order>
+<Ascii_20data_20vs_20to_20density_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/S40RTS/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/S40RTS/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a `/&apos;) or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+734
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value>
+vs_to_density_Steinberger.txt
+</value>
+<default_value>
+vs_to_density_Steinberger.txt
+</default_value>
+<documentation>
+The file name of the model data. Provide file in format: (Velocity file name).\%s\%d where \%s is a string specifying the boundary of the model according to the names of the boundary indicators (of the chosen geometry model).\%d is any sprintf integer qualifier, specifying the format of the current file number. 
+</documentation>
+<pattern>
+735
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+</documentation>
+<pattern>
+736
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+</Ascii_20data_20vs_20to_20density_20model>
+</S40RTS_20perturbation>
+<SAVANI_20perturbation>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/SAVANI/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/SAVANI/
+</default_value>
+<documentation>
+The path to the model data.
+</documentation>
+<pattern>
+737
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Initial_20condition_20file_20name>
+<value>
+savani.dlnvs.60.m.ab
+</value>
+<default_value>
+savani.dlnvs.60.m.ab
+</default_value>
+<documentation>
+The file name of the spherical harmonics coefficients from Auer et al.
+</documentation>
+<pattern>
+738
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Initial_20condition_20file_20name>
+<Spline_20knots_20depth_20file_20name>
+<value>
+Spline_knots.txt
+</value>
+<default_value>
+Spline_knots.txt
+</default_value>
+<documentation>
+The file name of the spline knots taken from the 28 spherical layers of SAVANI tomography model.
+</documentation>
+<pattern>
+739
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Spline_20knots_20depth_20file_20name>
+<Vs_20to_20density_20scaling_20method>
+<value>
+constant
+</value>
+<default_value>
+constant
+</default_value>
+<documentation>
+Method that is used to specify how the vs-to-density scaling varies with depth.
+</documentation>
+<pattern>
+740
+</pattern>
+<pattern_description>
+[Selection file|constant ]
+</pattern_description>
+</Vs_20to_20density_20scaling_20method>
+<Vs_20to_20density_20scaling>
+<value>
+0.25
+</value>
+<default_value>
+0.25
+</default_value>
+<documentation>
+This parameter specifies how the perturbation in shear wave velocity as prescribed by SAVANI is scaled into a density perturbation. See the general description of this model for more detailed information.
+</documentation>
+<pattern>
+741
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Vs_20to_20density_20scaling>
+<Thermal_20expansion_20coefficient_20in_20initial_20temperature_20scaling>
+<value>
+2e-5
+</value>
+<default_value>
+2e-5
+</default_value>
+<documentation>
+The value of the thermal expansion coefficient $\beta$. Units: $1/K$.
+</documentation>
+<pattern>
+742
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Thermal_20expansion_20coefficient_20in_20initial_20temperature_20scaling>
+<Use_20thermal_20expansion_20coefficient_20from_20material_20model>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Option to take the thermal expansion coefficient from the material model instead of from what is specified in this section.
+</documentation>
+<pattern>
+743
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20thermal_20expansion_20coefficient_20from_20material_20model>
+<Remove_20degree_200_20from_20perturbation>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+Option to remove the degree zero component from the perturbation, which will ensure that the laterally averaged temperature for a fixed depth is equal to the background temperature.
+</documentation>
+<pattern>
+744
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Remove_20degree_200_20from_20perturbation>
+<Reference_20temperature>
+<value>
+1600.0
+</value>
+<default_value>
+1600.0
+</default_value>
+<documentation>
+The reference temperature that is perturbed by the spherical harmonic functions. Only used in incompressible models.
+</documentation>
+<pattern>
+745
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+<Remove_20temperature_20heterogeneity_20down_20to_20specified_20depth>
+<value>
+-1.7976931348623157e+308
+</value>
+<default_value>
+-1.7976931348623157e+308
+</default_value>
+<documentation>
+This will set the heterogeneity prescribed by SAVANI to zero down to the specified depth (in meters). Note that your resolution has to be adequate to capture this cutoff. For example if you specify a depth of 660km, but your closest spherical depth layers are only at 500km and 750km (due to a coarse resolution) it will only zero out heterogeneities down to 500km. Similar caution has to be taken when using adaptive meshing.
+</documentation>
+<pattern>
+746
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Remove_20temperature_20heterogeneity_20down_20to_20specified_20depth>
+<Specify_20a_20lower_20maximum_20order>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Option to use a lower maximum order when reading the data file of spherical harmonic coefficients. This is probably used for the faster tests or when the users only want to see the spherical harmonic pattern up to a certain order.
+</documentation>
+<pattern>
+747
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Specify_20a_20lower_20maximum_20order>
+<Maximum_20order>
+<value>
+20
+</value>
+<default_value>
+20
+</default_value>
+<documentation>
+The maximum order the users specify when reading the data file of spherical harmonic coefficients, which must be smaller than the maximum order the data file stored. This parameter will be used only if &apos;Specify a lower maximum order&apos; is set to true.
+</documentation>
+<pattern>
+748
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Maximum_20order>
+<Ascii_20data_20vs_20to_20density_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/S40RTS/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/S40RTS/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a `/&apos;) or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+749
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value>
+vs_to_density_Steinberger.txt
+</value>
+<default_value>
+vs_to_density_Steinberger.txt
+</default_value>
+<documentation>
+The file name of the model data. Provide file in format: (Velocity file name).\%s\%d where \%s is a string specifying the boundary of the model according to the names of the boundary indicators (of the chosen geometry model).\%d is any sprintf integer qualifier, specifying the format of the current file number. 
+</documentation>
+<pattern>
+750
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+</documentation>
+<pattern>
+751
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+</Ascii_20data_20vs_20to_20density_20model>
+</SAVANI_20perturbation>
+<Adiabatic>
+<Age_20top_20boundary_20layer>
+<value>
+0e0
+</value>
+<default_value>
+0e0
+</default_value>
+<documentation>
+The age of the upper thermal boundary layer, used for the calculation of the half-space cooling model temperature. Units: years if the &apos;Use years in output instead of seconds&apos; parameter is set; seconds otherwise.
+</documentation>
+<pattern>
+752
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Age_20top_20boundary_20layer>
+<Age_20bottom_20boundary_20layer>
+<value>
+0e0
+</value>
+<default_value>
+0e0
+</default_value>
+<documentation>
+The age of the lower thermal boundary layer, used for the calculation of the half-space cooling model temperature. Units: years if the &apos;Use years in output instead of seconds&apos; parameter is set; seconds otherwise.
+</documentation>
+<pattern>
+753
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Age_20bottom_20boundary_20layer>
+<Radius>
+<value>
+0e0
+</value>
+<default_value>
+0e0
+</default_value>
+<documentation>
+The Radius (in m) of the initial spherical temperature perturbation at the bottom of the model domain.
+</documentation>
+<pattern>
+754
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Radius>
+<Amplitude>
+<value>
+0e0
+</value>
+<default_value>
+0e0
+</default_value>
+<documentation>
+The amplitude (in K) of the initial spherical temperature perturbation at the bottom of the model domain. This perturbation will be added to the adiabatic temperature profile, but not to the bottom thermal boundary layer. Instead, the maximum of the perturbation and the bottom boundary layer temperature will be used.
+</documentation>
+<pattern>
+755
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Amplitude>
+<Position>
+<value>
+center
+</value>
+<default_value>
+center
+</default_value>
+<documentation>
+Where the initial temperature perturbation should be placed. If `center&apos; is given, then the perturbation will be centered along a `midpoint&apos; of some sort of the bottom boundary. For example, in the case of a box geometry, this is the center of the bottom face; in the case of a spherical shell geometry, it is along the inner surface halfway between the bounding radial lines.
+</documentation>
+<pattern>
+756
+</pattern>
+<pattern_description>
+[Selection center ]
+</pattern_description>
+</Position>
+<Subadiabaticity>
+<value>
+0e0
+</value>
+<default_value>
+0e0
+</default_value>
+<documentation>
+If this value is larger than 0, the initial temperature profile will not be adiabatic, but subadiabatic. This value gives the maximal deviation from adiabaticity. Set to 0 for an adiabatic temperature profile. Units: K.
+
+The function object in the Function subsection represents the compositional fields that will be used as a reference profile for calculating the thermal diffusivity. This function is one-dimensional and depends only on depth. The format of this functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+</documentation>
+<pattern>
+757
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Subadiabaticity>
+<Function>
+<Variable_20names>
+<value>
+x,t
+</value>
+<default_value>
+x,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+758
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+759
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+760
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Function>
+</Adiabatic>
+<Adiabatic_20boundary>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/adiabatic-boundary/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/adiabatic-boundary/
+</default_value>
+<documentation>
+The path to the isotherm depth data file
+</documentation>
+<pattern>
+761
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Isotherm_20depth_20filename>
+<value>
+adiabatic_boundary.txt
+</value>
+<default_value>
+adiabatic_boundary.txt
+</default_value>
+<documentation>
+File from which the isotherm depth data is read.
+</documentation>
+<pattern>
+762
+</pattern>
+<pattern_description>
+[FileName (Type: input)]
+</pattern_description>
+</Isotherm_20depth_20filename>
+<Isotherm_20temperature>
+<value>
+1673.15
+</value>
+<default_value>
+1673.15
+</default_value>
+<documentation>
+The value of the isothermal boundary temperature. Units: Kelvin.
+</documentation>
+<pattern>
+763
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Isotherm_20temperature>
+<Surface_20temperature>
+<value>
+273.15
+</value>
+<default_value>
+273.15
+</default_value>
+<documentation>
+The value of the surface temperature. Units: Kelvin.
+</documentation>
+<pattern>
+764
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Surface_20temperature>
+<Adiabatic_20temperature_20gradient>
+<value>
+0.0005
+</value>
+<default_value>
+0.0005
+</default_value>
+<documentation>
+The value of the adiabatic temperature gradient. Units: $K m^{-1}$.
+</documentation>
+<pattern>
+765
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Adiabatic_20temperature_20gradient>
+</Adiabatic_20boundary>
+<Ascii_20data_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/ascii-data/test/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/ascii-data/test/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a `/&apos;) or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+766
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value>
+box_2d.txt
+</value>
+<default_value>
+box_2d.txt
+</default_value>
+<documentation>
+The file name of the model data. Provide file in format: (Velocity file name).\%s\%d where \%s is a string specifying the boundary of the model according to the names of the boundary indicators (of the chosen geometry model).\%d is any sprintf integer qualifier, specifying the format of the current file number. 
+</documentation>
+<pattern>
+767
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+</documentation>
+<pattern>
+768
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+</Ascii_20data_20model>
+<Ascii_20profile>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/ascii-profile/tests/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/ascii-profile/tests/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a `/&apos;) or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+769
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value>
+simple_test.txt
+</value>
+<default_value>
+simple_test.txt
+</default_value>
+<documentation>
+The file name of the model data. Provide file in format: (Velocity file name).\%s\%d where \%s is a string specifying the boundary of the model according to the names of the boundary indicators (of the chosen geometry model).\%d is any sprintf integer qualifier, specifying the format of the current file number. 
+</documentation>
+<pattern>
+770
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+</documentation>
+<pattern>
+771
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+</Ascii_20profile>
+<Inclusion_20shape_20perturbation>
+<Inclusion_20shape>
+<value>
+circle
+</value>
+<default_value>
+circle
+</default_value>
+<documentation>
+The shape of the inclusion to be generated.
+</documentation>
+<pattern>
+772
+</pattern>
+<pattern_description>
+[Selection square|circle ]
+</pattern_description>
+</Inclusion_20shape>
+<Inclusion_20gradient>
+<value>
+constant
+</value>
+<default_value>
+constant
+</default_value>
+<documentation>
+The gradient of the inclusion to be generated.
+</documentation>
+<pattern>
+773
+</pattern>
+<pattern_description>
+[Selection gaussian|linear|constant ]
+</pattern_description>
+</Inclusion_20gradient>
+<Shape_20radius>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+The radius of the inclusion to be generated. For shapes with no radius (e.g. square), this will be the width, and for shapes with no width, this gives a general guideline for the size of the shape.
+</documentation>
+<pattern>
+774
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Shape_20radius>
+<Ambient_20temperature>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+The background temperature for the temperature field.
+</documentation>
+<pattern>
+775
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Ambient_20temperature>
+<Inclusion_20temperature>
+<value>
+0.0
+</value>
+<default_value>
+0.0
+</default_value>
+<documentation>
+The temperature of the inclusion shape. This is only the true temperature in the case of the constant gradient. In all other cases, it gives one endpoint of the temperature gradient for the shape.
+</documentation>
+<pattern>
+776
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Inclusion_20temperature>
+<Center_20X>
+<value>
+0.5
+</value>
+<default_value>
+0.5
+</default_value>
+<documentation>
+The X coordinate for the center of the shape.
+</documentation>
+<pattern>
+777
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Center_20X>
+<Center_20Y>
+<value>
+0.5
+</value>
+<default_value>
+0.5
+</default_value>
+<documentation>
+The Y coordinate for the center of the shape.
+</documentation>
+<pattern>
+778
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Center_20Y>
+<Center_20Z>
+<value>
+0.5
+</value>
+<default_value>
+0.5
+</default_value>
+<documentation>
+The Z coordinate for the center of the shape. This is only necessary for three-dimensional fields.
+</documentation>
+<pattern>
+779
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Center_20Z>
+</Inclusion_20shape_20perturbation>
+<Function>
+<Coordinate_20system>
+<value>
+cartesian
+</value>
+<default_value>
+cartesian
+</default_value>
+<documentation>
+A selection that determines the assumed coordinate system for the function variables. Allowed values are `cartesian&apos;, `spherical&apos;, and `depth&apos;. `spherical&apos; coordinates are interpreted as r,phi or r,phi,theta in 2D/3D respectively with theta being the polar angle. `depth&apos; will create a function, in which only the first parameter is non-zero, which is interpreted to be the depth of the point.
+</documentation>
+<pattern>
+780
+</pattern>
+<pattern_description>
+[Selection cartesian|spherical|depth ]
+</pattern_description>
+</Coordinate_20system>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+781
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+782
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+783
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Function>
+<Harmonic_20perturbation>
+<Vertical_20wave_20number>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Doubled radial wave number of the harmonic perturbation.  One equals half of a sine period over the model domain.  This allows for single up-/downswings. Negative numbers  reverse the sign of the perturbation.
+</documentation>
+<pattern>
+784
+</pattern>
+<pattern_description>
+[Integer range -2147483648...2147483647 (inclusive)]
+</pattern_description>
+</Vertical_20wave_20number>
+<Lateral_20wave_20number_20one>
+<value>
+3
+</value>
+<default_value>
+3
+</default_value>
+<documentation>
+Doubled first lateral wave number of the harmonic perturbation. Equals the spherical harmonic degree in 3D spherical shells. In all other cases one equals half of a sine period over the model domain. This allows for single up-/downswings. Negative numbers reverse the sign of the perturbation but are not allowed for the spherical harmonic case.
+</documentation>
+<pattern>
+785
+</pattern>
+<pattern_description>
+[Integer range -2147483648...2147483647 (inclusive)]
+</pattern_description>
+</Lateral_20wave_20number_20one>
+<Lateral_20wave_20number_20two>
+<value>
+2
+</value>
+<default_value>
+2
+</default_value>
+<documentation>
+Doubled second lateral wave number of the harmonic perturbation. Equals the spherical harmonic order in 3D spherical shells. In all other cases one equals half of a sine period over the model domain. This allows for single up-/downswings. Negative numbers reverse the sign of the perturbation.
+</documentation>
+<pattern>
+786
+</pattern>
+<pattern_description>
+[Integer range -2147483648...2147483647 (inclusive)]
+</pattern_description>
+</Lateral_20wave_20number_20two>
+<Magnitude>
+<value>
+1.0
+</value>
+<default_value>
+1.0
+</default_value>
+<documentation>
+The magnitude of the Harmonic perturbation.
+</documentation>
+<pattern>
+787
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Magnitude>
+<Reference_20temperature>
+<value>
+1600.0
+</value>
+<default_value>
+1600.0
+</default_value>
+<documentation>
+The reference temperature that is perturbed by the harmonic function. Only used in incompressible models.
+</documentation>
+<pattern>
+788
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Reference_20temperature>
+</Harmonic_20perturbation>
+<Patch_20on_20S40RTS>
+<Maximum_20grid_20depth>
+<value>
+700000.0
+</value>
+<default_value>
+700000.0
+</default_value>
+<documentation>
+The maximum depth of the Vs ascii grid. The model will read in  Vs from S40RTS below this depth.
+</documentation>
+<pattern>
+789
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximum_20grid_20depth>
+<Smoothing_20length_20scale>
+<value>
+200000.0
+</value>
+<default_value>
+200000.0
+</default_value>
+<documentation>
+The depth range (above maximum grid depth) over which to smooth. The boundary is smoothed using a depth weighted combination of Vs values from the ascii grid and S40RTS at each point in the region of smoothing.
+</documentation>
+<pattern>
+790
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Smoothing_20length_20scale>
+<Remove_20temperature_20heterogeneity_20down_20to_20specified_20depth>
+<value>
+-1.7976931348623157e+308
+</value>
+<default_value>
+-1.7976931348623157e+308
+</default_value>
+<documentation>
+This will set the heterogeneity prescribed by the Vs ascii grid and S40RTS to zero down to the specified depth (in meters). Note that your resolution has to be adequate to capture this cutoff. For example if you specify a depth of 660km, but your closest spherical depth layers are only at 500km and 750km (due to a coarse resolution) it will only zero out heterogeneities down to 500km. Similar caution has to be taken when using adaptive meshing.
+</documentation>
+<pattern>
+791
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Remove_20temperature_20heterogeneity_20down_20to_20specified_20depth>
+<Ascii_20data_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/patch-on-S40RTS/test/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/initial-temperature/patch-on-S40RTS/test/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a `/&apos;) or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+792
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value>
+upper_shell_3d.txt
+</value>
+<default_value>
+upper_shell_3d.txt
+</default_value>
+<documentation>
+The file name of the model data. Provide file in format: (Velocity file name).\%s\%d where \%s is a string specifying the boundary of the model according to the names of the boundary indicators (of the chosen geometry model).\%d is any sprintf integer qualifier, specifying the format of the current file number. 
+</documentation>
+<pattern>
+793
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+</documentation>
+<pattern>
+794
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+</Ascii_20data_20model>
+</Patch_20on_20S40RTS>
+<Spherical_20hexagonal_20perturbation>
+<Angular_20mode>
+<value>
+6
+</value>
+<default_value>
+6
+</default_value>
+<documentation>
+The number of convection cells with which to perturb the system.
+</documentation>
+<pattern>
+795
+</pattern>
+<pattern_description>
+[Integer range -2147483648...2147483647 (inclusive)]
+</pattern_description>
+</Angular_20mode>
+<Rotation_20offset>
+<value>
+-45
+</value>
+<default_value>
+-45
+</default_value>
+<documentation>
+Amount of clockwise rotation in degrees to apply to the perturbations. Default is set to -45 in order to provide backwards compatibility.
+</documentation>
+<pattern>
+796
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Rotation_20offset>
+</Spherical_20hexagonal_20perturbation>
+<Spherical_20gaussian_20perturbation>
+<Angle>
+<value>
+0e0
+</value>
+<default_value>
+0e0
+</default_value>
+<documentation>
+The angle where the center of the perturbation is placed.
+</documentation>
+<pattern>
+797
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Angle>
+<Non_2ddimensional_20depth>
+<value>
+0.7
+</value>
+<default_value>
+0.7
+</default_value>
+<documentation>
+The non-dimensional radial distance where the center of the perturbation is placed.
+</documentation>
+<pattern>
+798
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Non_2ddimensional_20depth>
+<Amplitude>
+<value>
+0.01
+</value>
+<default_value>
+0.01
+</default_value>
+<documentation>
+The amplitude of the perturbation.
+</documentation>
+<pattern>
+799
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Amplitude>
+<Sigma>
+<value>
+0.2
+</value>
+<default_value>
+0.2
+</default_value>
+<documentation>
+The standard deviation of the Gaussian perturbation.
+</documentation>
+<pattern>
+800
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Sigma>
+<Sign>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+The sign of the perturbation.
+</documentation>
+<pattern>
+801
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Sign>
+<Filename_20for_20initial_20geotherm_20table>
+<value>
+initial-geotherm-table
+</value>
+<default_value>
+initial-geotherm-table
+</default_value>
+<documentation>
+The file from which the initial geotherm table is to be read. The format of the file is defined by what is read in source/initial\_conditions/spherical\_shell.cc.
+</documentation>
+<pattern>
+802
+</pattern>
+<pattern_description>
+[FileName (Type: input)]
+</pattern_description>
+</Filename_20for_20initial_20geotherm_20table>
+</Spherical_20gaussian_20perturbation>
+</Initial_20temperature_20model>
+<Initial_20composition_20model>
+<List_20of_20model_20names>
+<value/>
+<default_value/>
+<documentation>
+A comma-separated list of initial composition models that together describe the initial composition field. These plugins are loaded in the order given, and modify the existing composition field via the operators listed in &apos;List of model operators&apos;.
+
+The following composition models are available:
+
+`ascii data&apos;: Implementation of a model in which the initial composition is derived from files containing data in ascii format. Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of grid points in each dimension as for example `# POINTS: 3 3&apos;. The order of the data columns has to be `x&apos;, `y&apos;, `composition1&apos;, `composition2&apos;, etc. in a 2d model and `x&apos;, `y&apos;, `z&apos;, `composition1&apos;, `composition2&apos;, etc. in a 3d model, according to the number of compositional fields, which means that there has to be a single column for every composition in the model.Note that the data in the input files need to be sorted in a specific order: the first coordinate needs to ascend first, followed by the second and the third at last in order to assign the correct data to the prescribed coordinates. If you use a spherical model, then the assumed grid changes. `x&apos; will be replaced by the radial distance of the point to the bottom of the model, `y&apos; by the azimuth angle and `z&apos; by the polar angle measured positive from the north pole. The grid will be assumed to be a latitude-longitude grid. Note that the order of spherical coordinates is `r&apos;, `phi&apos;, `theta&apos; and not `r&apos;, `theta&apos;, `phi&apos;, since this allows for dimension independent expressions.
+
+`function&apos;: Specify the composition in terms of an explicit formula. The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
+`porosity&apos;: A class that implements initial conditions for the porosity field by computing the equilibrium melt fraction for the given initial condition and reference pressure profile. Note that this plugin only works if there is a compositional field called `porosity&apos;, and the used material model implements the &apos;MeltFractionModel&apos; interface. For all compositional fields except porosity this plugin returns 0.0, and they are therefore not changed as long as the default `add&apos; operator is selected for this plugin.
+
+`world builder&apos;: Specify the initial composition through the World Builder. More information on the World Builder can be found at \url{https://geodynamicworldbuilder.github.io}. Make sure to specify the location of the World Builder file in the parameter &apos;World builder file&apos;.
+</documentation>
+<pattern>
+803
+</pattern>
+<pattern_description>
+[MultipleSelection ascii data|function|porosity|world builder ]
+</pattern_description>
+</List_20of_20model_20names>
+<List_20of_20model_20operators>
+<value>
+add
+</value>
+<default_value>
+add
+</default_value>
+<documentation>
+A comma-separated list of operators that will be used to append the listed composition models onto the previous models. If only one operator is given, the same operator is applied to all models.
+</documentation>
+<pattern>
+804
+</pattern>
+<pattern_description>
+[MultipleSelection add|subtract|minimum|maximum ]
+</pattern_description>
+</List_20of_20model_20operators>
+<Model_20name>
+<value>
+unspecified
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Select one of the following models:
+
+`ascii data&apos;: Implementation of a model in which the initial composition is derived from files containing data in ascii format. Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of grid points in each dimension as for example `# POINTS: 3 3&apos;. The order of the data columns has to be `x&apos;, `y&apos;, `composition1&apos;, `composition2&apos;, etc. in a 2d model and `x&apos;, `y&apos;, `z&apos;, `composition1&apos;, `composition2&apos;, etc. in a 3d model, according to the number of compositional fields, which means that there has to be a single column for every composition in the model.Note that the data in the input files need to be sorted in a specific order: the first coordinate needs to ascend first, followed by the second and the third at last in order to assign the correct data to the prescribed coordinates. If you use a spherical model, then the assumed grid changes. `x&apos; will be replaced by the radial distance of the point to the bottom of the model, `y&apos; by the azimuth angle and `z&apos; by the polar angle measured positive from the north pole. The grid will be assumed to be a latitude-longitude grid. Note that the order of spherical coordinates is `r&apos;, `phi&apos;, `theta&apos; and not `r&apos;, `theta&apos;, `phi&apos;, since this allows for dimension independent expressions.
+
+`function&apos;: Specify the composition in terms of an explicit formula. The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
+`porosity&apos;: A class that implements initial conditions for the porosity field by computing the equilibrium melt fraction for the given initial condition and reference pressure profile. Note that this plugin only works if there is a compositional field called `porosity&apos;, and the used material model implements the &apos;MeltFractionModel&apos; interface. For all compositional fields except porosity this plugin returns 0.0, and they are therefore not changed as long as the default `add&apos; operator is selected for this plugin.
+
+`world builder&apos;: Specify the initial composition through the World Builder. More information on the World Builder can be found at \url{https://geodynamicworldbuilder.github.io}. Make sure to specify the location of the World Builder file in the parameter &apos;World builder file&apos;.
+
+\textbf{Warning}: This parameter provides an old and deprecated way of specifying initial composition models and shouldn&apos;t be used. Please use &apos;List of model names&apos; instead.
+</documentation>
+<pattern>
+805
+</pattern>
+<pattern_description>
+[Selection ascii data|function|porosity|world builder|unspecified ]
+</pattern_description>
+</Model_20name>
+<Ascii_20data_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/initial-composition/ascii-data/test/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/initial-composition/ascii-data/test/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a `/&apos;) or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+806
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value>
+box_2d.txt
+</value>
+<default_value>
+box_2d.txt
+</default_value>
+<documentation>
+The file name of the model data. Provide file in format: (Velocity file name).\%s\%d where \%s is a string specifying the boundary of the model according to the names of the boundary indicators (of the chosen geometry model).\%d is any sprintf integer qualifier, specifying the format of the current file number. 
+</documentation>
+<pattern>
+807
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+</documentation>
+<pattern>
+808
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+</Ascii_20data_20model>
+<Function>
+<Coordinate_20system>
+<value>
+cartesian
+</value>
+<default_value>
+cartesian
+</default_value>
+<documentation>
+A selection that determines the assumed coordinate system for the function variables. Allowed values are `cartesian&apos;, `spherical&apos;, and `depth&apos;. `spherical&apos; coordinates are interpreted as r,phi or r,phi,theta in 2D/3D respectively with theta being the polar angle. `depth&apos; will create a function, in which only the first parameter is non-zero, which is interpreted to be the depth of the point.
+</documentation>
+<pattern>
+809
+</pattern>
+<pattern_description>
+[Selection cartesian|spherical|depth ]
+</pattern_description>
+</Coordinate_20system>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+810
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+811
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+812
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Function>
+</Initial_20composition_20model>
+<Prescribed_20Stokes_20solution>
+<Model_20name>
+<value>
+unspecified
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Select one of the following models:
+
+`ascii data&apos;: Implementation of a model in which the velocity is derived from files containing data in ascii format. Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of grid points in each dimension as for example `# POINTS: 3 3&apos;. The order of the data columns has to be `x&apos;, `y&apos;, `v${}_x$&apos; , `v${}_y$&apos; in a 2d model and  `x&apos;, `y&apos;, `z&apos;, `v${}_x$&apos; , `v${}_y$&apos; , `v${}_z$&apos; in a 3d model. Note that the data in the input files need to be sorted in a specific order: the first coordinate needs to ascend first, followed by the second and the third at last in order to assign the correct data to the prescribed coordinates. If you use a spherical model, then the data will still be handled as Cartesian, however the assumed grid changes. `x&apos; will be replaced by the radial distance of the point to the bottom of the model, `y&apos; by the azimuth angle and `z&apos; by the polar angle measured positive from the north pole. The grid will be assumed to be a latitude-longitude grid. Note that the order of spherical coordinates is `r&apos;, `phi&apos;, `theta&apos; and not `r&apos;, `theta&apos;, `phi&apos;, since this allows for dimension independent expressions.
+
+`circle&apos;: This value describes a vector field that rotates around the z-axis with constant angular velocity (i.e., with a velocity that increases with distance from the axis). The pressure is set to zero.
+
+`function&apos;: This plugin allows to prescribe the Stokes solution for the velocity and pressure field in terms of an explicit formula. The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+</documentation>
+<pattern>
+813
+</pattern>
+<pattern_description>
+[Selection ascii data|circle|function|unspecified ]
+</pattern_description>
+</Model_20name>
+<Ascii_20data_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/prescribed-stokes-solution/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/prescribed-stokes-solution/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a `/&apos;) or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+814
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value>
+box_2d.txt
+</value>
+<default_value>
+box_2d.txt
+</default_value>
+<documentation>
+The file name of the model data. Provide file in format: (Velocity file name).\%s\%d where \%s is a string specifying the boundary of the model according to the names of the boundary indicators (of the chosen geometry model).\%d is any sprintf integer qualifier, specifying the format of the current file number. 
+</documentation>
+<pattern>
+815
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+</documentation>
+<pattern>
+816
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+</Ascii_20data_20model>
+<Velocity_20function>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+817
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0; 0
+</value>
+<default_value>
+0; 0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+818
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+819
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Velocity_20function>
+<Pressure_20function>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+820
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+821
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+822
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Pressure_20function>
+<Fluid_20pressure_20function>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+823
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+824
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+825
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Fluid_20pressure_20function>
+<Compaction_20pressure_20function>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+826
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+827
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+828
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Compaction_20pressure_20function>
+<Fluid_20velocity_20function>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+829
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0; 0
+</value>
+<default_value>
+0; 0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+830
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+831
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Fluid_20velocity_20function>
+</Prescribed_20Stokes_20solution>
+<Boundary_20temperature_20model>
+<List_20of_20model_20names>
+<value>
+box
+</value>
+<default_value/>
+<documentation>
+A comma-separated list of boundary temperature models that will be used to initialize the temperature. These plugins are loaded in the order given, and modify the existing temperature field via the operators listed in &apos;List of model operators&apos;.
+
+The following boundary temperature models are available:
+
+`Dynamic core&apos;: This is a boundary temperature model working only with spherical shell geometry and core statistics postprocessor. The temperature at the top is constant, and the core mantle boundary temperature is dynamically evolving through time by calculating the heat flux into the core and solving the core energy balance. The formulation is mainly following \cite{NPB+04}, and the plugin is used in Zhang et al. [2016]. The energy of core cooling and freeing of the inner core is included in the plugin. However, current plugin can not deal with the energy balance if the core is in the `snowing core&apos; regime (i.e., the core solidifies from the top instead of bottom).
+
+`ascii data&apos;: Implementation of a model in which the boundary data is derived from files containing data in ascii format. Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of grid points in each dimension as for example `# POINTS: 3 3&apos;. The order of the data columns has to be `x&apos;, `Temperature [K]&apos; in a 2d model and  `x&apos;, `y&apos;, `Temperature [K]&apos; in a 3d model, which means that there has to be a single column containing the temperature. Note that the data in the input files need to be sorted in a specific order: the first coordinate needs to ascend first, followed by the second in order to assign the correct data to the prescribed coordinates. If you use a spherical model, then the assumed grid changes. `x&apos; will be replaced by the radial distance of the point to the bottom of the model, `y&apos; by the azimuth angle and `z&apos; by the polar angle measured positive from the north pole. The grid will be assumed to be a latitude-longitude grid. Note that the order of spherical coordinates is `r&apos;, `phi&apos;, `theta&apos; and not `r&apos;, `theta&apos;, `phi&apos;, since this allows for dimension independent expressions.
+
+`box&apos;: A model in which the temperature is chosen constant on the sides of a box which are selected by the parameters Left/Right/Top/Bottom/Front/Back temperature
+
+`box with lithosphere boundary indicators&apos;: A model in which the temperature is chosen constant on all the sides of a box. Additional boundary indicators are added to the lithospheric parts of the vertical boundaries. This model is to be used with the &apos;Two Merged Boxes&apos; Geometry Model.
+
+`constant&apos;: A model in which the temperature is chosen constant on a given boundary indicator.  Parameters are read from the subsection &apos;Constant&apos;.
+
+`function&apos;: Implementation of a model in which the boundary temperature is given in terms of an explicit formula that is elaborated in the parameters in section ``Boundary temperature model|Function&apos;&apos;. 
+
+Since the symbol $t$ indicating time may appear in the formulas for the prescribed temperatures, it is interpreted as having units seconds unless the global input parameter ``Use years in output instead of seconds&apos;&apos; is set, in which case we interpret the formula expressions as having units year.
+
+Because this class simply takes what the function calculates, this class can not know certain pieces of information such as the minimal and maximal temperature on the boundary. For operations that require this, for example in post-processing, this boundary temperature model must therefore be told what the minimal and maximal values on the boundary are. This is done using parameters set in section ``Boundary temperature model/Initial temperature&apos;&apos;.
+
+The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
+`initial temperature&apos;: A model in which the temperature at the boundary is chosen to be the same as given in the initial conditions.
+
+Because this class simply takes what the initial temperature had described, this class can not know certain pieces of information such as the minimal and maximal temperature on the boundary. For operations that require this, for example in post-processing, this boundary temperature model must therefore be told what the minimal and maximal values on the boundary are. This is done using parameters set in section ``Boundary temperature model/Initial temperature&apos;&apos;.
+
+`spherical constant&apos;: A model in which the temperature is chosen constant on the inner and outer boundaries of a spherical shell, ellipsoidal chunk or chunk. Parameters are read from subsection &apos;Spherical constant&apos;.
+</documentation>
+<pattern>
+832
+</pattern>
+<pattern_description>
+[MultipleSelection Dynamic core|ascii data|box|box with lithosphere boundary indicators|constant|function|initial temperature|spherical constant ]
+</pattern_description>
+</List_20of_20model_20names>
+<List_20of_20model_20operators>
+<value>
+add
+</value>
+<default_value>
+add
+</default_value>
+<documentation>
+A comma-separated list of operators that will be used to append the listed temperature models onto the previous models. If only one operator is given, the same operator is applied to all models.
+</documentation>
+<pattern>
+833
+</pattern>
+<pattern_description>
+[MultipleSelection add|subtract|minimum|maximum ]
+</pattern_description>
+</List_20of_20model_20operators>
+<Model_20name>
+<value>
+unspecified
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Select one of the following models:
+
+`Dynamic core&apos;: This is a boundary temperature model working only with spherical shell geometry and core statistics postprocessor. The temperature at the top is constant, and the core mantle boundary temperature is dynamically evolving through time by calculating the heat flux into the core and solving the core energy balance. The formulation is mainly following \cite{NPB+04}, and the plugin is used in Zhang et al. [2016]. The energy of core cooling and freeing of the inner core is included in the plugin. However, current plugin can not deal with the energy balance if the core is in the `snowing core&apos; regime (i.e., the core solidifies from the top instead of bottom).
+
+`ascii data&apos;: Implementation of a model in which the boundary data is derived from files containing data in ascii format. Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of grid points in each dimension as for example `# POINTS: 3 3&apos;. The order of the data columns has to be `x&apos;, `Temperature [K]&apos; in a 2d model and  `x&apos;, `y&apos;, `Temperature [K]&apos; in a 3d model, which means that there has to be a single column containing the temperature. Note that the data in the input files need to be sorted in a specific order: the first coordinate needs to ascend first, followed by the second in order to assign the correct data to the prescribed coordinates. If you use a spherical model, then the assumed grid changes. `x&apos; will be replaced by the radial distance of the point to the bottom of the model, `y&apos; by the azimuth angle and `z&apos; by the polar angle measured positive from the north pole. The grid will be assumed to be a latitude-longitude grid. Note that the order of spherical coordinates is `r&apos;, `phi&apos;, `theta&apos; and not `r&apos;, `theta&apos;, `phi&apos;, since this allows for dimension independent expressions.
+
+`box&apos;: A model in which the temperature is chosen constant on the sides of a box which are selected by the parameters Left/Right/Top/Bottom/Front/Back temperature
+
+`box with lithosphere boundary indicators&apos;: A model in which the temperature is chosen constant on all the sides of a box. Additional boundary indicators are added to the lithospheric parts of the vertical boundaries. This model is to be used with the &apos;Two Merged Boxes&apos; Geometry Model.
+
+`constant&apos;: A model in which the temperature is chosen constant on a given boundary indicator.  Parameters are read from the subsection &apos;Constant&apos;.
+
+`function&apos;: Implementation of a model in which the boundary temperature is given in terms of an explicit formula that is elaborated in the parameters in section ``Boundary temperature model|Function&apos;&apos;. 
+
+Since the symbol $t$ indicating time may appear in the formulas for the prescribed temperatures, it is interpreted as having units seconds unless the global input parameter ``Use years in output instead of seconds&apos;&apos; is set, in which case we interpret the formula expressions as having units year.
+
+Because this class simply takes what the function calculates, this class can not know certain pieces of information such as the minimal and maximal temperature on the boundary. For operations that require this, for example in post-processing, this boundary temperature model must therefore be told what the minimal and maximal values on the boundary are. This is done using parameters set in section ``Boundary temperature model/Initial temperature&apos;&apos;.
+
+The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
+`initial temperature&apos;: A model in which the temperature at the boundary is chosen to be the same as given in the initial conditions.
+
+Because this class simply takes what the initial temperature had described, this class can not know certain pieces of information such as the minimal and maximal temperature on the boundary. For operations that require this, for example in post-processing, this boundary temperature model must therefore be told what the minimal and maximal values on the boundary are. This is done using parameters set in section ``Boundary temperature model/Initial temperature&apos;&apos;.
+
+`spherical constant&apos;: A model in which the temperature is chosen constant on the inner and outer boundaries of a spherical shell, ellipsoidal chunk or chunk. Parameters are read from subsection &apos;Spherical constant&apos;.
+
+\textbf{Warning}: This parameter provides an old and deprecated way of specifying boundary temperature models and shouldn&apos;t be used. Please use &apos;List of model names&apos; instead.
+</documentation>
+<pattern>
+834
+</pattern>
+<pattern_description>
+[Selection Dynamic core|ascii data|box|box with lithosphere boundary indicators|constant|function|initial temperature|spherical constant|unspecified ]
+</pattern_description>
+</Model_20name>
+<Fixed_20temperature_20boundary_20indicators>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of names denoting those boundaries on which the temperature is fixed and described by the boundary temperature object selected in the &apos;List of model names&apos; parameter. All boundary indicators used by the geometry but not explicitly listed here will end up with no-flux (insulating) boundary conditions, or, if they are listed in the &apos;Fixed heat flux boundary indicators&apos;, with Neumann boundary conditions.
+
+The names of the boundaries listed here can either be numbers (in which case they correspond to the numerical boundary indicators assigned by the geometry object), or they can correspond to any of the symbolic names the geometry object may have provided for each part of the boundary. You may want to compare this with the documentation of the geometry model you use in your model.
+
+This parameter only describes which boundaries have a fixed temperature, but not what temperature should hold on these boundaries. The latter piece of information needs to be implemented in a plugin in the BoundaryTemperature group, unless an existing implementation in this group already provides what you want.
+</documentation>
+<pattern>
+835
+</pattern>
+<pattern_description>
+[List of &lt;[Anything]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Fixed_20temperature_20boundary_20indicators>
+<Allow_20fixed_20temperature_20on_20outflow_20boundaries>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+When the temperature is fixed on a given boundary as determined by the list of &apos;Fixed temperature boundary indicators&apos;, there might be parts of the boundary where material flows out and one may want to prescribe the temperature only on the parts of the boundary where there is inflow. This parameter determines if temperatures are only prescribed at these inflow parts of the boundary (if false) or everywhere on a given boundary, independent of the flow direction (if true).Note that in this context, `fixed&apos; refers to the fact that these are the boundary indicators where Dirichlet boundary conditions are applied, and does not imply that the boundary temperature is time-independent. 
+
+Mathematically speaking, the temperature satisfies an advection-diffusion equation. For this type of equation, one can prescribe the temperature even on outflow boundaries as long as the diffusion coefficient is nonzero. This would correspond to the ``true&apos;&apos; setting of this parameter, which is correspondingly the default. In practice, however, this would only make physical sense if the diffusion coefficient is actually quite large to prevent the creation of a boundary layer. In addition, if there is no diffusion, one can only impose Dirichlet boundary conditions (i.e., prescribe a fixed temperature value at the boundary) at those boundaries where material flows in. This would correspond to the ``false&apos;&apos; setting of this parameter.
+</documentation>
+<pattern>
+836
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Allow_20fixed_20temperature_20on_20outflow_20boundaries>
+<Ascii_20data_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/boundary-temperature/ascii-data/test/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/boundary-temperature/ascii-data/test/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a `/&apos;) or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+837
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value>
+box_2d_%s.%d.txt
+</value>
+<default_value>
+box_2d_%s.%d.txt
+</default_value>
+<documentation>
+The file name of the model data. Provide file in format: (Velocity file name).\%s\%d where \%s is a string specifying the boundary of the model according to the names of the boundary indicators (of the chosen geometry model).\%d is any sprintf integer qualifier, specifying the format of the current file number. 
+</documentation>
+<pattern>
+838
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+</documentation>
+<pattern>
+839
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+<Data_20file_20time_20step>
+<value>
+1e6
+</value>
+<default_value>
+1e6
+</default_value>
+<documentation>
+Time step between following data files. Depending on the setting of the global `Use years in output instead of seconds&apos; flag in the input file, this number is either interpreted as seconds or as years. The default is one million, i.e., either one million seconds or one million years.
+</documentation>
+<pattern>
+840
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Data_20file_20time_20step>
+<First_20data_20file_20model_20time>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Time from which on the data file with number `First data file number&apos; is used as boundary condition. Until this time, a boundary condition equal to zero everywhere is assumed. Depending on the setting of the global `Use years in output instead of seconds&apos; flag in the input file, this number is either interpreted as seconds or as years.
+</documentation>
+<pattern>
+841
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</First_20data_20file_20model_20time>
+<First_20data_20file_20number>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Number of the first velocity file to be loaded when the model time is larger than `First velocity file model time&apos;.
+</documentation>
+<pattern>
+842
+</pattern>
+<pattern_description>
+[Integer range -2147483648...2147483647 (inclusive)]
+</pattern_description>
+</First_20data_20file_20number>
+<Decreasing_20file_20order>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+In some cases the boundary files are not numbered in increasing but in decreasing order (e.g. `Ma BP&apos;). If this flag is set to `True&apos; the plugin will first load the file with the number `First data file number&apos; and decrease the file number during the model run.
+</documentation>
+<pattern>
+843
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Decreasing_20file_20order>
+</Ascii_20data_20model>
+<Box>
+<Left_20temperature>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Temperature at the left boundary (at minimal x-value). Units: K.
+</documentation>
+<pattern>
+844
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Left_20temperature>
+<Right_20temperature>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Temperature at the right boundary (at maximal x-value). Units: K.
+</documentation>
+<pattern>
+845
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Right_20temperature>
+<Bottom_20temperature>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Temperature at the bottom boundary (at minimal z-value). Units: K.
+</documentation>
+<pattern>
+846
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Bottom_20temperature>
+<Top_20temperature>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Temperature at the top boundary (at maximal x-value). Units: K.
+</documentation>
+<pattern>
+847
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Top_20temperature>
+</Box>
+<Constant>
+<Boundary_20indicator_20to_20temperature_20mappings>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of mappings between boundary indicators and the temperature associated with the boundary indicators. The format for this list is ``indicator1 : value1, indicator2 : value2, ...&apos;&apos;, where each indicator is a valid boundary indicator (either a number or the symbolic name of a boundary as provided by the geometry model) and each value is the temperature of that boundary.
+</documentation>
+<pattern>
+848
+</pattern>
+<pattern_description>
+[Map of &lt;[Anything]&gt;:&lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Boundary_20indicator_20to_20temperature_20mappings>
+</Constant>
+<Dynamic_20core>
+<Outer_20temperature>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Temperature at the outer boundary (lithosphere water/air). Units: $K$.
+</documentation>
+<pattern>
+849
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Outer_20temperature>
+<Inner_20temperature>
+<value>
+6000
+</value>
+<default_value>
+6000
+</default_value>
+<documentation>
+Temperature at the inner boundary (core mantle boundary) at the beginning. Units: $K$.
+</documentation>
+<pattern>
+850
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Inner_20temperature>
+<dT_20over_20dt>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Initial CMB temperature changing rate. Units: $K/year$.
+</documentation>
+<pattern>
+851
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</dT_20over_20dt>
+<dR_20over_20dt>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Initial inner core radius changing rate. Units: $km/year$.
+</documentation>
+<pattern>
+852
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</dR_20over_20dt>
+<dX_20over_20dt>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Initial light composition changing rate. Units: $1/year$.
+</documentation>
+<pattern>
+853
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</dX_20over_20dt>
+<Core_20density>
+<value>
+12.5e3
+</value>
+<default_value>
+12.5e3
+</default_value>
+<documentation>
+Density of the core. Units: $kg/m^3$.
+</documentation>
+<pattern>
+854
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Core_20density>
+<Gravity_20acceleration>
+<value>
+9.8
+</value>
+<default_value>
+9.8
+</default_value>
+<documentation>
+Gravitation acceleration at CMB. Units: $m/s^2$.
+</documentation>
+<pattern>
+855
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Gravity_20acceleration>
+<CMB_20pressure>
+<value>
+0.14e12
+</value>
+<default_value>
+0.14e12
+</default_value>
+<documentation>
+Pressure at CMB. Units: $Pa$.
+</documentation>
+<pattern>
+856
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</CMB_20pressure>
+<Initial_20light_20composition>
+<value>
+0.01
+</value>
+<default_value>
+0.01
+</default_value>
+<documentation>
+Initial light composition (eg. S,O) concentration in weight fraction.
+</documentation>
+<pattern>
+857
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Initial_20light_20composition>
+<Max_20iteration>
+<value>
+30000
+</value>
+<default_value>
+30000
+</default_value>
+<documentation>
+The max iterations for nonliner core energy solver.
+</documentation>
+<pattern>
+858
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Max_20iteration>
+<Core_20heat_20capacity>
+<value>
+840
+</value>
+<default_value>
+840
+</default_value>
+<documentation>
+Heat capacity of the core. Units: $J/kg/K$.
+</documentation>
+<pattern>
+859
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Core_20heat_20capacity>
+<K0>
+<value>
+4.111e11
+</value>
+<default_value>
+4.111e11
+</default_value>
+<documentation>
+Core compressibility at zero pressure. See \cite{NPB+04} for more details.
+</documentation>
+<pattern>
+860
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</K0>
+<Rho0>
+<value>
+7.019e3
+</value>
+<default_value>
+7.019e3
+</default_value>
+<documentation>
+Core density at zero pressure. Units: $kg/m^3$. See \cite{NPB+04} for more details.
+</documentation>
+<pattern>
+861
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Rho0>
+<Alpha>
+<value>
+1.35e-5
+</value>
+<default_value>
+1.35e-5
+</default_value>
+<documentation>
+Core thermal expansivity. Units: $1/K$.
+</documentation>
+<pattern>
+862
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Alpha>
+<Lh>
+<value>
+750e3
+</value>
+<default_value>
+750e3
+</default_value>
+<documentation>
+The latent heat of core freeze. Units: $J/kg$.
+</documentation>
+<pattern>
+863
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Lh>
+<Rh>
+<value>
+-27.7e6
+</value>
+<default_value>
+-27.7e6
+</default_value>
+<documentation>
+The heat of reaction. Units: $J/kg$.
+</documentation>
+<pattern>
+864
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Rh>
+<Beta_20composition>
+<value>
+1.1
+</value>
+<default_value>
+1.1
+</default_value>
+<documentation>
+Compositional expansion coefficient $Beta_c$. See \cite{NPB+04} for more details.
+</documentation>
+<pattern>
+865
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Beta_20composition>
+<Delta>
+<value>
+0.5
+</value>
+<default_value>
+0.5
+</default_value>
+<documentation>
+Partition coefficient of the light element.
+</documentation>
+<pattern>
+866
+</pattern>
+<pattern_description>
+[Double 0...1 (inclusive)]
+</pattern_description>
+</Delta>
+<Core_20conductivity>
+<value>
+60
+</value>
+<default_value>
+60
+</default_value>
+<documentation>
+Core heat conductivity $k_c$. Units: $W/m/K$.
+</documentation>
+<pattern>
+867
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Core_20conductivity>
+<Geotherm_20parameters>
+<Tm0>
+<value>
+1695
+</value>
+<default_value>
+1695
+</default_value>
+<documentation>
+Melting curve (\cite{NPB+04} eq. (40)) parameter Tm0. Units: $K$.
+</documentation>
+<pattern>
+868
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Tm0>
+<Tm1>
+<value>
+10.9
+</value>
+<default_value>
+10.9
+</default_value>
+<documentation>
+Melting curve (\cite{NPB+04} eq. (40)) parameter Tm1. Units: $1/Tpa$.
+</documentation>
+<pattern>
+869
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Tm1>
+<Tm2>
+<value>
+-8.0
+</value>
+<default_value>
+-8.0
+</default_value>
+<documentation>
+Melting curve (\cite{NPB+04} eq. (40)) parameter Tm2. Units: $1/TPa^2$.
+</documentation>
+<pattern>
+870
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Tm2>
+<Theta>
+<value>
+0.11
+</value>
+<default_value>
+0.11
+</default_value>
+<documentation>
+Melting curve (\cite{NPB+04} eq. (40)) parameter Theta.
+</documentation>
+<pattern>
+871
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Theta>
+<Composition_20dependency>
+<value>
+true
+</value>
+<default_value>
+true
+</default_value>
+<documentation>
+If melting curve dependent on composition.
+</documentation>
+<pattern>
+872
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Composition_20dependency>
+<Use_20BW11>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+If using the Fe-FeS system solidus from Buono \&amp; Walker (2011) instead.
+</documentation>
+<pattern>
+873
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20BW11>
+</Geotherm_20parameters>
+<Radioactive_20heat_20source>
+<Number_20of_20radioactive_20heating_20elements>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Number of different radioactive heating elements in core
+</documentation>
+<pattern>
+874
+</pattern>
+<pattern_description>
+[Integer range 0...2147483647 (inclusive)]
+</pattern_description>
+</Number_20of_20radioactive_20heating_20elements>
+<Heating_20rates>
+<value/>
+<default_value/>
+<documentation>
+Heating rates of different elements (W/kg)
+</documentation>
+<pattern>
+875
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Heating_20rates>
+<Half_20life_20times>
+<value/>
+<default_value/>
+<documentation>
+Half decay times of different elements (Ga)
+</documentation>
+<pattern>
+876
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Half_20life_20times>
+<Initial_20concentrations>
+<value/>
+<default_value/>
+<documentation>
+Initial concentrations of different elements (ppm)
+</documentation>
+<pattern>
+877
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Initial_20concentrations>
+</Radioactive_20heat_20source>
+<Other_20energy_20source>
+<File_20name>
+<value/>
+<default_value/>
+<documentation>
+Data file name for other energy source into the core. The &apos;other energy source&apos; is used for external core energy source.For example if someone want to test the early lunar core powered by precession (Dwyer, C. A., et al. (2011). A long-lived lunar dynamo driven by continuous mechanical stirring. Nature 479(7372): 212-214.)Format [Time(Gyr)   Energy rate(W)]
+</documentation>
+<pattern>
+878
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</File_20name>
+</Other_20energy_20source>
+</Dynamic_20core>
+<Function>
+<Coordinate_20system>
+<value>
+cartesian
+</value>
+<default_value>
+cartesian
+</default_value>
+<documentation>
+A selection that determines the assumed coordinate system for the function variables. Allowed values are `cartesian&apos;, `spherical&apos;, and `depth&apos;. `spherical&apos; coordinates are interpreted as r,phi or r,phi,theta in 2D/3D respectively with theta being the polar angle. `depth&apos; will create a function, in which only the first parameter is non-zero, which is interpreted to be the depth of the point.
+</documentation>
+<pattern>
+879
+</pattern>
+<pattern_description>
+[Selection cartesian|spherical|depth ]
+</pattern_description>
+</Coordinate_20system>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+880
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+881
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+882
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+<Minimal_20temperature>
+<value>
+273
+</value>
+<default_value>
+273
+</default_value>
+<documentation>
+Minimal temperature. Units: K.
+</documentation>
+<pattern>
+883
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimal_20temperature>
+<Maximal_20temperature>
+<value>
+3773
+</value>
+<default_value>
+3773
+</default_value>
+<documentation>
+Maximal temperature. Units: K.
+</documentation>
+<pattern>
+884
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximal_20temperature>
+</Function>
+<Initial_20temperature>
+<Minimal_20temperature>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Minimal temperature. Units: K.
+</documentation>
+<pattern>
+885
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimal_20temperature>
+<Maximal_20temperature>
+<value>
+3773
+</value>
+<default_value>
+3773
+</default_value>
+<documentation>
+Maximal temperature. Units: K.
+</documentation>
+<pattern>
+886
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximal_20temperature>
+</Initial_20temperature>
+<Spherical_20constant>
+<Outer_20temperature>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Temperature at the outer boundary (lithosphere water/air). Units: K.
+</documentation>
+<pattern>
+887
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Outer_20temperature>
+<Inner_20temperature>
+<value>
+6000
+</value>
+<default_value>
+6000
+</default_value>
+<documentation>
+Temperature at the inner boundary (core mantle boundary). Units: K.
+</documentation>
+<pattern>
+888
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Inner_20temperature>
+</Spherical_20constant>
+<Box_20with_20lithosphere_20boundary_20indicators>
+<Left_20temperature>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Temperature at the left boundary (at minimal x-value). Units: K.
+</documentation>
+<pattern>
+889
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Left_20temperature>
+<Right_20temperature>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Temperature at the right boundary (at maximal x-value). Units: K.
+</documentation>
+<pattern>
+890
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Right_20temperature>
+<Bottom_20temperature>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Temperature at the bottom boundary (at minimal z-value). Units: K.
+</documentation>
+<pattern>
+891
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Bottom_20temperature>
+<Top_20temperature>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Temperature at the top boundary (at maximal x-value). Units: K.
+</documentation>
+<pattern>
+892
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Top_20temperature>
+<Left_20temperature_20lithosphere>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Temperature at the additional left lithosphere boundary (specified by user in Geometry Model). Units: K.
+</documentation>
+<pattern>
+893
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Left_20temperature_20lithosphere>
+<Right_20temperature_20lithosphere>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Temperature at the additional right lithosphere boundary (specified by user in Geometry Model). Units: K.
+</documentation>
+<pattern>
+894
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Right_20temperature_20lithosphere>
+</Box_20with_20lithosphere_20boundary_20indicators>
+</Boundary_20temperature_20model>
+<Boundary_20composition_20model>
+<List_20of_20model_20names>
+<value/>
+<default_value/>
+<documentation>
+A comma-separated list of boundary composition models that will be used to initialize the composition. These plugins are loaded in the order given, and modify the existing composition field via the operators listed in &apos;List of model operators&apos;.
+
+The following boundary composition models are available:
+
+`ascii data&apos;: Implementation of a model in which the boundary composition is derived from files containing data in ascii format. Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of grid points in each dimension as for example `# POINTS: 3 3&apos;. The order of the data columns has to be `x&apos;, `composition1&apos;, `composition2&apos;, etc. in a 2d model and `x&apos;, `y&apos;, `composition1&apos;, `composition2&apos;, etc., in a 3d model, according to the number of compositional fields, which means that there has to be a single column for every composition in the model. Note that the data in the input files need to be sorted in a specific order: the first coordinate needs to ascend first, followed by the second in order to assign the correct data to the prescribed coordinates.If you use a spherical model, then the assumed grid changes. `x&apos; will be replaced by the radial distance of the point to the bottom of the model, `y&apos; by the azimuth angle and `z&apos; by the polar angle measured positive from the north pole. The grid will be assumed to be a latitude-longitude grid. Note that the order of spherical coordinates is `r&apos;, `phi&apos;, `theta&apos; and not `r&apos;, `theta&apos;, `phi&apos;, since this allows for dimension independent expressions.
+
+`box&apos;: A model in which the composition is chosen constant on the sides of a box which are selected by the parameters Left/Right/Top/Bottom/Front/Back composition
+
+`box with lithosphere boundary indicators&apos;: A model in which the composition is chosen constant on all the sides of a box. Additional boundary indicators are added to the lithospheric parts of the vertical boundaries. This model is to be used with the &apos;Two Merged Boxes&apos; Geometry Model.
+
+`function&apos;: Implementation of a model in which the boundary composition is given in terms of an explicit formula that is elaborated in the parameters in section ``Boundary composition model|Function&apos;&apos;. 
+
+Since the symbol $t$ indicating time may appear in the formulas for the prescribed composition, it is interpreted as having units seconds unless the global input parameter ``Use years in output instead of seconds&apos;&apos; is set, in which case we interpret the formula expressions as having units year.
+
+The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
+`initial composition&apos;: A model in which the composition at the boundary is chosen to be the same as given in the initial conditions.
+
+Because this class simply takes what the initial composition had described, this class can not know certain pieces of information such as the minimal and maximal composition on the boundary. For operations that require this, for example in post-processing, this boundary composition model must therefore be told what the minimal and maximal values on the boundary are. This is done using parameters set in section ``Boundary composition model/Initial composition&apos;&apos;.
+
+`spherical constant&apos;: A model in which the composition is chosen constant on the inner and outer boundaries of a surface, spherical shell, chunk or ellipsoidal chunk. Parameters are read from subsection &apos;Spherical constant&apos;.
+</documentation>
+<pattern>
+895
+</pattern>
+<pattern_description>
+[MultipleSelection ascii data|box|box with lithosphere boundary indicators|function|initial composition|spherical constant ]
+</pattern_description>
+</List_20of_20model_20names>
+<List_20of_20model_20operators>
+<value>
+add
+</value>
+<default_value>
+add
+</default_value>
+<documentation>
+A comma-separated list of operators that will be used to append the listed composition models onto the previous models. If only one operator is given, the same operator is applied to all models.
+</documentation>
+<pattern>
+896
+</pattern>
+<pattern_description>
+[MultipleSelection add|subtract|minimum|maximum ]
+</pattern_description>
+</List_20of_20model_20operators>
+<Model_20name>
+<value>
+unspecified
+</value>
+<default_value>
+unspecified
+</default_value>
+<documentation>
+Select one of the following models:
+
+`ascii data&apos;: Implementation of a model in which the boundary composition is derived from files containing data in ascii format. Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of grid points in each dimension as for example `# POINTS: 3 3&apos;. The order of the data columns has to be `x&apos;, `composition1&apos;, `composition2&apos;, etc. in a 2d model and `x&apos;, `y&apos;, `composition1&apos;, `composition2&apos;, etc., in a 3d model, according to the number of compositional fields, which means that there has to be a single column for every composition in the model. Note that the data in the input files need to be sorted in a specific order: the first coordinate needs to ascend first, followed by the second in order to assign the correct data to the prescribed coordinates.If you use a spherical model, then the assumed grid changes. `x&apos; will be replaced by the radial distance of the point to the bottom of the model, `y&apos; by the azimuth angle and `z&apos; by the polar angle measured positive from the north pole. The grid will be assumed to be a latitude-longitude grid. Note that the order of spherical coordinates is `r&apos;, `phi&apos;, `theta&apos; and not `r&apos;, `theta&apos;, `phi&apos;, since this allows for dimension independent expressions.
+
+`box&apos;: A model in which the composition is chosen constant on the sides of a box which are selected by the parameters Left/Right/Top/Bottom/Front/Back composition
+
+`box with lithosphere boundary indicators&apos;: A model in which the composition is chosen constant on all the sides of a box. Additional boundary indicators are added to the lithospheric parts of the vertical boundaries. This model is to be used with the &apos;Two Merged Boxes&apos; Geometry Model.
+
+`function&apos;: Implementation of a model in which the boundary composition is given in terms of an explicit formula that is elaborated in the parameters in section ``Boundary composition model|Function&apos;&apos;. 
+
+Since the symbol $t$ indicating time may appear in the formulas for the prescribed composition, it is interpreted as having units seconds unless the global input parameter ``Use years in output instead of seconds&apos;&apos; is set, in which case we interpret the formula expressions as having units year.
+
+The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
+`initial composition&apos;: A model in which the composition at the boundary is chosen to be the same as given in the initial conditions.
+
+Because this class simply takes what the initial composition had described, this class can not know certain pieces of information such as the minimal and maximal composition on the boundary. For operations that require this, for example in post-processing, this boundary composition model must therefore be told what the minimal and maximal values on the boundary are. This is done using parameters set in section ``Boundary composition model/Initial composition&apos;&apos;.
+
+`spherical constant&apos;: A model in which the composition is chosen constant on the inner and outer boundaries of a surface, spherical shell, chunk or ellipsoidal chunk. Parameters are read from subsection &apos;Spherical constant&apos;.
+
+\textbf{Warning}: This parameter provides an old and deprecated way of specifying boundary composition models and shouldn&apos;t be used. Please use &apos;List of model names&apos; instead.
+</documentation>
+<pattern>
+897
+</pattern>
+<pattern_description>
+[Selection ascii data|box|box with lithosphere boundary indicators|function|initial composition|spherical constant|unspecified ]
+</pattern_description>
+</Model_20name>
+<Fixed_20composition_20boundary_20indicators>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of names denoting those boundaries on which the composition is fixed and described by the boundary composition object selected in its own section of this input file. All boundary indicators used by the geometry but not explicitly listed here will end up with no-flux (insulating) boundary conditions.
+
+The names of the boundaries listed here can either be numbers (in which case they correspond to the numerical boundary indicators assigned by the geometry object), or they can correspond to any of the symbolic names the geometry object may have provided for each part of the boundary. You may want to compare this with the documentation of the geometry model you use in your model.
+
+This parameter only describes which boundaries have a fixed composition, but not what composition should hold on these boundaries. The latter piece of information needs to be implemented in a plugin in the BoundaryComposition group, unless an existing implementation in this group already provides what you want.
+</documentation>
+<pattern>
+898
+</pattern>
+<pattern_description>
+[List of &lt;[Anything]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Fixed_20composition_20boundary_20indicators>
+<Allow_20fixed_20composition_20on_20outflow_20boundaries>
+<value>
+false for models without melt
+</value>
+<default_value>
+false for models without melt
+</default_value>
+<documentation>
+When the composition is fixed on a given boundary as determined by the list of &apos;Fixed composition boundary indicators&apos;, there might be parts of the boundary where material flows out and one may want to prescribe the composition only on those parts of the boundary where there is inflow. This parameter determines if compositions are only prescribed at these inflow parts of the boundary (if false) or everywhere on a given boundary, independent of the flow direction (if true). By default, this parameter is set to false, except in models with melt transport (see below). Note that in this context, `fixed&apos; refers to the fact that these are the boundary indicators where Dirichlet boundary conditions are applied, and does not imply that the boundary composition is time-independent. 
+
+Mathematically speaking, the compositional fields satisfy an advection equation that has no diffusion. For this equation, one can only impose Dirichlet boundary conditions (i.e., prescribe a fixed compositional field value at the boundary) at those boundaries where material flows in. This would correspond to the ``false&apos;&apos; setting of this parameter, which is correspondingly the default. On the other hand, on a finite dimensional discretization such as the one one obtains from the finite element method, it is possible to also prescribe values on outflow boundaries, even though this may make no physical sense. This would then correspond to the ``true&apos;&apos; setting of this parameter.
+
+A warning for models with melt transport: In models with fluid flow, some compositional fields (in particular the porosity) might be transported with the fluid velocity, and would need to set the constraints based on the fluid velocity. However, this is currently not possible, because we reuse the same matrix for all compositional fields, and therefore can not use different constraints for different fields. Consequently, we set this parameter to true by default in models where melt transport is enabled. Be aware that if you change this default setting, you will not use the melt velocity, but the solid velocity to determine on which parts of the boundaries there is outflow.
+</documentation>
+<pattern>
+899
+</pattern>
+<pattern_description>
+[Selection true|false|false for models without melt ]
+</pattern_description>
+</Allow_20fixed_20composition_20on_20outflow_20boundaries>
+<Ascii_20data_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/boundary-composition/ascii-data/test/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/boundary-composition/ascii-data/test/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a `/&apos;) or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+900
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value>
+box_2d_%s.%d.txt
+</value>
+<default_value>
+box_2d_%s.%d.txt
+</default_value>
+<documentation>
+The file name of the model data. Provide file in format: (Velocity file name).\%s\%d where \%s is a string specifying the boundary of the model according to the names of the boundary indicators (of the chosen geometry model).\%d is any sprintf integer qualifier, specifying the format of the current file number. 
+</documentation>
+<pattern>
+901
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+</documentation>
+<pattern>
+902
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+<Data_20file_20time_20step>
+<value>
+1e6
+</value>
+<default_value>
+1e6
+</default_value>
+<documentation>
+Time step between following data files. Depending on the setting of the global `Use years in output instead of seconds&apos; flag in the input file, this number is either interpreted as seconds or as years. The default is one million, i.e., either one million seconds or one million years.
+</documentation>
+<pattern>
+903
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Data_20file_20time_20step>
+<First_20data_20file_20model_20time>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Time from which on the data file with number `First data file number&apos; is used as boundary condition. Until this time, a boundary condition equal to zero everywhere is assumed. Depending on the setting of the global `Use years in output instead of seconds&apos; flag in the input file, this number is either interpreted as seconds or as years.
+</documentation>
+<pattern>
+904
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</First_20data_20file_20model_20time>
+<First_20data_20file_20number>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Number of the first velocity file to be loaded when the model time is larger than `First velocity file model time&apos;.
+</documentation>
+<pattern>
+905
+</pattern>
+<pattern_description>
+[Integer range -2147483648...2147483647 (inclusive)]
+</pattern_description>
+</First_20data_20file_20number>
+<Decreasing_20file_20order>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+In some cases the boundary files are not numbered in increasing but in decreasing order (e.g. `Ma BP&apos;). If this flag is set to `True&apos; the plugin will first load the file with the number `First data file number&apos; and decrease the file number during the model run.
+</documentation>
+<pattern>
+906
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Decreasing_20file_20order>
+</Ascii_20data_20model>
+<Box>
+<Left_20composition>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of composition boundary values at the left boundary (at minimal x-value). This list must have as many entries as there are compositional fields. Units: none.
+</documentation>
+<pattern>
+907
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Left_20composition>
+<Right_20composition>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of composition boundary values at the right boundary (at maximal x-value). This list must have as many entries as there are compositional fields. Units: none.
+</documentation>
+<pattern>
+908
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Right_20composition>
+<Bottom_20composition>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of composition boundary values at the bottom boundary (at minimal y-value in 2d, or minimal z-value in 3d). This list must have as many entries as there are compositional fields. Units: none.
+</documentation>
+<pattern>
+909
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Bottom_20composition>
+<Top_20composition>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of composition boundary values at the top boundary (at maximal y-value in 2d, or maximal z-value in 3d). This list must have as many entries as there are compositional fields. Units: none.
+</documentation>
+<pattern>
+910
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Top_20composition>
+</Box>
+<Function>
+<Coordinate_20system>
+<value>
+cartesian
+</value>
+<default_value>
+cartesian
+</default_value>
+<documentation>
+A selection that determines the assumed coordinate system for the function variables. Allowed values are &apos;cartesian&apos;, &apos;spherical&apos;, and &apos;depth&apos;. &apos;spherical&apos; coordinates are interpreted as r,phi or r,phi,theta in 2D/3D respectively with theta being the polar angle. &apos;depth&apos; will create a function, in which only the first parameter is non-zero, which is interpreted to be the depth of the point.
+</documentation>
+<pattern>
+911
+</pattern>
+<pattern_description>
+[Selection cartesian|spherical|depth ]
+</pattern_description>
+</Coordinate_20system>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+912
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+913
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+914
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Function>
+<Initial_20composition>
+<Minimal_20composition>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Minimal composition. Units: none.
+</documentation>
+<pattern>
+915
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Minimal_20composition>
+<Maximal_20composition>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Maximal composition. Units: none.
+</documentation>
+<pattern>
+916
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Maximal_20composition>
+</Initial_20composition>
+<Spherical_20constant>
+<Outer_20composition>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Composition at the outer boundary (lithosphere water/air). For a spherical geometry model, this is the only boundary. Units: none.
+</documentation>
+<pattern>
+917
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Outer_20composition>
+<Inner_20composition>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Composition at the inner boundary (core mantle boundary). Units: none.
+</documentation>
+<pattern>
+918
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Inner_20composition>
+</Spherical_20constant>
+<Box_20with_20lithosphere_20boundary_20indicators>
+<Left_20composition>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of composition boundary values at the left boundary (at minimal x-value). This list must have as many entries as there are compositional fields. Units: none.
+</documentation>
+<pattern>
+919
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Left_20composition>
+<Right_20composition>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of composition boundary values at the right boundary (at maximal x-value). This list must have as many entries as there are compositional fields. Units: none.
+</documentation>
+<pattern>
+920
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Right_20composition>
+<Left_20composition_20lithosphere>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of composition boundary values at the left boundary (at minimal x-value). This list must have as many entries as there are compositional fields. Units: none.
+</documentation>
+<pattern>
+921
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Left_20composition_20lithosphere>
+<Right_20composition_20lithosphere>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of composition boundary values at the right boundary (at maximal x-value). This list must have as many entries as there are compositional fields. Units: none.
+</documentation>
+<pattern>
+922
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Right_20composition_20lithosphere>
+<Bottom_20composition>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of composition boundary values at the bottom boundary (at minimal y-value in 2d, or minimal z-value in 3d). This list must have as many entries as there are compositional fields. Units: none.
+</documentation>
+<pattern>
+923
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Bottom_20composition>
+<Top_20composition>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of composition boundary values at the top boundary (at maximal y-value in 2d, or maximal z-value in 3d). This list must have as many entries as there are compositional fields. Units: none.
+</documentation>
+<pattern>
+924
+</pattern>
+<pattern_description>
+[List of &lt;[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Top_20composition>
+</Box_20with_20lithosphere_20boundary_20indicators>
+</Boundary_20composition_20model>
+<Adiabatic_20conditions_20model>
+<Model_20name>
+<value>
+compute profile
+</value>
+<default_value>
+compute profile
+</default_value>
+<documentation>
+Select one of the following models:
+
+`ascii data&apos;: A model in which the adiabatic profile is read from a file that describes the reference state. Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of points in the reference state as for example `# POINTS: 3&apos;. Following the comment lines there has to be a single line containing the names of all data columns, separated by arbitrarily many spaces. Column names are not allowed to contain spaces. The file can contain unnecessary columns, but for this plugin it needs to at least provide columns named `temperature&apos;, `pressure&apos;, and `density&apos;. Note that the data lines in the file need to be sorted in order of increasing depth from 0 to the maximal depth in the model domain. Points in the model that are outside of the provided depth range will be assigned the maximum or minimum depth values, respectively. Points do not need to be equidistant, but the computation of properties is optimized in speed if they are.
+
+`compute profile&apos;: A model in which the adiabatic profile is calculated by solving the hydrostatic equations for pressure and temperature in depth. The gravity is assumed to be in depth direction and the composition is either given by the initial composition at reference points or computed as a reference depth-function. All material parameters are computed by the material model plugin. The surface conditions are either constant or changing over time as prescribed by a user-provided function.
+
+`function&apos;: A model in which the adiabatic profile is specified by a user defined function. The supplied function has to contain temperature, pressure, and density as a function of depth in this order.
+</documentation>
+<pattern>
+925
+</pattern>
+<pattern_description>
+[Selection ascii data|compute profile|function ]
+</pattern_description>
+</Model_20name>
+<Ascii_20data_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/tests/adiabatic-conditions/ascii-data/test/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/tests/adiabatic-conditions/ascii-data/test/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a `/&apos;) or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+926
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value/>
+<default_value/>
+<documentation>
+The file name of the model data. Provide file in format: (Velocity file name).\%s\%d where \%s is a string specifying the boundary of the model according to the names of the boundary indicators (of the chosen geometry model).\%d is any sprintf integer qualifier, specifying the format of the current file number. 
+</documentation>
+<pattern>
+927
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+</documentation>
+<pattern>
+928
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+</Ascii_20data_20model>
+<Compute_20profile>
+<Variable_20names>
+<value>
+x,t
+</value>
+<default_value>
+x,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+929
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+930
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+931
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+<Composition_20reference_20profile>
+<value>
+initial composition
+</value>
+<default_value>
+initial composition
+</default_value>
+<documentation>
+Select how the reference profile for composition is computed. This profile is used to evaluate the material model, when computing the pressure and temperature profile.
+</documentation>
+<pattern>
+932
+</pattern>
+<pattern_description>
+[Selection initial composition|function ]
+</pattern_description>
+</Composition_20reference_20profile>
+<Number_20of_20points>
+<value>
+1000
+</value>
+<default_value>
+1000
+</default_value>
+<documentation>
+The number of points we use to compute the adiabatic profile. The higher the number of points, the more accurate the downward integration from the adiabatic surface temperature will be.
+</documentation>
+<pattern>
+933
+</pattern>
+<pattern_description>
+[Integer range 5...2147483647 (inclusive)]
+</pattern_description>
+</Number_20of_20points>
+<Use_20surface_20condition_20function>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Whether to use the &apos;Surface condition function&apos; to determine surface conditions, or the &apos;Adiabatic surface temperature&apos; and &apos;Surface pressure&apos; parameters. If this is set to true the reference profile is updated every timestep. The function expression of the function should be independent of space, but can depend on time &apos;t&apos;. The function must return two components, the first one being reference surface pressure, the second one being reference surface temperature.
+</documentation>
+<pattern>
+934
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20surface_20condition_20function>
+<Surface_20condition_20function>
+<Variable_20names>
+<value>
+x,t
+</value>
+<default_value>
+x,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+935
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0; 0
+</value>
+<default_value>
+0; 0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+936
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+937
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Surface_20condition_20function>
+</Compute_20profile>
+<Function>
+<Variable_20names>
+<value>
+depth
+</value>
+<default_value>
+depth
+</default_value>
+<documentation/>
+<pattern>
+942
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0.0; 0.0; 1.0
+</value>
+<default_value>
+0.0; 0.0; 1.0
+</default_value>
+<documentation>
+Expression for the adiabatic temperature, pressure, and density separated by semicolons as a function of `depth&apos;.
+</documentation>
+<pattern>
+941
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+940
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Function>
+</Adiabatic_20conditions_20model>
+<Boundary_20velocity_20model>
+<Prescribed_20velocity_20boundary_20indicators>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list denoting those boundaries on which the velocity is prescribed, i.e., where unknown external forces act to prescribe a particular velocity. This is often used to prescribe a velocity that equals that of overlying plates.
+
+The format of valid entries for this parameter is that of a map given as ``key1 [selector]: value1, key2 [selector]: value2, key3: value3, ...&apos;&apos; where each key must be a valid boundary indicator (which is either an integer or the symbolic name the geometry model in use may have provided for this part of the boundary) and each value must be one of the currently implemented boundary velocity models. ``selector&apos;&apos; is an optional string given as a subset of the letters `xyz&apos; that allows you to apply the boundary conditions only to the components listed. As an example, &apos;1 y: function&apos; applies the type `function&apos; to the y component on boundary 1. Without a selector it will affect all components of the velocity.
+
+Note that the no-slip boundary condition is a special case of the current one where the prescribed velocity happens to be zero. It can thus be implemented by indicating that a particular boundary is part of the ones selected using the current parameter and using ``zero velocity&apos;&apos; as the boundary values. Alternatively, you can simply list the part of the boundary on which the velocity is to be zero with the parameter ``Zero velocity boundary indicator&apos;&apos; in the current parameter section.
+
+Note that when ``Use years in output instead of seconds&apos;&apos; is set to true, velocity should be given in m/yr. The following boundary velocity models are available:
+
+`ascii data&apos;: Implementation of a model in which the boundary velocity is derived from files containing data in ascii format. Note the required format of the input data: The first lines may contain any number of comments if they begin with `#&apos;, but one of these lines needs to contain the number of grid points in each dimension as for example `# POINTS: 3 3&apos;. The order of the data columns has to be `x&apos;, `velocity${}_x$&apos;, `velocity${}_y$&apos; in a 2d model or `x&apos;, `y&apos;, `velocity${}_x$&apos;, `velocity${}_y$&apos;, `velocity${}_z$&apos; in a 3d model. Note that the data in the input files need to be sorted in a specific order: the first coordinate needs to ascend first, followed by the second in order to assign the correct data to the prescribed coordinates.If you use a spherical model, then the assumed grid changes. `x&apos; will be replaced by the radial distance of the point to the bottom of the model, `y&apos; by the azimuth angle and `z&apos; by the polar angle measured positive from the north pole. The grid will be assumed to be a latitude-longitude grid. Note that the order of spherical coordinates is `r&apos;, `phi&apos;, `theta&apos; and not `r&apos;, `theta&apos;, `phi&apos;, since this allows for dimension independent expressions. Velocities can be specified using cartesian (by default) or spherical unit vectors. No matter which geometry model is chosen, the unit of the velocities is assumed to be m/s or m/yr depending on the `Use years in output instead of seconds&apos; flag. If you provide velocities in cm/yr, set the `Scale factor&apos; option to 0.01.
+
+`function&apos;: Implementation of a model in which the boundary velocity is given in terms of an explicit formula that is elaborated in the parameters in section ``Boundary velocity model|Function&apos;&apos;. The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
+The formula you describe in the mentioned section is a semicolon separated list of velocities for each of the $d$ components of the velocity vector. These $d$ formulas are interpreted as having units m/s, unless the global input parameter ``Use years in output instead of seconds&apos;&apos; is set, in which case we interpret the formula expressions as having units m/year.
+
+Likewise, since the symbol $t$ indicating time may appear in the formulas for the prescribed velocities, it is interpreted as having units seconds unless the global parameter above has been set.
+
+`gplates&apos;: Implementation of a model in which the boundary velocity is derived from files that are generated by the GPlates program.
+
+`zero velocity&apos;: Implementation of a model in which the boundary velocity is zero. This is commonly referred to as a ``stick boundary condition&apos;&apos;, indicating that the material ``sticks&apos;&apos; to the material on the other side of the boundary.
+</documentation>
+<pattern>
+943
+</pattern>
+<pattern_description>
+[Map of &lt;[Anything]&gt;:&lt;[Selection ascii data|function|gplates|zero velocity ]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Prescribed_20velocity_20boundary_20indicators>
+<Zero_20velocity_20boundary_20indicators>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of names denoting those boundaries on which the velocity is zero.
+
+The names of the boundaries listed here can either by numbers (in which case they correspond to the numerical boundary indicators assigned by the geometry object), or they can correspond to any of the symbolic names the geometry object may have provided for each part of the boundary. You may want to compare this with the documentation of the geometry model you use in your model.
+</documentation>
+<pattern>
+944
+</pattern>
+<pattern_description>
+[List of &lt;[Anything]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Zero_20velocity_20boundary_20indicators>
+<Tangential_20velocity_20boundary_20indicators>
+<value/>
+<default_value/>
+<documentation>
+A comma separated list of names denoting those boundaries on which the velocity is tangential and unrestrained, i.e., free-slip where no external forces act to prescribe a particular tangential velocity (although there is a force that requires the flow to be tangential).
+
+The names of the boundaries listed here can either by numbers (in which case they correspond to the numerical boundary indicators assigned by the geometry object), or they can correspond to any of the symbolic names the geometry object may have provided for each part of the boundary. You may want to compare this with the documentation of the geometry model you use in your model.
+</documentation>
+<pattern>
+945
+</pattern>
+<pattern_description>
+[List of &lt;[Anything]&gt; of length 0...4294967295 (inclusive)]
+</pattern_description>
+</Tangential_20velocity_20boundary_20indicators>
+<Ascii_20data_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/boundary-velocity/ascii-data/test/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/boundary-velocity/ascii-data/test/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a `/&apos;) or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+946
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Data_20file_20name>
+<value>
+box_2d_%s.%d.txt
+</value>
+<default_value>
+box_2d_%s.%d.txt
+</default_value>
+<documentation>
+The file name of the model data. Provide file in format: (Velocity file name).\%s\%d where \%s is a string specifying the boundary of the model according to the names of the boundary indicators (of the chosen geometry model).\%d is any sprintf integer qualifier, specifying the format of the current file number. 
+</documentation>
+<pattern>
+947
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Data_20file_20name>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
+</documentation>
+<pattern>
+948
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+<Data_20file_20time_20step>
+<value>
+1e6
+</value>
+<default_value>
+1e6
+</default_value>
+<documentation>
+Time step between following data files. Depending on the setting of the global `Use years in output instead of seconds&apos; flag in the input file, this number is either interpreted as seconds or as years. The default is one million, i.e., either one million seconds or one million years.
+</documentation>
+<pattern>
+949
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Data_20file_20time_20step>
+<First_20data_20file_20model_20time>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Time from which on the data file with number `First data file number&apos; is used as boundary condition. Until this time, a boundary condition equal to zero everywhere is assumed. Depending on the setting of the global `Use years in output instead of seconds&apos; flag in the input file, this number is either interpreted as seconds or as years.
+</documentation>
+<pattern>
+950
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</First_20data_20file_20model_20time>
+<First_20data_20file_20number>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Number of the first velocity file to be loaded when the model time is larger than `First velocity file model time&apos;.
+</documentation>
+<pattern>
+951
+</pattern>
+<pattern_description>
+[Integer range -2147483648...2147483647 (inclusive)]
+</pattern_description>
+</First_20data_20file_20number>
+<Decreasing_20file_20order>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+In some cases the boundary files are not numbered in increasing but in decreasing order (e.g. `Ma BP&apos;). If this flag is set to `True&apos; the plugin will first load the file with the number `First data file number&apos; and decrease the file number during the model run.
+</documentation>
+<pattern>
+952
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Decreasing_20file_20order>
+<Use_20spherical_20unit_20vectors>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Specify velocity as r, phi, and theta components instead of x, y, and z. Positive velocities point up, north, and east (in 3D) or out and clockwise (in 2D). This setting only makes sense for spherical geometries.
+</documentation>
+<pattern>
+953
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20spherical_20unit_20vectors>
+</Ascii_20data_20model>
+<Function>
+<Coordinate_20system>
+<value>
+cartesian
+</value>
+<default_value>
+cartesian
+</default_value>
+<documentation>
+A selection that determines the assumed coordinate system for the function variables. Allowed values are `cartesian&apos;, `spherical&apos;, and `depth&apos;. `spherical&apos; coordinates are interpreted as r,phi or r,phi,theta in 2D/3D respectively with theta being the polar angle. `depth&apos; will create a function, in which only the first parameter is non-zero, which is interpreted to be the depth of the point.
+</documentation>
+<pattern>
+954
+</pattern>
+<pattern_description>
+[Selection cartesian|spherical|depth ]
+</pattern_description>
+</Coordinate_20system>
+<Use_20spherical_20unit_20vectors>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+Specify velocity as r, phi, and theta components instead of x, y, and z. Positive velocities point up, north, and east (in 3D) or out and clockwise (in 2D). This setting only makes sense for spherical geometries.
+</documentation>
+<pattern>
+955
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Use_20spherical_20unit_20vectors>
+<Variable_20names>
+<value>
+x,y,t
+</value>
+<default_value>
+x,y,t
+</default_value>
+<documentation>
+The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x&apos; (in 1d), `x,y&apos; (in 2d) or `x,y,z&apos; (in 3d) for spatial coordinates and `t&apos; for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t&apos; and then use these variable names in your function expression.
+</documentation>
+<pattern>
+956
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Variable_20names>
+<Function_20expression>
+<value>
+0; 0
+</value>
+<default_value>
+0; 0
+</default_value>
+<documentation>
+The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin&apos; or `cos&apos;. In addition, it may contain expressions like `if(x&gt;0, 1, -1)&apos; where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+</documentation>
+<pattern>
+957
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20expression>
+<Function_20constants>
+<value/>
+<default_value/>
+<documentation>
+Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...&apos;.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536&apos; and then use `pi&apos; in the expression of the actual formula. (That said, for convenience this class actually defines both `pi&apos; and `Pi&apos; by default, but you get the idea.)
+</documentation>
+<pattern>
+958
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Function_20constants>
+</Function>
+<GPlates_20model>
+<Data_20directory>
+<value>
+$ASPECT_SOURCE_DIR/data/boundary-velocity/gplates/
+</value>
+<default_value>
+$ASPECT_SOURCE_DIR/data/boundary-velocity/gplates/
+</default_value>
+<documentation>
+The name of a directory that contains the model data. This path may either be absolute (if starting with a &apos;/&apos;) or relative to the current directory. The path may also include the special text &apos;$ASPECT_SOURCE_DIR&apos; which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/&apos; subdirectory of ASPECT. 
+</documentation>
+<pattern>
+959
+</pattern>
+<pattern_description>
+[DirectoryName]
+</pattern_description>
+</Data_20directory>
+<Velocity_20file_20name>
+<value>
+phi.%d
+</value>
+<default_value>
+phi.%d
+</default_value>
+<documentation>
+The file name of the material data. Provide file in format: (Velocity file name).\%d.gpml where \%d is any sprintf integer qualifier, specifying the format of the current file number.
+</documentation>
+<pattern>
+960
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Velocity_20file_20name>
+<First_20data_20file_20model_20time>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Time from which on the velocity file with number &apos;First velocity file number&apos; is used as boundary condition. Previous to this time, a no-slip boundary condition is assumed. Depending on the setting of the global &apos;Use years in output instead of seconds&apos; flag in the input file, this number is either interpreted as seconds or as years.
+</documentation>
+<pattern>
+961
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</First_20data_20file_20model_20time>
+<First_20data_20file_20number>
+<value>
+0
+</value>
+<default_value>
+0
+</default_value>
+<documentation>
+Number of the first velocity file to be loaded when the model time is larger than &apos;First velocity file model time&apos;.
+</documentation>
+<pattern>
+962
+</pattern>
+<pattern_description>
+[Integer range -2147483648...2147483647 (inclusive)]
+</pattern_description>
+</First_20data_20file_20number>
+<Decreasing_20file_20order>
+<value>
+false
+</value>
+<default_value>
+false
+</default_value>
+<documentation>
+In some cases the boundary files are not numbered in increasing but in decreasing order (e.g. &apos;Ma BP&apos;). If this flag is set to &apos;True&apos; the plugin will first load the file with the number &apos;First velocity file number&apos; and decrease the file number during the model run.
+</documentation>
+<pattern>
+963
+</pattern>
+<pattern_description>
+[Bool]
+</pattern_description>
+</Decreasing_20file_20order>
+<Data_20file_20time_20step>
+<value>
+1e6
+</value>
+<default_value>
+1e6
+</default_value>
+<documentation>
+Time step between following velocity files. Depending on the setting of the global &apos;Use years in output instead of seconds&apos; flag in the input file, this number is either interpreted as seconds or as years. The default is one million, i.e., either one million seconds or one million years.
+</documentation>
+<pattern>
+964
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Data_20file_20time_20step>
+<Scale_20factor>
+<value>
+1
+</value>
+<default_value>
+1
+</default_value>
+<documentation>
+Scalar factor, which is applied to the boundary velocity. You might want to use this to scale the velocities to a reference model (e.g. with free-slip boundary) or another plate reconstruction.
+</documentation>
+<pattern>
+965
+</pattern>
+<pattern_description>
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Scale_20factor>
+<Point_20one>
+<value>
+1.570796,0.0
+</value>
+<default_value>
+1.570796,0.0
+</default_value>
+<documentation>
+Point that determines the plane in which a 2D model lies in. Has to be in the format `a,b&apos; where a and b are theta (polar angle)  and phi in radians.
+</documentation>
+<pattern>
+966
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Point_20one>
+<Point_20two>
+<value>
+1.570796,1.570796
+</value>
+<default_value>
+1.570796,1.570796
+</default_value>
+<documentation>
+Point that determines the plane in which a 2D model lies in. Has to be in the format `a,b&apos; where a and b are theta (polar angle)  and phi in radians.
+</documentation>
+<pattern>
+967
+</pattern>
+<pattern_description>
+[Anything]
+</pattern_description>
+</Point_20two>
+<Lithosphere_20thickness>
+<value>
+100000
+</value>
+<default_value>
+100000
+</default_value>
+<documentation>
+Determines the depth of the lithosphere, so that the GPlates velocities can be applied at the sides of the model as well as at the surface.
+</documentation>
+<pattern>
+968
+</pattern>
+<pattern_description>
+[Double 0...MAX_DOUBLE (inclusive)]
+</pattern_description>
+</Lithosphere_20thickness>
+</GPlates_20model>
+</Boundary_20velocity_20model>
+</ParameterHandler>

--- a/doc/parameter_view/parameters.xsl
+++ b/doc/parameter_view/parameters.xsl
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsl:stylesheet version="1.0"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns="http://www.w3.org/1999/xhtml">
+
+	<xsl:template match="/">
+		<html>
+			<head>
+				<link rel="stylesheet" type="text/css" href="parameters.css"></link>
+			</head>
+			<body>
+				<h2>ASPECT input parameters</h2>
+				<ul>
+					<xsl:apply-templates
+						select="ParameterHandler/*" />
+				</ul>
+                                <script src="parameters.js" type="text/javascript"></script>
+			</body>
+		</html>
+	</xsl:template>
+
+	<xsl:template match="ParameterHandler//*">
+
+			<xsl:choose>
+				<xsl:when test=".//value">
+					<li>
+						                        <xsl:choose>
+                                <xsl:when test="./value">
+						<div class="collapsible parameter mangled">
+							set <b> <xsl:value-of select="name()" /> </b> = <em> <xsl:value-of select="./default_value" /> </em> <xsl:value-of select="./pattern_description" />
+						</div>
+						        </xsl:when>
+							<xsl:otherwise>
+		                                <div class="collapsible mangled">
+							subsection <b> <xsl:value-of select="name()" /> </b>
+                                                </div>
+					</xsl:otherwise>
+				</xsl:choose>
+			<div class="content">
+					<ul>
+						<xsl:apply-templates select="child::*" />
+					</ul>
+				</div>
+		</li>
+	</xsl:when>
+	<xsl:when test="name() = 'value'"></xsl:when>
+	<xsl:when test="name() = 'default_value'"></xsl:when>
+	<xsl:when test="name() = 'pattern'"></xsl:when>
+	<xsl:when test="name() = 'pattern_description'"></xsl:when>
+				<xsl:otherwise>
+		<li>
+					<xsl:value-of select="." />
+		</li>
+				</xsl:otherwise>
+			</xsl:choose>
+	</xsl:template>
+</xsl:stylesheet>

--- a/doc/update_parameters.sh
+++ b/doc/update_parameters.sh
@@ -64,6 +64,27 @@ grep '[^\\]%' parameters.tex && echo "Error, please remove '%'!" && exit 1
 
 cd ../..
 
+
+# next, run ASPECT so that it produces the parameters.xml file that
+# documents all parameters and that we use for the web view of parameters
+echo Creating parameters.xml
+rm -f output/parameters.xml
+$ASPECT --output-xml doc/manual/empty.prm >doc/parameter_view/parameters.xml 2>/dev/null \
+    || (echo "Running ASPECT for parameters.xml failed" ; exit 1)
+
+echo Patching parameters.xml
+cd doc/parameter_view
+cp parameters.xml parameters.bak
+head -n 1 parameters.bak > parameters.xml
+echo '<?xml-stylesheet type="application/xml" href="parameters.xsl"?>' >> parameters.xml
+echo '' >> parameters.xml
+tail -n +2 parameters.bak >> parameters.xml
+rm parameters.bak
+sed -i 's/\(.\)</\1\n</g' parameters.xml
+sed -i 's/>\(.\)/>\n\1/g' parameters.xml
+
+cd ../..
+
 # next, generate the output file that is used to create the
 # connection graph between all plugins and the core of ASPECT
 echo Creating plugin graph

--- a/doc/update_parameters.sh
+++ b/doc/update_parameters.sh
@@ -69,19 +69,18 @@ cd ../..
 # documents all parameters and that we use for the web view of parameters
 echo Creating parameters.xml
 rm -f output/parameters.xml
-$ASPECT --output-xml doc/manual/empty.prm >doc/parameter_view/parameters.xml 2>/dev/null \
+$ASPECT --output-xml doc/manual/empty.prm >doc/parameter_view/parameters.bak 2>/dev/null \
     || (echo "Running ASPECT for parameters.xml failed" ; exit 1)
 
 echo Patching parameters.xml
 cd doc/parameter_view
-cp parameters.xml parameters.bak
 head -n 1 parameters.bak > parameters.xml
 echo '<?xml-stylesheet type="application/xml" href="parameters.xsl"?>' >> parameters.xml
 echo '' >> parameters.xml
 tail -n +2 parameters.bak >> parameters.xml
+sed -i.bak 's/\(.\)</\1\n</g' parameters.xml
+sed -i.bak 's/>\(.\)/>\n\1/g' parameters.xml
 rm parameters.bak
-sed -i 's/\(.\)</\1\n</g' parameters.xml
-sed -i 's/>\(.\)/>\n\1/g' parameters.xml
 
 cd ../..
 


### PR DESCRIPTION
This change makes `doc/update_parameters.sh` also create a parameters.xml file that can be used for an extremely convenient view of all parameters (better interface than the long list in the manual, and easier to use than the parameter gui). Since it is included in the usual update cycle, it will always be in sync with the parameters.tex in the repo and the latest manual. The xml file is combined with an .xsl stylefile that allows viewing the file in a browser offline or online. For an online preview see: https://gassmoeller.github.io/parameters/parameters.xml, but the file also works offline (just open the .xml file in your browser, I think Chrome has a security feature that disallows the offline view, but firefox works). In a follow up PR I will link to this file from our website. This might be the optimal solution for tutorials, and for users who want to see what options there are.

There are numerous options for improvements, but for now I would prefer to just get this in and make adjustments later. I already always use this option when I am checking parameter names or default values.

