### PR TITLE
Updated: Material model that sets a constant viscosity in the lithosphere

### DIFF
--- a/doc/modules/changes/20190628_coulson
+++ b/doc/modules/changes/20190628_coulson
@@ -1,0 +1,8 @@
+New: There is a new material model plug-in that sets viscosity to  
+a specified constant above the lithosphere-asthenosphere boundary,
+which is specified by an ascii file or a maximum lithosphere depth 
+value. Below this the viscosity is taken from any other available
+material model. All other material properties are taken from the
+base model.
+<br>
+(Sophie Coulson, 2019/06/28)

--- a/include/aspect/material_model/replace_lithosphere_viscosity.h
+++ b/include/aspect/material_model/replace_lithosphere_viscosity.h
@@ -58,9 +58,9 @@ namespace aspect
          */
         virtual
         void
-
         evaluate (const typename Interface<dim>::MaterialModelInputs &in,
                   typename Interface<dim>::MaterialModelOutputs &out) const;
+
         /**
          * Method to declare parameters related to replace lithosphere viscosity model
          */

--- a/include/aspect/material_model/replace_lithosphere_viscosity.h
+++ b/include/aspect/material_model/replace_lithosphere_viscosity.h
@@ -1,0 +1,107 @@
+/*
+  Copyright (C) 2014 - 2018 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _aspect_material_model_replace_lithosphere_viscosity_h
+#define _aspect_material_model_replace_lithosphere_viscosity_h
+
+#include <aspect/material_model/interface.h>
+#include <aspect/simulator_access.h>
+#include <aspect/utilities.h>
+#include <aspect/initial_temperature/lithosphere_mask.h>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    using namespace dealii;
+
+    /**
+     * A material model that applies a given constant viscosity in the lithosphere.
+     * Viscosity below this is taken from a ''base model'' chosen from any of the
+     * other available material models. The 'replace lithosphere viscosity'
+     * material model allows the user to specify the depth of the lithosphere-asthenosphre
+     * boundary either as one value or as a file. All other properties are derived
+     * from the base model.
+     * @ingroup MaterialModels
+     */
+    template <int dim>
+    class ReplaceLithosphereViscosity : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    {
+      public:
+
+        /**
+         * Initialize the base model at the beginning of the run.
+         */
+        virtual
+        void initialize();
+
+        /**
+         * Function to compute the material properties in @p out given the
+         * inputs in @p in.
+         */
+        virtual
+        void
+        evaluate (const typename Interface<dim>::MaterialModelInputs &in,
+                  typename Interface<dim>::MaterialModelOutputs &out) const;
+        /**
+         * Method to declare parameters related to depth-dependent model
+         */
+        static void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Method to parse parameters related to depth-dependent model
+         */
+        virtual void
+        parse_parameters (ParameterHandler &prm);
+
+        /**
+         * Method that indicates whether material is compressible. Depth dependent model is compressible
+         * if and only if base model is compressible.
+         */
+        virtual bool is_compressible () const;
+
+        /**
+         * Method to calculate reference viscosity for the model. The reference
+         * viscosity is simply the reference  viscosity from the base model.
+         */
+        virtual double reference_viscosity () const;
+
+      private:
+
+
+        /**
+        * This parameter gives the viscosity set within the lithosphere.
+        */
+        double lithosphere_viscosity;
+
+
+        /**
+         * Pointer to the material model used as the base model
+         */
+        std::shared_ptr<MaterialModel::Interface<dim> > base_model;
+
+
+        InitialTemperature::LABDepth::LABDepthLookup<dim> lab_depth_lookup;
+    };
+  }
+}
+
+#endif

--- a/include/aspect/material_model/replace_lithosphere_viscosity.h
+++ b/include/aspect/material_model/replace_lithosphere_viscosity.h
@@ -36,7 +36,7 @@ namespace aspect
      * A material model that applies a given constant viscosity in the lithosphere.
      * Viscosity below this is taken from a ''base model'' chosen from any of the
      * other available material models. The 'replace lithosphere viscosity'
-     * material model allows the user to specify the depth of the lithosphere-asthenosphre
+     * material model allows the user to specify the depth of the lithosphere-asthenosphere
      * boundary either as one value or as a file. All other properties are derived
      * from the base model.
      * @ingroup MaterialModels
@@ -58,22 +58,23 @@ namespace aspect
          */
         virtual
         void
+
         evaluate (const typename Interface<dim>::MaterialModelInputs &in,
                   typename Interface<dim>::MaterialModelOutputs &out) const;
         /**
-         * Method to declare parameters related to depth-dependent model
+         * Method to declare parameters related to replace lithosphere viscosity model
          */
         static void
         declare_parameters (ParameterHandler &prm);
 
         /**
-         * Method to parse parameters related to depth-dependent model
+         * Method to parse parameters related to replace lithosphere viscosity model
          */
         virtual void
         parse_parameters (ParameterHandler &prm);
 
         /**
-         * Method that indicates whether material is compressible. Depth dependent model is compressible
+         * Method that indicates whether material is compressible. Replace lithosphere viscosity model is compressible
          * if and only if base model is compressible.
          */
         virtual bool is_compressible () const;
@@ -85,7 +86,6 @@ namespace aspect
         virtual double reference_viscosity () const;
 
       private:
-
 
         /**
         * This parameter gives the viscosity set within the lithosphere.

--- a/source/material_model/replace_lithosphere_viscosity.cc
+++ b/source/material_model/replace_lithosphere_viscosity.cc
@@ -58,8 +58,6 @@ namespace aspect
 
           if (depth <= lab_depth)
             out.viscosities[i] = lithosphere_viscosity;
-          else
-            out.viscosities[i] *= 1;
         }
 
     }
@@ -80,7 +78,7 @@ namespace aspect
                             "are the names of models that are also valid for the "
                             "``Material models/Model name'' parameter. See the documentation for "
                             "more information.");
-          prm.declare_entry ("Lithosphere viscosity", "1600",
+          prm.declare_entry ("Lithosphere viscosity", "1e23",
                              Patterns::Double (0),
                              "The viscosity within lithosphere, applied above"
                              "the maximum lithosphere depth.");

--- a/source/material_model/replace_lithosphere_viscosity.cc
+++ b/source/material_model/replace_lithosphere_viscosity.cc
@@ -162,7 +162,7 @@ namespace aspect
                                    "In other words, it is a ``compositing material model''."
                                    "\n"
                                    "Parameters related to the replace lithosphere viscosity model are read from a subsection "
-                                   "``Material model/replace lithosphere vicsosity''. "
+                                   "``Material model/Replace lithosphere viscosity''. "
                                    "The user must specify a ``Base model'' from which other material properties are "
                                    "derived.  "
                                    "\n"

--- a/source/material_model/replace_lithosphere_viscosity.cc
+++ b/source/material_model/replace_lithosphere_viscosity.cc
@@ -1,0 +1,176 @@
+/*
+  Copyright (C) 2011 - 2019 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/material_model/replace_lithosphere_viscosity.h>
+#include <aspect/initial_temperature/lithosphere_mask.h>
+#include <aspect/utilities.h>
+#include <aspect/geometry_model/interface.h>
+
+#include <limits>
+
+#include <array>
+#include <utility>
+
+
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    template <int dim>
+    void
+    ReplaceLithosphereViscosity<dim>::initialize()
+    {
+      base_model->initialize();
+
+      lab_depth_lookup.initialize();
+    }
+
+
+    template <int dim>
+    void
+    ReplaceLithosphereViscosity<dim>::evaluate(const typename Interface<dim>::MaterialModelInputs &in,
+                                               typename Interface<dim>::MaterialModelOutputs &out) const
+    {
+      base_model->evaluate(in,out);
+
+      for (unsigned int i=0; i < in.position.size(); ++i)
+        {
+          const double depth = this->SimulatorAccess<dim>::get_geometry_model().depth(in.position[i]);
+          const double lab_depth = lab_depth_lookup.get_lab_depth(in.position[i]);
+
+          if (depth <= lab_depth)
+            out.viscosities[i] = lithosphere_viscosity;
+          else
+            out.viscosities[i] *= 1;
+        }
+
+    }
+
+
+    template <int dim>
+    void
+    ReplaceLithosphereViscosity<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Material model");
+      {
+        prm.enter_subsection("Replace lithosphere viscosity");
+        {
+          prm.declare_entry("Base model","simple",
+                            Patterns::Selection(MaterialModel::get_valid_model_names_pattern<dim>()),
+                            "The name of a material model that will be modified by a replacing"
+                            "the viscosity in the lithosphere by a constant value. Valid values for this parameter "
+                            "are the names of models that are also valid for the "
+                            "``Material models/Model name'' parameter. See the documentation for "
+                            "more information.");
+          prm.declare_entry ("Lithosphere viscosity", "1600",
+                             Patterns::Double (0),
+                             "The viscosity within lithosphere, applied above"
+                             "the maximum lithosphere depth.");
+
+          InitialTemperature::LABDepth::LABDepthLookup<dim>::declare_parameters(prm);
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+    template <int dim>
+    void
+    ReplaceLithosphereViscosity<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      AssertThrow (dim == 3,
+                   ExcMessage ("The 'Replace lithosphere viscosity' material model "
+                               "is only available for 3d computations."));
+
+      prm.enter_subsection("Material model");
+      {
+        prm.enter_subsection("Replace lithosphere viscosity");
+        {
+          AssertThrow( prm.get("Base model") != "replace lithosphere viscosity",
+                       ExcMessage("You may not use ``replace lithosphere viscosity'' as the base model for "
+                                  "a replace lithosphere viscosity model.") );
+
+          // create the base model and initialize its SimulatorAccess base
+          // class; it will get a chance to read its parameters below after we
+          // leave the current section
+          base_model.reset(create_material_model<dim>(prm.get("Base model")));
+          if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(base_model.get()))
+            sim->initialize_simulator (this->get_simulator());
+
+          lab_depth_lookup.initialize_simulator(this->get_simulator());
+          lab_depth_lookup.parse_parameters(prm);
+          lithosphere_viscosity   = prm.get_double ("Lithosphere viscosity");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+
+      /* After parsing the parameters for replace lithosphere viscosity, it is essential to parse
+      parameters related to the base model. */
+      base_model->parse_parameters(prm);
+      this->model_dependence = base_model->get_model_dependence();
+    }
+
+    template <int dim>
+    bool
+    ReplaceLithosphereViscosity<dim>::
+    is_compressible () const
+    {
+      return base_model->is_compressible();
+    }
+
+    template <int dim>
+    double
+    ReplaceLithosphereViscosity<dim>::
+    reference_viscosity() const
+    {
+      /* Return reference viscosity from base model*/
+      return base_model->reference_viscosity();
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    ASPECT_REGISTER_MATERIAL_MODEL(ReplaceLithosphereViscosity,
+                                   "replace lithosphere viscosity",
+                                   "The ``replace lithosphere viscosity'' Material model sets viscosity to a "
+                                   "prescribed constant above the lithosphere-asthenosphere boundary (specified by "
+                                   "an ascii file or maximum lithosphere depth). Below the lithosphere-asthenosphere"
+                                   "boundary the viscosity is taken from any of the other available material model. "
+                                   "In other words, it is a ``compositing material model''."
+                                   "\n"
+                                   "Parameters related to the depth dependent model are read from a subsection "
+                                   "``Material model/replace lithosphere vicsosity''. "
+                                   "The user must specify a ``Base model'' from which other material properties are "
+                                   "derived.  "
+                                   "\n"
+                                   "Note the required format of the input data file: The first lines may "
+                                   "contain any number of comments if they begin with ‘#’, but one of these lines "
+                                   "needs to contain the number of grid points in each dimension as for example"
+                                   "‘# POINTS: 3 3’. For a spherical model, the order of the data columns has to be"
+                                   "'phi', 'theta','depth (m)', where phi is the  azimuth angle and theta is the "
+                                   "polar angle measured positive from the north pole.")
+  }
+}

--- a/source/material_model/replace_lithosphere_viscosity.cc
+++ b/source/material_model/replace_lithosphere_viscosity.cc
@@ -161,7 +161,7 @@ namespace aspect
                                    "boundary the viscosity is taken from any of the other available material model. "
                                    "In other words, it is a ``compositing material model''."
                                    "\n"
-                                   "Parameters related to the depth dependent model are read from a subsection "
+                                   "Parameters related to the replace lithosphere viscosity model are read from a subsection "
                                    "``Material model/replace lithosphere vicsosity''. "
                                    "The user must specify a ``Base model'' from which other material properties are "
                                    "derived.  "

--- a/tests/replace_lithosphere_viscosity_file/screen-output
+++ b/tests/replace_lithosphere_viscosity_file/screen-output
@@ -1,0 +1,33 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+   Loading Ascii data lookup file ASPECT_DIR/data/initial-temperature/lithosphere-mask/LAB_CAM2016.txt.
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 96 (on 1 levels)
+Number of degrees of freedom: 4,030 (2,910+150+970)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+26 iterations.
+
+   Postprocessing:
+     RMS, max velocity: 2.82e-11 m/s, 7.03e-11 m/s
+
+*** Timestep 1:  t=100000 seconds
+   Solving temperature system... 0 iterations.
+   Solving Stokes system... 200+19 iterations.
+
+   Postprocessing:
+     RMS, max velocity: 2.82e-11 m/s, 7.03e-11 m/s
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------


### PR DESCRIPTION
Updated from #3089 according to Rene's comments. @gassmoeller

New material model plug-in that sets a constant specified lithosphere viscosity above the lithosphere-asthenosphere boundary and takes the viscosity from a base model below this. The LAB can be specified by an ascii file or a maximum lithosphere depth value. All other material properties are taken from the base model.
