### PR TITLE
Minor cleanup: Don't duplicate the value of an argument.

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -824,7 +824,7 @@ namespace aspect
              dof_handler.locally_owned_dofs_per_processor(),
              locally_active_dofs,
              mpi_communicator,
-             false /*verbose=false*/),
+             /*verbose = */ false),
            ExcMessage("Inconsistent Constraints detected!"));
 #endif
 


### PR DESCRIPTION
Follow-up to #2898.