### PR TITLE
Support sphere geometry in ascii data plugin

### DIFF
--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -39,6 +39,7 @@
 
 #include <aspect/geometry_model/box.h>
 #include <aspect/geometry_model/spherical_shell.h>
+#include <aspect/geometry_model/sphere.h>
 #include <aspect/geometry_model/chunk.h>
 
 #include <fstream>
@@ -1841,6 +1842,7 @@ namespace aspect
     {
       AssertThrow ((dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()))
                    || (dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model())) != nullptr
+                   || (dynamic_cast<const GeometryModel::Sphere<dim>*> (&this->get_geometry_model())) != nullptr
                    || (dynamic_cast<const GeometryModel::Box<dim>*> (&this->get_geometry_model())) != nullptr,
                    ExcMessage ("This ascii data plugin can only be used when using "
                                "a spherical shell, chunk or box geometry."));
@@ -2160,7 +2162,8 @@ namespace aspect
           Point<dim> internal_position = position;
 
           if (dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()) != nullptr
-              || dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model()) != nullptr)
+              || dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model()) != nullptr
+              || dynamic_cast<const GeometryModel::Sphere<dim>*> (&this->get_geometry_model()) != nullptr)
             {
               const std::array<double,dim> spherical_position =
                 Utilities::Coordinates::cartesian_to_spherical_coordinates(position);

--- a/tests/ascii_data_boundary_velocity_3d_sphere.prm
+++ b/tests/ascii_data_boundary_velocity_3d_sphere.prm
@@ -1,0 +1,77 @@
+# simple test for ascii data in a 3d sphere
+
+set Dimension                              = 3
+
+set Use years in output instead of seconds = true
+set End time                               = 1e3
+
+set Adiabatic surface temperature          = 1613.0
+
+subsection Geometry model
+  set Model name = sphere
+
+  subsection Sphere
+    set Radius = 6371000
+  end
+end
+
+subsection Initial temperature model
+  set Model name = function
+end
+
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = outer
+  set List of model names = spherical constant
+  subsection Spherical constant
+    set Inner temperature = 3000
+    set Outer temperature = 273
+  end
+end
+
+
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = outer: ascii data
+  subsection Ascii data model
+    set Data file name       = shell_3d_%s.0.txt
+    
+    set Data directory = $ASPECT_SOURCE_DIR/data/boundary-velocity/ascii-data/test/
+    set Scale factor = 10
+  end
+end
+
+
+subsection Gravity model
+  set Model name = radial constant
+
+  subsection Radial constant
+    set Magnitude = 10
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Viscosity = 1e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 1
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+  set Strategy                                 = temperature
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics
+
+  subsection Visualization
+    set Output format = vtu
+    set Interpolate output = true
+  end
+end
+

--- a/tests/ascii_data_boundary_velocity_3d_sphere/screen-output
+++ b/tests/ascii_data_boundary_velocity_3d_sphere/screen-output
@@ -1,0 +1,38 @@
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_top.0.txt.
+
+
+   Loading new data file did not succeed.
+   Assuming constant boundary conditions for rest of model run.
+
+Number of active cells: 56 (on 2 levels)
+Number of degrees of freedom: 2,147 (1,551+79+517)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 12 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 36+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  6.1 m/year, 23.8 m/year
+     Temperature min/avg/max:            -7.694e-14 K, 75.97 K, 273 K
+     Heat fluxes through boundary parts: 7.701e+15 W
+
+*** Timestep 1:  t=1000 years
+   Solving temperature system... 12 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 28+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  6.1 m/year, 23.8 m/year
+     Temperature min/avg/max:            -2.578 K, 76.47 K, 273 K
+     Heat fluxes through boundary parts: -4.773e+16 W
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/ascii_data_boundary_velocity_3d_sphere/statistics
+++ b/tests/ascii_data_boundary_velocity_3d_sphere/statistics
@@ -1,0 +1,19 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: RMS velocity (m/year)
+# 12: Max. velocity (m/year)
+# 13: Minimal temperature (K)
+# 14: Average temperature (K)
+# 15: Maximal temperature (K)
+# 16: Average nondimensional temperature (K)
+# 17: Outward heat flux through boundary with indicator 0 ("top") (W)
+0 0.000000000000e+00 0.000000000000e+00 56 1630 517 12 36 37 194 6.10337793e+00 2.38188582e+01 -7.69359624e-14 7.59708917e+01 2.73000000e+02 2.78587795e-02  7.70116407e+15 
+1 1.000000000000e+03 1.000000000000e+03 56 1630 517 12 28 29 156 6.10326073e+00 2.38189733e+01 -2.57803382e+00 7.64660076e+01 2.73000000e+02 2.89857137e-02 -4.77289215e+16 


### PR DESCRIPTION
The title says it all. The ascii data plugin already supports spherical geometries in general, but it did not recognize the sphere geometry as a supported geometry model.