### PR TITLE
Use phase functions for EoS in visco_plastic material model

### DIFF
--- a/doc/modules/changes/20191029_gassmoeller_2
+++ b/doc/modules/changes/20191029_gassmoeller_2
@@ -1,0 +1,5 @@
+New: The 'multicomponent incompressible' equation of state now allow multiple
+different phases per compositional field. So far the 'visco plastic' material
+model is the only material model that makes use of this new functionality.
+<br>
+(Rene Gassmoeller, 2019/09/29)

--- a/doc/modules/changes/20191029_gassmoeller_2
+++ b/doc/modules/changes/20191029_gassmoeller_2
@@ -1,4 +1,4 @@
-New: The 'multicomponent incompressible' equation of state now allow multiple
+New: The 'multicomponent incompressible' equation of state now allows multiple
 different phases per compositional field. So far the 'visco plastic' material
 model is the only material model that makes use of this new functionality.
 <br>

--- a/include/aspect/material_model/equation_of_state/interface.h
+++ b/include/aspect/material_model/equation_of_state/interface.h
@@ -47,11 +47,16 @@ namespace aspect
     {
       /**
        * Constructor. Initialize the various arrays of this structure with the
-       * given number of compositions and phases
+       * given number of compositions and phases.
        *
-       * @param n_compositions The number of vector quantities (in the order in which
-       * the Introspection class reports them) for which input will be
-       * provided, and outputs should be filled.
+       * @param n_individual_compositions_and_phases The number of vector quantities
+       * for which input will be provided, and outputs should be filled. Note that this
+       * number does not have to be the number of compositions, it can be smaller (if
+       * some compositional fields do not represent volumetric compositions, but tracked
+       * quantities like strain) or larger (if there is a background field, or some
+       * compositions have several high-pressure phases). It is the responsibility
+       * of the material model and equation of state object to interpret the
+       * entries consistently.
        */
       EquationOfStateOutputs (const unsigned int n_individual_compositions_and_phases);
 
@@ -93,6 +98,17 @@ namespace aspect
       std::vector<double> entropy_derivative_temperature;
     };
 
+    /**
+     * This function takes the output of an equation of state @p eos_outputs_all_phases,
+     * which contains the data for all compositions and all of their phases at the
+     * current conditions and uses a PhaseFunction object @phase_function to compute
+     * the effective value of equation of state properties. Essentially it computes which phase
+     * is stable at the current conditions (according to the phase function) and adds
+     * the properties of the stable phases into the equation of state output @eos_outputs.
+     * @p eos_outputs now only contains as many entries as compositional fields (potentially
+     * plus one for the background field, if the input @p eos_outputs_all_phases contained
+     * one and the phase function contained one as well).
+     */
     template <int dim>
     void
     phase_average_equation_of_state_outputs(const EquationOfStateOutputs<dim> &eos_outputs_all_phases,

--- a/include/aspect/material_model/equation_of_state/interface.h
+++ b/include/aspect/material_model/equation_of_state/interface.h
@@ -102,10 +102,11 @@ namespace aspect
      * This function takes the output of an equation of state @p eos_outputs_all_phases,
      * which contains the data for all compositions and all of their phases at the
      * current conditions and uses a PhaseFunction object @phase_function to compute
-     * the effective value of equation of state properties. Essentially it computes which phase
-     * is stable at the current conditions (according to the phase function) and adds
-     * the properties of the stable phases into the equation of state output @eos_outputs.
-     * @p eos_outputs now only contains as many entries as compositional fields (potentially
+     * the effective value of equation of state properties for each individual composition.
+     * Essentially it computes which phase is stable at the current conditions
+     * (described in @p phase_in) and fills the equation of state output @eos_outputs with
+     * the properties of these stable phases.
+     * @p eos_outputs now only contains as many entries as volumetric compositions (potentially
      * plus one for the background field, if the input @p eos_outputs_all_phases contained
      * one and the phase function contained one as well).
      */

--- a/include/aspect/material_model/equation_of_state/interface.h
+++ b/include/aspect/material_model/equation_of_state/interface.h
@@ -37,42 +37,42 @@ namespace aspect
      * evaluate() function of an EquationOfState model. It contains those
      * properties of the MaterialModelOutputs that are connected to the
      * equation of state (or the thermodynamic properties). Output values
-     * are computed separately for each composition.
+     * are computed separately for each composition and phase.
      *
      * Accordingly, the vectors are the values for each compositional field
-     * at one specific location.
+     * and individual phase at one specific location.
      */
     template <int dim>
     struct EquationOfStateOutputs
     {
       /**
        * Constructor. Initialize the various arrays of this structure with the
-       * given number of compositions.
+       * given number of compositions and phases
        *
        * @param n_compositions The number of vector quantities (in the order in which
        * the Introspection class reports them) for which input will be
        * provided, and outputs should be filled.
        */
-      EquationOfStateOutputs (const unsigned int n_compositions);
+      EquationOfStateOutputs (const unsigned int n_individual_compositions_and_phases);
 
       /**
-       * Density values for each composition.
+       * Density values for each composition and phase.
        */
       std::vector<double> densities;
 
       /**
-       * Thermal expansion coefficients for each composition. It is defined
+       * Thermal expansion coefficients for each composition and phase. It is defined
        * as $\alpha = - \frac{1}{\rho} \frac{\partial\rho}{\partial T}$
        */
       std::vector<double> thermal_expansion_coefficients;
 
       /**
-       * Specific heat for each composition.
+       * Specific heat for each composition and phase.
        */
       std::vector<double> specific_heat_capacities;
 
       /**
-       * Compressibility for each composition. The compressibility is defined
+       * Compressibility for each composition and phase. The compressibility is defined
        * as $\kappa = \frac{1}{\rho} \frac{\partial\rho}{\partial p}$.
        */
       std::vector<double> compressibilities;
@@ -80,7 +80,7 @@ namespace aspect
       /**
        * The product of the change of entropy $\Delta S$ at a phase transition
        * and the derivative of the phase function $X=X(p,T,\mathfrak c,\mathbf
-       * x)$ with regard to pressure for each composition.
+       * x)$ with regard to pressure for each composition and phase.
        */
       std::vector<double> entropy_derivative_pressure;
 
@@ -88,17 +88,17 @@ namespace aspect
        * The product of (minus) the change of entropy $-\Delta S$ at a phase
        * transition and the derivative of the phase function
        * $X=X(p,T,\mathfrak c,\mathbf x)$ with regard to temperature for
-       * each composition.
+       * each composition and phase.
        */
       std::vector<double> entropy_derivative_temperature;
     };
 
     template <int dim>
     void
-    compute_equation_of_state_phase_transitions(const EquationOfStateOutputs<dim> &eos_outputs_all_phases,
-                                                const MaterialUtilities::PhaseFunction<dim> &phase_function,
-                                                MaterialUtilities::PhaseFunctionInputs<dim> &phase_in,
-                                                EquationOfStateOutputs<dim> &eos_outputs);
+    phase_average_equation_of_state_outputs(const EquationOfStateOutputs<dim> &eos_outputs_all_phases,
+                                            const MaterialUtilities::PhaseFunction<dim> &phase_function,
+                                            MaterialUtilities::PhaseFunctionInputs<dim> &phase_in,
+                                            EquationOfStateOutputs<dim> &eos_outputs);
   }
 }
 

--- a/include/aspect/material_model/equation_of_state/interface.h
+++ b/include/aspect/material_model/equation_of_state/interface.h
@@ -92,6 +92,13 @@ namespace aspect
        */
       std::vector<double> entropy_derivative_temperature;
     };
+
+    template <int dim>
+    void
+    compute_equation_of_state_phase_transitions(const EquationOfStateOutputs<dim> &eos_outputs_all_phases,
+                                                const MaterialUtilities::PhaseFunction<dim> &phase_function,
+                                                MaterialUtilities::PhaseFunctionInputs<dim> &phase_in,
+                                                EquationOfStateOutputs<dim> &eos_outputs);
   }
 }
 

--- a/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
+++ b/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
@@ -36,11 +36,12 @@ namespace aspect
 
       /**
        * An incompressible equation of state that is intended for use with multiple compositional
-       * fields. For each material property, the user supplies a comma delimited list of
-       * length N+1, where N is the number of compositional fields used in the computation.
+       * fields and potentially phases. For each material property, the user supplies a comma
+       * delimited list of length N+P+1, where N is the number of compositional fields used in
+       * the computation, P is the total number of phase transitions.
        * The first entry corresponds to the "background" (which is also why there are N+1 entries).
        *
-       * If a single value is given, then all the compositional fields are given
+       * If a single value is given, then all the compositional fields and phases are given
        * that value. Other lengths of lists are not allowed. For a given
        * compositional field the material parameters are treated as constant,
        * except density, which varies linearly with temperature according to the equation:
@@ -55,8 +56,8 @@ namespace aspect
         public:
           /**
            * A function that computes the output of the equation of state @p out
-           * for all compositions, given the inputs in @p in and an index q that
-           * determines which entry of the vector of inputs is used.
+           * for all compositions and phases, given the inputs in @p in and an
+           * index input_index that determines which entry of the vector of inputs is used.
            */
           void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                         const unsigned int input_index,
@@ -85,10 +86,15 @@ namespace aspect
 
           /**
            * Read the parameters this class declares from the parameter file.
+           * If @p expected_n_phases_per_composition points to a vector of
+           * unsigned integers this is considered the number of phase transitions
+           * for each compositional field and will be checked against the parsed
+           * parameters.
            */
           void
-          parse_parameters (ParameterHandler &prm);
-
+          parse_parameters (ParameterHandler &prm,
+                            const std::shared_ptr<std::vector<unsigned int>> expected_n_phases_per_composition =
+                              std::shared_ptr<std::vector<unsigned int>>());
 
         private:
           /**
@@ -114,6 +120,11 @@ namespace aspect
            */
           std::vector<double> specific_heats;
 
+          /**
+           * A vector that stores how many separate phases there are per compositional
+           * field. In other words if there is a background field without phase transitions
+           * and one more composition that has 2 phase transitions this vector would store {1,3}.
+           */
           std::shared_ptr<std::vector<unsigned int> > n_phases_per_composition;
       };
     }

--- a/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
+++ b/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
@@ -39,11 +39,11 @@ namespace aspect
        * fields and potentially phases. For each material property, the user supplies a comma
        * delimited list of length N+P+1, where N is the number of compositional fields used in
        * the computation, P is the total number of phase transitions.
-       * The first entry corresponds to the "background" (which is also why there are N+1 entries).
+       * The first entry corresponds to the "background" (which is also why there are N+P+1 entries).
        *
        * If a single value is given, then all the compositional fields and phases are given
        * that value. Other lengths of lists are not allowed. For a given
-       * compositional field the material parameters are treated as constant,
+       * compositional field and phase the material parameters are treated as constant,
        * except density, which varies linearly with temperature according to the equation:
        *
        * $\rho(p,T,\mathfrak c) = \left(1-\alpha_i (T-T_0)\right) \rho_0(\mathfrak c_i).$
@@ -98,25 +98,26 @@ namespace aspect
 
         private:
           /**
-           * Vector of reference densities $\rho_0$ with one entry per composition,
-           * used in the computation of the density.
+           * Vector of reference densities $\rho_0$ with one entry per composition and phase plus one
+           * for the background field.
            */
           std::vector<double> densities;
 
           /**
            * The reference temperature $T_0$ used in the computation of the density.
-           * All component use the same reference temperature.
+           * All components use the same reference temperature.
            */
           double reference_T;
 
           /**
-           * Vector of constant thermal expansivities $\alpha$ with one entry per composition,
-           * used in the computation of the density.
+           * Vector of thermal expansivities with one entry per composition and phase plus one
+           * for the background field.
            */
           std::vector<double> thermal_expansivities;
 
           /**
-           * Vector of specific heat capacities with one entry per composition.
+           * Vector of specific heat capacities with one entry per composition and phase plus one
+           * for the background field.
            */
           std::vector<double> specific_heats;
 

--- a/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
+++ b/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
@@ -59,7 +59,7 @@ namespace aspect
            * determines which entry of the vector of inputs is used.
            */
           void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                        const unsigned int q,
+                        const unsigned int input_index,
                         MaterialModel::EquationOfStateOutputs<dim> &out) const;
 
           /**
@@ -113,6 +113,8 @@ namespace aspect
            * Vector of specific heat capacities with one entry per composition.
            */
           std::vector<double> specific_heats;
+
+          std::shared_ptr<std::vector<unsigned int> > n_phases_per_composition;
       };
     }
   }

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -291,6 +291,18 @@ namespace aspect
         double pressure;
         double depth;
         double pressure_depth_derivative;
+
+        /**
+         * This parameter determines which phase function of all the stored
+         * functions to compute. Phase functions are numbered consecutively,
+         * starting at 0 and the interpretation of their output is up to the
+         * calling side. For example the first phase function could be used to
+         * indicate a viscosity jump in the first compositional field,
+         * while the second function indicates a density jump in all
+         * compositions. None of this is known to the PhaseFunction object,
+         * which only has information that there are two phase functions
+         * and what their properties are.
+         */
         unsigned int phase_index;
       };
 

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -290,8 +290,11 @@ namespace aspect
                             const unsigned int phase_index);
 
         /**
-         * Constructor that computes the necessary values from
-         * existing objects.
+         * Constructor that computes the internal values from
+         * objects that typically exist in a material model. This
+         * makes setting up the PhaseFunctionInputs more convenient,
+         * because some computations can be done inside the constructor,
+         * and do not have to be repeated in all material models.
          */
         PhaseFunctionInputs(const SimulatorAccess<dim> &simulator_access,
                             const MaterialModelInputs<dim> &material_in,
@@ -342,11 +345,10 @@ namespace aspect
           double get_transition_slope (const unsigned int phase_index) const;
 
           /**
-           * Return how many phase transitions there are for composition
-           * @p composition_index.
+           * Return how many phase transitions there are for each composition.
            */
-          unsigned int
-          n_phase_transitions_for_composition (const unsigned int composition_index) const;
+          const std::vector<unsigned int> &
+          n_phase_transitions_for_each_composition () const;
 
           /**
            * Declare the parameters this class takes through input files.

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -34,8 +34,6 @@ namespace aspect
 
   namespace MaterialModel
   {
-    template <int dim> class MaterialModelInputs;
-
     using namespace dealii;
 
     /**
@@ -288,19 +286,6 @@ namespace aspect
                             const double depth,
                             const double pressure_depth_derivative,
                             const unsigned int phase_index);
-
-        /**
-         * Constructor that computes the internal values from
-         * objects that typically exist in a material model. This
-         * makes setting up the PhaseFunctionInputs more convenient,
-         * because some computations can be done inside the constructor,
-         * and do not have to be repeated in all material models.
-         */
-        PhaseFunctionInputs(const SimulatorAccess<dim> &simulator_access,
-                            const MaterialModelInputs<dim> &material_in,
-                            const unsigned int input_index,
-                            const double reference_density,
-                            const unsigned int phase_index_);
 
         double temperature;
         double pressure;

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -34,6 +34,8 @@ namespace aspect
 
   namespace MaterialModel
   {
+    template <int dim> class MaterialModelInputs;
+
     using namespace dealii;
 
     /**
@@ -287,6 +289,16 @@ namespace aspect
                             const double pressure_depth_derivative,
                             const unsigned int phase_index);
 
+        /**
+         * Constructor that computes the necessary values from
+         * existing objects.
+         */
+        PhaseFunctionInputs(const SimulatorAccess<dim> &simulator_access,
+                            const MaterialModelInputs<dim> &material_in,
+                            const unsigned int input_index,
+                            const double reference_density,
+                            const unsigned int phase_index_);
+
         double temperature;
         double pressure;
         double depth;
@@ -328,6 +340,13 @@ namespace aspect
            * phase transition number @p phase_index.
            */
           double get_transition_slope (const unsigned int phase_index) const;
+
+          /**
+           * Return how many phase transitions there are for composition
+           * @p composition_index.
+           */
+          unsigned int
+          n_phase_transitions_for_composition (const unsigned int composition_index) const;
 
           /**
            * Declare the parameters this class takes through input files.

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -272,6 +272,11 @@ namespace aspect
          * Input parameters for the drucker prager plasticity.
          */
         Rheology::DruckerPragerParameters drucker_prager_parameters;
+
+        /**
+         * Object that handles phase transitions.
+         */
+        MaterialUtilities::PhaseFunction<dim> phase_function;
     };
 
   }

--- a/source/material_model/equation_of_state/interface.cc
+++ b/source/material_model/equation_of_state/interface.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/material_model/equation_of_state/interface.h>
+#include <aspect/simulator_access.h>
 
 
 namespace aspect
@@ -36,6 +37,44 @@ namespace aspect
       entropy_derivative_pressure(n_compositions, numbers::signaling_nan<double>()),
       entropy_derivative_temperature(n_compositions, numbers::signaling_nan<double>())
     {}
+
+    template <int dim>
+    void
+    compute_equation_of_state_phase_transitions(const EquationOfStateOutputs<dim> &eos_outputs_all_phases,
+                                                const MaterialUtilities::PhaseFunction<dim> &phase_function,
+                                                MaterialUtilities::PhaseFunctionInputs<dim> &phase_in,
+                                                EquationOfStateOutputs<dim> &eos_outputs)
+    {
+      unsigned int j=0;
+      for (unsigned int c=0; c<eos_outputs.densities.size(); ++c)
+        {
+          Assert(j<eos_outputs_all_phases.densities.size(),
+                 ExcInternalError());
+
+          eos_outputs.densities[c] = eos_outputs_all_phases.densities[j];
+          eos_outputs.thermal_expansion_coefficients[c] = eos_outputs_all_phases.thermal_expansion_coefficients[j];
+          eos_outputs.specific_heat_capacities[c] = eos_outputs_all_phases.specific_heat_capacities[j];
+          eos_outputs.compressibilities[c] = eos_outputs_all_phases.compressibilities[j];
+          eos_outputs.entropy_derivative_pressure[c] = eos_outputs_all_phases.entropy_derivative_pressure[j];
+          eos_outputs.entropy_derivative_temperature[c] = eos_outputs_all_phases.entropy_derivative_temperature[j];
+
+          const unsigned int base_index = j;
+          ++j;
+
+          for (unsigned int p=0; p<phase_function.n_phase_transitions_for_composition(c); ++p)
+            {
+              Assert(j<eos_outputs_all_phases.densities.size(),
+                     ExcInternalError());
+
+              phase_in.phase_index = j-c-1;
+              eos_outputs.densities[c] += phase_function.compute_value(phase_in) * (eos_outputs_all_phases.densities[j]-eos_outputs_all_phases.densities[base_index]);
+              eos_outputs.thermal_expansion_coefficients[c] += phase_function.compute_value(phase_in) * (eos_outputs_all_phases.thermal_expansion_coefficients[j]-eos_outputs_all_phases.thermal_expansion_coefficients[base_index]);
+              eos_outputs.specific_heat_capacities[c] += phase_function.compute_value(phase_in) * (eos_outputs_all_phases.specific_heat_capacities[j]-eos_outputs_all_phases.specific_heat_capacities[base_index]);
+
+              ++j;
+            }
+        }
+    }
   }
 }
 
@@ -45,7 +84,12 @@ namespace aspect
   namespace MaterialModel
   {
 #define INSTANTIATE(dim) \
-  template struct EquationOfStateOutputs<dim>;
+  template struct EquationOfStateOutputs<dim>; \
+  template void compute_equation_of_state_phase_transitions<dim> (const EquationOfStateOutputs<dim> &, \
+                                                                  const MaterialUtilities::PhaseFunction<dim> &, \
+                                                                  MaterialUtilities::PhaseFunctionInputs<dim> &, \
+                                                                  EquationOfStateOutputs<dim> &);
+
     ASPECT_INSTANTIATE(INSTANTIATE)
   }
 }

--- a/source/material_model/equation_of_state/interface.cc
+++ b/source/material_model/equation_of_state/interface.cc
@@ -38,6 +38,8 @@ namespace aspect
       entropy_derivative_temperature(n_individual_compositions_and_phases, numbers::signaling_nan<double>())
     {}
 
+
+
     template <int dim>
     void
     phase_average_equation_of_state_outputs(const EquationOfStateOutputs<dim> &eos_outputs_all_phases,

--- a/source/material_model/equation_of_state/interface.cc
+++ b/source/material_model/equation_of_state/interface.cc
@@ -70,7 +70,11 @@ namespace aspect
               Assert(j<eos_outputs_all_phases.densities.size(),
                      ExcInternalError());
 
-              phase_in.phase_index = j-c-1;
+              // Compute which phase index the current phase of the current composition has
+              // in the list of all phase functions. This is the number of times we visited
+              // this line j minus one per composition c (the original state of each composition
+              // does not have a phase function).
+              phase_in.phase_index = j-(c+1);
               const double gamma = phase_function.compute_value(phase_in);
 
               eos_outputs.densities[c] += gamma * (eos_outputs_all_phases.densities[j]-eos_outputs_all_phases.densities[j-1]);

--- a/source/material_model/equation_of_state/multicomponent_incompressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_incompressible.cc
@@ -33,12 +33,12 @@ namespace aspect
       void
       MulticomponentIncompressible<dim>::
       evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-               const unsigned int q,
+               const unsigned int input_index,
                MaterialModel::EquationOfStateOutputs<dim> &out) const
       {
         for (unsigned int c=0; c < out.densities.size(); ++c)
           {
-            out.densities[c] = densities[c] * (1 - thermal_expansivities[c] * (in.temperature[q] - reference_T));
+            out.densities[c] = densities[c] * (1 - thermal_expansivities[c] * (in.temperature[input_index] - reference_T));
             out.thermal_expansion_coefficients[c] = thermal_expansivities[c];
             out.specific_heat_capacities[c] = specific_heats[c];
             out.compressibilities[c] = 0.0;
@@ -99,21 +99,29 @@ namespace aspect
         // Retrieve the list of composition names
         const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
 
+        n_phases_per_composition.reset(new std::vector<unsigned int>());
+
         // Parse multicomponent properties
         densities = Utilities::parse_map_to_double_array (prm.get("Densities"),
                                                           list_of_composition_names,
                                                           has_background_field,
-                                                          "Densities");
+                                                          "Densities",
+                                                          true,
+                                                          n_phases_per_composition);
 
         thermal_expansivities = Utilities::parse_map_to_double_array (prm.get("Thermal expansivities"),
                                                                       list_of_composition_names,
                                                                       has_background_field,
-                                                                      "Thermal expansivities");
+                                                                      "Thermal expansivities",
+                                                                      true,
+                                                                      n_phases_per_composition);
 
         specific_heats = Utilities::parse_map_to_double_array (prm.get("Heat capacities"),
                                                                list_of_composition_names,
                                                                has_background_field,
-                                                               "Specific heats");
+                                                               "Specific heats",
+                                                               true,
+                                                               n_phases_per_composition);
       }
     }
   }

--- a/source/material_model/equation_of_state/multicomponent_incompressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_incompressible.cc
@@ -89,7 +89,8 @@ namespace aspect
 
       template <int dim>
       void
-      MulticomponentIncompressible<dim>::parse_parameters (ParameterHandler &prm)
+      MulticomponentIncompressible<dim>::parse_parameters (ParameterHandler &prm,
+                                                           const std::shared_ptr<std::vector<unsigned int>> expected_n_phases_per_composition)
       {
         reference_T = prm.get_double ("Reference temperature");
 
@@ -99,29 +100,27 @@ namespace aspect
         // Retrieve the list of composition names
         const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
 
-        n_phases_per_composition.reset(new std::vector<unsigned int>());
-
         // Parse multicomponent properties
         densities = Utilities::parse_map_to_double_array (prm.get("Densities"),
                                                           list_of_composition_names,
                                                           has_background_field,
                                                           "Densities",
                                                           true,
-                                                          n_phases_per_composition);
+                                                          expected_n_phases_per_composition);
 
         thermal_expansivities = Utilities::parse_map_to_double_array (prm.get("Thermal expansivities"),
                                                                       list_of_composition_names,
                                                                       has_background_field,
                                                                       "Thermal expansivities",
                                                                       true,
-                                                                      n_phases_per_composition);
+                                                                      expected_n_phases_per_composition);
 
         specific_heats = Utilities::parse_map_to_double_array (prm.get("Heat capacities"),
                                                                list_of_composition_names,
                                                                has_background_field,
                                                                "Specific heats",
                                                                true,
-                                                               n_phases_per_composition);
+                                                               expected_n_phases_per_composition);
       }
     }
   }

--- a/source/material_model/latent_heat.cc
+++ b/source/material_model/latent_heat.cc
@@ -105,19 +105,7 @@ namespace aspect
             // Loop through phase transitions
             for (unsigned int phase=0; phase<phase_function.n_phase_transitions(); ++phase)
               {
-                const double depth = this->get_geometry_model().depth(in.position[i]);
-                const double pressure_depth_derivative = (depth > 0)
-                                                         ?
-                                                         pressure / depth
-                                                         :
-                                                         this->get_gravity_model().gravity_vector(in.position[i]).norm() * reference_rho;
-
-                const MaterialUtilities::PhaseFunctionInputs<dim> phase_in(temperature,
-                                                                           pressure,
-                                                                           depth,
-                                                                           pressure_depth_derivative,
-                                                                           phase);
-
+                const MaterialUtilities::PhaseFunctionInputs<dim> phase_in(*this,in,i,reference_rho,phase);
                 const double phaseFunction = phase_function.compute_value(phase_in);
 
                 // Note that for the densities we have a list of jumps, so the index used

--- a/source/material_model/latent_heat.cc
+++ b/source/material_model/latent_heat.cc
@@ -105,7 +105,19 @@ namespace aspect
             // Loop through phase transitions
             for (unsigned int phase=0; phase<phase_function.n_phase_transitions(); ++phase)
               {
-                const MaterialUtilities::PhaseFunctionInputs<dim> phase_in(*this,in,i,reference_rho,phase);
+                const double depth = this->get_geometry_model().depth(position);
+                const double pressure_depth_derivative = (depth > 0.0)
+                                                         ?
+                                                         pressure / depth
+                                                         :
+                                                         this->get_gravity_model().gravity_vector(in.position[i]).norm() * reference_rho;
+
+                const MaterialUtilities::PhaseFunctionInputs<dim> phase_in(temperature,
+                                                                           pressure,
+                                                                           depth,
+                                                                           pressure_depth_derivative,
+                                                                           phase);
+
                 const double phaseFunction = phase_function.compute_value(phase_in);
 
                 // Note that for the densities we have a list of jumps, so the index used

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -717,27 +717,6 @@ namespace aspect
 
 
       template <int dim>
-      PhaseFunctionInputs<dim>::PhaseFunctionInputs(const SimulatorAccess<dim> &simulator_access,
-                                                    const MaterialModelInputs<dim> &in,
-                                                    const unsigned int input_index,
-                                                    const double reference_density,
-                                                    const unsigned int phase_index_)
-      {
-        temperature = in.temperature[input_index];
-        pressure = in.pressure[input_index];
-        depth = simulator_access.get_geometry_model().depth(in.position[input_index]);
-        pressure_depth_derivative = (depth > 0)
-                                    ?
-                                    in.pressure[input_index] / depth
-                                    :
-                                    simulator_access.get_gravity_model().gravity_vector(in.position[input_index]).norm() *
-                                    reference_density;
-        phase_index = phase_index_;
-      }
-
-
-
-      template <int dim>
       double
       PhaseFunction<dim>::compute_value (const PhaseFunctionInputs<dim> &in) const
       {

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -715,6 +715,28 @@ namespace aspect
       {}
 
 
+
+      template <int dim>
+      PhaseFunctionInputs<dim>::PhaseFunctionInputs(const SimulatorAccess<dim> &simulator_access,
+                                                    const MaterialModelInputs<dim> &in,
+                                                    const unsigned int input_index,
+                                                    const double reference_density,
+                                                    const unsigned int phase_index_)
+      {
+        temperature = in.temperature[input_index];
+        pressure = in.pressure[input_index];
+        depth = simulator_access.get_geometry_model().depth(in.position[input_index]);
+        pressure_depth_derivative = (depth > 0)
+                                    ?
+                                    in.pressure[input_index] / depth
+                                    :
+                                    simulator_access.get_gravity_model().gravity_vector(in.position[input_index]).norm() *
+                                    reference_density;
+        phase_index = phase_index_;
+      }
+
+
+
       template <int dim>
       double
       PhaseFunction<dim>::compute_value (const PhaseFunctionInputs<dim> &in) const
@@ -812,6 +834,14 @@ namespace aspect
           return transition_depths.size();
         else
           return transition_pressures.size();
+      }
+
+
+      template <int dim>
+      unsigned int
+      PhaseFunction<dim>::n_phase_transitions_for_composition (const unsigned int composition_index) const
+      {
+        return (*n_phase_transitions_per_composition)[composition_index];
       }
 
 

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -838,10 +838,10 @@ namespace aspect
 
 
       template <int dim>
-      unsigned int
-      PhaseFunction<dim>::n_phase_transitions_for_composition (const unsigned int composition_index) const
+      const std::vector<unsigned int> &
+      PhaseFunction<dim>::n_phase_transitions_for_each_composition () const
       {
-        return (*n_phase_transitions_per_composition)[composition_index];
+        return *n_phase_transitions_per_composition;
       }
 
 

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -24,6 +24,7 @@
 #include <deal.II/base/signaling_nan.h>
 #include <aspect/newton.h>
 #include <aspect/adiabatic_conditions/interface.h>
+#include <aspect/gravity_model/interface.h>
 
 namespace aspect
 {
@@ -394,13 +395,21 @@ namespace aspect
       const ComponentMask volumetric_compositions = get_volumetric_composition_mask();
 
       EquationOfStateOutputs<dim> eos_outputs (this->n_compositional_fields()+1);
+      EquationOfStateOutputs<dim> eos_outputs_all_phases (this->n_compositional_fields()+1+phase_function.n_phase_transitions());
 
       // Loop through all requested points
       for (unsigned int i=0; i < in.temperature.size(); ++i)
         {
-          equation_of_state.evaluate(in, i, eos_outputs);
-
           // First compute the equation of state variables and thermodynamic properties
+          equation_of_state.evaluate(in, i, eos_outputs_all_phases);
+
+          MaterialUtilities::PhaseFunctionInputs<dim> phase_inputs(this,in,i,eos_outputs_all_phases.densities[0],0);
+
+          compute_equation_of_state_phase_transitions(eos_outputs_all_phases,
+                                                      phase_function,
+                                                      phase_inputs,
+                                                      eos_outputs);
+
           const std::vector<double> volume_fractions = MaterialUtilities::compute_volume_fractions(in.composition[i], volumetric_compositions);
 
           // not strictly correct if thermal expansivities are different, since we are interpreting
@@ -505,6 +514,8 @@ namespace aspect
       {
         prm.enter_subsection ("Visco Plastic");
         {
+          MaterialUtilities::PhaseFunction<dim>::declare_parameters(prm);
+
           EquationOfState::MulticomponentIncompressible<dim>::declare_parameters (prm);
 
           Rheology::StrainDependent<dim>::declare_parameters (prm);
@@ -612,6 +623,10 @@ namespace aspect
       {
         prm.enter_subsection ("Visco Plastic");
         {
+          // Phase transition parameters
+          phase_function.initialize_simulator (this->get_simulator());
+          phase_function.parse_parameters (prm);
+
           // Equation of state parameters
           equation_of_state.initialize_simulator (this->get_simulator());
           equation_of_state.parse_parameters (prm);

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -403,7 +403,7 @@ namespace aspect
           // First compute the equation of state variables and thermodynamic properties
           equation_of_state.evaluate(in, i, eos_outputs_all_phases);
 
-          MaterialUtilities::PhaseFunctionInputs<dim> phase_inputs(this,in,i,eos_outputs_all_phases.densities[0],0);
+          MaterialUtilities::PhaseFunctionInputs<dim> phase_inputs(*this,in,i,eos_outputs_all_phases.densities[0],0);
 
           compute_equation_of_state_phase_transitions(eos_outputs_all_phases,
                                                       phase_function,

--- a/tests/visco_plastic_derivatives_2d.cc
+++ b/tests/visco_plastic_derivatives_2d.cc
@@ -54,6 +54,12 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   in_base.pressure[3] = 2e11;
   in_base.pressure[4] = 5e8;
 
+  in_base.position[0] = Point<dim>();
+  in_base.position[1] = Point<dim>();
+  in_base.position[2] = Point<dim>();
+  in_base.position[3] = Point<dim>();
+  in_base.position[4] = Point<dim>();
+
   /**
    * We can't take too small strain-rates, because then the difference in the
    * viscosity will be too small for the double accuracy which stores

--- a/tests/visco_plastic_derivatives_3d.cc
+++ b/tests/visco_plastic_derivatives_3d.cc
@@ -54,6 +54,12 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   in_base.pressure[3] = 2e11;
   in_base.pressure[4] = 5e8;
 
+  in_base.position[0] = Point<dim>();
+  in_base.position[1] = Point<dim>();
+  in_base.position[2] = Point<dim>();
+  in_base.position[3] = Point<dim>();
+  in_base.position[4] = Point<dim>();
+
   /**
    * We can't take too small strain-rates, because then the difference in the
    * viscosity will be too small for the double accuracy which stores

--- a/tests/visco_plastic_phases.prm
+++ b/tests/visco_plastic_phases.prm
@@ -1,0 +1,113 @@
+# Copy of visco_plastic.prm, but include a phase transition for the EoS
+
+set Dimension                              = 2
+set Start time                             = 0
+set End time                               = 0
+set Use years in output instead of seconds = true
+set Nonlinear solver scheme                = single Advection, iterated Stokes
+set Max nonlinear iterations               = 1
+set Output directory                       = visco_plastic
+set Timing output frequency                = 1
+
+# Model geometry (100x100 km, 10 km spacing)
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X repetitions = 10
+    set Y repetitions = 10
+    set X extent      = 100e3
+    set Y extent      = 100e3
+  end
+end
+
+# Mesh refinement specifications 
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 0
+  set Time steps between mesh refinement = 0
+end
+
+
+# Boundary classifications (fixed T boundaries, prescribed velocity) 
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = bottom, top, left, right
+end
+
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = bottom y: function, top y: function, left x: function, right x: function
+end
+
+# Velocity on boundaries characterized by functions
+subsection Boundary velocity model
+  subsection Function
+    set Variable names      = x,y
+    set Function constants  = m=0.0005, year=1
+    set Function expression = if (x<50e3 , -1*m/year, 1*m/year); if (y<50e3 , 1*m/year, -1*m/year);
+  end
+end
+
+# Temperature boundary and initial conditions
+subsection Boundary temperature model
+  set List of model names = box
+  subsection Box
+    set Bottom temperature = 273
+    set Left temperature   = 273
+    set Right temperature  = 273
+    set Top temperature    = 273
+  end
+end
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 273
+  end
+end
+
+# Material model (values for background material)
+subsection Material model
+  set Model name = visco plastic
+  subsection Visco Plastic
+    set Phase transition depths = 50e3
+    set Phase transition widths = 1e3
+    set Phase transition temperatures = 273
+    set Phase transition Clapeyron slopes = 0
+
+    set Densities = background:3300|3400
+    set Thermal expansivities = background:3.5e-5|2e-5
+    set Heat capacities = background:1200|1000
+
+    set Reference strain rate = 1.e-16
+    set Viscous flow law = dislocation
+    set Prefactors for dislocation creep = 5.e-23
+    set Stress exponents for dislocation creep = 1.0
+    set Activation energies for dislocation creep = 0.
+    set Activation volumes for dislocation creep = 0.
+  end
+end
+
+# Gravity model
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+end
+
+# Post processing
+subsection Postprocess
+  set List of postprocessors = velocity statistics, mass flux statistics, visualization, material statistics
+
+  subsection Visualization
+    set List of output variables = material properties
+  end
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Number of cheap Stokes solver steps = 0
+  end
+end

--- a/tests/visco_plastic_phases/screen-output
+++ b/tests/visco_plastic_phases/screen-output
@@ -1,0 +1,30 @@
+
+Number of active cells: 100 (on 1 levels)
+Number of degrees of freedom: 1,444 (882+121+441)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+2 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
+
+   Postprocessing:
+     RMS, max velocity:                                 0.000408 m/year, 0.000691 m/year
+     Mass fluxes through boundary parts:                1.676e+05 kg/yr, 1.676e+05 kg/yr, -1.701e+05 kg/yr, -1.651e+05 kg/yr
+     Writing graphical output:                          output-visco_plastic_phases/solution/solution-00000
+     Average density / Average viscosity / Total mass:  3352 kg/m^3, 1e+22 Pa s, 3.352e+13 kg
+
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/visco_plastic_phases_compositions.prm
+++ b/tests/visco_plastic_phases_compositions.prm
@@ -1,10 +1,12 @@
-# Copy of visco_plastic.prm, but include a phase transition for the EoS
+# Copy of visco_plastic_phases.prm, but include multiple
+# compositions and have different numbers of phase transitions
+# for different compositions (including 0).
 
 set Dimension                              = 2
 set Start time                             = 0
 set End time                               = 0
 set Use years in output instead of seconds = true
-set Nonlinear solver scheme                = single Advection, iterated Stokes
+set Nonlinear solver scheme                = no Advection, no Stokes
 set Max nonlinear iterations               = 1
 set Output directory                       = visco_plastic
 set Timing output frequency                = 1
@@ -23,7 +25,7 @@ end
 # Mesh refinement specifications 
 subsection Mesh refinement
   set Initial adaptive refinement        = 0
-  set Initial global refinement          = 0
+  set Initial global refinement          = 2
   set Time steps between mesh refinement = 0
 end
 
@@ -55,18 +57,32 @@ subsection Initial temperature model
   end
 end
 
-# Material model (values for background material)
+subsection Compositional fields
+  set Number of fields = 2
+  # background is assumed to be lithosphere
+  set Names of fields  = upper_crust, lower_crust
+end
+
+subsection Initial composition model
+  set Model name = function
+
+  subsection Function
+    set Function expression = (y > 80000) ? 1.0 : 0.0; \
+                              (y > 50000) ? ((y <= 80000) ? 1.0 : 0.0) : 0.0
+  end
+end
+
 subsection Material model
   set Model name = visco plastic
   subsection Visco Plastic
-    set Phase transition depths = 50e3
-    set Phase transition widths = 1e3
-    set Phase transition temperatures = 273
-    set Phase transition Clapeyron slopes = 0
+    set Phase transition depths = upper_crust: 10e3, background: 70e3|90e3
+    set Phase transition widths = upper_crust: 1e3,background: 1e3|1e3
+    set Phase transition temperatures = upper_crust: 1000, background: 1000|1000
+    set Phase transition Clapeyron slopes = upper_crust: 0, background: 0|0 
 
-    set Densities = background:3300|3400
-    set Thermal expansivities = background:3.5e-5|2e-5
-    set Heat capacities = background:1200|1000
+    set Densities = upper_crust: 2700|2750, lower_crust: 2850, background:3300|3400|3500
+    set Thermal expansivities = upper_crust: 1e-5|1.5e-5, lower_crust: 7e-5, background:3.5e-5|2e-5|1e-5
+    set Heat capacities = upper_crust: 900|800, lower_crust: 600, background:1200|1000|700
 
     set Reference strain rate = 1.e-16
     set Viscous flow law = dislocation

--- a/tests/visco_plastic_phases_compositions/screen-output
+++ b/tests/visco_plastic_phases_compositions/screen-output
@@ -1,0 +1,25 @@
+
+Number of active cells: 1,600 (on 3 levels)
+Number of degrees of freedom: 34,486 (13,122+1,681+6,561+6,561+6,561)
+
+*** Timestep 0:  t=0 years
+
+   Postprocessing:
+     RMS, max velocity:                                 0 m/year, 0 m/year
+     Mass fluxes through boundary parts:                0 kg/yr, 0 kg/yr, 0 kg/yr, 0 kg/yr
+     Writing graphical output:                          output-visco_plastic_phases_compositions/solution/solution-00000
+     Average density / Average viscosity / Total mass:  3095 kg/m^3, 1e+22 Pa s, 3.095e+13 kg
+
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+


### PR DESCRIPTION
This PR builds on #3271 and #3267 and shows how the implemented improvements can be used. In this example it implements simple phase transitions for the equation of state that is used by the visco_plastic material model. This PR in itself is useful, but it is mostly meant as a starting point for @naliboff and @mibillen to start implementing this functionality for the rheology modules they want to use with phase transitions.