### PR TITLE
Use std::unique_ptr instead of std::shared_ptr for the boundary tractions.

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1646,7 +1646,7 @@ namespace aspect
       const std::unique_ptr<AdiabaticConditions::Interface<dim> >             adiabatic_conditions;
       const std::unique_ptr<WorldBuilder::World>                              world_builder;
       BoundaryVelocity::Manager<dim>                                          boundary_velocity_manager;
-      std::map<types::boundary_id,std::shared_ptr<BoundaryTraction::Interface<dim> > > boundary_traction;
+      std::map<types::boundary_id,std::unique_ptr<BoundaryTraction::Interface<dim> > > boundary_traction;
       const std::unique_ptr<BoundaryHeatFlux::Interface<dim> >                boundary_heat_flux;
 
       /**

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -630,7 +630,7 @@ namespace aspect
        * Return a reference to the object that describes traction
        * boundary conditions.
        */
-      const std::map<types::boundary_id,std::shared_ptr<BoundaryTraction::Interface<dim> > > &
+      const std::map<types::boundary_id,std::unique_ptr<BoundaryTraction::Interface<dim> > > &
       get_boundary_traction () const;
 
       /**

--- a/source/boundary_traction/ascii_data.cc
+++ b/source/boundary_traction/ascii_data.cc
@@ -35,15 +35,10 @@ namespace aspect
     void
     AsciiData<dim>::initialize ()
     {
-      const std::map<types::boundary_id,std::shared_ptr<BoundaryTraction::Interface<dim> > >
-      bvs = this->get_boundary_traction();
-      for (typename std::map<types::boundary_id,std::shared_ptr<BoundaryTraction::Interface<dim> > >::const_iterator
-           p = bvs.begin();
-           p != bvs.end(); ++p)
-        {
-          if (p->second.get() == this)
-            boundary_ids.insert(p->first);
-        }
+      for (const auto &bv : this->get_boundary_traction())
+        if (bv.second.get() == this)
+          boundary_ids.insert(bv.first);
+
       AssertThrow(*(boundary_ids.begin()) != numbers::invalid_boundary_id,
                   ExcMessage("Did not find the boundary indicator for the traction ascii data plugin."));
 

--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -46,14 +46,10 @@ namespace aspect
       // Ensure the initial lithostatic pressure traction boundary conditions are used,
       // and register for which boundary indicators these conditions are set.
       std::set<types::boundary_id> traction_bi;
-      const std::map<types::boundary_id,std::shared_ptr<BoundaryTraction::Interface<dim> > >
-      bvs = this->get_boundary_traction();
-      for (typename std::map<types::boundary_id,std::shared_ptr<BoundaryTraction::Interface<dim> > >::const_iterator
-           p = bvs.begin();
-           p != bvs.end(); ++p)
+      for (const auto &p : this->get_boundary_traction())
         {
-          if (p->second.get() == this)
-            traction_bi.insert(p->first);
+          if (p.second.get() == this)
+            traction_bi.insert(p.first);
         }
       AssertThrow(*(traction_bi.begin()) != numbers::invalid_boundary_id,
                   ExcMessage("Did not find any boundary indicators for the initial lithostatic pressure plugin."));

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -669,10 +669,8 @@ namespace aspect
     // that end up in the bilinear form. we update those that end up in
     // the constraints object when calling compute_current_constraints()
     // above
-    for (typename std::map<types::boundary_id,std::shared_ptr<BoundaryTraction::Interface<dim> > >::iterator
-         p = boundary_traction.begin();
-         p != boundary_traction.end(); ++p)
-      p->second->update ();
+    for (auto &p : boundary_traction)
+      p.second->update ();
   }
 
 

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -379,7 +379,7 @@ namespace aspect
 
 
   template <int dim>
-  const std::map<types::boundary_id,std::shared_ptr<BoundaryTraction::Interface<dim> > > &
+  const std::map<types::boundary_id,std::unique_ptr<BoundaryTraction::Interface<dim> > > &
   SimulatorAccess<dim>::get_boundary_traction () const
   {
     return simulator->boundary_traction;


### PR DESCRIPTION
Part of #2375 and #2811.