### PR TITLE
fix aliasing warning

### DIFF
--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -30,6 +30,25 @@ namespace aspect
 {
   namespace GeometryModel
   {
+    namespace
+    {
+      template <int dim>
+      void append_face_to_subcell_data(SubCellData &subcell_data, const CellData<dim-1> & face);
+
+      template <>
+      void append_face_to_subcell_data<2>(SubCellData &subcell_data, const CellData<1> &face)
+      {
+        subcell_data.boundary_lines.push_back(face);
+      }
+
+      template <>
+      void append_face_to_subcell_data<3>(SubCellData &subcell_data, const CellData<2> &face)
+      {
+        subcell_data.boundary_quads.push_back(face);
+      }
+    }
+
+
     template <int dim>
     SphericalShell<dim>::SphericalShell()
       :
@@ -181,10 +200,7 @@ namespace aspect
                               cell->vertex_index(vertex_n) + cell_layer * sphere_mesh.n_vertices();
                           face.boundary_id = 0;
 
-                          if (dim == 2)
-                            subcell_data.boundary_lines.push_back(reinterpret_cast<CellData<1>&>(face));
-                          else
-                            subcell_data.boundary_quads.push_back(reinterpret_cast<CellData<2>&>(face));
+                          append_face_to_subcell_data<dim>(subcell_data, face);
                         }
 
                       // Mark the top face of the cell as boundary 1 if we are in
@@ -200,10 +216,7 @@ namespace aspect
                               (cell_layer + 1) * sphere_mesh.n_vertices();
                           face.boundary_id = 1;
 
-                          if (dim == 2)
-                            subcell_data.boundary_lines.push_back(reinterpret_cast<CellData<1>&>(face));
-                          else
-                            subcell_data.boundary_quads.push_back(reinterpret_cast<CellData<2>&>(face));
+                          append_face_to_subcell_data<dim>(subcell_data, face);
                         }
 
                     }


### PR DESCRIPTION
fix warning with gcc7:
```
source/geometry_model/spherical_shell.cc:187:67: warning: dereferencing
type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]

subcell_data.boundary_quads.push_back(reinterpret_cast<CellData<2>&>(face));
```