### PR TITLE
Add missing braces around a case statement

### DIFF
--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -234,8 +234,10 @@ namespace aspect
             }
 
             case Parameters<dim>::AdvectionFieldMethod::volume_of_fluid:
+            {
               volume_of_fluid_handler->do_volume_of_fluid_update(adv_field);
               break;
+            }
 
             case Parameters<dim>::AdvectionFieldMethod::static_field:
             {


### PR DESCRIPTION
I found this by chance, just to make the code consistent.