### PR TITLE
add deviatoric stress postprocessing

### DIFF
--- a/include/aspect/postprocess/visualization/deviatoric_stress.h
+++ b/include/aspect/postprocess/visualization/deviatoric_stress.h
@@ -1,0 +1,93 @@
+/*
+  Copyright (C) 2015 - 2017 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef _aspect_postprocess_visualization_devatoric_stress_h
+#define _aspect_postprocess_visualization_devatoric_stress_h
+
+#include <aspect/postprocess/visualization.h>
+#include <aspect/simulator_access.h>
+
+#include <deal.II/numerics/data_postprocessor.h>
+
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    namespace VisualizationPostprocessors
+    {
+      /**
+       * A class derived from DataPostprocessor that takes an output vector
+       * and computes a variable that represents the 3 or 6 independent
+       * components (in 2d and 3d, respectively) of the deviatoric stress tensor at every
+       * point. The shear stress is defined as $2 \eta (\varepsilon(\mathbf u)
+       * - \tfrac 13 \textrm{trace}\ \varepsilon(\mathbf u) \mathbf 1) =
+       * 2\eta (\varepsilon(\mathbf u) - \frac 13 (\nabla \cdot \mathbf u)
+       * \mathbf I)$.  The second term in the parentheses is zero if the
+       * model is incompressible.
+       *
+       * The member functions are all implementations of those declared in the
+       * base class. See there for their meaning.
+       */
+      template <int dim>
+      class DeviatoricStress
+        : public DataPostprocessor<dim>,
+          public SimulatorAccess<dim>,
+          public Interface<dim>
+      {
+        public:
+          virtual
+          void
+          evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
+                                std::vector<Vector<double> > &computed_quantities) const;
+
+          /**
+           * Return the vector of strings describing the names of the computed
+           * quantities. Given the purpose of this class, this is a vector
+           * with entries all equal to the name of the plugin.
+           */
+          virtual std::vector<std::string> get_names () const;
+
+          /**
+           * This functions returns information about how the individual
+           * components of output files that consist of more than one data set
+           * are to be interpreted. The returned value is
+           * DataComponentInterpretation::component_is_scalar repeated
+           * SymmetricTensor::n_independent_components times. (These
+           * components should really be part of a symmetric tensor, but
+           * deal.II does not allow marking components as such.)
+           */
+          virtual
+          std::vector<DataComponentInterpretation::DataComponentInterpretation>
+          get_data_component_interpretation () const;
+
+          /**
+           * Return which data has to be provided to compute the derived
+           * quantities. The flags returned here are the ones passed to the
+           * constructor of this class.
+           */
+          virtual UpdateFlags get_needed_update_flags () const;
+      };
+    }
+  }
+}
+
+#endif

--- a/include/aspect/postprocess/visualization/devstress.h
+++ b/include/aspect/postprocess/visualization/devstress.h
@@ -1,0 +1,93 @@
+/*
+  Copyright (C) 2015 - 2017 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef _aspect_postprocess_visualization_devstress_h
+#define _aspect_postprocess_visualization_devstress_h
+
+#include <aspect/postprocess/visualization.h>
+#include <aspect/simulator_access.h>
+
+#include <deal.II/numerics/data_postprocessor.h>
+
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    namespace VisualizationPostprocessors
+    {
+      /**
+       * A class derived from DataPostprocessor that takes an output vector
+       * and computes a variable that represents the 3 or 6 independent
+       * components (in 2d and 3d, respectively) of the deviatoric stress tensor at every
+       * point. The shear stress is defined as $2 \eta (\varepsilon(\mathbf u)
+       * - \tfrac 13 \textrm{trace}\ \varepsilon(\mathbf u) \mathbf 1) =
+       * 2\eta (\varepsilon(\mathbf u) - \frac 13 (\nabla \cdot \mathbf u)
+       * \mathbf I)$.  The second term in the parentheses is zero if the
+       * model is incompressible.
+       *
+       * The member functions are all implementations of those declared in the
+       * base class. See there for their meaning.
+       */
+      template <int dim>
+      class DevStress
+        : public DataPostprocessor<dim>,
+          public SimulatorAccess<dim>,
+          public Interface<dim>
+      {
+        public:
+          virtual
+          void
+          evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
+                                std::vector<Vector<double> > &computed_quantities) const;
+
+          /**
+           * Return the vector of strings describing the names of the computed
+           * quantities. Given the purpose of this class, this is a vector
+           * with entries all equal to the name of the plugin.
+           */
+          virtual std::vector<std::string> get_names () const;
+
+          /**
+           * This functions returns information about how the individual
+           * components of output files that consist of more than one data set
+           * are to be interpreted. The returned value is
+           * DataComponentInterpretation::component_is_scalar repeated
+           * SymmetricTensor::n_independent_components times. (These
+           * components should really be part of a symmetric tensor, but
+           * deal.II does not allow marking components as such.)
+           */
+          virtual
+          std::vector<DataComponentInterpretation::DataComponentInterpretation>
+          get_data_component_interpretation () const;
+
+          /**
+           * Return which data has to be provided to compute the derived
+           * quantities. The flags returned here are the ones passed to the
+           * constructor of this class.
+           */
+          virtual UpdateFlags get_needed_update_flags () const;
+      };
+    }
+  }
+}
+
+#endif

--- a/source/postprocess/visualization/deviatoric_stress.cc
+++ b/source/postprocess/visualization/deviatoric_stress.cc
@@ -1,0 +1,146 @@
+/*
+  Copyright (C) 2011 - 2019 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/postprocess/visualization/deviatoric_stress.h>
+
+
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    namespace VisualizationPostprocessors
+    {
+      template <int dim>
+      void
+      DeviatoricStress<dim>::
+      evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
+                            std::vector<Vector<double> > &computed_quantities) const
+      {
+        const unsigned int n_quadrature_points = input_data.solution_values.size();
+        Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
+        Assert ((computed_quantities[0].size() == SymmetricTensor<2,dim>::n_independent_components),
+                ExcInternalError());
+        Assert (input_data.solution_values[0].size() == this->introspection().n_components,   ExcInternalError());
+        Assert (input_data.solution_gradients[0].size() == this->introspection().n_components,  ExcInternalError());
+
+        MaterialModel::MaterialModelInputs<dim> in(input_data,
+                                                   this->introspection());
+        MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points,
+                                                     this->n_compositional_fields());
+
+        // Compute the viscosity...
+        this->get_material_model().evaluate(in, out);
+
+        // ...and use it to compute the stresses
+        for (unsigned int q=0; q<n_quadrature_points; ++q)
+          {
+            const SymmetricTensor<2,dim> strain_rate = in.strain_rate[q];
+            const SymmetricTensor<2,dim> compressible_strain_rate
+              = (this->get_material_model().is_compressible()
+                 ?
+                 strain_rate - 1./3 * trace(strain_rate) * unit_symmetric_tensor<dim>()
+                 :
+                 strain_rate);
+
+            const double eta = out.viscosities[q];
+
+            const SymmetricTensor<2,dim> devstress = 2*eta*compressible_strain_rate;
+            for (unsigned int i=0; i<SymmetricTensor<2,dim>::n_independent_components; ++i)
+              computed_quantities[q](i) = devstress[devstress.unrolled_to_component_indices(i)];
+          }
+      }
+
+
+      template <int dim>
+      std::vector<std::string>
+      DeviatoricStress<dim>::get_names () const
+      {
+        std::vector<std::string> names;
+        switch (dim)
+          {
+            case 2:
+              names.emplace_back("deviatoric_stress_xx");
+              names.emplace_back("deviatoric_stress_yy");
+              names.emplace_back("deviatoric_stress_xy");
+              break;
+
+            case 3:
+              names.emplace_back("deviatoric_stress_xx");
+              names.emplace_back("deviatoric_stress_yy");
+              names.emplace_back("deviatoric_stress_zz");
+              names.emplace_back("deviatoric_stress_xy");
+              names.emplace_back("deviatoric_stress_xz");
+              names.emplace_back("deviatoric_stress_yz");
+              break;
+
+            default:
+              Assert (false, ExcNotImplemented());
+          }
+
+        return names;
+      }
+
+
+      template <int dim>
+      std::vector<DataComponentInterpretation::DataComponentInterpretation>
+      DeviatoricStress<dim>::get_data_component_interpretation () const
+      {
+        return
+          std::vector<DataComponentInterpretation::DataComponentInterpretation>
+          (SymmetricTensor<2,dim>::n_independent_components,
+           DataComponentInterpretation::component_is_scalar);
+      }
+
+
+
+      template <int dim>
+      UpdateFlags
+      DeviatoricStress<dim>::get_needed_update_flags () const
+      {
+        return update_gradients | update_values | update_quadrature_points;
+      }
+
+    }
+  }
+}
+
+
+// explicit instantiations
+namespace aspect
+{
+  namespace Postprocess
+  {
+    namespace VisualizationPostprocessors
+    {
+      ASPECT_REGISTER_VISUALIZATION_POSTPROCESSOR(DeviatoricStress,
+                                                  "deviatoric_stress",
+                                                  "A visualization output object that generates output "
+                                                  "for the 3 (in 2d) or 6 (in 3d) components of the deviatoric stress "
+                                                  "tensor, i.e., for the components of the tensor "
+                                                  "$2\\eta\\varepsilon(\\mathbf u)$ "
+                                                  "in the incompressible case and "
+                                                  "$2\\eta\\left[\\varepsilon(\\mathbf u)-"
+                                                  "\\tfrac 13(\\textrm{tr}\\;\\varepsilon(\\mathbf u))\\mathbf I\\right]$ "
+                                                  "in the compressible case.")
+    }
+  }
+}

--- a/source/postprocess/visualization/devstress.cc
+++ b/source/postprocess/visualization/devstress.cc
@@ -1,0 +1,146 @@
+/*
+  Copyright (C) 2011 - 2019 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/postprocess/visualization/devstress.h>
+
+
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    namespace VisualizationPostprocessors
+    {
+      template <int dim>
+      void
+      DevStress<dim>::
+      evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
+                            std::vector<Vector<double> > &computed_quantities) const
+      {
+        const unsigned int n_quadrature_points = input_data.solution_values.size();
+        Assert (computed_quantities.size() == n_quadrature_points,    ExcInternalError());
+        Assert ((computed_quantities[0].size() == SymmetricTensor<2,dim>::n_independent_components),
+                ExcInternalError());
+        Assert (input_data.solution_values[0].size() == this->introspection().n_components,   ExcInternalError());
+        Assert (input_data.solution_gradients[0].size() == this->introspection().n_components,  ExcInternalError());
+
+        MaterialModel::MaterialModelInputs<dim> in(input_data,
+                                                   this->introspection());
+        MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points,
+                                                     this->n_compositional_fields());
+
+        // Compute the viscosity...
+        this->get_material_model().evaluate(in, out);
+
+        // ...and use it to compute the stresses
+        for (unsigned int q=0; q<n_quadrature_points; ++q)
+          {
+            const SymmetricTensor<2,dim> strain_rate = in.strain_rate[q];
+            const SymmetricTensor<2,dim> compressible_strain_rate
+              = (this->get_material_model().is_compressible()
+                 ?
+                 strain_rate - 1./3 * trace(strain_rate) * unit_symmetric_tensor<dim>()
+                 :
+                 strain_rate);
+
+            const double eta = out.viscosities[q];
+
+            const SymmetricTensor<2,dim> devstress = 2*eta*compressible_strain_rate;
+            for (unsigned int i=0; i<SymmetricTensor<2,dim>::n_independent_components; ++i)
+              computed_quantities[q](i) = devstress[devstress.unrolled_to_component_indices(i)];
+          }
+      }
+
+
+      template <int dim>
+      std::vector<std::string>
+      DevStress<dim>::get_names () const
+      {
+        std::vector<std::string> names;
+        switch (dim)
+          {
+            case 2:
+              names.emplace_back("devstress_xx");
+              names.emplace_back("devstress_yy");
+              names.emplace_back("devstress_xy");
+              break;
+
+            case 3:
+              names.emplace_back("devstress_xx");
+              names.emplace_back("devstress_yy");
+              names.emplace_back("devstress_zz");
+              names.emplace_back("devstress_xy");
+              names.emplace_back("devstress_xz");
+              names.emplace_back("devstress_yz");
+              break;
+
+            default:
+              Assert (false, ExcNotImplemented());
+          }
+
+        return names;
+      }
+
+
+      template <int dim>
+      std::vector<DataComponentInterpretation::DataComponentInterpretation>
+      DevStress<dim>::get_data_component_interpretation () const
+      {
+        return
+          std::vector<DataComponentInterpretation::DataComponentInterpretation>
+          (SymmetricTensor<2,dim>::n_independent_components,
+           DataComponentInterpretation::component_is_scalar);
+      }
+
+
+
+      template <int dim>
+      UpdateFlags
+      DevStress<dim>::get_needed_update_flags () const
+      {
+        return update_gradients | update_values | update_quadrature_points;
+      }
+
+    }
+  }
+}
+
+
+// explicit instantiations
+namespace aspect
+{
+  namespace Postprocess
+  {
+    namespace VisualizationPostprocessors
+    {
+      ASPECT_REGISTER_VISUALIZATION_POSTPROCESSOR(DevStress,
+                                                  "devstress",
+                                                  "A visualization output object that generates output "
+                                                  "for the 3 (in 2d) or 6 (in 3d) components of the deviatoric stress "
+                                                  "tensor, i.e., for the components of the tensor "
+                                                  "$2\\eta\\varepsilon(\\mathbf u)$ "
+                                                  "in the incompressible case and "
+                                                  "$2\\eta\\left[\\varepsilon(\\mathbf u)-"
+                                                  "\\tfrac 13(\\textrm{tr}\\;\\varepsilon(\\mathbf u))\\mathbf I\\right]$ "
+                                                  "in the compressible case.")
+    }
+  }
+}


### PR DESCRIPTION
This is a small addition to postprocess/visualisation: 
the stress.cc (and stress.h) postprocessor was outputting all components of the (full) stress tensor. 
I created a slightly modified set of files (devstress.cc and devstress.h) that output the deviatoric stress: for each component, the full stress = viscosity*strainrate + pressure, and the deviatoric stress is simply devstress = viscosity*strainrate (i.e. without the pressure term). 

This is useful to (e.g.) visualize the stresses that drive shortening or extension in the lithosphere.