### PR TITLE
[DoNotMerge] Keep build container /home in memory only

### DIFF
--- a/Jenkinsfile.cig
+++ b/Jenkinsfile.cig
@@ -4,6 +4,8 @@ pipeline {
   agent {
     docker {
       image 'tjhei/dealii:v9.0.1-full-v9.0.1-r5-gcc5'
+      label 'tmpfs_capable'
+      args '--mount type=tmpfs,destination=/home'
     }
   }
 


### PR DESCRIPTION
This Jenkinsfile change will put the build container's `/home` directory in a tmpfs partition, effectively making the build occur only in memory. This is to try and narrow down the reason why Timo's server is building so much faster than CIG's servers.