### PR TITLE
Rename isothermal to isentropic compression

### DIFF
--- a/doc/modules/changes/20190614_gassmoeller
+++ b/doc/modules/changes/20190614_gassmoeller
@@ -1,0 +1,6 @@
+Changed: The 'isothermal compression' approximation for compressible mantle
+convection has been renamed to 'isentropic compression', which is a more
+appropriate name. The approximation is only correct if one uses the isentropic
+rather than the isothermal compressibility in material models.
+<br>
+(Rene Gassmoeller, 2019/06/14)

--- a/doc/update_scripts/prm_files/update_prm_files_to_2.2.0_isentropic_compression.sed
+++ b/doc/update_scripts/prm_files/update_prm_files_to_2.2.0_isentropic_compression.sed
@@ -1,0 +1,6 @@
+# A script for the stream editor sed to update .prm files for ASPECT
+# to account for the new name of the isentropic compression formulation.
+# This formulation was previously named isothermal compression, which
+# was misleading and wrong. 
+
+s/isothermal compression/isentropic compression/g

--- a/doc/update_scripts/source_files/update_source_files_to_2.2.0_isentropic_compression.pl
+++ b/doc/update_scripts/source_files/update_source_files_to_2.2.0_isentropic_compression.pl
@@ -1,0 +1,12 @@
+#!/bin/perl
+#
+# This script removes references to the isothermal compression formulation
+# and replaces them with the isentropic compression formulation.
+
+while (<>)
+{
+  s/isothermal_compression/isentropic_compression/g;
+  s/isothermal compression/isentropic compression/g;
+  s/IsothermalCompression/IsentropicCompression/g;
+  print;
+}

--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -320,11 +320,11 @@ namespace aspect
      * $ - \nabla \mathbf{u} = \frac{1}{\rho} \frac{\partial rho}{\partial p} \rho \mathbf{g} \cdot \mathbf{u}$
      */
     template <int dim>
-    class NewtonStokesIsothermalCompressionTerm : public Assemblers::Interface<dim>,
+    class NewtonStokesIsentropicCompressionTerm : public Assemblers::Interface<dim>,
       public SimulatorAccess<dim>
     {
       public:
-        virtual ~NewtonStokesIsothermalCompressionTerm () {}
+        virtual ~NewtonStokesIsentropicCompressionTerm () {}
 
         virtual
         void

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -138,7 +138,7 @@ namespace aspect
       {
         boussinesq_approximation,
         anelastic_liquid_approximation,
-        isothermal_compression,
+        isentropic_compression,
         custom
       };
 
@@ -150,8 +150,8 @@ namespace aspect
       Kind
       parse(const std::string &input)
       {
-        if (input == "isothermal compression")
-          return Formulation::isothermal_compression;
+        if (input == "isentropic compression")
+          return Formulation::isentropic_compression;
         else if (input == "anelastic liquid approximation")
           return Formulation::anelastic_liquid_approximation;
         else if (input == "Boussinesq approximation")
@@ -178,7 +178,7 @@ namespace aspect
          */
         enum Kind
         {
-          isothermal_compression,
+          isentropic_compression,
           hydrostatic_compression,
           reference_density_profile,
           implicit_reference_density_profile,
@@ -193,8 +193,8 @@ namespace aspect
         static Kind
         parse(const std::string &input)
         {
-          if (input == "isothermal compression")
-            return Formulation::MassConservation::isothermal_compression;
+          if (input == "isentropic compression")
+            return Formulation::MassConservation::isentropic_compression;
           else if (input == "hydrostatic compression")
             return Formulation::MassConservation::hydrostatic_compression;
           else if (input == "reference density profile")
@@ -459,7 +459,7 @@ namespace aspect
      * equations ASPECT will solve.
      * Common formulations are the Boussinesq or Anelastic Liquid
      * Approximations (BA, ALA). ASPECT's original formulation is termed
-     * 'isothermal compression'. 'Custom' allows
+     * 'isentropic compression'. 'Custom' allows
      * to set the approximations individually per equation.
      */
     typename Formulation::Kind formulation;
@@ -467,7 +467,7 @@ namespace aspect
     /**
      * Determines how to formulate the mass conservation equation in ASPECT.
      * Common approximations are 'incompressible' or 'reference density profile'.
-     * ASPECT's original formulation is termed 'isothermal compression'. See the
+     * ASPECT's original formulation is termed 'isentropic compression'. See the
      * manual for more details about the individual terms.
      */
     typename Formulation::MassConservation::Kind formulation_mass_conservation;

--- a/include/aspect/simulator/assemblers/stokes.h
+++ b/include/aspect/simulator/assemblers/stokes.h
@@ -143,7 +143,7 @@ namespace aspect
      * $\kappa = \frac{1}{\rho} \frac{\partial rho}{\partial p}$.
      */
     template <int dim>
-    class StokesIsothermalCompressionTerm : public Assemblers::Interface<dim>,
+    class StokesIsentropicCompressionTerm : public Assemblers::Interface<dim>,
       public SimulatorAccess<dim>
     {
       public:

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -623,7 +623,7 @@ namespace aspect
 
     template <int dim>
     void
-    NewtonStokesIsothermalCompressionTerm<dim>::
+    NewtonStokesIsentropicCompressionTerm<dim>::
     execute (internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
              internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const
     {
@@ -633,7 +633,7 @@ namespace aspect
       // assemble RHS of:
       //  - div u = 1/rho * drho/dp rho * g * u
       Assert(this->get_parameters().formulation_mass_conservation ==
-             Parameters<dim>::Formulation::MassConservation::isothermal_compression,
+             Parameters<dim>::Formulation::MassConservation::isentropic_compression,
              ExcInternalError());
 
       const Introspection<dim> &introspection = this->introspection();
@@ -692,7 +692,7 @@ namespace aspect
   template class NewtonStokesCompressibleStrainRateViscosityTerm<dim>; \
   template class NewtonStokesReferenceDensityCompressibilityTerm<dim>; \
   template class NewtonStokesImplicitReferenceDensityCompressibilityTerm<dim>; \
-  template class NewtonStokesIsothermalCompressionTerm<dim>;
+  template class NewtonStokesIsentropicCompressionTerm<dim>;
 
     ASPECT_INSTANTIATE(INSTANTIATE)
   }

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -592,7 +592,7 @@ namespace aspect
 
     template <int dim>
     void
-    StokesIsothermalCompressionTerm<dim>::
+    StokesIsentropicCompressionTerm<dim>::
     execute (internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
              internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const
     {
@@ -607,7 +607,7 @@ namespace aspect
       // -div(u) as the adjoint operator of grad(p)
 
       Assert(this->get_parameters().formulation_mass_conservation ==
-             Parameters<dim>::Formulation::MassConservation::isothermal_compression,
+             Parameters<dim>::Formulation::MassConservation::isentropic_compression,
              ExcInternalError());
 
       const Introspection<dim> &introspection = this->introspection();
@@ -811,7 +811,7 @@ namespace aspect
   template class StokesCompressibleStrainRateViscosityTerm<dim>; \
   template class StokesReferenceDensityCompressibilityTerm<dim>; \
   template class StokesImplicitReferenceDensityCompressibilityTerm<dim>; \
-  template class StokesIsothermalCompressionTerm<dim>; \
+  template class StokesIsentropicCompressionTerm<dim>; \
   template class StokesHydrostaticCompressionTerm<dim>; \
   template class StokesPressureRHSCompatibilityModification<dim>; \
   template class StokesBoundaryTraction<dim>;

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -156,10 +156,10 @@ namespace aspect
         // do nothing, because we assembled div u =0 above already
       }
     else if (parameters.formulation_mass_conservation ==
-             Parameters<dim>::Formulation::MassConservation::isothermal_compression)
+             Parameters<dim>::Formulation::MassConservation::isentropic_compression)
       {
         assemblers->stokes_system.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::StokesIsothermalCompressionTerm<dim> >());
+          std_cxx14::make_unique<aspect::Assemblers::StokesIsentropicCompressionTerm<dim> >());
       }
     else if (parameters.formulation_mass_conservation ==
              Parameters<dim>::Formulation::MassConservation::hydrostatic_compression)

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1861,7 +1861,7 @@ namespace aspect
     if (parameters.formulation_mass_conservation == Parameters<dim>::Formulation::MassConservation::ask_material_model)
       {
         if (material_model->is_compressible() == true)
-          parameters.formulation_mass_conservation = Parameters<dim>::Formulation::MassConservation::isothermal_compression;
+          parameters.formulation_mass_conservation = Parameters<dim>::Formulation::MassConservation::isentropic_compression;
         else
           parameters.formulation_mass_conservation = Parameters<dim>::Formulation::MassConservation::incompressible;
       }
@@ -1875,7 +1875,7 @@ namespace aspect
                                "but the provided material model reports that it is compressible. "
                                "Please check the consistency of your material model and selected formulation."));
       }
-    else if (parameters.formulation_mass_conservation == Parameters<dim>::Formulation::MassConservation::isothermal_compression
+    else if (parameters.formulation_mass_conservation == Parameters<dim>::Formulation::MassConservation::isentropic_compression
              || parameters.formulation_mass_conservation == Parameters<dim>::Formulation::MassConservation::reference_density_profile
              || parameters.formulation_mass_conservation == Parameters<dim>::Formulation::MassConservation::implicit_reference_density_profile)
       {
@@ -1889,17 +1889,17 @@ namespace aspect
     // Ensure that the correct heating terms have been selected for the chosen combined formulation
     // Note that if the combined formulation is 'custom' there is no check
     // (useful e.g. for smaller scale lithospheric models with shear heating but without adiabatic heating)
-    if (parameters.formulation == Parameters<dim>::Formulation::isothermal_compression)
+    if (parameters.formulation == Parameters<dim>::Formulation::isentropic_compression)
       {
         AssertThrow(heating_model_manager.adiabatic_heating_enabled(),
                     ExcMessage("ASPECT detected an inconsistency in the provided input file. "
-                               "The `isothermal compression' formulation expects adiabatic heating to be enabled, "
+                               "The `isentropic compression' formulation expects adiabatic heating to be enabled, "
                                "but the `adiabatic heating' plugin has not been selected in the input file. "
                                "Please check the consistency of your input file."));
 
         AssertThrow(heating_model_manager.shear_heating_enabled(),
                     ExcMessage("ASPECT detected an inconsistency in the provided input file. "
-                               "The `isothermal compression' formulation expects shear heating to be enabled, "
+                               "The `isentropic compression' formulation expects shear heating to be enabled, "
                                "but the `shear heating' plugin has not been selected in the input file. "
                                "Please check the consistency of your input file."));
       }

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1683,10 +1683,10 @@ namespace aspect
     assemblers.stokes_system.push_back(std_cxx14::make_unique<Assemblers::MeltStokesSystem<dim> > ());
 
     AssertThrow((this->get_parameters().formulation_mass_conservation ==
-                 Parameters<dim>::Formulation::MassConservation::isothermal_compression) ||
+                 Parameters<dim>::Formulation::MassConservation::isentropic_compression) ||
                 (this->get_parameters().formulation_mass_conservation ==
                  Parameters<dim>::Formulation::MassConservation::incompressible),
-                ExcMessage("The melt implementation currently only supports the isothermal compression "
+                ExcMessage("The melt implementation currently only supports the isentropic compression "
                            "approximation or the incompressible formulation of the mass conservation equation."));
 
     // add the boundary integral for melt migration

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -77,10 +77,10 @@ namespace aspect
         // do nothing, because we assembled div u =0 above already
       }
     else if (this->get_parameters().formulation_mass_conservation ==
-             Parameters<dim>::Formulation::MassConservation::isothermal_compression)
+             Parameters<dim>::Formulation::MassConservation::isentropic_compression)
       {
         assemblers.stokes_system.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::NewtonStokesIsothermalCompressionTerm<dim> >());
+          std_cxx14::make_unique<aspect::Assemblers::NewtonStokesIsentropicCompressionTerm<dim> >());
       }
     else
       AssertThrow(false,

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -527,13 +527,13 @@ namespace aspect
     prm.enter_subsection("Formulation");
     {
       prm.declare_entry ("Formulation", "custom",
-                         Patterns::Selection ("isothermal compression|custom|anelastic liquid approximation|Boussinesq approximation"),
+                         Patterns::Selection ("isentropic compression|custom|anelastic liquid approximation|Boussinesq approximation"),
                          "Select a formulation for the basic equations. Different "
                          "published formulations are available in ASPECT (see the list of "
                          "possible values for this parameter in the manual for available options). "
                          "Two ASPECT specific options are\n"
                          "\\begin{enumerate}\n"
-                         "  \\item `isothermal compression': ASPECT's original "
+                         "  \\item `isentropic compression': ASPECT's original "
                          "formulation, using the explicit compressible mass equation, "
                          "and the full density for the temperature equation.\n"
                          "  \\item `custom': A custom selection of `Mass conservation' and "
@@ -550,7 +550,7 @@ namespace aspect
                          "density that depends on temperature and depth and not on the pressure.}");
 
       prm.declare_entry ("Mass conservation", "ask material model",
-                         Patterns::Selection ("incompressible|isothermal compression|hydrostatic compression|"
+                         Patterns::Selection ("incompressible|isentropic compression|hydrostatic compression|"
                                               "reference density profile|implicit reference density profile|"
                                               "ask material model"),
                          "Possible approximations for the density derivatives in the mass "
@@ -1417,9 +1417,9 @@ namespace aspect
       // in Simulator<dim>::check_consistency_of_formulation() after the initialization of
       // material models, heating plugins, and adiabatic conditions.
       formulation = Formulation::parse(prm.get("Formulation"));
-      if (formulation == Formulation::isothermal_compression)
+      if (formulation == Formulation::isentropic_compression)
         {
-          formulation_mass_conservation = Formulation::MassConservation::isothermal_compression;
+          formulation_mass_conservation = Formulation::MassConservation::isentropic_compression;
           formulation_temperature_equation = Formulation::TemperatureEquation::real_density;
         }
       else if (formulation == Formulation::boussinesq_approximation)

--- a/tests/anisotropic_viscosity.cc
+++ b/tests/anisotropic_viscosity.cc
@@ -781,7 +781,7 @@ namespace aspect
   template class StokesCompressibleStrainRateViscosityTerm<dim>; \
   template class StokesReferenceDensityCompressibilityTerm<dim>; \
   template class StokesImplicitReferenceDensityCompressibilityTerm<dim>; \
-  template class StokesIsothermalCompressionTerm<dim>; \
+  template class StokesIsentropicCompressionTerm<dim>; \
   template class StokesHydrostaticCompressionTerm<dim>; \
   template class StokesPressureRHSCompatibilityModification<dim>; \
   template class StokesBoundaryTraction<dim>;


### PR DESCRIPTION
This changes the name of the isothermal compression approximation to isentropic compression. As discussed in our recent manuscript the current name is misleading and leads to inconsistent models. I have thought about keeping backward compatibility by still allowing the old name, but (1) I think nearly nobody specified this approximation explicitly in the input file (it was the default), and (2) if they did, crashing with an error will force everyone to think about the change and make sure they fix their models.