### PR TITLE
CitationInfo: add matrix-free

### DIFF
--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -862,7 +862,7 @@ namespace aspect
       fe_projection(FE_DGQ<dim>(0),1)
   {
     parse_parameters(prm);
-    //TODO CitationInfo::add("mf");
+    CitationInfo::add("mf");
 
     // This requires: porting the additional stabilization terms and using a
     // different mapping in the MatrixFree operators:


### PR DESCRIPTION
This adds mf=1 to the auto-generated link. This part is not parsed on
the website yet, but it doesn't hurt to have it in there already.
