### PR TITLE
use http git submodule for WorldBuilder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "contrib/WorldBuilder"]
 	path = contrib/WorldBuilder
-	url = git@github.com:GeodynamicWorldBuilder/WorldBuilder.git
+	url = https://github.com/GeodynamicWorldBuilder/WorldBuilder.git


### PR DESCRIPTION
The submodule is currently specified to use ssh. When somebody clones
aspect with ``git clone --recursive
https://github.com/geodynamics/aspect`` it will try to fetch the world
builder using ssh (and ask for authentication or fail).
Change this.
I don't see any disadvantage of doing so.