### PR TITLE
Provide a version of std_cxx14::make_unique() that takes arguments.

### DIFF
--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -152,16 +152,17 @@ namespace dealii
 #ifdef DEAL_II_WITH_CXX14
     using std::make_unique;
 #else
-    /* This is a simplified form of std::make_unique that only allows the default
-     * constructor (we would need C++11 for parameter forwarding), but this is
-     * sufficient for most cases.
+    /**
+     * An implementation of std::make_unique(). Since we require C++11
+     * even if the compiler does not support C++14, we can implement
+     * everything that they forgot to put into C++11.
      */
-    template <typename T>
+    template <typename T, class... Args>
     inline
     std::unique_ptr<T>
-    make_unique()
+    make_unique(Args &&... args)
     {
-      return std::unique_ptr<T>(new T());
+      return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
     }
 #endif
   }


### PR DESCRIPTION
We don't need this if the compiler supports C++14, as apparently most used by the developers
do. But when using a compiler that only supports C++11, we need to provide a version of
std_cxx14::make_unique() that accepts a variable number of arguments.

I have no way of testing this on any of my machines, and neither is this going to be
tested by the CI machines. I am pretty sure that this should work, though.