### PR TITLE
Fix shear bands benchmark input and FPE

### DIFF
--- a/benchmarks/shear_bands/run_angle_melt_bands.sh
+++ b/benchmarks/shear_bands/run_angle_melt_bands.sh
@@ -22,7 +22,7 @@ cp magmatic_shear_bands.prm temp.prm
 echo "subsection Mesh refinement" >>temp.prm
 echo "set Initial global refinement = 7" >> temp.prm
 echo "end" >> temp.prm
-echo "subsection Compositional initial conditions" >>temp.prm
+echo "subsection Initial composition model" >>temp.prm
 echo "subsection Plane wave melt bands initial condition" >>temp.prm
 echo "set Wave number = 4000" >>temp.prm
 echo "set Initial band angle = $a" >>temp.prm

--- a/benchmarks/shear_bands/run_plane_melt_bands.sh
+++ b/benchmarks/shear_bands/run_plane_melt_bands.sh
@@ -37,7 +37,7 @@ cp magmatic_shear_bands.prm temp.prm
 echo "subsection Mesh refinement" >>temp.prm
 echo "set Initial global refinement = $r" >> temp.prm
 echo "end" >> temp.prm
-echo "subsection Compositional initial conditions" >>temp.prm
+echo "subsection Initial composition model" >>temp.prm
 echo "subsection Plane wave melt bands initial condition" >>temp.prm
 echo "set Wave number = 8000" >>temp.prm
 echo "end" >>temp.prm

--- a/benchmarks/shear_bands/shear_bands.cc
+++ b/benchmarks/shear_bands/shear_bands.cc
@@ -857,12 +857,17 @@ namespace aspect
                                             :
                                             (1.0 - background_porosity) / (amplitude * background_porosity) * global_velocity_divergence_min);
 
+      const double relative_error = (analytical_growth_rate != 0.0) ?
+                                    std::abs(numerical_growth_rate - analytical_growth_rate)/analytical_growth_rate
+                                    :
+                                    1.0;
+
       // compute and output error
       std::ostringstream os;
       os << std::scientific << initial_band_angle
          << ", " << analytical_growth_rate
          << ", " << numerical_growth_rate
-         << ", " << std::abs(numerical_growth_rate - analytical_growth_rate)/analytical_growth_rate;
+         << ", " << relative_error;
 
       return std::make_pair("Initial angle, Analytical growth rate, Modelled growth rate, Error:", os.str());
     }


### PR DESCRIPTION
The shear bands benchmark had a leftover pre 2.0 input file, because the file is generated from a script and not stored in the repository. Also fixed a floating-point exception in the associated postprocessor that occurs if the analytical growth rate of the shear bands is 0.