### PR TITLE
Update Buiter et al. 2008 benchmarks

### DIFF
--- a/benchmarks/buiter_et_al_2008_jgr/README
+++ b/benchmarks/buiter_et_al_2008_jgr/README
@@ -24,12 +24,10 @@ In this benchmark, input files are provided for lower crustal viscosities
 of 1e20 and 1e22 Pa s.
 
 Localization of deformation is aided by strain weakening, with the cohesion
-and internal angle of friction reducing between finite strain invariant values
-of 0.5 and 1.5. The attached parameter files use a plugin to calculate the
-finite strain invariant, which is accessed through the material model class.
-Notably, finite strain in this case is determined by the magnitude of the
-deviatoric stress second invariant and time step size. This single measure
-of the finite strain magnitude differs from other measures of finite strain
-magnitude that use/calculate an invariant from the full finite strain tensor 
-(see finite strain cookbook and integrated strain particle property).   
+and internal angle of friction reducing between plastic finite strain invariant
+values of 0.5 and 1.5. Notably, This single measure of the plastic finite strain 
+magnitude is commonly used in long-term tectonic simulations, but differs from 
+other measures of finite strain magnitude that use/calculate an invariant from 
+the full finite strain tensor (see finite strain cookbook and integrated strain 
+particle property).   
  

--- a/benchmarks/buiter_et_al_2008_jgr/figure_6_1e20.prm
+++ b/benchmarks/buiter_et_al_2008_jgr/figure_6_1e20.prm
@@ -32,6 +32,15 @@ subsection Mesh refinement
 end
 
 
+# The nonlinear solver typically converges more quickly
+# when no cheap Stokes solver steps are used for 
+# problems with Drucker-Prager plasticity. 
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Number of cheap Stokes solver steps = 0
+  end
+end
+
 # Free surface boundary classifications.
 # Advecting the free surface vertically rather than
 # in the surface normal direction can result in a
@@ -56,12 +65,12 @@ end
 
 
 # Number and name of compositional fields
-# The field eii is used for tracking the finite strain invariant
+# The field plastic_strain is used for tracking the plastic finite strain invariant
 # upper: brittle upper crust; seed: 'weaker' brittle region
 # lower: viscous lower crust
 subsection Compositional fields
   set Number of fields = 4
-  set Names of fields = eii, upper, seed, lower
+  set Names of fields = plastic_strain, upper, seed, lower
 end
 
 
@@ -128,32 +137,34 @@ subsection Material model
   subsection Visco Plastic
 
     set Reference temperature = 273
-    set Minimum strain rate = 1.e-20
+    set Minimum strain rate   = 1.e-20
     set Reference strain rate = 1.e-16
-    set Minimum viscosity = 1e18
-    set Maximum viscosity = 1e26
+    set Minimum viscosity     = 1e18
+    set Maximum viscosity     = 1e26
 
     set Thermal diffusivities = 1.e-6
-    set Heat capacities = 750.
-    set Densities = 2800
+    set Heat capacities       = 750.
+    set Densities             = 2800
     set Thermal expansivities = 0.
 
     set Viscosity averaging scheme = harmonic
-    set Viscous flow law = dislocation
+    set Viscous flow law           = dislocation
 
-    set Prefactors for dislocation creep = 5.e-25, 5.e-25, 5.e-25, 5.e-25, 5.e-21
-    set Stress exponents for dislocation creep = 1.0
+    set Prefactors for dislocation creep          = 5.e-25, 5.e-25, 5.e-25, 5.e-25, 5.e-21
+    set Stress exponents for dislocation creep    = 1.0
     set Activation energies for dislocation creep = 0.
-    set Activation volumes for dislocation creep = 0.
+    set Activation volumes for dislocation creep  = 0.
 
-    set Angles of internal friction = 30., 30., 30., 4., 30.
-    set Cohesions = 20.e6, 20.e6, 20.e6, 2.e6, 1.e11
+    set Angles of internal friction =   30.,   30.,   30.,   4.,   30.
+    set Cohesions                   = 20.e6, 20.e6, 20.e6, 2.e6, 1.e11
 
-    set Use strain weakening = true
-    set Start strain weakening intervals  = 0.5    , 0.5   , 0.5   , 0.5, 0.5
-    set End strain weakening intervals    = 1.5    , 1.5   , 1.5   , 1.5, 1.5
-    set Cohesion strain weakening factors = 0.1    , 0.1   , 0.1   , 1.0, 1.0
-    set Friction strain weakening factors = 0.13333, 0.1333, 0.1333, 1.0, 1.0
+    set Use strain weakening         = true
+    set Use plastic strain weakening = true
+
+    set Start plasticity strain weakening intervals  =     0.5,    0.5,    0.5, 0.5, 0.5
+    set End plasticity strain weakening intervals    =     1.5,    1.5,    1.5, 1.5, 1.5
+    set Cohesion strain weakening factors            =     0.1,    0.1,    0.1, 1.0, 1.0
+    set Friction strain weakening factors            = 0.13333, 0.1333, 0.1333, 1.0, 1.0
 
   end
 end
@@ -176,11 +187,5 @@ subsection Postprocess
     set List of output variables = density, viscosity, strain rate, error indicator, partition
     set Time between graphical output = 1e5
     set Interpolate output = false
-  end
-end
-
-subsection Solver parameters
-  subsection Stokes solver parameters
-    set Number of cheap Stokes solver steps = 0
   end
 end

--- a/benchmarks/buiter_et_al_2008_jgr/figure_6_1e22.prm
+++ b/benchmarks/buiter_et_al_2008_jgr/figure_6_1e22.prm
@@ -1,6 +1,7 @@
 include figure_6_1e20.prm
 
 set Dimension                              = 2
+set Output directory                       = output_figure_6_1e22
 
 subsection Material model
   set Model name = visco plastic


### PR DESCRIPTION
This pull request addresses part of #2859, while also improving the documentation and formatting of the `buiter_et_al_2008_jgr` benchmarks.

The key change to these benchmarks is to update the strain weakening options, which currently use options that are no longer supported (e.g., they do not run). The strain weakening has also been updated to use the plastic finite strain invariant, which is consistent with the Buiter et al. 2008 study.