### PR TITLE
timing sparsity pattern setup

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -629,6 +629,8 @@ namespace aspect
     // constraints. Of course we need to force assembly too.
     if (rebuild_sparsity_and_matrices)
       {
+        TimerOutput::Scope timer (computing_timer, "Setup matrices");
+
         rebuild_sparsity_and_matrices = false;
         setup_system_matrix (introspection.index_sets.system_partitioning);
         setup_system_preconditioner (introspection.index_sets.system_partitioning);


### PR DESCRIPTION
Here was a significant section of code @tjhei and I found that wasn't being included in the timings.

I'll give an example of why this is a significant section using other setup sections that are being timed:
Ex. 3d, 4 cores, 1.2M DoFs:
Total runtime: 73.1s
Setup dof systems: 0.842s
Setup initial conditions: 2.42s
**_Setup sparsity patterns: 2.56s_**
