### PR TITLE
Extend parse function to allow multiple values per key

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -79,7 +79,7 @@ namespace aspect
      * This function takes a string argument that is interpreted as a map
      * of the form "key1 : value1, key2 : value2, etc", and then parses
      * it to return a vector of these values where the values are ordered
-     * in the same order as a given set of keys. If @p allow_subentries
+     * in the same order as a given set of keys. If @p allow_multiple_values_per_key
      * is set to 'true' it also allows entries of the form
      * "key1: value1|value2|value3, etc", in which case the returned
      * vector will have more entries than the provided
@@ -93,7 +93,8 @@ namespace aspect
      *   where "key1", "key2", ... are exactly the keys provided by the
      *   @p list_of_keys in the same order as provided. In this situation,
      *   if a background field is required, the background value is
-     *   assigned to the first element of the output vector.
+     *   assigned to the first element of the output vector. This form only
+     *   allows a single value per key.
      * - Whether or not a background field is required depends on
      *   the parameter being parsed. Requiring a background field
      *   increases the size of the output vector by 1. For example,
@@ -114,25 +115,36 @@ namespace aspect
      * @param[in] property_name A name that identifies the type of property
      *   that is being parsed by this function and that is used in generating
      *   error messages if the map does not conform to the expected format.
-     * @param [in] allow_subentries If true allow having multiple subentries
-     *   for each key. If false only allow a single entry per key. In either
+     * @param [in] allow_multiple_values_per_key If true allow having multiple values
+     *   for each key. If false only allow a single value per key. In either
      *   case each key is only allowed to appear once.
-     * @param [out] subentry_structure If handed over this
-     *   vector will be filled with as many components as
-     *   keys (+1 if there is a background field). Each value represents
-     *   how many subentries were found for this key. The sum over all
-     *   entries is the length of the returned vector of values.
+     * @param [in,out] n_values_per_key A pointer to a vector of unsigned
+     *   integers. If no pointer is handed over nothing happens. If a pointer
+     *   to an empty vector is handed over, the vector
+     *   is resized with as many components as
+     *   keys (+1 if there is a background field). Each value then stores
+     *   how many values were found for this key. The sum over all
+     *   entries is the length of the return value of this function.
+     *   If a pointer to an existing vector with one or more entries is
+     *   handed over (e.g. a n_values_per_key vector created by a
+     *   previous call to this function) then this vector is used as
+     *   expected structure of the input parameter, and it is checked that
+     *   @p key_value_map fulfills this structure.
      *
      * @return A vector of values that are parsed from the map, provided
      *   in the order in which the keys appear in the @p list_of_keys argument.
+     *   If multiple values per key are allowed, the vector contains first all
+     *   values for key 1, then all values for key 2 and so forth. Using the
+     *   @p n_values_per_key vector allows the caller to sort entries in the
+     *   returned vector to specific keys.
      */
     std::vector<double>
     parse_map_to_double_array (const std::string &key_value_map,
                                const std::vector<std::string> &list_of_keys,
                                const bool has_background_field,
                                const std::string &property_name,
-                               const bool allow_subentries = false,
-                               std::shared_ptr<std::vector<unsigned int> > subentry_structure = nullptr);
+                               const bool allow_multiple_values_per_key = false,
+                               std::shared_ptr<std::vector<unsigned int> > n_values_per_key = nullptr);
 
     /**
      * This function takes a string argument that is assumed to represent

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -79,7 +79,11 @@ namespace aspect
      * This function takes a string argument that is interpreted as a map
      * of the form "key1 : value1, key2 : value2, etc", and then parses
      * it to return a vector of these values where the values are ordered
-     * in the same order as a given set of keys.
+     * in the same order as a given set of keys. If @p allow_subentries
+     * is set to 'true' it also allows entries of the form
+     * "key1: value1|value2|value3, etc", in which case the returned
+     * vector will have more entries than the provided
+     * @p list_of_keys.
      *
      * This function also considers a number of special cases:
      * - If the input string consists of only a comma separated
@@ -95,7 +99,7 @@ namespace aspect
      *   increases the size of the output vector by 1. For example,
      *   some Material models require background fields, but input
      *   files may not.
-     * - Three special keys are recognized:
+     * - Two special keys are recognized:
      *      all --> Assign the associated value to all fields.
      *              Only one value is allowed in this case.
      *      background --> Assign associated value to the background.
@@ -110,6 +114,14 @@ namespace aspect
      * @param[in] property_name A name that identifies the type of property
      *   that is being parsed by this function and that is used in generating
      *   error messages if the map does not conform to the expected format.
+     * @param [in] allow_subentries If true allow having multiple subentries
+     *   for each key. If false only allow a single entry per key. In either
+     *   case each key is only allowed to appear once.
+     * @param [out] subentry_structure If handed over this
+     *   vector will be filled with as many components as
+     *   keys (+1 if there is a background field). Each value represents
+     *   how many subentries were found for this key. The sum over all
+     *   entries is the length of the returned vector of values.
      *
      * @return A vector of values that are parsed from the map, provided
      *   in the order in which the keys appear in the @p list_of_keys argument.
@@ -118,7 +130,9 @@ namespace aspect
     parse_map_to_double_array (const std::string &key_value_map,
                                const std::vector<std::string> &list_of_keys,
                                const bool has_background_field,
-                               const std::string &property_name);
+                               const std::string &property_name,
+                               const bool allow_subentries = false,
+                               std::shared_ptr<std::vector<unsigned int> > subentry_structure = nullptr);
 
     /**
      * This function takes a string argument that is assumed to represent

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -91,13 +91,13 @@ namespace aspect
 
     std::vector<double>
     parse_map_to_double_array (const std::string &input_string,
-                               const std::vector<std::string> &input_field_names,
+                               const std::vector<std::string> &list_of_keys,
                                const bool has_background_field,
                                const std::string &property_name,
                                const bool allow_multiple_values_per_key,
                                std::shared_ptr<std::vector<unsigned int> > n_values_per_key)
     {
-      std::vector<std::string> field_names = input_field_names;
+      std::vector<std::string> field_names = list_of_keys;
       if (has_background_field)
         field_names.insert(field_names.begin(),"background");
 
@@ -297,8 +297,11 @@ namespace aspect
             {
               for (unsigned int i=0; i<n_fields; ++i)
                 AssertThrow((*n_values_per_key)[i] == 1,
-                            ExcMessage("The input parameter " + property_name + " does not have "
-                                       + "the expected number of values for field index " + std::to_string(i) + "."));
+                            ExcMessage("The input parameter " + property_name + " seems to consist of a list "
+                                       "of doubles. In this case we only allow a single value per provided key, but the "
+                                       "assumed structure that was provided to the function expects " + std::to_string((*n_values_per_key)[i]) +
+                                       " values for key " + field_names[i] + ". To specify more than one value per field for this input parameter, "
+                                       "you need to use the format " + field_names[i] + ":value1|value2|..."));
             }
         }
       else

--- a/unit_tests/parse_map_to_double_array.cc
+++ b/unit_tests/parse_map_to_double_array.cc
@@ -82,6 +82,36 @@ TEST_CASE("Utilities::parse_map_to_double_array")
   "TestField"),
   {0.0,100.0,200.0,300.0,400.0,500.0});
 
+  {
+    INFO("check 9: ");
+    auto subentry_structure = std::make_shared<std::vector<unsigned int>>();
+
+    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200|100, C3:300, C4:400, C5:500, background:0",
+    {"C1","C2","C3","C4","C5"},
+    true,
+    "TestField",
+    true,
+    subentry_structure),
+    {0.0,100.0,200.0,100.0,300.0,400.0,500.0});
+
+    REQUIRE(*subentry_structure == std::vector<unsigned int>({1,1,2,1,1,1}));
+  }
+
+  {
+    INFO("check 10: ");
+    auto subentry_structure = std::make_shared<std::vector<unsigned int>>();
+
+    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200|, C3:300, C4:400, C5:500",
+    {"C1","C2","C3","C4","C5"},
+    false,
+    "TestField",
+    true,
+    subentry_structure),
+    {100.0,200.0,300.0,400.0,500.0});
+
+    REQUIRE(*subentry_structure == std::vector<unsigned int>({1,1,1,1,1}));
+  }
+
   INFO("check complete");
 
 }
@@ -135,6 +165,32 @@ TEST_CASE("Utilities::parse_map_to_double_array FAIL ON PURPOSE")
   {"C1","C2","C3","C4","C5"},
   true,
   "TestField"), Contains("The keyword `all' is expected but is not found"));
+
+  // Subentries not allowed
+  INFO("check fail 7: ");
+  REQUIRE_THROWS_WITH(
+    aspect::Utilities::parse_map_to_double_array ("C1:100, C2:|200, C3:300, C4:400, C5:500",
+  {"C1","C2","C3","C4","C5"},
+  false,
+  "TestField"), Contains("The required format for field"));
+
+  // Wrong subentry format
+  INFO("check fail 7: ");
+  REQUIRE_THROWS_WITH(
+    aspect::Utilities::parse_map_to_double_array ("C1:100, C2:|200, C3:300, C4:400, C5:500",
+  {"C1","C2","C3","C4","C5"},
+  false,
+  "TestField",
+  true), Contains("The required format for field"));
+
+  // No subentries
+  INFO("check fail 8: ");
+  REQUIRE_THROWS_WITH(
+    aspect::Utilities::parse_map_to_double_array ("C1:100, C2:|, C3:300, C4:400, C5:500",
+  {"C1","C2","C3","C4","C5"},
+  false,
+  "TestField",
+  true), Contains("The required format for field"));
 }
 
 

--- a/unit_tests/parse_map_to_double_array.cc
+++ b/unit_tests/parse_map_to_double_array.cc
@@ -259,7 +259,7 @@ TEST_CASE("Utilities::parse_map_to_double_array FAIL ON PURPOSE")
     "TestField",
     true,
     n_values_per_key),
-    Contains("the expected number of entries"));
+    Contains("the expected number of values"));
   }
 
   {
@@ -282,7 +282,7 @@ TEST_CASE("Utilities::parse_map_to_double_array FAIL ON PURPOSE")
     "TestField",
     true,
     n_values_per_key),
-    Contains("the expected number of entries"));
+    Contains("the expected number of values"));
   }
 }
 


### PR DESCRIPTION
This PR extends Utilities::parse_map_to_double_array to allow multiple entries per key using the syntax: `key1: value1|value2|value3, key2: value1, key3: value1|value2`. We would like to use this syntax to make progress with defining phase transitions for multiple compositional fields (like #2656). The unit tests should cover all cases, so I can make this as a separate PR without actual implementations using it (it will be used by several rheologies, equations of state and material models). 

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../tests/) directory.
