### PR TITLE
Refactor operator splitting function

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1284,6 +1284,19 @@ namespace aspect
       void compute_reactions ();
 
       /**
+       * Update the indicated block of the solution vector with the
+       * corresponding block of the handed over @p distributed_vector. Also
+       * update reaction_vector with the corresponding block of @p
+       * distributed_reaction_vector.
+       *
+       * This function is implemented in
+       * <code>source/simulator/helper_functions.cc</code>.
+       */
+      void update_solution_vectors_with_reaction_results (const unsigned int block_index,
+                                                          const LinearAlgebra::BlockVector &distributed_vector,
+                                                          const LinearAlgebra::BlockVector &distributed_reaction_vector);
+
+      /**
        * Initialize the current linearization point vector from the old
        * solution vector(s). Depending on the time of the call this
        * can be simply a copy of the solution of the last timestep,
@@ -1294,7 +1307,6 @@ namespace aspect
        * <code>source/simulator/helper_functions.cc</code>.
        */
       void initialize_current_linearization_point ();
-
 
       /**
        * Interpolate material model outputs onto an advection field (temperature

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1530,11 +1530,37 @@ namespace aspect
 
 
   template <int dim>
+  void Simulator<dim>::update_solution_vectors_with_reaction_results (const unsigned int block_index,
+                                                                      const LinearAlgebra::BlockVector &distributed_vector,
+                                                                      const LinearAlgebra::BlockVector &distributed_reaction_vector)
+  {
+    solution.block(block_index) = distributed_vector.block(block_index);
+
+    // we have to update the old solution with our reaction update too
+    // so that the advection scheme will have the correct time stepping in the next step
+    LinearAlgebra::BlockVector tmp(distributed_vector);
+
+    tmp.block(block_index) = old_solution.block(block_index);
+    tmp.block(block_index) +=  distributed_reaction_vector.block(block_index);
+    old_solution.block(block_index) = tmp.block(block_index);
+
+    tmp.block(block_index) = old_old_solution.block(block_index);
+    tmp.block(block_index) +=  distributed_reaction_vector.block(block_index);
+    old_old_solution.block(block_index) = tmp.block(block_index);
+
+    operator_split_reaction_vector.block(block_index) = distributed_reaction_vector.block(block_index);
+  }
+
+
+
+  template <int dim>
   void Simulator<dim>::compute_reactions ()
   {
     // if the time step has a length of zero, there are no reactions
     if (time_step == 0)
       return;
+
+    TimerOutput::Scope timer (computing_timer, "Solve composition reactions");
 
     // we need some temporary vectors to store our updates to composition and temperature in
     // while we do the time stepping, before we copy them over to the solution vector in the end
@@ -1554,10 +1580,7 @@ namespace aspect
     Assert (reaction_time_step_size > 0,
             ExcMessage("Reaction time step must be greater than 0."));
 
-    pcout << "   Solving composition reactions in "
-          << number_of_reaction_steps
-          << " substep(s)."
-          << std::endl;
+    pcout << "   Solving composition reactions ";
 
     // make one fevalues for the composition, and one for the temperature (they might use different finite elements)
     const Quadrature<dim> quadrature_C(dof_handler.get_fe().base_element(introspection.base_elements.compositional_fields).get_unit_support_points());
@@ -1571,6 +1594,11 @@ namespace aspect
     MaterialModel::MaterialModelInputs<dim> in_C(quadrature_C.size(), introspection.n_compositional_fields);
     MaterialModel::MaterialModelOutputs<dim> out_C(quadrature_C.size(), introspection.n_compositional_fields);
     HeatingModel::HeatingModelOutputs heating_model_outputs_C(quadrature_C.size(), introspection.n_compositional_fields);
+
+    const bool temperature_and_composition_use_same_fe =
+      (parameters.use_discontinuous_composition_discretization == parameters.use_discontinuous_temperature_discretization)
+      &&
+      (parameters.temperature_degree == parameters.composition_degree);
 
     // temperature element
     const Quadrature<dim> quadrature_T(dof_handler.get_fe().base_element(introspection.base_elements.temperature).get_unit_support_points());
@@ -1624,12 +1652,16 @@ namespace aspect
     for (const auto &cell : dof_handler.active_cell_iterators())
       if (cell->is_locally_owned())
         {
-          fe_values_C.reinit (cell);
           cell->get_dof_indices (local_dof_indices);
+
+          fe_values_C.reinit (cell);
           in_C.reinit(fe_values_C, cell, introspection, solution);
 
-          fe_values_T.reinit (cell);
-          in_T.reinit(fe_values_T, cell, introspection, solution);
+          if (!temperature_and_composition_use_same_fe)
+            {
+              fe_values_T.reinit (cell);
+              in_T.reinit(fe_values_T, cell, introspection, solution);
+            }
 
           std::vector<std::vector<double> > accumulated_reactions_C (quadrature_C.size(),std::vector<double> (introspection.n_compositional_fields));
           std::vector<double> accumulated_reactions_T (quadrature_T.size());
@@ -1659,24 +1691,30 @@ namespace aspect
                     }
                   in_C.temperature[j] = in_C.temperature[j]
                                         + reaction_time_step_size * heating_model_outputs_C.rates_of_temperature_change[j];
+
+                  if (temperature_and_composition_use_same_fe)
+                    accumulated_reactions_T[j] += reaction_time_step_size * heating_model_outputs_C.rates_of_temperature_change[j];
                 }
 
-              // loop over temperature element
-              material_model->fill_additional_material_model_inputs(in_T, solution, fe_values_T, introspection);
-
-              material_model->evaluate(in_T, out_T);
-              heating_model_manager.evaluate(in_T, out_T, heating_model_outputs_T);
-
-              for (unsigned int j=0; j<dof_handler.get_fe().base_element(introspection.base_elements.temperature).dofs_per_cell; ++j)
+              if (!temperature_and_composition_use_same_fe)
                 {
-                  // simple forward euler
-                  in_T.temperature[j] = in_T.temperature[j]
-                                        + reaction_time_step_size * heating_model_outputs_T.rates_of_temperature_change[j];
-                  accumulated_reactions_T[j] += reaction_time_step_size * heating_model_outputs_T.rates_of_temperature_change[j];
+                  // loop over temperature element
+                  material_model->fill_additional_material_model_inputs(in_T, solution, fe_values_T, introspection);
 
-                  for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
-                    in_T.composition[j][c] = in_T.composition[j][c]
-                                             + reaction_time_step_size * reaction_rate_outputs_T->reaction_rates[j][c];
+                  material_model->evaluate(in_T, out_T);
+                  heating_model_manager.evaluate(in_T, out_T, heating_model_outputs_T);
+
+                  for (unsigned int j=0; j<dof_handler.get_fe().base_element(introspection.base_elements.temperature).dofs_per_cell; ++j)
+                    {
+                      // simple forward euler
+                      in_T.temperature[j] = in_T.temperature[j]
+                                            + reaction_time_step_size * heating_model_outputs_T.rates_of_temperature_change[j];
+                      accumulated_reactions_T[j] += reaction_time_step_size * heating_model_outputs_T.rates_of_temperature_change[j];
+
+                      for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
+                        in_T.composition[j][c] = in_T.composition[j][c]
+                                                 + reaction_time_step_size * reaction_rate_outputs_T->reaction_rates[j][c];
+                    }
                 }
             }
 
@@ -1698,64 +1736,43 @@ namespace aspect
 
           // copy reaction rates and new values for the temperature field
           for (unsigned int j=0; j<dof_handler.get_fe().base_element(introspection.base_elements.temperature).dofs_per_cell; ++j)
-            for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
-              {
-                const unsigned int temperature_idx
-                  = dof_handler.get_fe().component_to_system_index(introspection.component_indices.temperature,
-                                                                   /*dof index within component=*/ j);
+            {
+              const unsigned int temperature_idx
+                = dof_handler.get_fe().component_to_system_index(introspection.component_indices.temperature,
+                                                                 /*dof index within component=*/ j);
 
-                // skip entries that are not locally owned:
-                if (dof_handler.locally_owned_dofs().is_element(local_dof_indices[temperature_idx]))
-                  {
+              // skip entries that are not locally owned:
+              if (dof_handler.locally_owned_dofs().is_element(local_dof_indices[temperature_idx]))
+                {
+                  if (temperature_and_composition_use_same_fe)
+                    distributed_vector(local_dof_indices[temperature_idx]) = in_C.temperature[j];
+                  else
                     distributed_vector(local_dof_indices[temperature_idx]) = in_T.temperature[j];
-                    distributed_reaction_vector(local_dof_indices[temperature_idx]) = accumulated_reactions_T[j];
-                  }
-              }
+
+                  distributed_reaction_vector(local_dof_indices[temperature_idx]) = accumulated_reactions_T[j];
+                }
+            }
         }
+
+    distributed_vector.compress(VectorOperation::insert);
+    distributed_reaction_vector.compress(VectorOperation::insert);
 
     // put the final values into the solution vector
     for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
       {
         const unsigned int block_c = introspection.block_indices.compositional_fields[c];
-        distributed_vector.block(block_c).compress(VectorOperation::insert);
-        solution.block(block_c) = distributed_vector.block(block_c);
-
-        // we have to update the old solution with our reaction update too
-        // so that the advection scheme will have the correct time stepping in the next step
-        distributed_reaction_vector.block(block_c).compress(VectorOperation::insert);
-
-        // we do not need distributed_vector any more, use it to temporarily store the update
-        distributed_vector.block(block_c) = old_solution.block(block_c);
-        distributed_vector.block(block_c) +=  distributed_reaction_vector.block(block_c);
-        old_solution.block(block_c) = distributed_vector.block(block_c);
-
-        distributed_vector.block(block_c) = old_old_solution.block(block_c);
-        distributed_vector.block(block_c) +=  distributed_reaction_vector.block(block_c);
-        old_old_solution.block(block_c) = distributed_vector.block(block_c);
-
-        operator_split_reaction_vector.block(block_c) = distributed_reaction_vector.block(block_c);
+        update_solution_vectors_with_reaction_results(block_c,distributed_vector,distributed_reaction_vector);
       }
 
     const unsigned int block_T = introspection.block_indices.temperature;
-    distributed_vector.block(block_T).compress(VectorOperation::insert);
-    solution.block(block_T) = distributed_vector.block(block_T);
-
-    // we have to update the old solution with our reaction update too
-    // so that the advection scheme will have the correct time stepping in the next step
-    distributed_reaction_vector.block(block_T).compress(VectorOperation::insert);
-
-    // we do not need distributed_vector any more, use it to temporarily store the update
-    distributed_vector.block(block_T) = old_solution.block(block_T);
-    distributed_vector.block(block_T) +=  distributed_reaction_vector.block(block_T);
-    old_solution.block(block_T) = distributed_vector.block(block_T);
-
-    distributed_vector.block(block_T) = old_old_solution.block(block_T);
-    distributed_vector.block(block_T) +=  distributed_reaction_vector.block(block_T);
-    old_old_solution.block(block_T) = distributed_vector.block(block_T);
-
-    operator_split_reaction_vector.block(block_T) = distributed_reaction_vector.block(block_T);
+    update_solution_vectors_with_reaction_results(block_T,distributed_vector,distributed_reaction_vector);
 
     initialize_current_linearization_point();
+
+    pcout << "in "
+          << number_of_reaction_steps
+          << " substep(s)."
+          << std::endl;
   }
 
 

--- a/tests/advection_reaction/screen-output
+++ b/tests/advection_reaction/screen-output
@@ -16,7 +16,7 @@ Number of degrees of freedom: 17,989 (8,450+1,089+4,225+4,225)
      Errors                     time=0.000000e+00 ndofs= 17989 C_L2_current= 3.076482e-05 C_L2_max= 3.076482e-05 T_L2_current= 3.076482e-05 T_L2_max= 3.076482e-05
 
 *** Timestep 1:  t=1 seconds
-   Solving composition reactions in 500 substep(s).
+   Solving composition reactions... in 500 substep(s).
    Solving temperature system... 22 iterations.
    Solving C_1 system ... 22 iterations.
    Rebuilding Stokes preconditioner...

--- a/tests/average_density_boundary_fluid_pressure/screen-output
+++ b/tests/average_density_boundary_fluid_pressure/screen-output
@@ -37,7 +37,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
 
 
 *** Timestep 1:  t=100000 years
-   Solving composition reactions in 50 substep(s).
+   Solving composition reactions... in 50 substep(s).
    Solving temperature system... 6 iterations.
    Solving porosity system ... 4 iterations.
    Skipping peridotite composition solve because RHS is zero.

--- a/tests/exponential_decay/screen-output
+++ b/tests/exponential_decay/screen-output
@@ -16,7 +16,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Errors                     time=0.000000e+00 ndofs= 1237 C_L2_current= 1.100813e-16 C_L2_max= 1.100813e-16 T_L2_current= 1.100813e-16 T_L2_max= 1.100813e-16
 
 *** Timestep 1:  t=10 seconds
-   Solving composition reactions in 312 substep(s).
+   Solving composition reactions... in 312 substep(s).
    Solving temperature system... 0 iterations.
    Solving C_1 system ... 0 iterations.
    Solving Stokes system... 2+0 iterations.
@@ -27,7 +27,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Errors                     time=1.000000e+01 ndofs= 1237 C_L2_current= 3.854009e-04 C_L2_max= 3.854009e-04 T_L2_current= 3.854009e-04 T_L2_max= 3.854009e-04
 
 *** Timestep 2:  t=20 seconds
-   Solving composition reactions in 312 substep(s).
+   Solving composition reactions... in 312 substep(s).
    Solving temperature system... 0 iterations.
    Solving C_1 system ... 0 iterations.
    Solving Stokes system... 2+0 iterations.
@@ -38,7 +38,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Errors                     time=2.000000e+01 ndofs= 1237 C_L2_current= 3.852524e-04 C_L2_max= 3.854009e-04 T_L2_current= 3.852524e-04 T_L2_max= 3.854009e-04
 
 *** Timestep 3:  t=30 seconds
-   Solving composition reactions in 312 substep(s).
+   Solving composition reactions... in 312 substep(s).
    Solving temperature system... 0 iterations.
    Solving C_1 system ... 0 iterations.
    Solving Stokes system... 2+0 iterations.
@@ -49,7 +49,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Errors                     time=3.000000e+01 ndofs= 1237 C_L2_current= 2.888279e-04 C_L2_max= 3.854009e-04 T_L2_current= 2.888279e-04 T_L2_max= 3.854009e-04
 
 *** Timestep 4:  t=40 seconds
-   Solving composition reactions in 312 substep(s).
+   Solving composition reactions... in 312 substep(s).
    Solving temperature system... 0 iterations.
    Solving C_1 system ... 0 iterations.
    Solving Stokes system... 2+0 iterations.
@@ -60,7 +60,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Errors                     time=4.000000e+01 ndofs= 1237 C_L2_current= 1.924778e-04 C_L2_max= 3.854009e-04 T_L2_current= 1.924778e-04 T_L2_max= 3.854009e-04
 
 *** Timestep 5:  t=50 seconds
-   Solving composition reactions in 312 substep(s).
+   Solving composition reactions... in 312 substep(s).
    Solving temperature system... 0 iterations.
    Solving C_1 system ... 0 iterations.
    Solving Stokes system... 2+0 iterations.
@@ -71,7 +71,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Errors                     time=5.000000e+01 ndofs= 1237 C_L2_current= 1.202523e-04 C_L2_max= 3.854009e-04 T_L2_current= 1.202523e-04 T_L2_max= 3.854009e-04
 
 *** Timestep 6:  t=60 seconds
-   Solving composition reactions in 312 substep(s).
+   Solving composition reactions... in 312 substep(s).
    Solving temperature system... 0 iterations.
    Solving C_1 system ... 0 iterations.
    Solving Stokes system... 2+0 iterations.
@@ -82,7 +82,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Errors                     time=6.000000e+01 ndofs= 1237 C_L2_current= 7.212356e-05 C_L2_max= 3.854009e-04 T_L2_current= 7.212356e-05 T_L2_max= 3.854009e-04
 
 *** Timestep 7:  t=70 seconds
-   Solving composition reactions in 312 substep(s).
+   Solving composition reactions... in 312 substep(s).
    Solving temperature system... 0 iterations.
    Solving C_1 system ... 0 iterations.
    Solving Stokes system... 2+0 iterations.
@@ -93,7 +93,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Errors                     time=7.000000e+01 ndofs= 1237 C_L2_current= 4.205588e-05 C_L2_max= 3.854009e-04 T_L2_current= 4.205588e-05 T_L2_max= 3.854009e-04
 
 *** Timestep 8:  t=80 seconds
-   Solving composition reactions in 312 substep(s).
+   Solving composition reactions... in 312 substep(s).
    Solving temperature system... 0 iterations.
    Solving C_1 system ... 0 iterations.
    Solving Stokes system... 3+0 iterations.
@@ -104,7 +104,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Errors                     time=8.000000e+01 ndofs= 1237 C_L2_current= 2.402267e-05 C_L2_max= 3.854009e-04 T_L2_current= 2.402267e-05 T_L2_max= 3.854009e-04
 
 *** Timestep 9:  t=90 seconds
-   Solving composition reactions in 312 substep(s).
+   Solving composition reactions... in 312 substep(s).
    Solving temperature system... 0 iterations.
    Solving C_1 system ... 0 iterations.
    Solving Stokes system... 3+0 iterations.
@@ -115,7 +115,7 @@ Number of degrees of freedom: 1,237 (578+81+289+289)
      Errors                     time=9.000000e+01 ndofs= 1237 C_L2_current= 1.350755e-05 C_L2_max= 3.854009e-04 T_L2_current= 1.350755e-05 T_L2_max= 3.854009e-04
 
 *** Timestep 10:  t=100 seconds
-   Solving composition reactions in 312 substep(s).
+   Solving composition reactions... in 312 substep(s).
    Solving temperature system... 0 iterations.
    Solving C_1 system ... 0 iterations.
    Solving Stokes system... 2+0 iterations.

--- a/tests/global_latent_heat/screen-output
+++ b/tests/global_latent_heat/screen-output
@@ -14,7 +14,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00000
 
 *** Timestep 1:  t=0.01 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 1 iterations.
    Skipping porosity composition solve because RHS is zero.
    Skipping peridotite composition solve because RHS is zero.
@@ -26,7 +26,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00001
 
 *** Timestep 2:  t=0.02 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -38,7 +38,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00002
 
 *** Timestep 3:  t=0.03 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -50,7 +50,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00003
 
 *** Timestep 4:  t=0.04 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -62,7 +62,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00004
 
 *** Timestep 5:  t=0.05 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -74,7 +74,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00005
 
 *** Timestep 6:  t=0.06 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -86,7 +86,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00006
 
 *** Timestep 7:  t=0.07 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -98,7 +98,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00007
 
 *** Timestep 8:  t=0.08 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -110,7 +110,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00008
 
 *** Timestep 9:  t=0.09 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -122,7 +122,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00009
 
 *** Timestep 10:  t=0.1 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -134,7 +134,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00010
 
 *** Timestep 11:  t=0.11 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -146,7 +146,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00011
 
 *** Timestep 12:  t=0.12 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -158,7 +158,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00012
 
 *** Timestep 13:  t=0.13 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -170,7 +170,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00013
 
 *** Timestep 14:  t=0.14 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -182,7 +182,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00014
 
 *** Timestep 15:  t=0.15 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -194,7 +194,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00015
 
 *** Timestep 16:  t=0.16 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -206,7 +206,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00016
 
 *** Timestep 17:  t=0.17 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -218,7 +218,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00017
 
 *** Timestep 18:  t=0.18 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -230,7 +230,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00018
 
 *** Timestep 19:  t=0.19 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -242,7 +242,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00019
 
 *** Timestep 20:  t=0.2 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -254,7 +254,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00020
 
 *** Timestep 21:  t=0.21 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -266,7 +266,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00021
 
 *** Timestep 22:  t=0.22 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -278,7 +278,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00022
 
 *** Timestep 23:  t=0.23 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -290,7 +290,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00023
 
 *** Timestep 24:  t=0.24 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -302,7 +302,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00024
 
 *** Timestep 25:  t=0.25 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -314,7 +314,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00025
 
 *** Timestep 26:  t=0.26 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -326,7 +326,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00026
 
 *** Timestep 27:  t=0.27 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -338,7 +338,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00027
 
 *** Timestep 28:  t=0.28 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -350,7 +350,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00028
 
 *** Timestep 29:  t=0.29 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -362,7 +362,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00029
 
 *** Timestep 30:  t=0.3 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -374,7 +374,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00030
 
 *** Timestep 31:  t=0.31 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -386,7 +386,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00031
 
 *** Timestep 32:  t=0.32 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -398,7 +398,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00032
 
 *** Timestep 33:  t=0.33 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -410,7 +410,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00033
 
 *** Timestep 34:  t=0.34 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -422,7 +422,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00034
 
 *** Timestep 35:  t=0.35 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -434,7 +434,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00035
 
 *** Timestep 36:  t=0.36 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -446,7 +446,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00036
 
 *** Timestep 37:  t=0.37 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -458,7 +458,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00037
 
 *** Timestep 38:  t=0.38 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -470,7 +470,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00038
 
 *** Timestep 39:  t=0.39 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -482,7 +482,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00039
 
 *** Timestep 40:  t=0.4 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -494,7 +494,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00040
 
 *** Timestep 41:  t=0.41 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -506,7 +506,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00041
 
 *** Timestep 42:  t=0.42 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -518,7 +518,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00042
 
 *** Timestep 43:  t=0.43 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -530,7 +530,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00043
 
 *** Timestep 44:  t=0.44 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -542,7 +542,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00044
 
 *** Timestep 45:  t=0.45 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -554,7 +554,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00045
 
 *** Timestep 46:  t=0.46 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -566,7 +566,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00046
 
 *** Timestep 47:  t=0.47 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -578,7 +578,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00047
 
 *** Timestep 48:  t=0.48 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -590,7 +590,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00048
 
 *** Timestep 49:  t=0.49 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -602,7 +602,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00049
 
 *** Timestep 50:  t=0.5 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -614,7 +614,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00050
 
 *** Timestep 51:  t=0.51 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -626,7 +626,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00051
 
 *** Timestep 52:  t=0.52 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -638,7 +638,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00052
 
 *** Timestep 53:  t=0.53 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -650,7 +650,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00053
 
 *** Timestep 54:  t=0.54 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -662,7 +662,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00054
 
 *** Timestep 55:  t=0.55 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -674,7 +674,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00055
 
 *** Timestep 56:  t=0.56 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -686,7 +686,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00056
 
 *** Timestep 57:  t=0.57 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -698,7 +698,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00057
 
 *** Timestep 58:  t=0.58 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -710,7 +710,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00058
 
 *** Timestep 59:  t=0.59 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -722,7 +722,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00059
 
 *** Timestep 60:  t=0.6 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -734,7 +734,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00060
 
 *** Timestep 61:  t=0.61 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -746,7 +746,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00061
 
 *** Timestep 62:  t=0.62 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -758,7 +758,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00062
 
 *** Timestep 63:  t=0.63 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -770,7 +770,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00063
 
 *** Timestep 64:  t=0.64 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -782,7 +782,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00064
 
 *** Timestep 65:  t=0.65 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -794,7 +794,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00065
 
 *** Timestep 66:  t=0.66 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -806,7 +806,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00066
 
 *** Timestep 67:  t=0.67 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -818,7 +818,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00067
 
 *** Timestep 68:  t=0.68 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -830,7 +830,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00068
 
 *** Timestep 69:  t=0.69 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -842,7 +842,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00069
 
 *** Timestep 70:  t=0.7 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -854,7 +854,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00070
 
 *** Timestep 71:  t=0.71 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -866,7 +866,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00071
 
 *** Timestep 72:  t=0.72 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -878,7 +878,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00072
 
 *** Timestep 73:  t=0.73 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -890,7 +890,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00073
 
 *** Timestep 74:  t=0.74 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -902,7 +902,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00074
 
 *** Timestep 75:  t=0.75 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -914,7 +914,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00075
 
 *** Timestep 76:  t=0.76 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -926,7 +926,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00076
 
 *** Timestep 77:  t=0.77 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -938,7 +938,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00077
 
 *** Timestep 78:  t=0.78 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -950,7 +950,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00078
 
 *** Timestep 79:  t=0.79 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -962,7 +962,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00079
 
 *** Timestep 80:  t=0.8 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -974,7 +974,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00080
 
 *** Timestep 81:  t=0.81 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -986,7 +986,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00081
 
 *** Timestep 82:  t=0.82 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -998,7 +998,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00082
 
 *** Timestep 83:  t=0.83 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1010,7 +1010,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00083
 
 *** Timestep 84:  t=0.84 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1022,7 +1022,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00084
 
 *** Timestep 85:  t=0.85 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1034,7 +1034,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00085
 
 *** Timestep 86:  t=0.86 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1046,7 +1046,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00086
 
 *** Timestep 87:  t=0.87 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1058,7 +1058,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00087
 
 *** Timestep 88:  t=0.88 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1070,7 +1070,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00088
 
 *** Timestep 89:  t=0.89 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1082,7 +1082,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00089
 
 *** Timestep 90:  t=0.9 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1094,7 +1094,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00090
 
 *** Timestep 91:  t=0.91 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1106,7 +1106,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00091
 
 *** Timestep 92:  t=0.92 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1118,7 +1118,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00092
 
 *** Timestep 93:  t=0.93 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1130,7 +1130,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00093
 
 *** Timestep 94:  t=0.94 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1142,7 +1142,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00094
 
 *** Timestep 95:  t=0.95 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1154,7 +1154,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00095
 
 *** Timestep 96:  t=0.96 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1166,7 +1166,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00096
 
 *** Timestep 97:  t=0.97 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1178,7 +1178,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00097
 
 *** Timestep 98:  t=0.98 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1190,7 +1190,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00098
 
 *** Timestep 99:  t=0.99 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
@@ -1202,7 +1202,7 @@ Number of degrees of freedom: 75 (18+8+18+4+9+9+9)
      Writing graphical output:  output-global_latent_heat/solution/solution-00099
 
 *** Timestep 100:  t=1 seconds
-   Solving composition reactions in 999 substep(s).
+   Solving composition reactions... in 999 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.

--- a/tests/heat_advection_by_melt_operator_splitting/screen-output
+++ b/tests/heat_advection_by_melt_operator_splitting/screen-output
@@ -30,7 +30,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
      Writing graphical output:      output-heat_advection_by_melt_operator_splitting/solution/solution-00000
 
 *** Timestep 1:  t=0.03125 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 6 iterations.
    Solving porosity system ... 0 iterations.
    Skipping peridotite composition solve because RHS is zero.
@@ -56,7 +56,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
      Writing graphical output:      output-heat_advection_by_melt_operator_splitting/solution/solution-00001
 
 *** Timestep 2:  t=0.0625 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 9 iterations.
    Solving porosity system ... 0 iterations.
    Skipping peridotite composition solve because RHS is zero.
@@ -82,7 +82,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
      Writing graphical output:      output-heat_advection_by_melt_operator_splitting/solution/solution-00002
 
 *** Timestep 3:  t=0.09375 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 8 iterations.
    Solving porosity system ... 0 iterations.
    Skipping peridotite composition solve because RHS is zero.
@@ -108,7 +108,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
      Writing graphical output:      output-heat_advection_by_melt_operator_splitting/solution/solution-00003
 
 *** Timestep 4:  t=0.1 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 7 iterations.
    Solving porosity system ... 0 iterations.
    Skipping peridotite composition solve because RHS is zero.

--- a/tests/latent_heat_melt_operator_split/screen-output
+++ b/tests/latent_heat_melt_operator_split/screen-output
@@ -13,7 +13,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 1000 K, 1000 K, 1000 K
 
 *** Timestep 1:  t=1.45878e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 14 iterations.
    Solving field2 system ... 14 iterations.
@@ -24,7 +24,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 1000 K, 1000 K, 1000 K
 
 *** Timestep 2:  t=2.91756e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 16 iterations.
    Solving porosity system ... 16 iterations.
    Solving field2 system ... 17 iterations.
@@ -35,7 +35,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 997.9 K, 1005 K, 1054 K
 
 *** Timestep 3:  t=4.37634e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 15 iterations.
    Solving porosity system ... 16 iterations.
    Solving field2 system ... 18 iterations.
@@ -46,7 +46,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.5 K, 1013 K, 1129 K
 
 *** Timestep 4:  t=5.83512e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 15 iterations.
    Solving porosity system ... 15 iterations.
    Solving field2 system ... 17 iterations.
@@ -57,7 +57,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 994.1 K, 1023 K, 1207 K
 
 *** Timestep 5:  t=7.2939e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 15 iterations.
    Solving porosity system ... 14 iterations.
    Solving field2 system ... 16 iterations.
@@ -68,7 +68,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 994.3 K, 1034 K, 1263 K
 
 *** Timestep 6:  t=8.75268e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 14 iterations.
    Solving porosity system ... 14 iterations.
    Solving field2 system ... 16 iterations.
@@ -79,7 +79,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 994.9 K, 1045 K, 1292 K
 
 *** Timestep 7:  t=1.02115e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 14 iterations.
    Solving porosity system ... 13 iterations.
    Solving field2 system ... 16 iterations.
@@ -90,7 +90,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.4 K, 1056 K, 1319 K
 
 *** Timestep 8:  t=1.16702e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 14 iterations.
    Solving porosity system ... 13 iterations.
    Solving field2 system ... 16 iterations.
@@ -101,7 +101,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.5 K, 1068 K, 1342 K
 
 *** Timestep 9:  t=1.3129e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 14 iterations.
    Solving porosity system ... 12 iterations.
    Solving field2 system ... 16 iterations.
@@ -112,7 +112,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.5 K, 1079 K, 1357 K
 
 *** Timestep 10:  t=1.45878e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 14 iterations.
    Solving porosity system ... 12 iterations.
    Solving field2 system ... 15 iterations.
@@ -123,7 +123,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.4 K, 1090 K, 1360 K
 
 *** Timestep 11:  t=1.60466e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 13 iterations.
    Solving porosity system ... 12 iterations.
    Solving field2 system ... 15 iterations.
@@ -134,7 +134,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.4 K, 1101 K, 1366 K
 
 *** Timestep 12:  t=1.75054e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 13 iterations.
    Solving porosity system ... 12 iterations.
    Solving field2 system ... 15 iterations.
@@ -145,7 +145,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.3 K, 1112 K, 1372 K
 
 *** Timestep 13:  t=1.89641e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 13 iterations.
    Solving porosity system ... 12 iterations.
    Solving field2 system ... 14 iterations.
@@ -156,7 +156,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.3 K, 1123 K, 1371 K
 
 *** Timestep 14:  t=2.04229e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 13 iterations.
    Solving porosity system ... 12 iterations.
    Solving field2 system ... 14 iterations.
@@ -167,7 +167,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.2 K, 1133 K, 1374 K
 
 *** Timestep 15:  t=2.18817e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 12 iterations.
    Solving porosity system ... 11 iterations.
    Solving field2 system ... 14 iterations.
@@ -178,7 +178,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.2 K, 1142 K, 1374 K
 
 *** Timestep 16:  t=2.33405e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 12 iterations.
    Solving porosity system ... 11 iterations.
    Solving field2 system ... 13 iterations.
@@ -189,7 +189,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.2 K, 1151 K, 1376 K
 
 *** Timestep 17:  t=2.47993e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 12 iterations.
    Solving porosity system ... 11 iterations.
    Solving field2 system ... 13 iterations.
@@ -200,7 +200,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.3 K, 1157 K, 1376 K
 
 *** Timestep 18:  t=2.6258e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 12 iterations.
    Solving porosity system ... 11 iterations.
    Solving field2 system ... 13 iterations.
@@ -211,7 +211,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.3 K, 1162 K, 1377 K
 
 *** Timestep 19:  t=2.77168e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 12 iterations.
    Solving porosity system ... 11 iterations.
    Solving field2 system ... 13 iterations.
@@ -222,7 +222,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.4 K, 1165 K, 1377 K
 
 *** Timestep 20:  t=2.91756e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 12 iterations.
    Solving porosity system ... 11 iterations.
    Solving field2 system ... 13 iterations.
@@ -233,7 +233,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.5 K, 1167 K, 1377 K
 
 *** Timestep 21:  t=3.06344e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 12 iterations.
    Solving porosity system ... 11 iterations.
    Solving field2 system ... 13 iterations.
@@ -244,7 +244,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.5 K, 1167 K, 1378 K
 
 *** Timestep 22:  t=3.20932e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 12 iterations.
    Solving porosity system ... 11 iterations.
    Solving field2 system ... 13 iterations.
@@ -255,7 +255,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.6 K, 1167 K, 1377 K
 
 *** Timestep 23:  t=3.35519e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 12 iterations.
    Solving porosity system ... 11 iterations.
    Solving field2 system ... 13 iterations.
@@ -266,7 +266,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.7 K, 1167 K, 1378 K
 
 *** Timestep 24:  t=3.50107e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 12 iterations.
    Solving porosity system ... 11 iterations.
    Solving field2 system ... 13 iterations.
@@ -277,7 +277,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.7 K, 1166 K, 1377 K
 
 *** Timestep 25:  t=3.64695e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 12 iterations.
    Solving porosity system ... 11 iterations.
    Solving field2 system ... 13 iterations.
@@ -288,7 +288,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.7 K, 1166 K, 1373 K
 
 *** Timestep 26:  t=3.79283e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 12 iterations.
    Solving porosity system ... 11 iterations.
    Solving field2 system ... 13 iterations.
@@ -299,7 +299,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.7 K, 1166 K, 1368 K
 
 *** Timestep 27:  t=3.93871e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 12 iterations.
    Solving porosity system ... 11 iterations.
    Solving field2 system ... 13 iterations.
@@ -310,7 +310,7 @@ Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)
      Temperature min/avg/max: 995.6 K, 1166 K, 1364 K
 
 *** Timestep 28:  t=4e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 12 iterations.
    Solving porosity system ... 12 iterations.
    Solving field2 system ... 12 iterations.

--- a/tests/latent_heat_melt_transport/screen-output
+++ b/tests/latent_heat_melt_transport/screen-output
@@ -27,7 +27,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00000
 
 *** Timestep 1:  t=2.91535e+15 seconds
-   Solving composition reactions in 7 substep(s).
+   Solving composition reactions... in 7 substep(s).
    Solving temperature system... 12 iterations.
    Solving porosity system ... 13 iterations.
    Solving peridotite system ... 13 iterations.
@@ -70,7 +70,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00001
 
 *** Timestep 2:  t=5.56346e+15 seconds
-   Solving composition reactions in 6 substep(s).
+   Solving composition reactions... in 6 substep(s).
    Solving temperature system... 10 iterations.
    Solving porosity system ... 13 iterations.
    Solving peridotite system ... 12 iterations.
@@ -113,7 +113,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00002
 
 *** Timestep 3:  t=8.20131e+15 seconds
-   Solving composition reactions in 6 substep(s).
+   Solving composition reactions... in 6 substep(s).
    Solving temperature system... 10 iterations.
    Solving porosity system ... 13 iterations.
    Solving peridotite system ... 11 iterations.
@@ -147,7 +147,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00003
 
 *** Timestep 4:  t=1.08807e+16 seconds
-   Solving composition reactions in 6 substep(s).
+   Solving composition reactions... in 6 substep(s).
    Solving temperature system... 10 iterations.
    Solving porosity system ... 12 iterations.
    Solving peridotite system ... 11 iterations.
@@ -181,7 +181,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00004
 
 *** Timestep 5:  t=1.35847e+16 seconds
-   Solving composition reactions in 6 substep(s).
+   Solving composition reactions... in 6 substep(s).
    Solving temperature system... 10 iterations.
    Solving porosity system ... 13 iterations.
    Solving peridotite system ... 11 iterations.
@@ -215,7 +215,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00005
 
 *** Timestep 6:  t=1.62237e+16 seconds
-   Solving composition reactions in 6 substep(s).
+   Solving composition reactions... in 6 substep(s).
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving peridotite system ... 11 iterations.
@@ -249,7 +249,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00006
 
 *** Timestep 7:  t=1.8827e+16 seconds
-   Solving composition reactions in 6 substep(s).
+   Solving composition reactions... in 6 substep(s).
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving peridotite system ... 11 iterations.
@@ -283,7 +283,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00007
 
 *** Timestep 8:  t=2.14094e+16 seconds
-   Solving composition reactions in 6 substep(s).
+   Solving composition reactions... in 6 substep(s).
    Solving temperature system... 10 iterations.
    Solving porosity system ... 11 iterations.
    Solving peridotite system ... 11 iterations.
@@ -317,7 +317,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00008
 
 *** Timestep 9:  t=2.39802e+16 seconds
-   Solving composition reactions in 6 substep(s).
+   Solving composition reactions... in 6 substep(s).
    Solving temperature system... 10 iterations.
    Solving porosity system ... 11 iterations.
    Solving peridotite system ... 11 iterations.
@@ -351,7 +351,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00009
 
 *** Timestep 10:  t=2.6546e+16 seconds
-   Solving composition reactions in 6 substep(s).
+   Solving composition reactions... in 6 substep(s).
    Solving temperature system... 10 iterations.
    Solving porosity system ... 10 iterations.
    Solving peridotite system ... 11 iterations.
@@ -385,7 +385,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00010
 
 *** Timestep 11:  t=2.91104e+16 seconds
-   Solving composition reactions in 6 substep(s).
+   Solving composition reactions... in 6 substep(s).
    Solving temperature system... 10 iterations.
    Solving porosity system ... 11 iterations.
    Solving peridotite system ... 11 iterations.
@@ -419,7 +419,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00011
 
 *** Timestep 12:  t=3.16739e+16 seconds
-   Solving composition reactions in 6 substep(s).
+   Solving composition reactions... in 6 substep(s).
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving peridotite system ... 11 iterations.
@@ -453,7 +453,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00012
 
 *** Timestep 13:  t=3.42406e+16 seconds
-   Solving composition reactions in 6 substep(s).
+   Solving composition reactions... in 6 substep(s).
    Solving temperature system... 11 iterations.
    Solving porosity system ... 12 iterations.
    Solving peridotite system ... 11 iterations.
@@ -487,7 +487,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00013
 
 *** Timestep 14:  t=3.68107e+16 seconds
-   Solving composition reactions in 6 substep(s).
+   Solving composition reactions... in 6 substep(s).
    Solving temperature system... 11 iterations.
    Solving porosity system ... 10 iterations.
    Solving peridotite system ... 11 iterations.
@@ -521,7 +521,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00014
 
 *** Timestep 15:  t=3.93841e+16 seconds
-   Solving composition reactions in 6 substep(s).
+   Solving composition reactions... in 6 substep(s).
    Solving temperature system... 11 iterations.
    Solving porosity system ... 11 iterations.
    Solving peridotite system ... 11 iterations.
@@ -555,7 +555,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
      Writing graphical output: output-latent_heat_melt_transport/solution/solution-00015
 
 *** Timestep 16:  t=4e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
    Solving peridotite system ... 9 iterations.

--- a/tests/mass_reaction_term/screen-output
+++ b/tests/mass_reaction_term/screen-output
@@ -27,7 +27,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00000
 
 *** Timestep 1:  t=6.25e+14 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 18 iterations.
    Solving peridotite system ... 19 iterations.
@@ -61,7 +61,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00001
 
 *** Timestep 2:  t=1.09488e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 17 iterations.
    Solving peridotite system ... 16 iterations.
@@ -95,7 +95,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00002
 
 *** Timestep 3:  t=1.57708e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 15 iterations.
    Solving peridotite system ... 15 iterations.
@@ -129,7 +129,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00003
 
 *** Timestep 4:  t=2.06639e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 15 iterations.
    Solving peridotite system ... 15 iterations.
@@ -163,7 +163,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00004
 
 *** Timestep 5:  t=2.56172e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 15 iterations.
    Solving peridotite system ... 14 iterations.
@@ -197,7 +197,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00005
 
 *** Timestep 6:  t=3.06203e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 14 iterations.
    Solving peridotite system ... 15 iterations.
@@ -231,7 +231,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00006
 
 *** Timestep 7:  t=3.56643e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 14 iterations.
    Solving peridotite system ... 15 iterations.
@@ -265,7 +265,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00007
 
 *** Timestep 8:  t=4.07415e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 14 iterations.
    Solving peridotite system ... 14 iterations.
@@ -299,7 +299,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00008
 
 *** Timestep 9:  t=4.58454e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 14 iterations.
    Solving peridotite system ... 15 iterations.
@@ -333,7 +333,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00009
 
 *** Timestep 10:  t=5.09709e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 14 iterations.
    Solving peridotite system ... 15 iterations.
@@ -367,7 +367,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00010
 
 *** Timestep 11:  t=5.61135e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 14 iterations.
    Solving peridotite system ... 14 iterations.
@@ -401,7 +401,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00011
 
 *** Timestep 12:  t=6.12697e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 14 iterations.
    Solving peridotite system ... 14 iterations.
@@ -435,7 +435,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00012
 
 *** Timestep 13:  t=6.64368e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 13 iterations.
    Solving peridotite system ... 14 iterations.
@@ -469,7 +469,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00013
 
 *** Timestep 14:  t=7.16125e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 13 iterations.
    Solving peridotite system ... 14 iterations.
@@ -503,7 +503,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00014
 
 *** Timestep 15:  t=7.67948e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 13 iterations.
    Solving peridotite system ... 15 iterations.
@@ -537,7 +537,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00015
 
 *** Timestep 16:  t=8.19826e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 13 iterations.
    Solving peridotite system ... 14 iterations.
@@ -571,7 +571,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00016
 
 *** Timestep 17:  t=8.71745e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 13 iterations.
    Solving peridotite system ... 14 iterations.
@@ -605,7 +605,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00017
 
 *** Timestep 18:  t=9.23697e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 12 iterations.
    Solving peridotite system ... 14 iterations.
@@ -639,7 +639,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00018
 
 *** Timestep 19:  t=9.75675e+15 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 12 iterations.
    Solving peridotite system ... 14 iterations.
@@ -673,7 +673,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00019
 
 *** Timestep 20:  t=1.02767e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 12 iterations.
    Solving peridotite system ... 14 iterations.
@@ -707,7 +707,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00020
 
 *** Timestep 21:  t=1.07969e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 12 iterations.
    Solving peridotite system ... 14 iterations.
@@ -741,7 +741,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00021
 
 *** Timestep 22:  t=1.13171e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 11 iterations.
    Solving peridotite system ... 14 iterations.
@@ -775,7 +775,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00022
 
 *** Timestep 23:  t=1.18375e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 12 iterations.
    Solving peridotite system ... 14 iterations.
@@ -809,7 +809,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00023
 
 *** Timestep 24:  t=1.23579e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 11 iterations.
    Solving peridotite system ... 14 iterations.
@@ -843,7 +843,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00024
 
 *** Timestep 25:  t=1.28784e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 11 iterations.
    Solving peridotite system ... 14 iterations.
@@ -877,7 +877,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00025
 
 *** Timestep 26:  t=1.3399e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 11 iterations.
    Solving peridotite system ... 14 iterations.
@@ -911,7 +911,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00026
 
 *** Timestep 27:  t=1.39196e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 11 iterations.
    Solving peridotite system ... 14 iterations.
@@ -945,7 +945,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00027
 
 *** Timestep 28:  t=1.44402e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 11 iterations.
    Solving peridotite system ... 14 iterations.
@@ -979,7 +979,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00028
 
 *** Timestep 29:  t=1.49608e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 11 iterations.
    Solving peridotite system ... 14 iterations.
@@ -1013,7 +1013,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00029
 
 *** Timestep 30:  t=1.54815e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 11 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1038,7 +1038,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00030
 
 *** Timestep 31:  t=1.60021e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 10 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1063,7 +1063,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00031
 
 *** Timestep 32:  t=1.65228e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 10 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1088,7 +1088,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00032
 
 *** Timestep 33:  t=1.70435e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 10 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1113,7 +1113,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00033
 
 *** Timestep 34:  t=1.75642e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 10 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1138,7 +1138,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00034
 
 *** Timestep 35:  t=1.80849e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 10 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1163,7 +1163,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00035
 
 *** Timestep 36:  t=1.86056e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 10 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1188,7 +1188,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00036
 
 *** Timestep 37:  t=1.91263e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 10 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1213,7 +1213,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00037
 
 *** Timestep 38:  t=1.9647e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 10 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1238,7 +1238,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00038
 
 *** Timestep 39:  t=2.01677e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 10 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1263,7 +1263,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00039
 
 *** Timestep 40:  t=2.06885e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 10 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1288,7 +1288,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00040
 
 *** Timestep 41:  t=2.12092e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 10 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1313,7 +1313,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00041
 
 *** Timestep 42:  t=2.17299e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 10 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1338,7 +1338,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00042
 
 *** Timestep 43:  t=2.22506e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 9 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1363,7 +1363,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00043
 
 *** Timestep 44:  t=2.27713e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 9 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1388,7 +1388,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00044
 
 *** Timestep 45:  t=2.3292e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 9 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1413,7 +1413,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00045
 
 *** Timestep 46:  t=2.38127e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 9 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1438,7 +1438,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00046
 
 *** Timestep 47:  t=2.43335e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 8 iterations.
    Solving peridotite system ... 15 iterations.
@@ -1463,7 +1463,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00047
 
 *** Timestep 48:  t=2.48542e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 8 iterations.
    Solving peridotite system ... 14 iterations.
@@ -1488,7 +1488,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00048
 
 *** Timestep 49:  t=2.53749e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 8 iterations.
    Solving peridotite system ... 14 iterations.
@@ -1513,7 +1513,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00049
 
 *** Timestep 50:  t=2.58956e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 8 iterations.
    Solving peridotite system ... 14 iterations.
@@ -1538,7 +1538,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
      Writing graphical output: output-mass_reaction_term/solution/solution-00050
 
 *** Timestep 51:  t=2.6e+16 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 9 iterations.
    Solving peridotite system ... 9 iterations.

--- a/tests/melt_and_traction/screen-output
+++ b/tests/melt_and_traction/screen-output
@@ -37,7 +37,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
 
 
 *** Timestep 1:  t=100000 years
-   Solving composition reactions in 50 substep(s).
+   Solving composition reactions... in 50 substep(s).
    Solving temperature system... 6 iterations.
    Solving porosity system ... 4 iterations.
    Skipping peridotite composition solve because RHS is zero.

--- a/tests/melt_transport/screen-output
+++ b/tests/melt_transport/screen-output
@@ -14,7 +14,7 @@ Number of degrees of freedom: 28,553 (12,611+8,450+1,089+4,225+1,089+1,089)
      RMS, max velocity:         0.000554 m/year, 0.00162 m/year
 
 *** Timestep 1:  t=4.8263e+06 years
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 23 iterations.
    Solving peridotite system ... 5 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -26,7 +26,7 @@ Number of degrees of freedom: 28,553 (12,611+8,450+1,089+4,225+1,089+1,089)
      RMS, max velocity:         0.000529 m/year, 0.00146 m/year
 
 *** Timestep 2:  t=1.01594e+07 years
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 18 iterations.
    Solving peridotite system ... 4 iterations.
    Skipping porosity composition solve because RHS is zero.
@@ -38,7 +38,7 @@ Number of degrees of freedom: 28,553 (12,611+8,450+1,089+4,225+1,089+1,089)
      RMS, max velocity:         0.000504 m/year, 0.00133 m/year
 
 *** Timestep 3:  t=1.5e+07 years
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 17 iterations.
    Solving peridotite system ... 4 iterations.
    Skipping porosity composition solve because RHS is zero.

--- a/tests/melting_rate_operator_splitting/screen-output
+++ b/tests/melting_rate_operator_splitting/screen-output
@@ -9,8 +9,8 @@ Number of degrees of freedom: 8,969 (2,178+1,057+2,178+289+1,089+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.1051e-16, 0, 0, 0
-      Relative nonlinear residual (total system) after nonlinear iteration 1: 1.1051e-16
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.02829e-16, 0, 0, 0
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.02829e-16
 
 
    Postprocessing:
@@ -19,15 +19,15 @@ Number of degrees of freedom: 8,969 (2,178+1,057+2,178+289+1,089+1,089+1,089)
      Writing graphical output:  output-melting_rate_operator_splitting/solution/solution-00000
 
 *** Timestep 1:  t=100000 years
-   Solving composition reactions in 100 substep(s).
+   Solving composition reactions... in 100 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.54802e-16, 3.14633e-16, 3.14633e-16, 0
-      Relative nonlinear residual (total system) after nonlinear iteration 1: 3.14633e-16
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.39115e-16, 3.37689e-16, 3.37689e-16, 0
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 3.37689e-16
 
 
    Postprocessing:
@@ -36,15 +36,15 @@ Number of degrees of freedom: 8,969 (2,178+1,057+2,178+289+1,089+1,089+1,089)
      Writing graphical output:  output-melting_rate_operator_splitting/solution/solution-00001
 
 *** Timestep 2:  t=200000 years
-   Solving composition reactions in 100 substep(s).
+   Solving composition reactions... in 100 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.86919e-17, 1.7158e-16, 1.7158e-16, 0
-      Relative nonlinear residual (total system) after nonlinear iteration 1: 1.7158e-16
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.91338e-17, 1.05088e-16, 1.05088e-16, 0
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1.05088e-16
 
 
    Postprocessing:

--- a/tests/melting_rate_operator_splitting2/screen-output
+++ b/tests/melting_rate_operator_splitting2/screen-output
@@ -9,8 +9,8 @@ Number of degrees of freedom: 8,969 (2,178+1,057+2,178+289+1,089+1,089+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.19657e-17, 0, 0, 0
-      Relative nonlinear residual (total system) after nonlinear iteration 1: 6.19657e-17
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.95637e-16, 0, 0, 0
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1.95637e-16
 
 
    Postprocessing:
@@ -19,15 +19,15 @@ Number of degrees of freedom: 8,969 (2,178+1,057+2,178+289+1,089+1,089+1,089)
      Writing graphical output:  output-melting_rate_operator_splitting2/solution/solution-00000
 
 *** Timestep 1:  t=100000 years
-   Solving composition reactions in 100 substep(s).
+   Solving composition reactions... in 100 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.02082e-16, 1.73376e-16, 1.73376e-16, 0
-      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.02082e-16
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.16753e-16, 7.61745e-17, 7.61745e-17, 0
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.16753e-16
 
 
    Postprocessing:
@@ -36,15 +36,15 @@ Number of degrees of freedom: 8,969 (2,178+1,057+2,178+289+1,089+1,089+1,089)
      Writing graphical output:  output-melting_rate_operator_splitting2/solution/solution-00001
 
 *** Timestep 2:  t=200000 years
-   Solving composition reactions in 100 substep(s).
+   Solving composition reactions... in 100 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
    Solving for u_f in 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.24489e-16, 9.51453e-17, 9.51453e-17, 0
-      Relative nonlinear residual (total system) after nonlinear iteration 1: 3.24489e-16
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.1095e-16, 7.82073e-17, 7.82073e-17, 0
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.1095e-16
 
 
    Postprocessing:

--- a/tests/mid_ocean_ridge/screen-output
+++ b/tests/mid_ocean_ridge/screen-output
@@ -28,7 +28,7 @@ Number of degrees of freedom: 13,321 (3,234+1,577+3,234+425+1,617+1,617+1,617)
      RMS, max velocity:         0.0169 m/year, 0.0298 m/year
 
 *** Timestep 1:  t=10000 years
-   Solving composition reactions in 50 substep(s).
+   Solving composition reactions... in 50 substep(s).
    Solving temperature system... 6 iterations.
    Skipping porosity composition solve because RHS is zero.
    Skipping peridotite composition solve because RHS is zero.

--- a/tests/prescribed_stokes_solution_melt/screen-output
+++ b/tests/prescribed_stokes_solution_melt/screen-output
@@ -13,7 +13,7 @@ Number of degrees of freedom: 2,058 (578+162+578+81+81+289+289)
      Heat fluxes through boundary parts: 0.1609 W, -0.1672 W, -1.469 W, 1.032 W
 
 *** Timestep 1:  t=0.0883883 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 9 iterations.
    Skipping porosity composition solve because RHS is zero.
    Skipping peridotite composition solve because RHS is zero.
@@ -24,7 +24,7 @@ Number of degrees of freedom: 2,058 (578+162+578+81+81+289+289)
      Heat fluxes through boundary parts: 0.1671 W, -0.181 W, -1.37 W, 1.153 W
 
 *** Timestep 2:  t=0.176777 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Skipping peridotite composition solve because RHS is zero.
@@ -35,7 +35,7 @@ Number of degrees of freedom: 2,058 (578+162+578+81+81+289+289)
      Heat fluxes through boundary parts: 0.1718 W, -0.1888 W, -1.311 W, 1.225 W
 
 *** Timestep 3:  t=0.265165 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Skipping peridotite composition solve because RHS is zero.
@@ -46,7 +46,7 @@ Number of degrees of freedom: 2,058 (578+162+578+81+81+289+289)
      Heat fluxes through boundary parts: 0.1746 W, -0.1924 W, -1.283 W, 1.259 W
 
 *** Timestep 4:  t=0.353553 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 8 iterations.
    Skipping porosity composition solve because RHS is zero.
    Skipping peridotite composition solve because RHS is zero.
@@ -57,7 +57,7 @@ Number of degrees of freedom: 2,058 (578+162+578+81+81+289+289)
      Heat fluxes through boundary parts: 0.1759 W, -0.1938 W, -1.272 W, 1.274 W
 
 *** Timestep 5:  t=0.441942 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Skipping peridotite composition solve because RHS is zero.
@@ -68,7 +68,7 @@ Number of degrees of freedom: 2,058 (578+162+578+81+81+289+289)
      Heat fluxes through boundary parts: 0.1765 W, -0.1943 W, -1.268 W, 1.279 W
 
 *** Timestep 6:  t=0.5 seconds
-   Solving composition reactions in 1 substep(s).
+   Solving composition reactions... in 1 substep(s).
    Solving temperature system... 7 iterations.
    Skipping porosity composition solve because RHS is zero.
    Skipping peridotite composition solve because RHS is zero.

--- a/tests/rising_melt_blob_freezing/screen-output
+++ b/tests/rising_melt_blob_freezing/screen-output
@@ -27,7 +27,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
      Writing graphical output:  output-rising_melt_blob_freezing/solution/solution-00000
 
 *** Timestep 1:  t=1 years
-   Solving composition reactions in 200 substep(s).
+   Solving composition reactions... in 200 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 6 iterations.
    Solving peridotite system ... 5 iterations.
@@ -484,7 +484,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
      Writing graphical output:  output-rising_melt_blob_freezing/solution/solution-00001
 
 *** Timestep 2:  t=2 years
-   Solving composition reactions in 200 substep(s).
+   Solving composition reactions... in 200 substep(s).
    Solving temperature system... 0 iterations.
    Solving porosity system ... 12 iterations.
    Solving peridotite system ... 10 iterations.

--- a/tests/shear_heating_with_melt/screen-output
+++ b/tests/shear_heating_with_melt/screen-output
@@ -90,7 +90,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
      Writing graphical output:           output-shear_heating_with_melt/solution/solution-00000
 
 *** Timestep 1:  t=2399.9 years
-   Solving composition reactions in 11 substep(s).
+   Solving composition reactions... in 11 substep(s).
    Solving temperature system... 19 iterations.
    Solving porosity system ... 1 iterations.
    Solving peridotite system ... 1 iterations.
@@ -136,7 +136,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
      Temperature min/avg/max:            282.7 K, 636 K, 2200 K
 
 *** Timestep 2:  t=4799.9 years
-   Solving composition reactions in 12 substep(s).
+   Solving composition reactions... in 12 substep(s).
    Solving temperature system... 16 iterations.
    Solving porosity system ... 1 iterations.
    Solving peridotite system ... 1 iterations.
@@ -183,7 +183,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
      Writing graphical output:           output-shear_heating_with_melt/solution/solution-00001
 
 *** Timestep 3:  t=7199.9 years
-   Solving composition reactions in 12 substep(s).
+   Solving composition reactions... in 12 substep(s).
    Solving temperature system... 16 iterations.
    Solving porosity system ... 1 iterations.
    Solving peridotite system ... 1 iterations.
@@ -221,7 +221,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
      Writing graphical output:           output-shear_heating_with_melt/solution/solution-00002
 
 *** Timestep 4:  t=9599.9 years
-   Solving composition reactions in 12 substep(s).
+   Solving composition reactions... in 12 substep(s).
    Solving temperature system... 15 iterations.
    Solving porosity system ... 1 iterations.
    Solving peridotite system ... 1 iterations.
@@ -259,7 +259,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
      Writing graphical output:           output-shear_heating_with_melt/solution/solution-00003
 
 *** Timestep 5:  t=10000 years
-   Solving composition reactions in 10 substep(s).
+   Solving composition reactions... in 10 substep(s).
    Solving temperature system... 7 iterations.
    Solving porosity system ... 1 iterations.
    Solving peridotite system ... 1 iterations.


### PR DESCRIPTION
This refactors the operator splitting functionality and includes the changes from #3167. #3167 should be merged first, as it contains changes to the test results. 
This PR should not create any changes. It usually saves 50% of the operator splitting time, because if the temperature and composition element are identical we can skip a lot of the duplicated computations.

This addresses a part of #1867.
