### PR TITLE
Fix: avoid MPI deadlock in constraints

### DIFF
--- a/doc/modules/changes/20190527_tjhei
+++ b/doc/modules/changes/20190527_tjhei
@@ -1,0 +1,3 @@
+New: Fix a rare deadlock caused by adaptive refinement in parallel runs.
+<br>
+(Timo Heister, 2019/05/27)


### PR DESCRIPTION
In rare cases, the code to check if the ConstraintMatrix changed can
cause a deadlock (only some processes would invoke the MPI::sum to check
if the mesh changed).
For this to happen, the total number of DoFs has to stay the same during
refinement. Fix this by unconditionally doing the communication step.