### PR TITLE
Replace if valid operator for initial temperature conditions

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1122,7 +1122,7 @@ namespace aspect
           subtract,
           minimum,
           maximum,
-		  replace_if_valid
+          replace_if_valid
         };
 
         /**

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1121,7 +1121,8 @@ namespace aspect
           add,
           subtract,
           minimum,
-          maximum
+          maximum,
+		  replace_if_valid
         };
 
         /**

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -204,7 +204,7 @@ namespace aspect
                           std::get<dim>(registered_plugins).get_description_string());
 
         prm.declare_entry("List of model operators", "add",
-                          Patterns::MultipleSelection("add|subtract|minimum|maximum"),
+                          Patterns::MultipleSelection("add|subtract|minimum|maximum|replace if valid"),
                           "A comma-separated list of operators that "
                           "will be used to append the listed temperature models onto "
                           "the previous models. If only one operator is given, "

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2795,11 +2795,11 @@ namespace aspect
             return std::max(x,y);
           }
           case Utilities::Operator::replace_if_valid:
-		  {
-        	  if (std::isnan(y))
-			  return x;
-			  else return y;
-		  }
+          {
+            if (std::isnan(y))
+              return x;
+            else return y;
+          }
           default:
           {
             Assert (false, ExcInternalError());

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2837,7 +2837,7 @@ namespace aspect
           else
             AssertThrow(false,
                         ExcMessage ("ASPECT only accepts the following operators: "
-                                    "add, subtract, minimum, maximum and replace if valid. But your parameter file "
+                                    "add, subtract, minimum, maximum, and replace if valid. But your parameter file "
                                     "contains: " + operator_names[i] + ". Please check your parameter file.") );
         }
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2794,6 +2794,12 @@ namespace aspect
           {
             return std::max(x,y);
           }
+          case Utilities::Operator::replace_if_valid:
+		  {
+        	  if (std::isnan(y))
+			  return x;
+			  else return y;
+		  }
           default:
           {
             Assert (false, ExcInternalError());
@@ -2826,10 +2832,12 @@ namespace aspect
             operator_list[i] = Operator(Operator::minimum);
           else if (operator_names[i] == "maximum")
             operator_list[i] = Operator(Operator::maximum);
+          else if (operator_names[i] == "replace if valid")
+            operator_list[i] = Operator(Operator::replace_if_valid);
           else
             AssertThrow(false,
                         ExcMessage ("ASPECT only accepts the following operators: "
-                                    "add, subtract, minimum and maximum. But your parameter file "
+                                    "add, subtract, minimum, maximum and replace if valid. But your parameter file "
                                     "contains: " + operator_names[i] + ". Please check your parameter file.") );
         }
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2798,7 +2798,8 @@ namespace aspect
           {
             if (std::isnan(y))
               return x;
-            else return y;
+            else
+              return y;
           }
           default:
           {

--- a/tests/initial_temperature_list_using_replace_if_valid.prm
+++ b/tests/initial_temperature_list_using_replace_if_valid.prm
@@ -1,0 +1,86 @@
+##### simple test for using multiple initial temperature plugins
+
+set Dimension                              = 2
+
+set Use years in output instead of seconds = true
+set End time                               = 0
+
+set Adiabatic surface temperature          = 1613.0
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 660000
+    set Y extent = 660000
+  end
+end
+
+subsection Initial temperature model
+  set List of model names = ascii data, function
+  set List of model operators = add, replace if valid
+  subsection Ascii data model
+    set Data directory       = $ASPECT_SOURCE_DIR/data/initial-temperature/ascii-data/test/
+    set Data file name       = box_2d.txt
+  end
+
+  subsection Function
+    set Variable names = x,y
+    set Function constants = Xmax=330000
+    set Function expression = if(x<Xmax,Nan,1600)
+  end
+end
+
+
+subsection Boundary temperature model
+  set List of model names = box
+end
+
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = bottom:function,left:function,right:function,top:function
+end
+
+
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = 1;0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Viscosity = 1e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 4
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+  set Strategy                                 = temperature
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics
+end
+
+
+

--- a/tests/initial_temperature_list_using_replace_if_valid.prm
+++ b/tests/initial_temperature_list_using_replace_if_valid.prm
@@ -25,7 +25,7 @@ subsection Initial temperature model
   subsection Function
     set Variable names = x,y
     set Function constants = Xmax=330000
-    set Function expression = if(x<Xmax,Nan,1600)
+    set Function expression = if(x<Xmax,nan,1600)
   end
 end
 

--- a/tests/initial_temperature_list_using_replace_if_valid.prm
+++ b/tests/initial_temperature_list_using_replace_if_valid.prm
@@ -1,6 +1,3 @@
-##### simple test for using multiple initial temperature plugins
-# This tests whether the 'replace if valid' operator is working
-'
 set Dimension                              = 2
 
 set Use years in output instead of seconds = true

--- a/tests/initial_temperature_list_using_replace_if_valid.prm
+++ b/tests/initial_temperature_list_using_replace_if_valid.prm
@@ -1,5 +1,6 @@
 ##### simple test for using multiple initial temperature plugins
-
+# This tests whether the 'replace if valid' operator is working
+'
 set Dimension                              = 2
 
 set Use years in output instead of seconds = true

--- a/tests/initial_temperature_list_using_replace_if_valid/screen-output
+++ b/tests/initial_temperature_list_using_replace_if_valid/screen-output
@@ -1,0 +1,26 @@
+
+
+   Loading Ascii data initial file ASPECT_DIR/data/initial-temperature/ascii-data/test/box_2d.txt.
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 3,556 (2,178+289+1,089)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 31+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  1 m/year, 1.11 m/year
+     Temperature min/avg/max:            0 K, 853.1 K, 1600 K
+     Heat fluxes through boundary parts: -4.333e+06 W, 1.344e+08 W, 0 W, 0 W
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/initial_temperature_list_using_replace_if_valid/statistics
+++ b/tests/initial_temperature_list_using_replace_if_valid/statistics
@@ -1,0 +1,20 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: RMS velocity (m/year)
+# 12: Max. velocity (m/year)
+# 13: Minimal temperature (K)
+# 14: Average temperature (K)
+# 15: Maximal temperature (K)
+# 16: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 17: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 18: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 19: Outward heat flux through boundary with indicator 3 ("top") (W)
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 0 30 32 32 1.00245387e+00 1.11118062e+00 0.00000000e+00 8.53125000e+02 1.60000000e+03 -4.33315589e+06 1.34427880e+08 0.00000000e+00 0.00000000e+00 


### PR DESCRIPTION
Create new 'replace if valid' operator for initial temperature conditions. It checks if the value in the second model in a nan, if so it replaces with the value from the first model.

Test also included based on the tests for the other operators.