### PR TITLE
Use the \degree symbol for degrees in the parameter descriptions.

### DIFF
--- a/source/material_model/latent_heat_melt.cc
+++ b/source/material_model/latent_heat_melt.cc
@@ -415,26 +415,26 @@ namespace aspect
                              "Constant parameter in the quadratic "
                              "function that approximates the solidus "
                              "of peridotite. "
-                             "Units: ${}^\\circ C$.");
+                             "Units: $\\degree C$.");
           prm.declare_entry ("A2", "1.329e-7",
                              Patterns::Double (),
                              "Prefactor of the linear pressure term "
                              "in the quadratic function that approximates "
                              "the solidus of peridotite. "
-                             "Units: ${}^\\circ C/Pa$.");
+                             "Units: $\\degree C/Pa$.");
           prm.declare_entry ("A3", "-5.1e-18",
                              Patterns::Double (),
                              "Prefactor of the quadratic pressure term "
                              "in the quadratic function that approximates "
                              "the solidus of peridotite. "
-                             "Units: ${}^\\circ C/(Pa^2)$.");
+                             "Units: $\\degree C/(Pa^2)$.");
           prm.declare_entry ("B1", "1475.0",
                              Patterns::Double (),
                              "Constant parameter in the quadratic "
                              "function that approximates the lherzolite "
                              "liquidus used for calculating the fraction "
                              "of peridotite-derived melt. "
-                             "Units: ${}^\\circ C$.");
+                             "Units: $\\degree C$.");
           prm.declare_entry ("B2", "8.0e-8",
                              Patterns::Double (),
                              "Prefactor of the linear pressure term "
@@ -442,7 +442,7 @@ namespace aspect
                              "the  lherzolite liquidus used for "
                              "calculating the fraction of peridotite-"
                              "derived melt. "
-                             "Units: ${}^\\circ C/Pa$.");
+                             "Units: $\\degree C/Pa$.");
           prm.declare_entry ("B3", "-3.2e-18",
                              Patterns::Double (),
                              "Prefactor of the quadratic pressure term "
@@ -450,25 +450,25 @@ namespace aspect
                              "the  lherzolite liquidus used for "
                              "calculating the fraction of peridotite-"
                              "derived melt. "
-                             "Units: ${}^\\circ C/(Pa^2)$.");
+                             "Units: $\\degree C/(Pa^2)$.");
           prm.declare_entry ("C1", "1780.0",
                              Patterns::Double (),
                              "Constant parameter in the quadratic "
                              "function that approximates the liquidus "
                              "of peridotite. "
-                             "Units: ${}^\\circ C$.");
+                             "Units: $\\degree C$.");
           prm.declare_entry ("C2", "4.50e-8",
                              Patterns::Double (),
                              "Prefactor of the linear pressure term "
                              "in the quadratic function that approximates "
                              "the liquidus of peridotite. "
-                             "Units: ${}^\\circ C/Pa$.");
+                             "Units: $\\degree C/Pa$.");
           prm.declare_entry ("C3", "-2.0e-18",
                              Patterns::Double (),
                              "Prefactor of the quadratic pressure term "
                              "in the quadratic function that approximates "
                              "the liquidus of peridotite. "
-                             "Units: ${}^\\circ C/(Pa^2)$.");
+                             "Units: $\\degree C/(Pa^2)$.");
           prm.declare_entry ("r1", "0.5",
                              Patterns::Double (),
                              "Constant in the linear function that "
@@ -501,7 +501,7 @@ namespace aspect
                              "Constant parameter in the quadratic "
                              "function that approximates the solidus "
                              "of pyroxenite. "
-                             "Units: ${}^\\circ C$.");
+                             "Units: $\\degree C$.");
           prm.declare_entry ("D2", "1.329e-7",
                              Patterns::Double (),
                              "Prefactor of the linear pressure term "
@@ -511,25 +511,25 @@ namespace aspect
                              "value given in Sobolev, 2011, because they use "
                              "the potential temperature whereas we use the "
                              "absolute temperature. "
-                             "Units: ${}^\\circ C/Pa$.");
+                             "Units: $\\degree C/Pa$.");
           prm.declare_entry ("D3", "-5.1e-18",
                              Patterns::Double (),
                              "Prefactor of the quadratic pressure term "
                              "in the quadratic function that approximates "
                              "the solidus of pyroxenite. "
-                             "Units: ${}^\\circ C/(Pa^2)$.");
+                             "Units: $\\degree C/(Pa^2)$.");
           prm.declare_entry ("E1", "663.8",
                              Patterns::Double (),
                              "Prefactor of the linear depletion term "
                              "in the quadratic function that approximates "
                              "the melt fraction of pyroxenite. "
-                             "Units: ${}^\\circ C/Pa$.");
+                             "Units: $\\degree C/Pa$.");
           prm.declare_entry ("E2", "-611.4",
                              Patterns::Double (),
                              "Prefactor of the quadratic depletion term "
                              "in the quadratic function that approximates "
                              "the melt fraction of pyroxenite. "
-                             "Units: ${}^\\circ C/(Pa^2)$.");
+                             "Units: $\\degree C/(Pa^2)$.");
           prm.declare_entry ("Pyroxenite melting entropy change", "-400",
                              Patterns::Double (),
                              "The entropy change for the phase transition "

--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -594,26 +594,26 @@ namespace aspect
                              "Constant parameter in the quadratic "
                              "function that approximates the solidus "
                              "of peridotite. "
-                             "Units: ${}^\\circ C$.");
+                             "Units: $\\degree C$.");
           prm.declare_entry ("A2", "1.329e-7",
                              Patterns::Double (),
                              "Prefactor of the linear pressure term "
                              "in the quadratic function that approximates "
                              "the solidus of peridotite. "
-                             "Units: ${}^\\circ C/Pa$.");
+                             "Units: $\\degree C/Pa$.");
           prm.declare_entry ("A3", "-5.1e-18",
                              Patterns::Double (),
                              "Prefactor of the quadratic pressure term "
                              "in the quadratic function that approximates "
                              "the solidus of peridotite. "
-                             "Units: ${}^\\circ C/(Pa^2)$.");
+                             "Units: $\\degree C/(Pa^2)$.");
           prm.declare_entry ("B1", "1475.0",
                              Patterns::Double (),
                              "Constant parameter in the quadratic "
                              "function that approximates the lherzolite "
                              "liquidus used for calculating the fraction "
                              "of peridotite-derived melt. "
-                             "Units: ${}^\\circ C$.");
+                             "Units: $\\degree C$.");
           prm.declare_entry ("B2", "8.0e-8",
                              Patterns::Double (),
                              "Prefactor of the linear pressure term "
@@ -621,7 +621,7 @@ namespace aspect
                              "the  lherzolite liquidus used for "
                              "calculating the fraction of peridotite-"
                              "derived melt. "
-                             "Units: ${}^\\circ C/Pa$.");
+                             "Units: $\\degree C/Pa$.");
           prm.declare_entry ("B3", "-3.2e-18",
                              Patterns::Double (),
                              "Prefactor of the quadratic pressure term "
@@ -629,25 +629,25 @@ namespace aspect
                              "the  lherzolite liquidus used for "
                              "calculating the fraction of peridotite-"
                              "derived melt. "
-                             "Units: ${}^\\circ C/(Pa^2)$.");
+                             "Units: $\\degree C/(Pa^2)$.");
           prm.declare_entry ("C1", "1780.0",
                              Patterns::Double (),
                              "Constant parameter in the quadratic "
                              "function that approximates the liquidus "
                              "of peridotite. "
-                             "Units: ${}^\\circ C$.");
+                             "Units: $\\degree C$.");
           prm.declare_entry ("C2", "4.50e-8",
                              Patterns::Double (),
                              "Prefactor of the linear pressure term "
                              "in the quadratic function that approximates "
                              "the liquidus of peridotite. "
-                             "Units: ${}^\\circ C/Pa$.");
+                             "Units: $\\degree C/Pa$.");
           prm.declare_entry ("C3", "-2.0e-18",
                              Patterns::Double (),
                              "Prefactor of the quadratic pressure term "
                              "in the quadratic function that approximates "
                              "the liquidus of peridotite. "
-                             "Units: ${}^\\circ C/(Pa^2)$.");
+                             "Units: $\\degree C/(Pa^2)$.");
           prm.declare_entry ("r1", "0.5",
                              Patterns::Double (),
                              "Constant in the linear function that "

--- a/source/postprocess/visualization/melt_fraction.cc
+++ b/source/postprocess/visualization/melt_fraction.cc
@@ -156,26 +156,26 @@ namespace aspect
                                  "Constant parameter in the quadratic "
                                  "function that approximates the solidus "
                                  "of peridotite. "
-                                 "Units: ${}^\\circ C$.");
+                                 "Units: $\\degree C$.");
               prm.declare_entry ("A2", "1.329e-7",
                                  Patterns::Double (),
                                  "Prefactor of the linear pressure term "
                                  "in the quadratic function that approximates "
                                  "the solidus of peridotite. "
-                                 "Units: ${}^\\circ C/Pa$.");
+                                 "Units: $\\degree C/Pa$.");
               prm.declare_entry ("A3", "-5.1e-18",
                                  Patterns::Double (),
                                  "Prefactor of the quadratic pressure term "
                                  "in the quadratic function that approximates "
                                  "the solidus of peridotite. "
-                                 "Units: ${}^\\circ C/(Pa^2)$.");
+                                 "Units: $\\degree C/(Pa^2)$.");
               prm.declare_entry ("B1", "1475.0",
                                  Patterns::Double (),
                                  "Constant parameter in the quadratic "
                                  "function that approximates the lherzolite "
                                  "liquidus used for calculating the fraction "
                                  "of peridotite-derived melt. "
-                                 "Units: ${}^\\circ C$.");
+                                 "Units: $\\degree C$.");
               prm.declare_entry ("B2", "8.0e-8",
                                  Patterns::Double (),
                                  "Prefactor of the linear pressure term "
@@ -183,7 +183,7 @@ namespace aspect
                                  "the  lherzolite liquidus used for "
                                  "calculating the fraction of peridotite-"
                                  "derived melt. "
-                                 "Units: ${}^\\circ C/Pa$.");
+                                 "Units: $\\degree C/Pa$.");
               prm.declare_entry ("B3", "-3.2e-18",
                                  Patterns::Double (),
                                  "Prefactor of the quadratic pressure term "
@@ -191,25 +191,25 @@ namespace aspect
                                  "the  lherzolite liquidus used for "
                                  "calculating the fraction of peridotite-"
                                  "derived melt. "
-                                 "Units: ${}^\\circ C/(Pa^2)$.");
+                                 "Units: $\\degree C/(Pa^2)$.");
               prm.declare_entry ("C1", "1780.0",
                                  Patterns::Double (),
                                  "Constant parameter in the quadratic "
                                  "function that approximates the liquidus "
                                  "of peridotite. "
-                                 "Units: ${}^\\circ C$.");
+                                 "Units: $\\degree C$.");
               prm.declare_entry ("C2", "4.50e-8",
                                  Patterns::Double (),
                                  "Prefactor of the linear pressure term "
                                  "in the quadratic function that approximates "
                                  "the liquidus of peridotite. "
-                                 "Units: ${}^\\circ C/Pa$.");
+                                 "Units: $\\degree C/Pa$.");
               prm.declare_entry ("C3", "-2.0e-18",
                                  Patterns::Double (),
                                  "Prefactor of the quadratic pressure term "
                                  "in the quadratic function that approximates "
                                  "the liquidus of peridotite. "
-                                 "Units: ${}^\\circ C/(Pa^2)$.");
+                                 "Units: $\\degree C/(Pa^2)$.");
               prm.declare_entry ("r1", "0.5",
                                  Patterns::Double (),
                                  "Constant in the linear function that "
@@ -237,7 +237,7 @@ namespace aspect
                                  "Constant parameter in the quadratic "
                                  "function that approximates the solidus "
                                  "of pyroxenite. "
-                                 "Units: ${}^\\circ C$.");
+                                 "Units: $\\degree C$.");
               prm.declare_entry ("D2", "1.329e-7",
                                  Patterns::Double (),
                                  "Prefactor of the linear pressure term "
@@ -247,25 +247,25 @@ namespace aspect
                                  "value given in Sobolev, 2011, because they use "
                                  "the potential temperature whereas we use the "
                                  "absolute temperature. "
-                                 "Units: ${}^\\circ C/Pa$.");
+                                 "Units: $\\degree C/Pa$.");
               prm.declare_entry ("D3", "-5.1e-18",
                                  Patterns::Double (),
                                  "Prefactor of the quadratic pressure term "
                                  "in the quadratic function that approximates "
                                  "the solidus of pyroxenite. "
-                                 "Units: ${}^\\circ C/(Pa^2)$.");
+                                 "Units: $\\degree C/(Pa^2)$.");
               prm.declare_entry ("E1", "663.8",
                                  Patterns::Double (),
                                  "Prefactor of the linear depletion term "
                                  "in the quadratic function that approximates "
                                  "the melt fraction of pyroxenite. "
-                                 "Units: ${}^\\circ C/Pa$.");
+                                 "Units: $\\degree C/Pa$.");
               prm.declare_entry ("E2", "-611.4",
                                  Patterns::Double (),
                                  "Prefactor of the quadratic depletion term "
                                  "in the quadratic function that approximates "
                                  "the melt fraction of pyroxenite. "
-                                 "Units: ${}^\\circ C/(Pa^2)$.");
+                                 "Units: $\\degree C/(Pa^2)$.");
             }
             prm.leave_subsection();
           }


### PR DESCRIPTION
Requires #3061.

Done with the command
```
perl -pi -e 's/\{\}\^\\\\circ/\\degree/g;' `find source | egrep '\.cc$'`
```
which is one of those things that seems completely normal to me...