### PR TITLE
Replace std::shared_ptr by std::unique_ptr in the heating models.

### DIFF
--- a/benchmarks/tangurnis/code/tangurnis.cc
+++ b/benchmarks/tangurnis/code/tangurnis.cc
@@ -400,7 +400,7 @@ namespace aspect
 
     std::vector<std::vector<double> > composition_values (this->n_compositional_fields(),std::vector<double> (n_q_points));
 
-    const std::list<std::shared_ptr<HeatingModel::Interface<dim> > > &heating_model_objects = this->get_heating_model_manager().get_active_heating_models();
+    const std::list<std::unique_ptr<HeatingModel::Interface<dim> > > &heating_model_objects = this->get_heating_model_manager().get_active_heating_models();
 
     std::vector<HeatingModel::HeatingModelOutputs> heating_model_outputs (heating_model_objects.size(),
                                                                           HeatingModel::HeatingModelOutputs (n_q_points, this->n_compositional_fields()));
@@ -441,7 +441,7 @@ namespace aspect
           }
 
         unsigned int index = 0;
-        for (typename std::list<std::shared_ptr<HeatingModel::Interface<dim> > >::const_iterator
+        for (typename std::list<std::unique_ptr<HeatingModel::Interface<dim> > >::const_iterator
              heating_model = heating_model_objects.begin();
              heating_model != heating_model_objects.end(); ++heating_model, ++index)
           {

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -333,7 +333,7 @@ namespace aspect
          * Return a list of pointers to all heating models currently used in the
          * computation, as specified in the input file.
          */
-        const std::list<std::shared_ptr<Interface<dim> > > &
+        const std::list<std::unique_ptr<Interface<dim> > > &
         get_active_heating_models () const;
 
         /**
@@ -397,7 +397,7 @@ namespace aspect
          * A list of heating model objects that have been requested in the
          * parameter file.
          */
-        std::list<std::shared_ptr<Interface<dim> > > heating_model_objects;
+        std::list<std::unique_ptr<Interface<dim> > > heating_model_objects;
 
         /**
          * A list of names of heating model objects that have been requested
@@ -414,10 +414,8 @@ namespace aspect
     HeatingModelType *
     Manager<dim>::find_heating_model () const
     {
-      for (typename std::list<std::shared_ptr<Interface<dim> > >::const_iterator
-           p = heating_model_objects.begin();
-           p != heating_model_objects.end(); ++p)
-        if (HeatingModelType *x = dynamic_cast<HeatingModelType *> ( (*p).get()) )
+      for (auto &p : heating_model_objects)
+        if (HeatingModelType *x = dynamic_cast<HeatingModelType *> (p.get()))
           return x;
       return nullptr;
     }
@@ -429,10 +427,8 @@ namespace aspect
     bool
     Manager<dim>::has_matching_heating_model () const
     {
-      for (typename std::list<std::shared_ptr<Interface<dim> > >::const_iterator
-           p = heating_model_objects.begin();
-           p != heating_model_objects.end(); ++p)
-        if (Plugins::plugin_type_matches<HeatingModelType>(*(*p)))
+      for (const auto &p : heating_model_objects)
+        if (Plugins::plugin_type_matches<HeatingModelType>(*p))
           return true;
       return false;
     }
@@ -450,8 +446,8 @@ namespace aspect
                              "that could not be found in the current model. Activate this "
                              "heating model in the input file."));
 
-      typename std::list<std::shared_ptr<Interface<dim> > >::const_iterator heating_model;
-      for (typename std::list<std::shared_ptr<Interface<dim> > >::const_iterator
+      typename std::list<std::unique_ptr<Interface<dim> > >::const_iterator heating_model;
+      for (typename std::list<std::unique_ptr<Interface<dim> > >::const_iterator
            p = heating_model_objects.begin();
            p != heating_model_objects.end(); ++p)
         if (Plugins::plugin_type_matches<HeatingModelType>(*(*p)))

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -189,7 +189,7 @@ namespace aspect
       // their own parameters
       for (unsigned int name=0; name<model_names.size(); ++name)
         {
-          heating_model_objects.push_back (std::shared_ptr<Interface<dim> >
+          heating_model_objects.push_back (std::unique_ptr<Interface<dim> >
                                            (std::get<dim>(registered_plugins)
                                             .create_plugin (model_names[name],
                                                             "Heating model::Model names")));
@@ -207,11 +207,9 @@ namespace aspect
     void
     Manager<dim>::update ()
     {
-      for (typename std::list<std::shared_ptr<HeatingModel::Interface<dim> > >::const_iterator
-           heating_model = heating_model_objects.begin();
-           heating_model != heating_model_objects.end(); ++heating_model)
+      for (const auto &heating_model : heating_model_objects)
         {
-          (*heating_model)->update();
+          heating_model->update();
         }
     }
 
@@ -236,11 +234,9 @@ namespace aspect
       const MaterialModel::ReactionRateOutputs<dim> *reaction_rate_outputs
         = material_model_outputs.template get_additional_output<MaterialModel::ReactionRateOutputs<dim> >();
 
-      for (typename std::list<std::shared_ptr<HeatingModel::Interface<dim> > >::const_iterator
-           heating_model = heating_model_objects.begin();
-           heating_model != heating_model_objects.end(); ++heating_model)
+      for (const auto &heating_model : heating_model_objects)
         {
-          (*heating_model)->evaluate(material_model_inputs, material_model_outputs, individual_heating_outputs);
+          heating_model->evaluate(material_model_inputs, material_model_outputs, individual_heating_outputs);
           for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
             {
               heating_model_outputs.heating_source_terms[q] += individual_heating_outputs.heating_source_terms[q];
@@ -270,18 +266,14 @@ namespace aspect
     create_additional_material_model_inputs_and_outputs(MaterialModel::MaterialModelInputs<dim>  &material_model_inputs,
                                                         MaterialModel::MaterialModelOutputs<dim> &material_model_outputs) const
     {
-      for (typename std::list<std::shared_ptr<HeatingModel::Interface<dim> > >::const_iterator
-           heating_model = heating_model_objects.begin();
-           heating_model != heating_model_objects.end(); ++heating_model)
+      for (const auto &heating_model : heating_model_objects)
         {
-          (*heating_model)->create_additional_material_model_inputs(material_model_inputs);
+          heating_model->create_additional_material_model_inputs(material_model_inputs);
         }
 
-      for (typename std::list<std::shared_ptr<HeatingModel::Interface<dim> > >::const_iterator
-           heating_model = heating_model_objects.begin();
-           heating_model != heating_model_objects.end(); ++heating_model)
+      for (const auto &heating_model : heating_model_objects)
         {
-          (*heating_model)->create_additional_material_model_outputs(material_model_outputs);
+          heating_model->create_additional_material_model_outputs(material_model_outputs);
         }
     }
 
@@ -296,7 +288,7 @@ namespace aspect
 
 
     template <int dim>
-    const std::list<std::shared_ptr<Interface<dim> > > &
+    const std::list<std::unique_ptr<Interface<dim> > > &
     Manager<dim>::get_active_heating_models () const
     {
       return heating_model_objects;

--- a/source/postprocess/heating_statistics.cc
+++ b/source/postprocess/heating_statistics.cc
@@ -57,7 +57,7 @@ namespace aspect
 
       std::vector<std::vector<double> > composition_values (this->n_compositional_fields(),std::vector<double> (quadrature_formula.size()));
 
-      const std::list<std::shared_ptr<HeatingModel::Interface<dim> > > &heating_model_objects = this->get_heating_model_manager().get_active_heating_models();
+      const auto &heating_model_objects = this->get_heating_model_manager().get_active_heating_models();
       const std::vector<std::string> &heating_model_names = this->get_heating_model_manager().get_active_heating_model_names();
 
       HeatingModel::HeatingModelOutputs heating_model_outputs(n_q_points, this->n_compositional_fields());
@@ -106,7 +106,7 @@ namespace aspect
               local_mass += out.densities[q] * fe_values.JxW(q);
 
             unsigned int index = 0;
-            for (typename std::list<std::shared_ptr<HeatingModel::Interface<dim> > >::const_iterator
+            for (typename std::list<std::unique_ptr<HeatingModel::Interface<dim> > >::const_iterator
                  heating_model = heating_model_objects.begin();
                  heating_model != heating_model_objects.end(); ++heating_model, ++index)
               {
@@ -128,7 +128,7 @@ namespace aspect
       global_mass = Utilities::MPI::sum (local_mass, this->get_mpi_communicator());
 
       unsigned int index = 0;
-      for (typename std::list<std::shared_ptr<HeatingModel::Interface<dim> > >::const_iterator
+      for (typename std::list<std::unique_ptr<HeatingModel::Interface<dim> > >::const_iterator
            heating_model = heating_model_objects.begin();
            heating_model != heating_model_objects.end(); ++heating_model, ++index)
         {

--- a/source/postprocess/visualization/heating.cc
+++ b/source/postprocess/visualization/heating.cc
@@ -80,7 +80,7 @@ namespace aspect
                             std::vector<Vector<double> > &computed_quantities) const
       {
         const unsigned int n_quadrature_points = input_data.solution_values.size();
-        const std::list<std::shared_ptr<HeatingModel::Interface<dim> > > &heating_model_objects = this->get_heating_model_manager().get_active_heating_models();
+        const auto &heating_model_objects = this->get_heating_model_manager().get_active_heating_models();
 
         // we do not want to write any output if there are no heating models
         // used in the computation
@@ -144,7 +144,7 @@ namespace aspect
           AssertThrow(false, ExcNotImplemented());
 
         unsigned int index = 0;
-        for (typename std::list<std::shared_ptr<HeatingModel::Interface<dim> > >::const_iterator
+        for (typename std::list<std::unique_ptr<HeatingModel::Interface<dim> > >::const_iterator
              heating_model = heating_model_objects.begin();
              heating_model != heating_model_objects.end(); ++heating_model, ++index)
           {


### PR DESCRIPTION
Strictly speaking, this is an incompatible change because the heating model manager
exports its list of heating models. I suspect that few plugins we don't have
in the tree ourselves (which I have all converted) make use of this.

Related to #2375 and #2811.