### PR TITLE
remove duplicate strain softening parameters

### DIFF
--- a/doc/modules/changes/20190917_naliboff
+++ b/doc/modules/changes/20190917_naliboff
@@ -1,5 +1,6 @@
-Remove: Input parameters and functionality related to the old syntax
-for strain softening in the Rheology::StrainDependent namespace. 
+Removed: Input parameters and functionality related to the old syntax
+for strain softening in the ViscoPlastic material model and the 
+Rheology::StrainDependent namespace. 
 <br>
 (John Naliboff, 2019/09/17)
 

--- a/doc/modules/changes/20190917_naliboff
+++ b/doc/modules/changes/20190917_naliboff
@@ -1,0 +1,5 @@
+Remove: Input parameters and functionality related to the old syntax
+for strain softening in the Rheology::StrainDependent namespace. 
+<br>
+(John Naliboff, 2019/09/17)
+

--- a/include/aspect/material_model/rheology/strain_dependent.h
+++ b/include/aspect/material_model/rheology/strain_dependent.h
@@ -133,46 +133,7 @@ namespace aspect
 
         private:
 
-          /**
-           * Enumeration for selecting which type of weakening mechanism to use.
-           * For none, no strain weakening occurs.
-           * Otherwise, the material can be weakened based on the second
-           * invariant of the full finite strain tensor, the total accumulated
-           * strain, or the plastic strain and viscous strain can be tracked
-           * separately and used only for the corresponding (plastic or viscous)
-           * part of the viscosity computation.
-           */
           WeakeningMechanism weakening_mechanism;
-
-          /**
-           * Whether to use the accumulated strain to weaken
-           * plastic parameters cohesion and friction angle
-           * and/or viscous parameters diffusion and dislocation prefactor.
-           * Additional flags can be set to specifically use the plastic
-           * strain for the plastic parameters and the viscous strain
-           * for the viscous parameters, instead of the total strain
-           * for all of them.
-           */
-          bool use_strain_weakening;
-
-          /**
-           * Whether to use only the accumulated plastic strain to weaken
-           * plastic parameters cohesion and friction angle.
-           */
-          bool use_plastic_strain_weakening;
-
-          /**
-           * Whether to use the accumulated viscous strain to weaken
-           * the viscous parameters diffusion and dislocation prefactor.
-           */
-          bool use_viscous_strain_weakening;
-
-          /**
-           * Whether to track the full finite strain tensor and use an
-           * an invariant measure of its accumulated values to weaken
-           * the cohesion and internal angle of friction.
-           */
-          bool use_finite_strain_tensor;
 
           /**
            * The start of the strain interval (plastic or total strain)


### PR DESCRIPTION

This PR is a follow-up to #3219 and removes input parameters and related checks for the old strain softening syntax. This removes backward compatibility for the prior strain softening, but removes a significant amount of code and tricky logic. 

* [X] I have followed the [instructions for indenting my code](../CONTRIBUTING.md#making-aspect-better).

* [X] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../tests/) directory.
* [X] I have added a changelog entry in the [doc/modules/changes](../doc/modules/changes) directory that will inform other users of my change.
