### PR TITLE
Add get_model_operator_options function in utilities so operator options don't get out of sync

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1162,6 +1162,11 @@ namespace aspect
     std::vector<Operator> create_model_operator_list(const std::vector<std::string> &operator_names);
 
     /**
+     * Create a string of model operators for use in declare_parameters
+     */
+    const std::string get_model_operator_options();
+
+    /**
      * A function that returns a SymmetricTensor, whose entries are zero, except for
      * the k'th component, which is set to one. If k is not on the main diagonal the
      * resulting tensor is symmetrized.

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -293,7 +293,7 @@ namespace aspect
                           std::get<dim>(registered_plugins).get_description_string());
 
         prm.declare_entry("List of model operators", "add",
-                          Patterns::MultipleSelection("add|subtract|minimum|maximum"),
+                          Patterns::MultipleSelection(Utilities::get_model_operator_options()),
                           "A comma-separated list of operators that "
                           "will be used to append the listed composition models onto "
                           "the previous models. If only one operator is given, "

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -312,7 +312,7 @@ namespace aspect
                           std::get<dim>(registered_plugins).get_description_string());
 
         prm.declare_entry("List of model operators", "add",
-                          Patterns::MultipleSelection("add|subtract|minimum|maximum"),
+                          Patterns::MultipleSelection(Utilities::get_model_operator_options()),
                           "A comma-separated list of operators that "
                           "will be used to append the listed temperature models onto "
                           "the previous models. If only one operator is given, "

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -214,7 +214,7 @@ namespace aspect
                           std::get<dim>(registered_plugins).get_description_string());
 
         prm.declare_entry("List of model operators", "add",
-                          Patterns::MultipleSelection("add|subtract|minimum|maximum"),
+                          Patterns::MultipleSelection(Utilities::get_model_operator_options()),
                           "A comma-separated list of operators that "
                           "will be used to append the listed composition models onto "
                           "the previous models. If only one operator is given, "

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -204,7 +204,7 @@ namespace aspect
                           std::get<dim>(registered_plugins).get_description_string());
 
         prm.declare_entry("List of model operators", "add",
-                          Patterns::MultipleSelection("add|subtract|minimum|maximum|replace if valid"),
+                          Patterns::MultipleSelection(Utilities::get_model_operator_options()),
                           "A comma-separated list of operators that "
                           "will be used to append the listed temperature models onto "
                           "the previous models. If only one operator is given, "

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2848,7 +2848,7 @@ namespace aspect
 
     const std::string get_model_operator_options()
     {
-          return "add|subtract|minimum|maximum|replace if valid";
+      return "add|subtract|minimum|maximum|replace if valid";
     }
 
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2846,6 +2846,13 @@ namespace aspect
 
 
 
+    const std::string get_model_operator_options()
+    {
+          return "add|subtract|minimum|maximum|replace if valid";
+    }
+
+
+
     template <int dim>
     SymmetricTensor<2,dim>
     nth_basis_for_symmetric_tensors (const unsigned int k)


### PR DESCRIPTION
I added a get_model_operator_options function in utilities which returns "add|subtract|minimum|maximum|replace if valid", and then replaced the list with a call to this function in all the relevant interface.cc files. This way they cannot become out of sync if someone adds a new operator.