### PR TITLE
fix clang warning

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1210,7 +1210,7 @@ namespace aspect
                       // we must be in 3d, or 'z' should never have gotten through
                       Assert (dim==3, ExcInternalError());
                       if (dim==3)
-                        mask[introspection.component_indices.velocities[2]] = true;
+                        mask[introspection.component_indices.velocities[dim-1]] = true;
                       break;
                     default:
                       Assert (false, ExcInternalError());


### PR DESCRIPTION
clang 6 warns about an array access out of bounds when instantiating for
dim=2. This is of course not a problem as this code is only executed for
dim=3. Silence the warning by using dim-1 instead of 2.