### PR TITLE
Allow particles to be applied to fields when particles aren't distributed throughout model.

### DIFF
--- a/include/aspect/particle/interpolator/cell_average.h
+++ b/include/aspect/particle/interpolator/cell_average.h
@@ -52,6 +52,29 @@ namespace aspect
 
           // avoid -Woverloaded-virtual:
           using Interface<dim>::properties_at_points;
+
+          /**
+          * @copydoc Interface<dim>::declare_parameters()
+          **/
+          static
+          void
+          declare_parameters (ParameterHandler &prm);
+
+          /**
+           * @copydoc Interface<dim>::parse_parameters()
+           **/
+          virtual
+          void
+          parse_parameters (ParameterHandler &prm);
+
+        private:
+          /**
+           * Generally, particles need to be distributed throughout the
+           * model domain when being applied to a field. This parameter
+           * allows particles to be applied as a field even if some cells
+           * have no particles.
+           */
+          bool allow_cells_without_particles;
       };
     }
   }

--- a/include/aspect/particle/interpolator/cell_average.h
+++ b/include/aspect/particle/interpolator/cell_average.h
@@ -69,10 +69,9 @@ namespace aspect
 
         private:
           /**
-           * Generally, particles need to be distributed throughout the
-           * model domain when being applied to a field. This parameter
-           * allows particles to be applied as a field even if some cells
-           * have no particles.
+           * By default, every cell needs to contain particles to use this interpolator
+           * plugin. If this parameter is set to true, cells are allowed to have no particles,
+           * in which case the interpolator will return 0 for the cell's properties.
            */
           bool allow_cells_without_particles;
       };

--- a/include/aspect/particle/interpolator/harmonic_average.h
+++ b/include/aspect/particle/interpolator/harmonic_average.h
@@ -52,6 +52,29 @@ namespace aspect
 
           // avoid -Woverloaded-virtual:
           using Interface<dim>::properties_at_points;
+
+          /**
+           * @copydoc Interface<dim>::declare_parameters()
+           */
+          static
+          void
+          declare_parameters (ParameterHandler &prm);
+
+          /**
+           * @copydoc Interface<dim>::parse_parameters()
+           */
+          virtual
+          void
+          parse_parameters (ParameterHandler &prm);
+
+        private:
+          /**
+           * Generally, particles need to be distributed throughout the
+           * model domain when being applied to a field. This parameter
+           * allows particles to be applied as a field even if some cells
+           * have no particles.
+           */
+          bool allow_cells_without_particles;
       };
     }
   }

--- a/include/aspect/particle/interpolator/harmonic_average.h
+++ b/include/aspect/particle/interpolator/harmonic_average.h
@@ -69,10 +69,9 @@ namespace aspect
 
         private:
           /**
-           * Generally, particles need to be distributed throughout the
-           * model domain when being applied to a field. This parameter
-           * allows particles to be applied as a field even if some cells
-           * have no particles.
+           * By default, every cell needs to contain particles to use this interpolator
+           * plugin. If this parameter is set to true, cells are allowed to have no particles,
+           * in which case the interpolator will return 0 for the cell's properties.
            */
           bool allow_cells_without_particles;
       };

--- a/include/aspect/particle/interpolator/nearest_neighbor.h
+++ b/include/aspect/particle/interpolator/nearest_neighbor.h
@@ -53,6 +53,29 @@ namespace aspect
 
           // avoid -Woverloaded-virtual:
           using Interface<dim>::properties_at_points;
+
+          /**
+           * @copydoc Interface<dim>::declare_parameters()
+           */
+          static
+          void
+          declare_parameters (ParameterHandler &prm);
+
+          /**
+           * @copydoc Interface<dim>::parse_parameters()
+           */
+          virtual
+          void
+          parse_parameters (ParameterHandler &prm);
+
+        private:
+          /**
+           * Generally, particles need to be distributed throughout the
+           * model domain when being applied to a field. This parameter
+           * allows particles to be applied as a field even if some cells
+           * have no particles.
+           */
+          bool allow_cells_without_particles;
       };
     }
   }

--- a/include/aspect/particle/interpolator/nearest_neighbor.h
+++ b/include/aspect/particle/interpolator/nearest_neighbor.h
@@ -70,10 +70,9 @@ namespace aspect
 
         private:
           /**
-           * Generally, particles need to be distributed throughout the
-           * model domain when being applied to a field. This parameter
-           * allows particles to be applied as a field even if some cells
-           * have no particles.
+           * By default, every cell needs to contain particles to use this interpolator
+           * plugin. If this parameter is set to true, cells are allowed to have no particles,
+           * in which case the interpolator will return 0 for the cell's properties.
            */
           bool allow_cells_without_particles;
       };

--- a/source/particle/interpolator/cell_average.cc
+++ b/source/particle/interpolator/cell_average.cc
@@ -21,7 +21,6 @@
 #include <aspect/particle/interpolator/cell_average.h>
 #include <aspect/postprocess/particles.h>
 #include <aspect/simulator.h>
-#include <aspect/particle/interpolator/interface.h>
 
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/base/signaling_nan.h>

--- a/source/particle/interpolator/cell_average.cc
+++ b/source/particle/interpolator/cell_average.cc
@@ -137,6 +137,8 @@ namespace aspect
         return std::vector<std::vector<double> > (positions.size(),cell_properties);
       }
 
+
+
       template <int dim>
       void
       CellAverage<dim>::declare_parameters (ParameterHandler &prm)
@@ -147,15 +149,16 @@ namespace aspect
           {
             prm.declare_entry ("Allow cells without particles", "false",
                                Patterns::Bool (),
-                               "Generally, particles need to be distributed throughout the "
-                               "model domain when being applied to a field. This parameter "
-                               "allows particles to be applied as a field even if some cells "
-                               "have no particles.");
+                               "By default, every cell needs to contain particles to use this interpolator "
+                               "plugin. If this parameter is set to true, cells are allowed to have no particles, "
+                               "in which case the interpolator will return 0 for the cell's properties.");
           }
           prm.leave_subsection ();
         }
         prm.leave_subsection ();
       }
+
+
 
       template <int dim>
       void
@@ -166,14 +169,11 @@ namespace aspect
           prm.enter_subsection("Particles");
           {
             allow_cells_without_particles = prm.get_bool("Allow cells without particles");
-
           }
           prm.leave_subsection ();
         }
         prm.leave_subsection ();
       }
-
-
     }
   }
 }

--- a/source/particle/interpolator/cell_average.cc
+++ b/source/particle/interpolator/cell_average.cc
@@ -115,13 +115,14 @@ namespace aspect
                 ++non_empty_neighbors;
               }
 
-            AssertThrow(non_empty_neighbors != 0,
-                        ExcMessage("A cell and all of its neighbors do not contain any particles. "
-                                   "The `cell average' interpolation scheme does not support this case."));
-
             for (unsigned int i = 0; i < n_particle_properties; ++i)
-              if (selected_properties[i])
-                cell_properties[i] /= non_empty_neighbors;
+              {
+                if (selected_properties[i] && non_empty_neighbors != 0)
+                  cell_properties[i] /= non_empty_neighbors;
+                // Assume property is zero for any areas with no particles
+                else
+                  cell_properties[i] = 0;
+              }
           }
 
         return std::vector<std::vector<double> > (positions.size(),cell_properties);

--- a/source/particle/interpolator/harmonic_average.cc
+++ b/source/particle/interpolator/harmonic_average.cc
@@ -118,13 +118,16 @@ namespace aspect
                 ++non_empty_neighbors;
               }
 
-            AssertThrow(non_empty_neighbors != 0,
-                        ExcMessage("A cell and all of its neighbors do not contain any particles. "
-                                   "The `harmonic average' interpolation scheme does not support this case."));
 
             for (unsigned int i = 0; i < n_particle_properties; ++i)
-              if (selected_properties[i])
-                cell_properties[i] = non_empty_neighbors/cell_properties[i];
+              {
+                if (selected_properties[i] && non_empty_neighbors !=0)
+                  cell_properties[i] = non_empty_neighbors/cell_properties[i];
+                // Assume property is zero for any areas with no particles
+                else
+                  cell_properties[i] = 0;
+              }
+
           }
 
         return std::vector<std::vector<double> > (positions.size(),cell_properties);

--- a/source/particle/interpolator/harmonic_average.cc
+++ b/source/particle/interpolator/harmonic_average.cc
@@ -118,19 +118,63 @@ namespace aspect
                 ++non_empty_neighbors;
               }
 
+            if (!allow_cells_without_particles)
+              {
+                AssertThrow(non_empty_neighbors != 0,
+                            ExcMessage("A cell and all of its neighbors do not contain any particles. "
+                                       "The `harmonic average' interpolation scheme does not support this case unless specified "
+                                       "in Allow cells without particles."));
+              }
+
 
             for (unsigned int i = 0; i < n_particle_properties; ++i)
               {
                 if (selected_properties[i] && non_empty_neighbors !=0)
                   cell_properties[i] = non_empty_neighbors/cell_properties[i];
                 // Assume property is zero for any areas with no particles
-                else
+                else if (allow_cells_without_particles && non_empty_neighbors == 0)
                   cell_properties[i] = 0;
               }
 
           }
 
         return std::vector<std::vector<double> > (positions.size(),cell_properties);
+      }
+
+      template <int dim>
+      void
+      HarmonicAverage<dim>::declare_parameters (ParameterHandler &prm)
+      {
+        prm.enter_subsection("Postprocess");
+        {
+          prm.enter_subsection("Particles");
+          {
+            prm.declare_entry ("Allow cells without particles", "false",
+                               Patterns::Bool (),
+                               "Generally, particles need to be distributed throughout the "
+                               "model domain when being applied to a field. This parameter "
+                               "allows particles to be applied as a field even if some cells "
+                               "have no particles.");
+          }
+          prm.leave_subsection ();
+        }
+        prm.leave_subsection ();
+      }
+
+      template <int dim>
+      void
+      HarmonicAverage<dim>::parse_parameters (ParameterHandler &prm)
+      {
+        prm.enter_subsection("Postprocess");
+        {
+          prm.enter_subsection("Particles");
+          {
+            allow_cells_without_particles = prm.get_bool("Allow cells without particles");
+
+          }
+          prm.leave_subsection ();
+        }
+        prm.leave_subsection ();
       }
     }
   }

--- a/source/particle/interpolator/harmonic_average.cc
+++ b/source/particle/interpolator/harmonic_average.cc
@@ -126,7 +126,6 @@ namespace aspect
                                        "in Allow cells without particles."));
               }
 
-
             for (unsigned int i = 0; i < n_particle_properties; ++i)
               {
                 if (selected_properties[i] && non_empty_neighbors !=0)
@@ -141,6 +140,8 @@ namespace aspect
         return std::vector<std::vector<double> > (positions.size(),cell_properties);
       }
 
+
+
       template <int dim>
       void
       HarmonicAverage<dim>::declare_parameters (ParameterHandler &prm)
@@ -151,15 +152,16 @@ namespace aspect
           {
             prm.declare_entry ("Allow cells without particles", "false",
                                Patterns::Bool (),
-                               "Generally, particles need to be distributed throughout the "
-                               "model domain when being applied to a field. This parameter "
-                               "allows particles to be applied as a field even if some cells "
-                               "have no particles.");
+                               "By default, every cell needs to contain particles to use this interpolator "
+                               "plugin. If this parameter is set to true, cells are allowed to have no particles, "
+                               "in which case the interpolator will return 0 for the cell's properties.");
           }
           prm.leave_subsection ();
         }
         prm.leave_subsection ();
       }
+
+
 
       template <int dim>
       void
@@ -170,7 +172,6 @@ namespace aspect
           prm.enter_subsection("Particles");
           {
             allow_cells_without_particles = prm.get_bool("Allow cells without particles");
-
           }
           prm.leave_subsection ();
         }

--- a/source/particle/interpolator/nearest_neighbor.cc
+++ b/source/particle/interpolator/nearest_neighbor.cc
@@ -139,6 +139,7 @@ namespace aspect
       }
 
 
+
       template <int dim>
       void
       NearestNeighbor<dim>::declare_parameters (ParameterHandler &prm)
@@ -149,15 +150,16 @@ namespace aspect
           {
             prm.declare_entry ("Allow cells without particles", "false",
                                Patterns::Bool (),
-                               "Generally, particles need to be distributed throughout the "
-                               "model domain when being applied to a field. This parameter "
-                               "allows particles to be applied as a field even if some cells "
-                               "have no particles.");
+                               "By default, every cell needs to contain particles to use this interpolator "
+                               "plugin. If this parameter is set to true, cells are allowed to have no particles, "
+                               "in which case the interpolator will return 0 for the cell's properties.");
           }
           prm.leave_subsection ();
         }
         prm.leave_subsection ();
       }
+
+
 
       template <int dim>
       void
@@ -168,7 +170,6 @@ namespace aspect
           prm.enter_subsection("Particles");
           {
             allow_cells_without_particles = prm.get_bool("Allow cells without particles");
-
           }
           prm.leave_subsection ();
         }

--- a/source/particle/interpolator/nearest_neighbor.cc
+++ b/source/particle/interpolator/nearest_neighbor.cc
@@ -109,18 +109,21 @@ namespace aspect
                       }
                   }
 
-                Assert(nearest_neighbor_cell != numbers::invalid_unsigned_int,
-                       ExcMessage("A cell and all of its neighbors do not contain any particles. "
-                                  "This case is not supported by the 'nearest neighbor' interpolation scheme."));
+                if (nearest_neighbor_cell != numbers::invalid_unsigned_int)
+                  {
+                    point_properties[pos_idx] = properties_at_points(particle_handler,
+                                                                     std::vector<Point<dim> > (1,positions[pos_idx]),
+                                                                     selected_properties,
+                                                                     neighbors[nearest_neighbor_cell])[0];
+                  }
+                else
+                  {
+                    for (unsigned int i = 0; i < n_particle_properties; ++i)
+                      if (selected_properties[i])
+                        point_properties[pos_idx][i] = 0;
+                  }
 
-                point_properties[pos_idx] = properties_at_points(particle_handler,
-                                                                 std::vector<Point<dim> > (1,positions[pos_idx]),
-                                                                 selected_properties,
-                                                                 neighbors[nearest_neighbor_cell])[0];
               }
-
-            AssertThrow(minimum_distance < std::numeric_limits<double>::max(),
-                        ExcMessage("Failed to find any neighbor particles."));
           }
 
         return point_properties;


### PR DESCRIPTION
These changes allow the cell/harmonic average, and nearest neighbor particle interpolators to apply the particles as a field even when there are areas with no particles. 

A few questions, as of now this assumes that any area with no particles should be given a value of zero. Would it be better to have this be user defined? Also, should I add a flag for this so that, generally, an assert would still be thrown unless this feature is specifically wanted?