### PR TITLE
fix several clang warnings

### DIFF
--- a/source/boundary_velocity/gplates.cc
+++ b/source/boundary_velocity/gplates.cc
@@ -854,15 +854,15 @@ namespace aspect
         {
           data_directory = Utilities::expand_ASPECT_SOURCE_DIR(prm.get ("Data directory"));
 
-          velocity_file_name              = prm.get ("Velocity file name");
-          data_file_time_step             = prm.get_double ("Data file time step");
-          first_data_file_model_time      = prm.get_double ("First data file model time");
-          first_data_file_number          = prm.get_double ("First data file number");
-          decreasing_file_order           = prm.get_bool   ("Decreasing file order");
-          scale_factor          = prm.get_double ("Scale factor");
-          point1                = prm.get ("Point one");
-          point2                = prm.get ("Point two");
-          lithosphere_thickness = prm.get_double ("Lithosphere thickness");
+          velocity_file_name         = prm.get        ("Velocity file name");
+          data_file_time_step        = prm.get_double ("Data file time step");
+          first_data_file_model_time = prm.get_double ("First data file model time");
+          first_data_file_number     = prm.get_integer("First data file number");
+          decreasing_file_order      = prm.get_bool   ("Decreasing file order");
+          scale_factor               = prm.get_double ("Scale factor");
+          point1                     = prm.get        ("Point one");
+          point2                     = prm.get        ("Point two");
+          lithosphere_thickness      = prm.get_double ("Lithosphere thickness");
 
           if (this->convert_output_to_years())
             {

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -519,10 +519,10 @@ namespace aspect
           bottom_depth = prm.get_double("Depth");
           semi_major_axis_a = prm.get_double("Semi-major axis");
           eccentricity = prm.get_double("Eccentricity");
-          semi_minor_axis_b=std::sqrt((1 - pow(eccentricity,2)) * pow(semi_major_axis_a,2));
-          EW_subdiv = prm.get_double("East-West subdivisions");
-          NS_subdiv = prm.get_double("North-South subdivisions");
-          depth_subdiv = prm.get_double("Depth subdivisions");
+          semi_minor_axis_b = std::sqrt((1 - pow(eccentricity,2.)) * pow(semi_major_axis_a,2.));
+          EW_subdiv = prm.get_integer("East-West subdivisions");
+          NS_subdiv = prm.get_integer("North-South subdivisions");
+          depth_subdiv = prm.get_integer("Depth subdivisions");
 
           // Check whether the corners of the rectangle are really place correctly
           if (present[0] == true && present[1] == true)

--- a/source/heating_model/latent_heat_melt.cc
+++ b/source/heating_model/latent_heat_melt.cc
@@ -49,7 +49,7 @@ namespace aspect
 
           if (this->introspection().compositional_name_exists("porosity") &&  this->get_timestep_number() > 0)
             {
-              const double porosity_idx = this->introspection().compositional_index_for_name("porosity");
+              const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
               double melting_rate = 0.0;
 
               if (!use_operator_split)

--- a/source/particle/generator/uniform_box.cc
+++ b/source/particle/generator/uniform_box.cc
@@ -50,7 +50,7 @@ namespace aspect
         // Calculate separation of particles
         for (unsigned int i = 0; i < dim; ++i)
           {
-            n_particles_per_direction[i] = round(std::pow(n_particles * std::pow(P_diff[i],dim) / volume, 1./dim));
+            n_particles_per_direction[i] = static_cast<unsigned int>(round(std::pow(n_particles * std::pow(P_diff[i],dim) / volume, 1./dim)));
             spacing[i] = P_diff[i] / fmax(n_particles_per_direction[i] - 1,1);
           }
 

--- a/source/particle/generator/uniform_radial.cc
+++ b/source/particle/generator/uniform_radial.cc
@@ -48,7 +48,7 @@ namespace aspect
             for (unsigned int i = 0; i < radial_layers; ++i)
               {
                 const double radius = P_min[0] + (radial_spacing * i);
-                particles_per_layer[i] = round(n_particles * radius / total_radius);
+                particles_per_layer[i] = static_cast<unsigned int>(round(n_particles * radius / total_radius));
               }
           }
         else if (dim == 3)
@@ -59,7 +59,7 @@ namespace aspect
             for (unsigned int i = 0; i < radial_layers; ++i)
               {
                 const double area = std::pow(P_min[0] + (radial_spacing * i),2);
-                particles_per_layer[i] = round(n_particles * area / total_area);
+                particles_per_layer[i] = static_cast<unsigned int>(round(n_particles * area / total_area));
               }
           }
         else
@@ -94,11 +94,13 @@ namespace aspect
               }
             else if (dim == 3)
               {
-                const unsigned int theta_particles = round(sqrt(particles_per_layer[i]));
-                const unsigned int phi_particles = round(
-                                                     static_cast<double>(particles_per_layer[i])
-                                                     /
-                                                     static_cast<double>(theta_particles));
+                const unsigned int theta_particles = static_cast<unsigned int>(
+                                                       round(sqrt(particles_per_layer[i])));
+                const unsigned int phi_particles = static_cast<unsigned int>(
+                                                     round(
+                                                       static_cast<double>(particles_per_layer[i])
+                                                       /
+                                                       static_cast<double>(theta_particles)));
                 const double theta_spacing = (P_max[2] - P_min[2]) / fmax(theta_particles-1,1);
 
                 for (unsigned int j = 0; j < theta_particles; ++j)

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -42,7 +42,10 @@ namespace aspect
     {
       // Get quadrature formula and increase the degree of quadrature over the velocity
       // element degree.
-      const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.velocities).degree+quadrature_degree_increase);
+      const unsigned int degree = static_cast<unsigned int>(
+                                    this->get_fe().base_element(this->introspection().base_elements.velocities).degree
+                                    + quadrature_degree_increase);
+      const QGauss<dim> quadrature_formula (degree);
       FEValues<dim> fe_values (this->get_mapping(),
                                this->get_fe(),
                                quadrature_formula,

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1280,7 +1280,7 @@ namespace aspect
 
     const unsigned int n_q_points_1 = quadrature_formula_1.size();
     const unsigned int n_q_points_2 = quadrature_formula_2.size();
-    const unsigned int n_q_points   = dim * n_q_points_2 *std::pow(n_q_points_1, dim-1) ;
+    const unsigned int n_q_points   = dim * n_q_points_2 * static_cast<unsigned int>(std::pow(n_q_points_1, dim-1));
 
     std::vector< Point <dim> > quadrature_points;
     quadrature_points.reserve(n_q_points);

--- a/source/termination_criteria/end_walltime.cc
+++ b/source/termination_criteria/end_walltime.cc
@@ -60,7 +60,8 @@ namespace aspect
     {
       prm.enter_subsection("Termination criteria");
       {
-        walltime_duration = prm.get_double ("Wall time") * 3600; // Change from hours to seconds.
+        // Change from hours to seconds:
+        walltime_duration = static_cast<unsigned int>(prm.get_double ("Wall time") * 3600.);
       }
       prm.leave_subsection ();
     }

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -722,7 +722,7 @@ namespace aspect
 
       for (unsigned int i = 0; i < n_poly_points; ++i)
         {
-          const std::array<Point<2>,2 > list = {point_list[i], shifted_point_list[i]};
+          const std::array<Point<2>,2 > list = {{point_list[i], shifted_point_list[i]}};
           distances[i] = distance_to_line(list, point);
         }
 
@@ -2267,7 +2267,7 @@ namespace aspect
       {
         data_file_time_step             = prm.get_double ("Data file time step");
         first_data_file_model_time      = prm.get_double ("First data file model time");
-        first_data_file_number          = prm.get_double ("First data file number");
+        first_data_file_number          = prm.get_integer("First data file number");
         decreasing_file_order           = prm.get_bool   ("Decreasing file order");
 
         if (this->convert_output_to_years() == true)


### PR DESCRIPTION
Interesting how often we ``get_double`` even though we want to do ``get_integer``...