### PR TITLE
Link to parameter view

### DIFF
--- a/header.include
+++ b/header.include
@@ -24,6 +24,7 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Info<b class="caret"></b></a>
               <ul class="dropdown-menu">
+                <li><a href="../doc/parameter_view/parameters.xml">Parameter Documentation</a></li>
                 <li><a href="http://www.math.clemson.edu/~heister/manual.pdf">Manual</a></li>
                 <li><a href="index.html#contact">Forum and Contact</a></li>
                 <li><a href="citing.html?src=www&ver=release">How to cite?</a></li>

--- a/index.html
+++ b/index.html
@@ -125,6 +125,18 @@
 
 	      <tr>
 		<td style="vertical-align:top;height:4em">
+		  <a class="btn btn-success" style="width:100%" href="../doc/parameter_view/parameters.xml">Parameters &raquo;</a>
+		</td>
+		<td></td>
+		<td style="vertical-align:top">
+		  <i>
+			  <abbr>ASPECT</abbr> is controlled by input parameters. Find all available options.
+		  </i>
+		</td>
+	      </tr>
+
+	      <tr>
+		<td style="vertical-align:top;height:4em">
 		  <a class="btn btn-success" style="width:100%" href="http://www.math.clemson.edu/~heister/manual.pdf">Manual &raquo;</a>
 		</td>
 		<td></td>


### PR DESCRIPTION
Companion PR to #2747 and should only be merged after that one (and a subsequent update of the website). This creates the link to the parameter view and places it prominently on the website. I think this will be a feature that will be used quite often (I know I use it often) so I made it easy to find.