### PR TITLE
CMakeLists.txt: prefer binary include dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ MESSAGE(STATUS "====================================================")
 SET(TARGET "aspect")
 
 FILE(GLOB_RECURSE TARGET_SRC  "source/*.cc" "unit_tests/*.cc" "include/*.h" "contrib/catch/catch.hpp")
-INCLUDE_DIRECTORIES(include ${CMAKE_BINARY_DIR}/include contrib/catch)
+INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/include include  contrib/catch)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
List the build/include dir before ./include to give it preference over
the source directory. Reasoning: I had a stray
include/aspect/revision.h (maybe from an accidental in-source build?)
that was used instead of the current generated one. As a result,
ASPECT would show the wrong git branch/version/etc..