### PR TITLE
Prohibit copying MaterialModelOutputs objects.

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -382,6 +382,38 @@ namespace aspect
                             const unsigned int n_comp);
 
       /**
+       * Copy constructor. This constructor copies all data members of the
+       * source object except for the additional output data (of type
+       * AdditionalMaterialOutputs) pointers, stored in the
+       * `source.additional_outputs` member variable.
+       *
+       * This is because these pointers can not be copied (they
+       * are unique to the @p source object). Since they can also not
+       * be recreated without the original code that created these objects
+       * in the first place, this constructor throws an exception if the
+       * @p source object had any additional input or output data objects
+       * associated with it.
+       */
+      MaterialModelOutputs (const MaterialModelOutputs &source);
+
+      /**
+       * Move constructor. This constructor simply moves all members.
+       */
+      MaterialModelOutputs (MaterialModelOutputs &&) = default;
+
+      /**
+       * Copy operator. This operator has the same restriction on the
+       * additional output data pointers as the copy constructor.
+       */
+      MaterialModelOutputs &operator= (const MaterialModelOutputs &source);
+
+      /**
+       * Move operator.
+       */
+      MaterialModelOutputs &operator= (MaterialModelOutputs &&) = default;
+
+
+      /**
        * Viscosity $\eta$ values at the given positions.
        */
       std::vector<double> viscosities;

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -413,6 +413,48 @@ namespace aspect
     {}
 
 
+    template <int dim>
+    MaterialModelOutputs<dim>::MaterialModelOutputs(const MaterialModelOutputs<dim> &source)
+      :
+      viscosities(source.viscosities),
+      densities(source.densities),
+      thermal_expansion_coefficients(source.thermal_expansion_coefficients),
+      specific_heat(source.specific_heat),
+      thermal_conductivities(source.thermal_conductivities),
+      compressibilities(source.compressibilities),
+      entropy_derivative_pressure(source.entropy_derivative_pressure),
+      entropy_derivative_temperature(source.entropy_derivative_temperature),
+      reaction_terms(source.reaction_terms),
+      additional_outputs()
+    {
+      Assert (source.additional_outputs.size() == 0,
+              ExcMessage ("You can not copy MaterialModelOutputs objects that have "
+                          "additional output objects attached"));
+    }
+
+
+    template <int dim>
+    MaterialModelOutputs<dim> &
+    MaterialModelOutputs<dim>::operator= (const MaterialModelOutputs<dim> &source)
+    {
+      viscosities = source.viscosities;
+      densities = source.densities;
+      thermal_expansion_coefficients = source.thermal_expansion_coefficients;
+      specific_heat = source.specific_heat;
+      thermal_conductivities = source.thermal_conductivities;
+      compressibilities = source.compressibilities;
+      entropy_derivative_pressure = source.entropy_derivative_pressure;
+      entropy_derivative_temperature = source.entropy_derivative_temperature;
+      reaction_terms = source.reaction_terms;
+      additional_outputs = {};
+      Assert (source.additional_outputs.size() == 0,
+              ExcMessage ("You can not copy MaterialModelOutputs objects that have "
+                          "additional output objects attached"));
+
+      return *this;
+    }
+
+
     namespace MaterialAveraging
     {
       std::string get_averaging_operation_names ()


### PR DESCRIPTION
This isn't going to compile, but because I think there is a debug I'd like to discuss with @jdannberg and @tjhei , I'm uploading it here anyway.

The point is this: `MaterialModelOutputs` objects can have additional output objects associated with them. Copying a `MaterialModelOutputs` object would require us to be able to re-create these additional output objects a second time, but we don't know how to do that without knowing who created the additional output objects. 

That said, in the current setup, we just store `std::shared_ptr`s to these additional outputs objects. That seems patently wrong, because now multiple `MaterialModelOutputs` objects might reference the same additional outputs objects, and that can surely not lead to anything useful.

The solution is to disallow copying these kinds of objects. This *should* work because I was hoping that nobody has made the mistake of copying them, but it turns out that's not the case: in `melt.cc` we have this:
```
      // Copy constructor
      PcConstraintsAssembleData (const PcConstraintsAssembleData &scratch)
        :
        finite_element_values (scratch.finite_element_values.get_mapping(),
                               scratch.finite_element_values.get_fe(),
                               scratch.finite_element_values.get_quadrature(),
                               scratch.finite_element_values.get_update_flags()),
        local_dof_indices (scratch.local_dof_indices),
        dof_component_indices( scratch.dof_component_indices),
        material_model_inputs(scratch.material_model_inputs),
        material_model_outputs(scratch.material_model_outputs)
      {}
```
and in `assemblers/interface.cc` we have this:
```
        template <int dim>
        StokesPreconditioner<dim>::
        StokesPreconditioner (const StokesPreconditioner &scratch)
          :
          ScratchBase<dim>(scratch),

          finite_element_values (scratch.finite_element_values.get_mapping(),
                                 scratch.finite_element_values.get_fe(),
                                 scratch.finite_element_values.get_quadrature(),
                                 scratch.finite_element_values.get_update_flags()),

          local_dof_indices (scratch.local_dof_indices),
          dof_component_indices( scratch.dof_component_indices),
          grads_phi_u (scratch.grads_phi_u),
          div_phi_u (scratch.div_phi_u),
          phi_p (scratch.phi_p),
          phi_p_c (scratch.phi_p_c),
          grad_phi_p(scratch.grad_phi_p),
          material_model_inputs(scratch.material_model_inputs),
          material_model_outputs(scratch.material_model_outputs),
          rebuild_stokes_matrix(scratch.rebuild_stokes_matrix)
        {}
```
(There is another similar occurrence in the same file.)

What do we do here? Do the additional material model outputs need to gain a `clone()` function?