### PR TITLE
GMG: allow no cheap iterations

### DIFF
--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1386,6 +1386,11 @@ namespace aspect
     // succeeds in n_cheap_stokes_solver_steps steps or less.
     try
       {
+        // if this cheaper solver is not desired, then simply short-cut
+        // the attempt at solving with the cheaper preconditioner
+        if (sim.parameters.n_cheap_stokes_solver_steps == 0)
+          throw SolverControl::NoConvergence(0,0);
+
         SolverFGMRES<dealii::LinearAlgebra::distributed::BlockVector<double> >
         solver(solver_control_cheap, mem,
                SolverFGMRES<dealii::LinearAlgebra::distributed::BlockVector<double> >::

--- a/tests/no_cheap_gmg.cc
+++ b/tests/no_cheap_gmg.cc
@@ -1,0 +1,2 @@
+#include "../benchmarks/solcx/solcx.cc"
+

--- a/tests/no_cheap_gmg.prm
+++ b/tests/no_cheap_gmg.prm
@@ -1,0 +1,122 @@
+# Like sol_cx_4_gmg but without cheap iterations.
+
+set Dimension = 2
+
+
+set CFL number                             = 1.0
+
+set End time                               = 0
+
+
+set Resume computation                     = false
+
+set Start time                             = 0
+
+set Adiabatic surface temperature          = 0
+
+set Surface pressure                       = 0
+
+set Use years in output instead of seconds = false  # default: true
+
+set Nonlinear solver scheme                = no Advection, iterated Stokes
+
+
+subsection Boundary temperature model
+  set List of model names = box
+
+end
+
+
+subsection Discretization
+  set Stokes velocity polynomial degree       = 2
+
+  set Temperature polynomial degree           = 2
+
+  set Use locally conservative discretization = false
+
+  subsection Stabilization parameters
+    set alpha = 2
+
+    set beta  = 0.078
+
+    set cR    = 0.5   # default: 0.11
+  end
+
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+
+    set Y extent = 1
+
+    set Z extent = 1
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+end
+
+
+subsection Initial temperature model
+  set Model name = perturbed box
+
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block GMG
+    set Number of cheap Stokes solver steps = 0
+  end
+end
+
+subsection Material model
+  set Model name = SolCxMaterial
+  set Material averaging = harmonic average
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0                       # default: 2
+  set Initial global refinement          = 4                       # default: 2
+
+  set Strategy                           = density, temperature
+end
+
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = 0, 1
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 0,1,2,3
+end
+
+
+subsection Postprocess
+  set List of postprocessors = SolCxPostprocessor
+
+  subsection Depth average
+    set Time between graphical output = 1e8
+  end
+
+  subsection Visualization
+    set Interpolate output = false
+    set Number of grouped files       = 0
+
+    set Output format                 = gnuplot
+
+    set Time between graphical output = 0   # default: 1e8
+  end
+end
+

--- a/tests/no_cheap_gmg/screen-output
+++ b/tests/no_cheap_gmg/screen-output
@@ -1,0 +1,31 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libno_cheap_gmg.so>
+
+Vectorization over 2 doubles = 128 bits (SSE2), VECTORIZATION_LEVEL=1
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 3,556 (2,178+289+1,089)
+
+*** Timestep 0:  t=0 seconds
+   Solving Stokes system... 0+9 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
+   Solving Stokes system... 0+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 9.78338e-09
+
+
+   Postprocessing:
+     Errors u_L1, p_L1, u_L2, p_L2: 1.211886e-05, 1.081998e-01, 1.694600e-05, 1.086266e-01
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/no_cheap_gmg/statistics
+++ b/tests/no_cheap_gmg/statistics
@@ -1,0 +1,11 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of nonlinear iterations
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 2 7 20 18 


### PR DESCRIPTION
The code in the Stokes solver was missing the throw to skip the cheap
solver if so desired by the user. As a consequence, we were always doing
1 cheap solver step. Fix this and add a test.
