### PR TITLE
Fix unity build

### DIFF
--- a/Jenkinsfile.cig
+++ b/Jenkinsfile.cig
@@ -68,17 +68,14 @@ pipeline {
 
           # Set up build system and compile ASPECT
           cmake \
-            -G 'Ninja' \
-            -D ASPECT_TEST_GENERATOR='Ninja' \
             -D ASPECT_USE_PETSC='OFF' \
-            -D ASPECT_RUN_ALL_TESTS='ON' \
             -D ASPECT_PRECOMPILE_HEADERS='ON' \
             ..
         '''
 
         sh '''
           cd build-gcc-unity
-          ninja aspect_unity
+          make aspect_unity
         '''
       }
     }

--- a/Jenkinsfile.cig
+++ b/Jenkinsfile.cig
@@ -56,6 +56,33 @@ pipeline {
       }
     }
 
+    stage('Unity Build') {
+      options {
+        timeout(time: 30, unit: 'MINUTES')
+      }
+      steps {
+        sh 'mkdir build-gcc-unity'
+
+        sh '''
+          cd build-gcc-unity
+
+          # Set up build system and compile ASPECT
+          cmake \
+            -G 'Ninja' \
+            -D ASPECT_TEST_GENERATOR='Ninja' \
+            -D ASPECT_USE_PETSC='OFF' \
+            -D ASPECT_RUN_ALL_TESTS='ON' \
+            -D ASPECT_PRECOMPILE_HEADERS='ON' \
+            ..
+        '''
+
+        sh '''
+          cd build-gcc-unity
+          ninja aspect_unity
+        '''
+      }
+    }
+
     stage('Build') {
       options {
         timeout(time: 30, unit: 'MINUTES')

--- a/source/postprocess/interface.cc
+++ b/source/postprocess/interface.cc
@@ -236,7 +236,7 @@ namespace aspect
                      "all") != postprocessor_names.end())
         {
           postprocessor_names.clear();
-          for (typename std::list<typename internal::Plugins::PluginList<Interface<dim> >::PluginInfo>::const_iterator
+          for (typename std::list<typename aspect::internal::Plugins::PluginList<Interface<dim> >::PluginInfo>::const_iterator
                p = std::get<dim>(registered_plugins).plugins->begin();
                p != std::get<dim>(registered_plugins).plugins->end(); ++p)
             postprocessor_names.push_back (std::get<0>(*p));


### PR DESCRIPTION
The unity build functionality was broken due to a namespace that was only unique in the non unity build. Fix that, and also add a test stage for the unity build. This is currently just to compare the two stages, we could also decide to switch the CIG tester over to the unity build altogether if it saves a bit of time.