### PR TITLE
add assert and notes about inhomogeneous constraints

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -686,6 +686,15 @@ namespace aspect
     if (rebuild_stokes_matrix == true)
       system_matrix = 0;
 
+    // We are using constraints.distribute_local_to_global() without a matrix
+    // if we do not rebuild the Stokes matrix. This produces incorrect results
+    // when having inhomogeneous constraints. Make sure that we can not have
+    // this situation (no active boundary conditions means that only
+    // no-slip/free slip are used). This should not happen as we set this up
+    // correctly before calling this function.
+    Assert(rebuild_stokes_matrix || boundary_velocity_manager.get_active_boundary_velocity_conditions().size()==0,
+           ExcInternalError("If we have inhomogeneous constraints, we must re-assemble the system matrix."));
+
     system_rhs = 0;
     if (do_pressure_rhs_compatibility_modification)
       pressure_shape_function_integrals = 0;

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -261,9 +261,13 @@ namespace aspect
   double Simulator<dim>::assemble_and_solve_stokes (const bool compute_initial_residual,
                                                     double *initial_nonlinear_residual)
   {
-    // If the Stokes matrix depends on the solution, or the boundary conditions
-    // for the Stokes system have changed rebuild the matrix and preconditioner
-    // before solving.
+    // If the Stokes matrix depends on the solution, or we have active
+    // velocity boundary conditions, we need to re-assemble the system matrix
+    // (and preconditioner) every time. If we have active boundary conditions,
+    // they could a) depend on the solution, or b) be inhomogeneous. In both
+    // cases, just assembling the RHS will be incorrect.  If no active
+    // boundaries exist, we only have no-slip or free slip conditions, so we
+    // don't need to force assembly of the matrix.
     if (stokes_matrix_depends_on_solution()
         ||
         (boundary_velocity_manager.get_active_boundary_velocity_conditions().size() > 0))


### PR DESCRIPTION
We use constraints.distribute_local_to_global() without a matrix in the
Stokes assembly. This gives incorrect results when we have inhomogeneous
constraints. Make sure that we never use this. Also add documentation
for this.