### PR TITLE
matrix-free free-slip and no-slip conflict

### DIFF
--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1855,7 +1855,8 @@ namespace aspect
               user_level_constraints.close();
               mg_constrained_dofs.add_user_constraints(level,user_level_constraints);
 
-              level_constraints.merge(user_level_constraints);
+              // let Dirichlet values win over no normal flux:
+              level_constraints.merge(user_level_constraints, ConstraintMatrix::left_object_wins);
               level_constraints.close();
 #else
               AssertThrow(false, ExcMessage("No normal flux for spherical domains requires "
@@ -1943,7 +1944,9 @@ namespace aspect
             boundary_constraints.add_lines (mg_constrained_dofs.get_refinement_edge_indices(level));
             boundary_constraints.add_lines (mg_constrained_dofs.get_boundary_indices(level));
 #if DEAL_II_VERSION_GTE(9,2,0)
-            boundary_constraints.merge(mg_constrained_dofs.get_user_constraint_matrix(level));
+            // let Dirichlet values win over no normal flux:
+            boundary_constraints.merge(mg_constrained_dofs.get_user_constraint_matrix(level),
+                                       ConstraintMatrix::left_object_wins);
 #endif
             boundary_constraints.close();
 

--- a/tests/shell_quarter_gmg.prm.dealii_9.2
+++ b/tests/shell_quarter_gmg.prm.dealii_9.2
@@ -1,0 +1,91 @@
+# 2d quarter shell with no flux top boundary to test GMG
+
+
+set Dimension                              = 2
+set Use years in output instead of seconds = true
+set End time                               = 1.0e5
+set Output directory                       = output-shell_2d_gmg
+
+
+subsection Material model
+  set Model name = simple
+
+    set Material averaging = harmonic average
+
+  subsection Simple model
+    set Thermal expansion coefficient = 4e-5
+    set Viscosity                     = 1e22
+  end
+end
+
+
+subsection Geometry model
+  set Model name = spherical shell
+
+  subsection Spherical shell
+    set Inner radius  = 3481000
+    set Outer radius  = 6336000
+    set Opening angle = 90
+  end
+end
+
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators       = inner
+  set Tangential velocity boundary indicators = top, left, right
+end
+
+
+subsection Heating model
+  set List of model names =  shear heating
+end
+
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = top, bottom
+  set List of model names = spherical constant
+
+  subsection Spherical constant
+    set Inner temperature = 4273
+    set Outer temperature = 973
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = spherical hexagonal perturbation
+end
+
+
+subsection Gravity model
+  set Model name = ascii data
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement          = 2
+  set Initial adaptive refinement        = 2
+  set Strategy                           = temperature
+  set Time steps between mesh refinement = 15
+end
+
+
+subsection Postprocess
+  set List of postprocessors = visualization, velocity statistics, temperature statistics, heat flux statistics, depth average
+
+  subsection Visualization
+    set Output format                 = vtu
+    set Time between graphical output = 1e6
+    set Number of grouped files       = 0
+  end
+
+  subsection Depth average
+    set Time between graphical output = 1e5
+  end
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block GMG
+  end
+end

--- a/tests/shell_quarter_gmg/screen-output
+++ b/tests/shell_quarter_gmg/screen-output
@@ -1,0 +1,53 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Vectorization over 4 doubles = 256 bits (AVX), VECTORIZATION_LEVEL=2
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 48 (on 3 levels)
+Number of degrees of freedom: 740 (450+65+225)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving Stokes system... 14+0 iterations.
+
+Number of active cells: 84 (on 4 levels)
+Number of degrees of freedom: 1,364 (834+113+417)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving Stokes system... 14+0 iterations.
+
+Number of active cells: 120 (on 4 levels)
+Number of degrees of freedom: 1,846 (1,130+151+565)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Solving Stokes system... 14+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:           output-shell_quarter_gmg/solution/solution-00000
+     RMS, max velocity:                  0.0659 m/year, 0.129 m/year
+     Temperature min/avg/max:            973 K, 2486 K, 4273 K
+     Heat fluxes through boundary parts: 6.629e+04 W, 5.805e+05 W, 0 W, 0 W
+     Writing depth average:              output-shell_quarter_gmg/depth_average.gnuplot
+
+*** Timestep 1:  t=100000 years
+   Solving temperature system... 9 iterations.
+   Solving Stokes system... 12+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.0698 m/year, 0.137 m/year
+     Temperature min/avg/max:            973 K, 2486 K, 4273 K
+     Heat fluxes through boundary parts: -6.968e+04 W, 7.214e+05 W, 0 W, 0 W
+     Writing depth average:              output-shell_quarter_gmg/depth_average.gnuplot
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes a crash caused by confliciting constraints between no-normal
flux and Dirichlet as observed with a quarter_shell.
