### PR TITLE
added if !DEAL_II_VERSION_GTE(9,2,0) back into compat.h

### DIFF
--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -31,7 +31,7 @@
 // for std_cxx14::make_unique:
 #include <deal.II/base/std_cxx14/memory.h>
 
-//#if !DEAL_II_VERSION_GTE(9,2,0)
+#if !DEAL_II_VERSION_GTE(9,2,0)
 #include <deal.II/base/table.h>
 #include <deal.II/base/function_lib.h>
 namespace aspect
@@ -382,6 +382,6 @@ namespace aspect
   }
 
 }
-//#endif
+#endif
 
 #endif


### PR DESCRIPTION
gradient/value is now implemented for InterpolatedUniformGridData in deal.II and will be contained in the 9.2 release. In this PR, we add an if statement in compat.h to only use the compatibility functions if the deal.II version is <9.2.
Fixes Issue #3144