### PR TITLE
use natural_coordinates in boundary get_data_component

### DIFF
--- a/include/aspect/geometry_model/sphere.h
+++ b/include/aspect/geometry_model/sphere.h
@@ -129,6 +129,23 @@ namespace aspect
         bool
         point_is_in_domain(const Point<dim> &point) const;
 
+        /**
+               * Takes the Cartesian points (x,z or x,y,z) and returns standardized
+               * coordinates which are most 'natural' to the geometry model. For a sphere
+               * this is (radius, longitude) in 2d and (radius, longitude, latitude) in 3d.
+               */
+        virtual
+        std::array<double,dim> cartesian_to_natural_coordinates(const Point<dim> &position) const;
+
+        /**
+         * Undoes the action of cartesian_to_natural_coordinates, and turns the
+         * coordinate system which is most 'natural' to the geometry model into
+         * Cartesian coordinates.
+         */
+        virtual
+        Point<dim> natural_to_cartesian_coordinates(const std::array<double,dim> &position) const;
+
+
         static
         void
         declare_parameters (ParameterHandler &prm);

--- a/source/geometry_model/sphere.cc
+++ b/source/geometry_model/sphere.cc
@@ -23,6 +23,7 @@
 #include <aspect/geometry_model/initial_topography_model/zero_topography.h>
 
 #include <deal.II/grid/grid_generator.h>
+#include <aspect/utilities.h>
 
 #if !DEAL_II_VERSION_GTE(9,0,0)
 #include <deal.II/grid/tria_boundary_lib.h>
@@ -174,11 +175,30 @@ namespace aspect
     }
 
 
+
+    template <int dim>
+    std::array<double,dim>
+    Sphere<dim>::cartesian_to_natural_coordinates(const Point<dim> &position) const
+    {
+      return Utilities::Coordinates::cartesian_to_spherical_coordinates<dim>(position);
+    }
+
+
+
     template <int dim>
     aspect::Utilities::Coordinates::CoordinateSystem
     Sphere<dim>::natural_coordinate_system() const
     {
       return aspect::Utilities::Coordinates::CoordinateSystem::spherical;
+    }
+
+
+
+    template <int dim>
+    Point<dim>
+    Sphere<dim>::natural_to_cartesian_coordinates(const std::array<double,dim> &position) const
+    {
+      return Utilities::Coordinates::spherical_to_cartesian_coordinates<dim>(position);
     }
 
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2167,18 +2167,11 @@ namespace aspect
     {
       if (this->get_time() - first_data_file_model_time >= 0.0)
         {
-          Point<dim> internal_position = position;
+          const std::array<double,dim> natural_position = this->get_geometry_model().cartesian_to_natural_coordinates(position);
 
-          if (dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()) != nullptr
-              || dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model()) != nullptr
-              || dynamic_cast<const GeometryModel::Sphere<dim>*> (&this->get_geometry_model()) != nullptr)
-            {
-              const std::array<double,dim> spherical_position =
-                Utilities::Coordinates::cartesian_to_spherical_coordinates(position);
-
-              for (unsigned int i = 0; i < dim; i++)
-                internal_position[i] = spherical_position[i];
-            }
+          Point<dim> internal_position;
+          for (unsigned int i = 0; i < dim; i++)
+            internal_position[i] = natural_position[i];
 
           const std::array<unsigned int,dim-1> boundary_dimensions =
             get_boundary_dimensions(boundary_indicator);

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2173,6 +2173,12 @@ namespace aspect
           for (unsigned int i = 0; i < dim; i++)
             internal_position[i] = natural_position[i];
 
+          // The chunk model has latitude as natural coordinate. We need to convert this to colatitude
+          if (dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model()) != nullptr && dim == 3)
+            {
+              internal_position[2] = numbers::PI/2. - internal_position[2];
+            }
+
           const std::array<unsigned int,dim-1> boundary_dimensions =
             get_boundary_dimensions(boundary_indicator);
 


### PR DESCRIPTION
Spherical geometry models (e.g. sphere, chunk) can accept information which runs from -pi to pi or 0 to 2pi. For the new initial topography/ascii data plugin, there is 
1) a call to `spherical_to_cartesian_coordinates` before 
2) a call to `Utilities::get_data_coordinates`, which then calls 
3) `spherical_to_cartesian_coordinates`.

This results in a loss of information; we no longer know whether our ascii data runs from -pi to pi or 0 to 2pi. In this particular case, we don't need the conversions at all.

This PR fixes this problem.



