### PR TITLE
Streamline pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,17 @@
-Pull Request Checklist. Please read and check each box with an X. Feel free to delete any part not applicable to your PR.
+Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.
 
-### Describe the content of this pull request, and why you did these changes:
+*Describe what you did in this PR and why you did it.*
 
-### Before submitting your first pull request:
+### Before your first pull request:
 
 * [ ] I have read the guidelines in our [CONTRIBUTING.md](../CONTRIBUTING.md) document.
 
-### For all Pull Requests:
+### For all pull requests:
 
-* [ ] I have followed the instructions for indenting my code according to ASPECT's code style as described in the last paragraph of the ['Making ASPECT better'](../CONTRIBUTING.md#making-aspect-better) section of CONTRIBUTING.md.
+* [ ] I have followed the [instructions for indenting my code](../CONTRIBUTING.md#making-aspect-better).
 
-### For Feature/Benchmark Submissions or Changes of Existing Behavior:
+### For new features/models or changes of existing features:
 
 * [ ] I have tested my new feature locally to ensure it is correct.
-* [ ] I have created a testcase for the new feature/benchmark in the [tests/](../tests/) directory as described in the corresponding section of the [manual](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests).
+* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../tests/) directory.
 * [ ] I have added a changelog entry in the [doc/modules/changes](../doc/modules/changes) directory that will inform other users of my change.


### PR DESCRIPTION
After a few pull requests with the new template, I would like to shorten it a bit in some places, and add a message for how to get help with the process. I hope this makes it less annoying for experienced developers, and less intimidating for new developers. I am open for suggestions about improvements.