### PR TITLE
Reduce memory consumption of unity build on tester

### DIFF
--- a/Jenkinsfile.cig
+++ b/Jenkinsfile.cig
@@ -76,6 +76,7 @@ pipeline {
         cmake \
         -D ASPECT_USE_PETSC='OFF' \
         -D ASPECT_PRECOMPILE_HEADERS='ON' \
+        -D COTIRE_MAXIMUM_NUMBER_OF_UNITY_INCLUDES='100' \
         ..
         '''
 


### PR DESCRIPTION
This should fix spurious tester failures with the unity build as observed in #3281. The problem arises, because compiling call files of ASPECT in a single file now requires > 7GB of RAM, and some of the tester machines only have 8 GB total (which also needs to hold the OS, Jenkins, etc). Whenever the tester needs to use swap space for frequently accessed data it does not finish in the wall time we set for the tester and so fails. This change splits the unity build into chunks of 100 files each (currently 3 chunks, for the 293 files it reports). This brings down maximum memory consumption from 7 GB to 4.6 GB on my system, and only increases the compile time slightly (from 2 minutes to 2:30 minutes).
The only drawback is that now a unity build with only a single chunk could fail, and we would not notice.