### PR TITLE
WIP: change nonlinear Picard solver to defect correction Picard.

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -579,7 +579,7 @@ namespace aspect
        * This function is implemented in
        * <code>source/simulator/solver_schemes.cc</code>.
        */
-      void solve_iterated_advection_and_newton_stokes ();
+      void solve_iterated_advection_and_newton_stokes (const bool only_picard);
 
       /**
        * This function implements one scheme for the various

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -661,7 +661,7 @@ namespace aspect
           // If plastic strain is tracked (so not the total strain), only overwrite
           // when plastically yielding.
           // If viscous strain is also tracked, overwrite the second reaction term as well.
-          if  (this->get_timestep_number() > 0 && in.strain_rate.size())
+          if  (this->get_timestep_number() != numbers::invalid_unsigned_int && this->get_timestep_number() > 0 && in.strain_rate.size())
             {
               const double edot_ii = std::max(sqrt(std::fabs(second_invariant(deviator(in.strain_rate[i])))),min_strain_rate);
               const double e_ii = edot_ii*this->get_timestep();

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -226,7 +226,9 @@ namespace aspect
 
     rebuild_stokes_matrix (true),
     assemble_newton_stokes_matrix (true),
-    assemble_newton_stokes_system (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes || parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Stokes ? true : false),
+    assemble_newton_stokes_system (parameters.include_melt_transport == false && 
+                                   (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes || 
+                                   parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Stokes) ? true : false),
     rebuild_stokes_preconditioner (true)
   {
     if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
@@ -368,7 +370,9 @@ namespace aspect
 
     // If the solver type is a Newton type of solver, we need to set make sure
     // assemble_newton_stokes_system set to true.
-    if (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes || parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Stokes)
+    if (parameters.include_melt_transport == false && 
+    (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes || 
+     parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Stokes))
       {
         assemble_newton_stokes_system = true;
         newton_handler->initialize_simulator(*this);
@@ -1721,8 +1725,10 @@ namespace aspect
 
         case NonlinearSolver::iterated_Advection_and_Stokes:
         {
-          //solve_iterated_advection_and_stokes();
-          solve_iterated_advection_and_newton_stokes(true);
+          if (parameters.include_melt_transport == true)
+            solve_iterated_advection_and_stokes();
+          else
+            solve_iterated_advection_and_newton_stokes(true);
           break;
         }
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -226,9 +226,9 @@ namespace aspect
 
     rebuild_stokes_matrix (true),
     assemble_newton_stokes_matrix (true),
-    assemble_newton_stokes_system (parameters.include_melt_transport == false && 
-                                   (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes || 
-                                   parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Stokes) ? true : false),
+    assemble_newton_stokes_system (parameters.include_melt_transport == false &&
+                                   (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes ||
+                                    parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Stokes) ? true : false),
     rebuild_stokes_preconditioner (true)
   {
     if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
@@ -370,9 +370,9 @@ namespace aspect
 
     // If the solver type is a Newton type of solver, we need to set make sure
     // assemble_newton_stokes_system set to true.
-    if (parameters.include_melt_transport == false && 
-    (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes || 
-     parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Stokes))
+    if (parameters.include_melt_transport == false &&
+        (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes ||
+         parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Stokes))
       {
         assemble_newton_stokes_system = true;
         newton_handler->initialize_simulator(*this);

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -369,11 +369,11 @@ namespace aspect
     // If the solver type is a Newton type of solver, we need to set make sure
     // assemble_newton_stokes_system set to true.
     if (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes || parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Stokes)
-    {
-      assemble_newton_stokes_system = true;
-      newton_handler->initialize_simulator(*this);
-      newton_handler->parameters.parse_parameters(prm);
-    }
+      {
+        assemble_newton_stokes_system = true;
+        newton_handler->initialize_simulator(*this);
+        newton_handler->parameters.parse_parameters(prm);
+      }
 
     if (parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::block_gmg)
       {

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1723,7 +1723,8 @@ namespace aspect
 
         case NonlinearSolver::iterated_Advection_and_Stokes:
         {
-          solve_iterated_advection_and_stokes();
+          //solve_iterated_advection_and_stokes();
+          solve_iterated_advection_and_newton_stokes(true);
           break;
         }
 
@@ -1735,7 +1736,7 @@ namespace aspect
 
         case NonlinearSolver::iterated_Advection_and_Newton_Stokes:
         {
-          solve_iterated_advection_and_newton_stokes();
+          solve_iterated_advection_and_newton_stokes(false);
           break;
         }
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1725,7 +1725,7 @@ namespace aspect
 
         case NonlinearSolver::iterated_Advection_and_Stokes:
         {
-          if (parameters.include_melt_transport == true)
+          if (parameters.include_melt_transport == true || parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::direct_solver)
             solve_iterated_advection_and_stokes();
           else
             solve_iterated_advection_and_newton_stokes(true);

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -226,7 +226,7 @@ namespace aspect
 
     rebuild_stokes_matrix (true),
     assemble_newton_stokes_matrix (true),
-    assemble_newton_stokes_system (true),
+    assemble_newton_stokes_system (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes || parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Stokes ? true : false),
     rebuild_stokes_preconditioner (true)
   {
     if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
@@ -368,7 +368,7 @@ namespace aspect
 
     // If the solver type is a Newton type of solver, we need to set make sure
     // assemble_newton_stokes_system set to true.
-    //if (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes)
+    if (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes || parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Stokes)
     {
       assemble_newton_stokes_system = true;
       newton_handler->initialize_simulator(*this);

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -148,9 +148,7 @@ namespace aspect
     melt_handler (parameters.include_melt_transport ?
                   std_cxx14::make_unique<MeltHandler<dim>>(prm) :
                   nullptr),
-    newton_handler (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes ?
-                    std_cxx14::make_unique<NewtonHandler<dim>>() :
-                    nullptr),
+    newton_handler (std_cxx14::make_unique<NewtonHandler<dim>>()),
     post_signal_creation(
       std::bind (&internals::SimulatorSignals::call_connector_functions<dim>,
                  std::ref(signals))),
@@ -228,7 +226,7 @@ namespace aspect
 
     rebuild_stokes_matrix (true),
     assemble_newton_stokes_matrix (true),
-    assemble_newton_stokes_system (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes ? true : false),
+    assemble_newton_stokes_system (true),
     rebuild_stokes_preconditioner (true)
   {
     if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
@@ -370,12 +368,12 @@ namespace aspect
 
     // If the solver type is a Newton type of solver, we need to set make sure
     // assemble_newton_stokes_system set to true.
-    if (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes)
-      {
-        assemble_newton_stokes_system = true;
-        newton_handler->initialize_simulator(*this);
-        newton_handler->parameters.parse_parameters(prm);
-      }
+    //if (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes)
+    {
+      assemble_newton_stokes_system = true;
+      newton_handler->initialize_simulator(*this);
+      newton_handler->parameters.parse_parameters(prm);
+    }
 
     if (parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::block_gmg)
       {

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -513,7 +513,7 @@ namespace aspect
 
 
   template <int dim>
-  void Simulator<dim>::solve_iterated_advection_and_newton_stokes ()
+  void Simulator<dim>::solve_iterated_advection_and_newton_stokes (const bool only_picard)
   {
     // Now store the linear_tolerance we started out with, because we might change
     // it within this timestep.
@@ -552,8 +552,9 @@ namespace aspect
         assemble_and_solve_temperature();
         assemble_and_solve_composition();
 
-        if (use_picard == true && (residual/initial_residual <= newton_handler->parameters.nonlinear_switch_tolerance ||
-                                   nonlinear_iteration >= newton_handler->parameters.max_pre_newton_nonlinear_iterations))
+        if (only_picard == false && use_picard == true &&
+            (residual/initial_residual <= newton_handler->parameters.nonlinear_switch_tolerance ||
+             nonlinear_iteration >= newton_handler->parameters.max_pre_newton_nonlinear_iterations))
           {
             use_picard = false;
             pcout << "   Switching from defect correction form of Picard to the Newton solver scheme." << std::endl;
@@ -937,7 +938,7 @@ namespace aspect
   template void Simulator<dim>::solve_no_advection_iterated_stokes(); \
   template void Simulator<dim>::solve_iterated_advection_and_stokes(); \
   template void Simulator<dim>::solve_single_advection_iterated_stokes(); \
-  template void Simulator<dim>::solve_iterated_advection_and_newton_stokes(); \
+  template void Simulator<dim>::solve_iterated_advection_and_newton_stokes(const bool); \
   template void Simulator<dim>::solve_single_advection_no_stokes(); \
   template void Simulator<dim>::solve_first_timestep_only_single_stokes(); \
   template void Simulator<dim>::solve_no_advection_no_stokes();

--- a/tests/iterated_advection_and_stokes.prm
+++ b/tests/iterated_advection_and_stokes.prm
@@ -140,7 +140,7 @@ end
 
 subsection Solver parameters
   subsection Stokes solver parameters
-    set Linear solver tolerance = 1e-12
+    set Linear solver tolerance = 1e-8
     set Use direct solver for Stokes system = false
   end
 end

--- a/tests/iterated_advection_and_stokes_residual.prm
+++ b/tests/iterated_advection_and_stokes_residual.prm
@@ -140,7 +140,7 @@ end
 
 subsection Solver parameters
   subsection Stokes solver parameters
-    set Linear solver tolerance = 1e-12
+    set Linear solver tolerance = 1e-8
     set Use direct solver for Stokes system = false
   end
 end

--- a/tests/postprocess_iterations_iterated_advection_and_stokes.prm
+++ b/tests/postprocess_iterations_iterated_advection_and_stokes.prm
@@ -146,7 +146,7 @@ end
 
 subsection Solver parameters
   subsection Stokes solver parameters
-    set Linear solver tolerance = 1e-12
+    set Linear solver tolerance = 1e-8
     set Use direct solver for Stokes system = false
   end
 end


### PR DESCRIPTION
only changed the one solver at the moment.

I currently just expended the `solve_iterated_advection_and_newton_stokes` function so that it can be forced to only do Picard iterations. I am thinking of just keep expanding this function, because otherwise there will be a lot of code duplication. @tjhei @bangerth @jdannberg @gassmoeller what are your opinions on this approach?