### PR TITLE
Provide a base class with a virtual destructor.

### DIFF
--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -224,6 +224,12 @@ namespace aspect
       {
         public:
           /**
+           * Destructor.
+           */
+          virtual
+          ~CellDataVectorCreator () = default;
+
+          /**
            * The function classes have to implement that want to output
            * cell-wise data.
            *


### PR DESCRIPTION
The class has a virtual member function but a non-virtual destructor. This is generally
a bad idea, though it doesn't matter here because we never store pointers to this
particular type of class (we use this class as one of several base classes of
the viz postprocessor classes, and only store pointers to the Interface class). But
it is bad practice, so fix this anyway.