### PR TITLE
Implement natural_to_cartesian_coordinates for SphericalShell

### DIFF
--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -147,6 +147,23 @@ namespace aspect
         aspect::Utilities::Coordinates::CoordinateSystem natural_coordinate_system() const;
 
         /**
+         * Takes the Cartesian points (x,z or x,y,z) and returns standardized
+         * coordinates which are most 'natural' to the geometry model. For a spherical shell
+         * this is (radius, longitude) in 2d and (radius, longitude, latitude) in 3d.
+         */
+        virtual
+        std::array<double,dim> cartesian_to_natural_coordinates(const Point<dim> &position) const;
+
+        /**
+         * Undoes the action of cartesian_to_natural_coordinates, and turns the
+         * coordinate system which is most 'natural' to the geometry model into
+         * Cartesian coordinates.
+         */
+        virtual
+        Point<dim> natural_to_cartesian_coordinates(const std::array<double,dim> &position) const;
+
+
+        /**
          * Declare the parameters this class takes through input files. The
          * default implementation of this function does not describe any
          * parameters. Consequently, derived classes do not have to overload

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -319,12 +319,32 @@ namespace aspect
     }
 
 
+
+    template <int dim>
+    std::array<double,dim>
+    SphericalShell<dim>::cartesian_to_natural_coordinates(const Point<dim> &position) const
+    {
+      return Utilities::Coordinates::cartesian_to_spherical_coordinates<dim>(position);
+    }
+
+
+
     template <int dim>
     aspect::Utilities::Coordinates::CoordinateSystem
     SphericalShell<dim>::natural_coordinate_system() const
     {
       return aspect::Utilities::Coordinates::CoordinateSystem::spherical;
     }
+
+
+
+    template <int dim>
+    Point<dim>
+    SphericalShell<dim>::natural_to_cartesian_coordinates(const std::array<double,dim> &position) const
+    {
+      return Utilities::Coordinates::spherical_to_cartesian_coordinates<dim>(position);
+    }
+
 
 
     template <int dim>


### PR DESCRIPTION
This fixes an oversight, and implements a function that is required for #3069 to work.