### PR TITLE
Reverse order natural coordinates

### DIFF
--- a/doc/modules/changes/20191030_glerum
+++ b/doc/modules/changes/20191030_glerum
@@ -1,0 +1,4 @@
+Fixed: The ellipsoidal natural coordinate conversion functions now use/output
+radius, lon, lat coordinates instead of radius, lat, lon.
+<br>
+(Anne Glerum, 2019/10/30)

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -775,8 +775,8 @@ namespace aspect
       const double radius = get_radius(position_point);
       std::array<double,dim> position_array;
       position_array[0] = radius + transformed_point(2);
-      position_array[1] = transformed_point(1);
-      position_array[2] = transformed_point(0);
+      position_array[1] = transformed_point(0);
+      position_array[2] = transformed_point(1);
 
       return position_array;
     }
@@ -797,10 +797,10 @@ namespace aspect
       // We receive radius, longitude, latitude and we need to turn it first back into
       // longitude, latitude, depth for internal use, and push_forward to cartesian coordiantes.
       Point<3> position_point;
-      position_point(0) = position_tensor[2];
-      position_point(1) = position_tensor[1];
+      position_point(0) = position_tensor[1];
+      position_point(1) = position_tensor[2];
 
-      const double radius = semi_major_axis_a / (std::sqrt(1 - eccentricity * eccentricity * std::sin(position_point(1)) * std::sin(position_point(1))));
+      const double radius = semi_major_axis_a / (std::sqrt(1 - eccentricity * eccentricity * std::sin(position_point(0)) * std::sin(position_point(0))));
       position_point(2) = position_tensor[0] - radius;
 
       Point<3> transformed_point = manifold.push_forward(position_point);

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -800,7 +800,7 @@ namespace aspect
       position_point(0) = position_tensor[1];
       position_point(1) = position_tensor[2];
 
-      const double radius = semi_major_axis_a / (std::sqrt(1 - eccentricity * eccentricity * std::sin(position_point(0)) * std::sin(position_point(0))));
+      const double radius = semi_major_axis_a / (std::sqrt(1 - eccentricity * eccentricity * std::sin(position_point(1)) * std::sin(position_point(1))));
       position_point(2) = position_tensor[0] - radius;
 
       Point<3> transformed_point = manifold.push_forward(position_point);

--- a/tests/natural_coordinates_conversion/screen-output
+++ b/tests/natural_coordinates_conversion/screen-output
@@ -12,4 +12,4 @@ Chunk 2D ok:                 point = 25000 50000, inter point = 55901.7, 1.10715
 Box 3D ok:                   point = 25000 25000 50000, inter point = 25000, 25000, 50000, new_point = 25000 25000 50000
 Two merged boxes 3d ok:      point = 25000 25000 50000, inter point = 25000, 25000, 50000, new_point = 25000 25000 50000
 Chunk 3D ok:                 point = 25000 25000 50000, inter point = 61237.2, 0.785398, new_point = 25000 25000 50000
-Ellipsoidal 3d chunk failed: point = 25000 25000 50000, inter point = 101768, 1.21599, 0.785398, new_point = 25000 25000 55272.2
+Ellipsoidal 3d chunk failed: point = 25000 25000 50000, inter point = 101768, 0.785398, 1.21599, new_point = 25000 25000 55272.2


### PR DESCRIPTION
While updating my models, I realized that the order of the coordinates that are read in for `AsciiData` with an `EllipsoidalChunk` has changed; the `cartesian_to_natural_coordinates` function outputs radius, lat, lon. Looking into the geometry model, the comments (radius, lon, lat) do not seem to match the order of the coordinates used in the `cartesian_to_natural_coordinates` and `natural_to_cartesian_coordinates` functions (radius, lat, lon). 

As I think the order should be as written in the comments (radius, lon, lat), I've reordered the coordinates. However, the failure of the `natural_coordinates_conversion` test is now even worse, so @MFraters, do you think these changes are correct? Note that for an eccentricity of zero, the functions recover the original coordinates. 

@bobmyhill pinging you as well as we introduced the natural coordinates during the hack.

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have updated the test results.
* [x] I have added a changelog entry in the [doc/modules/changes](../doc/modules/changes) directory that will inform other users of my change.
