### PR TITLE
Compressible computations with GMG

### DIFF
--- a/doc/modules/changes/20190806_clevenger
+++ b/doc/modules/changes/20190806_clevenger
@@ -1,0 +1,4 @@
+New: The matrix-free, block GMG Stokes solver can now be used for compressible
+flow computations (all except those involving implicit reference density). 
+<br>
+(Conrad Clevenger, 2019/08/06)

--- a/include/aspect/stokes_matrix_free.h
+++ b/include/aspect/stokes_matrix_free.h
@@ -72,12 +72,14 @@ namespace aspect
         void clear ();
 
         /**
-         * Fills in the viscosity table and set the value for the pressure scaling constant.
+         * Fills in the viscosity table, sets the value for the pressure scaling constant,
+         * and gives information regarding compressibility.
          */
-        void fill_viscosities_and_pressure_scaling(const dealii::LinearAlgebra::distributed::Vector<number> &viscosity_values,
-                                                   const double pressure_scaling,
-                                                   const Triangulation<dim> &tria,
-                                                   const DoFHandler<dim> &dof_handler_for_projection);
+        void fill_cell_data(const dealii::LinearAlgebra::distributed::Vector<number> &viscosity_values,
+                            const double pressure_scaling,
+                            const Triangulation<dim> &tria,
+                            const DoFHandler<dim> &dof_handler_for_projection,
+                            const bool is_compressible);
 
         /**
          * Returns the viscosity table.
@@ -118,6 +120,11 @@ namespace aspect
          * Pressure scaling constant.
          */
         double pressure_scaling;
+
+        /**
+          * Information on the compressibility of the flow.
+          */
+        bool is_compressible;
     };
 
     /**
@@ -140,12 +147,12 @@ namespace aspect
         void clear ();
 
         /**
-         * Fills in the viscosity table and set the value for the pressure scaling constant.
+         * Fills in the viscosity table and sets the value for the pressure scaling constant.
          */
-        void fill_viscosities_and_pressure_scaling (const dealii::LinearAlgebra::distributed::Vector<number> &viscosity_values,
-                                                    const double pressure_scaling,
-                                                    const Triangulation<dim> &tria,
-                                                    const DoFHandler<dim> &dof_handler_for_projection);
+        void fill_cell_data (const dealii::LinearAlgebra::distributed::Vector<number> &viscosity_values,
+                             const double pressure_scaling,
+                             const Triangulation<dim> &tria,
+                             const DoFHandler<dim> &dof_handler_for_projection);
 
 
         /**
@@ -213,12 +220,13 @@ namespace aspect
         void clear ();
 
         /**
-         * Fills in the viscosity table.
+         * Fills in the viscosity table and gives information regarding compressibility.
          */
-        void fill_viscosities(const dealii::LinearAlgebra::distributed::Vector<number> &viscosity_values,
-                              const Triangulation<dim> &tria,
-                              const DoFHandler<dim> &dof_handler_for_projection,
-                              const bool for_mg);
+        void fill_cell_data(const dealii::LinearAlgebra::distributed::Vector<number> &viscosity_values,
+                            const Triangulation<dim> &tria,
+                            const DoFHandler<dim> &dof_handler_for_projection,
+                            const bool for_mg,
+                            const bool is_compressible);
 
         /**
          * Computes the diagonal of the matrix. Since matrix-free operators have not access
@@ -256,6 +264,11 @@ namespace aspect
          * Table which stores the viscosity on each quadrature point.
          */
         Table<2, VectorizedArray<number> > viscosity_x_2;
+
+        /**
+          * Information on the compressibility of the flow.
+          */
+        bool is_compressible;
 
     };
   }
@@ -296,9 +309,10 @@ namespace aspect
       /**
        * Evalute the MaterialModel to query for the viscosity on the active cells,
        * project this viscosity to the multigrid hierarchy, and cache the information
-       * for later usage.
+       * for later usage. Also sets pressure scaling and information regarding the
+       * compressiblity of the flow.
        */
-      void evaluate_viscosity();
+      void evaluate_material_model();
 
       /**
        * Get the workload imbalance of the distribution
@@ -355,7 +369,6 @@ namespace aspect
 
       dealii::LinearAlgebra::distributed::Vector<double> active_coef_dof_vec;
       MGLevelObject<dealii::LinearAlgebra::distributed::Vector<double> > level_coef_dof_vec;
-
 
       MGTransferMatrixFree<dim,double> mg_transfer;
   };

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -307,7 +307,7 @@ namespace aspect
     // marix-free method
     if (stokes_matrix_free)
       {
-        stokes_matrix_free->evaluate_viscosity();
+        stokes_matrix_free->evaluate_material_model();
         stokes_matrix_free->correct_stokes_rhs();
       }
 

--- a/tests/tangurnis_tala_gmg.cc
+++ b/tests/tangurnis_tala_gmg.cc
@@ -1,0 +1,1 @@
+#include "tangurnis.cc"

--- a/tests/tangurnis_tala_gmg.prm
+++ b/tests/tangurnis_tala_gmg.prm
@@ -1,0 +1,18 @@
+# TanGurnis benchmark TALA using geometric multigrid preconditioner
+
+include $ASPECT_SOURCE_DIR/benchmarks/tangurnis/tala/tan.prm 
+
+subsection Material model
+  set Material averaging = harmonic average
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block GMG
+  end
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0                       # default: 2
+  set Initial global refinement          = 3                       # default: 2
+end

--- a/tests/tangurnis_tala_gmg/screen-output
+++ b/tests/tangurnis_tala_gmg/screen-output
@@ -1,0 +1,58 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libtangurnis_tala_gmg.so>
+
+Vectorization over 2 doubles = 128 bits (SSE2), VECTORIZATION_LEVEL=1
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 948 (578+81+289)
+
+*** Timestep 0:  t=0 seconds
+   Solving Stokes system... 7+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
+   Solving Stokes system... 5+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 4.15534
+
+   Solving Stokes system... 3+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.109711
+
+   Solving Stokes system... 3+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.00831267
+
+   Solving Stokes system... 2+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 0.00032806
+
+   Solving Stokes system... 1+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 2.41431e-05
+
+   Solving Stokes system... 1+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 1.2782e-06
+
+
+   Postprocessing:
+     writing:                       output.csv
+     Writing graphical output:      output-tangurnis_tala_gmg/solution/solution-00000
+     Heating rate (average/total):  -0.0001958 W/kg, -0.000254 W
+
+*** Timestep 1:  t=0.0001 seconds
+   Solving Stokes system... 0+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 3.69138e-08
+
+
+   Postprocessing:
+     writing:                       output.csv
+     Writing graphical output:      output-tangurnis_tala_gmg/solution/solution-00001
+     Heating rate (average/total):  -0.0001958 W/kg, -0.000254 W
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/tangurnis_tala_gmg/statistics
+++ b/tests/tangurnis_tala_gmg/statistics
@@ -1,0 +1,17 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of nonlinear iterations
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Visualization file name
+# 12: Average adiabatic heating rate (W/kg)
+# 13: Total adiabatic heating rate (W)
+# 14: Average shear heating rate (W/kg)
+# 15: Total shear heating rate (W)
+0 0.000000000000e+00 0.000000000000e+00 64 659 289 7         15 29 56 output-tangurnis_tala_gmg/solution/solution-00000 -3.79541889e-03 -4.92433793e-03 3.59962353e-03 4.67030470e-03 
+1 1.000000000000e-04 1.000000000000e-04 64 659 289 1 4294967295  0  0 output-tangurnis_tala_gmg/solution/solution-00001 -3.79541889e-03 -4.92433793e-03 3.59962353e-03 4.67030470e-03 


### PR DESCRIPTION
Adds functionality for compressible flow computations with the block GMG precoditioner. I verified with the tangurnis benchmarks that we are solving for the same solution as with the block AMG preconditioner and added a test based on tangurnis/tala

I've also changed some function names to be more appropriate to their functionality:
`evaluate_viscosity`->`evaluate_material_model` 
and 
`fill_viscosities_and_pressure_scaling`->`fill_cell_data`
so if you have any thoughts there, let me know.

Note: Does not yet include functionality for implicit reference density computations.