### PR TITLE
Further update the @misc template.

### DIFF
--- a/jabref-template/listrefs.misc.layout
+++ b/jabref-template/listrefs.misc.layout
@@ -29,8 +29,8 @@
         -->
 
     \begin{howpublished} PhD thesis, \format[HTMLChars]{\howpublished}\end{howpublished}<!--
-    -->\begin{publisher}, \format[HTMLChars]{\publisher}\end{publisher}<!--
-         -->\begin{year}, \format[HTMLChars]{\year}\end{year}<!--
+    -->\begin{publisher}\format[HTMLChars]{\publisher}. \end{publisher}<!--
+         -->\begin{year}\format[HTMLChars]{\year}\end{year}<!--
                      -->.
 
     


### PR DESCRIPTION
The previous version would just output ', 2015' if no publisher was given.

Further refinement of #2827.