### PR TITLE
Do not require composition input parameter for not prescribed boundaries in box plugin

### DIFF
--- a/source/boundary_composition/box.cc
+++ b/source/boundary_composition/box.cc
@@ -141,25 +141,27 @@ namespace aspect
     void
     Box<dim>::initialize()
     {
-      // verify that each of the lists for boundary values
-      // has the requisite number of elements
+      // Verify that each of the lists for boundary values
+      // has the requisite number of elements if it is in the set
+      // of prescribed boundary indicators.
       for (unsigned int f=0; f<2*dim; ++f)
-        AssertThrow (composition_values[f].size() == this->n_compositional_fields(),
-                     ExcMessage (std::string("The specification of boundary composition values for the `box' model "
-                                             "requires as many values on each face of the box as there are compositional "
-                                             "fields. However, for face ")
-                                 +
-                                 Utilities::int_to_string(f)
-                                 +
-                                 ", the input file specifies "
-                                 +
-                                 Utilities::int_to_string(composition_values[f].size())
-                                 +
-                                 " values even though there are "
-                                 +
-                                 Utilities::int_to_string(this->n_compositional_fields())
-                                 +
-                                 " compositional fields."));
+        if (this->get_boundary_composition_manager().get_fixed_composition_boundary_indicators().count(f) != 0)
+          AssertThrow (composition_values[f].size() == this->n_compositional_fields(),
+                       ExcMessage (std::string("The specification of boundary composition values for the `box' model "
+                                               "requires as many values on each face of the box as there are compositional "
+                                               "fields. However, for face ")
+                                   +
+                                   Utilities::int_to_string(f)
+                                   +
+                                   ", the input file specifies "
+                                   +
+                                   Utilities::int_to_string(composition_values[f].size())
+                                   +
+                                   " values even though there are "
+                                   +
+                                   Utilities::int_to_string(this->n_compositional_fields())
+                                   +
+                                   " compositional fields."));
     }
 
   }

--- a/tests/compositional_boundary_values.prm
+++ b/tests/compositional_boundary_values.prm
@@ -119,8 +119,5 @@ subsection Boundary composition model
   set List of model names = box
   subsection Box
     set Left composition = 10, 10
-    set Right composition = 20, 20
-    set Bottom composition = 30, 30
-    set Top composition = 40, 40
   end
 end


### PR DESCRIPTION
The boundary_composition/box plugin requires for each of its input parameters a list of as many entries as compositional fields, even if this parameter is never used because this boundary is not in the list of prescribed composition boundaries. This is not necessary and seems a bit silly when writing new parameter files. I removed that requirement (but still check the other parameters that are actually used). And I modified one of the tests that has only prescribed compositions on one boundary, but so far had to prescribe values for all of them.