### PR TITLE
disable adaptive refinement by default

### DIFF
--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -712,7 +712,7 @@ namespace aspect
                          "The number of adaptive refinement steps performed after "
                          "initial global refinement but while still within the first "
                          "time step.");
-      prm.declare_entry ("Time steps between mesh refinement", "10",
+      prm.declare_entry ("Time steps between mesh refinement", "0",
                          Patterns::Integer (0),
                          "The number of time steps after which the mesh is to be "
                          "adapted again based on computed error indicators. If 0 "


### PR DESCRIPTION
It is often a mistake that adaptive refinement is enabled by default and
more likely than not, that is not what is intended. Let's discuss if we should change the default...