### PR TITLE
cleanup: consistent parameter names

### DIFF
--- a/include/aspect/boundary_velocity/gplates.h
+++ b/include/aspect/boundary_velocity/gplates.h
@@ -51,8 +51,8 @@ namespace aspect
            * Initialize all members and calculates any necessary rotation
            * parameters for a 2D model.
            */
-          GPlatesLookup(const Tensor<1,2> &pointone,
-                        const Tensor<1,2> &pointtwo);
+          GPlatesLookup(const Tensor<1,2> &surface_point_one,
+                        const Tensor<1,2> &surface_point_two);
 
           /**
            * Outputs the GPlates module information at model start.
@@ -336,7 +336,7 @@ namespace aspect
          * time step.
          */
         void
-        update_data (const bool reload_both_files);
+        update_data (const bool load_both_files);
 
         /**
          * Handles settings and user notification in case the time-dependent

--- a/include/aspect/free_surface.h
+++ b/include/aspect/free_surface.h
@@ -46,8 +46,8 @@ namespace aspect
 
         virtual
         void
-        execute (internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                 internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute (internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                 internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
   }
 

--- a/include/aspect/geometry_model/box.h
+++ b/include/aspect/geometry_model/box.h
@@ -174,7 +174,7 @@ namespace aspect
          */
         virtual
         bool
-        point_is_in_domain(const Point<dim> &p) const;
+        point_is_in_domain(const Point<dim> &point) const;
 
         /*
          * Returns what the natural coordinate system for this geometry model is,

--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -219,7 +219,7 @@ namespace aspect
          */
         virtual
         bool
-        point_is_in_domain(const Point<dim> &p) const;
+        point_is_in_domain(const Point<dim> &point) const;
 
         /*
          * Returns what the natural coordinate system for this geometry model is,

--- a/include/aspect/geometry_model/ellipsoidal_chunk.h
+++ b/include/aspect/geometry_model/ellipsoidal_chunk.h
@@ -211,7 +211,7 @@ namespace aspect
          */
         virtual
         bool
-        point_is_in_domain(const Point<dim> &p) const;
+        point_is_in_domain(const Point<dim> &point) const;
 
         /**
          * Returns the bottom depth which was used to create the geometry and
@@ -283,7 +283,7 @@ namespace aspect
          * Calculate radius at current position.
          */
         double
-        get_radius(const Point<dim> &point) const;
+        get_radius(const Point<dim> &position) const;
 
         /**
          * Retrieve the semi minor axis b value.

--- a/include/aspect/geometry_model/initial_topography_model/ascii_data.h
+++ b/include/aspect/geometry_model/initial_topography_model/ascii_data.h
@@ -66,7 +66,7 @@ namespace aspect
          * @copydoc aspect::InitialTopographyModel::Interface::value()
          */
         double
-        value (const Point<dim-1> &p) const;
+        value (const Point<dim-1> &surface_point) const;
 
         /**
          * Return the maximum value of the elevation.

--- a/include/aspect/geometry_model/sphere.h
+++ b/include/aspect/geometry_model/sphere.h
@@ -127,7 +127,7 @@ namespace aspect
          */
         virtual
         bool
-        point_is_in_domain(const Point<dim> &p) const;
+        point_is_in_domain(const Point<dim> &point) const;
 
         static
         void

--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -140,7 +140,7 @@ namespace aspect
          */
         virtual
         bool
-        point_is_in_domain(const Point<dim> &p) const;
+        point_is_in_domain(const Point<dim> &point) const;
 
         /*
          * Returns what the natural coordinate system for this geometry model is,

--- a/include/aspect/geometry_model/two_merged_boxes.h
+++ b/include/aspect/geometry_model/two_merged_boxes.h
@@ -147,7 +147,7 @@ namespace aspect
          */
         virtual
         bool
-        point_is_in_domain(const Point<dim> &p) const;
+        point_is_in_domain(const Point<dim> &point) const;
 
         /*
          * Returns what the natural coordinate system for this geometry model is,

--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -185,7 +185,7 @@ namespace aspect
          */
         double p_c_scale (const MaterialModel::MaterialModelInputs<dim> &inputs,
                           const MaterialModel::MaterialModelOutputs<dim> &outputs,
-                          const MeltHandler<dim> &handler,
+                          const MeltHandler<dim> &melt_handler,
                           const bool consider_is_melt_cell) const;
     };
 
@@ -226,8 +226,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -240,8 +240,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
 
@@ -256,8 +256,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -270,8 +270,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
 
         /**
          * Compute the residual of the advection system on a single cell in
@@ -279,7 +279,7 @@ namespace aspect
          */
         virtual
         std::vector<double>
-        compute_residual(internal::Assembly::Scratch::ScratchBase<dim> &scratch) const;
+        compute_residual(internal::Assembly::Scratch::ScratchBase<dim> &scratch_base) const;
     };
 
     /**
@@ -293,8 +293,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -306,8 +306,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
   }
 

--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -237,8 +237,8 @@ namespace aspect
         virtual ~NewtonStokesPreconditioner () {}
 
         void
-        execute (internal::Assembly::Scratch::ScratchBase<dim>  &scratch,
-                 internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute (internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
+                 internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -252,8 +252,8 @@ namespace aspect
         virtual ~NewtonStokesIncompressibleTerms () {}
 
         void
-        execute (internal::Assembly::Scratch::ScratchBase<dim>  &scratch,
-                 internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute (internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
+                 internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -269,8 +269,8 @@ namespace aspect
 
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -288,8 +288,8 @@ namespace aspect
 
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -309,8 +309,8 @@ namespace aspect
 
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -328,8 +328,8 @@ namespace aspect
 
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
   }
 }

--- a/include/aspect/particle/generator/probability_density_function.h
+++ b/include/aspect/particle/generator/probability_density_function.h
@@ -146,14 +146,14 @@ namespace aspect
            *
            * @param [in] particles_per_cell A vector with n_locally_owned_cells entries
            * that determines how many particles are generated in each cell.
-           * @param [in] local_start_id The starting ID to assign to generated particles of the local process.
+           * @param [in] first_particle_index The starting ID to assign to generated particles of the local process.
            * @param [in] n_local_particles The total number of particles to generate locally.
            * @param [out] particles A map between cells and all generated particles.
            *
            */
           void
           generate_particles_in_subdomain (const std::vector<unsigned int> &particles_per_cell,
-                                           const types::particle_index local_start_id,
+                                           const types::particle_index first_particle_index,
                                            const types::particle_index n_local_particles,
                                            std::multimap<Particles::internal::LevelInd, Particle<dim> > &particles);
 

--- a/include/aspect/prescribed_stokes_solution/function.h
+++ b/include/aspect/prescribed_stokes_solution/function.h
@@ -53,7 +53,7 @@ namespace aspect
          */
         virtual
         void
-        stokes_solution (const Point<dim> &p, Vector<double> &value) const;
+        stokes_solution (const Point<dim> &position, Vector<double> &value) const;
 
         /**
          * A function that is called at the beginning of each time step to

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -644,7 +644,7 @@ namespace aspect
        * <code>source/simulator/solver_schemes.cc</code>.
        */
       double assemble_and_solve_stokes (const bool compute_initial_residual = false,
-                                        double *initial_residual = nullptr);
+                                        double *initial_nonlinear_residual = nullptr);
 
       /**
        * Initiate the assembly of one advection matrix and right hand side and
@@ -1320,7 +1320,7 @@ namespace aspect
        * This function is implemented in
        * <code>source/simulator/assembly.cc</code>.
        */
-      double get_entropy_variation (const double average_value,
+      double get_entropy_variation (const double average_field,
                                     const AdvectionField &advection_field) const;
 
       /**
@@ -1405,8 +1405,8 @@ namespace aspect
       double
       compute_viscosity(internal::Assembly::Scratch::AdvectionSystem<dim> &scratch,
                         const double                        global_u_infty,
-                        const double                        global_T_variation,
-                        const double                        average_temperature,
+                        const double                        global_field_variation,
+                        const double                        average_field,
                         const double                        global_entropy_variation,
                         const double                        cell_diameter,
                         const AdvectionField     &advection_field) const;

--- a/include/aspect/simulator/assemblers/advection.h
+++ b/include/aspect/simulator/assemblers/advection.h
@@ -40,12 +40,12 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
 
         virtual
         std::vector<double>
-        compute_residual(internal::Assembly::Scratch::ScratchBase<dim>  &scratch) const;
+        compute_residual(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base) const;
     };
 
     /**
@@ -59,11 +59,11 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
         virtual
         std::vector<double>
-        compute_residual(internal::Assembly::Scratch::ScratchBase<dim>  &scratch) const;
+        compute_residual(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base) const;
     };
 
     /**
@@ -78,8 +78,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -93,8 +93,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -108,8 +108,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
   }
 }

--- a/include/aspect/simulator/assemblers/interface.h
+++ b/include/aspect/simulator/assemblers/interface.h
@@ -100,7 +100,7 @@ namespace aspect
                                 const unsigned int        n_compositional_fields,
                                 const unsigned int        stokes_dofs_per_cell,
                                 const bool                add_compaction_pressure,
-                                const bool                rebuild_stokes_matrix);
+                                const bool                rebuild_matrix);
           StokesPreconditioner (const StokesPreconditioner &scratch);
 
           virtual ~StokesPreconditioner ();
@@ -154,11 +154,11 @@ namespace aspect
                         const unsigned int        n_compositional_fields,
                         const unsigned int        stokes_dofs_per_cell,
                         const bool                add_compaction_pressure,
-                        const bool                use_reference_profile,
+                        const bool                use_reference_density_profile,
                         const bool                rebuild_stokes_matrix,
-                        const bool                rebuild_stokes_newton_matrix);
+                        const bool                rebuild_newton_stokes_matrix);
 
-          StokesSystem (const StokesSystem<dim> &data);
+          StokesSystem (const StokesSystem<dim> &scratch);
 
           FEFaceValues<dim> face_finite_element_values;
 
@@ -218,8 +218,8 @@ namespace aspect
                            const UpdateFlags         update_flags,
                            const UpdateFlags         face_update_flags,
                            const unsigned int        n_compositional_fields,
-                           const typename Simulator<dim>::AdvectionField     &advection_field);
-          AdvectionSystem (const AdvectionSystem &data);
+                           const typename Simulator<dim>::AdvectionField     &field);
+          AdvectionSystem (const AdvectionSystem &scratch);
 
           FEValues<dim> finite_element_values;
 

--- a/include/aspect/simulator/assemblers/stokes.h
+++ b/include/aspect/simulator/assemblers/stokes.h
@@ -39,8 +39,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -54,8 +54,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -69,8 +69,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
 
         /**
          * Create AdditionalMaterialOutputsStokesRHS if we need to do so.
@@ -89,8 +89,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -109,8 +109,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -129,8 +129,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -149,8 +149,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
 
@@ -173,8 +173,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -188,8 +188,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
 
     /**
@@ -206,8 +206,8 @@ namespace aspect
       public:
         virtual
         void
-        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+        execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
+                internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const;
     };
   }
 }

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -895,7 +895,7 @@ namespace aspect
          * Create a filename out of the name template.
          */
         std::string
-        create_filename (const int timestep,
+        create_filename (const int filenumber,
                          const types::boundary_id boundary_id) const;
     };
 

--- a/include/aspect/volume_of_fluid/assembly.h
+++ b/include/aspect/volume_of_fluid/assembly.h
@@ -53,7 +53,7 @@ namespace aspect
                                const Mapping<dim>       &mapping,
                                const Quadrature<dim>    &quadrature,
                                const Quadrature<dim-1>  &face_quadrature);
-          VolumeOfFluidSystem (const VolumeOfFluidSystem &data);
+          VolumeOfFluidSystem (const VolumeOfFluidSystem &scratch);
 
           FEValues<dim>          finite_element_values;
           FEValues<dim>          neighbor_finite_element_values;

--- a/include/aspect/volume_of_fluid/handler.h
+++ b/include/aspect/volume_of_fluid/handler.h
@@ -45,7 +45,7 @@ namespace aspect
       /**
        * Standard initial constructor
        */
-      VolumeOfFluidHandler(Simulator<dim> &sim, ParameterHandler &prm);
+      VolumeOfFluidHandler(Simulator<dim> &simulator, ParameterHandler &prm);
 
       /**
        * Add the Volume of Fluid field declaration to the list to be included


### PR DESCRIPTION
found with clang-tidy option
readability-inconsistent-declaration-parameter-name

This should have no effect but makes things a bit more consistent.