### PR TITLE
use c++ override instead of virtual

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,7 +26,8 @@
 
 
 # enabled checks:
-Checks: '-*,modernize-use-emplace,modernize-make-shared,mpi-*,modernize-use-nullptr,modernize-replace-autoptr,modernize-make-unique,performance-*,-performance-inefficient-string-concatenation'
+Checks: '-*,modernize-use-emplace,modernize-make-shared,mpi-*,modernize-use-nullptr,modernize-replace-autoptr,modernize-make-unique,performance-*,-performance-inefficient-string-concatenation,modernize-use-override'
+
 
 
 # other options to be used in the future as soon as we compile cleanly:

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -55,10 +55,10 @@ namespace aspect
       class BaseVariablePostprocessor: public DataPostprocessor< dim >, public SimulatorAccess<dim>
       {
         public:
-          virtual
+
           void
           evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
-                                std::vector<Vector<double> > &computed_quantities) const
+                                std::vector<Vector<double> > &computed_quantities) const override
           {
             const double velocity_scaling_factor =
               this->convert_output_to_years() ? year_in_seconds : 1.0;
@@ -76,7 +76,7 @@ namespace aspect
                 }
           }
 
-          virtual std::vector<std::string> get_names () const
+          std::vector<std::string> get_names () const override
           {
             std::vector<std::string> solution_names (dim, "velocity");
 
@@ -96,9 +96,9 @@ namespace aspect
             return solution_names;
           }
 
-          virtual
+
           std::vector<DataComponentInterpretation::DataComponentInterpretation>
-          get_data_component_interpretation () const
+          get_data_component_interpretation () const override
           {
             std::vector<DataComponentInterpretation::DataComponentInterpretation>
             interpretation (dim,
@@ -118,7 +118,7 @@ namespace aspect
             return interpretation;
           }
 
-          virtual UpdateFlags get_needed_update_flags () const
+          UpdateFlags get_needed_update_flags () const override
           {
             return update_values;
           }
@@ -136,10 +136,10 @@ namespace aspect
             : DataPostprocessorVector<dim>( "mesh_velocity", UpdateFlags(update_values) )
           {}
 
-          virtual
+
           void
           evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
-                                std::vector<Vector<double> > &computed_quantities) const
+                                std::vector<Vector<double> > &computed_quantities) const override
           {
             // check that the first quadrature point has dim components
             Assert( computed_quantities[0].size() == dim,

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -540,8 +540,8 @@ namespace aspect
          * function given to the constructor
          * produces for this point.
          */
-        virtual double value (const Point<dim>   &p,
-                              const unsigned int  component = 0) const;
+        double value (const Point<dim>   &p,
+                      const unsigned int  component = 0) const override;
 
         /**
          * Return all components of a
@@ -552,8 +552,8 @@ namespace aspect
          * size beforehand,
          * i.e. #n_components.
          */
-        virtual void vector_value (const Point<dim>   &p,
-                                   Vector<double>     &values) const;
+        void vector_value (const Point<dim>   &p,
+                           Vector<double>     &values) const override;
 
       private:
         /**

--- a/source/simulator/lateral_averaging.cc
+++ b/source/simulator/lateral_averaging.cc
@@ -52,7 +52,7 @@ namespace aspect
                         const MaterialModel::MaterialModelOutputs<dim> &,
                         const FEValues<dim> &fe_values,
                         const LinearAlgebra::BlockVector &solution,
-                        std::vector<double> &output)
+                        std::vector<double> &output) override
         {
           fe_values[field_].get_function_values (solution, output);
         }
@@ -66,7 +66,7 @@ namespace aspect
     class FunctorDepthAverageViscosity: public internal::FunctorBase<dim>
     {
       public:
-        bool need_material_properties() const
+        bool need_material_properties() const override
         {
           return true;
         }
@@ -75,7 +75,7 @@ namespace aspect
                         const MaterialModel::MaterialModelOutputs<dim> &out,
                         const FEValues<dim> &,
                         const LinearAlgebra::BlockVector &,
-                        std::vector<double> &output)
+                        std::vector<double> &output) override
         {
           output = out.viscosities;
         }
@@ -92,7 +92,7 @@ namespace aspect
           : field_(field), convert_to_years_(convert_to_years)
         {}
 
-        void setup(const unsigned int q_points)
+        void setup(const unsigned int q_points) override
         {
           velocity_values.resize(q_points);
         }
@@ -101,7 +101,7 @@ namespace aspect
                         const MaterialModel::MaterialModelOutputs<dim> &,
                         const FEValues<dim> &fe_values,
                         const LinearAlgebra::BlockVector &solution,
-                        std::vector<double> &output)
+                        std::vector<double> &output) override
         {
           fe_values[field_].get_function_values (solution, velocity_values);
           for (unsigned int q=0; q<output.size(); ++q)
@@ -128,13 +128,13 @@ namespace aspect
             convert_to_years_(convert_to_years)
         {}
 
-        bool need_material_properties() const
+        bool need_material_properties() const override
         {
           // this is needed because we want to access in.position in operator()
           return true;
         }
 
-        void setup(const unsigned int q_points)
+        void setup(const unsigned int q_points) override
         {
           velocity_values.resize(q_points);
         }
@@ -143,7 +143,7 @@ namespace aspect
                         const MaterialModel::MaterialModelOutputs<dim> &,
                         const FEValues<dim> &fe_values,
                         const LinearAlgebra::BlockVector &solution,
-                        std::vector<double> &output)
+                        std::vector<double> &output) override
         {
           fe_values[field_].get_function_values (solution, velocity_values);
           for (unsigned int q=0; q<output.size(); ++q)
@@ -172,14 +172,14 @@ namespace aspect
           : vs_(vs)
         {}
 
-        bool need_material_properties() const
+        bool need_material_properties() const override
         {
           return true;
         }
 
         void
         create_additional_material_model_outputs (const unsigned int n_points,
-                                                  MaterialModel::MaterialModelOutputs<dim> &outputs) const
+                                                  MaterialModel::MaterialModelOutputs<dim> &outputs) const override
         {
           outputs.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
@@ -189,7 +189,7 @@ namespace aspect
                         const MaterialModel::MaterialModelOutputs<dim> &out,
                         const FEValues<dim> &,
                         const LinearAlgebra::BlockVector &,
-                        std::vector<double> &output)
+                        std::vector<double> &output) override
         {
           const MaterialModel::SeismicAdditionalOutputs<dim> *seismic_outputs
             = out.template get_additional_output<const MaterialModel::SeismicAdditionalOutputs<dim> >();
@@ -221,12 +221,12 @@ namespace aspect
             gravity_model(gm)
         {}
 
-        bool need_material_properties() const
+        bool need_material_properties() const override
         {
           return true;
         }
 
-        void setup(const unsigned int q_points)
+        void setup(const unsigned int q_points) override
         {
           velocity_values.resize(q_points);
           temperature_values.resize(q_points);
@@ -237,7 +237,7 @@ namespace aspect
                         const MaterialModel::MaterialModelOutputs<dim> &out,
                         const FEValues<dim> &fe_values,
                         const LinearAlgebra::BlockVector &solution,
-                        std::vector<double> &output)
+                        std::vector<double> &output) override
         {
           fe_values[velocity_field_].get_function_values (solution, velocity_values);
           fe_values[temperature_field_].get_function_values (solution, temperature_values);

--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -66,7 +66,7 @@ namespace aspect
           axis(rotation_axis)
         {}
 
-        virtual Tensor<1,dim> value (const Point<dim> &p) const
+        Tensor<1,dim> value (const Point<dim> &p) const override
         {
           if ( dim == 2)
             return cross_product_2d(p);
@@ -101,7 +101,7 @@ namespace aspect
           translation(t)
         {}
 
-        virtual Tensor<1,dim> value(const Point<dim> &) const
+        Tensor<1,dim> value(const Point<dim> &) const override
         {
           return translation;
         }

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -78,7 +78,7 @@ namespace aspect
 
         double
         value (const Point<dim> &p,
-               const unsigned int component) const
+               const unsigned int component) const override
         {
           Assert (component < this->n_components,
                   ExcIndexRange (component, 0, this->n_components));
@@ -99,7 +99,7 @@ namespace aspect
 
         void
         vector_value (const Point<dim>   &p,
-                      Vector<double>     &values) const
+                      Vector<double>     &values) const override
         {
           AssertDimension(values.size(), this->n_components);
 

--- a/unit_tests/additional_outputs.cc
+++ b/unit_tests/additional_outputs.cc
@@ -55,8 +55,8 @@ namespace
   {
     public:
 
-      virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &/*in*/,
-                            MaterialModel::MaterialModelOutputs<dim> &out) const
+      void evaluate(const MaterialModel::MaterialModelInputs<dim> &/*in*/,
+                    MaterialModel::MaterialModelOutputs<dim> &out) const override
       {
         AdditionalOutputs1<dim> *additional;
 


### PR DESCRIPTION
- replace virtual with override
- enable clang-tidy rule
- rationale is here:
https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md
