### PR TITLE
Continental geotherm initial temperature condition

### DIFF
--- a/doc/modules/changes/24052019_glerum
+++ b/doc/modules/changes/24052019_glerum
@@ -1,0 +1,5 @@
+New: There is a new initial temperature plugin that
+sets up a steady-state continental geotherm for a 3-layer
+lithosphere.
+<br>
+(Anne Glerum, 2019/05/24)

--- a/include/aspect/initial_temperature/continental_geotherm.h
+++ b/include/aspect/initial_temperature/continental_geotherm.h
@@ -65,6 +65,10 @@ namespace aspect
         virtual
         double temperature (const double depth) const;
 
+        virtual
+        double temperature (const double depth,
+                            const std::vector<double> thicknesses) const;
+
         /**
          * Declare the parameters this class takes through input files.
          */

--- a/include/aspect/initial_temperature/continental_geotherm.h
+++ b/include/aspect/initial_temperature/continental_geotherm.h
@@ -87,7 +87,7 @@ namespace aspect
 
         /**
          * Vector for the thicknesses of the compositional fields
-         * representing the layers `upper`, `lower` and `mantle_L`.
+         * representing the layers 'upper_crust', 'lower_crust' and 'lithospheric_mantle'.
          */
         std::vector<double> thicknesses;
 

--- a/include/aspect/initial_temperature/continental_geotherm.h
+++ b/include/aspect/initial_temperature/continental_geotherm.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2014 - 2016 by the authors of the ASPECT code.
+  Copyright (C) 2014 - 2019 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -93,7 +93,8 @@ namespace aspect
         double LAB_isotherm;
 
         /**
-         * Vector for field depths
+         * Vector for the thicknesses of the compositional fields
+         * representing the layers `upper`, `lower` and `mantle_L`.
          */
         std::vector<double> thicknesses;
 

--- a/include/aspect/initial_temperature/continental_geotherm.h
+++ b/include/aspect/initial_temperature/continental_geotherm.h
@@ -1,0 +1,117 @@
+/*
+  Copyright (C) 2014 - 2016 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+
+#ifndef _aspect_initial_temperature_continental_geotherm_h
+#define _aspect_initial_temperature_continental_geotherm_h
+
+#include <aspect/initial_temperature/interface.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+
+
+  namespace InitialTemperature
+  {
+
+    /**
+     *
+     * @ingroup InitialTemperatures
+     */
+    template <int dim>
+    class ContinentalGeotherm : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * Constructor.
+         */
+        ContinentalGeotherm ();
+
+        /**
+         * Initialization function. This function is called once at the
+         * beginning of the program. Checks preconditions.
+         */
+        void
+        initialize ();
+
+        /**
+         * Return the initial temperature as a function of position.
+         */
+        virtual
+        double initial_temperature (const Point<dim> &position) const;
+
+        /**
+         * Return the initial temperature as a function of position.
+         */
+        virtual
+        double temperature (const double depth) const;
+
+        /**
+         * Declare the parameters this class takes through input files.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         */
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
+
+      private:
+        /**
+         * Surface temperature
+         */
+        double T0;
+
+        /**
+         * LAB isotherm temperature
+         */
+        double LAB_isotherm;
+
+        /**
+         * Vector for field heat production rates, read from parameter file .
+         */
+        std::vector<double> heat_productivities;
+
+        /**
+         * Vector for thermal conductivities, read from parameter file .
+         */
+        std::vector<double> conductivities;
+
+        /**
+         * Vector for field densities, read from parameter file .
+         */
+        std::vector<double> densities;
+
+        /**
+         * Vector for field depths, read from parameter file .
+         */
+        std::vector<double> thicknesses;
+    };
+  }
+}
+
+
+#endif

--- a/include/aspect/initial_temperature/continental_geotherm.h
+++ b/include/aspect/initial_temperature/continental_geotherm.h
@@ -28,8 +28,6 @@
 
 namespace aspect
 {
-
-
   namespace InitialTemperature
   {
 
@@ -54,18 +52,12 @@ namespace aspect
         initialize ();
 
         /**
-         * Return the initial temperature as a function of position.
-         */
-        virtual
-        double initial_temperature (const Point<dim> &position) const;
-
-        /**
          * Return the initial temperature as a function of depth,
          * based on the solution of the steady-state heat conduction
          * differential equation.
          */
         virtual
-        double temperature (const double depth) const;
+        double initial_temperature (const Point<dim> &position) const;
 
         /**
          * Declare the parameters this class takes through input files.
@@ -88,7 +80,8 @@ namespace aspect
         double T0;
 
         /**
-         * LAB isotherm temperature
+         * Value of the isotherm defining the
+         * Lithosphere-Asthenosphere boundary.
          */
         double LAB_isotherm;
 
@@ -99,17 +92,20 @@ namespace aspect
         std::vector<double> thicknesses;
 
         /**
-         * Vector for field heat production rates, read from parameter file.
+         * Vector for the heat production rates of the different
+         * compositional fields, read from parameter file.
          */
         std::vector<double> heat_productivities;
 
         /**
-         * Vector for thermal conductivities, read from parameter file.
+         * Vector for the thermal conductivities of the different
+         * compositional fields, read from parameter file.
          */
         std::vector<double> conductivities;
 
         /**
-         * Vector for field densities, read from parameter file.
+         * Vector for the densities of the different compositional
+         * fields, read from parameter file.
          */
         std::vector<double> densities;
     };

--- a/include/aspect/initial_temperature/continental_geotherm.h
+++ b/include/aspect/initial_temperature/continental_geotherm.h
@@ -60,7 +60,9 @@ namespace aspect
         double initial_temperature (const Point<dim> &position) const;
 
         /**
-         * Return the initial temperature as a function of position.
+         * Return the initial temperature as a function of depth,
+         * based on the solution of the steady-state heat conduction
+         * differential equation.
          */
         virtual
         double temperature (const double depth) const;
@@ -95,24 +97,24 @@ namespace aspect
         double LAB_isotherm;
 
         /**
-         * Vector for field heat production rates, read from parameter file .
+         * Vector for field depths
+         */
+        std::vector<double> thicknesses;
+
+        /**
+         * Vector for field heat production rates, read from parameter file.
          */
         std::vector<double> heat_productivities;
 
         /**
-         * Vector for thermal conductivities, read from parameter file .
+         * Vector for thermal conductivities, read from parameter file.
          */
         std::vector<double> conductivities;
 
         /**
-         * Vector for field densities, read from parameter file .
+         * Vector for field densities, read from parameter file.
          */
         std::vector<double> densities;
-
-        /**
-         * Vector for field depths, read from parameter file .
-         */
-        std::vector<double> thicknesses;
     };
   }
 }

--- a/include/aspect/initial_temperature/continental_geotherm.h
+++ b/include/aspect/initial_temperature/continental_geotherm.h
@@ -67,10 +67,6 @@ namespace aspect
         virtual
         double temperature (const double depth) const;
 
-        virtual
-        double temperature (const double depth,
-                            const std::vector<double> thicknesses) const;
-
         /**
          * Declare the parameters this class takes through input files.
          */

--- a/source/initial_temperature/continental_geotherm.cc
+++ b/source/initial_temperature/continental_geotherm.cc
@@ -59,7 +59,7 @@ namespace aspect
     initial_temperature (const Point<dim> &position) const
     {
       const double depth = this->get_geometry_model().depth(position);
-      
+
       return temperature(depth);
     }
 
@@ -75,27 +75,27 @@ namespace aspect
       const double b = 1./(conductivities[0]/thicknesses[0]+conductivities[1]/thicknesses[1]);
       const double c = 0.5*densities[1]*heat_productivities[1]*thicknesses[1] + conductivities[2]/thicknesses[2]*LAB_isotherm;
       const double d = 1./(conductivities[1]/thicknesses[1]+conductivities[2]/thicknesses[2]);
-      
+
       //Temperature at boundary between layer 1 and 2
       const double T1 = (a*b + conductivities[1]/thicknesses[1]*c*d*b) / (1.-(conductivities[1]*conductivities[1])/(thicknesses[1]*thicknesses[1])*d*b);
       //Temperature at boundary between layer 2 and 3
       const double T2 = (c + conductivities[1]/thicknesses[1]*T1) * d;
 
       // Temperature in layer 1
-      if(depth <= thicknesses[0])
-          return -0.5*densities[0]*heat_productivities[0]/conductivities[0]*std::pow(depth,2) + (0.5*densities[0]*heat_productivities[0]*thicknesses[0]/conductivities[0] + (T1-T0)/thicknesses[0])*depth + T0;
+      if (depth <= thicknesses[0])
+        return -0.5*densities[0]*heat_productivities[0]/conductivities[0]*std::pow(depth,2) + (0.5*densities[0]*heat_productivities[0]*thicknesses[0]/conductivities[0] + (T1-T0)/thicknesses[0])*depth + T0;
       // Temperature in layer 2
       else if (depth <= thicknesses[0]+thicknesses[1])
-          return -0.5*densities[1]*heat_productivities[1]/conductivities[1]*std::pow(depth-thicknesses[0],2.) + (0.5*densities[1]*heat_productivities[1]*thicknesses[1]/conductivities[1] + (T2-T1)/thicknesses[1])*(depth-thicknesses[0]) + T1;
+        return -0.5*densities[1]*heat_productivities[1]/conductivities[1]*std::pow(depth-thicknesses[0],2.) + (0.5*densities[1]*heat_productivities[1]*thicknesses[1]/conductivities[1] + (T2-T1)/thicknesses[1])*(depth-thicknesses[0]) + T1;
       // Temperature in layer 3
       else if (depth <= thicknesses[0]+thicknesses[1]+thicknesses[2])
-          return (LAB_isotherm-T2)/thicknesses[2] *(depth-thicknesses[0]-thicknesses[1]) + T2;
+        return (LAB_isotherm-T2)/thicknesses[2] *(depth-thicknesses[0]-thicknesses[1]) + T2;
       // Return a constant sublithospheric temperature of 10*LAB_isotherm.
       // This way we can combine the continental geotherm with an adiabatic profile from the input file
       // using the "minimum" operator on the "List of initial temperature models"
       else
         return 10.*LAB_isotherm;
- 
+
     }
 
     template <int dim>
@@ -116,17 +116,17 @@ namespace aspect
       const double T2 = (c + conductivities[1]/layer_thicknesses[1]*T1) * d;
 
       // Temperature in layer 1
-      if(depth < layer_thicknesses[0])
-          return -0.5*densities[0]*heat_productivities[0]/conductivities[0]*std::pow(depth,2) + (0.5*densities[0]*heat_productivities[0]*layer_thicknesses[0]/conductivities[0] + (T1-T0)/layer_thicknesses[0])*depth + T0;
+      if (depth < layer_thicknesses[0])
+        return -0.5*densities[0]*heat_productivities[0]/conductivities[0]*std::pow(depth,2) + (0.5*densities[0]*heat_productivities[0]*layer_thicknesses[0]/conductivities[0] + (T1-T0)/layer_thicknesses[0])*depth + T0;
       // Temperature in layer 2
       else if (depth < layer_thicknesses[0]+layer_thicknesses[1])
-          return -0.5*densities[1]*heat_productivities[1]/conductivities[1]*std::pow(depth-layer_thicknesses[0],2.) + (0.5*densities[1]*heat_productivities[1]*layer_thicknesses[1]/conductivities[1] + (T2-T1)/layer_thicknesses[1])*(depth-layer_thicknesses[0]) + T1;
+        return -0.5*densities[1]*heat_productivities[1]/conductivities[1]*std::pow(depth-layer_thicknesses[0],2.) + (0.5*densities[1]*heat_productivities[1]*layer_thicknesses[1]/conductivities[1] + (T2-T1)/layer_thicknesses[1])*(depth-layer_thicknesses[0]) + T1;
       // Temperature in layer 3
       else if (depth < layer_thicknesses[0]+layer_thicknesses[1]+layer_thicknesses[2])
-          return (LAB_isotherm-T2)/layer_thicknesses[2] *(depth-layer_thicknesses[0]-layer_thicknesses[1]) + T2;
+        return (LAB_isotherm-T2)/layer_thicknesses[2] *(depth-layer_thicknesses[0]-layer_thicknesses[1]) + T2;
       // Return a constant sublithospheric temperature of 10*LAB_isotherm.
       // This way we can combine the continental geotherm with an adiabatic profile from the input file
-      // using the "minimum" operator on the "List of initial temperature models"
+      // using the "minimum" operator on the "List of initial temperature models".
       else
         return 10.*LAB_isotherm;
 
@@ -168,7 +168,7 @@ namespace aspect
       unsigned int n_fields = 0;
       prm.enter_subsection ("Compositional fields");
       {
-       n_fields = prm.get_integer ("Number of fields");
+        n_fields = prm.get_integer ("Number of fields");
       }
       prm.leave_subsection();
 
@@ -180,8 +180,8 @@ namespace aspect
           LAB_isotherm = prm.get_double ("LAB isotherm temperature");
           T0 = prm.get_double ("Surface temperature");
           thicknesses = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Layer thicknesses"))),
-                                                              3,
-                                                              "Layer thicknesses");
+                                                                3,
+                                                                "Layer thicknesses");
         }
         prm.leave_subsection();
       }
@@ -198,8 +198,8 @@ namespace aspect
       const unsigned int id_lower = this->introspection().compositional_index_for_name("lower");
       const unsigned int id_mantle_L = this->introspection().compositional_index_for_name("mantle_L");
 
-            // Retrieve other material properties set in different sections such that there
-            // is no need to set them twice.
+      // Retrieve other material properties set in different sections such that there
+      // is no need to set them twice.
 
       prm.enter_subsection("Heating model");
       {
@@ -207,8 +207,8 @@ namespace aspect
         {
           // The heating model compositional heating prefixes an entry for the background material
           const std::vector<double> temp_heat_productivities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Compositional heating values"))),
-                                                                   n_fields+1,
-                                                                   "Compositional heating values");
+                                                               n_fields+1,
+                                                               "Compositional heating values");
           // This sets the heat productivity in W/m3 units
           heat_productivities.push_back(temp_heat_productivities[id_upper+1]);
           heat_productivities.push_back(temp_heat_productivities[id_lower+1]);
@@ -224,14 +224,14 @@ namespace aspect
         {
           // The material model viscoplastic prefixes an entry for the background material
           const std::vector<double> temp_densities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Densities"))),
-                                                                   n_fields+1,
-                                                                   "Densities");
+                                                     n_fields+1,
+                                                     "Densities");
           const std::vector<double> temp_thermal_diffusivities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Thermal diffusivities"))),
-                                                                                  n_fields+1,
-                                                                         "Thermal diffusivities");
+                                                                 n_fields+1,
+                                                                 "Thermal diffusivities");
           const std::vector<double> temp_heat_capacities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Heat capacities"))),
-                                                                           n_fields+1,
-                                                                        "Heat capacities");
+                                                           n_fields+1,
+                                                           "Heat capacities");
 
           densities.push_back(temp_densities[id_upper+1]);
           densities.push_back(temp_densities[id_lower+1]);
@@ -247,7 +247,7 @@ namespace aspect
                       ExcMessage("The entries for density, conductivity and heat production do not match with the expected number of layers (3)."))
 
           for (unsigned int i = 0; i<3; ++i)
-          heat_productivities[i] /= densities[i];
+            heat_productivities[i] /= densities[i];
         }
         prm.leave_subsection();
       }
@@ -271,9 +271,18 @@ namespace aspect
                                               "This is a temperature initial condition that "
                                               "computes a continental geotherm based on the "
                                               "conductive equations of Turcotte and Schubert Ch. 4.6. "
-                                              "The geotherm can be computed for any number of crustal "
-                                              "layers, for each of which a density, heat production and thermal "
-                                              "conductivity should be supplied. "
+                                              "The geotherm is computed for a homogeneous lithosphere "
+                                              "composed of an upper crust, lower crust and mantle layer. "
+                                              "Layer thicknesses, surface temperature and LAB temperature "
+                                              "should be specified by the user. "
+                                              "For consistency, the density, heat production and thermal "
+                                              "conductivity of each layer are read from the visco plastic material model "
+                                              "and the compositional heating model. "
+                                              "\n"
+                                              "For any depths below the depth of the LAB, a unrealistically high "
+                                              "temperature is returned, such that this plugin can be combined with "
+                                              "another temperature plugin through the 'minimum' operator. "
+                                              "\n"
                                               "Make sure the top and bottom temperatures of the lithosphere "
                                               "agree with temperatures set in for example the temperature "
                                               "boundary conditions.")

--- a/source/initial_temperature/continental_geotherm.cc
+++ b/source/initial_temperature/continental_geotherm.cc
@@ -48,7 +48,7 @@ namespace aspect
                   ExcMessage("The continental geotherm initial temperature plugin requires the compositional heating plugin."));
 
       // Check that the required material model ("visco plastic") is used
-      AssertThrow((dynamic_cast<MaterialModel::ViscoPlastic<dim> *> (const_cast<MaterialModel::Interface<dim> *>(&this->get_material_model()))) != 0,
+      AssertThrow(Plugins::plugin_type_matches<MaterialModel::ViscoPlastic<dim> >(this->get_material_model()),
                   ExcMessage("The continental geotherm initial temperature plugin requires the viscoplastic material model plugin."));
     }
 
@@ -58,19 +58,9 @@ namespace aspect
     ContinentalGeotherm<dim>::
     initial_temperature (const Point<dim> &position) const
     {
-      // Return the temperature based on the depth of the point with
-      // respect to the reference surface.
+      // Get the depth of the point with respect to the reference surface.
       const double depth = this->get_geometry_model().depth(position);
 
-      return temperature(depth);
-    }
-
-
-    template <int dim>
-    double
-    ContinentalGeotherm<dim>::
-    temperature (const double depth) const
-    {
       // Compute some constants to calculate the temperatures T1 and T2 at the interfaces
       // between the layers upper crust/lower crust (depth y=h1) and lower crust/lithospheric mantle (depth y=h1+h2).
       // T1 = (ab + k2/h2 cdb) / (1 - k2^2/h2^2 db)
@@ -97,12 +87,11 @@ namespace aspect
       // Temperature in layer 3
       else if (depth <= thicknesses[0]+thicknesses[1]+thicknesses[2])
         return (LAB_isotherm-T2)/thicknesses[2] *(depth-thicknesses[0]-thicknesses[1]) + T2;
-      // Return a constant sublithospheric temperature of 100*LAB_isotherm.
+      // Return an unrealistically high temperature if we're below the lithosphere.
       // This way we can combine the continental geotherm with an adiabatic profile from the input file
       // using the "minimum" operator on the "List of initial temperature models"
       else
-        return 100.*LAB_isotherm;
-
+        return std::numeric_limits<double>::max();
     }
 
 
@@ -117,16 +106,17 @@ namespace aspect
         {
           prm.declare_entry ("Layer thicknesses", "30000.",
                              Patterns::List(Patterns::Double(0)),
-                             "List of thicknesses for the bottom of the lithospheric layers,"
-                             "for a total of N+1 values, where N is the number of compositional fields."
-                             "If only one value is given, then all use the same value.  Units: $kg / m^3$");
+                             "List of the 3 thicknesses of the lithospheric layers "
+                             "'upper_crust', 'lower_crust' and 'mantle_lithosphere'. "
+                             "If only one thickness is given, then the same thickness is used "
+                             "for all layers. Units: $m$");
           prm.declare_entry ("Surface temperature", "273.15",
                              Patterns::Double (0),
                              "The value of the surface temperature. Units: Kelvin.");
-          prm.declare_entry ("LAB isotherm temperature", "1673.15",
+          prm.declare_entry ("Lithosphere-Asthenosphere boundary isotherm", "1673.15",
                              Patterns::Double (0),
-                             "The value of the isothermal boundary temperature assumed at the LAB "
-                             "and up to the reference depth . Units: Kelvin.");
+                             "The value of the isotherm that is assumed at the Lithosphere-"
+                             "Asthenosphere boundary. Units: Kelvin.");
         }
         prm.leave_subsection();
       }
@@ -151,7 +141,7 @@ namespace aspect
       {
         prm.enter_subsection("Continental geotherm");
         {
-          LAB_isotherm = prm.get_double ("LAB isotherm temperature");
+          LAB_isotherm = prm.get_double ("Lithosphere-Asthenosphere boundary isotherm");
           T0 = prm.get_double ("Surface temperature");
           thicknesses = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Layer thicknesses"))),
                                                                 3,
@@ -163,14 +153,14 @@ namespace aspect
 
 
       // Retrieve the indices of the fields that represent the lithospheric layers.
-      AssertThrow(this->introspection().compositional_name_exists("upper"),ExcMessage("We need a compositional field called 'upper' representing the upper crust."));
-      AssertThrow(this->introspection().compositional_name_exists("lower"),ExcMessage("We need a compositional field called 'lower' representing the lower crust."));
-      AssertThrow(this->introspection().compositional_name_exists("mantle_L"),ExcMessage("We need a compositional field called 'mantle_L' representing the lithospheric part of the mantle."));
+      AssertThrow(this->introspection().compositional_name_exists("upper_crust"),ExcMessage("We need a compositional field called 'upper' representing the upper crust."));
+      AssertThrow(this->introspection().compositional_name_exists("lower_crust"),ExcMessage("We need a compositional field called 'lower' representing the lower crust."));
+      AssertThrow(this->introspection().compositional_name_exists("lithospheric_mantle"),ExcMessage("We need a compositional field called 'mantle_L' representing the lithospheric part of the mantle."));
 
       // For now, we assume a 3-layer system with an upper crust, lower crust and lithospheric mantle
-      const unsigned int id_upper = this->introspection().compositional_index_for_name("upper");
-      const unsigned int id_lower = this->introspection().compositional_index_for_name("lower");
-      const unsigned int id_mantle_L = this->introspection().compositional_index_for_name("mantle_L");
+      const unsigned int id_upper_crust = this->introspection().compositional_index_for_name("upper_crust");
+      const unsigned int id_lower_crust = this->introspection().compositional_index_for_name("lower_crust");
+      const unsigned int id_lithospheric_mantle = this->introspection().compositional_index_for_name("lithospheric_mantle");
 
       // Retrieve other material properties set in different sections such that there
       // is no need to set them twice.
@@ -184,9 +174,9 @@ namespace aspect
                                                                n_fields+1,
                                                                "Compositional heating values");
           // This sets the heat productivity in W/m3 units
-          heat_productivities.push_back(temp_heat_productivities[id_upper+1]);
-          heat_productivities.push_back(temp_heat_productivities[id_lower+1]);
-          heat_productivities.push_back(temp_heat_productivities[id_mantle_L+1]);
+          heat_productivities.push_back(temp_heat_productivities[id_upper_crust+1]);
+          heat_productivities.push_back(temp_heat_productivities[id_lower_crust+1]);
+          heat_productivities.push_back(temp_heat_productivities[id_lithospheric_mantle+1]);
         }
         prm.leave_subsection();
       }
@@ -196,7 +186,7 @@ namespace aspect
       {
         prm.enter_subsection("Visco Plastic");
         {
-          // The material model viscoplastic prefixes an entry for the background material
+          // The material model viscoplastic prefixes an entry for the background material, hence n_fields+1
           const std::vector<double> temp_densities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Densities"))),
                                                      n_fields+1,
                                                      "Densities");
@@ -207,14 +197,17 @@ namespace aspect
                                                            n_fields+1,
                                                            "Heat capacities");
 
-          densities.push_back(temp_densities[id_upper+1]);
-          densities.push_back(temp_densities[id_lower+1]);
-          densities.push_back(temp_densities[id_mantle_L+1]);
+          // The material model viscoplastic prefixes an entry for the background material, hence id+1
+          densities.push_back(temp_densities[id_upper_crust+1]);
+          densities.push_back(temp_densities[id_lower_crust+1]);
+          densities.push_back(temp_densities[id_lithospheric_mantle+1]);
 
-          // Thermal diffusivity kappa = k/(rho*cp), so thermal conducitivity k = kappa*rho*cp
-          conductivities.push_back(temp_thermal_diffusivities[id_upper+1] * densities[0] * temp_heat_capacities[id_upper+1]);
-          conductivities.push_back(temp_thermal_diffusivities[id_lower+1] * densities[1] * temp_heat_capacities[id_lower+1]);
-          conductivities.push_back(temp_thermal_diffusivities[id_mantle_L+1] * densities[2] * temp_heat_capacities[id_mantle_L+1]);
+          // Thermal diffusivity kappa = k/(rho*cp), so thermal conductivity k = kappa*rho*cp.
+          // The densities are already in the right order, so we don't need to use the compositional
+          // field ids.
+          conductivities.push_back(temp_thermal_diffusivities[id_upper_crust+1] * densities[0] * temp_heat_capacities[id_upper_crust+1]);
+          conductivities.push_back(temp_thermal_diffusivities[id_lower_crust+1] * densities[1] * temp_heat_capacities[id_lower_crust+1]);
+          conductivities.push_back(temp_thermal_diffusivities[id_lithospheric_mantle+1] * densities[2] * temp_heat_capacities[id_lithospheric_mantle+1]);
 
           // To obtain the radioactive heating rate in W/kg, we divide the volumetric heating rate by density
           AssertThrow(heat_productivities.size() == 3 && densities.size() == 3 && conductivities.size() == 3,

--- a/source/initial_temperature/continental_geotherm.cc
+++ b/source/initial_temperature/continental_geotherm.cc
@@ -70,7 +70,7 @@ namespace aspect
     temperature (const double depth) const
     {
       // Compute some constants to calculate the temperatures T1 and T2 at the interfaces
-      // between the layers.
+      // between the layers upper crust/lower crust and lower crust/lithospheric mantle.
       const double a = 0.5*densities[0]*heat_productivities[0]*thicknesses[0] + 0.5*densities[1]*heat_productivities[1]*thicknesses[1] + conductivities[0]/thicknesses[0]*T0;
       const double b = 1./(conductivities[0]/thicknesses[0]+conductivities[1]/thicknesses[1]);
       const double c = 0.5*densities[1]*heat_productivities[1]*thicknesses[1] + conductivities[2]/thicknesses[2]*LAB_isotherm;

--- a/source/initial_temperature/continental_geotherm.cc
+++ b/source/initial_temperature/continental_geotherm.cc
@@ -153,9 +153,9 @@ namespace aspect
 
 
       // Retrieve the indices of the fields that represent the lithospheric layers.
-      AssertThrow(this->introspection().compositional_name_exists("upper_crust"),ExcMessage("We need a compositional field called 'upper' representing the upper crust."));
-      AssertThrow(this->introspection().compositional_name_exists("lower_crust"),ExcMessage("We need a compositional field called 'lower' representing the lower crust."));
-      AssertThrow(this->introspection().compositional_name_exists("lithospheric_mantle"),ExcMessage("We need a compositional field called 'mantle_L' representing the lithospheric part of the mantle."));
+      AssertThrow(this->introspection().compositional_name_exists("upper_crust"),ExcMessage("We need a compositional field called 'upper_crust' representing the upper crust."));
+      AssertThrow(this->introspection().compositional_name_exists("lower_crust"),ExcMessage("We need a compositional field called 'lower_crust' representing the lower crust."));
+      AssertThrow(this->introspection().compositional_name_exists("lithospheric_mantle"),ExcMessage("We need a compositional field called 'lithospheric_mantle' representing the lithospheric part of the mantle."));
 
       // For now, we assume a 3-layer system with an upper crust, lower crust and lithospheric mantle
       const unsigned int id_upper_crust = this->introspection().compositional_index_for_name("upper_crust");
@@ -259,8 +259,8 @@ namespace aspect
                                               "Note that the current implementation only works for a 3-layer lithosphere, "
                                               "even though in principle the heat conduction equation can be solved "
                                               "for any number of layers. The naming of the compositional fields "
-                                              "that represent the layers is also very specific, namely 'upper', "
-                                              "'lower', and 'mantle_L'. "
+                                              "that represent the layers is also very specific, namely `upper_crust', "
+                                              "`lower_crust', and `lithospheric_mantle'. "
                                               "\n"
                                               "Make sure the top and bottom temperatures of the lithosphere "
                                               "agree with temperatures set in for example the temperature "

--- a/source/initial_temperature/continental_geotherm.cc
+++ b/source/initial_temperature/continental_geotherm.cc
@@ -69,7 +69,8 @@ namespace aspect
     ContinentalGeotherm<dim>::
     temperature (const double depth) const
     {
-      // Compute some constants
+      // Compute some constants to calculate the temperatures T1 and T2 at the interfaces
+      // between the layers.
       const double a = 0.5*densities[0]*heat_productivities[0]*thicknesses[0] + 0.5*densities[1]*heat_productivities[1]*thicknesses[1] + conductivities[0]/thicknesses[0]*T0;
       const double b = 1./(conductivities[0]/thicknesses[0]+conductivities[1]/thicknesses[1]);
       const double c = 0.5*densities[1]*heat_productivities[1]*thicknesses[1] + conductivities[2]/thicknesses[2]*LAB_isotherm;
@@ -81,13 +82,13 @@ namespace aspect
       const double T2 = (c + conductivities[1]/thicknesses[1]*T1) * d;
 
       // Temperature in layer 1
-      if(depth < thicknesses[0])
+      if(depth <= thicknesses[0])
           return -0.5*densities[0]*heat_productivities[0]/conductivities[0]*std::pow(depth,2) + (0.5*densities[0]*heat_productivities[0]*thicknesses[0]/conductivities[0] + (T1-T0)/thicknesses[0])*depth + T0;
       // Temperature in layer 2
-      else if (depth < thicknesses[0]+thicknesses[1])
+      else if (depth <= thicknesses[0]+thicknesses[1])
           return -0.5*densities[1]*heat_productivities[1]/conductivities[1]*std::pow(depth-thicknesses[0],2.) + (0.5*densities[1]*heat_productivities[1]*thicknesses[1]/conductivities[1] + (T2-T1)/thicknesses[1])*(depth-thicknesses[0]) + T1;
       // Temperature in layer 3
-      else if (depth < thicknesses[0]+thicknesses[1]+thicknesses[2])
+      else if (depth <= thicknesses[0]+thicknesses[1]+thicknesses[2])
           return (LAB_isotherm-T2)/thicknesses[2] *(depth-thicknesses[0]-thicknesses[1]) + T2;
       // Return a constant sublithospheric temperature of 10*LAB_isotherm.
       // This way we can combine the continental geotherm with an adiabatic profile from the input file
@@ -238,11 +239,10 @@ namespace aspect
 
           // Thermal diffusivity kappa = k/(rho*cp), so thermal conducitivity k = kappa*rho*cp
           conductivities.push_back(temp_thermal_diffusivities[id_upper+1] * densities[0] * temp_heat_capacities[id_upper+1]);
-          conductivities.push_back(temp_thermal_diffusivities[id_lower+1] * densities[0] * temp_heat_capacities[id_lower+1]);
-          conductivities.push_back(temp_thermal_diffusivities[id_mantle_L+1] * densities[0] * temp_heat_capacities[id_mantle_L+1]);
+          conductivities.push_back(temp_thermal_diffusivities[id_lower+1] * densities[1] * temp_heat_capacities[id_lower+1]);
+          conductivities.push_back(temp_thermal_diffusivities[id_mantle_L+1] * densities[2] * temp_heat_capacities[id_mantle_L+1]);
 
           // To obtain the radioactive heating rate in W/kg, we divide the volumetric heating rate by density
-          // TODO: does this work?
           AssertThrow(heat_productivities.size() == 3 && densities.size() == 3 && conductivities.size() == 3,
                       ExcMessage("The entries for density, conductivity and heat production do not match with the expected number of layers (3)."))
 

--- a/source/initial_temperature/continental_geotherm.cc
+++ b/source/initial_temperature/continental_geotherm.cc
@@ -1,0 +1,247 @@
+/*
+  Copyright (C) 2011 - 2016 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file doc/COPYING.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/initial_temperature/continental_geotherm.h>
+#include <aspect/utilities.h>
+#include <aspect/geometry_model/spherical_shell.h>
+#include <aspect/boundary_temperature/interface.h>
+#include <aspect/material_model/visco_plastic.h>
+#include <aspect/heating_model/interface.h>
+
+#include <cmath>
+
+namespace aspect
+{
+  namespace InitialTemperature
+  {
+    template <int dim>
+    ContinentalGeotherm<dim>::ContinentalGeotherm ()
+    {}
+
+
+    template <int dim>
+    void
+    ContinentalGeotherm<dim>::
+    initialize ()
+    {
+      // Check that the required radioactive heating model ("compositional heating") is used
+      const std::vector<std::string> &heating_models = this->get_heating_model_manager().get_active_heating_model_names();
+      AssertThrow(std::find(heating_models.begin(), heating_models.end(), "compositional heating") != heating_models.end(),
+                  ExcMessage("The continental geotherm initial temperature plugin requires the compositional heating plugin."));
+
+      // Check that the required material model ("visco plastic") is used
+      AssertThrow((dynamic_cast<MaterialModel::ViscoPlastic<dim> *> (const_cast<MaterialModel::Interface<dim> *>(&this->get_material_model()))) != 0,
+                  ExcMessage("The continental geotherm initial temperature plugin requires the viscoplastic material model plugin."));
+    }
+
+
+    template <int dim>
+    double
+    ContinentalGeotherm<dim>::
+    initial_temperature (const Point<dim> &position) const
+    {
+      const double depth = this->get_geometry_model().depth(position);
+      
+      return temperature(depth);
+    }
+
+
+    template <int dim>
+    double
+    ContinentalGeotherm<dim>::
+    temperature (const double depth) const
+    {
+      // Compute some constants
+      const double a = 0.5*densities[0]*heat_productivities[0]*thicknesses[0] + 0.5*densities[1]*heat_productivities[1]*thicknesses[1] + conductivities[0]/thicknesses[0]*T0;
+      const double b = 1./(conductivities[0]/thicknesses[0]+conductivities[1]/thicknesses[1]);
+      const double c = 0.5*densities[1]*heat_productivities[1]*thicknesses[1] + conductivities[2]/thicknesses[2]*LAB_isotherm;
+      const double d = 1./(conductivities[1]/thicknesses[1]+conductivities[2]/thicknesses[2]);
+      
+      //Temperature at boundary between layer 1 and 2
+      const double T1 = (a*b + conductivities[1]/thicknesses[1]*c*d*b) / (1.-(conductivities[1]*conductivities[1])/(thicknesses[1]*thicknesses[1])*d*b);
+      //Temperature at boundary between layer 2 and 3
+      const double T2 = (c + conductivities[1]/thicknesses[1]*T1) * d;
+
+      // Temperature in layer 1
+      if(depth < thicknesses[0])
+          return -0.5*densities[0]*heat_productivities[0]/conductivities[0]*std::pow(depth,2) + (0.5*densities[0]*heat_productivities[0]*thicknesses[0]/conductivities[0] + (T1-T0)/thicknesses[0])*depth + T0;
+      // Temperature in layer 2
+      else if (depth < thicknesses[0]+thicknesses[1])
+          return -0.5*densities[1]*heat_productivities[1]/conductivities[1]*std::pow(depth-thicknesses[0],2.) + (0.5*densities[1]*heat_productivities[1]*thicknesses[1]/conductivities[1] + (T2-T1)/thicknesses[1])*(depth-thicknesses[0]) + T1;
+      // Temperature in layer 3
+      else if (depth < thicknesses[0]+thicknesses[1]+thicknesses[2])
+          return (LAB_isotherm-T2)/thicknesses[2] *(depth-thicknesses[0]-thicknesses[1]) + T2;
+      // Return a constant sublithospheric temperature of 10*LAB_isotherm.
+      // This way we can combine the continental geotherm with an adiabatic profile from the input file
+      // using the "minimum" operator on the "List of initial temperature models"
+      else
+        return 10.*LAB_isotherm;
+ 
+    }
+
+
+    template <int dim>
+    void
+    ContinentalGeotherm<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection ("Initial temperature model");
+      {
+        prm.enter_subsection("Continental geotherm");
+        {
+          prm.declare_entry ("Layer thicknesses", "30000.",
+                             Patterns::List(Patterns::Double(0)),
+                             "List of thicknesses for the bottom of the lithospheric layers,"
+                             "for a total of N+1 values, where N is the number of compositional fields."
+                             "If only one value is given, then all use the same value.  Units: $kg / m^3$");
+          prm.declare_entry ("Surface temperature", "273.15",
+                             Patterns::Double (0),
+                             "The value of the surface temperature. Units: Kelvin.");
+          prm.declare_entry ("LAB isotherm temperature", "1673.15",
+                             Patterns::Double (0),
+                             "The value of the isothermal boundary temperature assumed at the LAB "
+                             "and up to the reference depth . Units: Kelvin.");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+
+
+    template <int dim>
+    void
+    ContinentalGeotherm<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      unsigned int n_fields = 0;
+      prm.enter_subsection ("Compositional fields");
+      {
+       n_fields = prm.get_integer ("Number of fields");
+      }
+      prm.leave_subsection();
+
+
+      prm.enter_subsection ("Initial temperature model");
+      {
+        prm.enter_subsection("Continental geotherm");
+        {
+          LAB_isotherm = prm.get_double ("LAB isotherm temperature");
+          T0 = prm.get_double ("Surface temperature");
+          thicknesses = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Layer thicknesses"))),
+                                                              3,
+                                                              "Layer thicknesses");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+
+
+      // Retrieve the indices of the fields that represent the lithospheric layers.
+      AssertThrow(this->introspection().compositional_name_exists("upper"),ExcMessage("We need a compositional field called 'upper' representing the upper crust."));
+      AssertThrow(this->introspection().compositional_name_exists("lower"),ExcMessage("We need a compositional field called 'lower' representing the lower crust."));
+      AssertThrow(this->introspection().compositional_name_exists("mantle_L"),ExcMessage("We need a compositional field called 'mantle_L' representing the lithospheric part of the mantle."));
+
+      // For now, we assume a 3-layer system with an upper crust, lower crust and lithospheric mantle
+      const unsigned int id_upper = this->introspection().compositional_index_for_name("upper");
+      const unsigned int id_lower = this->introspection().compositional_index_for_name("lower");
+      const unsigned int id_mantle_L = this->introspection().compositional_index_for_name("mantle_L");
+
+            // Retrieve other material properties set in different sections such that there
+            // is no need to set them twice.
+
+      prm.enter_subsection("Heating model");
+      {
+        prm.enter_subsection("Compositional heating");
+        {
+          // The heating model compositional heating prefixes an entry for the background material
+          const std::vector<double> temp_heat_productivities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Compositional heating values"))),
+                                                                   n_fields+1,
+                                                                   "Compositional heating values");
+          // This sets the heat productivity in W/m3 units
+          heat_productivities.push_back(temp_heat_productivities[id_upper+1]);
+          heat_productivities.push_back(temp_heat_productivities[id_lower+1]);
+          heat_productivities.push_back(temp_heat_productivities[id_mantle_L+1]);
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+
+      prm.enter_subsection("Material model");
+      {
+        prm.enter_subsection("Visco Plastic");
+        {
+          // The material model viscoplastic prefixes an entry for the background material
+          const std::vector<double> temp_densities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Densities"))),
+                                                                   n_fields+1,
+                                                                   "Densities");
+          const std::vector<double> temp_thermal_diffusivities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Thermal diffusivities"))),
+                                                                                  n_fields+1,
+                                                                         "Thermal diffusivities");
+          const std::vector<double> temp_heat_capacities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Heat capacities"))),
+                                                                           n_fields+1,
+                                                                        "Heat capacities");
+
+          densities.push_back(temp_densities[id_upper+1]);
+          densities.push_back(temp_densities[id_lower+1]);
+          densities.push_back(temp_densities[id_mantle_L+1]);
+
+          // Thermal diffusivity kappa = k/(rho*cp), so thermal conducitivity k = kappa*rho*cp
+          conductivities.push_back(temp_thermal_diffusivities[id_upper+1] * densities[0] * temp_heat_capacities[id_upper+1]);
+          conductivities.push_back(temp_thermal_diffusivities[id_lower+1] * densities[0] * temp_heat_capacities[id_lower+1]);
+          conductivities.push_back(temp_thermal_diffusivities[id_mantle_L+1] * densities[0] * temp_heat_capacities[id_mantle_L+1]);
+
+          // To obtain the radioactive heating rate in W/kg, we divide the volumetric heating rate by density
+          // TODO: does this work?
+          AssertThrow(heat_productivities.size() == 3 && densities.size() == 3 && conductivities.size() == 3,
+                      ExcMessage("The entries for density, conductivity and heat production do not match with the expected number of layers (3)."))
+
+          for (unsigned int i = 0; i<3; ++i)
+          heat_productivities[i] /= densities[i];
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+  }
+
+
+}
+
+
+
+
+// explicit instantiations
+namespace aspect
+{
+  namespace InitialTemperature
+  {
+    ASPECT_REGISTER_INITIAL_TEMPERATURE_MODEL(ContinentalGeotherm,
+                                              "continental geotherm",
+                                              "This is a temperature initial condition that "
+                                              "computes a continental geotherm based on the "
+                                              "conductive equations of Turcotte and Schubert Ch. 4.6. "
+                                              "The geotherm can be computed for any number of crustal "
+                                              "layers, for each of which a density, heat production and thermal "
+                                              "conductivity should be supplied. "
+                                              "Make sure the top and bottom temperatures of the lithosphere "
+                                              "agree with temperatures set in for example the temperature "
+                                              "boundary conditions.")
+  }
+}

--- a/source/initial_temperature/continental_geotherm.cc
+++ b/source/initial_temperature/continental_geotherm.cc
@@ -98,39 +98,6 @@ namespace aspect
 
     }
 
-    template <int dim>
-    double
-    ContinentalGeotherm<dim>::
-    temperature (const double depth,
-                 const std::vector<double> layer_thicknesses) const
-    {
-      // Compute some constants
-      const double a = 0.5*densities[0]*heat_productivities[0]*layer_thicknesses[0] + 0.5*densities[1]*heat_productivities[1]*layer_thicknesses[1] + conductivities[0]/layer_thicknesses[0]*T0;
-      const double b = 1./(conductivities[0]/layer_thicknesses[0]+conductivities[1]/layer_thicknesses[1]);
-      const double c = 0.5*densities[1]*heat_productivities[1]*layer_thicknesses[1] + conductivities[2]/layer_thicknesses[2]*LAB_isotherm;
-      const double d = 1./(conductivities[1]/layer_thicknesses[1]+conductivities[2]/layer_thicknesses[2]);
-
-      //Temperature at boundary between layer 1 and 2
-      const double T1 = (a*b + conductivities[1]/layer_thicknesses[1]*c*d*b) / (1.-(conductivities[1]*conductivities[1])/(layer_thicknesses[1]*layer_thicknesses[1])*d*b);
-      //Temperature at boundary between layer 2 and 3
-      const double T2 = (c + conductivities[1]/layer_thicknesses[1]*T1) * d;
-
-      // Temperature in layer 1
-      if (depth < layer_thicknesses[0])
-        return -0.5*densities[0]*heat_productivities[0]/conductivities[0]*std::pow(depth,2) + (0.5*densities[0]*heat_productivities[0]*layer_thicknesses[0]/conductivities[0] + (T1-T0)/layer_thicknesses[0])*depth + T0;
-      // Temperature in layer 2
-      else if (depth < layer_thicknesses[0]+layer_thicknesses[1])
-        return -0.5*densities[1]*heat_productivities[1]/conductivities[1]*std::pow(depth-layer_thicknesses[0],2.) + (0.5*densities[1]*heat_productivities[1]*layer_thicknesses[1]/conductivities[1] + (T2-T1)/layer_thicknesses[1])*(depth-layer_thicknesses[0]) + T1;
-      // Temperature in layer 3
-      else if (depth < layer_thicknesses[0]+layer_thicknesses[1]+layer_thicknesses[2])
-        return (LAB_isotherm-T2)/layer_thicknesses[2] *(depth-layer_thicknesses[0]-layer_thicknesses[1]) + T2;
-      // Return a constant sublithospheric temperature of 10*LAB_isotherm.
-      // This way we can combine the continental geotherm with an adiabatic profile from the input file
-      // using the "minimum" operator on the "List of initial temperature models".
-      else
-        return 10.*LAB_isotherm;
-
-    }
 
 
     template <int dim>

--- a/source/initial_temperature/continental_geotherm.cc
+++ b/source/initial_temperature/continental_geotherm.cc
@@ -97,6 +97,40 @@ namespace aspect
  
     }
 
+    template <int dim>
+    double
+    ContinentalGeotherm<dim>::
+    temperature (const double depth,
+                 const std::vector<double> layer_thicknesses) const
+    {
+      // Compute some constants
+      const double a = 0.5*densities[0]*heat_productivities[0]*layer_thicknesses[0] + 0.5*densities[1]*heat_productivities[1]*layer_thicknesses[1] + conductivities[0]/layer_thicknesses[0]*T0;
+      const double b = 1./(conductivities[0]/layer_thicknesses[0]+conductivities[1]/layer_thicknesses[1]);
+      const double c = 0.5*densities[1]*heat_productivities[1]*layer_thicknesses[1] + conductivities[2]/layer_thicknesses[2]*LAB_isotherm;
+      const double d = 1./(conductivities[1]/layer_thicknesses[1]+conductivities[2]/layer_thicknesses[2]);
+
+      //Temperature at boundary between layer 1 and 2
+      const double T1 = (a*b + conductivities[1]/layer_thicknesses[1]*c*d*b) / (1.-(conductivities[1]*conductivities[1])/(layer_thicknesses[1]*layer_thicknesses[1])*d*b);
+      //Temperature at boundary between layer 2 and 3
+      const double T2 = (c + conductivities[1]/layer_thicknesses[1]*T1) * d;
+
+      // Temperature in layer 1
+      if(depth < layer_thicknesses[0])
+          return -0.5*densities[0]*heat_productivities[0]/conductivities[0]*std::pow(depth,2) + (0.5*densities[0]*heat_productivities[0]*layer_thicknesses[0]/conductivities[0] + (T1-T0)/layer_thicknesses[0])*depth + T0;
+      // Temperature in layer 2
+      else if (depth < layer_thicknesses[0]+layer_thicknesses[1])
+          return -0.5*densities[1]*heat_productivities[1]/conductivities[1]*std::pow(depth-layer_thicknesses[0],2.) + (0.5*densities[1]*heat_productivities[1]*layer_thicknesses[1]/conductivities[1] + (T2-T1)/layer_thicknesses[1])*(depth-layer_thicknesses[0]) + T1;
+      // Temperature in layer 3
+      else if (depth < layer_thicknesses[0]+layer_thicknesses[1]+layer_thicknesses[2])
+          return (LAB_isotherm-T2)/layer_thicknesses[2] *(depth-layer_thicknesses[0]-layer_thicknesses[1]) + T2;
+      // Return a constant sublithospheric temperature of 10*LAB_isotherm.
+      // This way we can combine the continental geotherm with an adiabatic profile from the input file
+      // using the "minimum" operator on the "List of initial temperature models"
+      else
+        return 10.*LAB_isotherm;
+
+    }
+
 
     template <int dim>
     void

--- a/tests/continental_extension.prm
+++ b/tests/continental_extension.prm
@@ -1,6 +1,15 @@
 #### 
 # This test is based on the Continental Extension Cookbook
-# There, the initial temperature is computed from a function
+# There, the initial temperature is computed through a
+# somewhat cumbersome function specified in the input file. 
+# With the continental geotherm plugin, one only has to 
+# specify the boundary temperature constraints and layer
+# thicknesses of the upper crust, lower crust and mantle
+# lithosphere. Other parameters such as layer densities
+# are read from other sections in the input file, ensuring
+# consistency between the parameters set for the initial
+# temperature and those in the material model and compositional
+# heating plugins. 
 
 ####  Global parameters
 set Dimension                              = 2
@@ -228,11 +237,6 @@ end
 # Post processing
 subsection Postprocess
   set List of postprocessors = temperature statistics
-  subsection Visualization
-    set List of output variables = density, viscosity, strain rate, error indicator
-    set Output format = vtu
-    set Time between graphical output = 1e6
-  end
 end
 
 subsection Solver parameters

--- a/tests/continental_extension.prm
+++ b/tests/continental_extension.prm
@@ -1,0 +1,242 @@
+#### 
+# This test is based on the Continental Extension Cookbook
+# There, the initial temperature is computed from a function
+
+####  Global parameters
+set Dimension                              = 2
+set Start time                             = 0
+set End time                               = 5e6
+set Use years in output instead of seconds = true
+set Nonlinear solver scheme                = single Advection, iterated Stokes
+set Nonlinear solver tolerance             = 1e-4
+set Max nonlinear iterations               = 10
+set CFL number                             = 0.5
+set Pressure normalization                 = no
+
+#### Parameters describing the model
+
+# Model geometry (400x100 km, 2 km spacing)
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X repetitions = 40
+    set Y repetitions = 10
+    set X extent      = 400e3
+    set Y extent      = 100e3
+  end
+end
+
+# Mesh refinement specifications (no mesh refinement, 
+# but the coarse mesh is already 200x50, see above)
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 0
+  set Time steps between mesh refinement = 0
+end
+
+# Advecting the free surface vertically rather than
+# in the surface normal direction can result in a
+# more stable mesh when the deformation is large
+subsection Free surface
+  set Free surface boundary indicators        = top
+  set Surface velocity projection = vertical
+end
+
+# Velocity on boundaries characterized by functions
+# The outward velocity (x-direction) on the left and right walls is 0.25 cm/year
+# The vertical velocity at the base is 0.125 cm/year (balances outflow on sides)
+# Velocity components parallel to the base (x-velocity) and side walls (y-velocity)
+# are unconstrained (i.e. 'free'). 
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = left x: function, right x:function, bottom y:function
+
+  subsection Function
+    set Variable names      = x,y
+    set Function constants  = cm=0.01, year=1
+    set Function expression = if (x<200e3 , -0.25*cm/year, 0.25*cm/year) ; 0.125*cm/year
+  end
+end
+
+
+# Number and names of compositional fields
+# The four compositional fields represent the upper crust, lower crust, mantle
+# and a 'seed' placed in the mantle to help localize deformation.
+subsection Compositional fields
+  set Number of fields = 4
+  set Names of fields = upper, lower, mantle_L, seed
+end
+
+
+# Spatial domain of different compositional fields
+# The upper crust, lower crust and mantle are continuous horizontal layers
+# of varying thickness.  The top of the seed (4x8 km) is placed 2 km beneath
+# the base of the crust and straddles the horizontal midpoint.
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Variable names      = x,y
+    set Function expression = if(y>=80.e3, 1, 0); \
+                              if(y<80.e3 && y>=70.e3, 1, 0); \
+                              if(y<70.e3 && y>-100.e3,1, 0); \ 
+                              if(y<68.e3 && y>60.e3 && x>=198.e3 && x<=202.e3 , 1, 0);
+  end
+end
+
+# Composition: fixed on bottom, free on sides and top
+subsection Boundary composition model
+  set Fixed composition boundary indicators = bottom
+  set List of model names = initial composition
+end
+
+# Temperature boundary conditions
+# Top and bottom (fixed) temperatures are consistent with the initial temperature field
+# Note that while temperatures are specified for the model sides, these values are
+# not used as the sides are not specified "Fixed temperature boundaries".  Rather,
+# these boundaries are insulating (zero net heat flux).
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = bottom, top
+  set List of model names = box
+
+  subsection Box
+    set Bottom temperature = 1573
+    set Top temperature    =  273
+  end
+end
+
+# Initial temperature field
+# Typical continental geotherm based on equations 4-6 from:
+#   D.S. Chapman (1986), "Thermal gradients in the continental crust",
+#   Geological Society of London Special Publications, v.24, p.63-70.
+# The initial constraints are:
+#   Layer Surface Temperature - upper crust (ts1) = 273 K; 
+#                               mantle      (ts3) = 823 K;  
+#   Model Base Temperature - (tb) = 1573 K;
+#   Heat Production - upper crust (A) = 1.5e-6 W/m^3; 
+#   Thermal Conductivity - upper crust (k1) = 2.5 (W/(m K)); 
+#                          lower crust (k2) = 2.5 (W/(m K)); 
+#                          mantle      (k3) = 3.3 (W/(m K));
+# To satisfy these constraints, the following values are required:
+#   Layer Surface Heat Flow - upper crust (qs1) = 0.065357 W/m^2; 
+#                             lower crust (qs2) = 0.035357 W/m^2; 
+#                             mantle      (qs3) = 0.035357 W/m^2;
+#   Temperature - base of upper crust (ts2) = 681.5714
+subsection Initial temperature model
+  set Model name = continental geotherm #function
+  subsection Function
+    set Variable names = x,y
+    set Function constants = h=100e3,ts1=273,ts2=681.5714,ts3=823., \
+                                     k1=2.5,k2=2.5,k3=3.3,A=1.5e-6, \
+                             qs1=0.0653571,qs2=0.035357,qs3=0.035357,qb3=0.035357
+    set Function expression = if( (h-y)<=20.e3, \
+                                  ts1 + (qs1/k1)*(h-y) - (A*(h-y)*(h-y))/(2.0*k1), \
+                                  if((h-y)>20.e3 && (h-y)<=30.e3, ts2 + (qs2/k2)*(h-y-20.e3),\
+                                  ts3 + (qs3/k3)*(h-y-30.e3)));
+  end
+  subsection Continental geotherm
+          set LAB isotherm temperature = 1573.
+          set Surface temperature = 273.
+          set Layer thicknesses = 20000., 10000., 70000.
+  end
+end
+
+# Constant internal heat production values (W/m^3) for background material
+# and compositional fields.
+subsection Heating model
+  set List of model names = compositional heating
+  subsection Compositional heating
+    set Compositional heating values = 0., 1.5e-6, 0., 0., 0.
+  end
+end
+
+# Material model
+# Rheology: Non-linear viscous flow and Drucker Prager Plasticity
+# Values for most rheological parameters are specified for a background material and
+# each compositional field.  Values for viscous deformation are based on dislocation
+# creep flow-laws, with distinct values for the upper crust (wet quartzite), lower
+# crust (wet anorthite) and mantle (dry olivine).  Table 1 of Naliboff and Buiter (2015),
+# Earth Planet. Sci. Lett., v.421, p. 58-67 contains values for each of these flow laws.     
+subsection Material model
+  set Model name = visco plastic
+
+  subsection Visco Plastic
+
+    # Reference temperature and viscosity
+    set Reference temperature = 293
+    set Reference viscosity = 1e22
+    
+    # The minimum strain-rate helps limit large viscosities values that arise
+    # as the strain-rate approaches zero.
+    # The reference strain-rate is used on the first non-linear iteration
+    # of the first time step when the velocity has not been determined yet. 
+    set Minimum strain rate = 1.e-20
+    set Reference strain rate = 1.e-16
+
+    # Limit the viscosity with minimum and maximum values
+    set Minimum viscosity = 1e18
+    set Maximum viscosity = 1e26
+
+    # Thermal diffusivity is adjusted to match thermal conductivities
+    # assumed in assigning the initial geotherm
+    set Thermal diffusivities = 1.333333e-6, 1.190476e-6, 1.149425e-6, 1.333333e-6, 1.333333e-6
+    set Heat capacities       =        750.,        750.,        750.,        750.,         750.
+    set Densities             =        3300,        2800,        2900,        3300,         3300
+    set Thermal expansivities =        2e-5,        2e-5,        2e-5,        2e-5,         2e-5
+
+    # Harmonic viscosity averaging
+    set Viscosity averaging scheme = harmonic
+
+    # Choose to have the viscosity (pre-yield) follow a dislocation
+    # diffusion or composite flow law.  Here, dislocation is selected
+    # so no need to specify diffusion creep parameters below, which are
+    # only used if "diffusion" or "composite" option is selected.
+    set Viscous flow law = dislocation
+
+    # Dislocation creep parameters for 
+    # 1. Background material/mantle (dry olivine)
+    #    Hirth & Kohlstedt (2004),  Geophys. Monogr. Am. Geophys. Soc., v.138, p.83-105.
+    #    "Rheology of the upper mantle and the mantle wedge:a view from the experimentalists"
+    # 2. Upper crust (wet quartzite)
+    #    Rutter & Brodie (2004), J. Struct. Geol., v.26, p.2011-2023.
+    #    "Experimental grain size-sensitive flow of hot-pressed Brazilian quartz aggregates"
+    # 3. Lower crust and weak seed (wet anorthite)
+    #    Rybacki et al. (2006), J. Geophys. Res., v.111(B3).
+    #    "Influence of water fugacity and activation volume on the flow properties of fine-grained    
+    #    anorthite aggregates"
+    # Note that the viscous pre-factors below are scaled to plane strain from unixial strain experiments.
+    set Prefactors for dislocation creep          = 6.52e-16, 8.57e-28, 7.13e-18, 6.52e-16, 7.13e-18
+    set Stress exponents for dislocation creep    =      3.5,      4.0,      3.0,      3.5, 3.0
+    set Activation energies for dislocation creep =   530.e3,   223.e3,   345.e3,   530.e3, 345.e3
+    set Activation volumes for dislocation creep  =   18.e-6,       0.,       0.,   18.e-6, 0.
+
+    # Plasticity parameters
+    set Angles of internal friction =   20.,   20.,  20.,    20., 20.
+    set Cohesions                   = 20.e6, 20.e6, 20.e6, 20.e6, 20.e6
+
+  end
+end
+
+# Gravity model
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 9.81
+  end
+end
+
+
+# Post processing
+subsection Postprocess
+  set List of postprocessors = temperature statistics
+  subsection Visualization
+    set List of output variables = density, viscosity, strain rate, error indicator
+    set Output format = vtu
+    set Time between graphical output = 1e6
+  end
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Number of cheap Stokes solver steps = 0
+  end
+end

--- a/tests/continental_extension.prm
+++ b/tests/continental_extension.prm
@@ -42,7 +42,7 @@ end
 # and a 'seed' placed in the mantle to help localize deformation.
 subsection Compositional fields
   set Number of fields = 4
-  set Names of fields = upper, lower, mantle_L, seed
+  set Names of fields = upper_crust, lower_crust, lithospheric_mantle, seed
 end
 
 
@@ -65,7 +65,7 @@ end
 subsection Initial temperature model
   set Model name = continental geotherm
   subsection Continental geotherm
-          set LAB isotherm temperature = 1573.
+          set Lithosphere-Asthenosphere boundary isotherm = 1573.
           set Surface temperature = 273.
           set Layer thicknesses = 20000., 10000., 70000.
   end

--- a/tests/continental_extension.prm
+++ b/tests/continental_extension.prm
@@ -11,20 +11,12 @@
 # temperature and those in the material model and compositional
 # heating plugins. 
 
-####  Global parameters
-set Dimension                              = 2
-set Start time                             = 0
-set End time                               = 5e6
-set Use years in output instead of seconds = true
-set Nonlinear solver scheme                = single Advection, iterated Stokes
-set Nonlinear solver tolerance             = 1e-4
-set Max nonlinear iterations               = 10
-set CFL number                             = 0.5
-set Pressure normalization                 = no
+include $ASPECT_SOURCE_DIR/cookbooks/continental_extension.prm
+
 
 #### Parameters describing the model
 
-# Model geometry (400x100 km, 2 km spacing)
+# Model geometry (40x10 km, 10 km spacing)
 subsection Geometry model
   set Model name = box
   subsection Box
@@ -36,34 +28,11 @@ subsection Geometry model
 end
 
 # Mesh refinement specifications (no mesh refinement, 
-# but the coarse mesh is already 200x50, see above)
+# but the coarse mesh is already 40x10, see above)
 subsection Mesh refinement
   set Initial adaptive refinement        = 0
   set Initial global refinement          = 0
   set Time steps between mesh refinement = 0
-end
-
-# Advecting the free surface vertically rather than
-# in the surface normal direction can result in a
-# more stable mesh when the deformation is large
-subsection Free surface
-  set Free surface boundary indicators        = top
-  set Surface velocity projection = vertical
-end
-
-# Velocity on boundaries characterized by functions
-# The outward velocity (x-direction) on the left and right walls is 0.25 cm/year
-# The vertical velocity at the base is 0.125 cm/year (balances outflow on sides)
-# Velocity components parallel to the base (x-velocity) and side walls (y-velocity)
-# are unconstrained (i.e. 'free'). 
-subsection Boundary velocity model
-  set Prescribed velocity boundary indicators = left x: function, right x:function, bottom y:function
-
-  subsection Function
-    set Variable names      = x,y
-    set Function constants  = cm=0.01, year=1
-    set Function expression = if (x<200e3 , -0.25*cm/year, 0.25*cm/year) ; 0.125*cm/year
-  end
 end
 
 
@@ -75,27 +44,6 @@ subsection Compositional fields
   set Names of fields = upper, lower, mantle_L, seed
 end
 
-
-# Spatial domain of different compositional fields
-# The upper crust, lower crust and mantle are continuous horizontal layers
-# of varying thickness.  The top of the seed (4x8 km) is placed 2 km beneath
-# the base of the crust and straddles the horizontal midpoint.
-subsection Initial composition model
-  set Model name = function
-  subsection Function
-    set Variable names      = x,y
-    set Function expression = if(y>=80.e3, 1, 0); \
-                              if(y<80.e3 && y>=70.e3, 1, 0); \
-                              if(y<70.e3 && y>-100.e3,1, 0); \ 
-                              if(y<68.e3 && y>60.e3 && x>=198.e3 && x<=202.e3 , 1, 0);
-  end
-end
-
-# Composition: fixed on bottom, free on sides and top
-subsection Boundary composition model
-  set Fixed composition boundary indicators = bottom
-  set List of model names = initial composition
-end
 
 # Temperature boundary conditions
 # Top and bottom (fixed) temperatures are consistent with the initial temperature field
@@ -113,34 +61,8 @@ subsection Boundary temperature model
 end
 
 # Initial temperature field
-# Typical continental geotherm based on equations 4-6 from:
-#   D.S. Chapman (1986), "Thermal gradients in the continental crust",
-#   Geological Society of London Special Publications, v.24, p.63-70.
-# The initial constraints are:
-#   Layer Surface Temperature - upper crust (ts1) = 273 K; 
-#                               mantle      (ts3) = 823 K;  
-#   Model Base Temperature - (tb) = 1573 K;
-#   Heat Production - upper crust (A) = 1.5e-6 W/m^3; 
-#   Thermal Conductivity - upper crust (k1) = 2.5 (W/(m K)); 
-#                          lower crust (k2) = 2.5 (W/(m K)); 
-#                          mantle      (k3) = 3.3 (W/(m K));
-# To satisfy these constraints, the following values are required:
-#   Layer Surface Heat Flow - upper crust (qs1) = 0.065357 W/m^2; 
-#                             lower crust (qs2) = 0.035357 W/m^2; 
-#                             mantle      (qs3) = 0.035357 W/m^2;
-#   Temperature - base of upper crust (ts2) = 681.5714
 subsection Initial temperature model
-  set Model name = continental geotherm #function
-  subsection Function
-    set Variable names = x,y
-    set Function constants = h=100e3,ts1=273,ts2=681.5714,ts3=823., \
-                                     k1=2.5,k2=2.5,k3=3.3,A=1.5e-6, \
-                             qs1=0.0653571,qs2=0.035357,qs3=0.035357,qb3=0.035357
-    set Function expression = if( (h-y)<=20.e3, \
-                                  ts1 + (qs1/k1)*(h-y) - (A*(h-y)*(h-y))/(2.0*k1), \
-                                  if((h-y)>20.e3 && (h-y)<=30.e3, ts2 + (qs2/k2)*(h-y-20.e3),\
-                                  ts3 + (qs3/k3)*(h-y-30.e3)));
-  end
+  set Model name = continental geotherm
   subsection Continental geotherm
           set LAB isotherm temperature = 1573.
           set Surface temperature = 273.
@@ -148,99 +70,8 @@ subsection Initial temperature model
   end
 end
 
-# Constant internal heat production values (W/m^3) for background material
-# and compositional fields.
-subsection Heating model
-  set List of model names = compositional heating
-  subsection Compositional heating
-    set Compositional heating values = 0., 1.5e-6, 0., 0., 0.
-  end
-end
-
-# Material model
-# Rheology: Non-linear viscous flow and Drucker Prager Plasticity
-# Values for most rheological parameters are specified for a background material and
-# each compositional field.  Values for viscous deformation are based on dislocation
-# creep flow-laws, with distinct values for the upper crust (wet quartzite), lower
-# crust (wet anorthite) and mantle (dry olivine).  Table 1 of Naliboff and Buiter (2015),
-# Earth Planet. Sci. Lett., v.421, p. 58-67 contains values for each of these flow laws.     
-subsection Material model
-  set Model name = visco plastic
-
-  subsection Visco Plastic
-
-    # Reference temperature and viscosity
-    set Reference temperature = 293
-    set Reference viscosity = 1e22
-    
-    # The minimum strain-rate helps limit large viscosities values that arise
-    # as the strain-rate approaches zero.
-    # The reference strain-rate is used on the first non-linear iteration
-    # of the first time step when the velocity has not been determined yet. 
-    set Minimum strain rate = 1.e-20
-    set Reference strain rate = 1.e-16
-
-    # Limit the viscosity with minimum and maximum values
-    set Minimum viscosity = 1e18
-    set Maximum viscosity = 1e26
-
-    # Thermal diffusivity is adjusted to match thermal conductivities
-    # assumed in assigning the initial geotherm
-    set Thermal diffusivities = 1.333333e-6, 1.190476e-6, 1.149425e-6, 1.333333e-6, 1.333333e-6
-    set Heat capacities       =        750.,        750.,        750.,        750.,         750.
-    set Densities             =        3300,        2800,        2900,        3300,         3300
-    set Thermal expansivities =        2e-5,        2e-5,        2e-5,        2e-5,         2e-5
-
-    # Harmonic viscosity averaging
-    set Viscosity averaging scheme = harmonic
-
-    # Choose to have the viscosity (pre-yield) follow a dislocation
-    # diffusion or composite flow law.  Here, dislocation is selected
-    # so no need to specify diffusion creep parameters below, which are
-    # only used if "diffusion" or "composite" option is selected.
-    set Viscous flow law = dislocation
-
-    # Dislocation creep parameters for 
-    # 1. Background material/mantle (dry olivine)
-    #    Hirth & Kohlstedt (2004),  Geophys. Monogr. Am. Geophys. Soc., v.138, p.83-105.
-    #    "Rheology of the upper mantle and the mantle wedge:a view from the experimentalists"
-    # 2. Upper crust (wet quartzite)
-    #    Rutter & Brodie (2004), J. Struct. Geol., v.26, p.2011-2023.
-    #    "Experimental grain size-sensitive flow of hot-pressed Brazilian quartz aggregates"
-    # 3. Lower crust and weak seed (wet anorthite)
-    #    Rybacki et al. (2006), J. Geophys. Res., v.111(B3).
-    #    "Influence of water fugacity and activation volume on the flow properties of fine-grained    
-    #    anorthite aggregates"
-    # Note that the viscous pre-factors below are scaled to plane strain from unixial strain experiments.
-    set Prefactors for dislocation creep          = 6.52e-16, 8.57e-28, 7.13e-18, 6.52e-16, 7.13e-18
-    set Stress exponents for dislocation creep    =      3.5,      4.0,      3.0,      3.5, 3.0
-    set Activation energies for dislocation creep =   530.e3,   223.e3,   345.e3,   530.e3, 345.e3
-    set Activation volumes for dislocation creep  =   18.e-6,       0.,       0.,   18.e-6, 0.
-
-    # Plasticity parameters
-    set Angles of internal friction =   20.,   20.,  20.,    20., 20.
-    set Cohesions                   = 20.e6, 20.e6, 20.e6, 20.e6, 20.e6
-
-  end
-end
-
-# Gravity model
-subsection Gravity model
-  set Model name = vertical
-
-  subsection Vertical
-    set Magnitude = 9.81
-  end
-end
-
 
 # Post processing
 subsection Postprocess
   set List of postprocessors = temperature statistics
-end
-
-subsection Solver parameters
-  subsection Stokes solver parameters
-    set Number of cheap Stokes solver steps = 0
-  end
 end

--- a/tests/continental_extension.prm
+++ b/tests/continental_extension.prm
@@ -13,6 +13,7 @@
 
 include $ASPECT_SOURCE_DIR/cookbooks/continental_extension.prm
 
+set Timing output frequency                = 100
 
 #### Parameters describing the model
 

--- a/tests/continental_extension/screen-output
+++ b/tests/continental_extension/screen-output
@@ -10,9 +10,9 @@ Number of free surface degrees of freedom: 902
 *** Timestep 0:  t=0 years
    Solving mesh velocity system... 0 iterations.
    Solving temperature system... 0 iterations.
-   Solving upper system ... 0 iterations.
-   Solving lower system ... 0 iterations.
-   Solving mantle_L system ... 0 iterations.
+   Solving upper_crust system ... 0 iterations.
+   Solving lower_crust system ... 0 iterations.
+   Solving lithospheric_mantle system ... 0 iterations.
    Solving seed system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+20 iterations.
@@ -61,9 +61,9 @@ Number of free surface degrees of freedom: 902
 *** Timestep 1:  t=894427 years
    Solving mesh velocity system... 1 iterations.
    Solving temperature system... 16 iterations.
-   Solving upper system ... 10 iterations.
-   Solving lower system ... 11 iterations.
-   Solving mantle_L system ... 10 iterations.
+   Solving upper_crust system ... 10 iterations.
+   Solving lower_crust system ... 11 iterations.
+   Solving lithospheric_mantle system ... 10 iterations.
    Solving seed system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+19 iterations.
@@ -112,9 +112,9 @@ Number of free surface degrees of freedom: 902
 *** Timestep 2:  t=1.78885e+06 years
    Solving mesh velocity system... 1 iterations.
    Solving temperature system... 13 iterations.
-   Solving upper system ... 12 iterations.
-   Solving lower system ... 13 iterations.
-   Solving mantle_L system ... 12 iterations.
+   Solving upper_crust system ... 12 iterations.
+   Solving lower_crust system ... 13 iterations.
+   Solving lithospheric_mantle system ... 12 iterations.
    Solving seed system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+22 iterations.
@@ -163,9 +163,9 @@ Number of free surface degrees of freedom: 902
 *** Timestep 3:  t=2.49664e+06 years
    Solving mesh velocity system... 1 iterations.
    Solving temperature system... 11 iterations.
-   Solving upper system ... 14 iterations.
-   Solving lower system ... 14 iterations.
-   Solving mantle_L system ... 13 iterations.
+   Solving upper_crust system ... 14 iterations.
+   Solving lower_crust system ... 14 iterations.
+   Solving lithospheric_mantle system ... 13 iterations.
    Solving seed system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+26 iterations.
@@ -214,9 +214,9 @@ Number of free surface degrees of freedom: 902
 *** Timestep 4:  t=3.28887e+06 years
    Solving mesh velocity system... 1 iterations.
    Solving temperature system... 12 iterations.
-   Solving upper system ... 12 iterations.
-   Solving lower system ... 13 iterations.
-   Solving mantle_L system ... 12 iterations.
+   Solving upper_crust system ... 12 iterations.
+   Solving lower_crust system ... 13 iterations.
+   Solving lithospheric_mantle system ... 12 iterations.
    Solving seed system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+21 iterations.
@@ -265,9 +265,9 @@ Number of free surface degrees of freedom: 902
 *** Timestep 5:  t=3.95688e+06 years
    Solving mesh velocity system... 1 iterations.
    Solving temperature system... 11 iterations.
-   Solving upper system ... 12 iterations.
-   Solving lower system ... 13 iterations.
-   Solving mantle_L system ... 12 iterations.
+   Solving upper_crust system ... 12 iterations.
+   Solving lower_crust system ... 13 iterations.
+   Solving lithospheric_mantle system ... 12 iterations.
    Solving seed system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+24 iterations.
@@ -316,9 +316,9 @@ Number of free surface degrees of freedom: 902
 *** Timestep 6:  t=4.7025e+06 years
    Solving mesh velocity system... 1 iterations.
    Solving temperature system... 11 iterations.
-   Solving upper system ... 12 iterations.
-   Solving lower system ... 13 iterations.
-   Solving mantle_L system ... 12 iterations.
+   Solving upper_crust system ... 12 iterations.
+   Solving lower_crust system ... 13 iterations.
+   Solving lithospheric_mantle system ... 12 iterations.
    Solving seed system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+21 iterations.
@@ -367,9 +367,9 @@ Number of free surface degrees of freedom: 902
 *** Timestep 7:  t=5e+06 years
    Solving mesh velocity system... 1 iterations.
    Solving temperature system... 7 iterations.
-   Solving upper system ... 10 iterations.
-   Solving lower system ... 10 iterations.
-   Solving mantle_L system ... 10 iterations.
+   Solving upper_crust system ... 10 iterations.
+   Solving lower_crust system ... 10 iterations.
+   Solving lithospheric_mantle system ... 10 iterations.
    Solving seed system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+19 iterations.

--- a/tests/continental_extension/screen-output
+++ b/tests/continental_extension/screen-output
@@ -1,0 +1,426 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 400 (on 1 levels)
+Number of degrees of freedom: 12,358 (3,402+451+1,701+1,701+1,701+1,701+1,701)
+
+Number of free surface degrees of freedom: 902
+*** Timestep 0:  t=0 years
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 0 iterations.
+   Solving upper system ... 0 iterations.
+   Solving lower system ... 0 iterations.
+   Solving mantle_L system ... 0 iterations.
+   Solving seed system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+20 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+20 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.064316
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+17 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.0250548
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+16 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.0079803
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+15 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 0.00318284
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+14 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 0.00138678
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 0.000848317
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 8: 0.000630804
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+12 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 9: 0.000552774
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+12 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 0.000506245
+
+
+   Postprocessing:
+     Temperature min/avg/max: 273 K, 1011 K, 1573 K
+
+*** Timestep 1:  t=894427 years
+   Solving mesh velocity system... 1 iterations.
+   Solving temperature system... 16 iterations.
+   Solving upper system ... 10 iterations.
+   Solving lower system ... 11 iterations.
+   Solving mantle_L system ... 10 iterations.
+   Solving seed system ... 11 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+19 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0202742
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+17 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0117997
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+16 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.00691254
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+16 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.00527826
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+16 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 0.00432803
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+16 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 0.00371805
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+16 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 0.00330801
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+16 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 8: 0.00298398
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+16 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 9: 0.00281096
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+16 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 0.00274468
+
+
+   Postprocessing:
+     Temperature min/avg/max: 273 K, 1017 K, 1573 K
+
+*** Timestep 2:  t=1.78885e+06 years
+   Solving mesh velocity system... 1 iterations.
+   Solving temperature system... 13 iterations.
+   Solving upper system ... 12 iterations.
+   Solving lower system ... 13 iterations.
+   Solving mantle_L system ... 12 iterations.
+   Solving seed system ... 11 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+22 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.223523
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+20 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.037296
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+19 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.0166467
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+19 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.0108013
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+18 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 0.00956856
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+18 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 0.0108413
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+18 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 0.0143483
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+17 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 8: 0.0244157
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+17 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 9: 0.0151932
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+16 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 0.00333107
+
+
+   Postprocessing:
+     Temperature min/avg/max: 273 K, 1022 K, 1573 K
+
+*** Timestep 3:  t=2.49664e+06 years
+   Solving mesh velocity system... 1 iterations.
+   Solving temperature system... 11 iterations.
+   Solving upper system ... 14 iterations.
+   Solving lower system ... 14 iterations.
+   Solving mantle_L system ... 13 iterations.
+   Solving seed system ... 11 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+26 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.194755
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+20 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0339422
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+18 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.0238607
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+18 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.0425339
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+18 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 0.014996
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+18 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 0.00698543
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+17 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 0.00717049
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+17 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 8: 0.0084805
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+17 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 9: 0.00422415
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+16 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 0.00363903
+
+
+   Postprocessing:
+     Temperature min/avg/max: 273 K, 1026 K, 1573 K
+
+*** Timestep 4:  t=3.28887e+06 years
+   Solving mesh velocity system... 1 iterations.
+   Solving temperature system... 12 iterations.
+   Solving upper system ... 12 iterations.
+   Solving lower system ... 13 iterations.
+   Solving mantle_L system ... 12 iterations.
+   Solving seed system ... 11 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+21 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.104072
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+19 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0236251
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+19 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.0158286
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+18 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.0124648
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+18 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 0.0105516
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+18 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 0.00934151
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+17 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 0.00854758
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+17 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 8: 0.00804449
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+17 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 9: 0.00775929
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+16 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 0.0054997
+
+
+   Postprocessing:
+     Temperature min/avg/max: 273 K, 1031 K, 1573 K
+
+*** Timestep 5:  t=3.95688e+06 years
+   Solving mesh velocity system... 1 iterations.
+   Solving temperature system... 11 iterations.
+   Solving upper system ... 12 iterations.
+   Solving lower system ... 13 iterations.
+   Solving mantle_L system ... 12 iterations.
+   Solving seed system ... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+24 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.107371
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+19 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0165869
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+18 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.00915583
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+14 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.0058291
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+16 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 0.00474472
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+14 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 0.00402919
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+15 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 0.00353
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+15 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 8: 0.00316202
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+15 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 9: 0.00287333
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+15 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 0.0026331
+
+
+   Postprocessing:
+     Temperature min/avg/max: 273 K, 1034 K, 1573 K
+
+*** Timestep 6:  t=4.7025e+06 years
+   Solving mesh velocity system... 1 iterations.
+   Solving temperature system... 11 iterations.
+   Solving upper system ... 12 iterations.
+   Solving lower system ... 13 iterations.
+   Solving mantle_L system ... 12 iterations.
+   Solving seed system ... 11 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+21 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0399946
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+19 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0126535
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+19 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.00788756
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+18 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.00561024
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+18 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 0.00440457
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+16 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 0.00342965
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+12 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 0.00273732
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+15 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 8: 0.00227152
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+15 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 9: 0.00195021
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+15 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 0.00171431
+
+
+   Postprocessing:
+     Temperature min/avg/max: 273 K, 1038 K, 1573 K
+
+*** Timestep 7:  t=5e+06 years
+   Solving mesh velocity system... 1 iterations.
+   Solving temperature system... 7 iterations.
+   Solving upper system ... 10 iterations.
+   Solving lower system ... 10 iterations.
+   Solving mantle_L system ... 10 iterations.
+   Solving seed system ... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+19 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.00696143
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+15 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.00424427
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+14 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.00263566
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+14 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.00186445
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+13 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 0.00125046
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+12 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 0.000918941
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+11 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 0.000734186
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+10 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 8: 0.000636112
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+10 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 9: 0.000583122
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+10 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 0.000554344
+
+
+   Postprocessing:
+     Temperature min/avg/max: 273 K, 1039 K, 1573 K
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------


### PR DESCRIPTION
This sets up a laterally homogeneous continental geotherm as initial temperature condition for for example rift models. 