### PR TITLE
Add phase_function material utilities

### DIFF
--- a/doc/modules/changes/20190922_naliboff
+++ b/doc/modules/changes/20190922_naliboff
@@ -1,0 +1,5 @@
+New: Added a class MaterialModel::Utilities::PhaseFunction that can handle
+generic phase functions for phase transitions that are approximated by an
+analytic function.
+<br>
+(John Naliboff, Rene Gassmoeller, 2019/08/22)

--- a/include/aspect/material_model/latent_heat.h
+++ b/include/aspect/material_model/latent_heat.h
@@ -124,29 +124,6 @@ namespace aspect
 
         double compositional_delta_rho;
 
-        /**
-         * Percentage of material that has already undergone the phase
-         * transition to the higher-pressure material (this is done
-         * individually for each transition and summed up in the end)
-         */
-        virtual
-        double
-        phase_function (const Point<dim> &position,
-                        const double temperature,
-                        const double pressure,
-                        const int phase) const;
-
-        /**
-         * Derivative of the phase function (argument is the pressure
-         * deviation).
-         */
-        virtual
-        double
-        phase_function_derivative (const Point<dim> &position,
-                                   const double temperature,
-                                   const double pressure,
-                                   const int phase) const;
-
         // list of depth (or pressure), width and Clapeyron slopes
         // for the different phase transitions
         std::vector<double> transition_depths;

--- a/include/aspect/material_model/latent_heat.h
+++ b/include/aspect/material_model/latent_heat.h
@@ -55,6 +55,9 @@ namespace aspect
         virtual void evaluate(const MaterialModelInputs<dim> &in,
                               MaterialModelOutputs<dim> &out) const;
 
+
+
+
         /**
          * @name Qualitative properties one can ask a material model
          * @{
@@ -81,7 +84,6 @@ namespace aspect
         /**
          * @}
          */
-
 
         /**
          * @name Functions used in dealing with run-time parameters
@@ -123,6 +125,16 @@ namespace aspect
         double k_value;
 
         double compositional_delta_rho;
+
+        /**
+         * A function to compute the phase transition pressure and pressure width
+         * if the phase transitions are defined by the user in terms of depth.
+         * This function should be moved to the material model utilities.
+         */
+        virtual
+        std::pair<double, double>
+        transition_depth_to_pressure (const Point<dim> &position,
+                                      const int phase) const;
 
         // list of depth (or pressure), width and Clapeyron slopes
         // for the different phase transitions

--- a/include/aspect/material_model/latent_heat.h
+++ b/include/aspect/material_model/latent_heat.h
@@ -107,7 +107,6 @@ namespace aspect
          */
 
       private:
-        bool use_depth;
         double reference_rho;
         double reference_T;
         double eta;
@@ -126,27 +125,13 @@ namespace aspect
 
         double compositional_delta_rho;
 
-        /**
-         * A function to compute the phase transition pressure and pressure width
-         * if the phase transitions are defined by the user in terms of depth.
-         * This function should be moved to the material model utilities.
-         */
-        virtual
-        std::pair<double, double>
-        transition_depth_to_pressure (const Point<dim> &position,
-                                      const int phase) const;
-
         // list of depth (or pressure), width and Clapeyron slopes
         // for the different phase transitions
-        std::vector<double> transition_depths;
-        std::vector<double> transition_pressures;
-        std::vector<double> transition_temperatures;
-        std::vector<double> transition_widths;
-        std::vector<double> transition_pressure_widths;
-        std::vector<double> transition_slopes;
         std::vector<double> density_jumps;
-        std::vector<int> transition_phases;
         std::vector<double> phase_prefactors;
+        std::vector<int> transition_phases;
+
+        MaterialUtilities::PhaseFunction<dim> phase_function;
     };
 
   }

--- a/include/aspect/material_model/latent_heat.h
+++ b/include/aspect/material_model/latent_heat.h
@@ -55,9 +55,6 @@ namespace aspect
         virtual void evaluate(const MaterialModelInputs<dim> &in,
                               MaterialModelOutputs<dim> &out) const;
 
-
-
-
         /**
          * @name Qualitative properties one can ask a material model
          * @{
@@ -128,8 +125,8 @@ namespace aspect
         // list of depth (or pressure), width and Clapeyron slopes
         // for the different phase transitions
         std::vector<double> density_jumps;
-        std::vector<double> phase_prefactors;
         std::vector<int> transition_phases;
+        std::vector<double> phase_prefactors;
 
         MaterialUtilities::PhaseFunction<dim> phase_function;
     };

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -30,6 +30,10 @@
 
 namespace aspect
 {
+  template <int dim>
+  struct Introspection;
+
+
   namespace MaterialModel
   {
     using namespace dealii;
@@ -323,6 +327,123 @@ namespace aspect
       compute_drucker_prager_yielding (const DruckerPragerInputs &in,
                                        DruckerPragerOutputs &out);
 
+
+
+      /**
+       * A data structure with all inputs for the
+       * MaterialModel::Interface::compute_phase_function() method.
+       */
+      struct PhaseFunctionInputs
+      {
+        /**
+        * Constructor. Initializes the various variables of this
+        * structure with the input values.
+        */
+        PhaseFunctionInputs(const bool use_depth,
+                            const int phase,
+                            const double depth,
+                            const double gravity,
+                            const double temperature,
+                            const double pressure,
+                            const double transition_point,
+                            const double transition_width,
+                            const double transition_temperature,
+                            const double transition_slope);
+
+        const bool use_depth;
+        const int phase;
+        const double depth;
+        const double gravity;
+        const double temperature;
+        const double pressure;
+        const double transition_point;
+        const double transition_width;
+        const double transition_temperature;
+        const double transition_slope;
+      };
+
+
+      /**
+       * A data structure with all outputs computed by the
+       * MaterialModel::Interface::compute_phase_function() method.
+       */
+      struct PhaseFunctionOutputs
+      {
+        /**
+        * Constructor. Initializes the various variables of this
+        * structure to NaNs.
+        */
+        PhaseFunctionOutputs();
+
+        double phase_function;
+      };
+
+
+      /**
+       * For material models with phase changes:
+       * Function to compute the percentage of material that has 
+       * already undergone the phase transition to the higher-pressure 
+       * material. This is done individually for each transition and 
+       * summed up in the end.
+       */
+      template <int dim>
+      void
+      compute_phase_function (const PhaseFunctionInputs &in,
+                              PhaseFunctionOutputs &out);
+
+
+      /**
+       * A data structure with all inputs for the
+       * MaterialModel::Interface::compute_phase_function_derivative() method.
+       */
+      struct PhaseFunctionDerivativeInputs
+      {
+        /**
+        * Constructor. Initializes the various variables of this
+        * structure with the input values.
+        */
+        PhaseFunctionDerivativeInputs(const double temperature,
+                                      const double pressure,
+                                      const double transition_pressure,
+                                      const double pressure_width,
+                                      const double transition_temperature,
+                                      const double transition_slope);
+
+        const double temperature;
+        const double pressure;
+        const double transition_pressure;
+        const double pressure_width;
+        const double transition_temperature;
+        const double transition_slope;
+      };
+
+
+      /**
+       * A data structure with all outputs computed by the
+       * MaterialModel::Interface::compute_phase_function_derivative() method.
+       */
+      struct PhaseFunctionDerivativeOutputs
+      {
+        /**
+        * Constructor. Initializes the various variables of this
+        * structure to NaNs.
+        */
+        PhaseFunctionDerivativeOutputs();
+
+        double phase_function_derivative;
+      };
+
+
+      /**
+       * For material models with phase changes:
+       * Function to compute the derivative of the phase function, where
+       * the argument is the pressure deviation.
+       */
+      template <int dim>
+      void
+      compute_phase_function_derivative (const PhaseFunctionDerivativeInputs &in,
+                                         PhaseFunctionDerivativeOutputs &out);
+      
     }
   }
 }

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -331,6 +331,7 @@ namespace aspect
        * A data structure with all inputs for the
        * MaterialModel::Interface::compute_phase_function() method.
        */
+      template <int dim>
       struct PhaseFunctionInputs
       {
         /**
@@ -339,11 +340,13 @@ namespace aspect
         */
         PhaseFunctionInputs(const double temperature,
                             const double pressure,
+                            const Point<dim> &position,
                             const unsigned int phase_index,
                             const unsigned int composition_index);
 
         double temperature;
         double pressure;
+        Point<dim> position;
         unsigned int phase_index;
         unsigned int composition_index;
       };
@@ -367,13 +370,13 @@ namespace aspect
            * material. This is done individually for each transition and
            * summed up in the end.
            */
-          double phase_function (const PhaseFunctionInputs &in) const;
+          double phase_function (const PhaseFunctionInputs<dim> &in) const;
 
           /**
            * For material models with phase changes:
            * Function to compute the derivative of the phase function.
            */
-          double phase_function_derivative (const PhaseFunctionInputs &in) const;
+          double phase_function_derivative (const PhaseFunctionInputs<dim> &in) const;
 
           unsigned int n_phase_transitions () const;
 

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -30,10 +30,6 @@
 
 namespace aspect
 {
-  template <int dim>
-  struct Introspection;
-
-
   namespace MaterialModel
   {
     using namespace dealii;
@@ -339,57 +335,31 @@ namespace aspect
         * Constructor. Initializes the various variables of this
         * structure with the input values.
         */
-        PhaseFunctionInputs(const bool use_depth,
-                            const int phase,
-                            const double depth,
-                            const double gravity,
-                            const double temperature,
+        PhaseFunctionInputs(const double temperature,
                             const double pressure,
-                            const double transition_point,
-                            const double transition_width,
+                            const double transition_pressure,
+                            const double transition_pressure_width,
                             const double transition_temperature,
                             const double transition_slope);
 
-        const bool use_depth;
-        const int phase;
-        const double depth;
-        const double gravity;
         const double temperature;
         const double pressure;
-        const double transition_point;
-        const double transition_width;
+        const double transition_pressure;
+        const double transition_pressure_width;
         const double transition_temperature;
         const double transition_slope;
       };
 
 
       /**
-       * A data structure with all outputs computed by the
-       * MaterialModel::Interface::compute_phase_function() method.
-       */
-      struct PhaseFunctionOutputs
-      {
-        /**
-        * Constructor. Initializes the various variables of this
-        * structure to NaNs.
-        */
-        PhaseFunctionOutputs();
-
-        double phase_function;
-      };
-
-
-      /**
        * For material models with phase changes:
-       * Function to compute the percentage of material that has 
-       * already undergone the phase transition to the higher-pressure 
-       * material. This is done individually for each transition and 
+       * Function to compute the percentage of material that has
+       * already undergone the phase transition to the higher-pressure
+       * material. This is done individually for each transition and
        * summed up in the end.
        */
       template <int dim>
-      void
-      compute_phase_function (const PhaseFunctionInputs &in,
-                              PhaseFunctionOutputs &out);
+      double phase_function (const PhaseFunctionInputs &in);
 
 
       /**
@@ -405,45 +375,26 @@ namespace aspect
         PhaseFunctionDerivativeInputs(const double temperature,
                                       const double pressure,
                                       const double transition_pressure,
-                                      const double pressure_width,
+                                      const double transition_pressure_width,
                                       const double transition_temperature,
                                       const double transition_slope);
 
         const double temperature;
         const double pressure;
         const double transition_pressure;
-        const double pressure_width;
+        const double transition_pressure_width;
         const double transition_temperature;
         const double transition_slope;
       };
 
 
       /**
-       * A data structure with all outputs computed by the
-       * MaterialModel::Interface::compute_phase_function_derivative() method.
-       */
-      struct PhaseFunctionDerivativeOutputs
-      {
-        /**
-        * Constructor. Initializes the various variables of this
-        * structure to NaNs.
-        */
-        PhaseFunctionDerivativeOutputs();
-
-        double phase_function_derivative;
-      };
-
-
-      /**
        * For material models with phase changes:
-       * Function to compute the derivative of the phase function, where
-       * the argument is the pressure deviation.
+       * Function to compute the derivative of the phase function.
        */
       template <int dim>
-      void
-      compute_phase_function_derivative (const PhaseFunctionDerivativeInputs &in,
-                                         PhaseFunctionDerivativeOutputs &out);
-      
+      double phase_function_derivative (const PhaseFunctionDerivativeInputs &in);
+
     }
   }
 }

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -366,16 +366,16 @@ namespace aspect
            * transition to the higher-pressure material (this is done
            * individually for each transition and summed up in the end)
            */
-          double get_value (const PhaseFunctionInputs<dim> &in) const;
+          double compute_value (const PhaseFunctionInputs<dim> &in) const;
 
           /**
-           * Derivative of the phase function (argument is the pressure
-           * deviation).
+           * Return the derivative of the phase function with respect to
+           * pressure.
            */
-          double get_derivative (const PhaseFunctionInputs<dim> &in) const;
+          double compute_derivative (const PhaseFunctionInputs<dim> &in) const;
 
           /**
-           * The total number of phase transitions.
+           * Return the total number of phase transitions.
            */
           unsigned int n_phase_transitions () const;
 

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -22,7 +22,6 @@
 #define _aspect_material_model_utilities_h
 
 #include <aspect/global.h>
-
 #include <deal.II/base/point.h>
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/fe/component_mask.h>

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -76,6 +76,11 @@ namespace aspect
     template <int dim> class Manager;
   }
 
+  namespace MaterialModel
+  {
+    template <int dim> class Interface;
+  }
+
   namespace InitialTemperature
   {
     template <int dim> class Manager;

--- a/source/material_model/latent_heat.cc
+++ b/source/material_model/latent_heat.cc
@@ -117,8 +117,7 @@ namespace aspect
                                                                            pressure,
                                                                            depth,
                                                                            pressure_depth_derivative,
-                                                                           phase,
-                                                                           0);
+                                                                           phase);
 
                 const double phaseFunction = phase_function.get_value(phase_in);
 
@@ -175,8 +174,7 @@ namespace aspect
                                                                              pressure,
                                                                              depth,
                                                                              pressure_depth_derivative,
-                                                                             phase,
-                                                                             0);
+                                                                             phase);
 
                   const double PhaseFunctionDerivative = phase_function.get_derivative(phase_in);
                   const double clapeyron_slope = phase_function.get_transition_slope(phase);

--- a/source/material_model/latent_heat.cc
+++ b/source/material_model/latent_heat.cc
@@ -106,8 +106,6 @@ namespace aspect
             // Loop through phase transitions
             for (unsigned int phase=0; phase<number_of_phase_transitions; ++phase)
               {
-
-
                 const MaterialUtilities::PhaseFunctionInputs phase_in(temperature,
                                                                       pressure,
                                                                       phase,

--- a/source/material_model/latent_heat.cc
+++ b/source/material_model/latent_heat.cc
@@ -106,8 +106,9 @@ namespace aspect
             // Loop through phase transitions
             for (unsigned int phase=0; phase<number_of_phase_transitions; ++phase)
               {
-                const MaterialUtilities::PhaseFunctionInputs phase_in(temperature,
+                const MaterialUtilities::PhaseFunctionInputs<dim> phase_in(temperature,
                                                                       pressure,
+                                                                      in.position[i],
                                                                       phase,
                                                                       0);
 
@@ -128,6 +129,7 @@ namespace aspect
                       phase_dependence += phaseFunction * density_jumps[phase] * (1.0 - composition[0]);
                     else if (transition_phases[phase] == 1) // 2nd compositional field
                       phase_dependence += phaseFunction * density_jumps[phase] * composition[0];
+
                     viscosity_phase_dependence *= 1. + phaseFunction * (phase_prefactors[phase]-1.);
                   }
               }
@@ -154,8 +156,9 @@ namespace aspect
             if (this->get_adiabatic_conditions().is_initialized() && this->include_latent_heat())
               for (unsigned int phase=0; phase<number_of_phase_transitions; ++phase)
                 {
-                  const MaterialUtilities::PhaseFunctionInputs phase_in(temperature,
+                  const MaterialUtilities::PhaseFunctionInputs<dim> phase_in(temperature,
                                                                         pressure,
+                                                                        in.position[i],
                                                                         phase,
                                                                         0);
 

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -762,16 +762,14 @@ namespace aspect
                                                     const double pressure_,
                                                     const double depth_,
                                                     const double pressure_depth_derivative_,
-                                                    const unsigned int phase_index_,
-                                                    const unsigned int composition_index_)
+                                                    const unsigned int phase_index_)
 
         :
         temperature(temperature_),
         pressure(pressure_),
         depth(depth_),
         pressure_depth_derivative(pressure_depth_derivative_),
-        phase_index(phase_index_),
-        composition_index(composition_index_)
+        phase_index(phase_index_)
       {}
 
 

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -775,7 +775,7 @@ namespace aspect
 
       template <int dim>
       double
-      PhaseFunction<dim>::get_value (const PhaseFunctionInputs<dim> &in) const
+      PhaseFunction<dim>::compute_value (const PhaseFunctionInputs<dim> &in) const
       {
         // the percentage of material that has undergone the transition
         double function_value;
@@ -813,15 +813,18 @@ namespace aspect
 
       template <int dim>
       double
-      PhaseFunction<dim>::get_derivative (const PhaseFunctionInputs<dim> &in) const
+      PhaseFunction<dim>::compute_derivative (const PhaseFunctionInputs<dim> &in) const
       {
         double transition_pressure;
         double pressure_width;
         double width_temp;
 
         // we already should have the adiabatic conditions here
-        AssertThrow (this->get_adiabatic_conditions().is_initialized(),
-                     ExcMessage("need adiabatic conditions to incorporate phase transitions"));
+        Assert (this->get_adiabatic_conditions().is_initialized(),
+                ExcMessage("The adiabatic conditions need to be already initialized "
+                           "to calculate the derivative of phase functions. Either call this "
+                           "function after the reference conditions have been computed, or implement "
+                           "a workaround for the case without reference profile."));
 
         // phase transition based on depth
         if (use_depth_instead_of_pressure)

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -23,6 +23,7 @@
 #include <aspect/simulator_access.h>
 
 #include <aspect/adiabatic_conditions/interface.h>
+#include <aspect/gravity_model/interface.h>
 
 #include <aspect/material_model/interface.h>
 #include <aspect/material_model/utilities.h>
@@ -756,14 +757,17 @@ namespace aspect
 
 
 
-      PhaseFunctionInputs::PhaseFunctionInputs(const double temperature_,
+      template <int dim>
+      PhaseFunctionInputs<dim>::PhaseFunctionInputs(const double temperature_,
                                                const double pressure_,
+                                               const Point<dim> &position_,
                                                const unsigned int phase_index_,
                                                const unsigned int composition_index_)
 
         :
         temperature(temperature_),
         pressure(pressure_),
+        position(position_),
         phase_index(phase_index_),
         composition_index(composition_index_)
       {}
@@ -771,84 +775,109 @@ namespace aspect
 
       template <int dim>
       double
-      PhaseFunction<dim>::phase_function (const PhaseFunctionInputs &in) const
+      PhaseFunction<dim>::phase_function (const PhaseFunctionInputs<dim> &in) const
       {
-        double transition_pressure;
-        double transition_pressure_width;
-
-        if (use_depth_instead_of_pressure)
+        // We need to convert the depth to pressure (depth-based phase transitions),
+        // or else use the pressure itself if the phase transition is defined based off a pressure.
+        if (!use_depth_instead_of_pressure)
           {
-            const std::pair<double, double> phase_transition_pressure_range =
-              transition_depth_to_pressure(Point<dim>(), in.phase_index);
+            // first, get the pressure at which the phase transition occurs normally
+            // and get the pressure change in the range of the phase transition
 
-            transition_pressure = phase_transition_pressure_range.first;
-            transition_pressure_width = phase_transition_pressure_range.second;
-          }
-        else
-          {
+            double transition_pressure;
+            double pressure_width;
+            double width_temp;
+
             transition_pressure = transition_pressures[in.phase_index];
-            transition_pressure_width = transition_pressure_widths[in.phase_index];
+            pressure_width = transition_pressure_widths[in.phase_index];
+            width_temp = transition_pressure_widths[in.phase_index];
+
+            // then calculate the deviation from the transition point (both in temperature
+            // and in pressure)
+            double pressure_deviation = in.pressure - transition_pressure
+                                        - transition_slopes[in.phase_index] * (in.temperature - transition_temperatures[in.phase_index]);
+
+            // last, calculate the percentage of material that has undergone the transition
+            // (also in dependence of the phase transition width - this is an input parameter)
+            double phase_func;
+            // use delta function for width = 0
+            if (width_temp==0)
+              (pressure_deviation > 0) ? phase_func = 1 : phase_func = 0;
+            else
+              phase_func = 0.5*(1.0 + std::tanh(pressure_deviation / pressure_width));
+            return phase_func;
           }
-
-        // Calculate the deviation from the phase transition point
-        // (pressure here), with the current pressure and temperature.
-        double pressure_deviation = in.pressure - transition_pressure -
-                                    transition_slopes[in.phase_index] * (in.temperature - transition_temperatures[in.phase_index]);
-
-        double phase_function;
-
-        // Calculate the percentage of material that has undergone the phase transition as a function
-        // of the pressure deviation and phase transition width (defined in terms of a pressure range here).
-        if (transition_pressure_width == 0)
-          (pressure_deviation > 0) ? phase_function = 1 : phase_function = 0;
+        // this part of the loop is only implemented for phase transitions based off of depth,
+        // since pressure-based transitions are included above.
         else
-          phase_function = 0.5*(1.0 + std::tanh(pressure_deviation / transition_pressure_width));
+          {
+            const double depth = this->get_geometry_model().depth(in.position);
 
-        return phase_function;
+            const double depth_deviation = (in.pressure > 0
+                                      ?
+                                      depth - transition_depths[in.phase_index]
+                                      - transition_slopes[in.phase_index] * (depth / in.pressure) * (in.temperature - transition_temperatures[in.phase_index])
+                                      :
+                                      depth - transition_depths[in.phase_index]
+                               - transition_slopes[in.phase_index] / (this->get_gravity_model().gravity_vector(in.position).norm() * 3300.00)
+                                      * (in.temperature - transition_temperatures[in.phase_index]));
+
+            double phase_func;
+            // use delta function for width = 0
+            if (transition_widths[in.phase_index]==0)
+              phase_func = (depth_deviation > 0) ? 1 : 0;
+            else
+              phase_func = 0.5*(1.0 + std::tanh(depth_deviation / transition_widths[in.phase_index]));
+            return phase_func;
+          }
       }
 
 
 
       template <int dim>
       double
-      PhaseFunction<dim>::phase_function_derivative (const PhaseFunctionInputs &in) const
+      PhaseFunction<dim>::phase_function_derivative (const PhaseFunctionInputs<dim> &in) const
       {
         double transition_pressure;
-        double transition_pressure_width;
+         double pressure_width;
+         double width_temp;
 
-        if (use_depth_instead_of_pressure)
-          {
-            const std::pair<double, double> phase_transition_pressure_range =
-              transition_depth_to_pressure(Point<dim>(), in.phase_index);
+         // we already should have the adiabatic conditions here
+         AssertThrow (this->get_adiabatic_conditions().is_initialized(),
+                      ExcMessage("need adiabatic conditions to incorporate phase transitions"));
 
-            transition_pressure = phase_transition_pressure_range.first;
-            transition_pressure_width = phase_transition_pressure_range.second;
-          }
-        else
-          {
-            transition_pressure = transition_pressures[in.phase_index];
-            transition_pressure_width = transition_pressure_widths[in.phase_index];
-          }
+         // first, get the pressure at which the phase transition occurs normally
 
-        // Calculate the pressure deviation from the transition pressure (both in temperature
-        // and in pressure)
-        double pressure_deviation = in.pressure - transition_pressure -
-                                    transition_slopes[in.phase_index] * (in.temperature - transition_temperatures[in.phase_index]);
+         // phase transition based off of depth
+         if (use_depth_instead_of_pressure)
+           {
+             const Point<dim,double> transition_point = this->get_geometry_model().representative_point(transition_depths[in.phase_index]);
+             const Point<dim,double> transition_plus_width = this->get_geometry_model().representative_point(transition_depths[in.phase_index] + transition_widths[in.phase_index]);
+             const Point<dim,double> transition_minus_width = this->get_geometry_model().representative_point(transition_depths[in.phase_index] - transition_widths[in.phase_index]);
+             transition_pressure = this->get_adiabatic_conditions().pressure(transition_point);
+             pressure_width = 0.5 * (this->get_adiabatic_conditions().pressure(transition_plus_width)
+                                     - this->get_adiabatic_conditions().pressure(transition_minus_width));
+             width_temp = transition_widths[in.phase_index];
+           }
+         // using pressure instead of depth to define the phase transition
+         else
+           {
+             transition_pressure = transition_pressures[in.phase_index];
+             pressure_width = transition_pressure_widths[in.phase_index];
+             width_temp = transition_pressure_widths[in.phase_index];
+           }
 
-        double phase_function_derivative;
+         // then calculate the deviation from the transition point (both in temperature
+         // and in pressure)
+         double pressure_deviation = in.pressure - transition_pressure
+                                     - transition_slopes[in.phase_index] * (in.temperature - transition_temperatures[in.phase_index]);
 
-        // Calculate the analytical derivative of the phase function
-        if (transition_pressure_width == 0)
-          {
-            phase_function_derivative = 0.;
-          }
-        else
-          {
-            phase_function_derivative = 0.5 / transition_pressure_width * (1.0 - std::tanh(pressure_deviation / transition_pressure_width)
-                                                                           * std::tanh(pressure_deviation / transition_pressure_width));
-          }
-
-        return phase_function_derivative;
+         // last, calculate the analytical derivative of the phase function
+         if (width_temp==0)
+           return 0;
+         else
+           return 0.5 / pressure_width * (1.0 - std::tanh(pressure_deviation / pressure_width)
+                                          * std::tanh(pressure_deviation / pressure_width));
       }
 
 
@@ -1031,6 +1060,7 @@ namespace aspect
   void \
   compute_drucker_prager_yielding<dim> (const DruckerPragerInputs &, \
                                         DruckerPragerOutputs &); \
+  template struct PhaseFunctionInputs<dim>; \
   template class PhaseFunction<dim>;
 
       ASPECT_INSTANTIATE(INSTANTIATE)

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -879,13 +879,13 @@ namespace aspect
       template <int dim>
       std::pair<double, double>
       PhaseFunction<dim>::
-      transition_depth_to_pressure (const Point<dim> &position,
+      transition_depth_to_pressure (const Point<dim> &/*position*/,
                                     const int phase) const
       {
         double transition_pressure = 0.;
         double transition_pressure_width = 0.;
 
-        if (this->get_adiabatic_conditions().is_initialized() && this->include_latent_heat())
+        if (this->get_adiabatic_conditions().is_initialized())
           {
             const Point<dim,double> representative_transition_depth = this->get_geometry_model().representative_point(transition_depths[phase]);
 

--- a/tests/latent_heat_pressure.prm
+++ b/tests/latent_heat_pressure.prm
@@ -1,0 +1,148 @@
+# This is a copy of the latent_heat test that defines the
+# phase transition in terms of pressure instead of depth.
+
+set Dimension = 2
+
+set Start time                             = 0
+set End time                               = 1e15
+set Use years in output instead of seconds = false
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1000000
+    set Y extent = 1000000
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+end
+
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary temperature model
+  # We only fix the temperature at the upper boundary, the other boundaries
+  # are isolating. To guarantuee a steady downward flow, we fix the velocity
+  # at the top and bottom, and set it to free slip on the sides. 
+  set Fixed temperature boundary indicators   = 3
+end
+
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = 2:function, 3:function
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 0, 1
+end
+
+
+############### Boundary conditions
+# We set the top temperature to T1=1000K. 
+subsection Boundary temperature model
+  set List of model names = box
+  subsection Box
+    set Top temperature = 1000
+  end
+end
+
+# We prescribe a constant downward flow.
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = 0;-2.1422e-11
+    set Variable names      = x,y
+  end
+end
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 1000.0
+    set Variable names      = x,y
+  end
+end
+
+
+subsection Material model
+  set Model name = latent heat
+  subsection Latent heat
+
+    # The change of density across the phase transition. Together with the
+    # Clapeyron slope, this is what determines the entropy change.
+    set Phase transition density jumps                 = 115.6
+    set Corresponding phase for density jump           = 0
+
+    # If the temperature is equal to the phase transition temperature, the 
+    # phase transition will occur at the phase transition depth. However, 
+    # if the temperature deviates from this value, the Clapeyron slope 
+    # determines how much the pressure (and depth) of the phase boundary
+    # changes. Here, the phase transition will be in the middle of the box
+    # for T=T1. 
+    set Phase transition pressures                     = 1.7e10
+    set Phase transition pressure widths               = 6.8e8
+    set Define transition by depth instead of pressure = false
+
+    set Phase transition temperatures                  = 1000
+    set Phase transition Clapeyron slopes              = 1e7
+
+    set Reference density                              = 3400
+    set Reference specific heat                        = 1000
+    set Reference temperature                          = 1000
+    set Thermal conductivity                           = 2.38
+
+    # We set the thermal expansion amd the compressibility to zero, so that 
+    # all temperature (and density) changes are caused by advection, diffusion 
+    # and latent heating. 
+    set Thermal expansion coefficient                  = 0.0
+    set Compressibility                                = 0.0
+
+    # Viscosity is constant. 
+    set Thermal viscosity exponent                     = 0.0
+    set Viscosity                                      = 8.44e21
+    set Viscosity prefactors                           = 1.0, 1.0
+    set Composition viscosity prefactor                = 1.0
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0 
+  set Initial global refinement          = 4 
+  set Time steps between mesh refinement = 0
+
+end
+
+
+subsection Discretization
+  subsection Stabilization parameters
+    # The exponent $\alpha$ in the entropy viscosity stabilization. Units:
+    # None.
+    set alpha = 2
+
+    # The $\beta$ factor in the artificial viscosity stabilization. An
+    # appropriate value for 2d is 0.052 and 0.078 for 3d. Units: None.
+    set beta  = 0.078
+
+    # The $c_R$ factor in the entropy viscosity stabilization. Units: None.
+    set cR    = 0.5   # default: 0.11
+  end
+end
+
+
+subsection Postprocess
+
+  set List of postprocessors = temperature statistics
+end
+
+subsection Heating model
+  set List of model names =  latent heat
+end

--- a/tests/latent_heat_pressure/screen-output
+++ b/tests/latent_heat_pressure/screen-output
@@ -1,0 +1,27 @@
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 3,556 (2,178+289+1,089)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 33+0 iterations.
+
+   Postprocessing:
+     Temperature min/avg/max: 1000 K, 1000 K, 1000 K
+
+*** Timestep 1:  t=1e+15 seconds
+   Solving temperature system... 13 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 31+0 iterations.
+
+   Postprocessing:
+     Temperature min/avg/max: 1000 K, 1002 K, 1020 K
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/latent_heat_pressure/statistics
+++ b/tests/latent_heat_pressure/statistics
@@ -1,0 +1,15 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Minimal temperature (K)
+# 12: Average temperature (K)
+# 13: Maximal temperature (K)
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089  0 32 34 34 1.00000000e+03 1.00000000e+03 1.00000000e+03 
+1 1.000000000000e+15 1.000000000000e+15 256 2467 1089 13 30 32 32 1.00000000e+03 1.00168039e+03 1.01972379e+03 


### PR DESCRIPTION
First stab at moving the phase function routines over to the material model utilities. This needs to be implemented before proceeding further with #2656.