### PR TITLE
add cmake PROJECT directive

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 ################### top matter ################
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
 
+PROJECT(unittests CXX)
+
 SET(ASPECT_BINARY "${ASPECT_BINARY}" CACHE STRING "" FORCE)
 
 ENABLE_TESTING()


### PR DESCRIPTION
Newer versions of cmake produce a warning that the unittest cmake
project doesn't have a PROJECT() statement. Fix this.
