### PR TITLE
Capitalize Earth in manual - section 2.1.2, line 599

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -597,10 +597,10 @@ tangential component undetermined.
   just wants to prescribe a pressure component). It is possible to restrict
   prescribing the traction to only certain vector components.
   \item $\Gamma_{D,T}$ corresponds to places where the temperature is prescribed
-  (for example at the inner and outer boundaries of the Earth mantle).
+  (for example at the inner and outer boundaries of the Earth's mantle).
   \item $\Gamma_{N,T}$ corresponds to places where the temperature is unknown
   but the heat flux across the boundary is zero (for example on symmetry surfaces if only a part
-of the shell that constitutes the domain the Earth mantle occupies is
+of the shell that constitutes the domain the Earth's mantle occupies is
 simulated).
 \end{itemize}
 We require that one of these boundary conditions hold at each

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -597,7 +597,7 @@ tangential component undetermined.
   just wants to prescribe a pressure component). It is possible to restrict
   prescribing the traction to only certain vector components.
   \item $\Gamma_{D,T}$ corresponds to places where the temperature is prescribed
-  (for example at the inner and outer boundaries of the earth mantle).
+  (for example at the inner and outer boundaries of the Earth mantle).
   \item $\Gamma_{N,T}$ corresponds to places where the temperature is unknown
   but the heat flux across the boundary is zero (for example on symmetry surfaces if only a part
 of the shell that constitutes the domain the Earth mantle occupies is


### PR DESCRIPTION
Capitalized the E in Earth - line 600 of the manual