### PR TITLE
disable FPEs while averaging

### DIFF
--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -32,6 +32,11 @@
 
 #include <list>
 
+#ifdef DEBUG
+#ifdef ASPECT_USE_FP_EXCEPTIONS
+#include <fenv.h>
+#endif
+#endif
 
 namespace aspect
 {
@@ -455,6 +460,14 @@ namespace aspect
         if (values_out.size() == 0)
           return;
 
+#ifdef DEBUG
+#ifdef ASPECT_USE_FP_EXCEPTIONS
+        // disable floating point exceptions while averaging. Errors will be reported
+        // as soon as somebody will try to use the averaged values later.
+        fedisableexcept(FE_DIVBYZERO|FE_INVALID);
+#endif
+#endif
+
         const unsigned int N = values_out.size();
         const unsigned int P = expansion_matrix.n();
         Assert ((P==0) || (/*dim=2*/ P==4) || (/*dim=3*/ P==8),
@@ -602,6 +615,13 @@ namespace aspect
                            ExcMessage ("This averaging operation is not implemented."));
             }
           }
+
+#ifdef DEBUG
+#ifdef ASPECT_USE_FP_EXCEPTIONS
+        // enable floating point exceptions again:
+        feenableexcept(FE_DIVBYZERO|FE_INVALID);
+#endif
+#endif
       }
 
 


### PR DESCRIPTION
This disables FPEs while averaging quantities, which allows us to
average NaNs (values the user didn't fill) without crashing. This is
useful if the values are unused. Errors will still trigger on usage of
the averaged quantity. A good example is
output.entropy_derivative_pressure.

supersedes #2025