### PR TITLE
Move assignment to old_solution to the only place it is used

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1248,13 +1248,8 @@ namespace aspect
        * interpolated to the finite element space and consequently into the
        * solution vector.
        * This is useful for compositional fields whose advection mode is set
-       * to Parameters::AdvectionFieldMethod::prescribed_field.
-       *
-       * This function also sets the previous solution vectors (corresponding to the
-       * solution from previous time steps) to the same interpolated
-       * values. This implies that the compositional field method can then be
-       * combined with time-dependent problems like advection or diffusion of
-       * the field.
+       * to Parameters::AdvectionFieldMethod::prescribed_field or
+       * Parameters::AdvectionFieldMethod::prescribed_field_with_diffusion.
        *
        * This function is implemented in
        * <code>source/simulator/helper_functions.cc</code>.

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1871,10 +1871,6 @@ namespace aspect
     const unsigned int block_c = introspection.block_indices.compositional_fields[c];
     distributed_vector.block(block_c).compress(VectorOperation::insert);
     solution.block(block_c) = distributed_vector.block(block_c);
-
-    // We also want to copy the values into the old solution, because it might
-    // be used in other parts of the code.
-    old_solution.block(block_c) = distributed_vector.block(block_c);
   }
 
 

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -187,7 +187,14 @@ namespace aspect
               // if this is a prescribed field with diffusion, we first have to copy the material model
               // outputs into the prescribed field before we assemle and solve the equation
               if (method == Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion)
-                interpolate_material_output_into_compositional_field(c);
+                {
+                  interpolate_material_output_into_compositional_field(c);
+
+                  // Also set the old_solution block to the prescribed field. The old
+                  // solution is the one that is used to assemble the diffusion system in
+                  // assemble_advection_system() for this solver scheme.
+                  old_solution.block(adv_field.block_index(introspection)) = solution.block(adv_field.block_index(introspection));
+                }
 
               assemble_advection_system (adv_field);
 


### PR DESCRIPTION
Currently the `interpolate_material_output_into_compositional_field` function interpolates the material output both into `solution`and `old_solution`, because the `prescribed_field_with_diffusion` advection method needs it that way (because it afterwards solves a diffusion equation as if the interpolation had not happened). This does not matter for all current applications, but I want to use the prescribed field to compute a time-derivative of the composition, and the current assignment to `old_solution` prevents that.

Also it feels weird to me that the function modifies the solutions of previous time steps, because it is intended to create the current compositional field. This PR solves this, by moving the assignment out of the function into the advection method. Technically that changes the behavior of the function, but it is private and only used twice inside `Simulator`.