### PR TITLE
[WIP] fluid pressure boundary conditions

### DIFF
--- a/include/aspect/boundary_fluid_pressure/density.h
+++ b/include/aspect/boundary_fluid_pressure/density.h
@@ -80,7 +80,8 @@ namespace aspect
           {
             solid_density,
             fluid_density,
-            average_density
+            average_density,
+            zero
           };
         };
 

--- a/include/aspect/boundary_fluid_pressure/interface.h
+++ b/include/aspect/boundary_fluid_pressure/interface.h
@@ -90,6 +90,28 @@ namespace aspect
           std::vector<double> &fluid_pressure_gradient_outputs
         ) const = 0;
 
+
+        virtual
+        double fluid_pressure (const types::boundary_id boundary_indicator,
+                               const Point<dim> &position) const;
+
+
+        /**
+         * A function that is called at the beginning of each time step. The
+         * default implementation of the function does nothing, but derived
+         * classes that need more elaborate setups for a given time step may
+         * overload the function.
+         *
+         * The point of this function is to allow complex boundary fluid pressure
+         * models to do an initialization step once at the beginning of each
+         * time step. An example would be a model that needs to call an
+         * external program to compute temperature change at bottom.
+         */
+        virtual
+        void
+        update ();
+
+
         /**
          * Declare the parameters this class takes through input files. The
          * default implementation of this function does not describe any
@@ -110,6 +132,7 @@ namespace aspect
         void
         parse_parameters (ParameterHandler &prm);
     };
+
 
 
     /**

--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -370,6 +370,12 @@ namespace aspect
        * be averaged cell-wise.
        */
       bool average_melt_velocity;
+
+      /**
+       * A set of boundary ids on which the boundary_temperature_objects
+       * will be applied.
+       */
+      std::set<types::boundary_id> prescribed_boundary_fluid_pressure_indicators;
     };
   }
 
@@ -408,6 +414,18 @@ namespace aspect
        * matrices, and right hand side vectors.
        */
       void set_assemblers (Assemblers::Manager<dim> &assemblers) const;
+
+
+      /**
+       * Parse additional parameters that are needed in models with
+       * melt transport, and that depend on the model geometry.
+       *
+       * Because the parse_parameters function is called before
+       * edit_finite_element_variables, parameters that depend on the
+       * geometry have to be parsed later, after the geometry model
+       * and simulator access are initialized.
+       */
+      void parse_geometry_dependent_parameters (ParameterHandler &prm);
 
 
       /**
@@ -479,6 +497,13 @@ namespace aspect
        */
       const BoundaryFluidPressure::Interface<dim> &
       get_boundary_fluid_pressure () const;
+
+      /*
+       * Return a set of boundary indicators for which boundary
+       * fluid pressures are prescribed.
+       */
+      const std::set<types::boundary_id> &
+      get_prescribed_fluid_pressure_boundary_indicators() const;
 
       /**
        * The object that stores the run-time parameters that control the how the

--- a/source/boundary_fluid_pressure/density.cc
+++ b/source/boundary_fluid_pressure/density.cc
@@ -72,6 +72,12 @@ namespace aspect
                 break;
               }
 
+              case DensityFormulation::zero:
+              {
+                fluid_pressure_gradient_outputs[q] = 0.0;
+                break;
+              }
+
               default:
                 Assert (false, ExcNotImplemented());
             }
@@ -87,7 +93,7 @@ namespace aspect
         prm.enter_subsection("Density");
         {
           prm.declare_entry ("Density formulation", "solid density",
-                             Patterns::Selection ("solid density|fluid density|average density"),
+                             Patterns::Selection ("solid density|fluid density|average density|zero"),
                              "The density formulation used to compute the fluid pressure gradient "
                              "at the model boundary."
                              "\n\n"
@@ -130,6 +136,8 @@ namespace aspect
             density_formulation = DensityFormulation::fluid_density;
           else if (prm.get ("Density formulation") == "average density")
             density_formulation = DensityFormulation::average_density;
+          else if (prm.get ("Density formulation") == "zero")
+            density_formulation = DensityFormulation::zero;
           else
             AssertThrow (false, ExcNotImplemented());
         }

--- a/source/boundary_fluid_pressure/interface.cc
+++ b/source/boundary_fluid_pressure/interface.cc
@@ -37,10 +37,27 @@ namespace aspect
     Interface<dim>::~Interface ()
     {}
 
+
     template <int dim>
     void
     Interface<dim>::initialize ()
     {}
+
+
+    template <int dim>
+    double
+    Interface<dim>::fluid_pressure (const types::boundary_id,
+                                    const Point<dim> &) const
+    {
+      return numbers::signaling_nan<double>();
+    }
+
+
+    template <int dim>
+    void
+    Interface<dim>::update ()
+    {}
+
 
     template <int dim>
     void

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -365,6 +365,7 @@ namespace aspect
     if (parameters.include_melt_transport)
       {
         melt_handler->initialize_simulator (*this);
+        melt_handler->parse_geometry_dependent_parameters (prm);
         melt_handler->initialize();
       }
 

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -39,6 +39,7 @@
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/grid_tools.h>
+#include <deal.II/numerics/vector_tools.h>
 
 namespace aspect
 {
@@ -1506,6 +1507,33 @@ namespace aspect
   MeltHandler<dim>::
   add_current_constraints(ConstraintMatrix &constraints)
   {
+    // add constraints for the boundary fluid pressure
+    boundary_fluid_pressure->update();
+
+    for (std::set<types::boundary_id>::const_iterator
+         p = melt_parameters.prescribed_boundary_fluid_pressure_indicators.begin();
+         p != melt_parameters.prescribed_boundary_fluid_pressure_indicators.end();
+         ++p)
+      {
+        auto lambda = [&] (const Point<dim> &x) -> double
+        {
+          return boundary_fluid_pressure->fluid_pressure(*p, x);
+        };
+
+        VectorFunctionFromScalarFunctionObject<dim> vector_function_object(
+          lambda,
+          this->introspection().variable("fluid pressure").component_mask.first_selected_component(),
+          this->introspection().n_components);
+
+        VectorTools::interpolate_boundary_values (this->get_mapping(),
+                                                  this->get_dof_handler(),
+                                                  *p,
+                                                  vector_function_object,
+                                                  constraints,
+                                                  this->introspection().variable("fluid pressure").component_mask);
+      }
+
+    // In a second step, add constraints for the melt cells
     IndexSet nonzero_pc_dofs(this->introspection().index_sets.system_relevant_set.size());
 
     const QTrapez<dim> quadrature_formula;
@@ -1632,6 +1660,17 @@ namespace aspect
   {
     return *boundary_fluid_pressure.get();
   }
+
+
+
+  template <int dim>
+  const std::set<types::boundary_id> &
+  MeltHandler<dim>::
+  get_prescribed_fluid_pressure_boundary_indicators () const
+  {
+    return melt_parameters.prescribed_boundary_fluid_pressure_indicators;
+  }
+
 
 
   template <int dim>
@@ -1771,7 +1810,17 @@ namespace aspect
       prm.leave_subsection();
 
       BoundaryFluidPressure::declare_parameters<dim> (prm);
+
+      prm.enter_subsection ("Boundary fluid pressure model");
+      {
+        prm.declare_entry ("Prescribed fluid pressure boundary indicators", "",
+                           Patterns::List (Patterns::Anything()),
+                           "A comma separated list denoting those boundaries "
+                           "on which the fluid pressure is prescribed.");
+      }
+      prm.leave_subsection();
     }
+
 
     template <int dim>
     void
@@ -1789,6 +1838,7 @@ namespace aspect
     }
   }
 
+
   template <int dim>
   MeltHandler<dim>::MeltHandler (ParameterHandler &prm)
     :
@@ -1797,6 +1847,35 @@ namespace aspect
     CitationInfo::add("melt");
     melt_parameters.parse_parameters(prm);
     boundary_fluid_pressure->parse_parameters(prm);
+  }
+
+
+
+  template <int dim>
+  void
+  MeltHandler<dim>::
+  parse_geometry_dependent_parameters (ParameterHandler &prm)
+  {
+    prm.enter_subsection ("Boundary fluid pressure model");
+    {
+      try
+        {
+          const std::vector<types::boundary_id> x_prescribed_fluid_pressure_boundary_indicators
+            = this->get_geometry_model().translate_symbolic_boundary_names_to_ids(Utilities::split_string_list
+                                                                                  (prm.get ("Prescribed fluid pressure boundary indicators")));
+          melt_parameters.prescribed_boundary_fluid_pressure_indicators
+            = std::set<types::boundary_id> (x_prescribed_fluid_pressure_boundary_indicators.begin(),
+                                            x_prescribed_fluid_pressure_boundary_indicators.end());
+        }
+      catch (const std::string &error)
+        {
+          AssertThrow (false, ExcMessage ("While parsing the entry <Model settings/Boundary fluid pressure model "
+                                          "boundary indicators>, there was an error. Specifically, "
+                                          "the conversion function complained as follows: "
+                                          + error));
+        }
+    }
+    prm.leave_subsection();
   }
 
 
@@ -1818,6 +1897,7 @@ namespace aspect
     AssertThrow(!this->get_parameters().use_locally_conservative_discretization,
                 ExcMessage ("Discontinuous elements for the fluid pressure "
                             "are not supported in models with melt transport."));
+
   }
 
 

--- a/tests/fluid_pressure_boundary_conditions.prm
+++ b/tests/fluid_pressure_boundary_conditions.prm
@@ -1,0 +1,159 @@
+# Test for the boundary conditions for the fluid pressure 
+# (which can be set explicitly) with melt transport = on 
+# and a constant nonzero porosity at the top boundary.
+#
+# The test is similar to free_surface_blob_melt.
+
+set Dimension = 2
+set CFL number                             = 0.5
+set End time                               = 0
+set Output directory                       = output
+set Resume computation                     = false
+set Start time                             = 0
+set Adiabatic surface temperature          = 0
+set Surface pressure                       = 0
+set Pressure normalization                 = surface
+set Timing output frequency                = 5
+set Use years in output instead of seconds = true
+set Maximum time step                      = 1e4
+
+subsection Boundary temperature model
+  set List of model names = constant
+  subsection Constant
+    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+  end
+end
+
+subsection Boundary fluid pressure model
+  set Prescribed fluid pressure boundary indicators = top, left
+  set Plugin name = function
+  subsection Fluid pressure function
+    set Function expression = x
+  end
+end
+
+subsection Discretization
+  set Stokes velocity polynomial degree       = 2
+  set Temperature polynomial degree           = 2
+  set Use locally conservative discretization = false
+  subsection Stabilization parameters
+    set alpha = 2
+    set beta  = 0.078
+    set cR    = 0.5   # default: 0.11
+  end
+end
+
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent = 500.e3 
+    set Y extent = 200.e3
+    set X repetitions = 5
+    set Y repetitions = 2
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function 
+    set Variable names      = x,y
+    set Function expression =  if( sqrt( (x-250.e3)^2 + (y-100.e3)^2 ) < 25.e3, 200.0, 0.0)
+  end
+end
+
+
+subsection Material model
+  set Model name = melt global
+  subsection Simple model
+    set Reference density             = 3300
+    set Reference specific heat       = 1250
+    set Reference temperature         = 0.0
+    set Thermal conductivity          = 4.7
+    set Thermal expansion coefficient = 4e-5
+    set Viscosity                     = 1.e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Additional refinement times        =
+  set Initial adaptive refinement        = 0                       # default: 2
+  set Initial global refinement          = 3                      # default: 2
+  set Refinement fraction                = 0.3
+  set Coarsening fraction                = 0.00
+  set Strategy                           = temperature
+  set Time steps between mesh refinement = 0                     # default: 10
+end
+
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = 2,3
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 0,1,3
+end
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators       = 2
+end
+
+subsection Melt settings
+  set Include melt transport                  = true
+end
+
+subsection Free surface
+  set Free surface stabilization theta = 0.5
+end
+
+subsection Compositional fields
+  set Number of fields = 2
+  set Names of fields = porosity, peridotite
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Variable names      = x,y
+    set Function expression = 0.02 * y/2.e5; 0
+  end
+end
+
+subsection Postprocess
+  set List of postprocessors = topography,velocity statistics, visualization, composition statistics
+
+  subsection Visualization
+    set Interpolate output = false
+    set List of output variables =  melt material properties, material properties
+    set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity, reaction terms
+    end
+
+    subsection Melt material properties
+      set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
+    end
+  end
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Linear solver tolerance = 1.e-7
+    set Number of cheap Stokes solver steps = 0 
+  end
+end

--- a/tests/fluid_pressure_boundary_conditions/screen-output
+++ b/tests/fluid_pressure_boundary_conditions/screen-output
@@ -1,0 +1,31 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 640 (on 4 levels)
+Number of degrees of freedom: 22,025 (5,346+2,617+5,346+697+2,673+2,673+2,673)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+16 iterations.
+   Solving for u_f in 12 iterations.
+
+   Postprocessing:
+     Topography min/max:        0 m, 0 m
+     RMS, max velocity:         6.93e+11 m/year, 1.28e+12 m/year
+     Writing graphical output:  output-fluid_pressure_boundary_conditions/solution/solution-00000
+     Compositions min/max/mass: 0/0.02/1e+09 // 0/0/0
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/fluid_pressure_boundary_conditions/statistics
+++ b/tests/fluid_pressure_boundary_conditions/statistics
@@ -1,0 +1,25 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for composition solver 2
+# 11: Iterations for Stokes solver
+# 12: Velocity iterations in Stokes preconditioner
+# 13: Schur complement iterations in Stokes preconditioner
+# 14: Minimum topography (m)
+# 15: Maximum topography (m)
+# 16: RMS velocity (m/year)
+# 17: Max. velocity (m/year)
+# 18: Visualization file name
+# 19: Minimal value for composition porosity
+# 20: Maximal value for composition porosity
+# 21: Global mass for composition porosity
+# 22: Minimal value for composition peridotite
+# 23: Maximal value for composition peridotite
+# 24: Global mass for composition peridotite
+0 0.000000000000e+00 0.000000000000e+00 640 6043 2673 5346 0 0 0 15 76 341 0.00000000e+00 0.00000000e+00 6.93288169e+11 1.27802167e+12 output-fluid_pressure_boundary_conditions/solution/solution-00000 0.00000000e+00 2.00000000e-02 1.00000000e+09 0.00000000e+00 0.00000000e+00 0.00000000e+00 


### PR DESCRIPTION
This pull request adds the option to prescribe boundary conditions for the fluid pressure (and not just the gradient of the fluid pressure) in models with melt transport. 

Things I still have to do:

- [ ] make sure we do not assemble the fluid pressure gradient boundary terms on boundaries where the fluid pressure is prescribed
- [ ] make an enum that lets plugins report if the can prescribed the fluid pressure, the fluid pressure gradient, or both, and check that the plugin selected and the type of boundary condition selected works together. 