### PR TITLE
The bibtex generated by Mendeley incorrectly categorizes several mast…

### DIFF
--- a/doc/manual/citing_aspect.bib
+++ b/doc/manual/citing_aspect.bib
@@ -1,4 +1,4 @@
-@phdthesis{Fraters2014,
+@mastersthesis{Fraters2014,
 author = {Fraters, Menno},
 file = {:home/heister/.local/share/data/Mendeley Ltd./Mendeley Desktop/Downloaded/Fraters - 2014 - Thermo-mechanically coupled subductionmodelling with ASPECT(2).pdf:pdf},
 number = {August},
@@ -14,7 +14,7 @@ title = {{Dynamics of Mantle Plumes: Linking Scales and Coupling Physics}},
 url = {https://scholar.google.com/scholar?q=dannberg+Dynamics+of+mantle+plumes{\%}3A+Linking+scales+and+coupling+physics{\&}btnG={\&}hl=en{\&}as{\_}sdt=0{\%}2C6 https://publishup.uni-potsdam.de/frontdoor/index/index/docId/9102},
 year = {2016}
 }
-@phdthesis{Zelst2015,
+@mastersthesis{Zelst2015,
 author = {Zelst, I},
 file = {:home/heister/.local/share/data/Mendeley Ltd./Mendeley Desktop/Downloaded/Zelst - 2015 - Mantle dynamics on Venus insights from numerical modelling.pdf:pdf},
 school = {Utrecht University},
@@ -50,14 +50,7 @@ title = {{Variable inertia method: A novel numerical method for mantle convectio
 url = {http://www.sciencedirect.com/science/article/pii/S138410761630046X},
 year = {2017}
 }
-@phdthesis{Blom2016,
-author = {Blom, CAH},
-file = {:home/heister/.local/share/data/Mendeley Ltd./Mendeley Desktop/Downloaded/Blom - 2016 - State of the art numerical subduction modelling with ASPECT thermo-mechanically coupled viscoplastic compressible rheology.pdf:pdf},
-school = {Utrecht University},
-title = {{State of the art numerical subduction modelling with ASPECT; thermo-mechanically coupled viscoplastic compressible rheology, free surface, phase changes, latent}},
-url = {https://dspace.library.uu.nl/handle/1874/348133},
-year = {2016}
-}
+
 @article{He2017,
 author = {He, Y and Puckett, EG and Billen, MI},
 journal = {Physics of the Earth and Planetary Interiors},
@@ -321,7 +314,7 @@ title = {{ASPECT: Advanced Solver for Problems in Earth's ConvecTion, User Manua
 url = {https://doi.org/10.6084/m9.figshare.4865333},
 year = {2017}
 }
-@phdthesis{Schuurmans2018,
+@mastersthesis{Schuurmans2018,
 author = {Schuurmans, L F J},
 school = {Utrecht University},
 title = {{Numerical modelling of overriding plate deformation and slab rollback in the Western Mediterranean}},
@@ -412,7 +405,7 @@ year = {2018}
 author = {{Jonathan Perry-Hout}},
 school = {University of Oregon},
 title = {{Geodynamic Origin of the Columbia River Flood Basalts}},
-url = {https://search.proquest.com/docview/2188303382?accountid=10223},
+url = {http://hdl.handle.net/1794/24526},
 year = {2019}
 }
 @article{GiacomoCorti2019,
@@ -425,7 +418,7 @@ url = {https://doi.org/10.1038/s41467-019-09335-2},
 volume = {10},
 year = {2019}
 }
-@phdthesis{Ellowitz2018,
+@mastersthesis{Ellowitz2018,
 author = {Ellowitz, Molly},
 doi = {10.15760/etd.6429},
 school = {Portland State University},


### PR DESCRIPTION
The bibtex generated by Mendeley incorrectly categorizes several masters theses as phd theses.  I was unable to edit the metadata as Admin on Mendeley to correct.  After discussions with Timo, I corrected the file manually.  An issue will be open to change the workflow going forward to updating this file directly and NOT using Mendeley.

Updates the citing_aspect.bib file with the following corrections:
	▪	removes duplicate thesis entry for Blom
	▪	Changes Fraters2014, Schuurmans2018, Zelst2015, and Ellowitz2018 to @mastersthesis
	▪	changes JonathanPerry-Hout2019 URL to a URI. URL was not resolving