### PR TITLE
Use std::unique_ptr instead of std::shared_ptr in some initial temperature models.

### DIFF
--- a/include/aspect/initial_temperature/S40RTS_perturbation.h
+++ b/include/aspect/initial_temperature/S40RTS_perturbation.h
@@ -35,8 +35,40 @@ namespace aspect
     {
       namespace S40RTS
       {
-        class SphericalHarmonicsLookup;
-        class SplineDepthsLookup;
+        class SphericalHarmonicsLookup
+        {
+          public:
+            SphericalHarmonicsLookup(const std::string &filename,
+                                     const MPI_Comm &comm);
+
+            /// Declare a function that returns the cosine coefficients
+            const std::vector<double> &
+            cos_coeffs() const;
+
+            /// Declare a function that returns the sine coefficients
+            const std::vector<double> &
+            sin_coeffs() const;
+
+            unsigned int maxdegree() const;
+
+          private:
+            unsigned int order;
+            std::vector<double> a_lm;
+            std::vector<double> b_lm;
+        };
+
+        class SplineDepthsLookup
+        {
+          public:
+            SplineDepthsLookup(const std::string &filename,
+                               const MPI_Comm &comm);
+
+            const std::vector<double> &
+            spline_depths() const;
+
+          private:
+            std::vector<double> depths;
+        };
       }
     }
 
@@ -171,13 +203,13 @@ namespace aspect
          * Pointer to an object that reads and processes the spherical
          * harmonics coefficients
          */
-        std::shared_ptr<internal::S40RTS::SphericalHarmonicsLookup> spherical_harmonics_lookup;
+        std::unique_ptr<internal::S40RTS::SphericalHarmonicsLookup> spherical_harmonics_lookup;
 
         /**
          * Pointer to an object that reads and processes the depths for the
          * spline knot points.
          */
-        std::shared_ptr<internal::S40RTS::SplineDepthsLookup> spline_depths_lookup;
+        std::unique_ptr<internal::S40RTS::SplineDepthsLookup> spline_depths_lookup;
 
         /**
          * Object containing the data profile.

--- a/include/aspect/initial_temperature/SAVANI_perturbation.h
+++ b/include/aspect/initial_temperature/SAVANI_perturbation.h
@@ -160,13 +160,13 @@ namespace aspect
          * Pointer to an object that reads and processes the spherical
          * harmonics coefficients
          */
-        std::shared_ptr<internal::SAVANI::SphericalHarmonicsLookup> spherical_harmonics_lookup;
+        std::unique_ptr<internal::SAVANI::SphericalHarmonicsLookup> spherical_harmonics_lookup;
 
         /**
          * Pointer to an object that reads and processes the depths for the
          * spline knot points.
          */
-        std::shared_ptr<internal::SAVANI::SplineDepthsLookup> spline_depths_lookup;
+        std::unique_ptr<internal::SAVANI::SplineDepthsLookup> spline_depths_lookup;
 
         /**
          * Object containing the data profile.

--- a/source/initial_temperature/SAVANI_perturbation.cc
+++ b/source/initial_temperature/SAVANI_perturbation.cc
@@ -162,11 +162,11 @@ namespace aspect
     SAVANIPerturbation<dim>::initialize()
     {
       spherical_harmonics_lookup
-        = std::make_shared<internal::SAVANI::SphericalHarmonicsLookup>(data_directory+harmonics_coeffs_file_name,
-                                                                       this->get_mpi_communicator());
+        = std_cxx14::make_unique<internal::SAVANI::SphericalHarmonicsLookup>(data_directory+harmonics_coeffs_file_name,
+                                                                             this->get_mpi_communicator());
       spline_depths_lookup
-        = std::make_shared<internal::SAVANI::SplineDepthsLookup>(data_directory+spline_depth_file_name,
-                                                                 this->get_mpi_communicator());
+        = std_cxx14::make_unique<internal::SAVANI::SplineDepthsLookup>(data_directory+spline_depth_file_name,
+                                                                       this->get_mpi_communicator());
 
       if (vs_to_density_method == file)
         {


### PR DESCRIPTION
Part of #2375 and #2811.

For reasons not clear to me, using unique_ptr requires me to declare some
classes that are used in the S40RTS models in the header file instead of
the source file. They were previously only forward-declared there, but now
need to have a complete declaration in the header file. This is necessary
because we have a *separate* source file patch_on_S40RTS that derives
from/uses the main S40RTS class and now also wants to destroy these
kinds of objects.