### PR TITLE
Benchmark for brittle thrust wedge experiments in Buiter et al., 2016,JSG paper

### DIFF
--- a/benchmarks/buiter_et_al_2016_jsg/README
+++ b/benchmarks/buiter_et_al_2016_jsg/README
@@ -1,0 +1,40 @@
+This benchmark attempts to reproduce the results of Buiter et al. 2016:
+  Benchmarking numerical models of brittle thrust wedges,
+  Journal of Structural Geology, 92, 140-177, 
+  http://dx.doi.org/10.1016/j.jsg.2016.03.003.
+
+More specifically, the provided input files aim to reproduce two numerical simulations 
+of stable wedge experiment 1 illustrated in Figure 4-6 and unstable wedge experiment 2 
+illustrated in Figure 8-11. Setups of these two experiments are shown in Figure 3a-b. 
+
+Experiment 1 tests whether model wedges in the stable domain of critical wedge theory 
+remain stable when translated horizontally. A quartz sand wedge with a horizontal base 
+and a surface slope of 20 degrees is pushed horizontally by inward movement of a mobile 
+wall at the right boundary with a velocity of 2.5 cm/hour.
+  
+[...]
+
+Experiment 2 tests how an unstable subcritical wedge deforms to reach the critical taper 
+solution. Horizontal layers of sand have 10 cm shortening by inward movement of a mobile 
+wall with a velocity of 2.5 cm/hour. Both the base and the surface are horizontal and the 
+“wedge” is thus in the unstable field. This experiment builds a thrust wedge through a 
+combination of mainly in-sequence forward and backward thrusting. Deformation starts by 
+forming a pop-up structure near the mobile wall. 
+
+The strain (Figure 10a-b) and strain-rate (Figure 11) fields highlight several incipient 
+shear zones that do not always accumulate enough offset to become visible in the material 
+field (Figure 8-9). The pressure field of the models remains more or less lithostatic, 
+with lower pressure values in (incipient) shear zones (Figure 10c-d).
+
+In this benchmark, input files are provided for verifying that the model follows the 
+analytical wedge theory. For the top boundary condition, zero traction and a sticky air 
+layer is used to approximate a free surface. Additional testing revealed that using a true 
+free surface leads to significant mesh distortion and associated numerical instabilities.
+The material has a visco-plastic rheology. The plastic strain-weakening behaviour, with the 
+internal angle of friction reducing between total finite strain invariant values of 0.5 and 
+1.0, is prescribed to mimic the softening from peak to dynamic stable strength correlates 
+with sand dilation.
+
+In experiment 2, the model domain is 36 * 8 cm. The resolution in exp2_low_resolution.prm and
+exp2_high_resolution.prm is 2 mm/cell and 0.5 mm/cell, respectively. More details about the model
+setup are described in input files. 

--- a/benchmarks/buiter_et_al_2016_jsg/README
+++ b/benchmarks/buiter_et_al_2016_jsg/README
@@ -3,38 +3,36 @@ This benchmark attempts to reproduce the results of Buiter et al. 2016:
   Journal of Structural Geology, 92, 140-177, 
   http://dx.doi.org/10.1016/j.jsg.2016.03.003.
 
-More specifically, the provided input files aim to reproduce the numerical simulations 
-of stable wedge experiment 1 illustrated in Figure 4-6 and unstable wedge experiment 2 
-illustrated in Figure 8-11. The setups of these two experiments are shown in Figure 3a-b. 
+More specifically, the provided input files aim to reproduce the numerical 
+simulations of stable wedge experiment 1 illustrated in Figure 4-6 and unstable 
+wedge experiment 2 illustrated in Figure 8-11 (Buiter et al., 2016). The setups 
+of these experiments are shown in Figure 3a-b.
 
-Experiment 1 tests whether model wedges in the stable domain of critical wedge theory 
-remain stable when translated horizontally. A quartz sand wedge with a horizontal base 
-and a surface slope of 20 degrees is pushed horizontally by inward movement of a mobile 
-wall at the right boundary with a velocity of 2.5 cm/hour.
+Experiment 1 tests whether model wedges in the stable domain of critical wedge 
+theory remain stable when translated horizontally. A quartz sand wedge with a 
+horizontal base and a surface slope of 20 degrees is pushed horizontally by 
+inward movement of a mobile wall at the right boundary with a velocity of 2.5 
+cm/hour.
   
 [...]
 
-Experiment 2 tests how an unstable subcritical wedge deforms to reach the critical taper 
-solution. Horizontal layers of sand have 10 cm shortening by inward movement of a mobile 
-wall with a velocity of 2.5 cm/hour. Both the base and the surface are horizontal and the 
-“wedge” is thus in the unstable field. This experiment builds a thrust wedge through a 
-combination of mainly in-sequence forward and backward thrusting. Deformation starts by 
+Experiment 2 tests how an unstable subcritical wedge deforms to reach the 
+critical taper solution. This experiment builds a thrust wedge through a 
+combination of mainly in-sequence forward and backward thrusting. In this 
+experiment, horizontal layers of sand suffer 10 cm shortening by inward 
+movement of a mobile wall with a velocity of 2.5 cm/hour. Deformation starts by 
 forming a pop-up structure near the mobile wall. 
 
-The strain (Figure 10a-b) and strain-rate (Figure 11) fields highlight several incipient 
-shear zones that do not always accumulate enough offset to become visible in the material 
-field (Figure 8-9). The pressure field of the models remains more or less lithostatic, 
-with lower pressure values in (incipient) shear zones (Figure 10c-d).
+In the paper, it shows that the strain (Figure 10a-b) and strain-rate (Figure 
+11) fields highlight several incipient shear zones that do not always accumulate 
+enough offset to become visible in the material field (Figure 8-9). The pressure 
+field of the models remains more or less lithostatic, with lower pressure values 
+in (incipient) shear zones (Figure 10c-d).
 
-In this benchmark, input files are provided for verifying that the model follows the 
-analytical wedge theory. For the top boundary condition, zero traction and a sticky air 
-layer is used to approximate a free surface. Additional testing revealed that using a true 
-free surface leads to significant mesh distortion and associated numerical instabilities.
-The material has a visco-plastic rheology. The plastic strain-weakening behaviour, with the 
-internal angle of friction reducing between total finite strain invariant values of 0.5 and 
-1.0, is prescribed to mimic the softening from peak to dynamic stable strength correlates 
-with sand dilation.
+Input files are provided for verifying that the models of brittle thrust wedge 
+in this benchmark follows other numerical results and the analytical wedge 
+theory inthe paper. 
 
-In experiment 2, the model domain is 36 * 8 cm. The resolution in exp2_low_resolution.prm and
-exp2_high_resolution.prm is 2 mm/cell and 0.5 mm/cell, respectively. More details about the model
-setup are described in input files. 
+The resolution in exp2_low_resolution.prm and exp2_high_resolution.prm is 
+2 mm/cell and 0.5 mm/cell, respectively. More details about the model setup 
+are described in input files. 

--- a/benchmarks/buiter_et_al_2016_jsg/README
+++ b/benchmarks/buiter_et_al_2016_jsg/README
@@ -3,9 +3,9 @@ This benchmark attempts to reproduce the results of Buiter et al. 2016:
   Journal of Structural Geology, 92, 140-177, 
   http://dx.doi.org/10.1016/j.jsg.2016.03.003.
 
-More specifically, the provided input files aim to reproduce two numerical simulations 
+More specifically, the provided input files aim to reproduce the numerical simulations 
 of stable wedge experiment 1 illustrated in Figure 4-6 and unstable wedge experiment 2 
-illustrated in Figure 8-11. Setups of these two experiments are shown in Figure 3a-b. 
+illustrated in Figure 8-11. The setups of these two experiments are shown in Figure 3a-b. 
 
 Experiment 1 tests whether model wedges in the stable domain of critical wedge theory 
 remain stable when translated horizontally. A quartz sand wedge with a horizontal base 

--- a/benchmarks/buiter_et_al_2016_jsg/exp_2_high_resolution.prm
+++ b/benchmarks/buiter_et_al_2016_jsg/exp_2_high_resolution.prm
@@ -7,48 +7,48 @@
 ###  forming a pop-up structure near the high viscosity rigid indenter.
 
 ###  Global parameters
-set Dimension                              	    = 2
-set Start time                             	    = 0
-set End time                               	    = 14400	#Equivalent to ~10 cm of shortening
-set Use years in output instead of seconds 	    = false
-set CFL number				   	    = 0.5
-set Output directory                       	    = Brittle_thrust_wedge_exp2
-set Pressure normalization                 	    = no
-set Timing output frequency                	    = 20
+set Dimension                                    = 2
+set Start time                                   = 0
+set End time                                     = 14400  #Equivalent to ~10 cm of shortening
+set Use years in output instead of seconds       = false
+set CFL number                 = 0.5
+set Output directory                             = Brittle_thrust_wedge_exp2
+set Pressure normalization                       = no
+set Timing output frequency                      = 20
 
 ## Note that the Linear/Nonlinear solver tolerance should be sufficiently strict to avoid numerical instabilities.
-set Nonlinear solver scheme                	    = single Advection, iterated Stokes
-set Nonlinear solver tolerance             	    = 1e-7
-set Max nonlinear iterations               	    = 100
+set Nonlinear solver scheme                      = single Advection, iterated Stokes
+set Nonlinear solver tolerance                   = 1e-7
+set Max nonlinear iterations                     = 100
 
 subsection Solver parameters
   subsection Stokes solver parameters
-    set Linear solver tolerance		   	    = 1e-8		
-    set Number of cheap Stokes solver steps 	    = 0
-    set GMRES solver restart length        	    = 200   
+    set Linear solver tolerance             = 1e-8    
+    set Number of cheap Stokes solver steps       = 0
+    set GMRES solver restart length              = 200   
 ## a higher restart length makes the solver more robust for large viscosity contrasts.
   end
 end
 
 # Decreasing the DoFs in Temperature and composition
 subsection Discretization
-  set Composition polynomial degree        	    = 2
-  set Temperature polynomial degree        	    = 2
-  set Stokes velocity polynomial degree    	    = 2
+  set Composition polynomial degree              = 2
+  set Temperature polynomial degree              = 2
+  set Stokes velocity polynomial degree          = 2
   set Use locally conservative discretization       = false
 end
 
 # For restarting the model
-set Resume computation                     	    = auto
+set Resume computation                           = auto
 subsection Checkpointing
-  set Steps between checkpoint		   	    = 10
+  set Steps between checkpoint             = 10
 end
 
 # Gravity model
 subsection Gravity model
-  set Model name			   	    = vertical
+  set Model name               = vertical
   subsection Vertical
-    set Magnitude			   	    = 9.81
+    set Magnitude               = 9.81
   end
 end
 
@@ -56,21 +56,21 @@ end
 
 # Model geometry (36 x 8 cm)
  subsection Geometry model
-   set Model name			   	    = box
+   set Model name               = box
  
    subsection Box
-     set X repetitions			   	    = 180
-     set Y repetitions			   	    = 40
-     set X extent    			   	    = 0.36
-     set Y extent       		   	    = 0.08
+     set X repetitions               = 180
+     set Y repetitions               = 40
+     set X extent                   = 0.36
+     set Y extent                    = 0.08
    end
  end
 
 # Mesh refinement specifications 
 subsection Mesh refinement
-  set Initial adaptive refinement          	    = 0
-  set Initial global refinement            	    = 2	  #The resolution is 0.5 mm/cell
-  set Time steps between mesh refinement   	    = 0
+  set Initial adaptive refinement                = 0
+  set Initial global refinement                  = 2    #The resolution is 0.5 mm/cell
+  set Time steps between mesh refinement         = 0
 end
 
 # Boundary conditions & initial conditions
@@ -78,13 +78,13 @@ end
 # Composition boundary conditions
 subsection Boundary composition model
   set Fixed composition boundary indicators         = bottom, left, right
-  set List of model names 		            = initial composition
+  set List of model names                 = initial composition
 end
 
 # Number and names of compositional fields
 subsection Compositional fields
-  set Number of fields 				    = 6
-  set Names of fields 				    = qsand,csand,bound,block,sticky_air,total_strain
+  set Number of fields             = 6
+  set Names of fields             = qsand,csand,bound,block,sticky_air,total_strain
 end 
 
 # Spatial domain of different compositional fields:
@@ -100,7 +100,7 @@ end
 subsection Initial composition model
   set Model name = function
   subsection Function
-    set Variable names      			    = x,y
+    set Variable names                = x,y
     set Function expression   = if((x<=0.35 & y<=0.012 & y>0.002) || (x<=0.35 & y>0.022 & y<=0.032), 1,0); \
                               if((x<=0.35 & y>0.012 & y<=0.022), 1,0); \
                               if((x>0.35 & x<=0.352 & y>0.002) ||(y<=0.002), 1, 0); \
@@ -112,29 +112,29 @@ end
 # Temperature boundary conditions
 subsection Boundary temperature model
   set Fixed temperature boundary indicators         = bottom, top
-  set List of model names    		            = initial temperature
+  set List of model names                    = initial temperature
 end
 
 # Initial temperature field
 subsection Initial temperature model
-  set Model name 			            = function
+  set Model name                   = function
   subsection Function
-    set Function expression 		            = 293
+    set Function expression                 = 293
   end
 end
 
 # Velocity boundary conditions
 subsection Boundary velocity model
-  set Zero velocity boundary indicators	            = bottom		# bottom - no slip
-  set Tangential velocity boundary indicators       = left		# left - free slip
+  set Zero velocity boundary indicators              = bottom    # bottom - no slip
+  set Tangential velocity boundary indicators       = left    # left - free slip
 
 ## right - material inflow with a velocity of 2.5 cm/hour at the height of the pushing block.
 ## The velocity linearly decreases from the base of the rigid block to 0 cm/hour at the base of the model.
   set Prescribed velocity boundary indicators = right:function 
     subsection Function
-      set Variable names      		            = x,y
-      set Function constants  		            = cm=0.01, h=3600, th=0.002
-      set Function expression 		            = if(y>th, -2.5*cm/h, -(y/th)*2.5*cm/h); 0
+      set Variable names                      = x,y
+      set Function constants                  = cm=0.01, h=3600, th=0.002
+      set Function expression                 = if(y>th, -2.5*cm/h, -(y/th)*2.5*cm/h); 0
    end
 end
 
@@ -150,8 +150,8 @@ subsection Discretization
   set Use discontinuous composition discretization   = true
   subsection Stabilization parameters
       set Use limiter for discontinuous composition solution = true
-      set Global composition maximum 	             = 1, 1, 1, 1, 1, 100
-      set Global composition minimum 	             = 0, 0, 0, 0, 0, 0
+      set Global composition maximum                = 1, 1, 1, 1, 1, 100
+      set Global composition minimum                = 0, 0, 0, 0, 0, 0
   end
 end
 
@@ -159,34 +159,34 @@ end
 # Using harmonic material averaging is required to achieve reasonable convergence 
 # behavior, particulally when the viscosity contrast is large.
 subsection Material model
-  set Material averaging 		             = harmonic average	
-  set Model name 			             = visco plastic
+  set Material averaging                  = harmonic average  
+  set Model name                    = visco plastic
 
   subsection Visco Plastic
-    set Reference temperature 		             = 293
-    set Reference viscosity 		             = 1e8
-    set Minimum strain rate 		             = 1e-20
-    set Reference strain rate 		             = 2e-5
+    set Reference temperature                  = 293
+    set Reference viscosity                  = 1e8
+    set Minimum strain rate                  = 1e-20
+    set Reference strain rate                  = 2e-5
   
   # The viscosity contrast is 10^7 here and any value higher than this causes divergence of the solver. 
-    set Minimum viscosity 		             = 1e5  
-    set Maximum viscosity 		             = 1e12
+    set Minimum viscosity                  = 1e5  
+    set Maximum viscosity                  = 1e12
 
-    set Thermal diffusivities 		             = 1e-6
-    set Heat capacities 		             = 750
-    set Densities 		                     = 1560, 1560, 1890, 1560, 3000, 0, 1e5
-    set Thermal expansivities 		             = 0    # Density is independet of temperature
-    set Viscosity averaging scheme 	             = harmonic
-    set Viscous flow law 		             = dislocation 			
+    set Thermal diffusivities                  = 1e-6
+    set Heat capacities                  = 750
+    set Densities                          = 1560, 1560, 1890, 1560, 3000, 0, 1e5
+    set Thermal expansivities                  = 0    # Density is independet of temperature
+    set Viscosity averaging scheme                = harmonic
+    set Viscous flow law                  = dislocation       
 
     set Prefactors for dislocation creep             = 5e-15, 5e-15, 5e-15, 5e-15, 5e-18, 5e-5, 5e-18
     set Stress exponents for dislocation creep       = 1 
     set Activation energies for dislocation creep    = 0
     set Activation volumes for dislocation creep     = 0
 
-    set Angles of internal friction 	             = 36, 36, 36, 16, 0, 0, 1e18
-    set Cohesions 			             = 30, 30, 30, 30, 1e18, 1e18, 1e18
-    set Use strain weakening 		             = true
+    set Angles of internal friction                = 36, 36, 36, 16, 0, 0, 1e18
+    set Cohesions                    = 30, 30, 30, 30, 1e18, 1e18, 1e18
+    set Use strain weakening                  = true
     set Start plasticity strain weakening intervals  = 0.5 
     set End plasticity strain weakening intervals    = 1
     set Cohesion strain weakening factors            = 1
@@ -197,12 +197,12 @@ end
 
 # Post processing
 subsection Postprocess
-  set List of postprocessors		             = velocity statistics, basic statistics, temperature statistics, visualization
+  set List of postprocessors                 = velocity statistics, basic statistics, temperature statistics, visualization
   subsection Visualization
-    set List of output variables 	             = density, viscosity, strain rate, error indicator
-    set Output format 			             = vtu
-    set Time between graphical output 	             = 144   # Equivalent to ~0.5 cm of shortening
-    set Interpolate output 		             = true
+    set List of output variables                = density, viscosity, strain rate, error indicator
+    set Output format                    = vtu
+    set Time between graphical output                = 144   # Equivalent to ~0.5 cm of shortening
+    set Interpolate output                  = true
     set Number of grouped files                      = 1
   end
 end

--- a/benchmarks/buiter_et_al_2016_jsg/exp_2_high_resolution.prm
+++ b/benchmarks/buiter_et_al_2016_jsg/exp_2_high_resolution.prm
@@ -1,54 +1,58 @@
-#### This parameter file reproduces the unstable wedge experiment 2 from Buiter et al., 2016, JSG.
-###  Experiment 2 tests how an unstable subcritical wedge deforms to reach the critical taper
-###  solution. Horizontal layers of sand have 10 cm shortening by inward movement of a mobile
-###  wall with a velocity of 2.5 cm/hour. Both the base and the surface are horizontal and the 
-###  “wedge” is thus in the unstable field. This experiment builds a thrust wedge through a 
-###  combination of mainly in-sequence forward and backward thrusting. Deformation starts by 
-###  forming a pop-up structure near the high viscosity rigid indenter.
+# This parameter file reproduces the unstable wedge experiment 2 from 
+# Buiter et al., 2016, JSG.
+# Experiment 2 tests how an unstable subcritical wedge deforms to reach the 
+# critical taper solution. Horizontal layers of sand have 10 cm shortening 
+# by inward movement of a mobile wall with a velocity of 2.5 cm/hour. Both 
+# the base and the surface are horizontal and the “wedge” is thus in the 
+# unstable field. This experiment builds a thrust wedge through a combination 
+# of mainly in-sequence forward and backward thrusting. Deformation starts by 
+# forming a pop-up structure near the high viscosity rigid indenter.
 
-###  Global parameters
-set Dimension                                    = 2
-set Start time                                   = 0
-set End time                                     = 14400  #Equivalent to ~10 cm of shortening
-set Use years in output instead of seconds       = false
-set CFL number                 = 0.5
-set Output directory                             = Brittle_thrust_wedge_exp2
-set Pressure normalization                       = no
-set Timing output frequency                      = 20
+#  Global parameters
+set Dimension                                        = 2
+set Start time                                       = 0
+set End time                                         = 14400 #Equivalent to ~10 cm of shortening
+set Use years in output instead of seconds           = false
+set CFL number                                       = 0.5
+set Output directory                                 = Brittle_thrust_wedge_exp2
+set Pressure normalization                           = no
+set Timing output frequency                          = 20
 
-## Note that the Linear/Nonlinear solver tolerance should be sufficiently strict to avoid numerical instabilities.
-set Nonlinear solver scheme                      = single Advection, iterated Stokes
-set Nonlinear solver tolerance                   = 1e-7
-set Max nonlinear iterations                     = 100
+# Note that the Linear/Nonlinear solver tolerance should be sufficiently 
+# strict to avoid numerical instabilities.
+set Nonlinear solver scheme                          = single Advection, iterated Stokes
+set Nonlinear solver tolerance                       = 1e-7
+set Max nonlinear iterations                         = 100
 
 subsection Solver parameters
   subsection Stokes solver parameters
-    set Linear solver tolerance             = 1e-8    
-    set Number of cheap Stokes solver steps       = 0
-    set GMRES solver restart length              = 200   
-## a higher restart length makes the solver more robust for large viscosity contrasts.
+    set Linear solver tolerance                      = 1e-8    
+    set Number of cheap Stokes solver steps          = 0
+
+# A higher restart length makes the solver more robust for large viscosity 
+# contrasts.
+    set GMRES solver restart length                  = 200   
   end
 end
 
-# Decreasing the DoFs in Temperature and composition
 subsection Discretization
-  set Composition polynomial degree              = 2
-  set Temperature polynomial degree              = 2
-  set Stokes velocity polynomial degree          = 2
-  set Use locally conservative discretization       = false
+  set Composition polynomial degree                  = 2
+  set Temperature polynomial degree                  = 2
+  set Stokes velocity polynomial degree              = 2
+  set Use locally conservative discretization        = false
 end
 
 # For restarting the model
-set Resume computation                           = auto
+set Resume computation                               = auto
 subsection Checkpointing
-  set Steps between checkpoint             = 10
+  set Steps between checkpoint                       = 20
 end
 
 # Gravity model
 subsection Gravity model
-  set Model name               = vertical
+  set Model name                                     = vertical
   subsection Vertical
-    set Magnitude               = 9.81
+    set Magnitude                                    = 9.81
   end
 end
 
@@ -56,137 +60,149 @@ end
 
 # Model geometry (36 x 8 cm)
  subsection Geometry model
-   set Model name               = box
+   set Model name                                    = box
  
    subsection Box
-     set X repetitions               = 180
-     set Y repetitions               = 40
-     set X extent                   = 0.36
-     set Y extent                    = 0.08
+     set X repetitions                               = 180
+     set Y repetitions                               = 40
+     set X extent                                    = 0.36
+     set Y extent                                    = 0.08
    end
  end
 
 # Mesh refinement specifications 
 subsection Mesh refinement
-  set Initial adaptive refinement                = 0
-  set Initial global refinement                  = 2    #The resolution is 0.5 mm/cell
-  set Time steps between mesh refinement         = 0
+  set Initial adaptive refinement                    = 0
+#The resolution is 0.5 mm/cell
+  set Initial global refinement                      = 2
+  set Time steps between mesh refinement             = 0
 end
 
 # Boundary conditions & initial conditions
 
 # Composition boundary conditions
 subsection Boundary composition model
-  set Fixed composition boundary indicators         = bottom, left, right
-  set List of model names                 = initial composition
+  set Fixed composition boundary indicators          = bottom, left, right
+  set List of model names                            = initial composition
 end
 
 # Number and names of compositional fields
 subsection Compositional fields
-  set Number of fields             = 6
-  set Names of fields             = qsand,csand,bound,block,sticky_air,total_strain
+  set Number of fields                               = 6
+  set Names of fields                                = qsand,csand,bound,block, \
+                                                       sticky_air,total_strain
 end 
 
 # Spatial domain of different compositional fields:
-## Quartz sand (qsand) has two layers with 1 cm thick per each.
-## Corundum sand (csand) is in the middle of the 2-layer quatz sand and is 1 cm thick.
-## The boundary 2-mm-thin layers (bound) sit on both the bottom of the domain and between the sand and 
-## rigid indenter block. The right boundary has a constant inflow velocity, which pushes a rigid block 
-## that approximates a mobile wall. Movement of the rigid block drives deformation in the sand layers.  
-## The boundary between the rigid block and boundary layers produces a sharp velocity discontinuity 
-## that localizes brittle deformation.
-## The sticky air layer is set on top of the sand layer and approximates a free surface.   
+# Quartz sand (qsand) has two layers with 1 cm thickness each.
+# Corundum sand (csand) is in the middle of the 2-layer quatz sand and is 
+# 1 cm thick.
+# The boundary 2-mm-thin layers (bound) sit on both the bottom of the domain and
+# between the sand and rigid indenter block. The right boundary has a constant 
+# inflow velocity, which pushes a rigid block that approximates a mobile wall. 
+# Movement of the rigid block drives deformation in the sand layers. 
+# The boundary between the rigid block and boundary layers produces a sharp 
+# velocity discontinuity that localizes brittle deformation.
+# The sticky air layer is set on top of the sand layer and approximates a 
+# free surface.
 
 subsection Initial composition model
-  set Model name = function
+  set Model name                                     = function
   subsection Function
-    set Variable names                = x,y
-    set Function expression   = if((x<=0.35 & y<=0.012 & y>0.002) || (x<=0.35 & y>0.022 & y<=0.032), 1,0); \
-                              if((x<=0.35 & y>0.012 & y<=0.022), 1,0); \
-                              if((x>0.35 & x<=0.352 & y>0.002) ||(y<=0.002), 1, 0); \
-                              if(x>0.352 & y>0.002,1,0); \
-                              if(x<=0.35 & y>0.032,1,0); 0
+    set Variable names                               = x,y
+    set Function constants                           = w1=0.35, w2=0.352, \
+                                                     h1=0.002, h2=0.012, \
+                                                     h3=0.022, h4=0.032 
+    set Function expression = if((x<=w1 & y<=h2 & y>h1) || (x<= w1 & y>h3 & y<=h4), 1,0); \
+                              if((x<=w1 & y>h2 & y<=h3), 1,0); \
+                              if((x>w1 & x<=w2 & y>h1) ||(y<=h1), 1, 0); \
+                              if(x>w2 & y>h1,1,0); \
+                              if(x<=w1 & y>h4,1,0); 0
   end
 end
 
 # Temperature boundary conditions
 subsection Boundary temperature model
-  set Fixed temperature boundary indicators         = bottom, top
-  set List of model names                    = initial temperature
+  set Fixed temperature boundary indicators          = bottom, top
+  set List of model names                            = initial temperature
 end
 
 # Initial temperature field
 subsection Initial temperature model
-  set Model name                   = function
+  set Model name                                     = function
   subsection Function
-    set Function expression                 = 293
+    set Function expression                          = 293
   end
 end
 
 # Velocity boundary conditions
 subsection Boundary velocity model
-  set Zero velocity boundary indicators              = bottom    # bottom - no slip
-  set Tangential velocity boundary indicators       = left    # left - free slip
+  set Zero velocity boundary indicators              = bottom    #no slip
+  set Tangential velocity boundary indicators        = left      #free slip
 
-## right - material inflow with a velocity of 2.5 cm/hour at the height of the pushing block.
-## The velocity linearly decreases from the base of the rigid block to 0 cm/hour at the base of the model.
-  set Prescribed velocity boundary indicators = right:function 
+# right - material inflow with a velocity of 2.5 cm/hour at the height of 
+# the pushing block. The velocity linearly decreases from the base of the 
+# rigid block to 0 cm/hour at the base of the model.
+  set Prescribed velocity boundary indicators        = right:function 
     subsection Function
-      set Variable names                      = x,y
-      set Function constants                  = cm=0.01, h=3600, th=0.002
-      set Function expression                 = if(y>th, -2.5*cm/h, -(y/th)*2.5*cm/h); 0
+      set Variable names                             = x,y
+      set Function constants                         = cm=0.01, h=3600, th=0.002
+      set Function expression                        = if(y>th, -2.5*cm/h, -(y/th)*2.5*cm/h); 0
    end
 end
 
-# The top boundary is open (zero traction), which allows the sticky air to flow freely through it as 
-# topography develops along the wedge. Additional testing revealed that using a true free surface leads 
-# to significant mesh distortion and associated numerical instabilities.
+# The top boundary is open (zero traction), which allows the sticky air to 
+# flow freely through it as topography develops along the wedge. Additional 
+# testing revealed that using a true free surface leads to significant mesh 
+# distortion and associated numerical instabilities.
 subsection Boundary traction model
   set Prescribed traction boundary indicators        = top: zero traction
 end
 
-# The  discontinuous composition bound preserving limiter produces sharp interfaces between compositional layers.
+# The  discontinuous composition bound preserving limiter produces sharp 
+# interfaces between compositional layers.
 subsection Discretization
   set Use discontinuous composition discretization   = true
   subsection Stabilization parameters
       set Use limiter for discontinuous composition solution = true
-      set Global composition maximum                = 1, 1, 1, 1, 1, 100
-      set Global composition minimum                = 0, 0, 0, 0, 0, 0
+      set Global composition maximum                 = 1, 1, 1, 1, 1, 100
+      set Global composition minimum                 = 0, 0, 0, 0, 0, 0
   end
 end
 
-### Material properties
-# Using harmonic material averaging is required to achieve reasonable convergence 
-# behavior, particulally when the viscosity contrast is large.
+# Material properties
+# Using harmonic material averaging is required to achieve reasonable 
+# convergence behavior, particulally when the viscosity contrast is large.
 subsection Material model
-  set Material averaging                  = harmonic average  
-  set Model name                    = visco plastic
+  set Material averaging                             = harmonic average  
+  set Model name                                     = visco plastic
 
   subsection Visco Plastic
-    set Reference temperature                  = 293
-    set Reference viscosity                  = 1e8
-    set Minimum strain rate                  = 1e-20
-    set Reference strain rate                  = 2e-5
+    set Reference temperature                        = 293
+    set Reference viscosity                          = 1e8
+    set Minimum strain rate                          = 1e-20
+    set Reference strain rate                        = 2e-5
   
-  # The viscosity contrast is 10^7 here and any value higher than this causes divergence of the solver. 
-    set Minimum viscosity                  = 1e5  
-    set Maximum viscosity                  = 1e12
+# The viscosity contrast is 10^7 here and any value higher than this causes 
+# divergence of the solver. 
+    set Minimum viscosity                            = 1e5  
+    set Maximum viscosity                            = 1e12
 
-    set Thermal diffusivities                  = 1e-6
-    set Heat capacities                  = 750
-    set Densities                          = 1560, 1560, 1890, 1560, 3000, 0, 1e5
-    set Thermal expansivities                  = 0    # Density is independet of temperature
-    set Viscosity averaging scheme                = harmonic
-    set Viscous flow law                  = dislocation       
+    set Thermal diffusivities                        = 1e-6
+    set Heat capacities                              = 750
+    set Densities                                    = 1560, 1560, 1890, 1560, 3000, 0, 1e5
+    set Thermal expansivities                        = 0
+    set Viscosity averaging scheme                   = harmonic
+    set Viscous flow law                             = dislocation       
 
     set Prefactors for dislocation creep             = 5e-15, 5e-15, 5e-15, 5e-15, 5e-18, 5e-5, 5e-18
     set Stress exponents for dislocation creep       = 1 
     set Activation energies for dislocation creep    = 0
     set Activation volumes for dislocation creep     = 0
 
-    set Angles of internal friction                = 36, 36, 36, 16, 0, 0, 1e18
-    set Cohesions                    = 30, 30, 30, 30, 1e18, 1e18, 1e18
-    set Use strain weakening                  = true
+    set Angles of internal friction                  = 36, 36, 36, 16, 0, 0, 1e18
+    set Cohesions                                    = 30, 30, 30, 30, 1e18, 1e18, 1e18
+    set Use strain weakening                         = true
     set Start plasticity strain weakening intervals  = 0.5 
     set End plasticity strain weakening intervals    = 1
     set Cohesion strain weakening factors            = 1
@@ -197,12 +213,12 @@ end
 
 # Post processing
 subsection Postprocess
-  set List of postprocessors                 = velocity statistics, basic statistics, temperature statistics, visualization
+  set List of postprocessors                         = velocity statistics, basic statistics, temperature statistics, visualization
   subsection Visualization
-    set List of output variables                = density, viscosity, strain rate, error indicator
-    set Output format                    = vtu
+    set List of output variables                     = density, viscosity, strain rate, error indicator
+    set Output format                                = vtu
     set Time between graphical output                = 144   # Equivalent to ~0.5 cm of shortening
-    set Interpolate output                  = true
+    set Interpolate output                           = true
     set Number of grouped files                      = 1
   end
 end

--- a/benchmarks/buiter_et_al_2016_jsg/exp_2_high_resolution.prm
+++ b/benchmarks/buiter_et_al_2016_jsg/exp_2_high_resolution.prm
@@ -1,0 +1,208 @@
+#### This parameter file reproduces the unstable wedge experiment 2 from Buiter et al., 2016, JSG.
+###  Experiment 2 tests how an unstable subcritical wedge deforms to reach the critical taper
+###  solution. Horizontal layers of sand have 10 cm shortening by inward movement of a mobile
+###  wall with a velocity of 2.5 cm/hour. Both the base and the surface are horizontal and the 
+###  “wedge” is thus in the unstable field. This experiment builds a thrust wedge through a 
+###  combination of mainly in-sequence forward and backward thrusting. Deformation starts by 
+###  forming a pop-up structure near the high viscosity rigid indenter.
+
+###  Global parameters
+set Dimension                              	    = 2
+set Start time                             	    = 0
+set End time                               	    = 14400	#Equivalent to ~10 cm of shortening
+set Use years in output instead of seconds 	    = false
+set CFL number				   	    = 0.5
+set Output directory                       	    = Brittle_thrust_wedge_exp2
+set Pressure normalization                 	    = no
+set Timing output frequency                	    = 20
+
+## Note that the Linear/Nonlinear solver tolerance should be sufficient low to avoid numerical instabilities.
+set Nonlinear solver scheme                	    = single Advection, iterated Stokes
+set Nonlinear solver tolerance             	    = 1e-7
+set Max nonlinear iterations               	    = 100
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Linear solver tolerance		   	    = 1e-8		
+    set Number of cheap Stokes solver steps 	    = 0
+    set GMRES solver restart length        	    = 200   
+## a higher restart length makes the solver more robust for large viscosity contrasts.
+  end
+end
+
+# Decreasing the DoFs in Temperature and composition
+subsection Discretization
+  set Composition polynomial degree        	    = 2
+  set Temperature polynomial degree        	    = 2
+  set Stokes velocity polynomial degree    	    = 2
+  set Use locally conservative discretization       = false
+end
+
+# For restarting the model
+set Resume computation                     	    = auto
+subsection Checkpointing
+  set Steps between checkpoint		   	    = 10
+end
+
+# Gravity model
+subsection Gravity model
+  set Model name			   	    = vertical
+  subsection Vertical
+    set Magnitude			   	    = 9.81
+  end
+end
+
+### Parameters describing the model
+
+# Model geometry (36 x 8 cm)
+ subsection Geometry model
+   set Model name			   	    = box
+ 
+   subsection Box
+     set X repetitions			   	    = 180
+     set Y repetitions			   	    = 40
+     set X extent    			   	    = 0.36
+     set Y extent       		   	    = 0.08
+   end
+ end
+
+# Mesh refinement specifications 
+subsection Mesh refinement
+  set Initial adaptive refinement          	    = 0
+  set Initial global refinement            	    = 2	  #The resolution is 0.5 mm/cell
+  set Time steps between mesh refinement   	    = 0
+end
+
+# Boundary conditions & initial conditions
+
+# Composition boundary conditions
+subsection Boundary composition model
+  set Fixed composition boundary indicators         = bottom, left, right
+  set List of model names 		            = initial composition
+end
+
+# Number and names of compositional fields
+subsection Compositional fields
+  set Number of fields 				    = 6
+  set Names of fields 				    = qsand,csand,bound,block,sticky_air,total_strain
+end 
+
+# Spatial domain of different compositional fields:
+## Quartz sand (qsand) has two layers with 1 cm thick per each.
+## Corundum sand (csand) is in the middle of the 2-layer quatz sand and is 1 cm thick.
+## The boundary 2-mm-thin layers (bound) sit on both the bottom of the domain and between the sand and 
+## rigid indenter block. The right boundary has a constant inflow velocity, which pushes a rigid block 
+## that approximates a mobile wall. Movement of the rigid block drives deformation in the sand layers.  
+## The boundary between the rigid block and boundary layers produces a sharp velocity discontinuity 
+## that localizes brittle deformation.
+## The sticky air layer is set on top of the sand layer and approximates a free surface.   
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Variable names      			    = x,y
+    set Function expression   = if((x<=0.35 & y<=0.012 & y>0.002) || (x<=0.35 & y>0.022 & y<=0.032), 1,0); \
+                              if((x<=0.35 & y>0.012 & y<=0.022), 1,0); \
+                              if((x>0.35 & x<=0.352 & y>0.002) ||(y<=0.002), 1, 0); \
+                              if(x>0.352 & y>0.002,1,0); \
+                              if(x<=0.35 & y>0.032,1,0); 0
+  end
+end
+
+# Temperature boundary conditions
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators         = bottom, top
+  set List of model names    		            = initial temperature
+end
+
+# Initial temperature field
+subsection Initial temperature model
+  set Model name 			            = function
+  subsection Function
+    set Function expression 		            = 293
+  end
+end
+
+# Velocity boundary conditions
+subsection Boundary velocity model
+  set Zero velocity boundary indicators	            = bottom		# bottom - no slip
+  set Tangential velocity boundary indicators       = left		# left - free slip
+
+## right - material inflow with a velocity of 2.5 cm/hour at the height of the pushing block.
+## The velocity linearly decreases from the base of the rigid block to 0 cm/hour at the base of the model.
+  set Prescribed velocity boundary indicators = right:function 
+    subsection Function
+      set Variable names      		            = x,y
+      set Function constants  		            = cm=0.01, h=3600, th=0.002
+      set Function expression 		            = if(y>th, -2.5*cm/h, -(y/th)*2.5*cm/h); 0
+   end
+end
+
+# The top boundary is open (zero traction), which allows the sticky air to flow freely through it as 
+# topography develops along the wedge. Additional testing revealed that using a true free surface leads 
+# to significant mesh distortion and associated numerical instabilities.
+subsection Boundary traction model
+  set Prescribed traction boundary indicators        = top: zero traction
+end
+
+# The  discontinuous composition bound preserving limiter produces sharp interfaces between compositional layers.
+subsection Discretization
+  set Use discontinuous composition discretization   = true
+  subsection Stabilization parameters
+      set Use limiter for discontinuous composition solution = true
+      set Global composition maximum 	             = 1, 1, 1, 1, 1, 100
+      set Global composition minimum 	             = 0, 0, 0, 0, 0, 0
+  end
+end
+
+### Material properties
+# Using harmonic material averaging is required to achieve reasonable convergence 
+# behavior, particulally when the viscosity contrast is large.
+subsection Material model
+  set Material averaging 		             = harmonic average	
+  set Model name 			             = visco plastic
+
+  subsection Visco Plastic
+    set Reference temperature 		             = 293
+    set Reference viscosity 		             = 1e8
+    set Minimum strain rate 		             = 1e-20
+    set Reference strain rate 		             = 2e-5
+  
+  # The viscosity contrast is 10^7 here and any value higher than this causes divergence of the solver. 
+    set Minimum viscosity 		             = 1e5  
+    set Maximum viscosity 		             = 1e12
+
+    set Thermal diffusivities 		             = 1e-6
+    set Heat capacities 		             = 750
+    set Densities 		                     = 1560, 1560, 1890, 1560, 3000, 0, 1e5
+    set Thermal expansivities 		             = 0    # Density is independet of temperature
+    set Viscosity averaging scheme 	             = harmonic
+    set Viscous flow law 		             = dislocation 			
+
+    set Prefactors for dislocation creep             = 5e-15, 5e-15, 5e-15, 5e-15, 5e-18, 5e-5, 5e-18
+    set Stress exponents for dislocation creep       = 1 
+    set Activation energies for dislocation creep    = 0
+    set Activation volumes for dislocation creep     = 0
+
+    set Angles of internal friction 	             = 36, 36, 36, 16, 0, 0, 1e18
+    set Cohesions 			             = 30, 30, 30, 30, 1e18, 1e18, 1e18
+    set Use strain weakening 		             = true
+    set Start plasticity strain weakening intervals  = 0.5 
+    set End plasticity strain weakening intervals    = 1
+    set Cohesion strain weakening factors            = 1
+    set Friction strain weakening factors            = 1, 0.861, 0.861, 0.875, 1, 1, 1
+
+  end
+end
+
+# Post processing
+subsection Postprocess
+  set List of postprocessors		             = velocity statistics, basic statistics, temperature statistics, visualization
+  subsection Visualization
+    set List of output variables 	             = density, viscosity, strain rate, error indicator
+    set Output format 			             = vtu
+    set Time between graphical output 	             = 144   # Equivalent to ~0.5 cm of shortening
+    set Interpolate output 		             = true
+    set Number of grouped files                      = 1
+  end
+end

--- a/benchmarks/buiter_et_al_2016_jsg/exp_2_high_resolution.prm
+++ b/benchmarks/buiter_et_al_2016_jsg/exp_2_high_resolution.prm
@@ -16,7 +16,7 @@ set Output directory                       	    = Brittle_thrust_wedge_exp2
 set Pressure normalization                 	    = no
 set Timing output frequency                	    = 20
 
-## Note that the Linear/Nonlinear solver tolerance should be sufficient low to avoid numerical instabilities.
+## Note that the Linear/Nonlinear solver tolerance should be sufficiently strict to avoid numerical instabilities.
 set Nonlinear solver scheme                	    = single Advection, iterated Stokes
 set Nonlinear solver tolerance             	    = 1e-7
 set Max nonlinear iterations               	    = 100

--- a/benchmarks/buiter_et_al_2016_jsg/exp_2_low_resolution.prm
+++ b/benchmarks/buiter_et_al_2016_jsg/exp_2_low_resolution.prm
@@ -7,24 +7,24 @@ include $ASPECT_SOURCE_DIR/benchmarks/buiter_et_al_2016_jsg/exp_2_high_resolutio
 
 # Mesh refinement specifications 
 subsection Mesh refinement
-  set Initial adaptive refinement          	     = 0
-  set Initial global refinement            	     = 0	  #The resolution is 2 mm/cell
-  set Time steps between mesh refinement   	     = 0
+  set Initial adaptive refinement                 = 0
+  set Initial global refinement                   = 0    #The resolution is 2 mm/cell
+  set Time steps between mesh refinement          = 0
 end
 
 ### Material properties
 # Using harmonic material averaging is required to achieve reasonable convergence 
 # behavior, particularly when the viscosity contrast is large.
 subsection Material model
-  set Model name 			             = visco plastic
+  set Model name                    = visco plastic
 
   subsection Visco Plastic
 
   
   # Further testing revealed that decreasing the model resolution allows using a higher contrast between the minimum and maximum viscosity.
   # The viscosity contrast is 10^8 here and any value higher than this causes divergence of the solver.
-    set Minimum viscosity 		             = 1e4  
-    set Maximum viscosity 		             = 1e12
+    set Minimum viscosity                  = 1e4  
+    set Maximum viscosity                  = 1e12
 
   end
 end

--- a/benchmarks/buiter_et_al_2016_jsg/exp_2_low_resolution.prm
+++ b/benchmarks/buiter_et_al_2016_jsg/exp_2_low_resolution.prm
@@ -1,5 +1,8 @@
-#### This is the unstable wedge experiment 2
-#### This prm file is the same as the exp_2_high_resolution.prm file except changes below.
+# This is the unstable wedge experiment 2
+# This prm file is the same as the exp_2_high_resolution.prm file except 
+# changes below.
+
+
 
 include $ASPECT_SOURCE_DIR/benchmarks/buiter_et_al_2016_jsg/exp_2_high_resolution.prm
 
@@ -8,23 +11,24 @@ include $ASPECT_SOURCE_DIR/benchmarks/buiter_et_al_2016_jsg/exp_2_high_resolutio
 # Mesh refinement specifications 
 subsection Mesh refinement
   set Initial adaptive refinement                 = 0
-  set Initial global refinement                   = 0    #The resolution is 2 mm/cell
+
+# The resolution is 2 mm/cell.
+  set Initial global refinement                   = 0
   set Time steps between mesh refinement          = 0
 end
 
-### Material properties
-# Using harmonic material averaging is required to achieve reasonable convergence 
-# behavior, particularly when the viscosity contrast is large.
+# Material properties
+
 subsection Material model
-  set Model name                    = visco plastic
+  set Model name                                  = visco plastic
 
   subsection Visco Plastic
-
-  
-  # Further testing revealed that decreasing the model resolution allows using a higher contrast between the minimum and maximum viscosity.
-  # The viscosity contrast is 10^8 here and any value higher than this causes divergence of the solver.
-    set Minimum viscosity                  = 1e4  
-    set Maximum viscosity                  = 1e12
+# Further testing revealed that decreasing the model resolution allows 
+# using a higher contrast between the minimum and maximum viscosity.
+# The viscosity contrast is 10^8 here and any value higher than this 
+# causes divergence of the solver.
+    set Minimum viscosity                        = 1e4
+    set Maximum viscosity                        = 1e12
 
   end
 end

--- a/benchmarks/buiter_et_al_2016_jsg/exp_2_low_resolution.prm
+++ b/benchmarks/buiter_et_al_2016_jsg/exp_2_low_resolution.prm
@@ -1,0 +1,54 @@
+#### This is the unstable wedge experiment 2
+#### This prm file is the same as the exp_2_high_resolution.prm file except changes below.
+
+include $ASPECT_SOURCE_DIR/benchmarks/buiter_et_al_2016_jsg/exp_2_high_resolution.prm
+
+
+
+# Mesh refinement specifications 
+subsection Mesh refinement
+  set Initial adaptive refinement          	     = 0
+  set Initial global refinement            	     = 0	  #The resolution is 2 mm/cell
+  set Time steps between mesh refinement   	     = 0
+end
+
+### Material properties
+# Using harmonic material averaging is required to achieve reasonable convergence 
+# behavior, particulally when the viscosity contrast is large.
+subsection Material model
+  set Material averaging 		             = harmonic average	
+  set Model name 			             = visco plastic
+
+  subsection Visco Plastic
+    set Reference temperature 		             = 293
+    set Reference viscosity 		             = 1e8
+    set Minimum strain rate 		             = 1e-20
+    set Reference strain rate 		             = 2e-5
+  
+  # If the resolution of the model is low, then a higher value of the viscosity contrast can be used.
+  # The viscosity contrast is 10^8 here and any value higher than this causes divergence of the solver.
+    set Minimum viscosity 		             = 1e4  
+    set Maximum viscosity 		             = 1e12
+
+    set Thermal diffusivities 		             = 1e-6
+    set Heat capacities 		             = 750
+    set Densities 		                     = 1560, 1560, 1890, 1560, 3000, 0, 1e5
+    set Thermal expansivities 		             = 0    # Density is independet of temperature
+    set Viscosity averaging scheme 	             = harmonic
+    set Viscous flow law 		             = dislocation 			
+
+    set Prefactors for dislocation creep             = 5e-15, 5e-15, 5e-15, 5e-15, 5e-18, 5e-5, 5e-18
+    set Stress exponents for dislocation creep       = 1 
+    set Activation energies for dislocation creep    = 0
+    set Activation volumes for dislocation creep     = 0
+
+    set Angles of internal friction 	             = 36, 36, 36, 16, 0, 0, 1e18
+    set Cohesions 			             = 30, 30, 30, 30, 1e18, 1e18, 1e18
+    set Use strain weakening 		             = true
+    set Start plasticity strain weakening intervals  = 0.5 
+    set End plasticity strain weakening intervals    = 1
+    set Cohesion strain weakening factors            = 1
+    set Friction strain weakening factors            = 1, 0.861, 0.861, 0.875, 1, 1, 1
+
+  end
+end

--- a/benchmarks/buiter_et_al_2016_jsg/exp_2_low_resolution.prm
+++ b/benchmarks/buiter_et_al_2016_jsg/exp_2_low_resolution.prm
@@ -14,41 +14,17 @@ end
 
 ### Material properties
 # Using harmonic material averaging is required to achieve reasonable convergence 
-# behavior, particulally when the viscosity contrast is large.
+# behavior, particularly when the viscosity contrast is large.
 subsection Material model
-  set Material averaging 		             = harmonic average	
   set Model name 			             = visco plastic
 
   subsection Visco Plastic
-    set Reference temperature 		             = 293
-    set Reference viscosity 		             = 1e8
-    set Minimum strain rate 		             = 1e-20
-    set Reference strain rate 		             = 2e-5
+
   
-  # If the resolution of the model is low, then a higher value of the viscosity contrast can be used.
+  # Further testing revealed that decreasing the model resolution allows using a higher contrast between the minimum and maximum viscosity.
   # The viscosity contrast is 10^8 here and any value higher than this causes divergence of the solver.
     set Minimum viscosity 		             = 1e4  
     set Maximum viscosity 		             = 1e12
-
-    set Thermal diffusivities 		             = 1e-6
-    set Heat capacities 		             = 750
-    set Densities 		                     = 1560, 1560, 1890, 1560, 3000, 0, 1e5
-    set Thermal expansivities 		             = 0    # Density is independet of temperature
-    set Viscosity averaging scheme 	             = harmonic
-    set Viscous flow law 		             = dislocation 			
-
-    set Prefactors for dislocation creep             = 5e-15, 5e-15, 5e-15, 5e-15, 5e-18, 5e-5, 5e-18
-    set Stress exponents for dislocation creep       = 1 
-    set Activation energies for dislocation creep    = 0
-    set Activation volumes for dislocation creep     = 0
-
-    set Angles of internal friction 	             = 36, 36, 36, 16, 0, 0, 1e18
-    set Cohesions 			             = 30, 30, 30, 30, 1e18, 1e18, 1e18
-    set Use strain weakening 		             = true
-    set Start plasticity strain weakening intervals  = 0.5 
-    set End plasticity strain weakening intervals    = 1
-    set Cohesion strain weakening factors            = 1
-    set Friction strain weakening factors            = 1, 0.861, 0.861, 0.875, 1, 1, 1
 
   end
 end


### PR DESCRIPTION
We (Sibiao, Stephanie, John, and Cederic) did benchmark numerical models for brittle thrust wedge experiment 1 and 2 in the JSG paper of Butter et al., 2016.

This benchmark models reproduced similar results (e.g., material fields, strain, strain rate, pressure) as that in other numerical and analogue models indicating that the late version of Aspect has a great performance to simulate sandbox thrust wedge experiments with significant computational challenges.
 
We only reproduce the model and do not do the model analysis, i.e., measuring the surface slope,  the dip angle, etc.