### PR TITLE
fix missing ElasticAdditionalOutputs instantiation

### DIFF
--- a/source/material_model/viscoelastic.cc
+++ b/source/material_model/viscoelastic.cc
@@ -520,6 +520,11 @@ namespace aspect
 {
   namespace MaterialModel
   {
+#define INSTANTIATE(dim) \
+  template class ElasticAdditionalOutputs<dim>;
+
+    ASPECT_INSTANTIATE(INSTANTIATE)
+
     ASPECT_REGISTER_MATERIAL_MODEL(Viscoelastic,
                                    "viscoelastic",
                                    "An implementation of a simple linear viscoelastic rheology that "


### PR DESCRIPTION
clang + lld complains about a missing instantiation. I guess gcc doesn't
require it, but it is certainly correct to do so.