### PR TITLE
depletion strengthening in melt_global material model 

### DIFF
--- a/include/aspect/material_model/melt_global.h
+++ b/include/aspect/material_model/melt_global.h
@@ -132,6 +132,8 @@ namespace aspect
         double melt_compressibility;
         bool include_melting_and_freezing;
         double melting_time_scale;
+        double alpha_depletion;
+        double delta_eta_depletion_max;
 
         // entropy change upon melting
         double peridotite_melting_entropy_change;

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -424,16 +424,16 @@ namespace aspect
                              "computed. If the model does not use operator splitting, this parameter is not used. "
                              "Units: yr or s, depending on the ``Use years "
                              "in output instead of seconds'' parameter.");
-           prm.declare_entry ("Exponential depletion strengthening factor", "0.0",
-                              Patterns::Double (0),
-                              "$\\alpha_F$: exponential dependency of viscosity on the depletion "
-							  "field $F$ (called peridotite). "
-                              "Dimensionless factor. With a value of 0.0 (the default) the "
-                              "viscosity does not depend on the depletion. The effective viscosity increase"
-                              "due to depletion is defined as $exp( \\alpha_F * F)$. ");
-           prm.declare_entry ("Maximum Depletion viscosity change", "1.0e3",
-                              Patterns::Double (0),
-                              "$\\Delta \\eta_{F,max}$: maximum depletion strengthening of viscosity. ");
+          prm.declare_entry ("Exponential depletion strengthening factor", "0.0",
+                             Patterns::Double (0),
+                             "$\\alpha_F$: exponential dependency of viscosity on the depletion "
+                             "field $F$ (called peridotite). "
+                             "Dimensionless factor. With a value of 0.0 (the default) the "
+                             "viscosity does not depend on the depletion. The effective viscosity increase"
+                             "due to depletion is defined as $exp( \\alpha_F * F)$. ");
+          prm.declare_entry ("Maximum Depletion viscosity change", "1.0e3",
+                             Patterns::Double (0),
+                             "$\\Delta \\eta_{F,max}$: maximum depletion strengthening of viscosity. ");
         }
         prm.leave_subsection();
       }
@@ -472,7 +472,7 @@ namespace aspect
           include_melting_and_freezing      = prm.get_bool ("Include melting and freezing");
           melting_time_scale                = prm.get_double ("Melting time scale for operator splitting");
           alpha_depletion                   = prm.get_double ("Exponential depletion strengthening factor");
-		  delta_eta_depletion_max           = prm.get_double ("Maximum Depletion viscosity change");
+          delta_eta_depletion_max           = prm.get_double ("Maximum Depletion viscosity change");
 
           if (thermal_viscosity_exponent!=0.0 && reference_T == 0.0)
             AssertThrow(false, ExcMessage("Error: Material model Melt simple with Thermal viscosity exponent can not have reference_T=0."));

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -430,10 +430,18 @@ namespace aspect
                              "field $F$ (called peridotite). "
                              "Dimensionless factor. With a value of 0.0 (the default) the "
                              "viscosity does not depend on the depletion. The effective viscosity increase"
-                             "due to depletion is defined as $exp( \\alpha_F * F)$. ");
+                             "due to depletion is defined as $exp( \\alpha_F * F)$. "
+                             "Rationale: melting dehydrates the source rock by removing most of the volatiles,"
+                             "and makes it stronger. Hirth and Kohlstedt (1996) report typical values around a "
+                             "factor 100 to 1000 viscosity contrast between wet and dry rocks, although some "
+                             "experimental studies report a smaller (factor 10) contrast (e.g. Fei et al., 2013).");
           prm.declare_entry ("Maximum Depletion viscosity change", "1.0e3",
                              Patterns::Double (0),
-                             "$\\Delta \\eta_{F,max}$: maximum depletion strengthening of viscosity. ");
+                             "$\\Delta \\eta_{F,max}$: maximum depletion strengthening of viscosity. "
+                             "Rationale: melting dehydrates the source rock by removing most of the volatiles,"
+                             "and makes it stronger. Hirth and Kohlstedt (1996) report typical values around a "
+                             "factor 100 to 1000 viscosity contrast between wet and dry rocks, although some "
+                             "experimental studies report a smaller (factor 10) contrast (e.g. Fei et al., 2013).");
         }
         prm.leave_subsection();
       }

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -211,7 +211,15 @@ namespace aspect
                 }
 
               const double porosity = std::min(1.0, std::max(in.composition[i][porosity_idx],0.0));
-              out.viscosities[i] = eta_0 * exp(- alpha_phi * porosity);
+
+              // find depletion = peridotite, which might affect shear viscosity:
+              const double depletion_visc = std::min(1.0, std::max(in.composition[i][peridotite_idx],0.0));
+
+              // calculate strengthening due to depletion:
+              const double depletion_strengthening = std::min(exp(alpha_depletion*depletion_visc),delta_eta_depletion_max);
+
+              // calculate viscosity change due to local melt and depletion:
+              out.viscosities[i] = eta_0 * exp(- alpha_phi * porosity) * depletion_strengthening;
             }
           else
             {
@@ -416,6 +424,16 @@ namespace aspect
                              "computed. If the model does not use operator splitting, this parameter is not used. "
                              "Units: yr or s, depending on the ``Use years "
                              "in output instead of seconds'' parameter.");
+           prm.declare_entry ("Exponential depletion strengthening factor", "1.0",
+                              Patterns::Double (0),
+                              "$\\alpha_F$: exponential dependency of viscosity on the depletion "
+							  "field $F$ (called peridotite). "
+                              "Dimensionless factor. With a value of 1.0 (the default) the "
+                              "viscosity does not depend on the depletion. The effective viscosity increase"
+                              "due to depletion is defined as $exp( \\alpha_F * F)$. ");
+           prm.declare_entry ("Maximum Depletion viscosity change", "1.0e3",
+                              Patterns::Double (0),
+                              "$\\Delta \\eta_{F,max}$: maximum depletion strengthening of viscosity. ");
         }
         prm.leave_subsection();
       }
@@ -453,6 +471,8 @@ namespace aspect
           melt_compressibility              = prm.get_double ("Melt compressibility");
           include_melting_and_freezing      = prm.get_bool ("Include melting and freezing");
           melting_time_scale                = prm.get_double ("Melting time scale for operator splitting");
+          alpha_depletion                   = prm.get_double ("Exponential depletion strengthening factor");
+		  delta_eta_depletion_max           = prm.get_double ("Maximum Depletion viscosity change");
 
           if (thermal_viscosity_exponent!=0.0 && reference_T == 0.0)
             AssertThrow(false, ExcMessage("Error: Material model Melt simple with Thermal viscosity exponent can not have reference_T=0."));

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -424,11 +424,11 @@ namespace aspect
                              "computed. If the model does not use operator splitting, this parameter is not used. "
                              "Units: yr or s, depending on the ``Use years "
                              "in output instead of seconds'' parameter.");
-           prm.declare_entry ("Exponential depletion strengthening factor", "1.0",
+           prm.declare_entry ("Exponential depletion strengthening factor", "0.0",
                               Patterns::Double (0),
                               "$\\alpha_F$: exponential dependency of viscosity on the depletion "
 							  "field $F$ (called peridotite). "
-                              "Dimensionless factor. With a value of 1.0 (the default) the "
+                              "Dimensionless factor. With a value of 0.0 (the default) the "
                               "viscosity does not depend on the depletion. The effective viscosity increase"
                               "due to depletion is defined as $exp( \\alpha_F * F)$. ");
            prm.declare_entry ("Maximum Depletion viscosity change", "1.0e3",


### PR DESCRIPTION
The melt_global material model tracks depletion through the ‘peridotite’ composition. This peridotite value can affect density, but not yet viscosity. Changing viscosity due to depletion is very useful to model, as it is, e.g., an essential contribution to craton strength and stability (e.g., Wang et al., 2014).

The reason for a ‘depletion’-dependent viscosity is that melting removes most of the volatiles from the source rock, and dry rocks are typically stronger than hydrated ones. The exact dependence of this strengthening on depletion, and even the maximum amount of strengthening is quite unknown. Hirth and Kohlstedt (1996) report typical values around a factor 100 to 1000 viscosity contrast between wet and dry rocks, although some experimental studies report a smaller (factor 10) contrast (e.g. Fei et al., 2013).

I added this depletion strengthening to the melt_global material model. To keep the viscosity-depletion relationship simple and flexible, I parameterised it using two parameters:

an exponent alpha_depletion to describe how rapidly strength increases with depletion
a maximum strengthening value delta_eta_depletion_max.
I changed the composition-dependent viscosity from:
viscosity = eta_0 * exp(- alpha_phi * porosity)
to:
viscosity = eta_0 * exp(- alpha_phi * porosity) * depl_strengthening
with:
depl_strengthening = min ( exp(alpha_depletion*depletion_visc), delta_eta_depletion_max)
where:
depletion_visc = the peridotite value (bound between [0,1])
and
alpha_depletion and delta_eta_deplation_max are read in from the input file.

The attached zip file contains input files and a few viscosity plots and profiles to illustrate two models modified from the global_melt.prm cookbook example by @jdannberg to a 660x660 km box with initial depletion in the lithosphere, one with and one without the depletion strengthening.

References:
Hirth, G., and D. L. Kohlstedt (1996), Water in the oceanic upper mantle: Implications for rheology, melt extraction and the evolution of the lithosphere, Earth Planet. Sci. Lett., 144(1–2), 93–108.
Fei, H., M. Wiedenbeck, D. Yamazaki, and T. Katsura (2013), Small effect of water on upper-mantle rheology based on silicon self-diffusion coefficients, Nature, 498(7453), 213–215, doi:10.1038/nature12193
Wang, H.L., van Hunen, J., Pearson, D.G. & Allen, M.B. (2014). Craton stability and longevity: The roles of composition-dependent rheology and buoyancy. Earth and Planetary Science Letters 391: 224-233.

[depletion_strengthening.zip](https://github.com/geodynamics/aspect/files/2981917/depletion_strengthening.zip)
