### PR TITLE
Finish removing 9.0.0 references from geometry_model

### DIFF
--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -55,23 +55,12 @@ namespace aspect
     {
       public:
 
-#if !DEAL_II_VERSION_GTE(9,0,0)
-        void initialize ();
-#endif
-
         /**
          * Generate a coarse mesh for the geometry described by this class.
          */
         virtual
         void create_coarse_mesh (parallel::distributed::Triangulation<dim> &coarse_grid) const;
 
-#if !DEAL_II_VERSION_GTE(9,0,0)
-        /**
-         * Connect the set/clear manifold id functions to the post/pre_compute_no_normal_flux signals.
-         */
-        void
-        connect_to_signal(SimulatorSignals<dim> &signals);
-#endif
 
         /**
          * Return the set of boundary indicators that are used by this model.
@@ -319,14 +308,12 @@ namespace aspect
             void
             set_min_longitude(const double p1_lon);
 
-#if DEAL_II_VERSION_GTE(9,0,0)
             /**
              * Return a copy of this manifold.
              */
             virtual
             std::unique_ptr<Manifold<dim,dim> >
             clone() const;
-#endif
 
           private:
             // The minimum longitude of the domain
@@ -337,11 +324,6 @@ namespace aspect
          * An object that describes the geometry.
          */
         ChunkGeometry manifold;
-
-#if !DEAL_II_VERSION_GTE(9,0,0)
-        void set_manifold_ids (typename parallel::distributed::Triangulation<dim> &triangulation);
-        void clear_manifold_ids (typename parallel::distributed::Triangulation<dim> &triangulation);
-#endif
     };
   }
 }

--- a/include/aspect/geometry_model/ellipsoidal_chunk.h
+++ b/include/aspect/geometry_model/ellipsoidal_chunk.h
@@ -107,14 +107,12 @@ namespace aspect
             Point<3>
             push_forward(const Point<3> &chart_point) const;
 
-#if DEAL_II_VERSION_GTE(9,0,0)
             /**
              * Return a copy of this manifold.
              */
             virtual
             std::unique_ptr<Manifold<dim,3> >
             clone() const;
-#endif
 
           private:
             /**

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -28,10 +28,6 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/grid_tools.h>
 
-#if !DEAL_II_VERSION_GTE(9,0,0)
-#include <deal.II/grid/tria_boundary_lib.h>
-#endif
-
 
 namespace aspect
 {
@@ -186,8 +182,6 @@ namespace aspect
     }
 
 
-
-#if DEAL_II_VERSION_GTE(9,0,0)
     template <int dim>
     std::unique_ptr<Manifold<dim,dim> >
     Chunk<dim>::ChunkGeometry::
@@ -195,22 +189,6 @@ namespace aspect
     {
       return std_cxx14::make_unique<ChunkGeometry>(*this);
     }
-#endif
-
-
-
-#if !DEAL_II_VERSION_GTE(9,0,0)
-    template <int dim>
-    void
-    Chunk<dim>::initialize ()
-    {
-      // Call function to connect the set/clear manifold id functions
-      // to the right signal
-      connect_to_signal(this->get_signals());
-
-    }
-#endif
-
 
 
     template <int dim>
@@ -224,50 +202,6 @@ namespace aspect
                                                  point1,
                                                  point2,
                                                  true);
-
-#if !DEAL_II_VERSION_GTE(9,0,0)
-      // At this point, all boundary faces have their correct boundary
-      // indicators, but the edges do not. We want the edges of curved
-      // faces to be curved as well, so we set the edge boundary indicators
-      // to the same boundary indicators as their faces.
-      for (typename Triangulation<dim>::active_cell_iterator
-           cell = coarse_grid.begin_active();
-           cell != coarse_grid.end(); ++cell)
-        for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
-          if (cell->face(f)->at_boundary())
-            // Set edges on the radial faces; both adjacent faces
-            // should agree on where new points along the boundary lie
-            // for these edges, so the order of the boundaries does not matter
-            if ((cell->face(f)->boundary_id() == 2)
-                ||
-                (cell->face(f)->boundary_id() == 3))
-              cell->face(f)->set_all_boundary_ids(cell->face(f)->boundary_id());
-
-      for (typename Triangulation<dim>::active_cell_iterator
-           cell = coarse_grid.begin_active();
-           cell != coarse_grid.end(); ++cell)
-        for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
-          if (cell->face(f)->at_boundary())
-            // Set edges on the radial faces; both adjacent faces
-            // should agree on where new points along the boundary lie
-            // for these edges, so the order of the boundaries does not matter
-            if ((cell->face(f)->boundary_id() == 4)
-                ||
-                (cell->face(f)->boundary_id() == 5))
-              cell->face(f)->set_all_boundary_ids(cell->face(f)->boundary_id());
-
-      for (typename Triangulation<dim>::active_cell_iterator
-           cell = coarse_grid.begin_active();
-           cell != coarse_grid.end(); ++cell)
-        for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
-          if (cell->face(f)->at_boundary())
-            // (Re-)Set edges on the spherical shells to ensure that
-            // they are all curved as expected
-            if ((cell->face(f)->boundary_id() == 0)
-                ||
-                (cell->face(f)->boundary_id() == 1))
-              cell->face(f)->set_all_boundary_ids(cell->face(f)->boundary_id());
-#endif
 
       // Transform box into spherical chunk
       GridTools::transform (
@@ -283,98 +217,8 @@ namespace aspect
       for (typename Triangulation<dim>::active_cell_iterator cell =
              coarse_grid.begin_active(); cell != coarse_grid.end(); ++cell)
         cell->set_all_manifold_ids (15);
-
-#if !DEAL_II_VERSION_GTE(9,0,0)
-      // On the boundary faces, set boundary objects.
-      // The east and west boundaries are straight,
-      // the inner and outer boundary are part of
-      // a spherical shell. In 3D, the north and south boundaries
-      // are part of a cone with the tip at the origin.
-      static const StraightBoundary<dim> boundary_straight;
-
-      // Attach boundary objects to the straight east and west boundaries
-      coarse_grid.set_boundary(2, boundary_straight);
-      coarse_grid.set_boundary(3, boundary_straight);
-
-      if (dim == 3)
-        {
-          // Define the center point of the greater radius end of the
-          // north and south boundary cones.
-          // These lie along the z-axis.
-          Point<dim> center;
-          Point<dim> north, south;
-          const double outer_radius = point2[0];
-          north[dim-1] = outer_radius * std::sin(point2[2]);
-          south[dim-1] = outer_radius * std::sin(point1[2]);
-          // Define the radius of the cones
-          const double north_radius = std::sqrt(outer_radius*outer_radius-north[dim-1]*north[dim-1]);
-          const double south_radius = std::sqrt(outer_radius*outer_radius-south[dim-1]*south[dim-1]);
-          static const ConeBoundary<dim> boundary_cone_north(0.0,north_radius,center,north);
-          static const ConeBoundary<dim> boundary_cone_south(0.0,south_radius,center,south);
-
-          // Attach boundary objects to the conical north and south boundaries
-          // If one of the boundaries lies at the equator,
-          // just use the straight boundary.
-          if (point2[2] != 0.0)
-            coarse_grid.set_boundary (5, boundary_cone_north);
-          else
-            coarse_grid.set_boundary (5, boundary_straight);
-
-          if (point1[2] != 0.0)
-            coarse_grid.set_boundary (4, boundary_cone_south);
-          else
-            coarse_grid.set_boundary (4, boundary_straight);
-        }
-
-      // Attach shell boundary objects to the curved inner and outer boundaries
-      static const HyperShellBoundary<dim> boundary_shell;
-      coarse_grid.set_boundary (0, boundary_shell);
-      coarse_grid.set_boundary (1, boundary_shell);
-#endif
     }
 
-#if !DEAL_II_VERSION_GTE(9,0,0)
-    template <int dim>
-    void
-    Chunk<dim>::set_manifold_ids (typename parallel::distributed::Triangulation<dim> &triangulation)
-    {
-      // Set all cells, faces and edges to manifold_id 15
-      for (typename Triangulation<dim>::active_cell_iterator cell =
-             triangulation.begin_active(); cell != triangulation.end(); ++cell)
-        cell->set_all_manifold_ids (15);
-    }
-
-    template <int dim>
-    void
-    Chunk<dim>::clear_manifold_ids (typename parallel::distributed::Triangulation<dim> &triangulation)
-    {
-      // Clear the manifold_id from the faces and edges at the boundary
-      // so that the boundary objects can be used
-      for (typename Triangulation<dim>::active_cell_iterator cell =
-             triangulation.begin_active(); cell != triangulation.end(); ++cell)
-        for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
-          if (cell->face(f)->at_boundary())
-            cell->face(f)->set_all_manifold_ids (numbers::flat_manifold_id);
-    }
-
-    template <int dim>
-    void
-    Chunk<dim>::connect_to_signal (SimulatorSignals<dim> &signals)
-    {
-      // Connect the topography function to the signal
-      signals.pre_compute_no_normal_flux_constraints.connect (
-        [&](typename parallel::distributed::Triangulation<dim> &tria)
-      {
-        this->clear_manifold_ids(tria);
-      });
-
-      signals.post_compute_no_normal_flux_constraints.connect (
-        [&](typename parallel::distributed::Triangulation<dim> &tria)
-      {
-        this->set_manifold_ids(tria);
-      });
-    }
-#endif
 
     template <int dim>
     std::set<types::boundary_id>

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -22,11 +22,6 @@
 #include <aspect/geometry_model/ellipsoidal_chunk.h>
 #include <aspect/utilities.h>
 #include <deal.II/grid/tria_iterator.h>
-
-#if !DEAL_II_VERSION_GTE(9,0,0)
-#include <deal.II/grid/tria_boundary_lib.h>
-#endif
-
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>
@@ -232,14 +227,12 @@ namespace aspect
       return push_forward_ellipsoid (push_forward_topography(chart_point), semi_major_axis_a, eccentricity);
     }
 
-#if DEAL_II_VERSION_GTE(9,0,0)
     template <int dim>
     std::unique_ptr<Manifold<dim,3> >
     EllipsoidalChunk<dim>::EllipsoidalChunkGeometry::clone() const
     {
       return std_cxx14::make_unique<EllipsoidalChunkGeometry>(*this);
     }
-#endif
 
     template <int dim>
     void


### PR DESCRIPTION
Referenced in this issue: https://github.com/geodynamics/aspect/issues/2921

Combined with https://github.com/geodynamics/aspect/pull/3122 there are no more references to DEAL9.0.0 in `geometry_model`