### PR TITLE
add drucker prager rheology module

### DIFF
--- a/doc/modules/changes/20191010_naliboff
+++ b/doc/modules/changes/20191010_naliboff
@@ -1,7 +1,6 @@
 New: There is a new model in the MaterialModel::Rheology namespace for plastic
-material behavior based on the Drucker Prager yield criterion. The functionality
-is largely based on existing functions in MaterialUtilities and is currently used 
-in the visco plastic material. *Note, will updated once PR is approved and further
-changes are made. 
+material behavior based on the Drucker Prager yield criterion. This functionality
+replaces existing functionality in MaterialUtilities and is currently used in the 
+visco plastic, drucker prager, and dynamic friction material models.
 <br>
-(John Naliboff, 2019-10-10)
+(John Naliboff, 2019/10/10)

--- a/doc/modules/changes/20191010_naliboff
+++ b/doc/modules/changes/20191010_naliboff
@@ -1,0 +1,7 @@
+New: There is a new model in the MaterialModel::Rheology namespace for plastic
+material behavior based on the Drucker Prager yield criterion. The functionality
+is largely based on existing functions in MaterialUtilities and is currently used 
+in the visco plastic material. *Note, will updated once PR is approved and further
+changes are made. 
+<br>
+(John Naliboff, 2019-10-10)

--- a/include/aspect/material_model/drucker_prager.h
+++ b/include/aspect/material_model/drucker_prager.h
@@ -152,6 +152,11 @@ namespace aspect
          */
         Rheology::DruckerPrager<dim> drucker_prager_plasticity;
 
+        /*
+         * Input parameters for Drucker Prager plasticity.
+         */
+        Rheology::DruckerPragerParameters drucker_prager_parameters;
+
         /**
          * The angle of internal friction
          */

--- a/include/aspect/material_model/drucker_prager.h
+++ b/include/aspect/material_model/drucker_prager.h
@@ -152,11 +152,6 @@ namespace aspect
          */
         Rheology::DruckerPrager<dim> drucker_prager_plasticity;
 
-        /*
-         * Input parameters for Drucker Prager plasticity.
-         */
-        Rheology::DruckerPragerParameters drucker_prager_parameters;
-
         /**
          * The angle of internal friction
          */

--- a/include/aspect/material_model/drucker_prager.h
+++ b/include/aspect/material_model/drucker_prager.h
@@ -22,6 +22,7 @@
 #define _aspect_material_model_drucker_prager_h
 
 #include <aspect/material_model/interface.h>
+#include <aspect/material_model/rheology/drucker_prager.h>
 #include <aspect/material_model/equation_of_state/linearized_incompressible.h>
 #include <aspect/simulator_access.h>
 
@@ -145,6 +146,11 @@ namespace aspect
         double thermal_conductivities;
 
         EquationOfState::LinearizedIncompressible<dim> equation_of_state;
+
+        /*
+         * Objects for computing plastic stresses, viscosities, and additional outputs
+         */
+        Rheology::DruckerPrager<dim> drucker_prager_plasticity;
 
         /**
          * The angle of internal friction

--- a/include/aspect/material_model/dynamic_friction.h
+++ b/include/aspect/material_model/dynamic_friction.h
@@ -145,11 +145,6 @@ namespace aspect
           */
         Rheology::DruckerPrager<dim> drucker_prager_plasticity;
 
-        /*
-         * Input parameters for the Drucker Prager plasticity.
-         */
-        Rheology::DruckerPragerParameters drucker_prager_parameters;
-
         /**
          * The dynamic coefficient of friction
          */

--- a/include/aspect/material_model/dynamic_friction.h
+++ b/include/aspect/material_model/dynamic_friction.h
@@ -140,9 +140,9 @@ namespace aspect
 
         EquationOfState::MulticomponentIncompressible<dim> equation_of_state;
 
-       /*
-         * Objects for computing plastic stresses, viscosities, and additional outputs
-         */
+        /*
+          * Objects for computing plastic stresses, viscosities, and additional outputs
+          */
         Rheology::DruckerPrager<dim> drucker_prager_plasticity;
 
         /**

--- a/include/aspect/material_model/dynamic_friction.h
+++ b/include/aspect/material_model/dynamic_friction.h
@@ -145,6 +145,11 @@ namespace aspect
           */
         Rheology::DruckerPrager<dim> drucker_prager_plasticity;
 
+        /*
+         * Input parameters for the Drucker Prager plasticity.
+         */
+        Rheology::DruckerPragerParameters drucker_prager_parameters;
+
         /**
          * The dynamic coefficient of friction
          */

--- a/include/aspect/material_model/dynamic_friction.h
+++ b/include/aspect/material_model/dynamic_friction.h
@@ -23,6 +23,7 @@
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>
+#include <aspect/material_model/rheology/drucker_prager.h>
 #include <aspect/material_model/equation_of_state/multicomponent_incompressible.h>
 
 namespace aspect
@@ -138,6 +139,11 @@ namespace aspect
         MaterialUtilities::CompositionalAveragingOperation viscosity_averaging;
 
         EquationOfState::MulticomponentIncompressible<dim> equation_of_state;
+
+       /*
+         * Objects for computing plastic stresses, viscosities, and additional outputs
+         */
+        Rheology::DruckerPrager<dim> drucker_prager_plasticity;
 
         /**
          * The dynamic coefficient of friction

--- a/include/aspect/material_model/rheology/drucker_prager.h
+++ b/include/aspect/material_model/rheology/drucker_prager.h
@@ -1,0 +1,125 @@
+/*
+  Copyright (C) 2019 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _aspect_material_model_rheology_drucker_prager_h
+#define _aspect_material_model_rheology_drucker_prager_h
+
+#include <aspect/global.h>
+#include <aspect/material_model/interface.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    using namespace dealii;
+
+    namespace Rheology
+    {
+      template <int dim>
+      class DruckerPrager : public ::aspect::SimulatorAccess<dim>
+      {
+        public:
+          /**
+           * Constructor.
+           */
+          DruckerPrager();
+
+          /**
+           * Declare the parameters this function takes through input files.
+           */
+          static
+          void
+          declare_parameters (ParameterHandler &prm);
+
+          /**
+           * Read the parameters from the parameter file.
+           */
+          void
+          parse_parameters (ParameterHandler &prm);
+
+          /**
+           * Compute the plastic yield stress based on the Drucker Prager yield criterion.
+           */
+          double
+          compute_stress (const double cohesion,
+                          const double angle_internal_friction,
+                          const double pressure) const;
+
+          /**
+           * Compute the plastic viscosity with the yield stress and effective strain rate.
+           */
+          double
+          compute_viscosity (const double cohesion,
+                             const double angle_internal_friction,
+                             const double pressure,
+                             const double effective_strain_rate) const;
+
+          /**
+           * Compute the derivative of the plastic viscosity with respect to pressure.
+           */
+          double
+          compute_derivative (const double angle_internal_friction,
+                              const double effective_strain_rate) const;
+
+
+          /**
+           * Return the value of the maximum yield stress for each composition used in
+           * the rheology model.
+           */
+          double
+          get_max_yield_strength () const;
+
+          /**
+           * Return the values of the cohesions for each composition used in the
+           * rheology model.
+           */
+          std::vector<double>
+          get_cohesions () const;
+
+          /**
+           * Return the values of the angles of internal friction for each
+           * composition used in the rheology model.
+           */
+          std::vector<double>
+          get_angles_internal_friction () const;
+
+        private:
+
+          /**
+           * List of internal friction angles (phi).
+           */
+          std::vector<double> angles_internal_friction;
+
+          /**
+           * List of the cohesions.
+           */
+          std::vector<double> cohesions;
+
+          /**
+           * Limit maximum yield stress from drucker prager yield criterion.
+           */
+          double max_yield_strength;
+
+      };
+    }
+  }
+}
+#endif

--- a/include/aspect/material_model/rheology/drucker_prager.h
+++ b/include/aspect/material_model/rheology/drucker_prager.h
@@ -23,7 +23,6 @@
 
 #include <aspect/global.h>
 #include <aspect/material_model/interface.h>
-#include <aspect/simulator_access.h>
 
 namespace aspect
 {
@@ -55,7 +54,7 @@ namespace aspect
       };
 
       template <int dim>
-      class DruckerPrager : public ::aspect::SimulatorAccess<dim>
+      class DruckerPrager
       {
         public:
           /**
@@ -69,9 +68,14 @@ namespace aspect
            * Read the parameters from the parameter file. These parameters might
            * be modified outside of this class for each call to the functions below,
            * so the read parameters are returned to the caller instead of stored as members.
+           *
+           * @param [in] n_fields The number of expected values for the angle of friction and
+           * cohesion lists. Generally either the number of compositional fields or this number
+           * plus one (for a background field), depending on how the user handles background fields.
            */
           DruckerPragerParameters
-          parse_parameters (ParameterHandler &prm);
+          parse_parameters (const unsigned int n_fields,
+                            ParameterHandler &prm);
 
           /**
            * Compute the plastic yield stress based on the Drucker Prager yield criterion.

--- a/include/aspect/material_model/rheology/drucker_prager.h
+++ b/include/aspect/material_model/rheology/drucker_prager.h
@@ -59,9 +59,9 @@ namespace aspect
            * Compute the plastic yield stress based on the Drucker Prager yield criterion.
            */
           double
-          compute_stress (const double cohesion,
-                          const double angle_internal_friction,
-                          const double pressure) const;
+          compute_yield_stress (const double cohesion,
+                                const double angle_internal_friction,
+                                const double pressure) const;
 
           /**
            * Compute the plastic viscosity with the yield stress and effective strain rate.
@@ -85,7 +85,7 @@ namespace aspect
            * the rheology model.
            */
           double
-          get_max_yield_strength () const;
+          get_max_yield_stress () const;
 
           /**
            * Return the values of the cohesions for each composition used in the
@@ -116,7 +116,7 @@ namespace aspect
           /**
            * Limit maximum yield stress from drucker prager yield criterion.
            */
-          double max_yield_strength;
+          double max_yield_stress;
 
       };
     }

--- a/include/aspect/material_model/rheology/drucker_prager.h
+++ b/include/aspect/material_model/rheology/drucker_prager.h
@@ -33,15 +33,31 @@ namespace aspect
 
     namespace Rheology
     {
+      /**
+         * A data structure with all input file parameters relevant to Drucker-Prager plasticity.
+         */
+      struct DruckerPragerParameters
+      {
+        /**
+         * List of internal friction angles (phi).
+         */
+        std::vector<double> angles_internal_friction;
+
+        /**
+         * List of the cohesions.
+         */
+        std::vector<double> cohesions;
+
+        /**
+         * Limit maximum yield stress from drucker prager yield criterion.
+         */
+        double max_yield_stress;
+      };
+
       template <int dim>
       class DruckerPrager : public ::aspect::SimulatorAccess<dim>
       {
         public:
-          /**
-           * Constructor.
-           */
-          DruckerPrager();
-
           /**
            * Declare the parameters this function takes through input files.
            */
@@ -50,9 +66,11 @@ namespace aspect
           declare_parameters (ParameterHandler &prm);
 
           /**
-           * Read the parameters from the parameter file.
+           * Read the parameters from the parameter file. These parameters might
+           * be modified outside of this class for each call to the functions below,
+           * so the read parameters are returned to the caller instead of stored as members.
            */
-          void
+          DruckerPragerParameters
           parse_parameters (ParameterHandler &prm);
 
           /**
@@ -61,7 +79,8 @@ namespace aspect
           double
           compute_yield_stress (const double cohesion,
                                 const double angle_internal_friction,
-                                const double pressure) const;
+                                const double pressure,
+                                const double max_yield_stress) const;
 
           /**
            * Compute the plastic viscosity with the yield stress and effective strain rate.
@@ -70,7 +89,8 @@ namespace aspect
           compute_viscosity (const double cohesion,
                              const double angle_internal_friction,
                              const double pressure,
-                             const double effective_strain_rate) const;
+                             const double effective_strain_rate,
+                             const double max_yield_stress) const;
 
           /**
            * Compute the derivative of the plastic viscosity with respect to pressure.
@@ -78,46 +98,6 @@ namespace aspect
           double
           compute_derivative (const double angle_internal_friction,
                               const double effective_strain_rate) const;
-
-
-          /**
-           * Return the value of the maximum yield stress for each composition used in
-           * the rheology model.
-           */
-          double
-          get_max_yield_stress () const;
-
-          /**
-           * Return the values of the cohesions for each composition used in the
-           * rheology model.
-           */
-          std::vector<double>
-          get_cohesions () const;
-
-          /**
-           * Return the values of the angles of internal friction for each
-           * composition used in the rheology model.
-           */
-          std::vector<double>
-          get_angles_internal_friction () const;
-
-        private:
-
-          /**
-           * List of internal friction angles (phi).
-           */
-          std::vector<double> angles_internal_friction;
-
-          /**
-           * List of the cohesions.
-           */
-          std::vector<double> cohesions;
-
-          /**
-           * Limit maximum yield stress from drucker prager yield criterion.
-           */
-          double max_yield_stress;
-
       };
     }
   }

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -269,62 +269,6 @@ namespace aspect
                             const CompositionalAveragingOperation &average_type);
 
 
-
-      /**
-       * A data structure with all inputs for the
-       * MaterialModel::Interface::compute_drucker_prager_yielding() method.
-       */
-      struct DruckerPragerInputs
-      {
-        /**
-         * Constructor. Initializes the various variables of this structure
-         * with the input values. By default, there is no maximum yield
-         * strength, so the parameter is set to infinity.
-         */
-        DruckerPragerInputs(const double cohesion,
-                            const double friction_angle,
-                            const double pressure,
-                            const double effective_strain_rate,
-                            const double max_yield_strength = std::numeric_limits<double>::infinity());
-
-        const double cohesion;
-        const double friction_angle;
-        const double pressure;
-        const double effective_strain_rate;
-        const double max_yield_strength;
-      };
-
-
-
-      /**
-       * A data structure with all outputs computed by the
-       * MaterialModel::Interface::compute_drucker_prager_yielding() method.
-       */
-      struct DruckerPragerOutputs
-      {
-        /**
-         * Constructor. Initializes the various variables of this structure to
-         * NaNs.
-         */
-        DruckerPragerOutputs();
-
-        double yield_strength;
-        double plastic_viscosity;
-        double viscosity_pressure_derivative;
-      };
-
-
-
-      /**
-       * For material models with plasticity:
-       * Function to compute the material properties in @p out given the
-       * inputs in @p in according to the the Drucker-Prager yield criterion.
-       */
-      template <int dim>
-      void
-      compute_drucker_prager_yielding (const DruckerPragerInputs &in,
-                                       DruckerPragerOutputs &out);
-
       /**
        * A data structure with all inputs for the
        * PhaseFunction::phase_function_value() and

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -26,6 +26,7 @@
 #include <aspect/simulator_access.h>
 #include <aspect/material_model/rheology/diffusion_creep.h>
 #include <aspect/material_model/rheology/dislocation_creep.h>
+#include <aspect/material_model/rheology/drucker_prager.h>
 #include <aspect/material_model/equation_of_state/multicomponent_incompressible.h>
 
 #include<deal.II/fe/component_mask.h>
@@ -254,11 +255,6 @@ namespace aspect
         std::vector<double> exponents_stress_limiter;
 
         /**
-         * Limit maximum yield stress from drucker-prager.
-         */
-        double max_yield_strength;
-
-        /**
          * temperature gradient added to temperature used in the flow law.
          */
         double adiabatic_temperature_gradient_for_viscosity;
@@ -270,6 +266,11 @@ namespace aspect
          */
         Rheology::DiffusionCreep<dim> diffusion_creep;
         Rheology::DislocationCreep<dim> dislocation_creep;
+
+        /*
+         * Objects for computing plastic stresses, viscosities, and additional outputs
+         */
+        Rheology::DruckerPrager<dim> drucker_prager_plasticity;
     };
 
   }

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -269,6 +269,11 @@ namespace aspect
          * Objects for computing plastic stresses, viscosities, and additional outputs
          */
         Rheology::DruckerPrager<dim> drucker_prager_plasticity;
+
+        /*
+         * Input parameters for the drucker prager plasticity.
+         */
+        Rheology::DruckerPragerParameters drucker_prager_parameters;
     };
 
   }

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -250,8 +250,6 @@ namespace aspect
          */
         ComponentMask get_volumetric_composition_mask() const;
 
-        std::vector<double> angles_internal_friction;
-        std::vector<double> cohesions;
         std::vector<double> exponents_stress_limiter;
 
         /**

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -65,7 +65,7 @@ namespace aspect
         std::vector<double> friction_angles;
 
         /**
-         * The area where the viscous stress exceeds the plastic yield strength,
+         * The area where the viscous stress exceeds the plastic yield stress,
          * and viscosity is rescaled back to the yield envelope.
          */
         std::vector<double> yielding;

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -105,8 +105,8 @@ namespace aspect
               else
                 {
                   // plasticity
-                  const double eta_plastic = drucker_prager_plasticity.compute_viscosity(cohesion,angle_of_internal_friction,pressure, std::sqrt(strain_rate_effective));                  
-                  
+                  const double eta_plastic = drucker_prager_plasticity.compute_viscosity(cohesion,angle_of_internal_friction,pressure, std::sqrt(strain_rate_effective));
+
                   const double viscosity_pressure_derivative = drucker_prager_plasticity.compute_derivative(angle_of_internal_friction,std::sqrt(strain_rate_effective));
 
                   // Cut off the viscosity between a minimum and maximum value to avoid
@@ -189,7 +189,7 @@ namespace aspect
         prm.enter_subsection("Drucker Prager");
         {
           EquationOfState::LinearizedIncompressible<dim>::declare_parameters (prm);
-          
+
           Rheology::DruckerPrager<dim>::declare_parameters(prm);
 
           prm.declare_entry ("Reference temperature", "293",
@@ -224,7 +224,7 @@ namespace aspect
                              "Units: $W/m/K$.");
           prm.enter_subsection ("Viscosity");
           {
-  
+
             prm.declare_entry ("Minimum viscosity", "1e19",
                                Patterns::Double (0),
                                "The value of the minimum viscosity cutoff $\\eta_min$. Units: $Pa\\;s$.");

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -109,7 +109,7 @@ namespace aspect
                                                                                          angle_of_internal_friction,
                                                                                          pressure,
                                                                                          std::sqrt(strain_rate_effective),
-                                                                                         drucker_prager_parameters.max_yield_stress);
+                                                                                         std::numeric_limits<double>::infinity());
 
                   const double viscosity_pressure_derivative = drucker_prager_plasticity.compute_derivative(angle_of_internal_friction,std::sqrt(strain_rate_effective));
 
@@ -194,8 +194,6 @@ namespace aspect
         {
           EquationOfState::LinearizedIncompressible<dim>::declare_parameters (prm);
 
-          Rheology::DruckerPrager<dim>::declare_parameters(prm);
-
           prm.declare_entry ("Reference temperature", "293",
                              Patterns::Double (0),
                              "The reference temperature $T_0$. The reference temperature is used "
@@ -267,9 +265,6 @@ namespace aspect
         prm.enter_subsection("Drucker Prager");
         {
           equation_of_state.parse_parameters (prm);
-
-          drucker_prager_plasticity.initialize_simulator (this->get_simulator());
-          drucker_prager_parameters = drucker_prager_plasticity.parse_parameters(prm);
 
           reference_T                = prm.get_double ("Reference temperature");
           reference_eta              = prm.get_double ("Reference viscosity");

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -105,7 +105,11 @@ namespace aspect
               else
                 {
                   // plasticity
-                  const double eta_plastic = drucker_prager_plasticity.compute_viscosity(cohesion,angle_of_internal_friction,pressure, std::sqrt(strain_rate_effective));
+                  const double eta_plastic = drucker_prager_plasticity.compute_viscosity(cohesion,
+                                                                                         angle_of_internal_friction,
+                                                                                         pressure,
+                                                                                         std::sqrt(strain_rate_effective),
+                                                                                         drucker_prager_parameters.max_yield_stress);
 
                   const double viscosity_pressure_derivative = drucker_prager_plasticity.compute_derivative(angle_of_internal_friction,std::sqrt(strain_rate_effective));
 
@@ -265,7 +269,7 @@ namespace aspect
           equation_of_state.parse_parameters (prm);
 
           drucker_prager_plasticity.initialize_simulator (this->get_simulator());
-          drucker_prager_plasticity.parse_parameters(prm);
+          drucker_prager_parameters = drucker_prager_plasticity.parse_parameters(prm);
 
           reference_T                = prm.get_double ("Reference temperature");
           reference_eta              = prm.get_double ("Reference viscosity");

--- a/source/material_model/dynamic_friction.cc
+++ b/source/material_model/dynamic_friction.cc
@@ -62,7 +62,7 @@ namespace aspect
                                                                                        phi,
                                                                                        std::max(pressure,0.0),
                                                                                        std::sqrt(strain_rate_dev_inv2),
-                                                                                       drucker_prager_parameters.max_yield_stress);
+                                                                                       std::numeric_limits<double>::infinity());
 
           // Cut off the viscosity between a minimum and maximum value to avoid
           // a numerically unfavourable large viscosity range.
@@ -141,8 +141,6 @@ namespace aspect
         {
           EquationOfState::MulticomponentIncompressible<dim>::declare_parameters (prm, 4.e-5);
 
-          Rheology::DruckerPrager<dim>::declare_parameters(prm);
-
           prm.declare_entry ("Reference temperature", "293",
                              Patterns::Double (0),
                              "The reference temperature $T_0$. Units: $\\si{K}$.");
@@ -214,10 +212,6 @@ namespace aspect
         {
           equation_of_state.initialize_simulator (this->get_simulator());
           equation_of_state.parse_parameters (prm);
-
-          drucker_prager_plasticity.initialize_simulator (this->get_simulator());
-          drucker_prager_parameters = drucker_prager_plasticity.parse_parameters(prm);
-
 
           reference_T = prm.get_double ("Reference temperature");
 

--- a/source/material_model/dynamic_friction.cc
+++ b/source/material_model/dynamic_friction.cc
@@ -58,7 +58,11 @@ namespace aspect
           const double phi = std::atan (mu);
 
           // Compute the viscosity according to the Drucker-Prager yield criterion.
-          const double plastic_viscosity = drucker_prager_plasticity.compute_viscosity(cohesions[i], phi, std::max(pressure,0.0), std::sqrt(strain_rate_dev_inv2));
+          const double plastic_viscosity = drucker_prager_plasticity.compute_viscosity(cohesions[i],
+                                                                                       phi,
+                                                                                       std::max(pressure,0.0),
+                                                                                       std::sqrt(strain_rate_dev_inv2),
+                                                                                       drucker_prager_parameters.max_yield_stress);
 
           // Cut off the viscosity between a minimum and maximum value to avoid
           // a numerically unfavourable large viscosity range.
@@ -212,7 +216,8 @@ namespace aspect
           equation_of_state.parse_parameters (prm);
 
           drucker_prager_plasticity.initialize_simulator (this->get_simulator());
-          drucker_prager_plasticity.parse_parameters(prm);
+          drucker_prager_parameters = drucker_prager_plasticity.parse_parameters(prm);
+
 
           reference_T = prm.get_double ("Reference temperature");
 

--- a/source/material_model/rheology/drucker_prager.cc
+++ b/source/material_model/rheology/drucker_prager.cc
@@ -1,0 +1,191 @@
+/*
+  Copyright (C) 2019 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/material_model/rheology/drucker_prager.h>
+#include <aspect/utilities.h>
+
+#include <deal.II/base/signaling_nan.h>
+#include <deal.II/base/parameter_handler.h>
+
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace Rheology
+    {
+      template <int dim>
+      DruckerPrager<dim>::DruckerPrager ()
+      {}
+
+
+
+      template <int dim>
+      double
+      DruckerPrager<dim>::compute_stress (const double cohesion,
+                                          const double angle_internal_friction,
+                                          const double pressure) const
+      {
+        const double sin_phi = std::sin(angle_internal_friction);
+        const double cos_phi = std::cos(angle_internal_friction);
+        const double strength_inv_part = 1. / (std::sqrt(3.0) * (3.0 + sin_phi));
+
+        double yield_strength = ( (dim==3)
+                                  ?
+                                  ( 6.0 * cohesion * cos_phi + 6.0 * pressure * sin_phi) * strength_inv_part
+                                  :
+                                  cohesion * cos_phi + pressure * sin_phi);
+
+        return std::min(yield_strength, max_yield_strength);
+      }
+
+
+
+      template <int dim>
+      double
+      DruckerPrager<dim>::compute_viscosity (const double cohesion,
+                                             const double angle_internal_friction,
+                                             const double pressure,
+                                             const double effective_strain_rate) const
+      {
+        const double yield_strength = compute_stress(cohesion, angle_internal_friction, pressure);
+
+        const double strain_rate_effective_inv = 1./(2.*effective_strain_rate);
+
+        return yield_strength * strain_rate_effective_inv;
+      }
+
+
+
+      template <int dim>
+      double
+      DruckerPrager<dim>::compute_derivative (const double angle_internal_friction,
+                                              const double effective_strain_rate) const
+      {
+        const double sin_phi = std::sin(angle_internal_friction);
+
+        const double strength_inv_part = 1. / (std::sqrt(3.0) * (3.0 + sin_phi));
+
+        const double strain_rate_effective_inv = 1./(2.*effective_strain_rate);
+
+        const double viscosity_pressure_derivative = sin_phi * strain_rate_effective_inv *
+                                                     (dim == 3
+                                                      ?
+                                                      (6.0 * strength_inv_part)
+                                                      :
+                                                      1);
+
+        return viscosity_pressure_derivative;
+      }
+
+
+
+      template <int dim>
+      double
+      DruckerPrager<dim>::get_max_yield_strength () const
+      {
+        return max_yield_strength;
+      }
+
+
+
+      template <int dim>
+      std::vector<double>
+      DruckerPrager<dim>::get_cohesions () const
+      {
+        return cohesions;
+      }
+
+
+
+      template <int dim>
+      std::vector<double>
+      DruckerPrager<dim>::get_angles_internal_friction () const
+      {
+        return angles_internal_friction;
+      }
+
+
+      template <int dim>
+      void
+      DruckerPrager<dim>::declare_parameters (ParameterHandler &prm)
+      {
+        prm.declare_entry ("Angles of internal friction", "0",
+                           Patterns::List(Patterns::Double(0)),
+                           "List of angles of internal friction, $\\phi$, for background material and compositional fields, "
+                           "for a total of N+1 values, where N is the number of compositional fields. "
+                           "For a value of zero, in 2D the von Mises criterion is retrieved. "
+                           "Angles higher than 30 degrees are harder to solve numerically. Units: degrees.");
+        prm.declare_entry ("Cohesions", "1e20",
+                           Patterns::List(Patterns::Double(0)),
+                           "List of cohesions, $C$, for background material and compositional fields, "
+                           "for a total of N+1 values, where N is the number of compositional fields. "
+                           "The extremely large default cohesion value (1e20 Pa) prevents the viscous stress from "
+                           "exceeding the yield stress. Units: $Pa$.");
+        prm.declare_entry ("Maximum yield stress", "1e12", Patterns::Double(0),
+                           "Limits the maximum value of the yield stress determined by the "
+                           "drucker-prager plasticity parameters. Default value is chosen so this "
+                           "is not automatically used. Values of 100e6--1000e6 $Pa$ have been used "
+                           "in previous models. Units: $Pa$");
+      }
+
+
+
+      template <int dim>
+      void
+      DruckerPrager<dim>::parse_parameters (ParameterHandler &prm)
+      {
+        // increment by one for background:
+        const unsigned int n_fields = this->n_compositional_fields() + 1;
+
+        angles_internal_friction = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Angles of internal friction"))),
+                                                                           n_fields,
+                                                                           "Angles of internal friction");
+        // Convert angles from degrees to radians
+        for (unsigned int i = 0; i<n_fields; ++i)
+          angles_internal_friction[i] *= numbers::PI/180.0;
+
+        cohesions = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Cohesions"))),
+                                                            n_fields,
+                                                            "Cohesions");
+
+        // Limit maximum value of the drucker-prager yield stress
+        max_yield_strength = prm.get_double("Maximum yield stress");
+      }
+
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace MaterialModel
+  {
+#define INSTANTIATE(dim) \
+  namespace Rheology \
+  { \
+    template class DruckerPrager<dim>; \
+  }
+
+    ASPECT_INSTANTIATE(INSTANTIATE)
+  }
+}

--- a/source/material_model/rheology/drucker_prager.cc
+++ b/source/material_model/rheology/drucker_prager.cc
@@ -49,10 +49,10 @@ namespace aspect
         const double stress_inv_part = 1. / (std::sqrt(3.0) * (3.0 + sin_phi));
 
         double yield_stress = ( (dim==3)
-                                  ?
-                                  ( 6.0 * cohesion * cos_phi + 6.0 * pressure * sin_phi) * stress_inv_part
-                                  :
-                                  cohesion * cos_phi + pressure * sin_phi);
+                                ?
+                                ( 6.0 * cohesion * cos_phi + 6.0 * pressure * sin_phi) * stress_inv_part
+                                :
+                                cohesion * cos_phi + pressure * sin_phi);
 
         return std::min(yield_stress, max_yield_stress);
       }

--- a/source/material_model/rheology/drucker_prager.cc
+++ b/source/material_model/rheology/drucker_prager.cc
@@ -22,9 +22,6 @@
 #include <aspect/material_model/rheology/drucker_prager.h>
 #include <aspect/utilities.h>
 
-#include <deal.II/base/signaling_nan.h>
-#include <deal.II/base/parameter_handler.h>
-
 
 namespace aspect
 {
@@ -121,18 +118,16 @@ namespace aspect
 
       template <int dim>
       DruckerPragerParameters
-      DruckerPrager<dim>::parse_parameters (ParameterHandler &prm)
+      DruckerPrager<dim>::parse_parameters (const unsigned int n_fields,
+                                            ParameterHandler &prm)
       {
         DruckerPragerParameters parameters;
-
-        // increment by one for background:
-        const unsigned int n_fields = this->n_compositional_fields() + 1;
 
         parameters.angles_internal_friction = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Angles of internal friction"))),
                                                                                       n_fields,
                                                                                       "Angles of internal friction");
         // Convert angles from degrees to radians
-        for (unsigned int i = 0; i<n_fields; ++i)
+        for (unsigned int i = 0; i<parameters.angles_internal_friction.size(); ++i)
           parameters.angles_internal_friction[i] *= numbers::PI/180.0;
 
         parameters.cohesions = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Cohesions"))),

--- a/source/material_model/rheology/drucker_prager.cc
+++ b/source/material_model/rheology/drucker_prager.cc
@@ -40,21 +40,21 @@ namespace aspect
 
       template <int dim>
       double
-      DruckerPrager<dim>::compute_stress (const double cohesion,
-                                          const double angle_internal_friction,
-                                          const double pressure) const
+      DruckerPrager<dim>::compute_yield_stress (const double cohesion,
+                                                const double angle_internal_friction,
+                                                const double pressure) const
       {
         const double sin_phi = std::sin(angle_internal_friction);
         const double cos_phi = std::cos(angle_internal_friction);
-        const double strength_inv_part = 1. / (std::sqrt(3.0) * (3.0 + sin_phi));
+        const double stress_inv_part = 1. / (std::sqrt(3.0) * (3.0 + sin_phi));
 
-        double yield_strength = ( (dim==3)
+        double yield_stress = ( (dim==3)
                                   ?
-                                  ( 6.0 * cohesion * cos_phi + 6.0 * pressure * sin_phi) * strength_inv_part
+                                  ( 6.0 * cohesion * cos_phi + 6.0 * pressure * sin_phi) * stress_inv_part
                                   :
                                   cohesion * cos_phi + pressure * sin_phi);
 
-        return std::min(yield_strength, max_yield_strength);
+        return std::min(yield_stress, max_yield_stress);
       }
 
 
@@ -66,11 +66,11 @@ namespace aspect
                                              const double pressure,
                                              const double effective_strain_rate) const
       {
-        const double yield_strength = compute_stress(cohesion, angle_internal_friction, pressure);
+        const double yield_stress = compute_yield_stress(cohesion, angle_internal_friction, pressure);
 
         const double strain_rate_effective_inv = 1./(2.*effective_strain_rate);
 
-        return yield_strength * strain_rate_effective_inv;
+        return yield_stress * strain_rate_effective_inv;
       }
 
 
@@ -82,14 +82,14 @@ namespace aspect
       {
         const double sin_phi = std::sin(angle_internal_friction);
 
-        const double strength_inv_part = 1. / (std::sqrt(3.0) * (3.0 + sin_phi));
+        const double stress_inv_part = 1. / (std::sqrt(3.0) * (3.0 + sin_phi));
 
         const double strain_rate_effective_inv = 1./(2.*effective_strain_rate);
 
         const double viscosity_pressure_derivative = sin_phi * strain_rate_effective_inv *
                                                      (dim == 3
                                                       ?
-                                                      (6.0 * strength_inv_part)
+                                                      (6.0 * stress_inv_part)
                                                       :
                                                       1);
 
@@ -100,9 +100,9 @@ namespace aspect
 
       template <int dim>
       double
-      DruckerPrager<dim>::get_max_yield_strength () const
+      DruckerPrager<dim>::get_max_yield_stress () const
       {
-        return max_yield_strength;
+        return max_yield_stress;
       }
 
 
@@ -168,7 +168,7 @@ namespace aspect
                                                             "Cohesions");
 
         // Limit maximum value of the drucker-prager yield stress
-        max_yield_strength = prm.get_double("Maximum yield stress");
+        max_yield_stress = prm.get_double("Maximum yield stress");
       }
 
     }

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -699,64 +699,6 @@ namespace aspect
       }
 
 
-
-      DruckerPragerInputs::DruckerPragerInputs(const double cohesion_,
-                                               const double friction_angle_,
-                                               const double pressure_,
-                                               const double effective_strain_rate_,
-                                               const double max_yield_strength_)
-        :
-        cohesion(cohesion_),
-        friction_angle(friction_angle_),
-        pressure(pressure_),
-        effective_strain_rate(effective_strain_rate_),
-        max_yield_strength(max_yield_strength_)
-      {}
-
-
-      DruckerPragerOutputs::DruckerPragerOutputs ()
-        :
-        yield_strength(numbers::signaling_nan<double>()),
-        plastic_viscosity(numbers::signaling_nan<double>()),
-        viscosity_pressure_derivative(numbers::signaling_nan<double>())
-      {}
-
-
-
-      template <int dim>
-      void
-      compute_drucker_prager_yielding (const DruckerPragerInputs &in,
-                                       DruckerPragerOutputs &out)
-      {
-        // plasticity
-        const double sin_phi = std::sin(in.friction_angle);
-        const double cos_phi = std::cos(in.friction_angle);
-        const double strength_inv_part = 1. / (std::sqrt(3.0) * (3.0 + sin_phi));
-
-        out.yield_strength = ( (dim==3)
-                               ?
-                               ( 6.0 * in.cohesion * cos_phi + 6.0 * in.pressure * sin_phi) * strength_inv_part
-                               :
-                               in.cohesion * cos_phi + in.pressure * sin_phi);
-
-        out.yield_strength = std::min(out.yield_strength, in.max_yield_strength);
-
-        // Rescale the viscosity back onto the yield surface
-        const double strain_rate_effective_inv = 1./(2.*in.effective_strain_rate);
-        out.plastic_viscosity = out.yield_strength * strain_rate_effective_inv;
-
-        out.viscosity_pressure_derivative = sin_phi * strain_rate_effective_inv *
-                                            (dim == 3
-                                             ?
-                                             (6.0 * strength_inv_part)
-                                             :
-                                             1);
-
-        return;
-      }
-
-
-
       template <int dim>
       PhaseFunctionInputs<dim>::PhaseFunctionInputs(const double temperature_,
                                                     const double pressure_,
@@ -997,10 +939,6 @@ namespace aspect
     namespace MaterialUtilities
     {
 #define INSTANTIATE(dim) \
-  template \
-  void \
-  compute_drucker_prager_yielding<dim> (const DruckerPragerInputs &, \
-                                        DruckerPragerOutputs &); \
   template struct PhaseFunctionInputs<dim>; \
   template class PhaseFunction<dim>;
 

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -663,8 +663,8 @@ namespace aspect
           dislocation_creep.parse_parameters(prm);
 
           // Plasticity parameters
-          drucker_prager_plasticity.initialize_simulator (this->get_simulator());
-          drucker_prager_parameters = drucker_prager_plasticity.parse_parameters(prm);
+          drucker_prager_parameters = drucker_prager_plasticity.parse_parameters(this->n_compositional_fields()+1,
+                                                                                 prm);
 
           // Stress limiter parameter
           exponents_stress_limiter  = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Stress limiter exponents"))),

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -575,20 +575,8 @@ namespace aspect
           // Dislocation creep parameters
           Rheology::DislocationCreep<dim>::declare_parameters(prm);
 
-
-          // Plasticity parameters
-          prm.declare_entry ("Angles of internal friction", "0",
-                             Patterns::List(Patterns::Double(0)),
-                             "List of angles of internal friction, $\\phi$, for background material and compositional fields, "
-                             "for a total of N+1 values, where N is the number of compositional fields. "
-                             "For a value of zero, in 2D the von Mises criterion is retrieved. "
-                             "Angles higher than 30 degrees are harder to solve numerically. Units: degrees.");
-          prm.declare_entry ("Cohesions", "1e20",
-                             Patterns::List(Patterns::Double(0)),
-                             "List of cohesions, $C$, for background material and compositional fields, "
-                             "for a total of N+1 values, where N is the number of compositional fields. "
-                             "The extremely large default cohesion value (1e20 Pa) prevents the viscous stress from "
-                             "exceeding the yield stress. Units: $Pa$.");
+          // Drucker Prager plasticity parameters
+          Rheology::DruckerPrager<dim>::declare_parameters(prm);
 
           // Stress limiter parameters
           prm.declare_entry ("Stress limiter exponents", "1.0",
@@ -597,13 +585,6 @@ namespace aspect
                              "for background material and compositional fields, "
                              "for a total of N+1 values, where N is the number of compositional fields. "
                              "Units: none.");
-
-          // Limit maximum value of the drucker-prager yield stress
-          prm.declare_entry ("Maximum yield stress", "1e12", Patterns::Double(0),
-                             "Limits the maximum value of the yield stress determined by the "
-                             "drucker-prager plasticity parameters. Default value is chosen so this "
-                             "is not automatically used. Values of 100e6--1000e6 $Pa$ have been used "
-                             "in previous models. Units: $Pa$");
 
           // Temperature in viscosity laws to include an adiabat (note units of K/Pa)
           prm.declare_entry ("Adiabat temperature gradient for viscosity", "0.0", Patterns::Double(0),

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -194,12 +194,12 @@ namespace aspect
 
           // Third step: plastic yielding
 
-          // Calculate Drucker-Prager yield strength (i.e. yield stress)
-          const double yield_strength = drucker_prager_plasticity.compute_stress(current_cohesion,current_friction,std::max(pressure,0.0));
+          // Calculate Drucker-Prager yield stress
+          const double yield_stress = drucker_prager_plasticity.compute_yield_stress(current_cohesion,current_friction,std::max(pressure,0.0));
 
-          // If the viscous stress is greater than the yield strength, indicate we are in the yielding regime.
+          // If the viscous stress is greater than the yield stress, indicate we are in the yielding regime.
           const double viscous_stress = 2. * viscosity_pre_yield * edot_ii;
-          if (viscous_stress >= yield_strength)
+          if (viscous_stress >= yield_stress)
             composition_yielding[j] = true;
 
           // Select if yield viscosity is based on Drucker Prager or stress limiter rheology
@@ -208,15 +208,15 @@ namespace aspect
             {
               case stress_limiter:
               {
-                const double viscosity_limiter = yield_strength / (2.0 * ref_strain_rate)
+                const double viscosity_limiter = yield_stress / (2.0 * ref_strain_rate)
                                                  * std::pow((edot_ii/ref_strain_rate), 1./exponents_stress_limiter[j] - 1.0);
                 viscosity_yield = 1. / ( 1./viscosity_limiter + 1./viscosity_pre_yield);
                 break;
               }
               case drucker_prager:
               {
-                // If the viscous stress is greater than the yield strength, rescale the viscosity back to yield surface
-                if (viscous_stress >= yield_strength)
+                // If the viscous stress is greater than the yield stress, rescale the viscosity back to yield surface
+                if (viscous_stress >= yield_stress)
                   viscosity_yield = drucker_prager_plasticity.compute_viscosity(current_cohesion,current_friction,std::max(pressure,0.0), edot_ii);
                 break;
               }
@@ -818,7 +818,7 @@ namespace aspect
                                    "the full finite strain tensor through particles."
                                    "When only the second invariant of the strain is tracked, one has the option to "
                                    "track the full strain or only the plastic strain. In the latter case, strain is only tracked "
-                                   "in case the material is plastically yielding, i.e. the viscous stess > yield strength. "
+                                   "in case the material is plastically yielding, i.e. the viscous stess > yield stress. "
                                    ""
                                    "\n\n"
                                    "Viscous stress may also be limited by a non-linear stress limiter "


### PR DESCRIPTION
This PR adds a new model in the `Rheology` namespace for Drucker Prager plasticity, which will replace the similar functionality in `MaterialUtilities`.

This is currently work in progress and I wanted to let @anne-glerum take a look before proceeding further. 

Remaining tasks and topics for discussion:
- Use the new functions in the `drucker_prager` and `viscoelastic_plastic` material models.
- Remove the related functionality in MaterialUtilities
- Consistently use "yield stress" or "yield strength"
- Rename various functions to be more intuitive/descriptive
- Simplify existing documentation and make code more readable

* [X] I have followed the [instructions for indenting my code](../CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../tests/) directory.
* [X] I have added a changelog entry in the [doc/modules/changes](../doc/modules/changes) directory that will inform other users of my change.
