### PR TITLE
Also check additional input objects when copying MaterialModelInputs.

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -180,179 +180,196 @@ namespace aspect
     template <int dim>
     struct MaterialModelInputs
     {
-        /**
-         * Constructor. Initialize the various arrays of this structure with the
-         * given number of quadrature points and (finite element) components.
-         *
-         * @param n_points The number of quadrature points for which input
-         * quantities will be provided.
-         * @param n_comp The number of vector quantities (in the order in which
-         * the Introspection class reports them) for which input will be
-         * provided.
-         */
-        MaterialModelInputs(const unsigned int n_points,
-                            const unsigned int n_comp);
+      /**
+       * Constructor. Initialize the various arrays of this structure with the
+       * given number of quadrature points and (finite element) components.
+       *
+       * @param n_points The number of quadrature points for which input
+       * quantities will be provided.
+       * @param n_comp The number of vector quantities (in the order in which
+       * the Introspection class reports them) for which input will be
+       * provided.
+       */
+      MaterialModelInputs(const unsigned int n_points,
+                          const unsigned int n_comp);
 
-        /**
-         * Constructor. Initialize the arrays of the structure with the number
-         * of points in the `input_data` structure, and fills them appropriately.
-         *
-         * @param input_data The data used to populate the material model input quantities.
-         * @param introspection A reference to the simulator introspection object.
-         * @param use_strain_rate Whether to compute the strain rates.
-         */
-        MaterialModelInputs(const DataPostprocessorInputs::Vector<dim> &input_data,
-                            const Introspection<dim> &introspection,
-                            const bool use_strain_rate = true);
-
-
-        /**
-         * Constructor. Initializes the various arrays of this
-         * structure with the FEValues and introspection objects and
-         * the solution_vector. This constructor calls the function
-         * reinit to populate the newly created arrays.
-         *
-         * @param fe_values An FEValuesBase object used to evaluate the finite elements.
-         * @param cell The currently active cell for the fe_values object.
-         * @param introspection A reference to the simulator introspection object.
-         * @param solution_vector The finite element vector from which to construct the inputs.
-         * @param use_strain_rates Whether to compute the strain rates.
-         */
-        MaterialModelInputs(const FEValuesBase<dim,dim> &fe_values,
-                            const typename DoFHandler<dim>::active_cell_iterator &cell,
-                            const Introspection<dim> &introspection,
-                            const LinearAlgebra::BlockVector &solution_vector,
-                            const bool use_strain_rates = true);
-
-        /**
-         * Copy Constructor.
-         */
-        MaterialModelInputs(const MaterialModelInputs<dim> &material);
-
-        /**
-         * Function to re-initialize and populate the pre-existing arrays
-         * created by the constructor MaterialModelInputs.
-         */
-        void reinit(const FEValuesBase<dim,dim> &fe_values,
-                    const typename DoFHandler<dim>::active_cell_iterator &cell,
-                    const Introspection<dim> &introspection,
-                    const LinearAlgebra::BlockVector &solution_vector,
-                    const bool use_strain_rates = true);
+      /**
+       * Constructor. Initialize the arrays of the structure with the number
+       * of points in the `input_data` structure, and fills them appropriately.
+       *
+       * @param input_data The data used to populate the material model input quantities.
+       * @param introspection A reference to the simulator introspection object.
+       * @param use_strain_rate Whether to compute the strain rates.
+       */
+      MaterialModelInputs(const DataPostprocessorInputs::Vector<dim> &input_data,
+                          const Introspection<dim> &introspection,
+                          const bool use_strain_rate = true);
 
 
-        /**
-         * Vector with global positions where the material has to be evaluated
-         * in evaluate().
-         */
-        std::vector<Point<dim> > position;
+      /**
+       * Constructor. Initializes the various arrays of this
+       * structure with the FEValues and introspection objects and
+       * the solution_vector. This constructor calls the function
+       * reinit to populate the newly created arrays.
+       *
+       * @param fe_values An FEValuesBase object used to evaluate the finite elements.
+       * @param cell The currently active cell for the fe_values object.
+       * @param introspection A reference to the simulator introspection object.
+       * @param solution_vector The finite element vector from which to construct the inputs.
+       * @param use_strain_rates Whether to compute the strain rates.
+       */
+      MaterialModelInputs(const FEValuesBase<dim,dim> &fe_values,
+                          const typename DoFHandler<dim>::active_cell_iterator &cell,
+                          const Introspection<dim> &introspection,
+                          const LinearAlgebra::BlockVector &solution_vector,
+                          const bool use_strain_rates = true);
 
-        /**
-         * Temperature values at the points given in the #position vector.
-         */
-        std::vector<double> temperature;
+      /**
+       * Copy constructor. This constructor copies all data members of the
+       * source object except for the additional input data (of type
+       * AdditionalMaterialInputs) pointers, stored in the
+       * `source.additional_inputs` member variable.
+       *
+       * This is because these pointers can not be copied (they
+       * are unique to the @p source object). Since they can also not
+       * be recreated without the original code that created these objects
+       * in the first place, this constructor throws an exception if the
+       * @p source object had any additional input data objects
+       * associated with it.
+       */
+      MaterialModelInputs (const MaterialModelInputs &source);
 
-        /**
-         * Pressure values at the points given in the #position vector.
-         */
-        std::vector<double> pressure;
+      /**
+       * Move constructor. This constructor simply moves all members.
+       */
+      MaterialModelInputs (MaterialModelInputs &&) = default;
 
-        /**
-         * Pressure gradients at the points given in the #position vector.
-         * This is important for the heating models.
-         */
-        std::vector<Tensor<1,dim> > pressure_gradient;
+      /**
+       * Copy operator. This operator has the same restriction on the
+       * additional input data pointers as the copy constructor.
+       */
+      MaterialModelInputs &operator= (const MaterialModelInputs &source);
 
-        /**
-         * Velocity values at the points given in the #position vector.
-         * This value is mostly important in the case of determining
-         * whether material crossed a certain region (e.g. a phase boundary).
-         * The timestep that is needed for this check can be requested from
-         * SimulatorAccess.
-         */
-        std::vector<Tensor<1,dim> > velocity;
+      /**
+       * Move operator.
+       */
+      MaterialModelInputs &operator= (MaterialModelInputs &&) = default;
 
-        /**
-         * Values of the compositional fields at the points given in the
-         * #position vector: composition[i][c] is the compositional field c at
-         * point i.
-         */
-        std::vector<std::vector<double> > composition;
+      /**
+       * Function to re-initialize and populate the pre-existing arrays
+       * created by the constructor MaterialModelInputs.
+       */
+      void reinit(const FEValuesBase<dim,dim> &fe_values,
+                  const typename DoFHandler<dim>::active_cell_iterator &cell,
+                  const Introspection<dim> &introspection,
+                  const LinearAlgebra::BlockVector &solution_vector,
+                  const bool use_strain_rates = true);
 
-        /**
-         * Strain rate at the points given in the #position vector. Only the
-         * viscosity may depend on these values. This std::vector can be set to
-         * size 0 if the viscosity is not needed.
-         *
-         * @note The strain rate is computed as $\varepsilon(\mathbf u)=\frac 12
-         * (\nabla \mathbf u + \nabla \mathbf u^T)$, regardless of whether the
-         * model is compressible or not. This is relevant since in some other
-         * contexts, the strain rate in the compressible case is computed as
-         * $\varepsilon(\mathbf u)=\frac 12 (\nabla \mathbf u + \nabla \mathbf
-         * u^T) - \frac 13 \nabla \cdot \mathbf u \mathbf 1$.
-         */
-        std::vector<SymmetricTensor<2,dim> > strain_rate;
 
-        /**
-         * Optional reference to the cell that contains these quadrature
-         * points. This allows for evaluating properties at the cell vertices
-         * and interpolating to the quadrature points, or to query the cell for
-         * material ids, neighbors, or other information that is not available
-         * solely from the locations. Note that not all calling functions can set
-         * this reference. In these cases it will be a nullptr, so make sure
-         * that your material model either fails with a proper error message
-         * or provide an alternative calculation for these cases.
-         *
-         * @deprecated Use DoFHandler<dim>::active_cell_iterator current_cell instead.
-         */
-        const typename DoFHandler<dim>::active_cell_iterator *cell DEAL_II_DEPRECATED;
+      /**
+       * Vector with global positions where the material has to be evaluated
+       * in evaluate().
+       */
+      std::vector<Point<dim> > position;
 
-        /**
-         * Optional cell object that contains these quadrature
-         * points. This allows for evaluating properties at the cell vertices
-         * and interpolating to the quadrature points, or to query the cell for
-         * material ids, neighbors, or other information that is not available
-         * solely from the locations. Note that not all calling functions will
-         * set this cell iterator. In these cases it will be an invalid iterator
-         * constructed using the default constructor, so make sure that your
-         * material model either fails
-         * with a proper error message, or provides an alternative calculation for
-         * these cases. You can detect this with
-         * @code
-         * if (in.current_cell.state() == IteratorState::valid)
-         * @endcode
-         */
-        typename DoFHandler<dim>::active_cell_iterator current_cell;
+      /**
+       * Temperature values at the points given in the #position vector.
+       */
+      std::vector<double> temperature;
 
-        /**
-         * Vector of shared pointers to additional material model input
-         * objects that can be added to MaterialModelInputs. By default,
-         * no inputs are added.
-         */
-        std::vector<std::shared_ptr<AdditionalMaterialInputs<dim> > > additional_inputs;
+      /**
+       * Pressure values at the points given in the #position vector.
+       */
+      std::vector<double> pressure;
 
-        /**
-         * Given an additional material model input class as explicitly specified
-         * template argument, returns a pointer to this additional material model
-         * input object if it is used in the current simulation.
-         * If the output does not exist, a null pointer is returned.
-         */
-        template <class AdditionalInputType>
-        AdditionalInputType *get_additional_input();
+      /**
+       * Pressure gradients at the points given in the #position vector.
+       * This is important for the heating models.
+       */
+      std::vector<Tensor<1,dim> > pressure_gradient;
 
-        /**
-         * Constant version of get_additional_input() returning a const pointer.
-         */
-        template <class AdditionalInputType>
-        const AdditionalInputType *get_additional_input() const;
+      /**
+       * Velocity values at the points given in the #position vector.
+       * This value is mostly important in the case of determining
+       * whether material crossed a certain region (e.g. a phase boundary).
+       * The timestep that is needed for this check can be requested from
+       * SimulatorAccess.
+       */
+      std::vector<Tensor<1,dim> > velocity;
 
-      private:
-        /**
-         * Assignment operator. It is forbidden to copy this object, because this
-         * would be too expensive. Hence, this function is private and no
-         * implementation is provided, so that trying to use it will throw an
-         * error indicating where the problem is.
-         */
-        MaterialModelInputs &operator=(const MaterialModelInputs &material);
+      /**
+       * Values of the compositional fields at the points given in the
+       * #position vector: composition[i][c] is the compositional field c at
+       * point i.
+       */
+      std::vector<std::vector<double> > composition;
+
+      /**
+       * Strain rate at the points given in the #position vector. Only the
+       * viscosity may depend on these values. This std::vector can be set to
+       * size 0 if the viscosity is not needed.
+       *
+       * @note The strain rate is computed as $\varepsilon(\mathbf u)=\frac 12
+       * (\nabla \mathbf u + \nabla \mathbf u^T)$, regardless of whether the
+       * model is compressible or not. This is relevant since in some other
+       * contexts, the strain rate in the compressible case is computed as
+       * $\varepsilon(\mathbf u)=\frac 12 (\nabla \mathbf u + \nabla \mathbf
+       * u^T) - \frac 13 \nabla \cdot \mathbf u \mathbf 1$.
+       */
+      std::vector<SymmetricTensor<2,dim> > strain_rate;
+
+      /**
+       * Optional reference to the cell that contains these quadrature
+       * points. This allows for evaluating properties at the cell vertices
+       * and interpolating to the quadrature points, or to query the cell for
+       * material ids, neighbors, or other information that is not available
+       * solely from the locations. Note that not all calling functions can set
+       * this reference. In these cases it will be a nullptr, so make sure
+       * that your material model either fails with a proper error message
+       * or provide an alternative calculation for these cases.
+       *
+       * @deprecated Use DoFHandler<dim>::active_cell_iterator current_cell instead.
+       */
+      const typename DoFHandler<dim>::active_cell_iterator *cell DEAL_II_DEPRECATED;
+
+      /**
+       * Optional cell object that contains these quadrature
+       * points. This allows for evaluating properties at the cell vertices
+       * and interpolating to the quadrature points, or to query the cell for
+       * material ids, neighbors, or other information that is not available
+       * solely from the locations. Note that not all calling functions will
+       * set this cell iterator. In these cases it will be an invalid iterator
+       * constructed using the default constructor, so make sure that your
+       * material model either fails
+       * with a proper error message, or provides an alternative calculation for
+       * these cases. You can detect this with
+       * @code
+       * if (in.current_cell.state() == IteratorState::valid)
+       * @endcode
+       */
+      typename DoFHandler<dim>::active_cell_iterator current_cell;
+
+      /**
+       * Vector of shared pointers to additional material model input
+       * objects that can be added to MaterialModelInputs. By default,
+       * no inputs are added.
+       */
+      std::vector<std::shared_ptr<AdditionalMaterialInputs<dim> > > additional_inputs;
+
+      /**
+       * Given an additional material model input class as explicitly specified
+       * template argument, returns a pointer to this additional material model
+       * input object if it is used in the current simulation.
+       * If the output does not exist, a null pointer is returned.
+       */
+      template <class AdditionalInputType>
+      AdditionalInputType *get_additional_input();
+
+      /**
+       * Constant version of get_additional_input() returning a const pointer.
+       */
+      template <class AdditionalInputType>
+      const AdditionalInputType *get_additional_input() const;
     };
 
 
@@ -391,7 +408,7 @@ namespace aspect
        * are unique to the @p source object). Since they can also not
        * be recreated without the original code that created these objects
        * in the first place, this constructor throws an exception if the
-       * @p source object had any additional input or output data objects
+       * @p source object had any additional output data objects
        * associated with it.
        */
       MaterialModelOutputs (const MaterialModelOutputs &source);

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -337,19 +337,50 @@ namespace aspect
       this->reinit(fe_values, current_cell, introspection, solution_vector, use_strain_rate);
     }
 
+
+
     template <int dim>
-    MaterialModelInputs<dim>::MaterialModelInputs(const MaterialModelInputs &material)
+    MaterialModelInputs<dim>::MaterialModelInputs(const MaterialModelInputs &source)
       :
-      position(material.position),
-      temperature(material.temperature),
-      pressure(material.pressure),
-      pressure_gradient(material.pressure_gradient),
-      velocity(material.velocity),
-      composition(material.composition),
-      strain_rate(material.strain_rate),
-      cell(material.cell),
-      current_cell(material.current_cell)
-    {}
+      position(source.position),
+      temperature(source.temperature),
+      pressure(source.pressure),
+      pressure_gradient(source.pressure_gradient),
+      velocity(source.velocity),
+      composition(source.composition),
+      strain_rate(source.strain_rate),
+      cell(source.cell),
+      current_cell(source.current_cell)
+    {
+      Assert (source.additional_inputs.size() == 0,
+              ExcMessage ("You can not copy MaterialModelInputs objects that have "
+                          "additional input objects attached"));
+    }
+
+
+    template <int dim>
+    MaterialModelInputs<dim> &
+    MaterialModelInputs<dim>::operator=(const MaterialModelInputs &source)
+    {
+      position = source.position;
+      temperature = source.temperature;
+      pressure = source.pressure;
+      pressure_gradient = source.pressure_gradient;
+      velocity = source.velocity;
+      composition = source.composition;
+      strain_rate = source.strain_rate;
+      cell = source.cell;
+      current_cell = source.current_cell;
+
+      Assert (source.additional_inputs.size() == 0,
+              ExcMessage ("You can not copy MaterialModelInputs objects that have "
+                          "additional input objects attached"));
+
+      return *this;
+    }
+
+
+
     DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 


### PR DESCRIPTION
Companion to #2984.