### PR TITLE
macro names without double underscore

### DIFF
--- a/include/aspect/adiabatic_conditions/ascii_data.h
+++ b/include/aspect/adiabatic_conditions/ascii_data.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef _aspect__adiabatic_conditions_ascii_data_h
-#define _aspect__adiabatic_conditions_ascii_data_h
+#ifndef _aspect_adiabatic_conditions_ascii_data_h
+#define _aspect_adiabatic_conditions_ascii_data_h
 
 
 #include <aspect/adiabatic_conditions/interface.h>

--- a/include/aspect/geometry_model/initial_topography_model/ascii_data.h
+++ b/include/aspect/geometry_model/initial_topography_model/ascii_data.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef _aspect_geometry_model__initial_topography_model_ascii_data_h
-#define _aspect_geometry_model__initial_topography_model_ascii_data_h
+#ifndef _aspect_geometry_model_initial_topography_model_ascii_data_h
+#define _aspect_geometry_model_initial_topography_model_ascii_data_h
 
 #include <aspect/geometry_model/initial_topography_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/geometry_model/initial_topography_model/interface.h
+++ b/include/aspect/geometry_model/initial_topography_model/interface.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef _aspect_geometry_model__initial_topography_model_interface_h
-#define _aspect_geometry_model__initial_topography_model_interface_h
+#ifndef _aspect_geometry_model_initial_topography_model_interface_h
+#define _aspect_geometry_model_initial_topography_model_interface_h
 
 #include <aspect/plugins.h>
 #include <deal.II/base/parameter_handler.h>

--- a/include/aspect/geometry_model/initial_topography_model/prm_polygon.h
+++ b/include/aspect/geometry_model/initial_topography_model/prm_polygon.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef _aspect_geometry_model__initial_topography_prm_polygon_h
-#define _aspect_geometry_model__initial_topography_prm_polygon_h
+#ifndef _aspect_geometry_model_initial_topography_prm_polygon_h
+#define _aspect_geometry_model_initial_topography_prm_polygon_h
 
 #include <aspect/geometry_model/initial_topography_model/interface.h>
 

--- a/include/aspect/geometry_model/initial_topography_model/zero_topography.h
+++ b/include/aspect/geometry_model/initial_topography_model/zero_topography.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef _aspect_geometry_model__initial_topography_model_zero_topography_h
-#define _aspect_geometry_model__initial_topography_model_zero_topography_h
+#ifndef _aspect_geometry_model_initial_topography_model_zero_topography_h
+#define _aspect_geometry_model_initial_topography_model_zero_topography_h
 
 #include <aspect/geometry_model/initial_topography_model/interface.h>
 

--- a/include/aspect/gravity_model/ascii_data.h
+++ b/include/aspect/gravity_model/ascii_data.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef _aspect__gravity_model_ascii_data_h
-#define _aspect__gravity_model_ascii_data_h
+#ifndef _aspect_gravity_model_ascii_data_h
+#define _aspect_gravity_model_ascii_data_h
 
 #include <aspect/gravity_model/interface.h>
 #include <aspect/utilities.h>

--- a/include/aspect/initial_temperature/ascii_profile.h
+++ b/include/aspect/initial_temperature/ascii_profile.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef _aspect__initial_temperature_ascii_profile_h
-#define _aspect__initial_temperature_ascii_profile_h
+#ifndef _aspect_initial_temperature_ascii_profile_h
+#define _aspect_initial_temperature_ascii_profile_h
 
 #include <aspect/initial_temperature/interface.h>
 #include <aspect/utilities.h>

--- a/include/aspect/material_model/ascii_reference_profile.h
+++ b/include/aspect/material_model/ascii_reference_profile.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef _aspect__model_ascii_reference_profile_h
-#define _aspect__model_ascii_reference_profile_h
+#ifndef _aspect_model_ascii_reference_profile_h
+#define _aspect_model_ascii_reference_profile_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__model_grain_size_h
-#define __aspect__model_grain_size_h
+#ifndef _aspect_model_grain_size_h
+#define _aspect_model_grain_size_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -19,8 +19,8 @@
  */
 
 
-#ifndef _aspect__newton_h
-#define _aspect__newton_h
+#ifndef _aspect_newton_h
+#define _aspect_newton_h
 
 #include <aspect/simulator/assemblers/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/particle/interpolator/nearest_neighbor.h
+++ b/include/aspect/particle/interpolator/nearest_neighbor.h
@@ -18,8 +18,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _aspect__particle_interpolator_nearest_neighbor_h
-#define _aspect__particle_interpolator_nearest_neighbor_h
+#ifndef _aspect_particle_interpolator_nearest_neighbor_h
+#define _aspect_particle_interpolator_nearest_neighbor_h
 
 #include <aspect/particle/interpolator/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/geoid.h
+++ b/include/aspect/postprocess/geoid.h
@@ -19,8 +19,8 @@
  */
 
 
-#ifndef _aspect__postprocess_geoid_h
-#define _aspect__postprocess_geoid_h
+#ifndef _aspect_postprocess_geoid_h
+#define _aspect_postprocess_geoid_h
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/visualization/geoid.h
+++ b/include/aspect/postprocess/visualization/geoid.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__postprocess_visualization_geoid_h
-#define __aspect__postprocess_visualization_geoid_h
+#ifndef _aspect_postprocess_visualization_geoid_h
+#define _aspect_postprocess_visualization_geoid_h
 
 #include <aspect/simulator_access.h>
 #include <aspect/postprocess/visualization.h>

--- a/include/aspect/termination_criteria/end_walltime.h
+++ b/include/aspect/termination_criteria/end_walltime.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef __aspect__termination_criteria_end_walltime_h
-#define __aspect__termination_criteria_end_walltime_h
+#ifndef _aspect_termination_criteria_end_walltime_h
+#define _aspect_termination_criteria_end_walltime_h
 
 #include <aspect/termination_criteria/interface.h>
 #include <aspect/simulator.h>


### PR DESCRIPTION
because this is not valid c++ otherwise.