### PR TITLE
Refactor writing data in the viz postprocessor.

### DIFF
--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -490,6 +490,14 @@ namespace aspect
         bool output_mesh_velocity;
 
         /**
+         * File operations can potentially take a long time, blocking the
+         * progress of the rest of the model run. Setting this variable to
+         * 'true' moves this process into a background thread, while the
+         * rest of the model continues.
+         */
+        bool write_in_background_thread;
+
+        /**
          * Set the time output was supposed to be written. In the simplest
          * case, this is the previous last output time plus the interval, but
          * in general we'd like to ensure that it is the largest supposed
@@ -517,16 +525,9 @@ namespace aspect
         std::string last_mesh_file_name;
 
         /**
-         * File operations can potentially take a long time, blocking the
-         * progress of the rest of the model run. Setting this variable to
-         * 'true' moves this process into a background thread, while the
-         * rest of the model continues.
-         */
-        bool write_in_background_thread;
-
-        /**
          * Handle to a thread that is used to write data in the background.
-         * The writer() function runs on this background thread.
+         * The writer() function runs on this background thread when outputting
+         * data for the `data_out` object.
          */
         Threads::Thread<void> background_thread;
 
@@ -561,6 +562,19 @@ namespace aspect
         void write_master_files (const DataOut<dim> &data_out,
                                  const std::string &solution_file_prefix,
                                  const std::vector<std::string> &filenames);
+
+
+        /**
+         * A function, called from the execute() function, that takes a
+         * DataOut object, does some preliminary work with it, and then
+         * writes the result out to files via the writer() function (in the
+         * case of VTU output) or through the XDMF facilities.
+         *
+         * The function returns the base name of the output files produced,
+         * which can then be used for the statistics file and screen output.
+         */
+        template <typename DataOutType>
+        std::string write_data_out_data(DataOutType &data_out);
 
         /**
          * A list of postprocessor objects that have been requested in the


### PR DESCRIPTION
This is the first step towards being able to writing face data (on the surface of the domain). There are no functional changes in this patch. The only thing I'm doing is breaking out a substantial chunk of work from `Visualization::execute()` into a function of its own (`Visualization::write_data_out_data()`).

I want to get this part out of the way before I make functional changes because the large-scale code motion without functionality change will be difficult to review if I also mix in functionality changes.

(The new function has a template argument that I don't currently use but will in the follow-up patches.)