### PR TITLE
Mark up physical units in latex.

### DIFF
--- a/source/boundary_composition/box.cc
+++ b/source/boundary_composition/box.cc
@@ -61,23 +61,23 @@ namespace aspect
           prm.declare_entry ("Left composition", "",
                              Patterns::List(Patterns::Double ()),
                              "A comma separated list of composition boundary values "
-                             "at the left boundary (at minimal x-value). This list must have as many "
+                             "at the left boundary (at minimal $x$-value). This list must have as many "
                              "entries as there are compositional fields. Units: none.");
           prm.declare_entry ("Right composition", "",
                              Patterns::List(Patterns::Double ()),
                              "A comma separated list of composition boundary values "
-                             "at the right boundary (at maximal x-value). This list must have as many "
+                             "at the right boundary (at maximal $x$-value). This list must have as many "
                              "entries as there are compositional fields. Units: none.");
           prm.declare_entry ("Bottom composition", "",
                              Patterns::List(Patterns::Double ()),
                              "A comma separated list of composition boundary values "
-                             "at the bottom boundary (at minimal y-value in 2d, or minimal "
+                             "at the bottom boundary (at minimal $y$-value in 2d, or minimal "
                              "z-value in 3d). This list must have as many "
                              "entries as there are compositional fields. Units: none.");
           prm.declare_entry ("Top composition", "",
                              Patterns::List(Patterns::Double ()),
                              "A comma separated list of composition boundary values "
-                             "at the top boundary (at maximal y-value in 2d, or maximal "
+                             "at the top boundary (at maximal $y$-value in 2d, or maximal "
                              "z-value in 3d). This list must have as many "
                              "entries as there are compositional fields. Units: none.");
           if (dim==3)

--- a/source/boundary_composition/two_merged_boxes.cc
+++ b/source/boundary_composition/two_merged_boxes.cc
@@ -61,33 +61,33 @@ namespace aspect
           prm.declare_entry ("Left composition", "",
                              Patterns::List(Patterns::Double ()),
                              "A comma separated list of composition boundary values "
-                             "at the left boundary (at minimal x-value). This list must have as many "
+                             "at the left boundary (at minimal $x$-value). This list must have as many "
                              "entries as there are compositional fields. Units: none.");
           prm.declare_entry ("Right composition", "",
                              Patterns::List(Patterns::Double ()),
                              "A comma separated list of composition boundary values "
-                             "at the right boundary (at maximal x-value). This list must have as many "
+                             "at the right boundary (at maximal $x$-value). This list must have as many "
                              "entries as there are compositional fields. Units: none.");
           prm.declare_entry ("Left composition lithosphere", "",
                              Patterns::List(Patterns::Double ()),
                              "A comma separated list of composition boundary values "
-                             "at the left boundary (at minimal x-value). This list must have as many "
+                             "at the left boundary (at minimal $x$-value). This list must have as many "
                              "entries as there are compositional fields. Units: none.");
           prm.declare_entry ("Right composition lithosphere", "",
                              Patterns::List(Patterns::Double ()),
                              "A comma separated list of composition boundary values "
-                             "at the right boundary (at maximal x-value). This list must have as many "
+                             "at the right boundary (at maximal $x$-value). This list must have as many "
                              "entries as there are compositional fields. Units: none.");
           prm.declare_entry ("Bottom composition", "",
                              Patterns::List(Patterns::Double ()),
                              "A comma separated list of composition boundary values "
-                             "at the bottom boundary (at minimal y-value in 2d, or minimal "
+                             "at the bottom boundary (at minimal $y$-value in 2d, or minimal "
                              "z-value in 3d). This list must have as many "
                              "entries as there are compositional fields. Units: none.");
           prm.declare_entry ("Top composition", "",
                              Patterns::List(Patterns::Double ()),
                              "A comma separated list of composition boundary values "
-                             "at the top boundary (at maximal y-value in 2d, or maximal "
+                             "at the top boundary (at maximal $y$-value in 2d, or maximal "
                              "z-value in 3d). This list must have as many "
                              "entries as there are compositional fields. Units: none.");
           if (dim==3)
@@ -95,12 +95,12 @@ namespace aspect
               prm.declare_entry ("Front composition", "",
                                  Patterns::List(Patterns::Double ()),
                                  "A comma separated list of composition boundary values "
-                                 "at the front boundary (at minimal y-value). This list must have as many "
+                                 "at the front boundary (at minimal $y$-value). This list must have as many "
                                  "entries as there are compositional fields. Units: none.");
               prm.declare_entry ("Back composition", "",
                                  Patterns::List(Patterns::Double ()),
                                  "A comma separated list of composition boundary values "
-                                 "at the back boundary (at maximal y-value). This list must have as many "
+                                 "at the back boundary (at maximal $y$-value). This list must have as many "
                                  "entries as there are compositional fields. Units: none.");
               prm.declare_entry ("Front composition lithosphere", "",
                                  Patterns::List(Patterns::Double ()),
@@ -110,7 +110,7 @@ namespace aspect
               prm.declare_entry ("Back composition lithosphere", "",
                                  Patterns::List(Patterns::Double ()),
                                  "A comma separated list of composition boundary values "
-                                 "at the back lithosphere boundary (at maximal y-value). This list must have as many "
+                                 "at the back lithosphere boundary (at maximal $y$-value). This list must have as many "
                                  "entries as there are compositional fields. Units: none.");
             }
         }

--- a/source/boundary_temperature/box.cc
+++ b/source/boundary_temperature/box.cc
@@ -100,24 +100,24 @@ namespace aspect
         {
           prm.declare_entry ("Left temperature", "1",
                              Patterns::Double (),
-                             "Temperature at the left boundary (at minimal x-value). Units: K.");
+                             "Temperature at the left boundary (at minimal $x$-value). Units: $\\text{K}$.");
           prm.declare_entry ("Right temperature", "0",
                              Patterns::Double (),
-                             "Temperature at the right boundary (at maximal x-value). Units: K.");
+                             "Temperature at the right boundary (at maximal $x$-value). Units: $\\text{K}$.");
           prm.declare_entry ("Bottom temperature", "0",
                              Patterns::Double (),
-                             "Temperature at the bottom boundary (at minimal z-value). Units: K.");
+                             "Temperature at the bottom boundary (at minimal $z$-value). Units: $\\text{K}$.");
           prm.declare_entry ("Top temperature", "0",
                              Patterns::Double (),
-                             "Temperature at the top boundary (at maximal x-value). Units: K.");
+                             "Temperature at the top boundary (at maximal $x$-value). Units: $\\text{K}$.");
           if (dim==3)
             {
               prm.declare_entry ("Front temperature", "0",
                                  Patterns::Double (),
-                                 "Temperature at the front boundary (at minimal y-value). Units: K.");
+                                 "Temperature at the front boundary (at minimal $y$-value). Units: $\\text{K}$.");
               prm.declare_entry ("Back temperature", "0",
                                  Patterns::Double (),
-                                 "Temperature at the back boundary (at maximal y-value). Units: K.");
+                                 "Temperature at the back boundary (at maximal $y$-value). Units: $\\text{K}$.");
             }
         }
         prm.leave_subsection ();

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -96,11 +96,11 @@ namespace aspect
         {
           prm.declare_entry ("Outer temperature", "0",
                              Patterns::Double (),
-                             "Temperature at the outer boundary (lithosphere water/air). Units: $K$.");
+                             "Temperature at the outer boundary (lithosphere water/air). Units: $\\text{K}$.");
           prm.declare_entry ("Inner temperature", "6000",
                              Patterns::Double (),
                              "Temperature at the inner boundary (core mantle boundary) at the "
-                             "beginning. Units: $K$.");
+                             "beginning. Units: $\\text{K}$.");
           prm.declare_entry ("dT over dt", "0",
                              Patterns::Double (),
                              "Initial CMB temperature changing rate. Units: $K/year$.");
@@ -160,7 +160,7 @@ namespace aspect
           {
             prm.declare_entry ("Tm0","1695",
                                Patterns::Double (0),
-                               "Melting curve (\\cite{NPB+04} eq. (40)) parameter Tm0. Units: $K$.");
+                               "Melting curve (\\cite{NPB+04} eq. (40)) parameter Tm0. Units: $\\text{K}$.");
             prm.declare_entry ("Tm1","10.9",
                                Patterns::Double (),
                                "Melting curve (\\cite{NPB+04} eq. (40)) parameter Tm1. Units: $1/Tpa$.");

--- a/source/boundary_temperature/function.cc
+++ b/source/boundary_temperature/function.cc
@@ -103,10 +103,10 @@ namespace aspect
 
           prm.declare_entry ("Minimal temperature", "273",
                              Patterns::Double (),
-                             "Minimal temperature. Units: K.");
+                             "Minimal temperature. Units: $\\text{K}$.");
           prm.declare_entry ("Maximal temperature", "3773",
                              Patterns::Double (),
-                             "Maximal temperature. Units: K.");
+                             "Maximal temperature. Units: $\\text{K}$.");
         }
         prm.leave_subsection();
       }

--- a/source/boundary_temperature/initial_temperature.cc
+++ b/source/boundary_temperature/initial_temperature.cc
@@ -69,10 +69,10 @@ namespace aspect
         {
           prm.declare_entry ("Minimal temperature", "0",
                              Patterns::Double (),
-                             "Minimal temperature. Units: K.");
+                             "Minimal temperature. Units: $\\text{K}$.");
           prm.declare_entry ("Maximal temperature", "3773",
                              Patterns::Double (),
-                             "Maximal temperature. Units: K.");
+                             "Maximal temperature. Units: $\\text{K}$.");
         }
         prm.leave_subsection ();
       }

--- a/source/boundary_temperature/spherical_constant.cc
+++ b/source/boundary_temperature/spherical_constant.cc
@@ -87,10 +87,10 @@ namespace aspect
         {
           prm.declare_entry ("Outer temperature", "0",
                              Patterns::Double (),
-                             "Temperature at the outer boundary (lithosphere water/air). Units: K.");
+                             "Temperature at the outer boundary (lithosphere water/air). Units: $\\text{K}$.");
           prm.declare_entry ("Inner temperature", "6000",
                              Patterns::Double (),
-                             "Temperature at the inner boundary (core mantle boundary). Units: K.");
+                             "Temperature at the inner boundary (core mantle boundary). Units: $\\text{K}$.");
         }
         prm.leave_subsection ();
       }

--- a/source/boundary_temperature/two_merged_boxes.cc
+++ b/source/boundary_temperature/two_merged_boxes.cc
@@ -99,36 +99,36 @@ namespace aspect
         {
           prm.declare_entry ("Left temperature", "1",
                              Patterns::Double (),
-                             "Temperature at the left boundary (at minimal x-value). Units: K.");
+                             "Temperature at the left boundary (at minimal $x$-value). Units: $\\text{K}$.");
           prm.declare_entry ("Right temperature", "0",
                              Patterns::Double (),
-                             "Temperature at the right boundary (at maximal x-value). Units: K.");
+                             "Temperature at the right boundary (at maximal $x$-value). Units: $\\text{K}$.");
           prm.declare_entry ("Bottom temperature", "0",
                              Patterns::Double (),
-                             "Temperature at the bottom boundary (at minimal z-value). Units: K.");
+                             "Temperature at the bottom boundary (at minimal $z$-value). Units: $\\text{K}$.");
           prm.declare_entry ("Top temperature", "0",
                              Patterns::Double (),
-                             "Temperature at the top boundary (at maximal x-value). Units: K.");
+                             "Temperature at the top boundary (at maximal $x$-value). Units: $\\text{K}$.");
           prm.declare_entry ("Left temperature lithosphere", "0",
                              Patterns::Double (),
-                             "Temperature at the additional left lithosphere boundary (specified by user in Geometry Model). Units: K.");
+                             "Temperature at the additional left lithosphere boundary (specified by user in Geometry Model). Units: $\\text{K}$.");
           prm.declare_entry ("Right temperature lithosphere", "0",
                              Patterns::Double (),
-                             "Temperature at the additional right lithosphere boundary (specified by user in Geometry Model). Units: K.");
+                             "Temperature at the additional right lithosphere boundary (specified by user in Geometry Model). Units: $\\text{K}$.");
           if (dim==3)
             {
               prm.declare_entry ("Front temperature", "0",
                                  Patterns::Double (),
-                                 "Temperature at the front boundary (at minimal y-value). Units: K.");
+                                 "Temperature at the front boundary (at minimal $y$-value). Units: $\\text{K}$.");
               prm.declare_entry ("Back temperature", "0",
                                  Patterns::Double (),
-                                 "Temperature at the back boundary (at maximal y-value). Units: K.");
+                                 "Temperature at the back boundary (at maximal $y$-value). Units: $\\text{K}$.");
               prm.declare_entry ("Front temperature lithosphere", "0",
                                  Patterns::Double (),
-                                 "Temperature at the additional front lithosphere boundary (at minimal y-value). Units: K.");
+                                 "Temperature at the additional front lithosphere boundary (at minimal $y$-value). Units: $\\text{K}$.");
               prm.declare_entry ("Back temperature lithosphere", "0",
                                  Patterns::Double (),
-                                 "Temperature at the additional back lithosphere boundary (at maximal y-value). Units: K.");
+                                 "Temperature at the additional back lithosphere boundary (at maximal $y$-value). Units: $\\text{K}$.");
             }
         }
         prm.leave_subsection ();

--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -271,7 +271,7 @@ namespace aspect
                              "The point where the pressure profile will be calculated. "
                              "Cartesian coordinates when geometry is a box, otherwise enter radius, longitude, "
                              "and in 3D latitude."
-                             "Units: m or degrees.");
+                             "Units: $\\text{m}$ or degrees.");
           prm.declare_entry("Number of integration points", "1000",
                             Patterns::Integer(0),
                             "The number of integration points over which we integrate the lithostatic pressure "

--- a/source/geometry_model/box.cc
+++ b/source/geometry_model/box.cc
@@ -326,25 +326,25 @@ namespace aspect
         {
           prm.declare_entry ("X extent", "1",
                              Patterns::Double (0),
-                             "Extent of the box in x-direction. Units: m.");
+                             "Extent of the box in x-direction. Units: $\\text{m}$.");
           prm.declare_entry ("Y extent", "1",
                              Patterns::Double (0),
-                             "Extent of the box in y-direction. Units: m.");
+                             "Extent of the box in y-direction. Units: $\\text{m}$.");
           prm.declare_entry ("Z extent", "1",
                              Patterns::Double (0),
                              "Extent of the box in z-direction. This value is ignored "
-                             "if the simulation is in 2d. Units: m.");
+                             "if the simulation is in 2d. Units: $\\text{m}$.");
 
           prm.declare_entry ("Box origin X coordinate", "0",
                              Patterns::Double (),
-                             "X coordinate of box origin. Units: m.");
+                             "X coordinate of box origin. Units: $\\text{m}$.");
           prm.declare_entry ("Box origin Y coordinate", "0",
                              Patterns::Double (),
-                             "Y coordinate of box origin. Units: m.");
+                             "Y coordinate of box origin. Units: $\\text{m}$.");
           prm.declare_entry ("Box origin Z coordinate", "0",
                              Patterns::Double (),
                              "Z coordinate of box origin. This value is ignored "
-                             "if the simulation is in 2d. Units: m.");
+                             "if the simulation is in 2d. Units: $\\text{m}$.");
 
           prm.declare_entry ("X repetitions", "1",
                              Patterns::Integer (1),

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -655,10 +655,10 @@ namespace aspect
         {
           prm.declare_entry ("Chunk inner radius", "0",
                              Patterns::Double (0),
-                             "Radius at the bottom surface of the chunk. Units: m.");
+                             "Radius at the bottom surface of the chunk. Units: $\\text{m}$.");
           prm.declare_entry ("Chunk outer radius", "1",
                              Patterns::Double (0),
-                             "Radius at the top surface of the chunk. Units: m.");
+                             "Radius at the top surface of the chunk. Units: $\\text{m}$.");
 
           prm.declare_entry ("Chunk minimum longitude", "0",
                              Patterns::Double (-180, 360), // enables crossing of either hemisphere

--- a/source/geometry_model/sphere.cc
+++ b/source/geometry_model/sphere.cc
@@ -193,7 +193,7 @@ namespace aspect
         {
           prm.declare_entry ("Radius", "6371000",
                              Patterns::Double (0),
-                             "Radius of the sphere. Units: m.");
+                             "Radius of the sphere. Units: $\\text{m}$.");
         }
         prm.leave_subsection();
       }

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -337,7 +337,7 @@ namespace aspect
         {
           prm.declare_entry ("Inner radius", "3481000",  // 6371-2890 in km
                              Patterns::Double (0),
-                             "Inner radius of the spherical shell. Units: m. "
+                             "Inner radius of the spherical shell. Units: $\\text{m}$. "
                              "\n\n"
                              "\\note{The default value of 3,481,000 m equals the "
                              "radius of a sphere with equal volume as Earth (i.e., "
@@ -345,7 +345,7 @@ namespace aspect
                              "boundary (i.e., 2890 km).}");
           prm.declare_entry ("Outer radius", "6336000",  // 6371-35 in km
                              Patterns::Double (0),
-                             "Outer radius of the spherical shell. Units: m. "
+                             "Outer radius of the spherical shell. Units: $\\text{m}$. "
                              "\n\n"
                              "\\note{The default value of 6,336,000 m equals the "
                              "radius of a sphere with equal volume as Earth (i.e., "

--- a/source/geometry_model/two_merged_boxes.cc
+++ b/source/geometry_model/two_merged_boxes.cc
@@ -345,26 +345,26 @@ namespace aspect
           // Total box extents
           prm.declare_entry ("X extent", "1",
                              Patterns::Double (0),
-                             "Extent of the box in x-direction. Units: m.");
+                             "Extent of the box in x-direction. Units: $\\text{m}$.");
           prm.declare_entry ("Y extent", "1",
                              Patterns::Double (0),
-                             "Extent of the box in y-direction. Units: m.");
+                             "Extent of the box in y-direction. Units: $\\text{m}$.");
           prm.declare_entry ("Z extent", "1",
                              Patterns::Double (0),
                              "Extent of the box in z-direction. This value is ignored "
-                             "if the simulation is in 2d. Units: m.");
+                             "if the simulation is in 2d. Units: $\\text{m}$.");
 
           // Total box origin
           prm.declare_entry ("Box origin X coordinate", "0",
                              Patterns::Double (),
-                             "X coordinate of box origin. Units: m.");
+                             "X coordinate of box origin. Units: $\\text{m}$.");
           prm.declare_entry ("Box origin Y coordinate", "0",
                              Patterns::Double (),
-                             "Y coordinate of box origin. Units: m.");
+                             "Y coordinate of box origin. Units: $\\text{m}$.");
           prm.declare_entry ("Box origin Z coordinate", "0",
                              Patterns::Double (),
                              "Z coordinate of box origin. This value is ignored "
-                             "if the simulation is in 2d. Units: m.");
+                             "if the simulation is in 2d. Units: $\\text{m}$.");
 
           // Lower box repetitions
           prm.declare_entry ("X repetitions", "1",

--- a/source/heating_model/radioactive_decay.cc
+++ b/source/heating_model/radioactive_decay.cc
@@ -110,7 +110,7 @@ namespace aspect
           prm.declare_entry("Crust depth","0",
                             Patterns::Double(),
                             "Depth of the crust when crust if defined by depth. "
-                            "Units: m");
+                            "Units: $\\text{m}$");
           prm.declare_entry("Crust composition number","0",
                             Patterns::Integer(0),
                             "Which composition field should be treated as crust");

--- a/source/initial_temperature/adiabatic.cc
+++ b/source/initial_temperature/adiabatic.cc
@@ -263,7 +263,7 @@ namespace aspect
                              "If this value is larger than 0, the initial temperature profile will "
                              "not be adiabatic, but subadiabatic. This value gives the maximal "
                              "deviation from adiabaticity. Set to 0 for an adiabatic temperature "
-                             "profile. Units: K.\n\n"
+                             "profile. Units: $\\text{K}$.\n\n"
                              "The function object in the Function subsection "
                              "represents the compositional fields that will be used as a reference "
                              "profile for calculating the thermal diffusivity. "

--- a/source/initial_temperature/adiabatic_boundary.cc
+++ b/source/initial_temperature/adiabatic_boundary.cc
@@ -98,10 +98,10 @@ namespace aspect
                              "File from which the isotherm depth data is read.");
           prm.declare_entry ("Isotherm temperature", "1673.15",
                              Patterns::Double (0),
-                             "The value of the isothermal boundary temperature. Units: Kelvin.");
+                             "The value of the isothermal boundary temperature. Units: $\\text{K}$.");
           prm.declare_entry ("Surface temperature", "273.15",
                              Patterns::Double (0),
-                             "The value of the surface temperature. Units: Kelvin.");
+                             "The value of the surface temperature. Units: $\\text{K}$.");
           prm.declare_entry ("Adiabatic temperature gradient", "0.0005",
                              Patterns::Double (0),
                              "The value of the adiabatic temperature gradient. Units: $K m^{-1}$.");

--- a/source/initial_temperature/continental_geotherm.cc
+++ b/source/initial_temperature/continental_geotherm.cc
@@ -112,11 +112,11 @@ namespace aspect
                              "for all layers. Units: $m$");
           prm.declare_entry ("Surface temperature", "273.15",
                              Patterns::Double (0),
-                             "The value of the surface temperature. Units: Kelvin.");
+                             "The value of the surface temperature. Units: $\\text{K}$.");
           prm.declare_entry ("Lithosphere-Asthenosphere boundary isotherm", "1673.15",
                              Patterns::Double (0),
                              "The value of the isotherm that is assumed at the Lithosphere-"
-                             "Asthenosphere boundary. Units: Kelvin.");
+                             "Asthenosphere boundary. Units: $\\text{K}$.");
         }
         prm.leave_subsection();
       }

--- a/source/material_model/composition_reaction.cc
+++ b/source/material_model/composition_reaction.cc
@@ -147,7 +147,7 @@ namespace aspect
                              "Reference density $\\rho_0$. Units: $kg/m^3$.");
           prm.declare_entry ("Reference temperature", "293",
                              Patterns::Double (0),
-                             "The reference temperature $T_0$. Units: $K$.");
+                             "The reference temperature $T_0$. Units: $\\text{K}$.");
           prm.declare_entry ("Viscosity", "5e24",
                              Patterns::Double (0),
                              "The value of the constant viscosity. Units: $kg/m/s$.");

--- a/source/material_model/diffusion_dislocation.cc
+++ b/source/material_model/diffusion_dislocation.cc
@@ -275,7 +275,7 @@ namespace aspect
         {
           // Reference and minimum/maximum values
           prm.declare_entry ("Reference temperature", "293", Patterns::Double(0),
-                             "For calculating density by thermal expansivity. Units: $K$");
+                             "For calculating density by thermal expansivity. Units: $\\text{K}$");
           prm.declare_entry ("Minimum strain rate", "1.4e-20", Patterns::Double(0),
                              "Stabilizes strain dependent viscosity. Units: $1 / s$");
           prm.declare_entry ("Minimum viscosity", "1e17", Patterns::Double(0),

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -196,7 +196,7 @@ namespace aspect
           prm.declare_entry ("Reference temperature", "293",
                              Patterns::Double (0),
                              "The reference temperature $T_0$. The reference temperature is used "
-                             "in the density calculation. Units: $K$.");
+                             "in the density calculation. Units: $\\text{K}$.");
           prm.declare_entry ("Reference viscosity", "1e22",
                              Patterns::Double (0),
                              "The reference viscosity that is used for pressure scaling. "

--- a/source/material_model/dynamic_friction.cc
+++ b/source/material_model/dynamic_friction.cc
@@ -155,7 +155,7 @@ namespace aspect
         {
           prm.declare_entry ("Reference temperature", "293",
                              Patterns::Double (0),
-                             "The reference temperature $T_0$. Units: $K$.");
+                             "The reference temperature $T_0$. Units: $\\text{K}$.");
           prm.declare_entry ("Densities", "3300.",
                              Patterns::List(Patterns::Double(0)),
                              "List of densities for background mantle and compositional fields,"

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -1489,7 +1489,7 @@ namespace aspect
                              "The reference density $\\rho_0$. Units: $kg/m^3$.");
           prm.declare_entry ("Reference temperature", "293",
                              Patterns::Double (0),
-                             "The reference temperature $T_0$. Units: $K$.");
+                             "The reference temperature $T_0$. Units: $\\text{K}$.");
           prm.declare_entry ("Viscosity", "5e24",
                              Patterns::Double (0),
                              "The value of the constant viscosity. Units: $kg/m/s$.");
@@ -1521,7 +1521,7 @@ namespace aspect
                              "depths than given in Phase transition depths, depending on the "
                              "Clapeyron slope given in Phase transition Clapeyron slopes. "
                              "List must have the same number of entries as Phase transition depths. "
-                             "Units: $K$.");
+                             "Units: $\\text{K}$.");
           prm.declare_entry ("Phase transition widths", "",
                              Patterns::List (Patterns::Double(0)),
                              "A list of widths for each phase transition. This is only use to specify "
@@ -1573,7 +1573,7 @@ namespace aspect
                              Patterns::List (Patterns::Double(0)),
                              "The grain size $d_{ph}$ to that a phase will be reduced to when crossing a phase transition. "
                              "When set to zero, grain size will not be reduced. "
-                             "Units: m.");
+                             "Units: $\\text{m}$.");
           prm.declare_entry ("Use paleowattmeter", "true",
                              Patterns::Bool (),
                              "A flag indicating whether the computation should be use the "
@@ -1685,7 +1685,7 @@ namespace aspect
                              "The minimum grain size that is used for the material model. This parameter "
                              "is introduced to limit local viscosity contrasts, but still allows for a widely "
                              "varying viscosity over the whole mantle range. "
-                             "Units: m.");
+                             "Units: $\\text{m}$.");
           prm.declare_entry ("Lower mantle grain size scaling", "1.0",
                              Patterns::Double (0),
                              "A scaling factor for the grain size in the lower mantle. In models where the "

--- a/source/material_model/latent_heat.cc
+++ b/source/material_model/latent_heat.cc
@@ -351,7 +351,7 @@ namespace aspect
                              "Reference density $\\rho_0$. Units: $kg/m^3$.");
           prm.declare_entry ("Reference temperature", "293",
                              Patterns::Double (0),
-                             "The reference temperature $T_0$. Units: $K$.");
+                             "The reference temperature $T_0$. Units: $\\text{K}$.");
           prm.declare_entry ("Viscosity", "5e24",
                              Patterns::Double (0),
                              "The value of the constant viscosity. Units: $kg/m/s$.");
@@ -429,7 +429,7 @@ namespace aspect
                              "depths than given in Phase transition depths, depending on the "
                              "Clapeyron slope given in Phase transition Clapeyron slopes. "
                              "List must have the same number of entries as Phase transition depths. "
-                             "Units: $K$.");
+                             "Units: $\\text{K}$.");
           prm.declare_entry ("Phase transition Clapeyron slopes", "",
                              Patterns::List (Patterns::Double()),
                              "A list of Clapeyron slopes for each phase transition. A positive "

--- a/source/material_model/latent_heat_melt.cc
+++ b/source/material_model/latent_heat_melt.cc
@@ -369,7 +369,7 @@ namespace aspect
                              "Reference density $\\rho_0$. Units: $kg/m^3$.");
           prm.declare_entry ("Reference temperature", "293",
                              Patterns::Double (0),
-                             "The reference temperature $T_0$. Units: $K$.");
+                             "The reference temperature $T_0$. Units: $\\text{K}$.");
           prm.declare_entry ("Viscosity", "5e24",
                              Patterns::Double (0),
                              "The value of the constant viscosity. Units: $kg/m/s$.");

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -310,7 +310,7 @@ namespace aspect
           prm.declare_entry ("Reference temperature", "293",
                              Patterns::Double (0),
                              "The reference temperature $T_0$. The reference temperature is used "
-                             "in both the density and viscosity formulas. Units: $K$.");
+                             "in both the density and viscosity formulas. Units: $\\text{K}$.");
           prm.declare_entry ("Reference shear viscosity", "5e20",
                              Patterns::Double (0),
                              "The value of the constant viscosity $\\eta_0$ of the solid matrix. "
@@ -366,7 +366,7 @@ namespace aspect
           prm.declare_entry ("Surface solidus", "1300",
                              Patterns::Double (0),
                              "Solidus for a pressure of zero. "
-                             "Units: $K$.");
+                             "Units: $\\text{K}$.");
           prm.declare_entry ("Depletion solidus change", "200.0",
                              Patterns::Double (),
                              "The solidus temperature change for a depletion of 100\\%. For positive "
@@ -374,7 +374,7 @@ namespace aspect
                              "(depletion) and lowered for a negative peridotite field (enrichment). "
                              "Scaling with depletion is linear. Only active when fractional melting "
                              "is used. "
-                             "Units: $K$.");
+                             "Units: $\\text{K}$.");
           prm.declare_entry ("Pressure solidus change", "6e-8",
                              Patterns::Double (),
                              "The linear solidus temperature change with pressure. For positive "

--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -448,7 +448,7 @@ namespace aspect
           prm.declare_entry ("Reference temperature", "293",
                              Patterns::Double (0),
                              "The reference temperature $T_0$. The reference temperature is used "
-                             "in both the density and viscosity formulas. Units: $K$.");
+                             "in both the density and viscosity formulas. Units: $\\text{K}$.");
           prm.declare_entry ("Reference shear viscosity", "5e20",
                              Patterns::Double (0),
                              "The value of the constant viscosity $\\eta_0$ of the solid matrix. "
@@ -588,7 +588,7 @@ namespace aspect
                              "(depletion) and lowered for a negative peridotite field (enrichment). "
                              "Scaling with depletion is linear. Only active when fractional melting "
                              "is used. "
-                             "Units: $K$.");
+                             "Units: $\\text{K}$.");
           prm.declare_entry ("A1", "1085.7",
                              Patterns::Double (),
                              "Constant parameter in the quadratic "

--- a/source/material_model/multicomponent.cc
+++ b/source/material_model/multicomponent.cc
@@ -109,7 +109,7 @@ namespace aspect
         {
           prm.declare_entry ("Reference temperature", "293",
                              Patterns::Double (0),
-                             "The reference temperature $T_0$. Units: $K$.");
+                             "The reference temperature $T_0$. Units: $\\text{K}$.");
           prm.declare_entry ("Densities", "3300.",
                              Patterns::Anything(),
                              "List of densities for background mantle and compositional fields,"

--- a/source/material_model/perplex_lookup.cc
+++ b/source/material_model/perplex_lookup.cc
@@ -161,11 +161,11 @@ namespace aspect
           prm.declare_entry ("Minimum material temperature", "0.",
                              Patterns::Double (0),
                              "The value of the minimum temperature used to query PerpleX. "
-                             "Units: $K$.");
+                             "Units: $\\text{K}$.");
           prm.declare_entry ("Maximum material temperature", "6000.",
                              Patterns::Double (0),
                              "The value of the maximum temperature used to query PerpleX. "
-                             "Units: $K$.");
+                             "Units: $\\text{K}$.");
           prm.declare_entry ("Minimum material pressure", "1.e5",
                              Patterns::Double (0),
                              "The value of the minimum pressure used to query PerpleX. "

--- a/source/material_model/simple.cc
+++ b/source/material_model/simple.cc
@@ -116,7 +116,7 @@ namespace aspect
           prm.declare_entry ("Reference temperature", "293",
                              Patterns::Double (0),
                              "The reference temperature $T_0$. The reference temperature is used "
-                             "in both the density and viscosity formulas. Units: $K$.");
+                             "in both the density and viscosity formulas. Units: $\\text{K}$.");
           prm.declare_entry ("Viscosity", "5e24",
                              Patterns::Double (0),
                              "The value of the constant viscosity $\\eta_0$. This viscosity may be "

--- a/source/material_model/simpler.cc
+++ b/source/material_model/simpler.cc
@@ -78,7 +78,7 @@ namespace aspect
           prm.declare_entry ("Reference temperature", "293",
                              Patterns::Double (0),
                              "The reference temperature $T_0$. The reference temperature is used "
-                             "in the density formula. Units: $K$.");
+                             "in the density formula. Units: $\\text{K}$.");
           prm.declare_entry ("Thermal conductivity", "4.7",
                              Patterns::Double (0),
                              "The value of the thermal conductivity $k$. "

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -723,7 +723,7 @@ namespace aspect
         {
           // Reference and minimum/maximum values
           prm.declare_entry ("Reference temperature", "293", Patterns::Double(0),
-                             "For calculating density by thermal expansivity. Units: $K$");
+                             "For calculating density by thermal expansivity. Units: $\\text{K}$");
           prm.declare_entry ("Minimum strain rate", "1.0e-20", Patterns::Double(0),
                              "Stabilizes strain dependent viscosity. Units: $1 / s$");
           prm.declare_entry ("Reference strain rate","1.0e-15",Patterns::Double(0),

--- a/source/material_model/viscoelastic.cc
+++ b/source/material_model/viscoelastic.cc
@@ -302,7 +302,7 @@ namespace aspect
         {
           prm.declare_entry ("Reference temperature", "293",
                              Patterns::Double (0),
-                             "The reference temperature $T_0$. Units: $K$.");
+                             "The reference temperature $T_0$. Units: $\\text{K}$.");
           prm.declare_entry ("Densities", "3300.",
                              Patterns::List(Patterns::Double(0)),
                              "List of densities for background mantle and compositional fields, "

--- a/source/material_model/viscoelastic_plastic.cc
+++ b/source/material_model/viscoelastic_plastic.cc
@@ -273,7 +273,7 @@ namespace aspect
           // Reference and minimum/maximum values
           prm.declare_entry ("Reference temperature", "293",
                              Patterns::Double (0),
-                             "The reference temperature $T_0$. Units: $K$.");
+                             "The reference temperature $T_0$. Units: $\\text{K}$.");
           prm.declare_entry ("Minimum strain rate", "1.0e-20", Patterns::Double(0),
                              "Stabilizes strain dependent viscosity. Units: $1 / s$");
           prm.declare_entry ("Reference strain rate","1.0e-15",Patterns::Double(0),

--- a/source/postprocess/visualization/geoid.cc
+++ b/source/postprocess/visualization/geoid.cc
@@ -92,7 +92,7 @@ namespace aspect
                                                   "geoid",
                                                   "Visualization for the geoid solution. The geoid is given "
                                                   "by the equivalent water column height due to a gravity perturbation. "
-                                                  "(Units: m)")
+                                                  "Units: $\\text{m}$.")
     }
   }
 }

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -511,7 +511,7 @@ namespace aspect
                            "More precisely, this length scale represents the square root of the "
                            "product of diffusivity and time in the diffusion equation, and controls "
                            "the distance over which features are diffused."
-                           "Units: m.");
+                           "Units: $\\text{m}$.");
       }
       prm.leave_subsection ();
     }


### PR DESCRIPTION
We are quite inconsistent in marking up units. This is a small step towards being marginally be more consistent.

(There are 435 places in the source directory where we declare parameters and say `Units:`. It's going to be a substantial task to convert these all. I'm not volunteering, but I though we could at least address a small piece of it.)