### PR TITLE
implement higher order Stokes GMG

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1914,7 +1914,7 @@ namespace aspect
       friend class MeshDeformation::MeshDeformationHandler<dim>;   // MeshDeformationHandler needs access to the internals of the Simulator
       friend class VolumeOfFluidHandler<dim>; // VolumeOfFluidHandler needs access to the internals of the Simulator
       friend class StokesMatrixFreeHandler<dim>;
-      template <int dimi, int velocity_degree>
+      template <int dimension, int velocity_degree>
       friend class StokesMatrixFreeHandlerImplementation;
       friend struct Parameters<dim>;
   };

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -97,6 +97,9 @@ namespace aspect
   template <int dim>
   class StokesMatrixFreeHandler;
 
+  template <int dim, int velocity_degree>
+  class StokesMatrixFreeHandlerImplementation;
+
   namespace MeshDeformation
   {
     template <int dim>
@@ -1912,7 +1915,7 @@ namespace aspect
       friend class VolumeOfFluidHandler<dim>; // VolumeOfFluidHandler needs access to the internals of the Simulator
       friend class StokesMatrixFreeHandler<dim>;
       template <int dimi, int velocity_degree>
-      friend class StokesMatrixFreeHandlerImpl;
+      friend class StokesMatrixFreeHandlerImplementation;
       friend struct Parameters<dim>;
   };
 }

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1911,6 +1911,8 @@ namespace aspect
       friend class MeshDeformation::MeshDeformationHandler<dim>;   // MeshDeformationHandler needs access to the internals of the Simulator
       friend class VolumeOfFluidHandler<dim>; // VolumeOfFluidHandler needs access to the internals of the Simulator
       friend class StokesMatrixFreeHandler<dim>;
+      template <int dimi, int velocity_degree>
+      friend class StokesMatrixFreeHandlerImpl;
       friend struct Parameters<dim>;
   };
 }

--- a/include/aspect/stokes_matrix_free.h
+++ b/include/aspect/stokes_matrix_free.h
@@ -306,23 +306,10 @@ namespace aspect
       virtual void setup_dofs()=0;
 
       /**
-       * Evalute the MaterialModel to query for the viscosity on the active cells,
-       * project this viscosity to the multigrid hierarchy, and cache the information
-       * for later usage. Also sets pressure scaling and information regarding the
-       * compressiblity of the flow.
+       * Evaluate the material model and update internal data structures before the
+       * actual solve().
        */
-      virtual void evaluate_material_model()=0;
-
-      /**
-       * Get the workload imbalance of the distribution
-       * of the level hierarchy.
-       */
-      virtual double get_workload_imbalance()=0;
-
-      /**
-       * Add correction to system RHS for non-zero boundary condition.
-       */
-      virtual void correct_stokes_rhs()=0;
+      virtual void build_preconditioner()=0;
 
       /**
        * Declare parameters.
@@ -374,17 +361,21 @@ namespace aspect
        * Evaluate the material model and update internal data structures before the
        * actual solve().
        */
-      void build_preconditioner();
+      void build_preconditioner() override;
 
       /**
        * Get the workload imbalance of the distribution
        * of the level hierarchy.
        */
-      double get_workload_imbalance() override;
+      double get_workload_imbalance();
 
       /**
-    private:
+       * Declare parameters. (No actual parameters at the moment).
+       */
+      static
+      void declare_parameters (ParameterHandler &prm);
 
+    private:
       /**
        * Evalute the MaterialModel to query for the viscosity on the active cells,
        * project this viscosity to the multigrid hierarchy, and cache the information
@@ -399,21 +390,16 @@ namespace aspect
       void correct_stokes_rhs();
 
       /**
-       * Parse parameters. (No actual parameters at the moment).
-       */
-      void parse_parameters (ParameterHandler &prm);
-
-      /**
-       * Declare parameters. (No actual parameters at the moment).
-       */
-      static
-      void declare_parameters (ParameterHandler &prm);
-
-      /**
        * Computes and sets the diagonal for the A-block operators on each level for
        * the purpose of smoothing inside the multigrid v-cycle.
        */
       void compute_A_block_diagonals();
+
+      /**
+       * Parse parameters. (No actual parameters at the moment).
+       */
+      void parse_parameters (ParameterHandler &prm);
+
 
       Simulator<dim> &sim;
 

--- a/include/aspect/stokes_matrix_free.h
+++ b/include/aspect/stokes_matrix_free.h
@@ -282,14 +282,14 @@ namespace aspect
 
   /**
     * Base class for the matrix free GMG solver for the Stokes system. The
-    * actual implementation is found inside StokesMatrixFreeHandlerImpl below.
+    * actual implementation is found inside StokesMatrixFreeHandlerImplementation below.
     */
   template<int dim>
   class StokesMatrixFreeHandler
   {
     public:
       /**
-       * Destructor.
+       * virtual Destructor.
        */
       virtual ~StokesMatrixFreeHandler();
 
@@ -325,15 +325,10 @@ namespace aspect
       virtual void correct_stokes_rhs()=0;
 
       /**
-       * Declare parameters. (No actual parameters at the moment).
+       * Declare parameters.
        */
       static
       void declare_parameters (ParameterHandler &prm);
-
-      /**
-       * Parse parameters. (No actual parameters at the moment).
-       */
-      virtual void parse_parameters (ParameterHandler &prm);
   };
 
   /**
@@ -343,10 +338,11 @@ namespace aspect
    * We need to derive from StokesMatrixFreeHandler to be able to introduce a
    * second template argument for the degree of the Stokes finite
    * element. This way, the main simulator does not need to know about the
-   * degree and we can pick the desired class to use at runtime.
+   * degree by using a pointer to the base class and we can pick the desired
+   * velocity degree at runtime.
    */
   template<int dim, int velocity_degree>
-  class StokesMatrixFreeHandlerImpl: public StokesMatrixFreeHandler<dim>
+  class StokesMatrixFreeHandlerImplementation: public StokesMatrixFreeHandler<dim>
   {
     public:
       /**
@@ -355,24 +351,24 @@ namespace aspect
        * Simulator that owns it, since it needs to make fairly extensive
        * changes to the internals of the simulator.
        */
-      StokesMatrixFreeHandlerImpl(Simulator<dim> &, ParameterHandler &prm);
+      StokesMatrixFreeHandlerImplementation(Simulator<dim> &, ParameterHandler &prm);
 
       /**
        * Destructor.
        */
-      ~StokesMatrixFreeHandlerImpl();
+      ~StokesMatrixFreeHandlerImplementation();
 
       /**
        * Solves the Stokes linear system matrix-free. This is called
        * by Simulator<dim>::solve_stokes().
        */
-      std::pair<double,double> solve();
+      std::pair<double,double> solve() override;
 
       /**
        * Allocates and sets up the members of the StokesMatrixFreeHandler. This
        * is called by Simulator<dim>::setup_dofs()
        */
-      void setup_dofs();
+      void setup_dofs() override;
 
       /**
        * Evaluate the material model and update internal data structures before the
@@ -384,7 +380,7 @@ namespace aspect
        * Get the workload imbalance of the distribution
        * of the level hierarchy.
        */
-      double get_workload_imbalance();
+      double get_workload_imbalance() override;
 
       /**
     private:
@@ -401,6 +397,17 @@ namespace aspect
        * Add correction to system RHS for non-zero boundary condition.
        */
       void correct_stokes_rhs();
+
+      /**
+       * Parse parameters. (No actual parameters at the moment).
+       */
+      void parse_parameters (ParameterHandler &prm);
+
+      /**
+       * Declare parameters. (No actual parameters at the moment).
+       */
+      static
+      void declare_parameters (ParameterHandler &prm);
 
       /**
        * Computes and sets the diagonal for the A-block operators on each level for
@@ -432,7 +439,7 @@ namespace aspect
       ConstraintMatrix constraints_projection;
 
       MGLevelObject<ABlockMatrixType> mg_matrices;
-      MGConstrainedDoFs              mg_constrained_dofs;
+      MGConstrainedDoFs mg_constrained_dofs;
       MGConstrainedDoFs mg_constrained_dofs_projection;
 
       dealii::LinearAlgebra::distributed::Vector<double> active_coef_dof_vec;

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -379,7 +379,18 @@ namespace aspect
 
     if (parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::block_gmg)
       {
-        stokes_matrix_free = std_cxx14::make_unique<StokesMatrixFreeHandler<dim>>(*this, prm);
+        switch (parameters.stokes_velocity_degree)
+          {
+            case 2:
+              stokes_matrix_free = std_cxx14::make_unique<StokesMatrixFreeHandlerImpl<dim,2>>(*this, prm);
+              break;
+            case 3:
+              stokes_matrix_free = std_cxx14::make_unique<StokesMatrixFreeHandlerImpl<dim,3>>(*this, prm);
+              break;
+            default:
+              AssertThrow(false, ExcMessage("The finite element degree for the Stokes system you selected is not supported yet."));
+          }
+
       }
 
     postprocess_manager.initialize_simulator (*this);

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -382,10 +382,10 @@ namespace aspect
         switch (parameters.stokes_velocity_degree)
           {
             case 2:
-              stokes_matrix_free = std_cxx14::make_unique<StokesMatrixFreeHandlerImpl<dim,2>>(*this, prm);
+              stokes_matrix_free = std_cxx14::make_unique<StokesMatrixFreeHandlerImplementation<dim,2>>(*this, prm);
               break;
             case 3:
-              stokes_matrix_free = std_cxx14::make_unique<StokesMatrixFreeHandlerImpl<dim,3>>(*this, prm);
+              stokes_matrix_free = std_cxx14::make_unique<StokesMatrixFreeHandlerImplementation<dim,3>>(*this, prm);
               break;
             default:
               AssertThrow(false, ExcMessage("The finite element degree for the Stokes system you selected is not supported yet."));

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1229,6 +1229,7 @@ namespace aspect
   }
 
 
+
   template <int dim, int velocity_degree>
   void StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::correct_stokes_rhs()
   {
@@ -1681,6 +1682,7 @@ namespace aspect
   }
 
 
+
   template <int dim, int velocity_degree>
   void StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::setup_dofs()
   {
@@ -1892,8 +1894,8 @@ namespace aspect
 
 
 
-  template <int dim>
-  void StokesMatrixFreeHandler<dim>::build_preconditioner()
+  template <int dim, int velocity_degree>
+  void StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::build_preconditioner()
   {
     evaluate_material_model();
     correct_stokes_rhs();
@@ -1902,8 +1904,8 @@ namespace aspect
 
 
 
-  template <int dim>
-  void StokesMatrixFreeHandler<dim>::compute_A_block_diagonals()
+  template <int dim, int velocity_degree>
+  void StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::compute_A_block_diagonals()
   {
     for (unsigned int level=0; level < sim.triangulation.n_global_levels(); ++level)
       {

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -959,6 +959,14 @@ namespace aspect
       }
   }
 
+
+
+  template <int dim>
+  StokesMatrixFreeHandler<dim>::~StokesMatrixFreeHandler ()
+  {}
+
+
+
   template <int dim, int degree_v, typename number>
   void
   MatrixFreeStokesOperators::ABlockOperator<dim,degree_v,number>
@@ -984,12 +992,52 @@ namespace aspect
       }
   }
 
-  /**
-   * Matrix-free setup, assmeble, and solve function implementations.
-   */
   template <int dim, int velocity_degree>
-  StokesMatrixFreeHandlerImpl<dim, velocity_degree>::StokesMatrixFreeHandlerImpl (Simulator<dim> &simulator,
-                                                                                  ParameterHandler &prm)
+  StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::~StokesMatrixFreeHandlerImplementation ()
+  {}
+
+
+
+  template <int dim>
+  void StokesMatrixFreeHandler<dim>::declare_parameters(ParameterHandler &prm)
+  {
+    StokesMatrixFreeHandlerImplementation<dim,2>::declare_parameters(prm);
+  }
+
+
+
+  template <int dim, int velocity_degree>
+  void
+  StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::declare_parameters(ParameterHandler &prm)
+  {
+    prm.enter_subsection ("Solver parameters");
+    prm.enter_subsection ("Matrix Free");
+    {
+
+    }
+    prm.leave_subsection ();
+    prm.leave_subsection ();
+  }
+
+
+
+  template <int dim, int velocity_degree>
+  void StokesMatrixFreeHandlerImplementation<dim,velocity_degree>::parse_parameters(ParameterHandler &prm)
+  {
+    prm.enter_subsection ("Solver parameters");
+    prm.enter_subsection ("Matrix Free");
+    {
+
+    }
+    prm.leave_subsection ();
+    prm.leave_subsection ();
+  }
+
+
+
+  template <int dim, int velocity_degree>
+  StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::StokesMatrixFreeHandlerImplementation (Simulator<dim> &simulator,
+      ParameterHandler &prm)
     : sim(simulator),
 
       dof_handler_v(simulator.triangulation),
@@ -1002,7 +1050,7 @@ namespace aspect
       fe_p (FE_Q<dim>(sim.parameters.stokes_velocity_degree-1),1),
       fe_projection(FE_DGQ<dim>(0),1)
   {
-    this->parse_parameters(prm);
+    parse_parameters(prm);
     CitationInfo::add("mf");
 
     // This requires: porting the additional stabilization terms and using a
@@ -1050,17 +1098,9 @@ namespace aspect
     }
   }
 
-  template <int dim>
-  StokesMatrixFreeHandler<dim>::~StokesMatrixFreeHandler ()
-  {
-  }
-  template <int dim, int velocity_degree>
-  StokesMatrixFreeHandlerImpl<dim, velocity_degree>::~StokesMatrixFreeHandlerImpl ()
-  {
-  }
 
   template <int dim, int velocity_degree>
-  double StokesMatrixFreeHandlerImpl<dim, velocity_degree>::get_workload_imbalance ()
+  double StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::get_workload_imbalance ()
   {
     unsigned int n_proc = Utilities::MPI::n_mpi_processes(sim.triangulation.get_communicator());
     unsigned int n_global_levels = sim.triangulation.n_global_levels();
@@ -1097,7 +1137,7 @@ namespace aspect
 
 
   template <int dim, int velocity_degree>
-  void StokesMatrixFreeHandlerImpl<dim, velocity_degree>::evaluate_material_model ()
+  void StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::evaluate_material_model ()
   {
     {
       const QGauss<dim> quadrature_formula (sim.parameters.stokes_velocity_degree+1);
@@ -1190,7 +1230,7 @@ namespace aspect
 
 
   template <int dim, int velocity_degree>
-  void StokesMatrixFreeHandlerImpl<dim, velocity_degree>::correct_stokes_rhs()
+  void StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::correct_stokes_rhs()
   {
     dealii::LinearAlgebra::distributed::BlockVector<double> rhs_correction(2);
     dealii::LinearAlgebra::distributed::BlockVector<double> u0(2);
@@ -1251,33 +1291,9 @@ namespace aspect
   }
 
 
-  template <int dim>
-  void StokesMatrixFreeHandler<dim>::declare_parameters(ParameterHandler &prm)
-  {
-    prm.enter_subsection ("Solver parameters");
-    prm.enter_subsection ("Matrix Free");
-    {
-
-    }
-    prm.leave_subsection ();
-    prm.leave_subsection ();
-  }
-
-  template <int dim>
-  void StokesMatrixFreeHandler<dim>::parse_parameters(ParameterHandler &prm)
-  {
-    prm.enter_subsection ("Solver parameters");
-    prm.enter_subsection ("Matrix Free");
-    {
-
-    }
-    prm.leave_subsection ();
-    prm.leave_subsection ();
-  }
-
 
   template <int dim, int velocity_degree>
-  std::pair<double,double> StokesMatrixFreeHandlerImpl<dim,velocity_degree>::solve()
+  std::pair<double,double> StokesMatrixFreeHandlerImplementation<dim,velocity_degree>::solve()
   {
     double initial_nonlinear_residual = numbers::signaling_nan<double>();
     double final_linear_residual      = numbers::signaling_nan<double>();
@@ -1666,7 +1682,7 @@ namespace aspect
 
 
   template <int dim, int velocity_degree>
-  void StokesMatrixFreeHandlerImpl<dim, velocity_degree>::setup_dofs()
+  void StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::setup_dofs()
   {
     // Velocity DoFHandler
     {
@@ -1982,8 +1998,8 @@ namespace aspect
 // explicit instantiation of the functions we implement in this file
 #define INSTANTIATE(dim) \
   template class StokesMatrixFreeHandler<dim>; \
-  template class StokesMatrixFreeHandlerImpl<dim,2>; \
-  template class StokesMatrixFreeHandlerImpl<dim,3>;
+  template class StokesMatrixFreeHandlerImplementation<dim,2>; \
+  template class StokesMatrixFreeHandlerImplementation<dim,3>;
 
   ASPECT_INSTANTIATE(INSTANTIATE)
 }

--- a/tests/hollow_sphere_gmg_q3.cc
+++ b/tests/hollow_sphere_gmg_q3.cc
@@ -1,0 +1,2 @@
+#include "../benchmarks/hollow_sphere/hollow_sphere.cc"
+

--- a/tests/hollow_sphere_gmg_q3.prm
+++ b/tests/hollow_sphere_gmg_q3.prm
@@ -1,0 +1,115 @@
+# Like hollow_sphere_gmg.prm but with Q3 elements
+
+
+############### Global parameters
+
+set Additional shared libraries            = ./libhollow_sphere.so
+set Dimension                              = 3
+set Start time                             = 0
+set End time                               = 0
+set Use years in output instead of seconds = false
+set Nonlinear solver scheme                = no Advection, iterated Stokes
+set Output directory                       = output
+set Pressure normalization                 = surface
+
+############### Parameters describing the model
+# The setup is a 3D shell 
+# Because the temperature plays no role in this model we need not
+# bother to describe temperature boundary conditions or
+# the material parameters that pertain to the temperature.
+
+subsection Geometry model
+  set Model name = spherical shell
+
+  subsection Spherical shell
+    set Inner radius = 0.5
+    set Outer radius = 1.0
+    set Cells along circumference = 12
+  end
+
+end
+
+#Boundary conditions
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = inner : HollowSphereBoundary, \
+                                                outer : HollowSphereBoundary
+end
+
+
+subsection Gravity model
+  set Model name = radial constant
+  subsection Radial constant
+    set Magnitude = 1.0
+  end
+end
+
+subsection HollowSphere benchmark
+   #Viscosity parameter is m 
+   set Viscosity parameter             = -1
+end 
+
+############### Parameters describing the temperature field
+# As above, there is no need to set anything for the
+# temperature boundary conditions.
+
+subsection Boundary temperature model
+  set List of model names = box 
+end
+
+subsection Initial temperature model 
+  set Model name = function
+
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+
+############### Parameters describing the discretization
+# The following parameters describe how often we want to refine
+# the mesh globally and adaptively, what fraction of cells should
+# be refined in each adaptive refinement step, and what refinement
+# indicator to use when refining the mesh adaptively. 
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 1
+  set Initial global refinement          = 1
+  set Refinement fraction                = 0.1
+  set Strategy                           = velocity
+  set Run postprocessors on initial refinement            = true
+end
+
+
+############### Parameters describing what to do with the solution
+# The final section allows us to choose which postprocessors to
+# run at the end of each time step. 
+
+subsection Postprocess
+  set List of postprocessors = visualization, velocity statistics, HollowSpherePostprocessor
+
+  subsection Visualization
+    set Interpolate output = false
+    set List of output variables = density, viscosity, strain rate
+  end
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block GMG
+    set Linear solver tolerance = 1e-8
+    set Number of cheap Stokes solver steps = 200
+  end
+end
+
+subsection Material model
+  set Model name = HollowSphereMaterial
+  set Material averaging = harmonic average
+end
+
+subsection Discretization
+  set Stokes velocity polynomial degree            = 3
+end

--- a/tests/hollow_sphere_gmg_q3/screen-output
+++ b/tests/hollow_sphere_gmg_q3/screen-output
@@ -1,0 +1,53 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libhollow_sphere_gmg_q3.so>
+
+Vectorization over 2 doubles = 128 bits (SSE2), VECTORIZATION_LEVEL=1
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 96 (on 2 levels)
+Number of degrees of freedom: 11,054 (9,114+970+970)
+
+*** Timestep 0:  t=0 seconds
+   Solving Stokes system... 18+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.456641
+
+   Solving Stokes system... 0+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 4.19168e-09
+
+
+   Postprocessing:
+     Writing graphical output:              output-hollow_sphere_gmg_q3/solution/solution-00000
+     RMS, max velocity:                     1.55 m/s, 4.49 m/s
+     Pressure at top/bottom of domain:      -4.625e-11 Pa, 499.9 Pa
+     Computing dynamic topography           
+     Errors u_L1, p_L1, u_L2, p_L2 topo_L2: 4.488958e-02, 1.684940e+00, 1.927885e-02, 1.061151e+00, 1.939583e-03
+
+Number of active cells: 180 (on 3 levels)
+Number of degrees of freedom: 23,080 (18,924+2,078+2,078)
+
+*** Timestep 0:  t=0 seconds
+   Solving Stokes system... 37+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.48442
+
+   Solving Stokes system... 0+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 4.40129e-09
+
+
+   Postprocessing:
+     Writing graphical output:              output-hollow_sphere_gmg_q3/solution/solution-00001
+     RMS, max velocity:                     1.55 m/s, 4.49 m/s
+     Pressure at top/bottom of domain:      -2.43e-08 Pa, 499.9 Pa
+     Computing dynamic topography           
+     Errors u_L1, p_L1, u_L2, p_L2 topo_L2: 4.815761e-02, 1.735017e+00, 2.038848e-02, 1.098952e+00, 2.387474e-03
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------


### PR DESCRIPTION
First working version of higher order FEM support for the geometric multigrid solver. This requires introducing a base class for the StokesMatrixFreeHandler to be able to have the degree be a compile time template argument.

This PR works, but needs some cleanup (ordering of functions in .cc, possibly different class names, etc.) and tests. I can confirm that we get identical errors for the burstedde benchmark for Q3 between matrix-free and matrix-based.

@tcclevenger can you please take a look?