### PR TITLE
Fix formatting problems in the documentation.

### DIFF
--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -226,14 +226,17 @@ namespace aspect
           /**
            * The function classes have to implement that want to output
            * cell-wise data.
-           * @return A pair of values with the following meaning: - The first
-           * element provides the name by which this data should be written to
-           * the output file. - The second element is a pointer to a vector
-           * with one element per active cell on the current processor.
-           * Elements corresponding to active cells that are either artificial
-           * or ghost cells (in deal.II language, see the deal.II glossary)
-           * will be ignored but must nevertheless exist in the returned
-           * vector. While implementations of this function must create this
+           *
+           * @return A pair of values with the following meaning:
+           * - The first element provides the name by which this data should
+           *   be written to the output file.
+           * - The second element is a pointer to a vector with one element
+           *   per active cell on the current processor. Elements corresponding
+           *   to active cells that are either artificial or ghost cells (in
+           *   deal.II language, see the deal.II glossary)
+           *   will be ignored but must nevertheless exist in the returned
+           *   vector.
+           * While implementations of this function must create this
            * vector, ownership is taken over by the caller of this function
            * and the caller will take care of destroying the vector pointed
            * to.

--- a/include/aspect/postprocess/visualization/ISA_rotation_timescale.h
+++ b/include/aspect/postprocess/visualization/ISA_rotation_timescale.h
@@ -54,7 +54,11 @@ namespace aspect
       {
         public:
 
-          virtual std::pair<std::string, Vector<float> *>
+          /**
+           * @copydoc CellDataVectorCreator<dim>::execute()
+           */
+          virtual
+          std::pair<std::string, Vector<float> *>
           execute() const;
 
       };

--- a/include/aspect/postprocess/visualization/artificial_viscosity.h
+++ b/include/aspect/postprocess/visualization/artificial_viscosity.h
@@ -43,21 +43,8 @@ namespace aspect
       {
         public:
           /**
-           * The function classes have to implement that want to output
-           * cellwise data.
-           * @return A pair of values with the following meaning: - The first
-           * element provides the name by which this data should be written to
-           * the output file. - The second element is a pointer to a vector
-           * with one element per active cell on the current processor.
-           * Elements corresponding to active cells that are either artificial
-           * or ghost cells (in deal.II language, see the deal.II glossary)
-           * will be ignored but must nevertheless exist in the returned
-           * vector. While implementations of this function must create this
-           * vector, ownership is taken over by the caller of this function
-           * and the caller will take care of destroying the vector pointed
-           * to.
+           * @copydoc CellDataVectorCreator<dim>::execute()
            */
-          virtual
           std::pair<std::string, Vector<float> *>
           execute () const;
       };

--- a/include/aspect/postprocess/visualization/boundary_indicator.h
+++ b/include/aspect/postprocess/visualization/boundary_indicator.h
@@ -47,21 +47,7 @@ namespace aspect
       {
         public:
           /**
-           * Evaluate the triangulation for the boundary indicators.
-           *
-           * The function classes have to implement that want to output
-           * cellwise data.
-           * @return A pair of values with the following meaning: - The first
-           * element provides the name by which this data should be written to
-           * the output file. - The second element is a pointer to a vector
-           * with one element per active cell on the current processor.
-           * Elements corresponding to active cells that are either artificial
-           * or ghost cells (in deal.II language, see the deal.II glossary)
-           * will be ignored but must nevertheless exist in the returned
-           * vector. While implementations of this function must create this
-           * vector, ownership is taken over by the caller of this function
-           * and the caller will take care of destroying the vector pointed
-           * to.
+           * @copydoc CellDataVectorCreator<dim>::execute()
            */
           virtual
           std::pair<std::string, Vector<float> *>

--- a/include/aspect/postprocess/visualization/dynamic_topography.h
+++ b/include/aspect/postprocess/visualization/dynamic_topography.h
@@ -49,21 +49,7 @@ namespace aspect
       {
         public:
           /**
-           * Evaluate the solution for the dynamic topography.
-           *
-           * The function classes have to implement that want to output
-           * cellwise data.
-           * @return A pair of values with the following meaning: - The first
-           * element provides the name by which this data should be written to
-           * the output file. - The second element is a pointer to a vector
-           * with one element per active cell on the current processor.
-           * Elements corresponding to active cells that are either artificial
-           * or ghost cells (in deal.II language, see the deal.II glossary)
-           * will be ignored but must nevertheless exist in the returned
-           * vector. While implementations of this function must create this
-           * vector, ownership is taken over by the caller of this function
-           * and the caller will take care of destroying the vector pointed
-           * to.
+           * @copydoc CellDataVectorCreator<dim>::execute()
            */
           virtual
           std::pair<std::string, Vector<float> *>

--- a/include/aspect/postprocess/visualization/error_indicator.h
+++ b/include/aspect/postprocess/visualization/error_indicator.h
@@ -42,19 +42,7 @@ namespace aspect
       {
         public:
           /**
-           * The function classes have to implement that want to output
-           * cellwise data.
-           * @return A pair of values with the following meaning: - The first
-           * element provides the name by which this data should be written to
-           * the output file. - The second element is a pointer to a vector
-           * with one element per active cell on the current processor.
-           * Elements corresponding to active cells that are either artificial
-           * or ghost cells (in deal.II language, see the deal.II glossary)
-           * will be ignored but must nevertheless exist in the returned
-           * vector. While implementations of this function must create this
-           * vector, ownership is taken over by the caller of this function
-           * and the caller will take care of destroying the vector pointed
-           * to.
+           * @copydoc CellDataVectorCreator<dim>::execute()
            */
           virtual
           std::pair<std::string, Vector<float> *>

--- a/include/aspect/postprocess/visualization/geoid.h
+++ b/include/aspect/postprocess/visualization/geoid.h
@@ -50,19 +50,7 @@ namespace aspect
       {
         public:
           /**
-           * Get the visualization vector for the geoid.
-           *
-           * @return A pair of values with the following meaning: - The first
-           * element provides the name by which this data should be written to
-           * the output file. - The second element is a pointer to a vector
-           * with one element per active cell on the current processor.
-           * Elements corresponding to active cells that are either artificial
-           * or ghost cells (in deal.II language, see the deal.II glossary)
-           * will be ignored but must nevertheless exist in the returned
-           * vector. While implementations of this function must create this
-           * vector, ownership is taken over by the caller of this function
-           * and the caller will take care of destroying the vector pointed
-           * to.
+           * @copydoc CellDataVectorCreator<dim>::execute()
            */
           virtual
           std::pair<std::string, Vector<float> *>

--- a/include/aspect/postprocess/visualization/grain_lag_angle.h
+++ b/include/aspect/postprocess/visualization/grain_lag_angle.h
@@ -61,7 +61,11 @@ namespace aspect
       {
         public:
 
-          virtual std::pair<std::string, Vector<float> *>
+          /**
+           * @copydoc CellDataVectorCreator<dim>::execute()
+           */
+          virtual
+          std::pair<std::string, Vector<float> *>
           execute() const;
 
       };

--- a/include/aspect/postprocess/visualization/heat_flux_map.h
+++ b/include/aspect/postprocess/visualization/heat_flux_map.h
@@ -44,7 +44,7 @@ namespace aspect
       {
         public:
           /**
-           * Evaluate the solution for the heat flux.
+           * @copydoc CellDataVectorCreator<dim>::execute()
            */
           virtual
           std::pair<std::string, Vector<float> *>

--- a/include/aspect/postprocess/visualization/particle_count.h
+++ b/include/aspect/postprocess/visualization/particle_count.h
@@ -47,21 +47,7 @@ namespace aspect
       {
         public:
           /**
-           * Count the number of particles in every cell.
-           *
-           * The function classes have to implement that want to output
-           * cellwise data.
-           * @return A pair of values with the following meaning: - The first
-           * element provides the name by which this data should be written to
-           * the output file. - The second element is a pointer to a vector
-           * with one element per active cell on the current processor.
-           * Elements corresponding to active cells that are either artificial
-           * or ghost cells (in deal.II language, see the deal.II glossary)
-           * will be ignored but must nevertheless exist in the returned
-           * vector. While implementations of this function must create this
-           * vector, ownership is taken over by the caller of this function
-           * and the caller will take care of destroying the vector pointed
-           * to.
+           * @copydoc CellDataVectorCreator<dim>::execute()
            */
           virtual
           std::pair<std::string, Vector<float> *>

--- a/include/aspect/postprocess/visualization/seismic_anomalies.h
+++ b/include/aspect/postprocess/visualization/seismic_anomalies.h
@@ -44,19 +44,7 @@ namespace aspect
       {
         public:
           /**
-           * The function classes have to implement that want to output
-           * cellwise data.
-           * @return A pair of values with the following meaning: - The first
-           * element provides the name by which this data should be written to
-           * the output file. - The second element is a pointer to a vector
-           * with one element per active cell on the current processor.
-           * Elements corresponding to active cells that are either artificial
-           * or ghost cells (in deal.II language, see the deal.II glossary)
-           * will be ignored but must nevertheless exist in the returned
-           * vector. While implementations of this function must create this
-           * vector, ownership is taken over by the caller of this function
-           * and the caller will take care of destroying the vector pointed
-           * to.
+           * @copydoc CellDataVectorCreator<dim>::execute()
            */
           virtual
           std::pair<std::string, Vector<float> *>
@@ -113,19 +101,7 @@ namespace aspect
       {
         public:
           /**
-           * The function classes have to implement that want to output
-           * cellwise data.
-           * @return A pair of values with the following meaning: - The first
-           * element provides the name by which this data should be written to
-           * the output file. - The second element is a pointer to a vector
-           * with one element per active cell on the current processor.
-           * Elements corresponding to active cells that are either artificial
-           * or ghost cells (in deal.II language, see the deal.II glossary)
-           * will be ignored but must nevertheless exist in the returned
-           * vector. While implementations of this function must create this
-           * vector, ownership is taken over by the caller of this function
-           * and the caller will take care of destroying the vector pointed
-           * to.
+           * @copydoc CellDataVectorCreator<dim>::execute()
            */
           virtual
           std::pair<std::string, Vector<float> *>


### PR DESCRIPTION
While there, also don't copy things literally, but use doxygen facilities.