### PR TITLE
Fix manual compile by removing non-ASCII character

### DIFF
--- a/cookbooks/inner_core_convection/inner_core_assembly.cc
+++ b/cookbooks/inner_core_convection/inner_core_assembly.cc
@@ -36,7 +36,7 @@ namespace aspect
    * normal stress and the normal velocity that take into account the
    * rate of phase change (melting/freezing) at the inner-outer core
    * boundary. The model is based on Deguen, Alboussiere, and Cardin
-   * (2013), Thermal convection in Earth’s inner core with phase change
+   * (2013), Thermal convection in Earth's inner core with phase change
    * at its boundary. GJI, 194, 1310-133.
    *
    * The mechanical boundary conditions for the inner core are


### PR DESCRIPTION
My manual did not compile because of non-ASCII characters in this file. I am not sure why this did not happen before, the line did not change for a long time. Anyway, this change fixes the latex error.