### PR TITLE
clang-tidy with worldbuilder

### DIFF
--- a/contrib/.clang-tidy
+++ b/contrib/.clang-tidy
@@ -1,0 +1,6 @@
+# Disable all checks because we don't want to fix things inside
+# contrib/. Clang-tidy fails if nothing is chosen, so we just enable a single
+# harmless warning:
+
+Checks: "-*,misc-sizeof-container"
+

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -643,7 +643,7 @@ namespace aspect
   SimulatorAccess<dim>::get_world_builder () const
   {
 #ifdef ASPECT_USE_WORLD_BUILDER
-    Assert (simulator->world_builder.get() != 0,
+    Assert (simulator->world_builder.get() != nullptr,
             ExcMessage("You can not call this function if the World Builder is not enabled. "
                        "Enable it by providing a path to a world builder file."));
 #else


### PR DESCRIPTION
- WorldBuilder does not run cleanly with our clang-tidy checks, instead
of fixing those, disable it inside contrib/
- fix one nullptr location