### PR TITLE
Remove more references to std::shared_ptr.

### DIFF
--- a/include/aspect/boundary_velocity/gplates.h
+++ b/include/aspect/boundary_velocity/gplates.h
@@ -321,13 +321,13 @@ namespace aspect
          * Pointer to an object that reads and processes data we get from
          * gplates files.
          */
-        std::shared_ptr<internal::GPlatesLookup<dim> > lookup;
+        std::unique_ptr<internal::GPlatesLookup<dim> > lookup;
 
         /**
          * Pointer to an object that reads and processes data we get from
          * gplates files. This saves the previous data time step.
          */
-        std::shared_ptr<internal::GPlatesLookup<dim> > old_lookup;
+        std::unique_ptr<internal::GPlatesLookup<dim> > old_lookup;
 
         /**
          * Handles the update of the velocity data in lookup. The input

--- a/source/boundary_velocity/gplates.cc
+++ b/source/boundary_velocity/gplates.cc
@@ -571,8 +571,8 @@ namespace aspect
       if (((dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model())) != nullptr)
           || ((dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model())) != nullptr))
         {
-          lookup = std::make_shared<internal::GPlatesLookup<dim>>(pointone, pointtwo);
-          old_lookup = std::make_shared<internal::GPlatesLookup<dim>>(pointone, pointtwo);
+          lookup = std_cxx14::make_unique<internal::GPlatesLookup<dim>>(pointone, pointtwo);
+          old_lookup = std_cxx14::make_unique<internal::GPlatesLookup<dim>>(pointone, pointtwo);
         }
       else
         AssertThrow (false,ExcMessage ("This gplates plugin can only be used when using "


### PR DESCRIPTION
We're now down to less than one page of references to `std::shared_ptr`.

Part of #2811 and #2375.