### PR TITLE
Simply prohibit copying material model inputs/outputs.

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -245,10 +245,10 @@ namespace aspect
       MaterialModelInputs (MaterialModelInputs &&) = default;
 
       /**
-       * Copy operator. This operator has the same restriction on the
-       * additional input data pointers as the copy constructor.
+       * Copy operator. Copying these objects is expensive and
+       * consequently prohibited
        */
-      MaterialModelInputs &operator= (const MaterialModelInputs &source);
+      MaterialModelInputs &operator= (const MaterialModelInputs &source) = delete;
 
       /**
        * Move operator.
@@ -419,10 +419,10 @@ namespace aspect
       MaterialModelOutputs (MaterialModelOutputs &&) = default;
 
       /**
-       * Copy operator. This operator has the same restriction on the
-       * additional output data pointers as the copy constructor.
+       * Copy operator. Copying these objects is expensive, and consequently
+       * prohibited.
        */
-      MaterialModelOutputs &operator= (const MaterialModelOutputs &source);
+      MaterialModelOutputs &operator= (const MaterialModelOutputs &source) = delete;
 
       /**
        * Move operator.

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -358,29 +358,6 @@ namespace aspect
     }
 
 
-    template <int dim>
-    MaterialModelInputs<dim> &
-    MaterialModelInputs<dim>::operator=(const MaterialModelInputs &source)
-    {
-      position = source.position;
-      temperature = source.temperature;
-      pressure = source.pressure;
-      pressure_gradient = source.pressure_gradient;
-      velocity = source.velocity;
-      composition = source.composition;
-      strain_rate = source.strain_rate;
-      cell = source.cell;
-      current_cell = source.current_cell;
-
-      Assert (source.additional_inputs.size() == 0,
-              ExcMessage ("You can not copy MaterialModelInputs objects that have "
-                          "additional input objects attached"));
-
-      return *this;
-    }
-
-
-
     DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 
@@ -463,27 +440,6 @@ namespace aspect
                           "additional output objects attached"));
     }
 
-
-    template <int dim>
-    MaterialModelOutputs<dim> &
-    MaterialModelOutputs<dim>::operator= (const MaterialModelOutputs<dim> &source)
-    {
-      viscosities = source.viscosities;
-      densities = source.densities;
-      thermal_expansion_coefficients = source.thermal_expansion_coefficients;
-      specific_heat = source.specific_heat;
-      thermal_conductivities = source.thermal_conductivities;
-      compressibilities = source.compressibilities;
-      entropy_derivative_pressure = source.entropy_derivative_pressure;
-      entropy_derivative_temperature = source.entropy_derivative_temperature;
-      reaction_terms = source.reaction_terms;
-      additional_outputs = {};
-      Assert (source.additional_outputs.size() == 0,
-              ExcMessage ("You can not copy MaterialModelOutputs objects that have "
-                          "additional output objects attached"));
-
-      return *this;
-    }
 
 
     namespace MaterialAveraging


### PR DESCRIPTION
Follow-up to #2993.