### PR TITLE
Clean up an unused parameter file subsection.

### DIFF
--- a/benchmarks/time_dependent_annulus/time_dependent_annulus.prm
+++ b/benchmarks/time_dependent_annulus/time_dependent_annulus.prm
@@ -99,16 +99,6 @@ subsection Initial composition model
 end
 
 
-subsection Boundary temperature model
-  set List of model names = box
-
-  subsection Box
-    set Bottom temperature = 0
-    set Top temperature    = 0
-  end
-end
-
-
 subsection Initial temperature model
   set Model name = function
   subsection Function


### PR DESCRIPTION
This benchmark has no temperature boundary conditions (there are no indicators prescribed). Additionally, it is in a spherical shell, not a box.