### PR TITLE
Correct inflow boundary condition for Volume of fluid method

### DIFF
--- a/doc/modules/changes/20191019_jrobey
+++ b/doc/modules/changes/20191019_jrobey
@@ -1,0 +1,6 @@
+Fixed: The volume of fluid composition advection algorithm incorrectly computed
+the boundry fluxes on inflow boundries with fixed composition. This has been
+fixed by correcting the calculation for the amount of composition which is
+advected into the modeled region during the assembly step.
+<br>
+(Jonathan Robey, 2019/10/19)

--- a/doc/modules/changes/20191019_jrobey
+++ b/doc/modules/changes/20191019_jrobey
@@ -1,6 +1,6 @@
-Fixed: The volume of fluid composition advection algorithm incorrectly computed
-the boundry fluxes on inflow boundries with fixed composition. This has been
-fixed by correcting the calculation for the amount of composition which is
-advected into the modeled region during the assembly step.
+Fixed: The volume of fluid composition advection algorithm the boundary fluxes
+on inflow boundries with fixed composition incorrectly. This has been fixed by
+correcting the calculation for the amount of composition which is advected into
+the modeled region during the assembly step.
 <br>
 (Jonathan Robey, 2019/10/19)

--- a/source/volume_of_fluid/assembler.cc
+++ b/source/volume_of_fluid/assembler.cc
@@ -213,6 +213,7 @@ namespace aspect
                                            face->boundary_id(),
                                            scratch.face_finite_element_values.quadrature_point(q),
                                            field.composition_index) *
+                                         this->get_timestep() *
                                          current_u *
                                          scratch.face_finite_element_values.normal_vector(q) *
                                          scratch.face_finite_element_values.JxW(q);
@@ -265,7 +266,7 @@ namespace aspect
             }
           else if (face_flux < 0.0) // edge is upwind (inflow boundary), so use the volume fraction implied by the boundary condition
             {
-              flux_volume_of_fluid = -boundary_fluid_flux/face_flux;
+              flux_volume_of_fluid = boundary_fluid_flux/face_flux;
             }
           else // Cell is upwind of boundary, so compute the volume fraction on the advected volume
             {

--- a/tests/vof_linear_inflow.prm
+++ b/tests/vof_linear_inflow.prm
@@ -1,0 +1,88 @@
+# Debugging inflow boundary condition 
+
+set Dimension                              = 2
+set Start time                             = 0
+set End time                               = 0.03125
+set Use years in output instead of seconds = false
+set CFL number                             = 0.5
+set Output directory                       = output
+
+subsection Volume of Fluid
+    set Number initialization samples = 16
+end
+
+subsection Compositional fields
+    set Number of fields = 1
+    set Names of fields = F_1
+    set Compositional field methods = volume of fluid
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 3
+  set Time steps between mesh refinement = 0
+end
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+    set Y extent = 1
+  end
+end
+
+subsection Material model
+  set Model name = simple
+end
+
+subsection Gravity model
+  set Model name = vertical
+end
+
+subsection Initial temperature model
+  set Model name = function
+end
+
+subsection Initial composition model
+  set List of model names = function
+
+  subsection Function
+    set Variable names = x,y,t
+    set Function constants = init=1.25, x0=1.0, y0=0.0, xv=-0.25, yv=-0.25
+    set Function expression = if(y<=0.5,1,0)
+  end
+end
+
+# Composition boundary conditions
+subsection Boundary composition model
+  set List of model names = initial composition
+  set Fixed composition boundary indicators   = bottom, top, left, right
+end
+
+subsection Prescribed Stokes solution
+  set Model name = function
+  subsection Velocity function
+    set Variable names = x,y,t
+
+    set Function constants = init=1.25, x0=1.0, y0=0.0, xv=-0.25, yv=-0.25
+    set Function expression = 0;1
+  end
+end
+
+set Nonlinear solver scheme                   = Advection only
+
+subsection Postprocess
+  set List of postprocessors = volume of fluid statistics
+
+  subsection Visualization
+    set Interpolate output = false
+    set Time between graphical output = 1.0
+
+    set List of output variables = volume of fluid values
+
+    subsection Volume of Fluid
+      set Output interface reconstruction contour = true
+    end
+  end
+end

--- a/tests/vof_linear_inflow/screen-output
+++ b/tests/vof_linear_inflow/screen-output
@@ -1,0 +1,27 @@
+
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 1,749 (578+81+289+289+64+192+256)
+
+*** Timestep 0:  t=0 seconds
+   Skipping temperature solve because RHS is zero.
+   Solving volume of fluid system... 0 iterations.
+   Solving volume of fluid system... 0 iterations.
+
+   Postprocessing:
+     Global volume of fluid volumes (m^3): 0.5
+
+*** Timestep 1:  t=0.03125 seconds
+   Skipping temperature solve because RHS is zero.
+   Solving volume of fluid system... 1 iterations.
+   Solving volume of fluid system... 0 iterations.
+
+   Postprocessing:
+     Global volume of fluid volumes (m^3): 0.531
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+


### PR DESCRIPTION
Corrects the inflow boundary assembly calculations for VOF composition fields, and adds a basic test case to ensure that it does not break in the future.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../tests/) directory.

