### PR TITLE
no temperature matrix for Stokes only

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -905,7 +905,12 @@ namespace aspect
               coupling[x.pressure][x.velocities[d]] = DoFTools::always;
             }
         }
-      coupling[x.temperature][x.temperature] = DoFTools::always;
+      // Do not allocate a temperature matrix if no temperature
+      // solves are going to be performed.
+      if (!(parameters.nonlinear_solver == NonlinearSolver::Kind::no_Advection_iterated_Stokes
+            ||
+            parameters.nonlinear_solver == NonlinearSolver::Kind::no_Advection_no_Stokes))
+        coupling[x.temperature][x.temperature] = DoFTools::always;
 
       // If we have at least one compositional field that is a FEM field, we
       // create a matrix block in the first compositional block. Its sparsity


### PR DESCRIPTION
We are still reserving memory for the temperature matrix even when it is not needed. Adding an if-statement that ignores the Stokes-only case.