### PR TITLE
Avoid MPI error messages when calling 'aspect' without arguments.

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -746,6 +746,10 @@ int main (int argc, char *argv[])
         }
       else
         {
+          // If only help or version is requested, we are done.
+          if (output_help || output_version)
+            return 0;
+
           // We hook into the abort handler on ranks != 0 to avoid an MPI
           // deadlock. The deal.II library will call std::abort() when an
           // Assert is triggered, which can lead to a deadlock because it
@@ -773,7 +777,7 @@ int main (int argc, char *argv[])
         {
           if (i_am_proc_0)
             print_help();
-          return 2;
+          return 0;
         }
 
       // See where to read input from, then do the reading and


### PR DESCRIPTION
When running `mpirun -np 2 ./aspect` without further arguments (maybe not the smartest thing to do, but I'm unlikely the first one to try), then one gets an error message as follows:
```
> mpirun -np 2 ./aspect 
-----------------------------------------------------------------------------
-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
--     . version 2.2.0-pre (master, cf178d357)
--     . using deal.II 9.2.0-pre (master, e1068ad104)
--     .       with 32 bit indices and vectorization level 1 (128 bits)
--     . using Trilinos 12.8.1
--     . using p4est 2.0.0
--     . running in DEBUG mode
--     . running with 2 MPI processes
-----------------------------------------------------------------------------

Usage: ./aspect [args] <parameter_file.prm>   (to read from an input file)
    or ./aspect [args] --                     (to read parameters from stdin)

    optional arguments [args]:
       -h, --help             (for this usage help)
       -v, --version          (for information about library versions)
       -j, --threads          (to use multi-threading)
       --output-xml           (print parameters in xml format to standard output and exit)
       --output-plugin-graph  (write a representation of all plugins to standard output and exit)
       --validate             (parse parameter file and exit or report errors)
       --test                 (run the unit tests from unit_tests/, run --test -h for more info)

-------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code.. Per user-direction, the job has been aborted.
-------------------------------------------------------
--------------------------------------------------------------------------
mpirun detected that one or more processes exited with non-zero status, thus causing
the job to be terminated. The first process to do so was:

  Process name: [[47576,1],0]
  Exit code:    2
--------------------------------------------------------------------------
```
The MPI error at the bottom is annoying. But it's easy to work around by just letting the relevant code paths return zero if no argument is given. 

That said, is that what we want? Does calling ASPECT without an argument an error, or should it simply return the help text?