### PR TITLE
Add a reference to the ASPECT II paper to the manual.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -1630,8 +1630,10 @@ algorithms:
 \end{itemize}
 
 Rather than detailing the various techniques upon which \aspect{} is built, we
-refer to the paper by Kronbichler, Heister and Bangerth \cite{KHB12} that
-gives a detailed description and rationale for the various building blocks.
+refer to the papers by Kronbichler, Heister and Bangerth \cite{KHB12} 
+and Heister, Dannberg, Gassm{\"o}ller and Bangerth \cite{heister_aspect_methods2}
+that
+give a detailed description and rationale for the various building blocks.
 
 
 \subsection{Approximate equations}


### PR DESCRIPTION
This is at the end of the short section about design criteria, where we talk about
the numerical methods underlying ASPECT. We never updated the references there to
include the second ASPECT paper.