### PR TITLE
Update docker instructions to geodynamics/aspect

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2691,7 +2691,7 @@ precompiled \aspect{} image from Docker Hub is as simple as typing in a
 terminal:
 
 \begin{lstlisting}[frame=single,language=ksh]
-docker pull gassmoeller/aspect
+docker pull geodynamics/aspect
 \end{lstlisting}
 
 Note that the transfer size of the compressed image containing \aspect{} and
@@ -2727,7 +2727,7 @@ different versions see Section~\ref{sec:debug-mode}, in essence: You should run
 To sum up, the steps you will want to execute are:
 \begin{lstlisting}[frame=single,language=ksh,showstringspaces=false]
 docker run -it -v "$(pwd):/home/dealii/aspect/model_input:ro" \
-  gassmoeller/aspect:latest bash
+  geodynamics/aspect:latest bash
 \end{lstlisting}
 
 Within the container, simply run your model by executing:

--- a/doc/release-tasklist
+++ b/doc/release-tasklist
@@ -114,6 +114,10 @@
        create entry for the new release
        update the list of contributors
        ... (to be completed when we go through the 2.0 release process)
+  . update docker image geodynamics/aspect:
+    - modify docker/Dockerfile and docker/build.sh to checkout the release
+      cd docker && ./build.sh
+      docker push geodynamics/aspect:v$TAG
   . announce on
        cig-all@geodynamics.org
        https://community.geodynamics.org/c/aspect

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -7,4 +7,4 @@
 # Note: This container is build from the developer version on Github, it does not use
 # the local ASPECT folder. Therefore local changes are not included in the container.
 
-docker build -t gassmoeller/aspect .
+docker build -t geodynamics/aspect .


### PR DESCRIPTION
I pushed a docker image to https://hub.docker.com/r/geodynamics/aspect that is identical to the current gassmoeller/aspect image. This PR modifies the documentation to use the new image instead of my own.