### PR TITLE
Fix Volume of Fluid visualization plugin

### DIFF
--- a/source/postprocess/visualization/volume_of_fluid_values.cc
+++ b/source/postprocess/visualization/volume_of_fluid_values.cc
@@ -153,8 +153,8 @@ namespace aspect
           {
             prm.enter_subsection("Volume of Fluid");
             {
-              include_contour = prm.get_bool("Include internal reconstruction contour");
-              include_normal = prm.get_bool("Include normals");
+              include_contour = prm.get_bool("Output interface reconstruction contour");
+              include_normal = prm.get_bool("Output interface normals");
 
               for (unsigned int f=0; f<this->get_volume_of_fluid_handler().get_n_fields(); ++f)
                 {


### PR DESCRIPTION
While working on putting together a cookbook for the VoF composition advection method, I found that I had not corrected the names of the parameters for the vis postprocessor when reading from the parameter file. This PR makes that correction.