### PR TITLE
Add missing benchmark to check script

### DIFF
--- a/benchmarks/check.sh
+++ b/benchmarks/check.sh
@@ -155,6 +155,8 @@ wait # newton_solver_benchmark_set/nonlinear_channel_flow depends on nonlinear_c
 
 ( (cd viscoelastic_stress_build-up && run_all_prms ) || { echo "FAILED"; exit 1; } ) &
 
+( (cd viscoelastic_plastic_shear_bands && run_all_prms ) || { echo "FAILED"; exit 1; } ) &
+
 ( (cd zhong_et_al_93 && run_all_prms ) || { echo "FAILED"; exit 1; } ) &
 
 ( (cd compressibility_benchmarks/plugins && make_lib && cd .. && bash run.sh ) || { echo "FAILED"; exit 1; } ) &


### PR DESCRIPTION
I noticed this while reviewing #3292. This benchmark was not in the check script and somehow we forgot to update its parameter file. This should fix it. Edit: ~~The tests will fail until #3292 is merged.~~ 