### PR TITLE
[CI]: test manual on CIG tester

### DIFF
--- a/Jenkinsfile.cig
+++ b/Jenkinsfile.cig
@@ -110,7 +110,9 @@ pipeline {
 
     stage('Build Documentation') {
       steps {
-        sh 'cd doc && make manual.pdf'
+        sh 'cd doc && make manual.pdf || touch ~/FAILED-DOC'
+        archiveArtifacts artifacts: 'doc/manual/manual.log', allowEmptyArchive: true
+        sh 'if [ -f ~/FAILED-DOC ]; then exit 1; fi'
       }
     }
 

--- a/Jenkinsfile.cig
+++ b/Jenkinsfile.cig
@@ -110,7 +110,7 @@ pipeline {
 
     stage('Build Documentation') {
       steps {
-        sh './doc/update_parameters.sh ./build-gcc-fast/aspect || touch ~/FAILED-DOC'
+        sh 'cd doc && ./update_parameters.sh ./build-gcc-fast/aspect'
         sh 'cd doc && make manual.pdf || touch ~/FAILED-DOC'
         archiveArtifacts artifacts: 'doc/manual/manual.log', allowEmptyArchive: true
         sh 'if [ -f ~/FAILED-DOC ]; then exit 1; fi'

--- a/Jenkinsfile.cig
+++ b/Jenkinsfile.cig
@@ -2,8 +2,8 @@
 
 pipeline {
   agent {
-    docker {
-      image 'tjhei/dealii:v9.0.1-full-v9.0.1-r5-gcc5'
+    dockerfile {
+      dir 'contrib/ci'
     }
   }
 
@@ -105,6 +105,12 @@ pipeline {
         cd build-gcc-fast
         ninja
         '''
+      }
+    }
+
+    stage('Build Documentation') {
+      steps {
+        sh 'cd doc && make manual.pdf'
       }
     }
 

--- a/Jenkinsfile.cig
+++ b/Jenkinsfile.cig
@@ -110,6 +110,7 @@ pipeline {
 
     stage('Build Documentation') {
       steps {
+        sh './doc/update_parameters.sh ./build-gcc-fast/aspect || touch ~/FAILED-DOC'
         sh 'cd doc && make manual.pdf || touch ~/FAILED-DOC'
         archiveArtifacts artifacts: 'doc/manual/manual.log', allowEmptyArchive: true
         sh 'if [ -f ~/FAILED-DOC ]; then exit 1; fi'

--- a/contrib/ci/Dockerfile
+++ b/contrib/ci/Dockerfile
@@ -4,6 +4,6 @@ LABEL maintainer <rene.gassmoeller@mailbox.org>
 
 USER root
 
-RUN apt-get update && apt-get install -yq --no-install-recommends texlive-generic-extra texlive-base texlive-latex-recommended texlive-latex-base texlive-fonts-recommended texlive-bibtex-extra lmodern texlive-latex-extra texlive-science
+RUN apt-get update && apt-get install -yq --no-install-recommends texlive-generic-extra texlive-base texlive-latex-recommended texlive-latex-base texlive-fonts-recommended texlive-bibtex-extra lmodern texlive-latex-extra texlive-science graphviz
 
 USER dealii

--- a/contrib/ci/build.sh
+++ b/contrib/ci/build.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-# This script generates a docker image from the latest aspect development version.
+# This script generates a docker image for the ASPECT tester.
 # It requires a docker installation on the local machine, and the ability to
 # communicate with the docker daemon without root user privileges (see the docker
 # webpage for an explanation).
-# Note: This container is build from the developer version on Github, it does not use
-# the local ASPECT folder. Therefore local changes are not included in the container.
 
 docker build -t geodynamics/aspect-tester .

--- a/contrib/ci/build.sh
+++ b/contrib/ci/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script generates a docker image from the latest aspect development version.
+# It requires a docker installation on the local machine, and the ability to
+# communicate with the docker daemon without root user privileges (see the docker
+# webpage for an explanation).
+# Note: This container is build from the developer version on Github, it does not use
+# the local ASPECT folder. Therefore local changes are not included in the container.
+
+docker build -t geodynamics/aspect-tester .

--- a/source/material_model/modified_tait.cc
+++ b/source/material_model/modified_tait.cc
@@ -146,10 +146,10 @@ namespace aspect
         {
           prm.declare_entry ("Reference pressure", "1e5",
                              Patterns::Double (0),
-                             "Reference pressure $\\P_0$. Units: $\\text{Pa}$.");
+                             "Reference pressure $P_0$. Units: $\\text{Pa}$.");
           prm.declare_entry ("Reference temperature", "298.15",
                              Patterns::Double (0),
-                             "Reference temperature $\\T_0$. Units: $\\text{K}$.");
+                             "Reference temperature $T_0$. Units: $\\text{K}$.");
           prm.declare_entry ("Reference density", "3300",
                              Patterns::Double (0),
                              "The density at the reference pressure and temperature. "
@@ -157,7 +157,7 @@ namespace aspect
           prm.declare_entry ("Reference isothermal bulk modulus", "125e9",
                              Patterns::Double (0),
                              "The isothermal bulk modulus at the reference pressure and temperature. "
-                             "Units: $\\text{Pa}.");
+                             "Units: $\\text{Pa}$.");
           prm.declare_entry ("Reference bulk modulus derivative", "4",
                              Patterns::Double (0),
                              "The value of the first pressure derivative of the isothermal bulk modulus "

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -165,7 +165,7 @@ namespace aspect
                            "to compare this with the documentation of the geometry model you "
                            "use in your model. "
                            "\n\n"
-                           "The format is id1: object1 & object2, id2: object3 & object2, where "
+                           "The format is id1: object1 \\& object2, id2: object3 \\& object2, where "
                            "objects are one of " + std::get<dim>(registered_plugins).get_description_string());
       }
       prm.leave_subsection ();


### PR DESCRIPTION
We keep breaking our manual, because we do not have a test for it. This PR creates a new docker image for the tester (including latex) and should test the creation of the manual for every PR. We can also extend it later to update the input parameters.

Having the tester as a separate image from the deal.II image will also be helpful for #2978.