### PR TITLE
Get rid of the remaining uses of std::shared_ptr.

### DIFF
--- a/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
+++ b/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
@@ -210,8 +210,7 @@ namespace aspect
         {
           const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(
-            std::shared_ptr<MaterialModel::AdditionalMaterialOutputs<dim> >
-            (new MaterialModel::ReactionRateOutputs<dim> (n_points, this->n_compositional_fields())));
+            std_cxx14::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
         }
     }
   }

--- a/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
+++ b/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
@@ -207,8 +207,7 @@ namespace aspect
         {
           const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(
-            std::shared_ptr<MaterialModel::AdditionalMaterialOutputs<dim> >
-            (new MaterialModel::ReactionRateOutputs<dim> (n_points, this->n_compositional_fields())));
+            std_cxx14::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
         }
     }
   }

--- a/include/aspect/material_model/averaging.h
+++ b/include/aspect/material_model/averaging.h
@@ -164,7 +164,7 @@ namespace aspect
         /**
          * Pointer to the material model used as the base model
          */
-        std::shared_ptr<MaterialModel::Interface<dim> > base_model;
+        std::unique_ptr<MaterialModel::Interface<dim> > base_model;
     };
   }
 }

--- a/include/aspect/material_model/compositing.h
+++ b/include/aspect/material_model/compositing.h
@@ -123,7 +123,7 @@ namespace aspect
          * compositing.
          */
         std::vector<std::string>                             model_names;
-        std::vector<std::shared_ptr<Interface<dim> > > models;
+        std::vector<std::unique_ptr<Interface<dim> > > models;
     };
   }
 }

--- a/include/aspect/material_model/depth_dependent.h
+++ b/include/aspect/material_model/depth_dependent.h
@@ -121,7 +121,7 @@ namespace aspect
          * Data structures to store depth and viscosity lookup tables as well as interpolating
          * function to calculate viscosity for File Depth dependence method
          */
-        std::shared_ptr< Functions::InterpolatedTensorProductGridData<1> > viscosity_file_function;
+        std::unique_ptr< Functions::InterpolatedTensorProductGridData<1> > viscosity_file_function;
 
         /**
          * Function to calculate viscosity at depth using values provided as List input
@@ -156,7 +156,7 @@ namespace aspect
         /**
          * Pointer to the material model used as the base model
          */
-        std::shared_ptr<MaterialModel::Interface<dim> > base_model;
+        std::unique_ptr<MaterialModel::Interface<dim> > base_model;
     };
   }
 }

--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -558,7 +558,7 @@ namespace aspect
          * material data files. There is one pointer/object per compositional
          * field provided.
          */
-        std::vector<std::shared_ptr<MaterialModel::Lookup::MaterialLookup> > material_lookup;
+        std::vector<std::unique_ptr<MaterialModel::Lookup::MaterialLookup> > material_lookup;
     };
 
   }

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -354,7 +354,7 @@ namespace aspect
        * objects that can be added to MaterialModelInputs. By default,
        * no inputs are added.
        */
-      std::vector<std::shared_ptr<AdditionalMaterialInputs<dim> > > additional_inputs;
+      std::vector<std::unique_ptr<AdditionalMaterialInputs<dim> > > additional_inputs;
 
       /**
        * Given an additional material model input class as explicitly specified
@@ -520,7 +520,7 @@ namespace aspect
        * objects that can then be added to MaterialModelOutputs. By default,
        * no outputs are added.
        */
-      std::vector<std::shared_ptr<AdditionalMaterialOutputs<dim> > > additional_outputs;
+      std::vector<std::unique_ptr<AdditionalMaterialOutputs<dim> > > additional_outputs;
 
       /**
        * Given an additional material model output class as explicitly specified

--- a/include/aspect/material_model/steinberger.h
+++ b/include/aspect/material_model/steinberger.h
@@ -308,19 +308,19 @@ namespace aspect
          * List of pointers to objects that read and process data we get from
          * Perplex files.
          */
-        std::vector<std::shared_ptr<Lookup::PerplexReader> > material_lookup;
+        std::vector<std::unique_ptr<Lookup::PerplexReader> > material_lookup;
 
         /**
          * Pointer to an object that reads and processes data for the lateral
          * temperature dependency of viscosity.
          */
-        std::shared_ptr<internal::LateralViscosityLookup> lateral_viscosity_lookup;
+        std::unique_ptr<internal::LateralViscosityLookup> lateral_viscosity_lookup;
 
         /**
          * Pointer to an object that reads and processes data for the radial
          * viscosity profile.
          */
-        std::shared_ptr<internal::RadialViscosityLookup> radial_viscosity_lookup;
+        std::unique_ptr<internal::RadialViscosityLookup> radial_viscosity_lookup;
 
     };
   }

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -441,7 +441,6 @@ namespace aspect
     }
 
 
-
     namespace MaterialAveraging
     {
       std::string get_averaging_operation_names ()

--- a/source/material_model/viscoelastic_plastic.cc
+++ b/source/material_model/viscoelastic_plastic.cc
@@ -540,8 +540,7 @@ namespace aspect
         {
           const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(
-            std::shared_ptr<MaterialModel::AdditionalMaterialOutputs<dim> >
-            (new MaterialModel::ElasticAdditionalOutputs<dim> (n_points)));
+            std_cxx14::make_unique<MaterialModel::ElasticAdditionalOutputs<dim>> (n_points));
         }
     }
   }

--- a/tests/additional_outputs_02.cc
+++ b/tests/additional_outputs_02.cc
@@ -79,7 +79,7 @@ namespace aspect
           return;
 
         std::cout << "   creating additional output!" << std::endl;
-        out.additional_outputs.push_back(std::make_shared<MaterialModel::AdditionalOutputs1<dim> > (1));
+        out.additional_outputs.push_back(std_cxx14::make_unique<MaterialModel::AdditionalOutputs1<dim> > (1));
 
       }
 

--- a/tests/additional_outputs_03.cc
+++ b/tests/additional_outputs_03.cc
@@ -93,7 +93,7 @@ namespace aspect
           return;
 
         std::cout << "   creating additional output!" << std::endl;
-        out.additional_outputs.push_back(std::make_shared<MaterialModel::AdditionalOutputs1<dim> > (2));
+        out.additional_outputs.push_back(std_cxx14::make_unique<MaterialModel::AdditionalOutputs1<dim> > (2));
 
       }
 

--- a/tests/anisotropic_viscosity.cc
+++ b/tests/anisotropic_viscosity.cc
@@ -223,7 +223,7 @@ namespace aspect
       if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std::make_shared<MaterialModel::AnisotropicViscosity<dim>> (n_points));
+            std_cxx14::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
         }
     }
 
@@ -405,14 +405,14 @@ namespace aspect
       if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std::make_shared<MaterialModel::AnisotropicViscosity<dim>> (n_points));
+            std_cxx14::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
         }
 
       if (this->get_parameters().enable_additional_stokes_rhs
           && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std::make_shared<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> (n_points));
+            std_cxx14::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> (n_points));
         }
       Assert(!this->get_parameters().enable_additional_stokes_rhs
              ||
@@ -578,7 +578,7 @@ namespace aspect
       if (material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >() == nullptr)
         {
           material_model_outputs.additional_outputs.push_back(
-            std::make_shared<MaterialModel::AnisotropicViscosity<dim>> (n_points));
+            std_cxx14::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
         }
 
       this->get_material_model().create_additional_named_outputs(material_model_outputs);

--- a/tests/drucker_prager_derivatives.cc
+++ b/tests/drucker_prager_derivatives.cc
@@ -115,7 +115,7 @@ int f()
   if (out_base.template get_additional_output<MaterialModelDerivatives<dim> >() != nullptr)
     throw "error";
 
-  out_base.additional_outputs.push_back(std::make_shared<MaterialModelDerivatives<dim> > (5));
+  out_base.additional_outputs.push_back(std_cxx14::make_unique<MaterialModelDerivatives<dim> > (5));
 
   // initialize the material we want to test.
   DruckerPrager<dim> mat;

--- a/tests/multiple_named_additional_outputs.cc
+++ b/tests/multiple_named_additional_outputs.cc
@@ -66,14 +66,14 @@ namespace aspect
         {
           const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(
-            std::make_shared<MaterialModel::PrescribedFieldOutputs<dim>> (n_points,this->n_compositional_fields()));
+            std_cxx14::make_unique<MaterialModel::PrescribedFieldOutputs<dim>> (n_points,this->n_compositional_fields()));
         }
 
       if (out.template get_additional_output<SeismicAdditionalOutputs<dim> >() == NULL)
         {
           const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(
-            std::make_shared<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
+            std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
         }
     }
   }

--- a/tests/prescribed_field.cc
+++ b/tests/prescribed_field.cc
@@ -53,7 +53,7 @@ namespace aspect
         {
           const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(
-            std::make_shared<MaterialModel::PrescribedFieldOutputs<dim>> (n_points, this->n_compositional_fields()));
+            std_cxx14::make_unique<MaterialModel::PrescribedFieldOutputs<dim>> (n_points, this->n_compositional_fields()));
         }
     }
   }

--- a/tests/prescribed_field_with_diffusion.cc
+++ b/tests/prescribed_field_with_diffusion.cc
@@ -56,7 +56,7 @@ namespace aspect
         {
           const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(
-            std::make_shared<MaterialModel::PrescribedFieldOutputs<dim>> (n_points, this->n_compositional_fields()));
+            std_cxx14::make_unique<MaterialModel::PrescribedFieldOutputs<dim>> (n_points, this->n_compositional_fields()));
         }
     }
   }

--- a/tests/simple_nonlinear.cc
+++ b/tests/simple_nonlinear.cc
@@ -118,7 +118,7 @@ int f(double parameter)
   if (out_base.template get_additional_output<MaterialModelDerivatives<dim> >() != nullptr)
     throw "error";
 
-  out_base.additional_outputs.push_back(std::make_shared<MaterialModelDerivatives<dim> > (5));
+  out_base.additional_outputs.push_back(std_cxx14::make_unique<MaterialModelDerivatives<dim> > (5));
 
   // initialize the material we want to test.
   SimpleNonlinear<dim> mat;

--- a/tests/spiegelman_material.cc
+++ b/tests/spiegelman_material.cc
@@ -132,7 +132,7 @@ int f(double parameter)
   if (out_base.get_additional_output<MaterialModelDerivatives<dim> >() != nullptr)
     throw "error";
 
-  out_base.additional_outputs.push_back(std::make_shared<MaterialModelDerivatives<dim> > (5));
+  out_base.additional_outputs.push_back(std_cxx14::make_unique<MaterialModelDerivatives<dim> > (5));
 
   SpiegelmanMaterial<dim> mat;
   ParameterHandler prm;

--- a/tests/visco_plastic_derivatives_2d.cc
+++ b/tests/visco_plastic_derivatives_2d.cc
@@ -117,7 +117,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
 
   const_cast<aspect::MaterialModel::Interface<dim> &>(simulator_access.get_material_model()).parse_parameters(prm);
 
-  out_base.additional_outputs.push_back(std::make_shared<MaterialModelDerivatives<dim> > (5));
+  out_base.additional_outputs.push_back(std_cxx14::make_unique<MaterialModelDerivatives<dim> > (5));
 
   simulator_access.get_material_model().evaluate(in_base, out_base);
 

--- a/tests/visco_plastic_derivatives_3d.cc
+++ b/tests/visco_plastic_derivatives_3d.cc
@@ -132,7 +132,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
 
   const_cast<aspect::MaterialModel::Interface<dim> &>(simulator_access.get_material_model()).parse_parameters(prm);
 
-  out_base.additional_outputs.push_back(std::make_shared<MaterialModelDerivatives<dim> > (5));
+  out_base.additional_outputs.push_back(std_cxx14::make_unique<MaterialModelDerivatives<dim> > (5));
 
   simulator_access.get_material_model().evaluate(in_base, out_base);
 


### PR DESCRIPTION
In reference to #2811 and #2375.

This in fact closes #2811.