### PR TITLE
Replace dynamic cast in cookbooks and benchmarks

### DIFF
--- a/benchmarks/burstedde/burstedde.cc
+++ b/benchmarks/burstedde/burstedde.cc
@@ -443,11 +443,11 @@ namespace aspect
     {
       std::unique_ptr<Function<dim> > ref_func;
       {
-        const BursteddeMaterial<dim> *
+        const BursteddeMaterial<dim> &
         material_model
-          = dynamic_cast<const BursteddeMaterial<dim> *>(&this->get_material_model());
+          = Plugins::get_plugin_as_type<const BursteddeMaterial<dim>>(this->get_material_model());
 
-        ref_func.reset (new AnalyticSolutions::FunctionBurstedde<dim>(material_model->get_beta()));
+        ref_func.reset (new AnalyticSolutions::FunctionBurstedde<dim>(material_model.get_beta()));
       }
 
       const QGauss<dim> quadrature_formula (this->introspection().polynomial_degree.velocities+2);

--- a/benchmarks/hollow_sphere/hollow_sphere.cc
+++ b/benchmarks/hollow_sphere/hollow_sphere.cc
@@ -503,11 +503,11 @@ namespace aspect
     {
       std::unique_ptr<Function<dim> > ref_func;
       {
-        const HollowSphereMaterial<dim> *
+        const HollowSphereMaterial<dim> &
         material_model
-          = dynamic_cast<const HollowSphereMaterial<dim> *>(&this->get_material_model());
+          = Plugins::get_plugin_as_type<const HollowSphereMaterial<dim>>(this->get_material_model());
 
-        ref_func.reset (new AnalyticSolutions::FunctionHollowSphere<dim>(material_model->get_mmm()));
+        ref_func.reset (new AnalyticSolutions::FunctionHollowSphere<dim>(material_model.get_mmm()));
       }
 
       const QGauss<dim> quadrature_formula (this->introspection().polynomial_degree.velocities+2);

--- a/benchmarks/inclusion/inclusion.h
+++ b/benchmarks/inclusion/inclusion.h
@@ -292,21 +292,17 @@ namespace aspect
         execute (TableHandler &/*statistics*/)
         {
           std::unique_ptr<Function<dim> > ref_func;
-          if (dynamic_cast<const InclusionMaterial<dim> *>(&this->get_material_model()) != NULL)
-            {
-              const InclusionMaterial<dim> *
-              material_model
-                = dynamic_cast<const InclusionMaterial<dim> *>(&this->get_material_model());
 
-              ref_func.reset (new AnalyticSolutions::FunctionInclusion<dim>(
-                                material_model->get_eta_B(),
-                                this->n_compositional_fields()));
-            }
-          else
-            {
-              AssertThrow(false,
-                          ExcMessage("Postprocessor only works with the inclusion material model."));
-            }
+          AssertThrow(Plugins::plugin_type_matches<const InclusionMaterial<dim>>(this->get_material_model()),
+                      ExcMessage("Postprocessor only works with the inclusion material model."));
+
+          const InclusionMaterial<dim> &
+          material_model
+            = Plugins::get_plugin_as_type<const InclusionMaterial<dim> >(this->get_material_model());
+
+          ref_func.reset (new AnalyticSolutions::FunctionInclusion<dim>(
+                            material_model.get_eta_B(),
+                            this->n_compositional_fields()));
 
           const QGauss<dim> quadrature_formula (this->introspection().polynomial_degree.velocities+2);
 

--- a/benchmarks/layeredflow/layeredflow.cc
+++ b/benchmarks/layeredflow/layeredflow.cc
@@ -306,11 +306,12 @@ namespace aspect
     boundary_velocity (const types::boundary_id ,
                        const Point<2> &p) const
     {
-      const LayeredFlowMaterial<2> *
+      const LayeredFlowMaterial<2> &
       material_model
-        = dynamic_cast<const LayeredFlowMaterial<2> *>(&this->get_material_model());
-      return AnalyticSolutions::LayeredFlow_velocity (p, material_model->get_beta(),
-                                                      material_model->get_epsilon());
+        = Plugins::get_plugin_as_type<const LayeredFlowMaterial<2>>(this->get_material_model());
+
+      return AnalyticSolutions::LayeredFlow_velocity (p, material_model.get_beta(),
+                                                      material_model.get_epsilon());
     }
 
 
@@ -350,12 +351,12 @@ namespace aspect
     {
       std::unique_ptr<Function<dim> > ref_func;
       {
-        const LayeredFlowMaterial<dim> *
+        const LayeredFlowMaterial<dim> &
         material_model
-          = dynamic_cast<const LayeredFlowMaterial<dim> *>(&this->get_material_model());
+          = Plugins::get_plugin_as_type<const LayeredFlowMaterial<dim>>(this->get_material_model());
 
-        ref_func.reset (new AnalyticSolutions::FunctionLayeredFlow<dim>(material_model->get_beta(),
-                                                                        material_model->get_epsilon()));
+        ref_func.reset (new AnalyticSolutions::FunctionLayeredFlow<dim>(material_model.get_beta(),
+                                                                        material_model.get_epsilon()));
       }
 
       const QGauss<dim> quadrature_formula (this->introspection().polynomial_degree.velocities+2);

--- a/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
+++ b/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
@@ -186,8 +186,8 @@ namespace aspect
           // class; it will get a chance to read its parameters below after we
           // leave the current section
           base_model.reset(create_material_model<dim>(prm.get("Base model")));
-          if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(base_model.get()))
-            sim->initialize_simulator (this->get_simulator());
+          if (Plugins::plugin_type_matches<SimulatorAccess<dim>>(*base_model))
+            Plugins::get_plugin_as_type<SimulatorAccess<dim>>(*base_model).initialize_simulator (this->get_simulator());
 
           half_life              = prm.get_double ("Half life");
         }

--- a/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
+++ b/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
@@ -183,8 +183,8 @@ namespace aspect
           // class; it will get a chance to read its parameters below after we
           // leave the current section
           base_model.reset(create_material_model<dim>(prm.get("Base model")));
-          if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(base_model.get()))
-            sim->initialize_simulator (this->get_simulator());
+          if (Plugins::plugin_type_matches<SimulatorAccess<dim>>(*base_model))
+            Plugins::get_plugin_as_type<SimulatorAccess<dim>>(*base_model).initialize_simulator (this->get_simulator());
 
           half_life              = prm.get_double ("Half life");
         }

--- a/benchmarks/rigid_shear/plugin/rigid_shear.cc
+++ b/benchmarks/rigid_shear/plugin/rigid_shear.cc
@@ -270,12 +270,9 @@ namespace aspect
         {
           AnalyticSolutions::FunctionRigidShear<dim> ref_func(this->introspection().n_components);
 
-          if (dynamic_cast<const RigidShearMaterial<dim> *>(&this->get_material_model()) == NULL)
-            {
-              AssertThrow(false,
-                          ExcMessage(
-                            "Postprocessor RigidShearPostprocessor only works with the material model RigidShearMaterial."));
-            }
+          AssertThrow(Plugins::plugin_type_matches<const RigidShearMaterial<dim>>(this->get_material_model()),
+                      ExcMessage(
+                        "Postprocessor RigidShearPostprocessor only works with the material model RigidShearMaterial."));
 
           const QGauss<dim> quadrature_formula(this->introspection().polynomial_degree.velocities + 2);
 

--- a/benchmarks/shear_bands/shear_bands.cc
+++ b/benchmarks/shear_bands/shear_bands.cc
@@ -323,20 +323,14 @@ namespace aspect
     void
     ShearBandsInitialCondition<dim>::initialize ()
     {
-      if (dynamic_cast<const ShearBandsMaterial<dim> *>(&this->get_material_model()) != NULL)
-        {
-          const ShearBandsMaterial<dim> *
-          material_model
-            = dynamic_cast<const ShearBandsMaterial<dim> *>(&this->get_material_model());
+      AssertThrow(Plugins::plugin_type_matches<const ShearBandsMaterial<dim>>(this->get_material_model()),
+                  ExcMessage("Initial condition shear bands only works with the material model shear bands."));
 
-          background_porosity = material_model->get_background_porosity();
-        }
-      else
-        {
-          AssertThrow(false,
-                      ExcMessage("Initial condition shear bands only works with the material model shear bands."));
-        }
+      const ShearBandsMaterial<dim> &
+      material_model
+        = Plugins::get_plugin_as_type<const ShearBandsMaterial<dim>>(this->get_material_model());
 
+      background_porosity = material_model.get_background_porosity();
 
       AssertThrow(noise_amplitude < background_porosity,
                   ExcMessage("Amplitude of the white noise must be smaller "
@@ -351,19 +345,14 @@ namespace aspect
       white_noise.TableBase<dim,double>::reinit(size_idx);
       std::array<std::pair<double,double>,dim> grid_extents;
 
-      if (dynamic_cast<const GeometryModel::Box<dim> *>(&this->get_geometry_model()) != NULL)
-        {
-          const GeometryModel::Box<dim> *
-          geometry_model
-            = dynamic_cast<const GeometryModel::Box<dim> *>(&this->get_geometry_model());
+      AssertThrow(Plugins::plugin_type_matches<const GeometryModel::Box<dim>>(this->get_geometry_model()),
+                  ExcMessage("Initial condition shear bands only works with the box geometry model."));
 
-          extents = geometry_model->get_extents();
-        }
-      else
-        {
-          AssertThrow(false,
-                      ExcMessage("Initial condition shear bands only works with the box geometry model."));
-        }
+      const GeometryModel::Box<dim> &
+      geometry_model
+        = Plugins::get_plugin_as_type<const GeometryModel::Box<dim>>(this->get_geometry_model());
+
+      extents = geometry_model.get_extents();
 
       for (unsigned int d=0; d<dim; ++d)
         {
@@ -506,20 +495,14 @@ namespace aspect
     void
     PlaneWaveMeltBandsInitialCondition<dim>::initialize ()
     {
-      if (dynamic_cast<const ShearBandsMaterial<dim> *>(&this->get_material_model()) != NULL)
-        {
-          const ShearBandsMaterial<dim> *
-          material_model
-            = dynamic_cast<const ShearBandsMaterial<dim> *>(&this->get_material_model());
+      AssertThrow(Plugins::plugin_type_matches<ShearBandsMaterial<dim>>(this->get_material_model()),
+                  ExcMessage("Initial condition shear bands only works with the material model shear bands."));
 
-          background_porosity = material_model->get_background_porosity();
-        }
-      else
-        {
-          AssertThrow(false,
-                      ExcMessage("Initial condition plane wave melt bands only works with the material model shear bands."));
-        }
+      const ShearBandsMaterial<dim> &
+      material_model
+        = Plugins::get_plugin_as_type<const ShearBandsMaterial<dim>>(this->get_material_model());
 
+      background_porosity = material_model.get_background_porosity();
 
       AssertThrow(amplitude < 1.0,
                   ExcMessage("Amplitude of the melt bands must be smaller "
@@ -758,22 +741,17 @@ namespace aspect
     void
     ShearBandsGrowthRate<dim>::initialize ()
     {
-      if (dynamic_cast<const ShearBandsMaterial<dim> *>(&this->get_material_model()) != NULL)
-        {
-          const ShearBandsMaterial<dim> *
-          material_model
-            = dynamic_cast<const ShearBandsMaterial<dim> *>(&this->get_material_model());
+      AssertThrow(Plugins::plugin_type_matches<const ShearBandsMaterial<dim>>(this->get_material_model()),
+                  ExcMessage("Postprocessor shear bands growth rate only works with the material model shear bands."));
 
-          background_porosity = material_model->get_background_porosity();
-          eta_0               = material_model->reference_viscosity();
-          xi_0                = material_model->get_reference_compaction_viscosity();
-          alpha               = material_model->get_porosity_exponent();
-        }
-      else
-        {
-          AssertThrow(false,
-                      ExcMessage("Postprocessor shear bands growth rate only works with the material model shear bands."));
-        }
+      const ShearBandsMaterial<dim> &
+      material_model
+        = Plugins::get_plugin_as_type<const ShearBandsMaterial<dim>>(this->get_material_model());
+
+      background_porosity = material_model.get_background_porosity();
+      eta_0               = material_model.reference_viscosity();
+      xi_0                = material_model.get_reference_compaction_viscosity();
+      alpha               = material_model.get_porosity_exponent();
 
       const PlaneWaveMeltBandsInitialCondition<dim> &initial_composition
         = this->get_initial_composition_manager().template

--- a/benchmarks/solcx/solcx.h
+++ b/benchmarks/solcx/solcx.h
@@ -3129,21 +3129,17 @@ namespace aspect
         execute (TableHandler &/*statistics*/)
         {
           std::unique_ptr<Function<dim> > ref_func;
-          if (dynamic_cast<const SolCxMaterial<dim> *>(&this->get_material_model()) != NULL)
-            {
-              const SolCxMaterial<dim> *
-              material_model
-                = dynamic_cast<const SolCxMaterial<dim> *>(&this->get_material_model());
 
-              ref_func.reset (new AnalyticSolutions::FunctionSolCx<dim>(material_model->get_eta_B(),
-                                                                        material_model->get_background_density(),
-                                                                        this->n_compositional_fields()));
-            }
-          else
-            {
-              AssertThrow(false,
-                          ExcMessage("Postprocessor DuretzEtAl only works with the material model SolCx, SolKz, and Inclusion."));
-            }
+          AssertThrow(Plugins::plugin_type_matches<const SolCxMaterial<dim>>(this->get_material_model()),
+                      ExcMessage("Postprocessor DuretzEtAl only works with the material model SolCx, SolKz, and Inclusion."));
+
+          const SolCxMaterial<dim> &
+          material_model
+            = Plugins::get_plugin_as_type<const SolCxMaterial<dim>>(this->get_material_model());
+
+          ref_func.reset (new AnalyticSolutions::FunctionSolCx<dim>(material_model.get_eta_B(),
+                                                                    material_model.get_background_density(),
+                                                                    this->n_compositional_fields()));
 
           const QGauss<dim> quadrature_formula (this->introspection().polynomial_degree.velocities + 2);
 

--- a/benchmarks/solitary_wave/solitary_wave.cc
+++ b/benchmarks/solitary_wave/solitary_wave.cc
@@ -555,19 +555,14 @@ namespace aspect
       std::cout << "Initialize solitary wave solution"
                 << std::endl;
 
-      if (dynamic_cast<const SolitaryWaveMaterial<dim> *>(&this->get_material_model()) != NULL)
-        {
-          const SolitaryWaveMaterial<dim> *
-          material_model
-            = dynamic_cast<const SolitaryWaveMaterial<dim> *>(&this->get_material_model());
+      AssertThrow(Plugins::plugin_type_matches<const SolitaryWaveMaterial<dim>>(this->get_material_model()),
+                  ExcMessage("Initial condition Solitary Wave only works with the material model Solitary wave."));
 
-          compaction_length = material_model->length_scaling(background_porosity);
-        }
-      else
-        {
-          AssertThrow(false,
-                      ExcMessage("Initial condition Solitary Wave only works with the material model Solitary wave."));
-        }
+      const SolitaryWaveMaterial<dim> &
+      material_model
+        = Plugins::get_plugin_as_type<const SolitaryWaveMaterial<dim>>(this->get_material_model());
+
+      compaction_length = material_model.length_scaling(background_porosity);
 
       AnalyticSolutions::compute_porosity(amplitude,
                                           background_porosity,
@@ -945,17 +940,9 @@ namespace aspect
 
       double delta=0;
 
-      if (dynamic_cast<const SolitaryWaveMaterial<dim> *>(&this->get_material_model()) != NULL)
-        {
-          delta = compute_phase_shift();
-          // reset the phase shift of the analytical solution so we can compare the shape of the wave
-          ref_func->set_delta(delta);
-        }
-      else
-        {
-          AssertThrow(false,
-                      ExcMessage("Postprocessor Solitary Wave only works with the material model Solitary wave."));
-        }
+      delta = compute_phase_shift();
+      // reset the phase shift of the analytical solution so we can compare the shape of the wave
+      ref_func->set_delta(delta);
 
       // what we want to compare:
       // (1) error of the numerical phase speed c:

--- a/benchmarks/solkz/solkz.h
+++ b/benchmarks/solkz/solkz.h
@@ -747,12 +747,9 @@ namespace aspect
         {
           AnalyticSolutions::FunctionSolKz<dim> ref_func(this->introspection().n_components);
 
-          if (dynamic_cast<const SolKzMaterial<dim> *>(&this->get_material_model()) == NULL)
-            {
-              AssertThrow(false,
-                          ExcMessage(
-                            "Postprocessor SolKzPostprocessor only works with the material model SolKzn."));
-            }
+          AssertThrow(Plugins::plugin_type_matches<const SolKzMaterial<dim>>(this->get_material_model()),
+                      ExcMessage(
+                        "Postprocessor SolKzPostprocessor only works with the material model SolKzn."));
 
           const QGauss<dim> quadrature_formula(this->introspection().polynomial_degree.velocities + 2);
 

--- a/benchmarks/tangurnis/code/tangurnis.cc
+++ b/benchmarks/tangurnis/code/tangurnis.cc
@@ -365,20 +365,21 @@ namespace aspect
     AssertThrow(Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) == 1,
                 ExcNotImplemented());
 
-    const MaterialModel::TanGurnis<dim> *
-    material_model = dynamic_cast<const MaterialModel::TanGurnis<dim> *>(&this->get_material_model());
+    AssertThrow(Plugins::plugin_type_matches<const MaterialModel::TanGurnis<dim>>(this->get_material_model()),
+                ExcMessage("tan gurnis postprocessor only works with tan gurnis material model"));
 
-    AssertThrow(material_model!=NULL, ExcMessage("tan gurnis postprocessor only works with tan gurnis material model"));
+    const MaterialModel::TanGurnis<dim> &
+    material_model = Plugins::get_plugin_as_type<const MaterialModel::TanGurnis<dim>>(this->get_material_model());
 
     double ref=1.0/this->get_triangulation().begin_active()->minimum_vertex_distance();
     std::ofstream f ((this->get_output_directory() + "vel_" +
                       Utilities::int_to_string(static_cast<unsigned int>(ref)) +
                       ".csv").c_str());
     f.precision (16);
-    f << material_model->parameter_Di() << ' '
-      << material_model->parameter_gamma() << ' '
-      << material_model->parameter_wavenumber() << ' '
-      << material_model->parameter_a();
+    f << material_model.parameter_Di() << ' '
+      << material_model.parameter_gamma() << ' '
+      << material_model.parameter_wavenumber() << ' '
+      << material_model.parameter_a();
 
     // pad the first line to the same number of columns as the data below to make MATLAB happy
     for (unsigned int i=4; i<7+this->get_heating_model_manager().get_active_heating_models().size(); ++i)
@@ -398,8 +399,6 @@ namespace aspect
     MaterialModel::MaterialModelInputs<dim> in(fe_values.n_quadrature_points, this->n_compositional_fields());
     MaterialModel::MaterialModelOutputs<dim> out(fe_values.n_quadrature_points, this->n_compositional_fields());
 
-    std::vector<std::vector<double> > composition_values (this->n_compositional_fields(),std::vector<double> (n_q_points));
-
     const std::list<std::unique_ptr<HeatingModel::Interface<dim> > > &heating_model_objects = this->get_heating_model_manager().get_active_heating_models();
 
     std::vector<HeatingModel::HeatingModelOutputs> heating_model_outputs (heating_model_objects.size(),
@@ -411,23 +410,7 @@ namespace aspect
     for (; cell != endc; ++cell)
       {
         fe_values.reinit (cell);
-        fe_values[this->introspection().extractors.temperature].get_function_values (this->get_solution(), in.temperature);
-        fe_values[this->introspection().extractors.pressure].get_function_values (this->get_solution(), in.pressure);
-        fe_values[this->introspection().extractors.velocities].get_function_values (this->get_solution(), in.velocity);
-        fe_values[this->introspection().extractors.pressure].get_function_gradients (this->get_solution(), in.pressure_gradient);
-
-        for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-          fe_values[this->introspection().extractors.compositional_fields[c]].get_function_values(this->get_solution(),
-              composition_values[c]);
-        for (unsigned int i=0; i<fe_values.n_quadrature_points; ++i)
-          {
-            for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              in.composition[i][c] = composition_values[c][i];
-          }
-
-        fe_values[this->introspection().extractors.velocities].get_function_symmetric_gradients (this->get_solution(),
-            in.strain_rate);
-        in.position = fe_values.get_quadrature_points();
+        in.reinit(fe_values,cell,this->introspection(),this->get_solution(),true);
 
         this->get_material_model().evaluate(in, out);
 

--- a/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
+++ b/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
@@ -411,10 +411,10 @@ namespace aspect
     std::pair<std::string,std::string>
     TosiPostprocessor<dim>::execute (TableHandler &statistics)
     {
-      AssertThrow(dynamic_cast<const GeometryModel::Box<dim> *>(&this->get_geometry_model()) != 0,
+      AssertThrow(Plugins::plugin_type_matches<const GeometryModel::Box<dim> >(this->get_geometry_model()),
                   ExcMessage("The current calculation of rate of work only makes sense in a Cartesian geometry."));
 
-      AssertThrow(dynamic_cast<const TosiMaterial<dim> *>(&this->get_material_model()) != 0,
+      AssertThrow(Plugins::plugin_type_matches<const TosiMaterial<dim>>(this->get_material_model()),
                   ExcMessage("The current calculation of viscous dissipation is only for incompressible models "
                              "and specifically computes the difference between work and dissipation as requested "
                              "in the paper of Tosi et al. 2015."));

--- a/cookbooks/anisotropic_viscosity/av_material.cc
+++ b/cookbooks/anisotropic_viscosity/av_material.cc
@@ -193,6 +193,7 @@ namespace aspect
     {
       internal::Assembly::Scratch::StokesPreconditioner<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesPreconditioner<dim>& > (scratch_base);
       internal::Assembly::CopyData::StokesPreconditioner<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesPreconditioner<dim>& > (data_base);
+
       const MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
         scratch.material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >();
 
@@ -525,13 +526,13 @@ namespace aspect
     {
       for (unsigned int i=0; i<assemblers.stokes_preconditioner.size(); ++i)
         {
-          if (dynamic_cast<Assemblers::StokesPreconditioner<dim> *>(assemblers.stokes_preconditioner[i].get()) != nullptr)
+          if (Plugins::plugin_type_matches<Assemblers::StokesPreconditioner<dim>>(*(assemblers.stokes_preconditioner[i])))
             assemblers.stokes_preconditioner[i] = std_cxx14::make_unique<Assemblers::StokesPreconditionerAnisotropicViscosity<dim> > ();
         }
 
       for (unsigned int i=0; i<assemblers.stokes_system.size(); ++i)
         {
-          if (dynamic_cast<Assemblers::StokesIncompressibleTerms<dim> *>(assemblers.stokes_system[i].get()) != nullptr)
+          if (Plugins::plugin_type_matches<Assemblers::StokesIncompressibleTerms<dim>>(*(assemblers.stokes_system[i])))
             assemblers.stokes_system[i] = std_cxx14::make_unique<Assemblers::StokesIncompressibleTermsAnisotropicViscosity<dim> > ();
         }
     }

--- a/cookbooks/inner_core_convection/inner_core_assembly.cc
+++ b/cookbooks/inner_core_convection/inner_core_assembly.cc
@@ -86,7 +86,7 @@ namespace aspect
 
             for (unsigned int q=0; q<n_q_points; ++q)
               {
-                const double P = dynamic_cast<const MaterialModel::InnerCore<dim>&>
+                const double P = Plugins::get_plugin_as_type<const MaterialModel::InnerCore<dim>>
                                  (this->get_material_model()).resistance_to_phase_change
                                  .value(scratch.material_model_inputs.position[q]);
 
@@ -122,13 +122,12 @@ namespace aspect
   void set_assemblers_phase_boundary(const SimulatorAccess<dim> &simulator_access,
                                      Assemblers::Manager<dim> &assemblers)
   {
-    AssertThrow (dynamic_cast<const MaterialModel::InnerCore<dim>*>
-                 (&simulator_access.get_material_model()) != 0,
+    AssertThrow (Plugins::plugin_type_matches<const MaterialModel::InnerCore<dim>>
+                 (simulator_access.get_material_model()),
                  ExcMessage ("The phase boundary assembler can only be used with the "
                              "material model 'inner core material'!"));
 
-    PhaseBoundaryAssembler<dim> *phase_boundary_assembler = new PhaseBoundaryAssembler<dim>();
-    assemblers.stokes_system_on_boundary_face.push_back (std::unique_ptr<PhaseBoundaryAssembler<dim> > (phase_boundary_assembler));
+    assemblers.stokes_system_on_boundary_face.push_back (std_cxx14::make_unique<PhaseBoundaryAssembler<dim>>());
   }
 }
 

--- a/cookbooks/inner_core_convection/inner_core_convection.cc
+++ b/cookbooks/inner_core_convection/inner_core_convection.cc
@@ -169,8 +169,7 @@ namespace aspect
       if (compute_quadratic_pressure_profile)
         {
           // Compute a quadratic hydrostatic pressure profile, based on a linear gravity model.
-          AssertThrow (dynamic_cast<const GravityModel::RadialLinear<dim>*>(&this->get_gravity_model())
-                       != 0,
+          AssertThrow (Plugins::plugin_type_matches<const GravityModel::RadialLinear<dim>>(this->get_gravity_model()),
                        ExcMessage ("Automatic computation of the hydrostatic pressure profile is "
                                    "only implemented for the 'radial linear' gravity model."));
 


### PR DESCRIPTION
Since #2148 there is not really a use any more for casting pointers to determine the type of a plugin, and it is confusing for new users. This PR replaces all occurences of `dynamic_cast` with the appropriate functions. In a few cases I had to change the order of checks, and I removed a bit outdated code.