### PR TITLE
Fix misspelled function names in error messages.

### DIFF
--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -365,7 +365,7 @@ namespace aspect
     Manager<dim>::get_matching_boundary_composition_model () const
     {
       AssertThrow(has_matching_boundary_composition_model<BoundaryCompositionType> (),
-                  ExcMessage("You asked BoundaryComposition:Manager::get_boundary_composition_model() for a "
+                  ExcMessage("You asked BoundaryComposition::Manager::get_boundary_composition_model() for a "
                              "boundary composition model of type <" + boost::core::demangle(typeid(BoundaryCompositionType).name()) + "> "
                              "that could not be found in the current model. Activate this "
                              "boundary composition model in the input file."));

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -393,7 +393,7 @@ namespace aspect
     Manager<dim>::get_matching_boundary_temperature_model () const
     {
       AssertThrow(has_matching_boundary_temperature_model<BoundaryTemperatureType> (),
-                  ExcMessage("You asked BoundaryTemperature:Manager::get_boundary_temperature_model() for a "
+                  ExcMessage("You asked BoundaryTemperature::Manager::get_boundary_temperature_model() for a "
                              "boundary temperature model of type <" + boost::core::demangle(typeid(BoundaryTemperatureType).name()) + "> "
                              "that could not be found in the current model. Activate this "
                              "boundary temperature model in the input file."));

--- a/include/aspect/boundary_velocity/interface.h
+++ b/include/aspect/boundary_velocity/interface.h
@@ -364,7 +364,7 @@ namespace aspect
     Manager<dim>::get_matching_boundary_velocity_model () const
     {
       AssertThrow(has_matching_boundary_velocity_model<BoundaryVelocityType> (),
-                  ExcMessage("You asked BoundaryVelocity:Manager::get_boundary_velocity_model() for a "
+                  ExcMessage("You asked BoundaryVelocity::Manager::get_boundary_velocity_model() for a "
                              "boundary velocity model of type <" + boost::core::demangle(typeid(BoundaryVelocityType).name()) + "> "
                              "that could not be found in the current model. Activate this "
                              "boundary velocity model in the input file."));

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -445,7 +445,7 @@ namespace aspect
     Manager<dim>::get_matching_heating_model () const
     {
       AssertThrow(has_matching_heating_model<HeatingModelType> (),
-                  ExcMessage("You asked HeatingModel:Manager::get_heating_model() for a "
+                  ExcMessage("You asked HeatingModel::Manager::get_heating_model() for a "
                              "heating model of type <" + boost::core::demangle(typeid(HeatingModelType).name()) + "> "
                              "that could not be found in the current model. Activate this "
                              "heating model in the input file."));

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -308,7 +308,7 @@ namespace aspect
     Manager<dim>::get_matching_initial_composition_model () const
     {
       AssertThrow(has_matching_initial_composition_model<InitialCompositionType> (),
-                  ExcMessage("You asked InitialComposition:Manager::get_initial_composition_model() for a "
+                  ExcMessage("You asked InitialComposition::Manager::get_initial_composition_model() for a "
                              "initial composition model of type <" + boost::core::demangle(typeid(InitialCompositionType).name()) + "> "
                              "that could not be found in the current model. Activate this "
                              "initial composition model in the input file."));

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -296,7 +296,7 @@ namespace aspect
     Manager<dim>::get_matching_initial_temperature_model () const
     {
       AssertThrow(has_matching_initial_temperature_model<InitialTemperatureType> (),
-                  ExcMessage("You asked InitialTemperature:Manager::get_initial_temperature_model() for a "
+                  ExcMessage("You asked InitialTemperature::Manager::get_initial_temperature_model() for a "
                              "initial temperature model of type <" + boost::core::demangle(typeid(InitialTemperatureType).name()) + "> "
                              "that could not be found in the current model. Activate this "
                              "initial temperature model in the input file."));

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -347,7 +347,7 @@ namespace aspect
     Manager<dim>::get_matching_mesh_refinement_strategy () const
     {
       AssertThrow(has_matching_mesh_refinement_strategy<MeshRefinementType> (),
-                  ExcMessage("You asked MeshRefinement:Manager::get_matching_mesh_refinement_strategy() for a "
+                  ExcMessage("You asked MeshRefinement::Manager::get_matching_mesh_refinement_strategy() for a "
                              "mesh refinement strategy of type <" + boost::core::demangle(typeid(MeshRefinementType).name()) + "> "
                              "that could not be found in the current model. Activate this "
                              "mesh refinement strategy in the input file."));

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -434,7 +434,7 @@ namespace aspect
     Manager<dim>::get_matching_postprocessor () const
     {
       AssertThrow(has_matching_postprocessor<PostprocessorType> (),
-                  ExcMessage("You asked Postprocess:Manager::get_matching_postprocessor() for a "
+                  ExcMessage("You asked Postprocess::Manager::get_matching_postprocessor() for a "
                              "postprocessor of type <" + boost::core::demangle(typeid(PostprocessorType).name()) + "> "
                              "that could not be found in the current model. Activate this "
                              "postprocessor in the input file."));

--- a/tests/find_boundary_composition_model_fail_1/screen-output
+++ b/tests/find_boundary_composition_model_fail_1/screen-output
@@ -7,13 +7,13 @@ Number of degrees of freedom: 1,526 (578+81+289+289+289)
 ERROR: Uncaught exception in MPI_InitFinalize on proc 0. Skipping MPI_Finalize() to avoid a deadlock.
 
 
-Exception 'ExcMessage("You asked BoundaryComposition:Manager::get_boundary_composition_model() for a " "boundary composition model of type <" + boost::core::demangle(typeid(BoundaryCompositionType).name()) + "> " "that could not be found in the current model. Activate this " "boundary composition model in the input file.")' on rank 0 on processing: 
+Exception 'ExcMessage("You asked BoundaryComposition::Manager::get_boundary_composition_model() for a " "boundary composition model of type <" + boost::core::demangle(typeid(BoundaryCompositionType).name()) + "> " "that could not be found in the current model. Activate this " "boundary composition model in the input file.")' on rank 0 on processing: 
 
 An error occurred in file <interface.h> in function
 (line in output replaced by default.sh script)
 The violated condition was: 
     has_matching_boundary_composition_model<BoundaryCompositionType> ()
 Additional information: 
-    You asked BoundaryComposition:Manager::get_boundary_composition_model() for a boundary composition model of type <aspect::BoundaryComposition::Box<2>> that could not be found in the current model. Activate this boundary composition model in the input file.
+    You asked BoundaryComposition::Manager::get_boundary_composition_model() for a boundary composition model of type <aspect::BoundaryComposition::Box<2>> that could not be found in the current model. Activate this boundary composition model in the input file.
 
 Aborting!

--- a/tests/find_mesh_refinement_fail_1/screen-output
+++ b/tests/find_mesh_refinement_fail_1/screen-output
@@ -7,13 +7,13 @@ Number of degrees of freedom: 948 (578+81+289)
 ERROR: Uncaught exception in MPI_InitFinalize on proc 0. Skipping MPI_Finalize() to avoid a deadlock.
 
 
-Exception 'ExcMessage("You asked MeshRefinement:Manager::get_matching_mesh_refinement_strategy() for a " "mesh refinement strategy of type <" + boost::core::demangle(typeid(MeshRefinementType).name()) + "> " "that could not be found in the current model. Activate this " "mesh refinement strategy in the input file.")' on rank 0 on processing: 
+Exception 'ExcMessage("You asked MeshRefinement::Manager::get_matching_mesh_refinement_strategy() for a " "mesh refinement strategy of type <" + boost::core::demangle(typeid(MeshRefinementType).name()) + "> " "that could not be found in the current model. Activate this " "mesh refinement strategy in the input file.")' on rank 0 on processing: 
 
 An error occurred in file <interface.h> in function
 (line in output replaced by default.sh script)
 The violated condition was: 
     has_matching_mesh_refinement_strategy<MeshRefinementType> ()
 Additional information: 
-    You asked MeshRefinement:Manager::get_matching_mesh_refinement_strategy() for a mesh refinement strategy of type <aspect::MeshRefinement::Boundary<2>> that could not be found in the current model. Activate this mesh refinement strategy in the input file.
+    You asked MeshRefinement::Manager::get_matching_mesh_refinement_strategy() for a mesh refinement strategy of type <aspect::MeshRefinement::Boundary<2>> that could not be found in the current model. Activate this mesh refinement strategy in the input file.
 
 Aborting!

--- a/tests/find_postprocess_fail_1/screen-output
+++ b/tests/find_postprocess_fail_1/screen-output
@@ -7,13 +7,13 @@ Number of degrees of freedom: 948 (578+81+289)
 ERROR: Uncaught exception in MPI_InitFinalize on proc 0. Skipping MPI_Finalize() to avoid a deadlock.
 
 
-Exception 'ExcMessage("You asked Postprocess:Manager::get_matching_postprocessor() for a " "postprocessor of type <" + boost::core::demangle(typeid(PostprocessorType).name()) + "> " "that could not be found in the current model. Activate this " "postprocessor in the input file.")' on rank 0 on processing: 
+Exception 'ExcMessage("You asked Postprocess::Manager::get_matching_postprocessor() for a " "postprocessor of type <" + boost::core::demangle(typeid(PostprocessorType).name()) + "> " "that could not be found in the current model. Activate this " "postprocessor in the input file.")' on rank 0 on processing: 
 
 An error occurred in file <interface.h> in function
 (line in output replaced by default.sh script)
 The violated condition was: 
     has_matching_postprocessor<PostprocessorType> ()
 Additional information: 
-    You asked Postprocess:Manager::get_matching_postprocessor() for a postprocessor of type <aspect::Postprocess::PressureStatistics<2>> that could not be found in the current model. Activate this postprocessor in the input file.
+    You asked Postprocess::Manager::get_matching_postprocessor() for a postprocessor of type <aspect::Postprocess::PressureStatistics<2>> that could not be found in the current model. Activate this postprocessor in the input file.
 
 Aborting!


### PR DESCRIPTION
There is really just a : missing as a namespace separator.