### PR TITLE
fix melt global model for zero temperature

### DIFF
--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -240,7 +240,7 @@ namespace aspect
               const double delta_temp = in.temperature[i]-this->get_adiabatic_conditions().temperature(in.position[i]);
               visc_temperature_dependence = std::max(std::min(std::exp(-thermal_viscosity_exponent*delta_temp/this->get_adiabatic_conditions().temperature(in.position[i])),1e4),1e-4);
             }
-          else
+          else if (thermal_viscosity_exponent != 0.0)
             {
               const double delta_temp = in.temperature[i]-reference_T;
               visc_temperature_dependence = std::max(std::min(std::exp(-thermal_viscosity_exponent*delta_temp/reference_T),1e4),1e-4);
@@ -281,7 +281,7 @@ namespace aspect
                   const double delta_temp = in.temperature[i]-this->get_adiabatic_conditions().temperature(in.position[i]);
                   visc_temperature_dependence = std::max(std::min(std::exp(-thermal_bulk_viscosity_exponent*delta_temp/this->get_adiabatic_conditions().temperature(in.position[i])),1e4),1e-4);
                 }
-              else
+              else if (thermal_viscosity_exponent != 0.0)
                 {
                   const double delta_temp = in.temperature[i]-reference_T;
                   visc_temperature_dependence = std::max(std::min(std::exp(-thermal_bulk_viscosity_exponent*delta_temp/reference_T),1e4),1e-4);


### PR DESCRIPTION
The global melt model triggered a floating point exception for a zero reference temperature. Usually, a zero reference temperature is not allowed, except for the case where the thermal_viscosity_exponent is also zero (there is an Assert that checks that if the reference temperature is zero, the thermal_viscosity_exponent also has to be zero). 
This pull request makes this case actually work (without triggering the floating point exception). 