### PR TITLE
cleanup virtual destructors

### DIFF
--- a/include/aspect/mesh_deformation/free_surface.h
+++ b/include/aspect/mesh_deformation/free_surface.h
@@ -47,8 +47,6 @@ namespace aspect
       public:
         ApplyStabilization(const double stabilization_theta);
 
-        virtual ~ApplyStabilization () {};
-
         void
         execute (internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
                  internal::Assembly::CopyData::CopyDataBase<dim> &data) const override;

--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -215,8 +215,6 @@ namespace aspect
       public SimulatorAccess<dim>
     {
       public:
-        virtual ~NewtonInterface () {};
-
         /**
          * Attach Newton outputs. Since most Newton assemblers require the
          * material model derivatives they are created in this base class
@@ -233,8 +231,6 @@ namespace aspect
     class NewtonStokesPreconditioner : public NewtonInterface<dim>
     {
       public:
-        virtual ~NewtonStokesPreconditioner () {}
-
         void
         execute (internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
                  internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const override;
@@ -248,8 +244,6 @@ namespace aspect
     class NewtonStokesIncompressibleTerms : public NewtonInterface<dim>
     {
       public:
-        virtual ~NewtonStokesIncompressibleTerms () {}
-
         void
         execute (internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
                  internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const override;
@@ -264,8 +258,6 @@ namespace aspect
       public SimulatorAccess<dim>
     {
       public:
-        virtual ~NewtonStokesCompressibleStrainRateViscosityTerm () {}
-
         void
         execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
                 internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const override;
@@ -282,8 +274,6 @@ namespace aspect
       public SimulatorAccess<dim>
     {
       public:
-        virtual ~NewtonStokesReferenceDensityCompressibilityTerm () {}
-
         void
         execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
                 internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const override;
@@ -302,8 +292,6 @@ namespace aspect
       public SimulatorAccess<dim>
     {
       public:
-        virtual ~NewtonStokesImplicitReferenceDensityCompressibilityTerm () {}
-
         void
         execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
                 internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const override;
@@ -320,8 +308,6 @@ namespace aspect
       public SimulatorAccess<dim>
     {
       public:
-        virtual ~NewtonStokesIsentropicCompressionTerm () {}
-
         void
         execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
                 internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const override;

--- a/include/aspect/simulator/assemblers/interface.h
+++ b/include/aspect/simulator/assemblers/interface.h
@@ -70,7 +70,7 @@ namespace aspect
             face_number(scratch.face_number)
           {}
 
-          virtual ~ScratchBase () {};
+          virtual ~ScratchBase ()  = default;
 
           /**
            * Cell object on which we currently operate.
@@ -344,7 +344,7 @@ namespace aspect
         template <int dim>
         struct CopyDataBase
         {
-          virtual ~CopyDataBase () {};
+          virtual ~CopyDataBase () = default;
         };
 
         /**

--- a/include/aspect/stokes_matrix_free.h
+++ b/include/aspect/stokes_matrix_free.h
@@ -291,7 +291,7 @@ namespace aspect
       /**
        * virtual Destructor.
        */
-      virtual ~StokesMatrixFreeHandler();
+      virtual ~StokesMatrixFreeHandler() = default;
 
       /**
        * Solves the Stokes linear system matrix-free. This is called
@@ -343,7 +343,7 @@ namespace aspect
       /**
        * Destructor.
        */
-      ~StokesMatrixFreeHandlerImplementation();
+      ~StokesMatrixFreeHandlerImplementation() override = default;
 
       /**
        * Solves the Stokes linear system matrix-free. This is called

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -961,12 +961,6 @@ namespace aspect
 
 
 
-  template <int dim>
-  StokesMatrixFreeHandler<dim>::~StokesMatrixFreeHandler ()
-  {}
-
-
-
   template <int dim, int degree_v, typename number>
   void
   MatrixFreeStokesOperators::ABlockOperator<dim,degree_v,number>
@@ -991,10 +985,6 @@ namespace aspect
           1./inverse_diagonal.local_element(i);
       }
   }
-
-  template <int dim, int velocity_degree>
-  StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::~StokesMatrixFreeHandlerImplementation ()
-  {}
 
 
 


### PR DESCRIPTION
- use =default if possible
- empty destructors in derived classes are not needed at all
