### PR TITLE
Remove duplicated headers

### DIFF
--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -26,16 +26,6 @@
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 
-#ifdef ASPECT_USE_PETSC
-#  include <deal.II/lac/petsc_parallel_block_vector.h>
-#  include <deal.II/lac/petsc_parallel_block_sparse_matrix.h>
-#  include <deal.II/lac/petsc_precondition.h>
-#else
-#  include <deal.II/lac/trilinos_parallel_block_vector.h>
-#  include <deal.II/lac/trilinos_block_sparse_matrix.h>
-#  include <deal.II/lac/trilinos_precondition.h>
-#endif
-
 #include <deal.II/lac/generic_linear_algebra.h>
 
 #include <boost/archive/binary_oarchive.hpp>


### PR DESCRIPTION
These includes are already part of ` #include <deal.II/lac/generic_linear_algebra.h>` (in the line below) so no need to repeat them. I have checked that this works for deal.II 9.0 and current master. They are likely a remnant from an earlier version.