### PR TITLE
cmake: do not configure test project every time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ CONFIGURE_FILE(
 # Next, set up the testsuite
 
 SET(ASPECT_RUN_ALL_TESTS OFF CACHE BOOL "Set up complete test suite to run.")
+SET(ASPECT_NEED_TEST_CONFIGURE ON CACHE BOOL "If true, reconfigure test project.")
 SET(ASPECT_COMPARE_TEST_RESULTS ON CACHE BOOL "Compare test results with high accuracy.")
 
 CONFIGURE_FILE(
@@ -165,8 +166,9 @@ CONFIGURE_FILE(
   @ONLY
 )
 
+# enable all tests and force a re-run of the cmake configuration in the test/ folder:
 ADD_CUSTOM_TARGET(setup_tests
-  COMMAND ${CMAKE_COMMAND} -D ASPECT_RUN_ALL_TESTS=ON -D PRINT_TEST_SUMMARY_AS_IMPORTANT=ON . >/dev/null
+  COMMAND ${CMAKE_COMMAND} -D ASPECT_RUN_ALL_TESTS=ON -D ASPECT_NEED_TEST_CONFIGURE=ON -D PRINT_TEST_SUMMARY_AS_IMPORTANT=ON . >/dev/null
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Enabling all tests ...")
 
@@ -222,13 +224,18 @@ IF(EXISTS ${CMAKE_SOURCE_DIR}/unit_tests/CMakeLists.txt)
   ADD_DEPENDENCIES(test run_unit_tests)
 ENDIF()
 
-IF(EXISTS ${CMAKE_SOURCE_DIR}/tests/CMakeLists.txt)
+IF(EXISTS ${CMAKE_SOURCE_DIR}/tests/CMakeLists.txt
+  AND ${ASPECT_NEED_TEST_CONFIGURE})
+
   # Hook up the tests:
   FILE(APPEND ${CMAKE_BINARY_DIR}/CTestTestfile.cmake "SUBDIRS(tests)\n")
 
   FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests)
 
   SET(aspect_binary ${CMAKE_BINARY_DIR}/aspect)
+
+  # set a flag so we don't need to rerun this configuration step every time:
+  SET(ASPECT_NEED_TEST_CONFIGURE OFF CACHE BOOL "" FORCE)
 
   MESSAGE(STATUS "Setting up test project, see tests/setup_tests.log for details.")
   EXECUTE_PROCESS(
@@ -328,7 +335,7 @@ FILE(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/print_usage.cmake
 #      ${_make_command} distclean      - to clean the directory from all generated
 #                               files (includes clean, runclean and the removal
 #                               of the generated build system)
-#      ${_make_command} setup_tests    - enable all tests
+#      ${_make_command} setup_tests    - enable all tests and re-run test detection
 #      ${_make_command} indent         - fix indentation of all source files
 #      ${_make_command} info           - to view this message again
 \")")

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -12729,7 +12729,7 @@ test and rename it to the name of your parameter file.
 
 To actually run the test, you have to go to your \aspect{} build directory and run 
 \begin{lstlisting}[frame=single,language=ksh] 
-    cmake .
+    make setup\_tests
 \end{lstlisting}
 so that your new test is added to the test suite. Then you can run it by executing 
 \begin{lstlisting}[frame=single,language=ksh] 

--- a/doc/modules/changes/20190426_tjhei
+++ b/doc/modules/changes/20190426_tjhei
@@ -1,0 +1,5 @@
+Changed: The test project will no longer automatically re-configure,
+when cmake is running. To force re-detection of new tests, you need
+to run "make setup_tests" again.
+<br>
+(Timo Heister, 2019/05/26)


### PR DESCRIPTION
The wait is kind of annoying, so only configure the tests when it is
actually needed.