### PR TITLE
fix particle vector output for dealii 9.1.0

### DIFF
--- a/include/aspect/postprocess/particles.h
+++ b/include/aspect/postprocess/particles.h
@@ -73,9 +73,19 @@ namespace aspect
           /**
            * Implementation of the corresponding function of the base class.
            */
+#if DEAL_II_VERSION_GTE(9,1,0)
+          virtual
+          std::vector<
+          std::tuple<unsigned int,
+              unsigned int,
+              std::string,
+              DataComponentInterpretation::DataComponentInterpretation> >
+              get_nonscalar_data_ranges () const;
+#else
           virtual
           std::vector<std::tuple<unsigned int, unsigned int, std::string> >
-          get_vector_data_ranges () const;
+          get_vector_data_ranges() const;
+#endif
 
           /**
            * Output information that is filled by build_patches() and
@@ -91,7 +101,17 @@ namespace aspect
           /**
            * Store which of the data fields are vectors.
            */
-          std::vector<std::tuple<unsigned int, unsigned int, std::string> > vector_datasets;
+#if DEAL_II_VERSION_GTE(9,1,0)
+          std::vector<
+          std::tuple<unsigned int,
+              unsigned int,
+              std::string,
+              DataComponentInterpretation::DataComponentInterpretation> >
+              vector_datasets;
+#else
+          std::vector<std::tuple<unsigned int, unsigned int, std::string> >
+          vector_datasets;
+#endif
       };
     }
 

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -78,9 +78,16 @@ namespace aspect
               {
                 const unsigned int field_position = property_information.get_position_by_field_index(field_index);
                 const std::string field_name = property_information.get_field_name_by_index(field_index);
+#if DEAL_II_VERSION_GTE(9,1,0)
+                vector_datasets.push_back(std::make_tuple(field_position+1,
+                                                          field_position+n_components,
+                                                          field_name,
+                                                          DataComponentInterpretation::component_is_part_of_vector));
+#else
                 vector_datasets.push_back(std::make_tuple(field_position+1,
                                                           field_position+n_components,
                                                           field_name));
+#endif
               }
           }
 
@@ -122,12 +129,24 @@ namespace aspect
         return dataset_names;
       }
 
+#if DEAL_II_VERSION_GTE(9,1,0)
+      template <int dim>
+      std::vector<
+      std::tuple<unsigned int,
+          unsigned int, std::string,
+          DataComponentInterpretation::DataComponentInterpretation> >
+          ParticleOutput<dim>::get_nonscalar_data_ranges () const
+      {
+        return vector_datasets;
+      }
+#else
       template <int dim>
       std::vector<std::tuple<unsigned int, unsigned int, std::string> >
       ParticleOutput<dim>::get_vector_data_ranges () const
       {
         return vector_datasets;
       }
+#endif
 
     }
 


### PR DESCRIPTION
This pull request fixes the vtu (and probably also for other formats) output for vectors made by the particle postprocessor. This was needed because deal.ii 9.1.0 changed from using `get_vector_data_ranges()` to `get_nonscalar_data_ranges()`.

### Before your first pull request:

* [X] I have read the guidelines in our [CONTRIBUTING.md](../CONTRIBUTING.md) document.

### For all pull requests:

* [X] I have followed the [instructions for indenting my code](../CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.
