### PR TITLE
 clang-tidy: more checks

### DIFF
--- a/include/aspect/postprocess/particles.h
+++ b/include/aspect/postprocess/particles.h
@@ -322,8 +322,8 @@ namespace aspect
          * of these arguments and deletes them at the end of its work.
          */
         static
-        void writer (const std::string filename,
-                     const std::string temporary_filename,
+        void writer (const std::string &filename,
+                     const std::string &temporary_filename,
                      const std::string *file_contents);
 
         /**

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -532,8 +532,8 @@ namespace aspect
          * of these arguments and deletes them at the end of its work.
          */
         static
-        void writer (const std::string filename,
-                     const std::string temporary_filename,
+        void writer (const std::string &filename,
+                     const std::string &temporary_filename,
                      const std::string *file_contents);
 
         /**

--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -165,7 +165,7 @@ namespace aspect
         this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::DynamicTopography<dim> >();
 
       // Get the already-computed dynamic topography solution.
-      const LinearAlgebra::BlockVector topo_vector = dynamic_topography.topography_vector();
+      const LinearAlgebra::BlockVector &topo_vector = dynamic_topography.topography_vector();
 
       // Get a pointer to the boundary densities postprocessor.
       const Postprocess::BoundaryDensities<dim> &boundary_densities =

--- a/source/postprocess/matrix_statistics.cc
+++ b/source/postprocess/matrix_statistics.cc
@@ -31,7 +31,7 @@ namespace
 {
   const std::string
   get_stats(const aspect::LinearAlgebra::BlockSparseMatrix &matrix,
-            const std::string matrix_name,
+            const std::string &matrix_name,
             const MPI_Comm &comm)
   {
     std::ostringstream output;

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -188,8 +188,8 @@ namespace aspect
 
 #if DEAL_II_VERSION_GTE(9,0,0)
     template <int dim>
-    void Particles<dim>::writer (const std::string filename,
-                                 const std::string temporary_output_location,
+    void Particles<dim>::writer (const std::string &filename,
+                                 const std::string &temporary_output_location,
                                  const std::string *file_contents)
     {
       std::string tmp_filename = filename;

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -670,8 +670,8 @@ namespace aspect
 
 
     template <int dim>
-    void Visualization<dim>::writer (const std::string filename,
-                                     const std::string temporary_output_location,
+    void Visualization<dim>::writer (const std::string &filename,
+                                     const std::string &temporary_output_location,
                                      const std::string *file_contents)
     {
       std::string tmp_filename = filename;

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -203,7 +203,7 @@ namespace aspect
      * it, so we need to work on a copy. This copy is deleted at the end
      * of this function.
      */
-    void do_output_statistics (const std::string stat_file_name,
+    void do_output_statistics (const std::string &stat_file_name,
                                const TableHandler *copy_of_table)
     {
       // write into a temporary file for now so that we don't


### PR DESCRIPTION
fix a couple of clang-tidy performance complaints (missing references) reported with checks:
performance-unnecessary-value-param
performance-unnecessary-copy-initialization