### PR TITLE
Use our usual capitalization scheme for manual section headings.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -10522,7 +10522,7 @@ obtained with a resolution of $32\times 32$ elements. (a) Gravity field, (b) pre
 \end{figure}
 
 
-\subsubsection{Advection Stabilization Benchmarks}
+\subsubsection{Advection stabilization benchmarks}
 
 The underlying PDEs of the temperature and compositional field are typically advection-dominated and as such, require a stabilization scheme, see \ref{sec:advection-stabilization} for
 an introduction for the methods implemented in \aspect{}.


### PR DESCRIPTION
Follow-up to #3018 (?).