### PR TITLE
Make sure we get a reasonable exception when using volume of fluid in 3d

### DIFF
--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1710,7 +1710,13 @@ namespace aspect
           else if (x_compositional_field_methods[i] == "particles")
             compositional_field_methods[i] = AdvectionFieldMethod::particles;
           else if (x_compositional_field_methods[i] == "volume of fluid")
-            compositional_field_methods[i] = AdvectionFieldMethod::volume_of_fluid;
+            {
+              AssertThrow (dim==2,
+                           ExcMessage ("The 'volume of fluid' method is currently "
+                                       "only implemented for two-dimensional "
+                                       "computations."));
+              compositional_field_methods[i] = AdvectionFieldMethod::volume_of_fluid;
+            }
           else if (x_compositional_field_methods[i] == "static")
             compositional_field_methods[i] = AdvectionFieldMethod::static_field;
           else if (x_compositional_field_methods[i] == "melt field")


### PR DESCRIPTION
As mentioned in #3186 (and #835), the volume of fluid method isn't implemented in 3d right now. Make sure we get an error message at the earliest possible place about this.

@class4kayaker , @egpuckett -- FYI.