### PR TITLE
Provide a way to check whether the simulator has been completely initialized

### DIFF
--- a/doc/modules/changes/20190522_bangerth-4
+++ b/doc/modules/changes/20190522_bangerth-4
@@ -1,0 +1,6 @@
+New: There is now a function
+SimulatorAccess::simulator_is_past_initialization() that can be used
+to test whether the simulator has been completely initialized and has
+started the time loop.
+<br>
+(Wolfgang Bangerth, 2019/05/22)

--- a/doc/modules/changes/20190524_bangerth
+++ b/doc/modules/changes/20190524_bangerth
@@ -1,0 +1,6 @@
+Remove: The
+SimulatorAccessor::simulator_is_initialized() function has been
+removed. It was not used anywhere before. It has been superseded by
+the SimulatorAccess::simulator_is_past_initialization() function.
+<br>
+(Wolfgang Bangerth, 2019/05/24)

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -333,6 +333,25 @@ namespace aspect
 
     private:
 
+      /**
+       * A member variable that tracks whether we are completely done
+       * with initialization and have started the time loop. This
+       * variable needs to be the first one that is initialized in
+       * the constructor, so that its value correctly tracks the
+       * status of the overall object. As a consequence, it has to
+       * be the first one declared in this class.
+       *
+       * The variable is set to @p true just before we start the time
+       * stepping loop, but may be temporarily reset to @p false
+       * if, for example, we are during the initial mesh refinement
+       * steps where we start the time loop, but then go back to
+       * initialization steps (mesh refinement, interpolation of initial
+       * conditions, etc.) before re-starting the time loop.
+       *
+       * This variable is queried by
+       * SimulatorAccess::simulator_is_past_initialization().
+       */
+      bool simulator_is_initialized;
 
       /**
        * A class that is empty but that can be used as a member variable and

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -775,12 +775,6 @@ namespace aspect
       get_current_constraints () const;
 
       /**
-       * Return whether or not the current object has been initialized by providing it with
-       * a pointer to a Simulator class object.
-       */
-      bool simulator_is_initialized () const;
-
-      /**
        * Return whether the Simulator object has been completely initialized
        * and has started to run its time stepping loop.
        *

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -781,6 +781,40 @@ namespace aspect
       bool simulator_is_initialized () const;
 
       /**
+       * Return whether the Simulator object has been completely initialized
+       * and has started to run its time stepping loop.
+       *
+       * This function is useful to determine in a plugin whether some
+       * of the information one can query about the Simulator can be trusted
+       * because it has already been set up completely. For example,
+       * while the Simulator is being
+       * set up, plugins may already have access to it via the current
+       * SimulatorAccess object, but data such as the current time, the
+       * time step number, etc, may all still be in a state that is not
+       * reliable since it may not have been initialized at that time. (As
+       * an example, at the very beginning of the Simulator object's existence,
+       * the time step number is set to numbers::invalid_unsigned_int, and
+       * only when the time step loop is started is it set to a valid
+       * value). Similar examples are that at some point the Simulator
+       * sets the solution vector to the correct size, but only at a later
+       * time (though before the time stepping starts), the *contents* of
+       * the solution vector are set based on the initial conditions
+       * specified in the input file.
+       *
+       * Only when this function returns @p true is all of the information
+       * returned by the SimulatorAccess object reliable and correct.
+       *
+       * @note This function returns @p true starting with the moment where the
+       *   Simulator starts the time stepping loop. However, it may
+       *   temporarily revert to returning @p false if, for example,
+       *   the Simulator does the initial mesh refinement steps where
+       *   it starts the time loop, but then goes back to
+       *   initialization steps (mesh refinement, interpolation of initial
+       *   conditions, etc.) before re-starting the time loop.
+       */
+      bool simulator_is_past_initialization () const;
+
+      /**
        * Return the value used for rescaling the pressure in the linear
        * solver.
        */

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -66,9 +66,14 @@ namespace aspect
               // The negative of the second principle invariant is equal to 0.5 e_dot_dev_ij e_dot_dev_ji,
               // where e_dot_dev is the deviatoric strain rate tensor. The square root of this quantity
               // gives the common definition of effective strain rate.
-              const double edot_ii_strict = (this->simulator_is_initialized() == false
+              const double edot_ii_strict = (this->simulator_is_past_initialization() == false
                                              ?
-                                             // no simulator object available -- we are probably in a unit test
+                                             // no simulator object available via
+                                             // the SimulatorAccess base class, or the
+                                             // Simulator itself has not been completely
+                                             // initialized. This might mean that we are
+                                             // in a unit test, or at least that we can't
+                                             // rely on any simulator information
                                              std::fabs(second_invariant(strain_rate_deviator))
                                              :
                                              // simulator object is available, but we need to treat the

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -145,6 +145,7 @@ namespace aspect
   Simulator<dim>::Simulator (const MPI_Comm mpi_communicator_,
                              ParameterHandler &prm)
     :
+    simulator_is_initialized (false),
     assemblers (std_cxx14::make_unique<Assemblers::Manager<dim>>()),
     parameters (prm, mpi_communicator_),
     melt_handler (parameters.include_melt_transport ?
@@ -1802,7 +1803,9 @@ namespace aspect
           }
       }
 
-    // start the principal loop over time steps:
+    // Start the principal loop over time steps. At this point, everything
+    // is completely initialized, so set that status as well
+    simulator_is_initialized = true;
     do
       {
         // Only solve if we are not in pre-refinement, or we do not want to skip
@@ -1816,13 +1819,19 @@ namespace aspect
             solve_timestep ();
           }
 
-        // see if we have to start over with a new adaptive refinement cycle
-        // at the beginning of the simulation.
+        // See if we have to start over with a new adaptive refinement cycle
+        // at the beginning of the simulation. If so, set the
+        // simulator_is_initialized variable back to false because we will
+        // have to re-initialize some variables such as the size of vectors,
+        // the initial state, etc.
         if (timestep_number == 0)
           {
             const bool initial_refinement_done = maybe_do_initial_refinement(max_refinement_level);
             if (initial_refinement_done)
-              goto start_time_iteration;
+              {
+                simulator_is_initialized = false;
+                goto start_time_iteration;
+              }
           }
 
         // if we postprocess nonlinear iterations, this function is called within

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -685,6 +685,18 @@ namespace aspect
     return (simulator != nullptr);
   }
 
+
+
+  template <int dim>
+  bool
+  SimulatorAccess<dim>::simulator_is_past_initialization () const
+  {
+    return (simulator_is_initialized()
+            &&
+            (simulator->simulator_is_initialized == true));
+  }
+
+
   template <int dim>
   double
   SimulatorAccess<dim>::get_pressure_scaling () const

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -678,20 +678,13 @@ namespace aspect
     return simulator->current_constraints;
   }
 
-  template <int dim>
-  bool
-  SimulatorAccess<dim>::simulator_is_initialized () const
-  {
-    return (simulator != nullptr);
-  }
-
 
 
   template <int dim>
   bool
   SimulatorAccess<dim>::simulator_is_past_initialization () const
   {
-    return (simulator_is_initialized()
+    return ((simulator != nullptr)
             &&
             (simulator->simulator_is_initialized == true));
   }


### PR DESCRIPTION
This should provide @anne-glerum and @naliboff a way to do what they want to do, and more elegantly than they try to do in #2529.