### PR TITLE
Use std::unique_ptr instead of std::shared_ptr.

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1795,8 +1795,8 @@ namespace aspect
 
 
 
-      std::shared_ptr<LinearAlgebra::PreconditionAMG>     Amg_preconditioner;
-      std::shared_ptr<LinearAlgebra::PreconditionBase>    Mp_preconditioner;
+      std::unique_ptr<LinearAlgebra::PreconditionAMG>           Amg_preconditioner;
+      std::unique_ptr<LinearAlgebra::PreconditionBase>          Mp_preconditioner;
 
       bool                                                      rebuild_sparsity_and_matrices;
       bool                                                      rebuild_stokes_matrix;

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -440,11 +440,11 @@ namespace aspect
                                       constant_modes);
 
     if (parameters.include_melt_transport)
-      Mp_preconditioner.reset (new LinearAlgebra::PreconditionAMG());
+      Mp_preconditioner = std_cxx14::make_unique<LinearAlgebra::PreconditionAMG>();
     else
-      Mp_preconditioner.reset (new LinearAlgebra::PreconditionILU());
+      Mp_preconditioner = std_cxx14::make_unique<LinearAlgebra::PreconditionILU>();
 
-    Amg_preconditioner.reset (new LinearAlgebra::PreconditionAMG());
+    Amg_preconditioner = std_cxx14::make_unique<LinearAlgebra::PreconditionAMG>();
 
     LinearAlgebra::PreconditionAMG::AdditionalData Amg_data;
 #ifdef ASPECT_USE_PETSC


### PR DESCRIPTION
I suspect that this is a left-over from the time when we used boost's shared_ptr
but there was no equivalent for shared_ptr.