### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 Pull Request Checklist. Please read and check each box with an X. Feel free to delete any part not applicable to your PR.
 
+### Describe the content of this pull request, and why you did these changes:
+
 ### Before submitting your first pull request:
 
 * [ ] I have read the guidelines in our [CONTRIBUTING.md](../CONTRIBUTING.md) document.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+Pull Request Checklist. Please read and check each box with an X. Feel free to delete any part not applicable to your PR.
+
+### Before submitting your first pull request:
+
+* [ ] I have read the guidelines in our [CONTRIBUTING.md](../CONTRIBUTING.md) document.
+
+### For all Pull Requests:
+
+* [ ] I have followed the instructions for indenting my code according to ASPECT's code style as described in the last paragraph of the ['Making ASPECT better'](../CONTRIBUTING.md#making-aspect-better) section of CONTRIBUTING.md.
+
+### For Feature/Benchmark Submissions or Changes of Existing Behavior:
+
+* [ ] I have tested my new feature locally to ensure it is correct.
+* [ ] I have created a testcase for the new feature/benchmark in the [tests/](../tests/) directory as described in the corresponding section of the [manual](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests).
+* [ ] I have added a changelog entry in the [doc/modules/changes](../doc/modules/changes) directory that will inform other users of my change.


### PR DESCRIPTION
How does everyone feel about adding a default pull request template to the repository? I feel like it can save some time doing reviews, and I constantly forget to add (or ask for) changelog entries, or wait for half an hour for the tester only to discover I forgot to run `make indent` again. I admit it can be a bit annoying to always have the text field prefilled with a lot of text, but maybe if we keep the template short enough it is worth it? Opinions?