### PR TITLE
Fix a missing space in a function declaration.

### DIFF
--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -772,7 +772,7 @@ namespace aspect
        * constraints for the time step we are currently solving.
        */
       const ConstraintMatrix &
-      get_current_constraints() const;
+      get_current_constraints () const;
 
       /**
        * Return whether or not the current object has been initialized by providing it with


### PR DESCRIPTION
See the review done by @gassmoeller (but credited to @tjhei) of #2972.