### PR TITLE
avoid warning in gravity point postprocessor

### DIFF
--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -53,6 +53,7 @@ namespace aspect
     {}
 
 
+
     template <int dim>
     std::pair<std::string,std::string>
     GravityPointValues<dim>::execute (TableHandler &)
@@ -60,6 +61,7 @@ namespace aspect
       AssertThrow(false, ExcNotImplemented());
       return std::pair<std::string,std::string>();
     }
+
 
 
     template <>
@@ -408,6 +410,8 @@ namespace aspect
       return std::pair<std::string, std::string> ("gravity computation file:",filename);
     }
 
+
+
     template <int dim>
     void
     GravityPointValues<dim>::declare_parameters (ParameterHandler &prm)
@@ -514,6 +518,8 @@ namespace aspect
       prm.leave_subsection();
     }
 
+
+
     template <int dim>
     void
     GravityPointValues<dim>::parse_parameters (ParameterHandler &prm)
@@ -571,16 +577,20 @@ namespace aspect
       prm.leave_subsection();
     }
 
-    // This deals with having the correct behavior during checkpoint/restart cycles:
+
+
     template <int dim>
     template <class Archive>
     void GravityPointValues<dim>::serialize (Archive &ar, const unsigned int)
     {
+      // This deals with having the correct behavior during checkpoint/restart cycles:
       ar &last_output_time
       & last_output_timestep
       & output_file_number
       ;
     }
+
+
 
     template <int dim>
     void
@@ -600,6 +610,8 @@ namespace aspect
         }
     }
 
+
+
     template <int dim>
     void
     GravityPointValues<dim>::save (std::map<std::string, std::string> &status_strings) const
@@ -610,6 +622,7 @@ namespace aspect
 
       status_strings["GravityPointValues"] = os.str();
     }
+
 
 
     template <int dim>

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -52,10 +52,22 @@ namespace aspect
       output_file_number (numbers::invalid_unsigned_int)
     {}
 
+
     template <int dim>
     std::pair<std::string,std::string>
     GravityPointValues<dim>::execute (TableHandler &)
     {
+      AssertThrow(false, ExcNotImplemented());
+      return std::pair<std::string,std::string>();
+    }
+
+
+    template <>
+    std::pair<std::string,std::string>
+    GravityPointValues<3>::execute (TableHandler &)
+    {
+      const int dim = 3;
+
       // Check time to see if we output gravity
       if (std::isnan(last_output_time))
         {


### PR DESCRIPTION
I am getting warnings about un-initialized variables for the dim=2
instantiation that doesn't work anyways. Fix this.