### PR TITLE
clang-tidy: suppress warnings

### DIFF
--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -188,8 +188,9 @@ namespace aspect
 
 #if DEAL_II_VERSION_GTE(9,0,0)
     template <int dim>
-    void Particles<dim>::writer (const std::string filename,
-                                 const std::string temporary_output_location,
+    // We need to pass the arguments by value, as this function can be called on a separate thread:
+    void Particles<dim>::writer (const std::string filename, //NOLINT(performance-unnecessary-value-param)
+                                 const std::string temporary_output_location, //NOLINT(performance-unnecessary-value-param)
                                  const std::string *file_contents)
     {
       std::string tmp_filename = filename;

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -670,8 +670,9 @@ namespace aspect
 
 
     template <int dim>
-    void Visualization<dim>::writer (const std::string filename,
-                                     const std::string temporary_output_location,
+    // We need to pass the arguments by value, as this function can be called on a separate thread:
+    void Visualization<dim>::writer (const std::string filename, //NOLINT(performance-unnecessary-value-param)
+                                     const std::string temporary_output_location, //NOLINT(performance-unnecessary-value-param)
                                      const std::string *file_contents)
     {
       std::string tmp_filename = filename;

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -203,7 +203,8 @@ namespace aspect
      * it, so we need to work on a copy. This copy is deleted at the end
      * of this function.
      */
-    void do_output_statistics (const std::string stat_file_name,
+    // We need to pass the arguments by value, as this function can be called on a separate thread:
+    void do_output_statistics (const std::string stat_file_name, //NOLINT(performance-unnecessary-value-param)
                                const TableHandler *copy_of_table)
     {
       // write into a temporary file for now so that we don't


### PR DESCRIPTION
Suppress the three locations where we want to ignore performance-
unnecessary-value-param.

followup to #2879 and required for clang-tidy to pass again.