### PR TITLE
Convert more std::shared_ptr to std::unique_ptr.

### DIFF
--- a/doc/modules/changes/20190522_bangerth-2
+++ b/doc/modules/changes/20190522_bangerth-2
@@ -1,0 +1,7 @@
+Changed: The
+BoundaryVelocity::Manager::get_active_boundary_velocity_conditions()
+function used to return a `std::vector` of `std::shared_ptr` objects
+to heating models enabled for the current run. This has been changed:
+It now returns a `std::vector` of `std::unique_ptr` objects.
+<br>
+(Wolfgang Bangerth, 2019/05/22)

--- a/doc/modules/changes/20190522_bangerth-3
+++ b/doc/modules/changes/20190522_bangerth-3
@@ -1,0 +1,5 @@
+Changed: The
+BoundaryVelocity::Manager::get_prescribed_boundary_velocity() function
+has been removed. It had previously already been removed.
+<br>
+(Wolfgang Bangerth, 2019/05/22)

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -698,15 +698,6 @@ namespace aspect
       get_free_surface_boundary_indicators () const;
 
       /**
-       * Return the map of prescribed_boundary_velocity
-       *
-       * @deprecated: Use get_boundary_velocity_manager() instead.
-       */
-      DEAL_II_DEPRECATED
-      const std::map<types::boundary_id,std::shared_ptr<BoundaryVelocity::Interface<dim> > >
-      get_prescribed_boundary_velocity () const;
-
-      /**
        * Return an reference to the manager of the boundary velocity models.
        * This can then, for example, be used to get the names of the boundary velocity
        * models used in a computation, or to compute the boundary velocity

--- a/source/boundary_velocity/ascii_data.cc
+++ b/source/boundary_velocity/ascii_data.cc
@@ -39,16 +39,11 @@ namespace aspect
     void
     AsciiData<dim>::initialize ()
     {
-      const std::map<types::boundary_id,std::vector<std::shared_ptr<BoundaryVelocity::Interface<dim> > > >
-      bvs = this->get_boundary_velocity_manager().get_active_boundary_velocity_conditions();
-      for (typename std::map<types::boundary_id,std::vector<std::shared_ptr<BoundaryVelocity::Interface<dim> > > >::const_iterator
-           p = bvs.begin();
-           p != bvs.end(); ++p)
+      for (const auto &p : this->get_boundary_velocity_manager().get_active_boundary_velocity_conditions())
         {
-          for (typename std::vector<std::shared_ptr<BoundaryVelocity::Interface<dim> > >::const_iterator
-               plugin = p->second.begin(); plugin != p->second.end(); ++plugin)
-            if (plugin->get() == this)
-              boundary_ids.insert(p->first);
+          for (const auto &plugin : p.second)
+            if (plugin.get() == this)
+              boundary_ids.insert(p.first);
         }
       AssertThrow(*(boundary_ids.begin()) != numbers::invalid_boundary_id,
                   ExcMessage("Did not find the boundary indicator for the prescribed data plugin."));
@@ -56,6 +51,8 @@ namespace aspect
       Utilities::AsciiDataBoundary<dim>::initialize(boundary_ids,
                                                     dim);
     }
+
+
 
     template <int dim>
     void

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -490,27 +490,6 @@ namespace aspect
   }
 
 
-  template <int dim>
-  const std::map<types::boundary_id,std::shared_ptr<BoundaryVelocity::Interface<dim> > >
-  SimulatorAccess<dim>::get_prescribed_boundary_velocity () const
-  {
-    const std::map<types::boundary_id,std::vector<std::shared_ptr<BoundaryVelocity::Interface<dim> > > > &
-    boundary_map = simulator->boundary_velocity_manager.get_active_boundary_velocity_conditions();
-
-    std::map<types::boundary_id,std::shared_ptr<BoundaryVelocity::Interface<dim> > >
-    legacy_map;
-
-    for (typename std::map<types::boundary_id,std::vector<std::shared_ptr<BoundaryVelocity::Interface<dim> > > >::const_iterator
-         boundary = boundary_map.begin(); boundary != boundary_map.end(); ++boundary)
-      {
-        Assert (boundary->second.size() <= 1,
-                ExcMessage("You can only use this function if there is at most one boundary velocity plugin per boundary."));
-        legacy_map[boundary->first] = boundary->second.front();
-      }
-
-    return legacy_map;
-  }
-
 
   template <int dim>
   const BoundaryVelocity::Manager<dim> &

--- a/tests/ascii_boundary_member.cc
+++ b/tests/ascii_boundary_member.cc
@@ -64,7 +64,7 @@ namespace aspect
       void
       parse_parameters (ParameterHandler &prm);
 
-      std::shared_ptr<Utilities::AsciiDataBoundary<dim> > member;
+      std::unique_ptr<Utilities::AsciiDataBoundary<dim> > member;
 
       std::set<types::boundary_id> boundary_ids;
   };
@@ -78,15 +78,14 @@ namespace aspect
   void
   AsciiBoundaryMember<dim>::initialize ()
   {
-    const std::map<types::boundary_id,std::shared_ptr<BoundaryVelocity::Interface<dim> > >
-    bvs = this->get_prescribed_boundary_velocity();
-    for (typename std::map<types::boundary_id,std::shared_ptr<BoundaryVelocity::Interface<dim> > >::const_iterator
-         p = bvs.begin();
-         p != bvs.end(); ++p)
-      {
-        if (p->second.get() == this)
-          boundary_ids.insert(p->first);
-      }
+    const std::map<types::boundary_id,std::vector<std::unique_ptr<BoundaryVelocity::Interface<dim> > > > &
+    bvs = this->get_boundary_velocity_manager().get_active_boundary_velocity_conditions();
+    for (const auto &boundary : bvs)
+      for (const auto &p : boundary.second)
+        {
+          if (p.get() == this)
+            boundary_ids.insert(boundary.first);
+        }
     AssertThrow(*(boundary_ids.begin()) != numbers::invalid_boundary_id,
                 ExcMessage("Did not find the boundary indicator for the prescribed data plugin."));
 
@@ -137,7 +136,7 @@ namespace aspect
   {
     prm.enter_subsection("Boundary velocity model");
     {
-      member = std::make_shared<Utilities::AsciiDataBoundary<dim>>();
+      member = std_cxx14::make_unique<Utilities::AsciiDataBoundary<dim>>();
       member->initialize_simulator(this->get_simulator());
 
       member->parse_parameters(prm);


### PR DESCRIPTION
This also removes a deprecated function that can't easily be converted.

Part of #2811 and #2375.