### PR TITLE
Added missing grid interpolator

### DIFF
--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -42,7 +42,7 @@ namespace aspect
    * deal.II (dealii/include/deal.II/base/function_lib.h)
    */
   template <int dim>
-  class InterpolatedUniformGridData : public dealii::Functions::InterpolatedUniformGridData<dim>
+  class InterpolatedUniformGridData : public dealii::Function<dim>
   {
     public:
       /**
@@ -77,13 +77,170 @@ namespace aspect
       virtual
       Tensor<1, dim>
       gradient(const Point<dim> &p,
-               const unsigned int component) const;
+               const unsigned int component = 0) const override;
+
+      /**
+       * Compute the value of the function set by bilinear interpolation of the
+       * given data set.
+       *
+       * @param p The point at which the function is to be evaluated.
+       * @param component The vector component. Since this function is scalar,
+       * only zero is a valid argument here.
+       * @return The interpolated value at this point. If the point lies outside
+       * the set of coordinates, the function is extended by a constant.
+       */
+      virtual
+      double
+      value(const Point<dim> &p,
+            const unsigned int component = 0) const override;
+
+
+    private:
+      /**
+       * The set of interval endpoints in each of the coordinate directions.
+       */
+      const std::array<std::pair<double, double>, dim> interval_endpoints;
+
+      /**
+       * The number of subintervals in each of the coordinate directions.
+       */
+      const std::array<unsigned int, dim> n_subintervals;
+
+      /**
+       * The data that is to be interpolated.
+       */
+      const Table<dim, double> data_values;
 
   };
 }
 
 namespace aspect
 {
+  namespace
+     {
+       // interpolate a data value from a table where ix denotes
+       // the (lower) left endpoint of the interval to interpolate
+       // in, and p_unit denotes the point in unit coordinates to do so.
+       double
+       interpolate(const Table<1, double> &data_values,
+                   const TableIndices<1> & ix,
+                   const Point<1> &        xi)
+       {
+         return ((1 - xi[0]) * data_values[ix[0]] +
+                 xi[0] * data_values[ix[0] + 1]);
+       }
+
+       double
+       interpolate(const Table<2, double> &data_values,
+                   const TableIndices<2> & ix,
+                   const Point<2> &        p_unit)
+       {
+         return (((1 - p_unit[0]) * data_values[ix[0]][ix[1]] +
+                  p_unit[0] * data_values[ix[0] + 1][ix[1]]) *
+                   (1 - p_unit[1]) +
+                 ((1 - p_unit[0]) * data_values[ix[0]][ix[1] + 1] +
+                  p_unit[0] * data_values[ix[0] + 1][ix[1] + 1]) *
+                   p_unit[1]);
+       }
+
+       double
+       interpolate(const Table<3, double> &data_values,
+                   const TableIndices<3> & ix,
+                   const Point<3> &        p_unit)
+       {
+         return ((((1 - p_unit[0]) * data_values[ix[0]][ix[1]][ix[2]] +
+                   p_unit[0] * data_values[ix[0] + 1][ix[1]][ix[2]]) *
+                    (1 - p_unit[1]) +
+                  ((1 - p_unit[0]) * data_values[ix[0]][ix[1] + 1][ix[2]] +
+                   p_unit[0] * data_values[ix[0] + 1][ix[1] + 1][ix[2]]) *
+                    p_unit[1]) *
+                   (1 - p_unit[2]) +
+                 (((1 - p_unit[0]) * data_values[ix[0]][ix[1]][ix[2] + 1] +
+                   p_unit[0] * data_values[ix[0] + 1][ix[1]][ix[2] + 1]) *
+                    (1 - p_unit[1]) +
+                  ((1 - p_unit[0]) * data_values[ix[0]][ix[1] + 1][ix[2] + 1] +
+                   p_unit[0] * data_values[ix[0] + 1][ix[1] + 1][ix[2] + 1]) *
+                    p_unit[1]) *
+                   p_unit[2]);
+       }
+
+
+       // Interpolate the gradient of a data value from a table where ix
+       // denotes the lower left endpoint of the interval to interpolate
+       // in, p_unit denotes the point in unit coordinates, and dx
+       // denotes the width of the interval in each dimension.
+       Tensor<1, 1>
+       gradient_interpolate(const Table<1, double> &data_values,
+                            const TableIndices<1> & ix,
+                            const Point<1> &        p_unit,
+                            const Point<1> &        dx)
+       {
+         (void)p_unit;
+         Tensor<1, 1> grad;
+         grad[0] = (data_values[ix[0] + 1] - data_values[ix[0]]) / dx[0];
+         return grad;
+       }
+
+
+       Tensor<1, 2>
+       gradient_interpolate(const Table<2, double> &data_values,
+                            const TableIndices<2> & ix,
+                            const Point<2> &        p_unit,
+                            const Point<2> &        dx)
+       {
+         Tensor<1, 2> grad;
+         double       u00 = data_values[ix[0]][ix[1]],
+                u01       = data_values[ix[0] + 1][ix[1]],
+                u10       = data_values[ix[0]][ix[1] + 1],
+                u11       = data_values[ix[0] + 1][ix[1] + 1];
+
+         grad[0] =
+           ((1 - p_unit[1]) * (u01 - u00) + p_unit[1] * (u11 - u10)) / dx[0];
+         grad[1] =
+           ((1 - p_unit[0]) * (u10 - u00) + p_unit[0] * (u11 - u01)) / dx[1];
+         return grad;
+       }
+
+
+       Tensor<1, 3>
+       gradient_interpolate(const Table<3, double> &data_values,
+                            const TableIndices<3> & ix,
+                            const Point<3> &        p_unit,
+                            const Point<3> &        dx)
+       {
+         Tensor<1, 3> grad;
+         double       u000 = data_values[ix[0]][ix[1]][ix[2]],
+                u001       = data_values[ix[0] + 1][ix[1]][ix[2]],
+                u010       = data_values[ix[0]][ix[1] + 1][ix[2]],
+                u100       = data_values[ix[0]][ix[1]][ix[2] + 1],
+                u011       = data_values[ix[0] + 1][ix[1] + 1][ix[2]],
+                u101       = data_values[ix[0] + 1][ix[1]][ix[2] + 1],
+                u110       = data_values[ix[0]][ix[1] + 1][ix[2] + 1],
+                u111       = data_values[ix[0] + 1][ix[1] + 1][ix[2] + 1];
+
+         grad[0] =
+           ((1 - p_unit[2]) *
+              ((1 - p_unit[1]) * (u001 - u000) + p_unit[1] * (u011 - u010)) +
+            p_unit[2] *
+              ((1 - p_unit[1]) * (u101 - u100) + p_unit[1] * (u111 - u110))) /
+           dx[0];
+         grad[1] =
+           ((1 - p_unit[2]) *
+              ((1 - p_unit[0]) * (u010 - u000) + p_unit[0] * (u011 - u001)) +
+            p_unit[2] *
+              ((1 - p_unit[0]) * (u110 - u100) + p_unit[0] * (u111 - u101))) /
+           dx[1];
+         grad[2] =
+           ((1 - p_unit[1]) *
+              ((1 - p_unit[0]) * (u100 - u000) + p_unit[0] * (u101 - u001)) +
+            p_unit[1] *
+              ((1 - p_unit[0]) * (u110 - u010) + p_unit[0] * (u111 - u011))) /
+           dx[2];
+
+         return grad;
+       }
+   } // namespace
+
   template <int dim>
   inline
   InterpolatedUniformGridData<dim>::InterpolatedUniformGridData(
@@ -91,8 +248,22 @@ namespace aspect
     const std::array<unsigned int, dim>              &n_subintervals,
     const Table<dim, double>                         &data_values)
     :
-    dealii::Functions::InterpolatedUniformGridData<dim>(&interval_endpoints, &n_subintervals, &data_values)
-  {}
+    interval_endpoints(interval_endpoints),
+    n_subintervals(n_subintervals),
+    data_values(data_values)
+  {
+    for (unsigned int d = 0; d < dim; ++d)
+      {
+        Assert(n_subintervals[d] >= 1,
+               ExcMessage("There needs to be at least one subinterval in each "
+                          "coordinate direction."));
+        Assert(interval_endpoints[d].first < interval_endpoints[d].second,
+               ExcMessage("The interval in each coordinate direction needs "
+                          "to have positive size"));
+        Assert(data_values.size()[d] == n_subintervals[d] + 1,
+               ExcMessage("The data table does not have the correct size."));
+      }
+  }
 
 
   /**
@@ -112,21 +283,91 @@ namespace aspect
       ExcMessage(
         "This is a scalar function object, the component can only be zero."));
 
-    // find out where this data point lies
-    const TableIndices<dim> ix = table_index_of_point(p);
-
-    Point<dim> dx;
+    // find out where this data point lies, relative to the given
+    // subdivision points
+    TableIndices<dim> ix;
     for (unsigned int d = 0; d < dim; ++d)
-      dx[d] = (this->interval_endpoints[d].second - this->interval_endpoints[d].first)/this->n_subintervals[d];
+      {
+        const double delta_x =
+          ((this->interval_endpoints[d].second - this->interval_endpoints[d].first) /
+              this->n_subintervals[d]);
+        if (p[d] <= this->interval_endpoints[d].first)
+          ix[d] = 0;
+        else if (p[d] >= this->interval_endpoints[d].second - delta_x)
+          ix[d] = this->n_subintervals[d] - 1;
+        else
+          ix[d] = static_cast<unsigned int>(
+                    (p[d] - this->interval_endpoints[d].first) / delta_x);
+      }
 
+    // now compute the relative point within the interval/rectangle/box
+    // defined by the point coordinates found above. truncate below and
+    // above to accommodate points that may lie outside the range
+    Point<dim> p_unit;
+    Point<dim> delta_x;
+    for (unsigned int d = 0; d < dim; ++d)
+      {
+        delta_x[d] =
+          ((this->interval_endpoints[d].second - this->interval_endpoints[d].first) /
+              this->n_subintervals[d]);
+        p_unit[d] = std::max(std::min((p[d] - this->interval_endpoints[d].first -
+                                       ix[d] * delta_x[d]) /
+                                      delta_x[d],
+                                      1.),
+                             0.);
+      }
+
+    return gradient_interpolate(this->data_values, ix, p_unit, delta_x);
+  }
+
+  template <int dim>
+  inline
+  double
+  InterpolatedUniformGridData<dim>::value(const Point<dim> & p,
+                                          const unsigned int component) const
+  {
+    (void)component;
+    Assert(
+      component == 0,
+      ExcMessage(
+        "This is a scalar function object, the component can only be zero."));
+
+    // find out where this data point lies, relative to the given
+    // subdivision points
+    TableIndices<dim> ix;
+    for (unsigned int d = 0; d < dim; ++d)
+      {
+        const double delta_x =
+          ((interval_endpoints[d].second - interval_endpoints[d].first) /
+           n_subintervals[d]);
+        if (p[d] <= interval_endpoints[d].first)
+          ix[d] = 0;
+        else if (p[d] >= interval_endpoints[d].second - delta_x)
+          ix[d] = n_subintervals[d] - 1;
+        else
+          ix[d] = static_cast<unsigned int>(
+            (p[d] - interval_endpoints[d].first) / delta_x);
+      }
+
+    // now compute the relative point within the interval/rectangle/box
+    // defined by the point coordinates found above. truncate below and
+    // above to accommodate points that may lie outside the range
     Point<dim> p_unit;
     for (unsigned int d = 0; d < dim; ++d)
-      p_unit[d] =
-        std::max(std::min((p[d] - this->coordinate_values[d][ix[d]]) / dx[d], 1.),
-                 0.0);
+      {
+        const double delta_x =
+          ((interval_endpoints[d].second - interval_endpoints[d].first) /
+           n_subintervals[d]);
+        p_unit[d] = std::max(std::min((p[d] - interval_endpoints[d].first -
+                                       ix[d] * delta_x) /
+                                        delta_x,
+                                      1.),
+                             0.);
+      }
 
-    return gradient_interpolate(this->data_values, ix, p_unit, dx);
-  }
+    return interpolate(data_values, ix, p_unit);
+}
+
 
 }
 #endif

--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -34,8 +34,7 @@
 #include <deal.II/base/function_lib.h>
 namespace aspect
 {
-  namespace dealii
-  {
+  using namespace dealii;
   /**
    * A scalar function that computes its values by (bi-, tri-)linear
    * interpolation from a set of point data that are arranged on a uniformly
@@ -43,89 +42,68 @@ namespace aspect
    * deal.II (dealii/include/deal.II/base/function_lib.h)
    */
   template <int dim>
-  class InterpolatedUniformGridData : public dealii::InterpolatedUniformGridData<dim>
+  class InterpolatedUniformGridData : public dealii::Functions::InterpolatedUniformGridData<dim>
   {
-  public:
-    /**
-     * Constructor
-     * @param interval_endpoints The left and right end points of the
-     * (uniformly subdivided) intervals in each of the coordinate directions.
-     * @param n_subintervals The number of subintervals in each coordinate
-     * direction. A value of one for a coordinate means that the interval is
-     * considered as one subinterval consisting of the entire range. A value
-     * of two means that there are two subintervals each with one half of the
-     * range, etc.
-     * @param data_values A dim-dimensional table of data at each of the mesh
-     * points defined by the coordinate arrays above. Note that the Table
-     * class has a number of conversion constructors that allow converting
-     * other data types into a table where you specify this argument.
-     */
-    InterpolatedUniformGridData(
-      const std::array<std::pair<double, double>, dim> &interval_endpoints,
-      const std::array<unsigned int, dim> &             n_subintervals,
-      const Table<dim, double> &                        data_values);
+    public:
+      /**
+       * Constructor
+       * @param interval_endpoints The left and right end points of the
+       * (uniformly subdivided) intervals in each of the coordinate directions.
+       * @param n_subintervals The number of subintervals in each coordinate
+       * direction. A value of one for a coordinate means that the interval is
+       * considered as one subinterval consisting of the entire range. A value
+       * of two means that there are two subintervals each with one half of the
+       * range, etc.
+       * @param data_values A dim-dimensional table of data at each of the mesh
+       * points defined by the coordinate arrays above. Note that the Table
+       * class has a number of conversion constructors that allow converting
+       * other data types into a table where you specify this argument.
+       */
+      InterpolatedUniformGridData(
+        const std::array<std::pair<double, double>, dim> &interval_endpoints,
+        const std::array<unsigned int, dim>              &n_subintervals,
+        const Table<dim, double>                         &data_values);
 
-    /**
-     * Compute the value of the function set by bilinear interpolation of the
-     * given data set.
-     *
-     * @param p The point at which the function is to be evaluated.
-     * @param component The vector component. Since this function is scalar,
-     * only zero is a valid argument here.
-     * @return The interpolated value at this point. If the point lies outside
-     * the set of coordinates, the function is extended by a constant.
-     */
-    virtual double
-    value(const Point<dim> &p, const unsigned int component = 0) const override;
+      /**
+       * Compute the value of the function set by bilinear interpolation of the
+       * given data set.
+       *
+       * @param p The point at which the function is to be evaluated.
+       * @param component The vector component. Since this function is scalar,
+       * only zero is a valid argument here.
+       * @return The interpolated value at this point. If the point lies outside
+       * the set of coordinates, the function is extended by a constant.
+       */
+      virtual
+      Tensor<1, dim>
+      gradient(const Point<dim> &p,
+               const unsigned int component) const;
 
-  private:
-    /**
-     * The set of interval endpoints in each of the coordinate directions.
-     */
-    const std::array<std::pair<double, double>, dim> interval_endpoints;
+  };
+}
 
-    /**
-     * The number of subintervals in each of the coordinate directions.
-     */
-    const std::array<unsigned int, dim> n_subintervals;
-
-    /**
-     * The data that is to be interpolated.
-     */
-    const Table<dim, double> data_values;
-};
-
+namespace aspect
+{
   template <int dim>
+  inline
   InterpolatedUniformGridData<dim>::InterpolatedUniformGridData(
     const std::array<std::pair<double, double>, dim> &interval_endpoints,
-    const std::array<unsigned int, dim> &             n_subintervals,
-    const Table<dim, double> &                        data_values)
-    : interval_endpoints(interval_endpoints)
-    , n_subintervals(n_subintervals)
-    , data_values(data_values)
-  {
-    for (unsigned int d = 0; d < dim; ++d)
-      {
-        Assert(n_subintervals[d] >= 1,
-               ExcMessage("There needs to be at least one subinterval in each "
-                          "coordinate direction."));
-        Assert(interval_endpoints[d].first < interval_endpoints[d].second,
-               ExcMessage("The interval in each coordinate direction needs "
-                          "to have positive size"));
-        Assert(data_values.size()[d] == n_subintervals[d] + 1,
-               ExcMessage("The data table does not have the correct size."));
-      }
-  }
+    const std::array<unsigned int, dim>              &n_subintervals,
+    const Table<dim, double>                         &data_values)
+    :
+    dealii::Functions::InterpolatedUniformGridData<dim>(&interval_endpoints, &n_subintervals, &data_values)
+  {}
 
 
   /**
    * This function is derived from
    * deal.II (dealii/source/base/function_lib.cc)
   */
- template <int dim>
+  template <int dim>
+  inline
   Tensor<1, dim>
   InterpolatedUniformGridData<dim>::gradient(
-    const Point<dim> & p,
+    const Point<dim> &p,
     const unsigned int component) const
   {
     (void)component;
@@ -139,18 +117,16 @@ namespace aspect
 
     Point<dim> dx;
     for (unsigned int d = 0; d < dim; ++d)
-      dx[d] = (interval_endpoints[d].second - interval_endpoints[d].first)/n_subintervals[d];
+      dx[d] = (this->interval_endpoints[d].second - this->interval_endpoints[d].first)/this->n_subintervals[d];
 
     Point<dim> p_unit;
     for (unsigned int d = 0; d < dim; ++d)
       p_unit[d] =
-        std::max(std::min((p[d] - coordinate_values[d][ix[d]]) / dx[d], 1.),
+        std::max(std::min((p[d] - this->coordinate_values[d][ix[d]]) / dx[d], 1.),
                  0.0);
 
-    return gradient_interpolate(data_values, ix, p_unit, dx);
-  }
+    return gradient_interpolate(this->data_values, ix, p_unit, dx);
   }
 
 }
 #endif
-  

--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -29,347 +29,351 @@
 #include <memory>
 
 #if !DEAL_II_VERSION_GTE(9,2,0)
-
 #include <deal.II/base/table.h>
 #include <deal.II/base/function_lib.h>
 namespace aspect
 {
-  using namespace dealii;
-  /**
-   * A scalar function that computes its values by (bi-, tri-)linear
-   * interpolation from a set of point data that are arranged on a uniformly
-   * spaced tensor product mesh. This function is derived from
-   * deal.II (dealii/include/deal.II/base/function_lib.h)
-   */
-  template <int dim>
-  class InterpolatedUniformGridData : public dealii::Function<dim>
+  namespace Functions
   {
-    public:
-      /**
-       * Constructor
-       * @param interval_endpoints The left and right end points of the
-       * (uniformly subdivided) intervals in each of the coordinate directions.
-       * @param n_subintervals The number of subintervals in each coordinate
-       * direction. A value of one for a coordinate means that the interval is
-       * considered as one subinterval consisting of the entire range. A value
-       * of two means that there are two subintervals each with one half of the
-       * range, etc.
-       * @param data_values A dim-dimensional table of data at each of the mesh
-       * points defined by the coordinate arrays above. Note that the Table
-       * class has a number of conversion constructors that allow converting
-       * other data types into a table where you specify this argument.
-       */
-      InterpolatedUniformGridData(
-        const std::array<std::pair<double, double>, dim> &interval_endpoints,
-        const std::array<unsigned int, dim>              &n_subintervals,
-        const Table<dim, double>                         &data_values);
+    using namespace dealii;
+    using namespace dealii::Functions;
+    /**
+     * A scalar function that computes its values by (bi-, tri-)linear
+     * interpolation from a set of point data that are arranged on a uniformly
+     * spaced tensor product mesh. This function is derived from
+     * deal.II (dealii/include/deal.II/base/function_lib.h)
+     */
+    template <int dim>
+    class InterpolatedUniformGridData : public dealii::Function<dim>
+    {
+      public:
+        /**
+         * Constructor
+         * @param interval_endpoints The left and right end points of the
+         * (uniformly subdivided) intervals in each of the coordinate directions.
+         * @param n_subintervals The number of subintervals in each coordinate
+         * direction. A value of one for a coordinate means that the interval is
+         * considered as one subinterval consisting of the entire range. A value
+         * of two means that there are two subintervals each with one half of the
+         * range, etc.
+         * @param data_values A dim-dimensional table of data at each of the mesh
+         * points defined by the coordinate arrays above. Note that the Table
+         * class has a number of conversion constructors that allow converting
+         * other data types into a table where you specify this argument.
+         */
+        InterpolatedUniformGridData(
+          const std::array<std::pair<double, double>, dim> &interval_endpoints,
+          const std::array<unsigned int, dim>              &n_subintervals,
+          const Table<dim, double>                         &data_values);
 
-      /**
-       * Compute the value of the function set by bilinear interpolation of the
-       * given data set.
-       *
-       * @param p The point at which the function is to be evaluated.
-       * @param component The vector component. Since this function is scalar,
-       * only zero is a valid argument here.
-       * @return The interpolated value at this point. If the point lies outside
-       * the set of coordinates, the function is extended by a constant.
-       */
-      virtual
-      Tensor<1, dim>
-      gradient(const Point<dim> &p,
-               const unsigned int component = 0) const override;
+        /**
+         * Compute the value of the function set by bilinear interpolation of the
+         * given data set.
+         *
+         * @param p The point at which the function is to be evaluated.
+         * @param component The vector component. Since this function is scalar,
+         * only zero is a valid argument here.
+         * @return The interpolated value at this point. If the point lies outside
+         * the set of coordinates, the function is extended by a constant.
+         */
+        virtual
+        Tensor<1, dim>
+        gradient(const Point<dim> &p,
+                 const unsigned int component = 0) const override;
 
-      /**
-       * Compute the value of the function set by bilinear interpolation of the
-       * given data set.
-       *
-       * @param p The point at which the function is to be evaluated.
-       * @param component The vector component. Since this function is scalar,
-       * only zero is a valid argument here.
-       * @return The interpolated value at this point. If the point lies outside
-       * the set of coordinates, the function is extended by a constant.
-       */
-      virtual
-      double
-      value(const Point<dim> &p,
-            const unsigned int component = 0) const override;
+        /**
+         * Compute the value of the function set by bilinear interpolation of the
+         * given data set.
+         *
+         * @param p The point at which the function is to be evaluated.
+         * @param component The vector component. Since this function is scalar,
+         * only zero is a valid argument here.
+         * @return The interpolated value at this point. If the point lies outside
+         * the set of coordinates, the function is extended by a constant.
+         */
+        virtual
+        double
+        value(const Point<dim> &p,
+              const unsigned int component = 0) const override;
 
 
-    private:
-      /**
-       * The set of interval endpoints in each of the coordinate directions.
-       */
-      const std::array<std::pair<double, double>, dim> interval_endpoints;
+      private:
+        /**
+         * The set of interval endpoints in each of the coordinate directions.
+         */
+        const std::array<std::pair<double, double>, dim> interval_endpoints;
 
-      /**
-       * The number of subintervals in each of the coordinate directions.
-       */
-      const std::array<unsigned int, dim> n_subintervals;
+        /**
+         * The number of subintervals in each of the coordinate directions.
+         */
+        const std::array<unsigned int, dim> n_subintervals;
 
-      /**
-       * The data that is to be interpolated.
-       */
-      const Table<dim, double> data_values;
-
-  };
+        /**
+         * The data that is to be interpolated.
+         */
+        const Table<dim, double> data_values;
+    };
+  }
 }
 
 namespace aspect
 {
-  DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-  namespace
+  namespace Functions
   {
-    // interpolate a data value from a table where ix denotes
-    // the (lower) left endpoint of the interval to interpolate
-    // in, and p_unit denotes the point in unit coordinates to do so.
+    DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+    namespace
+    {
+      // interpolate a data value from a table where ix denotes
+      // the (lower) left endpoint of the interval to interpolate
+      // in, and p_unit denotes the point in unit coordinates to do so.
+      double
+      interpolate(const Table<1, double> &data_values,
+                  const TableIndices<1> &ix,
+                  const Point<1>         &xi)
+      {
+        return ((1 - xi[0]) * data_values[ix[0]] +
+                xi[0] * data_values[ix[0] + 1]);
+      }
+
+      double
+      interpolate(const Table<2, double> &data_values,
+                  const TableIndices<2> &ix,
+                  const Point<2>         &p_unit)
+      {
+        return (((1 - p_unit[0]) * data_values[ix[0]][ix[1]] +
+                 p_unit[0] * data_values[ix[0] + 1][ix[1]]) *
+                (1 - p_unit[1]) +
+                ((1 - p_unit[0]) * data_values[ix[0]][ix[1] + 1] +
+                 p_unit[0] * data_values[ix[0] + 1][ix[1] + 1]) *
+                p_unit[1]);
+      }
+
+      double
+      interpolate(const Table<3, double> &data_values,
+                  const TableIndices<3> &ix,
+                  const Point<3>         &p_unit)
+      {
+        return ((((1 - p_unit[0]) * data_values[ix[0]][ix[1]][ix[2]] +
+                  p_unit[0] * data_values[ix[0] + 1][ix[1]][ix[2]]) *
+                 (1 - p_unit[1]) +
+                 ((1 - p_unit[0]) * data_values[ix[0]][ix[1] + 1][ix[2]] +
+                  p_unit[0] * data_values[ix[0] + 1][ix[1] + 1][ix[2]]) *
+                 p_unit[1]) *
+                (1 - p_unit[2]) +
+                (((1 - p_unit[0]) * data_values[ix[0]][ix[1]][ix[2] + 1] +
+                  p_unit[0] * data_values[ix[0] + 1][ix[1]][ix[2] + 1]) *
+                 (1 - p_unit[1]) +
+                 ((1 - p_unit[0]) * data_values[ix[0]][ix[1] + 1][ix[2] + 1] +
+                  p_unit[0] * data_values[ix[0] + 1][ix[1] + 1][ix[2] + 1]) *
+                 p_unit[1]) *
+                p_unit[2]);
+      }
+
+
+      // Interpolate the gradient of a data value from a table where ix
+      // denotes the lower left endpoint of the interval to interpolate
+      // in, p_unit denotes the point in unit coordinates, and dx
+      // denotes the width of the interval in each dimension.
+      Tensor<1, 1>
+      gradient_interpolate(const Table<1, double> &data_values,
+                           const TableIndices<1> &ix,
+                           const Point<1>         &p_unit,
+                           const Point<1>         &dx)
+      {
+        (void)p_unit;
+        Tensor<1, 1> grad;
+        grad[0] = (data_values[ix[0] + 1] - data_values[ix[0]]) / dx[0];
+        return grad;
+      }
+
+
+      Tensor<1, 2>
+      gradient_interpolate(const Table<2, double> &data_values,
+                           const TableIndices<2> &ix,
+                           const Point<2>         &p_unit,
+                           const Point<2>         &dx)
+      {
+        Tensor<1, 2> grad;
+        double       u00 = data_values[ix[0]][ix[1]],
+                     u01       = data_values[ix[0] + 1][ix[1]],
+                     u10       = data_values[ix[0]][ix[1] + 1],
+                     u11       = data_values[ix[0] + 1][ix[1] + 1];
+
+        grad[0] =
+          ((1 - p_unit[1]) * (u01 - u00) + p_unit[1] * (u11 - u10)) / dx[0];
+        grad[1] =
+          ((1 - p_unit[0]) * (u10 - u00) + p_unit[0] * (u11 - u01)) / dx[1];
+        return grad;
+      }
+
+
+      Tensor<1, 3>
+      gradient_interpolate(const Table<3, double> &data_values,
+                           const TableIndices<3> &ix,
+                           const Point<3>         &p_unit,
+                           const Point<3>         &dx)
+      {
+        Tensor<1, 3> grad;
+        double       u000 = data_values[ix[0]][ix[1]][ix[2]],
+                     u001       = data_values[ix[0] + 1][ix[1]][ix[2]],
+                     u010       = data_values[ix[0]][ix[1] + 1][ix[2]],
+                     u100       = data_values[ix[0]][ix[1]][ix[2] + 1],
+                     u011       = data_values[ix[0] + 1][ix[1] + 1][ix[2]],
+                     u101       = data_values[ix[0] + 1][ix[1]][ix[2] + 1],
+                     u110       = data_values[ix[0]][ix[1] + 1][ix[2] + 1],
+                     u111       = data_values[ix[0] + 1][ix[1] + 1][ix[2] + 1];
+
+        grad[0] =
+          ((1 - p_unit[2]) *
+           ((1 - p_unit[1]) * (u001 - u000) + p_unit[1] * (u011 - u010)) +
+           p_unit[2] *
+           ((1 - p_unit[1]) * (u101 - u100) + p_unit[1] * (u111 - u110))) /
+          dx[0];
+        grad[1] =
+          ((1 - p_unit[2]) *
+           ((1 - p_unit[0]) * (u010 - u000) + p_unit[0] * (u011 - u001)) +
+           p_unit[2] *
+           ((1 - p_unit[0]) * (u110 - u100) + p_unit[0] * (u111 - u101))) /
+          dx[1];
+        grad[2] =
+          ((1 - p_unit[1]) *
+           ((1 - p_unit[0]) * (u100 - u000) + p_unit[0] * (u101 - u001)) +
+           p_unit[1] *
+           ((1 - p_unit[0]) * (u110 - u010) + p_unit[0] * (u111 - u011))) /
+          dx[2];
+
+        return grad;
+      }
+    } // namespace internal
+    DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
+    template <int dim>
+    inline
+    InterpolatedUniformGridData<dim>::InterpolatedUniformGridData(
+      const std::array<std::pair<double, double>, dim> &interval_endpoints,
+      const std::array<unsigned int, dim>              &n_subintervals,
+      const Table<dim, double>                         &data_values)
+      :
+      interval_endpoints(interval_endpoints),
+      n_subintervals(n_subintervals),
+      data_values(data_values)
+    {
+      for (unsigned int d = 0; d < dim; ++d)
+        {
+          Assert(n_subintervals[d] >= 1,
+                 ExcMessage("There needs to be at least one subinterval in each "
+                            "coordinate direction."));
+          Assert(interval_endpoints[d].first < interval_endpoints[d].second,
+                 ExcMessage("The interval in each coordinate direction needs "
+                            "to have positive size"));
+          Assert(data_values.size()[d] == n_subintervals[d] + 1,
+                 ExcMessage("The data table does not have the correct size."));
+        }
+    }
+
+
+    /**
+     * This function is derived from
+     * deal.II (dealii/source/base/function_lib.cc)
+    */
+    template <int dim>
+    inline
+    Tensor<1, dim>
+    InterpolatedUniformGridData<dim>::gradient(
+      const Point<dim> &p,
+      const unsigned int component) const
+    {
+      (void)component;
+      Assert(
+        component == 0,
+        ExcMessage(
+          "This is a scalar function object, the component can only be zero."));
+
+      // find out where this data point lies, relative to the given
+      // subdivision points
+      TableIndices<dim> ix;
+      for (unsigned int d = 0; d < dim; ++d)
+        {
+          const double delta_x =
+            ((this->interval_endpoints[d].second - this->interval_endpoints[d].first) /
+             this->n_subintervals[d]);
+          if (p[d] <= this->interval_endpoints[d].first)
+            ix[d] = 0;
+          else if (p[d] >= this->interval_endpoints[d].second - delta_x)
+            ix[d] = this->n_subintervals[d] - 1;
+          else
+            ix[d] = static_cast<unsigned int>(
+                      (p[d] - this->interval_endpoints[d].first) / delta_x);
+        }
+
+      // now compute the relative point within the interval/rectangle/box
+      // defined by the point coordinates found above. truncate below and
+      // above to accommodate points that may lie outside the range
+      Point<dim> p_unit;
+      Point<dim> delta_x;
+      for (unsigned int d = 0; d < dim; ++d)
+        {
+          delta_x[d] =
+            ((this->interval_endpoints[d].second - this->interval_endpoints[d].first) /
+             this->n_subintervals[d]);
+          p_unit[d] = std::max(std::min((p[d] - this->interval_endpoints[d].first -
+                                         ix[d] * delta_x[d]) /
+                                        delta_x[d],
+                                        1.),
+                               0.);
+        }
+
+      return gradient_interpolate(this->data_values, ix, p_unit, delta_x);
+    }
+
+    template <int dim>
+    inline
     double
-    interpolate(const Table<1, double> &data_values,
-                const TableIndices<1> &ix,
-                const Point<1>         &xi)
+    InterpolatedUniformGridData<dim>::value(const Point<dim> &p,
+                                            const unsigned int component) const
     {
-      return ((1 - xi[0]) * data_values[ix[0]] +
-              xi[0] * data_values[ix[0] + 1]);
+      (void)component;
+      Assert(
+        component == 0,
+        ExcMessage(
+          "This is a scalar function object, the component can only be zero."));
+
+      // find out where this data point lies, relative to the given
+      // subdivision points
+      TableIndices<dim> ix;
+      for (unsigned int d = 0; d < dim; ++d)
+        {
+          const double delta_x =
+            ((interval_endpoints[d].second - interval_endpoints[d].first) /
+             n_subintervals[d]);
+          if (p[d] <= interval_endpoints[d].first)
+            ix[d] = 0;
+          else if (p[d] >= interval_endpoints[d].second - delta_x)
+            ix[d] = n_subintervals[d] - 1;
+          else
+            ix[d] = static_cast<unsigned int>(
+                      (p[d] - interval_endpoints[d].first) / delta_x);
+        }
+
+      // now compute the relative point within the interval/rectangle/box
+      // defined by the point coordinates found above. truncate below and
+      // above to accommodate points that may lie outside the range
+      Point<dim> p_unit;
+      for (unsigned int d = 0; d < dim; ++d)
+        {
+          const double delta_x =
+            ((interval_endpoints[d].second - interval_endpoints[d].first) /
+             n_subintervals[d]);
+          p_unit[d] = std::max(std::min((p[d] - interval_endpoints[d].first -
+                                         ix[d] * delta_x) /
+                                        delta_x,
+                                        1.),
+                               0.);
+        }
+
+      return interpolate(data_values, ix, p_unit);
     }
-
-    double
-    interpolate(const Table<2, double> &data_values,
-                const TableIndices<2> &ix,
-                const Point<2>         &p_unit)
-    {
-      return (((1 - p_unit[0]) * data_values[ix[0]][ix[1]] +
-               p_unit[0] * data_values[ix[0] + 1][ix[1]]) *
-              (1 - p_unit[1]) +
-              ((1 - p_unit[0]) * data_values[ix[0]][ix[1] + 1] +
-               p_unit[0] * data_values[ix[0] + 1][ix[1] + 1]) *
-              p_unit[1]);
-    }
-
-    double
-    interpolate(const Table<3, double> &data_values,
-                const TableIndices<3> &ix,
-                const Point<3>         &p_unit)
-    {
-      return ((((1 - p_unit[0]) * data_values[ix[0]][ix[1]][ix[2]] +
-                p_unit[0] * data_values[ix[0] + 1][ix[1]][ix[2]]) *
-               (1 - p_unit[1]) +
-               ((1 - p_unit[0]) * data_values[ix[0]][ix[1] + 1][ix[2]] +
-                p_unit[0] * data_values[ix[0] + 1][ix[1] + 1][ix[2]]) *
-               p_unit[1]) *
-              (1 - p_unit[2]) +
-              (((1 - p_unit[0]) * data_values[ix[0]][ix[1]][ix[2] + 1] +
-                p_unit[0] * data_values[ix[0] + 1][ix[1]][ix[2] + 1]) *
-               (1 - p_unit[1]) +
-               ((1 - p_unit[0]) * data_values[ix[0]][ix[1] + 1][ix[2] + 1] +
-                p_unit[0] * data_values[ix[0] + 1][ix[1] + 1][ix[2] + 1]) *
-               p_unit[1]) *
-              p_unit[2]);
-    }
-
-
-    // Interpolate the gradient of a data value from a table where ix
-    // denotes the lower left endpoint of the interval to interpolate
-    // in, p_unit denotes the point in unit coordinates, and dx
-    // denotes the width of the interval in each dimension.
-    Tensor<1, 1>
-    gradient_interpolate(const Table<1, double> &data_values,
-                         const TableIndices<1> &ix,
-                         const Point<1>         &p_unit,
-                         const Point<1>         &dx)
-    {
-      (void)p_unit;
-      Tensor<1, 1> grad;
-      grad[0] = (data_values[ix[0] + 1] - data_values[ix[0]]) / dx[0];
-      return grad;
-    }
-
-
-    Tensor<1, 2>
-    gradient_interpolate(const Table<2, double> &data_values,
-                         const TableIndices<2> &ix,
-                         const Point<2>         &p_unit,
-                         const Point<2>         &dx)
-    {
-      Tensor<1, 2> grad;
-      double       u00 = data_values[ix[0]][ix[1]],
-                   u01       = data_values[ix[0] + 1][ix[1]],
-                   u10       = data_values[ix[0]][ix[1] + 1],
-                   u11       = data_values[ix[0] + 1][ix[1] + 1];
-
-      grad[0] =
-        ((1 - p_unit[1]) * (u01 - u00) + p_unit[1] * (u11 - u10)) / dx[0];
-      grad[1] =
-        ((1 - p_unit[0]) * (u10 - u00) + p_unit[0] * (u11 - u01)) / dx[1];
-      return grad;
-    }
-
-
-    Tensor<1, 3>
-    gradient_interpolate(const Table<3, double> &data_values,
-                         const TableIndices<3> &ix,
-                         const Point<3>         &p_unit,
-                         const Point<3>         &dx)
-    {
-      Tensor<1, 3> grad;
-      double       u000 = data_values[ix[0]][ix[1]][ix[2]],
-                   u001       = data_values[ix[0] + 1][ix[1]][ix[2]],
-                   u010       = data_values[ix[0]][ix[1] + 1][ix[2]],
-                   u100       = data_values[ix[0]][ix[1]][ix[2] + 1],
-                   u011       = data_values[ix[0] + 1][ix[1] + 1][ix[2]],
-                   u101       = data_values[ix[0] + 1][ix[1]][ix[2] + 1],
-                   u110       = data_values[ix[0]][ix[1] + 1][ix[2] + 1],
-                   u111       = data_values[ix[0] + 1][ix[1] + 1][ix[2] + 1];
-
-      grad[0] =
-        ((1 - p_unit[2]) *
-         ((1 - p_unit[1]) * (u001 - u000) + p_unit[1] * (u011 - u010)) +
-         p_unit[2] *
-         ((1 - p_unit[1]) * (u101 - u100) + p_unit[1] * (u111 - u110))) /
-        dx[0];
-      grad[1] =
-        ((1 - p_unit[2]) *
-         ((1 - p_unit[0]) * (u010 - u000) + p_unit[0] * (u011 - u001)) +
-         p_unit[2] *
-         ((1 - p_unit[0]) * (u110 - u100) + p_unit[0] * (u111 - u101))) /
-        dx[1];
-      grad[2] =
-        ((1 - p_unit[1]) *
-         ((1 - p_unit[0]) * (u100 - u000) + p_unit[0] * (u101 - u001)) +
-         p_unit[1] *
-         ((1 - p_unit[0]) * (u110 - u010) + p_unit[0] * (u111 - u011))) /
-        dx[2];
-
-      return grad;
-    }
-  } // namespace internal
-  DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
-
-  template <int dim>
-  inline
-  InterpolatedUniformGridData<dim>::InterpolatedUniformGridData(
-    const std::array<std::pair<double, double>, dim> &interval_endpoints,
-    const std::array<unsigned int, dim>              &n_subintervals,
-    const Table<dim, double>                         &data_values)
-    :
-    interval_endpoints(interval_endpoints),
-    n_subintervals(n_subintervals),
-    data_values(data_values)
-  {
-    for (unsigned int d = 0; d < dim; ++d)
-      {
-        Assert(n_subintervals[d] >= 1,
-               ExcMessage("There needs to be at least one subinterval in each "
-                          "coordinate direction."));
-        Assert(interval_endpoints[d].first < interval_endpoints[d].second,
-               ExcMessage("The interval in each coordinate direction needs "
-                          "to have positive size"));
-        Assert(data_values.size()[d] == n_subintervals[d] + 1,
-               ExcMessage("The data table does not have the correct size."));
-      }
   }
-
-
-  /**
-   * This function is derived from
-   * deal.II (dealii/source/base/function_lib.cc)
-  */
-  template <int dim>
-  inline
-  Tensor<1, dim>
-  InterpolatedUniformGridData<dim>::gradient(
-    const Point<dim> &p,
-    const unsigned int component) const
-  {
-    (void)component;
-    Assert(
-      component == 0,
-      ExcMessage(
-        "This is a scalar function object, the component can only be zero."));
-
-    // find out where this data point lies, relative to the given
-    // subdivision points
-    TableIndices<dim> ix;
-    for (unsigned int d = 0; d < dim; ++d)
-      {
-        const double delta_x =
-          ((this->interval_endpoints[d].second - this->interval_endpoints[d].first) /
-           this->n_subintervals[d]);
-        if (p[d] <= this->interval_endpoints[d].first)
-          ix[d] = 0;
-        else if (p[d] >= this->interval_endpoints[d].second - delta_x)
-          ix[d] = this->n_subintervals[d] - 1;
-        else
-          ix[d] = static_cast<unsigned int>(
-                    (p[d] - this->interval_endpoints[d].first) / delta_x);
-      }
-
-    // now compute the relative point within the interval/rectangle/box
-    // defined by the point coordinates found above. truncate below and
-    // above to accommodate points that may lie outside the range
-    Point<dim> p_unit;
-    Point<dim> delta_x;
-    for (unsigned int d = 0; d < dim; ++d)
-      {
-        delta_x[d] =
-          ((this->interval_endpoints[d].second - this->interval_endpoints[d].first) /
-           this->n_subintervals[d]);
-        p_unit[d] = std::max(std::min((p[d] - this->interval_endpoints[d].first -
-                                       ix[d] * delta_x[d]) /
-                                      delta_x[d],
-                                      1.),
-                             0.);
-      }
-
-    return gradient_interpolate(this->data_values, ix, p_unit, delta_x);
-  }
-
-  template <int dim>
-  inline
-  double
-  InterpolatedUniformGridData<dim>::value(const Point<dim> &p,
-                                          const unsigned int component) const
-  {
-    (void)component;
-    Assert(
-      component == 0,
-      ExcMessage(
-        "This is a scalar function object, the component can only be zero."));
-
-    // find out where this data point lies, relative to the given
-    // subdivision points
-    TableIndices<dim> ix;
-    for (unsigned int d = 0; d < dim; ++d)
-      {
-        const double delta_x =
-          ((interval_endpoints[d].second - interval_endpoints[d].first) /
-           n_subintervals[d]);
-        if (p[d] <= interval_endpoints[d].first)
-          ix[d] = 0;
-        else if (p[d] >= interval_endpoints[d].second - delta_x)
-          ix[d] = n_subintervals[d] - 1;
-        else
-          ix[d] = static_cast<unsigned int>(
-                    (p[d] - interval_endpoints[d].first) / delta_x);
-      }
-
-    // now compute the relative point within the interval/rectangle/box
-    // defined by the point coordinates found above. truncate below and
-    // above to accommodate points that may lie outside the range
-    Point<dim> p_unit;
-    for (unsigned int d = 0; d < dim; ++d)
-      {
-        const double delta_x =
-          ((interval_endpoints[d].second - interval_endpoints[d].first) /
-           n_subintervals[d]);
-        p_unit[d] = std::max(std::min((p[d] - interval_endpoints[d].first -
-                                       ix[d] * delta_x) /
-                                      delta_x,
-                                      1.),
-                             0.);
-      }
-
-    return interpolate(data_values, ix, p_unit);
-  }
-
 
 }
 #endif

--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -116,130 +116,132 @@ namespace aspect
 
 namespace aspect
 {
+  DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
   namespace
-     {
-       // interpolate a data value from a table where ix denotes
-       // the (lower) left endpoint of the interval to interpolate
-       // in, and p_unit denotes the point in unit coordinates to do so.
-       double
-       interpolate(const Table<1, double> &data_values,
-                   const TableIndices<1> & ix,
-                   const Point<1> &        xi)
-       {
-         return ((1 - xi[0]) * data_values[ix[0]] +
-                 xi[0] * data_values[ix[0] + 1]);
-       }
+  {
+    // interpolate a data value from a table where ix denotes
+    // the (lower) left endpoint of the interval to interpolate
+    // in, and p_unit denotes the point in unit coordinates to do so.
+    double
+    interpolate(const Table<1, double> &data_values,
+                const TableIndices<1> &ix,
+                const Point<1>         &xi)
+    {
+      return ((1 - xi[0]) * data_values[ix[0]] +
+              xi[0] * data_values[ix[0] + 1]);
+    }
 
-       double
-       interpolate(const Table<2, double> &data_values,
-                   const TableIndices<2> & ix,
-                   const Point<2> &        p_unit)
-       {
-         return (((1 - p_unit[0]) * data_values[ix[0]][ix[1]] +
-                  p_unit[0] * data_values[ix[0] + 1][ix[1]]) *
-                   (1 - p_unit[1]) +
-                 ((1 - p_unit[0]) * data_values[ix[0]][ix[1] + 1] +
-                  p_unit[0] * data_values[ix[0] + 1][ix[1] + 1]) *
-                   p_unit[1]);
-       }
+    double
+    interpolate(const Table<2, double> &data_values,
+                const TableIndices<2> &ix,
+                const Point<2>         &p_unit)
+    {
+      return (((1 - p_unit[0]) * data_values[ix[0]][ix[1]] +
+               p_unit[0] * data_values[ix[0] + 1][ix[1]]) *
+              (1 - p_unit[1]) +
+              ((1 - p_unit[0]) * data_values[ix[0]][ix[1] + 1] +
+               p_unit[0] * data_values[ix[0] + 1][ix[1] + 1]) *
+              p_unit[1]);
+    }
 
-       double
-       interpolate(const Table<3, double> &data_values,
-                   const TableIndices<3> & ix,
-                   const Point<3> &        p_unit)
-       {
-         return ((((1 - p_unit[0]) * data_values[ix[0]][ix[1]][ix[2]] +
-                   p_unit[0] * data_values[ix[0] + 1][ix[1]][ix[2]]) *
-                    (1 - p_unit[1]) +
-                  ((1 - p_unit[0]) * data_values[ix[0]][ix[1] + 1][ix[2]] +
-                   p_unit[0] * data_values[ix[0] + 1][ix[1] + 1][ix[2]]) *
-                    p_unit[1]) *
-                   (1 - p_unit[2]) +
-                 (((1 - p_unit[0]) * data_values[ix[0]][ix[1]][ix[2] + 1] +
-                   p_unit[0] * data_values[ix[0] + 1][ix[1]][ix[2] + 1]) *
-                    (1 - p_unit[1]) +
-                  ((1 - p_unit[0]) * data_values[ix[0]][ix[1] + 1][ix[2] + 1] +
-                   p_unit[0] * data_values[ix[0] + 1][ix[1] + 1][ix[2] + 1]) *
-                    p_unit[1]) *
-                   p_unit[2]);
-       }
-
-
-       // Interpolate the gradient of a data value from a table where ix
-       // denotes the lower left endpoint of the interval to interpolate
-       // in, p_unit denotes the point in unit coordinates, and dx
-       // denotes the width of the interval in each dimension.
-       Tensor<1, 1>
-       gradient_interpolate(const Table<1, double> &data_values,
-                            const TableIndices<1> & ix,
-                            const Point<1> &        p_unit,
-                            const Point<1> &        dx)
-       {
-         (void)p_unit;
-         Tensor<1, 1> grad;
-         grad[0] = (data_values[ix[0] + 1] - data_values[ix[0]]) / dx[0];
-         return grad;
-       }
+    double
+    interpolate(const Table<3, double> &data_values,
+                const TableIndices<3> &ix,
+                const Point<3>         &p_unit)
+    {
+      return ((((1 - p_unit[0]) * data_values[ix[0]][ix[1]][ix[2]] +
+                p_unit[0] * data_values[ix[0] + 1][ix[1]][ix[2]]) *
+               (1 - p_unit[1]) +
+               ((1 - p_unit[0]) * data_values[ix[0]][ix[1] + 1][ix[2]] +
+                p_unit[0] * data_values[ix[0] + 1][ix[1] + 1][ix[2]]) *
+               p_unit[1]) *
+              (1 - p_unit[2]) +
+              (((1 - p_unit[0]) * data_values[ix[0]][ix[1]][ix[2] + 1] +
+                p_unit[0] * data_values[ix[0] + 1][ix[1]][ix[2] + 1]) *
+               (1 - p_unit[1]) +
+               ((1 - p_unit[0]) * data_values[ix[0]][ix[1] + 1][ix[2] + 1] +
+                p_unit[0] * data_values[ix[0] + 1][ix[1] + 1][ix[2] + 1]) *
+               p_unit[1]) *
+              p_unit[2]);
+    }
 
 
-       Tensor<1, 2>
-       gradient_interpolate(const Table<2, double> &data_values,
-                            const TableIndices<2> & ix,
-                            const Point<2> &        p_unit,
-                            const Point<2> &        dx)
-       {
-         Tensor<1, 2> grad;
-         double       u00 = data_values[ix[0]][ix[1]],
-                u01       = data_values[ix[0] + 1][ix[1]],
-                u10       = data_values[ix[0]][ix[1] + 1],
-                u11       = data_values[ix[0] + 1][ix[1] + 1];
-
-         grad[0] =
-           ((1 - p_unit[1]) * (u01 - u00) + p_unit[1] * (u11 - u10)) / dx[0];
-         grad[1] =
-           ((1 - p_unit[0]) * (u10 - u00) + p_unit[0] * (u11 - u01)) / dx[1];
-         return grad;
-       }
+    // Interpolate the gradient of a data value from a table where ix
+    // denotes the lower left endpoint of the interval to interpolate
+    // in, p_unit denotes the point in unit coordinates, and dx
+    // denotes the width of the interval in each dimension.
+    Tensor<1, 1>
+    gradient_interpolate(const Table<1, double> &data_values,
+                         const TableIndices<1> &ix,
+                         const Point<1>         &p_unit,
+                         const Point<1>         &dx)
+    {
+      (void)p_unit;
+      Tensor<1, 1> grad;
+      grad[0] = (data_values[ix[0] + 1] - data_values[ix[0]]) / dx[0];
+      return grad;
+    }
 
 
-       Tensor<1, 3>
-       gradient_interpolate(const Table<3, double> &data_values,
-                            const TableIndices<3> & ix,
-                            const Point<3> &        p_unit,
-                            const Point<3> &        dx)
-       {
-         Tensor<1, 3> grad;
-         double       u000 = data_values[ix[0]][ix[1]][ix[2]],
-                u001       = data_values[ix[0] + 1][ix[1]][ix[2]],
-                u010       = data_values[ix[0]][ix[1] + 1][ix[2]],
-                u100       = data_values[ix[0]][ix[1]][ix[2] + 1],
-                u011       = data_values[ix[0] + 1][ix[1] + 1][ix[2]],
-                u101       = data_values[ix[0] + 1][ix[1]][ix[2] + 1],
-                u110       = data_values[ix[0]][ix[1] + 1][ix[2] + 1],
-                u111       = data_values[ix[0] + 1][ix[1] + 1][ix[2] + 1];
+    Tensor<1, 2>
+    gradient_interpolate(const Table<2, double> &data_values,
+                         const TableIndices<2> &ix,
+                         const Point<2>         &p_unit,
+                         const Point<2>         &dx)
+    {
+      Tensor<1, 2> grad;
+      double       u00 = data_values[ix[0]][ix[1]],
+                   u01       = data_values[ix[0] + 1][ix[1]],
+                   u10       = data_values[ix[0]][ix[1] + 1],
+                   u11       = data_values[ix[0] + 1][ix[1] + 1];
 
-         grad[0] =
-           ((1 - p_unit[2]) *
-              ((1 - p_unit[1]) * (u001 - u000) + p_unit[1] * (u011 - u010)) +
-            p_unit[2] *
-              ((1 - p_unit[1]) * (u101 - u100) + p_unit[1] * (u111 - u110))) /
-           dx[0];
-         grad[1] =
-           ((1 - p_unit[2]) *
-              ((1 - p_unit[0]) * (u010 - u000) + p_unit[0] * (u011 - u001)) +
-            p_unit[2] *
-              ((1 - p_unit[0]) * (u110 - u100) + p_unit[0] * (u111 - u101))) /
-           dx[1];
-         grad[2] =
-           ((1 - p_unit[1]) *
-              ((1 - p_unit[0]) * (u100 - u000) + p_unit[0] * (u101 - u001)) +
-            p_unit[1] *
-              ((1 - p_unit[0]) * (u110 - u010) + p_unit[0] * (u111 - u011))) /
-           dx[2];
+      grad[0] =
+        ((1 - p_unit[1]) * (u01 - u00) + p_unit[1] * (u11 - u10)) / dx[0];
+      grad[1] =
+        ((1 - p_unit[0]) * (u10 - u00) + p_unit[0] * (u11 - u01)) / dx[1];
+      return grad;
+    }
 
-         return grad;
-       }
-   } // namespace
+
+    Tensor<1, 3>
+    gradient_interpolate(const Table<3, double> &data_values,
+                         const TableIndices<3> &ix,
+                         const Point<3>         &p_unit,
+                         const Point<3>         &dx)
+    {
+      Tensor<1, 3> grad;
+      double       u000 = data_values[ix[0]][ix[1]][ix[2]],
+                   u001       = data_values[ix[0] + 1][ix[1]][ix[2]],
+                   u010       = data_values[ix[0]][ix[1] + 1][ix[2]],
+                   u100       = data_values[ix[0]][ix[1]][ix[2] + 1],
+                   u011       = data_values[ix[0] + 1][ix[1] + 1][ix[2]],
+                   u101       = data_values[ix[0] + 1][ix[1]][ix[2] + 1],
+                   u110       = data_values[ix[0]][ix[1] + 1][ix[2] + 1],
+                   u111       = data_values[ix[0] + 1][ix[1] + 1][ix[2] + 1];
+
+      grad[0] =
+        ((1 - p_unit[2]) *
+         ((1 - p_unit[1]) * (u001 - u000) + p_unit[1] * (u011 - u010)) +
+         p_unit[2] *
+         ((1 - p_unit[1]) * (u101 - u100) + p_unit[1] * (u111 - u110))) /
+        dx[0];
+      grad[1] =
+        ((1 - p_unit[2]) *
+         ((1 - p_unit[0]) * (u010 - u000) + p_unit[0] * (u011 - u001)) +
+         p_unit[2] *
+         ((1 - p_unit[0]) * (u110 - u100) + p_unit[0] * (u111 - u101))) /
+        dx[1];
+      grad[2] =
+        ((1 - p_unit[1]) *
+         ((1 - p_unit[0]) * (u100 - u000) + p_unit[0] * (u101 - u001)) +
+         p_unit[1] *
+         ((1 - p_unit[0]) * (u110 - u010) + p_unit[0] * (u111 - u011))) /
+        dx[2];
+
+      return grad;
+    }
+  } // namespace internal
+  DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
   template <int dim>
   inline
@@ -290,7 +292,7 @@ namespace aspect
       {
         const double delta_x =
           ((this->interval_endpoints[d].second - this->interval_endpoints[d].first) /
-              this->n_subintervals[d]);
+           this->n_subintervals[d]);
         if (p[d] <= this->interval_endpoints[d].first)
           ix[d] = 0;
         else if (p[d] >= this->interval_endpoints[d].second - delta_x)
@@ -309,7 +311,7 @@ namespace aspect
       {
         delta_x[d] =
           ((this->interval_endpoints[d].second - this->interval_endpoints[d].first) /
-              this->n_subintervals[d]);
+           this->n_subintervals[d]);
         p_unit[d] = std::max(std::min((p[d] - this->interval_endpoints[d].first -
                                        ix[d] * delta_x[d]) /
                                       delta_x[d],
@@ -323,7 +325,7 @@ namespace aspect
   template <int dim>
   inline
   double
-  InterpolatedUniformGridData<dim>::value(const Point<dim> & p,
+  InterpolatedUniformGridData<dim>::value(const Point<dim> &p,
                                           const unsigned int component) const
   {
     (void)component;
@@ -346,7 +348,7 @@ namespace aspect
           ix[d] = n_subintervals[d] - 1;
         else
           ix[d] = static_cast<unsigned int>(
-            (p[d] - interval_endpoints[d].first) / delta_x);
+                    (p[d] - interval_endpoints[d].first) / delta_x);
       }
 
     // now compute the relative point within the interval/rectangle/box
@@ -360,13 +362,13 @@ namespace aspect
            n_subintervals[d]);
         p_unit[d] = std::max(std::min((p[d] - interval_endpoints[d].first -
                                        ix[d] * delta_x) /
-                                        delta_x,
+                                      delta_x,
                                       1.),
                              0.);
       }
 
     return interpolate(data_values, ix, p_unit);
-}
+  }
 
 
 }

--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -28,8 +28,129 @@
 #include <functional>
 #include <memory>
 
-// for std_cxx14::make_unique:
-#include <deal.II/base/std_cxx14/memory.h>
+#if !DEAL_II_VERSION_GTE(9,2,0)
+
+#include <deal.II/base/table.h>
+#include <deal.II/base/function_lib.h>
+namespace aspect
+{
+  namespace dealii
+  {
+  /**
+   * A scalar function that computes its values by (bi-, tri-)linear
+   * interpolation from a set of point data that are arranged on a uniformly
+   * spaced tensor product mesh. This function is derived from
+   * deal.II (dealii/include/deal.II/base/function_lib.h)
+   */
+  template <int dim>
+  class InterpolatedUniformGridData : public dealii::InterpolatedUniformGridData<dim>
+  {
+  public:
+    /**
+     * Constructor
+     * @param interval_endpoints The left and right end points of the
+     * (uniformly subdivided) intervals in each of the coordinate directions.
+     * @param n_subintervals The number of subintervals in each coordinate
+     * direction. A value of one for a coordinate means that the interval is
+     * considered as one subinterval consisting of the entire range. A value
+     * of two means that there are two subintervals each with one half of the
+     * range, etc.
+     * @param data_values A dim-dimensional table of data at each of the mesh
+     * points defined by the coordinate arrays above. Note that the Table
+     * class has a number of conversion constructors that allow converting
+     * other data types into a table where you specify this argument.
+     */
+    InterpolatedUniformGridData(
+      const std::array<std::pair<double, double>, dim> &interval_endpoints,
+      const std::array<unsigned int, dim> &             n_subintervals,
+      const Table<dim, double> &                        data_values);
+
+    /**
+     * Compute the value of the function set by bilinear interpolation of the
+     * given data set.
+     *
+     * @param p The point at which the function is to be evaluated.
+     * @param component The vector component. Since this function is scalar,
+     * only zero is a valid argument here.
+     * @return The interpolated value at this point. If the point lies outside
+     * the set of coordinates, the function is extended by a constant.
+     */
+    virtual double
+    value(const Point<dim> &p, const unsigned int component = 0) const override;
+
+  private:
+    /**
+     * The set of interval endpoints in each of the coordinate directions.
+     */
+    const std::array<std::pair<double, double>, dim> interval_endpoints;
+
+    /**
+     * The number of subintervals in each of the coordinate directions.
+     */
+    const std::array<unsigned int, dim> n_subintervals;
+
+    /**
+     * The data that is to be interpolated.
+     */
+    const Table<dim, double> data_values;
+};
+
+  template <int dim>
+  InterpolatedUniformGridData<dim>::InterpolatedUniformGridData(
+    const std::array<std::pair<double, double>, dim> &interval_endpoints,
+    const std::array<unsigned int, dim> &             n_subintervals,
+    const Table<dim, double> &                        data_values)
+    : interval_endpoints(interval_endpoints)
+    , n_subintervals(n_subintervals)
+    , data_values(data_values)
+  {
+    for (unsigned int d = 0; d < dim; ++d)
+      {
+        Assert(n_subintervals[d] >= 1,
+               ExcMessage("There needs to be at least one subinterval in each "
+                          "coordinate direction."));
+        Assert(interval_endpoints[d].first < interval_endpoints[d].second,
+               ExcMessage("The interval in each coordinate direction needs "
+                          "to have positive size"));
+        Assert(data_values.size()[d] == n_subintervals[d] + 1,
+               ExcMessage("The data table does not have the correct size."));
+      }
+  }
 
 
+  /**
+   * This function is derived from
+   * deal.II (dealii/source/base/function_lib.cc)
+  */
+ template <int dim>
+  Tensor<1, dim>
+  InterpolatedUniformGridData<dim>::gradient(
+    const Point<dim> & p,
+    const unsigned int component) const
+  {
+    (void)component;
+    Assert(
+      component == 0,
+      ExcMessage(
+        "This is a scalar function object, the component can only be zero."));
+
+    // find out where this data point lies
+    const TableIndices<dim> ix = table_index_of_point(p);
+
+    Point<dim> dx;
+    for (unsigned int d = 0; d < dim; ++d)
+      dx[d] = (interval_endpoints[d].second - interval_endpoints[d].first)/n_subintervals[d];
+
+    Point<dim> p_unit;
+    for (unsigned int d = 0; d < dim; ++d)
+      p_unit[d] =
+        std::max(std::min((p[d] - coordinate_values[d][ix[d]]) / dx[d], 1.),
+                 0.0);
+
+    return gradient_interpolate(data_values, ix, p_unit, dx);
+  }
+  }
+
+}
 #endif
+  

--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -28,7 +28,10 @@
 #include <functional>
 #include <memory>
 
-#if !DEAL_II_VERSION_GTE(9,2,0)
+// for std_cxx14::make_unique:
+#include <deal.II/base/std_cxx14/memory.h>
+
+//#if !DEAL_II_VERSION_GTE(9,2,0)
 #include <deal.II/base/table.h>
 #include <deal.II/base/function_lib.h>
 namespace aspect
@@ -120,12 +123,12 @@ namespace aspect
 {
   namespace Functions
   {
-    DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
     namespace
     {
       // interpolate a data value from a table where ix denotes
       // the (lower) left endpoint of the interval to interpolate
       // in, and p_unit denotes the point in unit coordinates to do so.
+      inline
       double
       interpolate(const Table<1, double> &data_values,
                   const TableIndices<1> &ix,
@@ -135,6 +138,7 @@ namespace aspect
                 xi[0] * data_values[ix[0] + 1]);
       }
 
+      inline
       double
       interpolate(const Table<2, double> &data_values,
                   const TableIndices<2> &ix,
@@ -148,6 +152,7 @@ namespace aspect
                 p_unit[1]);
       }
 
+      inline
       double
       interpolate(const Table<3, double> &data_values,
                   const TableIndices<3> &ix,
@@ -174,6 +179,7 @@ namespace aspect
       // denotes the lower left endpoint of the interval to interpolate
       // in, p_unit denotes the point in unit coordinates, and dx
       // denotes the width of the interval in each dimension.
+      inline
       Tensor<1, 1>
       gradient_interpolate(const Table<1, double> &data_values,
                            const TableIndices<1> &ix,
@@ -187,6 +193,7 @@ namespace aspect
       }
 
 
+      inline
       Tensor<1, 2>
       gradient_interpolate(const Table<2, double> &data_values,
                            const TableIndices<2> &ix,
@@ -206,7 +213,7 @@ namespace aspect
         return grad;
       }
 
-
+      inline
       Tensor<1, 3>
       gradient_interpolate(const Table<3, double> &data_values,
                            const TableIndices<3> &ix,
@@ -245,7 +252,6 @@ namespace aspect
         return grad;
       }
     } // namespace internal
-    DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
     template <int dim>
     inline
@@ -376,4 +382,6 @@ namespace aspect
   }
 
 }
+//#endif
+
 #endif

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1727,9 +1727,9 @@ namespace aspect
         {
           if (coordinate_values_are_equidistant)
             data[i]
-              = std_cxx14::make_unique<aspect::InterpolatedUniformGridData<dim>> (grid_extent,
-                                                                                  table_intervals,
-                                                                                  data_tables[dim+i]);
+              = std_cxx14::make_unique<Functions::InterpolatedUniformGridData<dim>> (grid_extent,
+                                                                                     table_intervals,
+                                                                                     data_tables[dim+i]);
           else
             data[i]
               = std_cxx14::make_unique<Functions::InterpolatedTensorProductGridData<dim>> (coordinate_values,

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1727,7 +1727,7 @@ namespace aspect
         {
           if (coordinate_values_are_equidistant)
             data[i]
-              = std_cxx14::make_unique<Functions::InterpolatedUniformGridData<dim>> (grid_extent,
+              = std_cxx14::make_unique<aspect::InterpolatedUniformGridData<dim>> (grid_extent,
                                                                                      table_intervals,
                                                                                      data_tables[dim+i]);
           else

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1728,8 +1728,8 @@ namespace aspect
           if (coordinate_values_are_equidistant)
             data[i]
               = std_cxx14::make_unique<aspect::InterpolatedUniformGridData<dim>> (grid_extent,
-                                                                                     table_intervals,
-                                                                                     data_tables[dim+i]);
+                                                                                  table_intervals,
+                                                                                  data_tables[dim+i]);
           else
             data[i]
               = std_cxx14::make_unique<Functions::InterpolatedTensorProductGridData<dim>> (coordinate_values,


### PR DESCRIPTION
InterpolatedUniformGridData is needed for some planned ascii data plugins, but is not yet implemented in deal.ii. This PR is a workaround for that problem. 

It has been tested using the new functionality in PR #3039.