### PR TITLE
Move ownership and responiblity of particle world to simulator

### DIFF
--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -44,10 +44,26 @@
 
 namespace aspect
 {
+  template<int dim>
+  class SimulatorSignals;
+
   namespace Particle
   {
     using namespace dealii;
     using namespace dealii::Particles;
+
+    namespace Generator
+    {
+      template <int dim>
+      class Interface;
+    }
+
+
+    namespace Property
+    {
+      template <int dim>
+      class Manager;
+    }
 
     /**
      * This class manages the storage and handling of particles. It provides

--- a/include/aspect/postprocess/particles.h
+++ b/include/aspect/postprocess/particles.h
@@ -22,7 +22,6 @@
 #define _aspect_postprocess_particle_h
 
 #include <aspect/postprocess/interface.h>
-#include <aspect/particle/world.h>
 
 #include <aspect/simulator_access.h>
 
@@ -138,40 +137,6 @@ namespace aspect
         ~Particles() override;
 
         /**
-         * Generate the particles. This can not be done in another
-         * place, because we want to generate the particles
-         * before the first timestep, but after the initial conditions have
-         * been set.
-         */
-        void
-        generate_particles();
-
-        /**
-         * Initialize particle properties. This can not be done in another
-         * place, because we want to initialize the particle properties
-         * before the first timestep, but after the initial conditions have
-         * been set.
-         */
-        void
-        initialize_particles();
-
-        /**
-         * Returns a const reference to the particle world, in case anyone
-         * wants to query something about particles.
-         */
-        const Particle::World<dim> &
-        get_particle_world() const;
-
-        /**
-         * Returns a reference to the particle world, in case anyone wants to
-         * change something within the particle world. Use with care, usually
-         * you want to only let the functions within the particle subsystem
-         * change member variables of the particle world.
-         */
-        Particle::World<dim> &
-        get_particle_world();
-
-        /**
          * Execute this postprocessor. Derived classes will implement this
          * function to do whatever they want to do to evaluate the solution at
          * the current time step.
@@ -221,11 +186,6 @@ namespace aspect
         parse_parameters (ParameterHandler &prm) override;
 
       private:
-        /**
-         * The world holding the particles
-         */
-        Particle::World<dim> world;
-
         /**
          * Interval between output (in years if appropriate simulation
          * parameter is set, otherwise seconds)

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -67,6 +67,7 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #include <aspect/termination_criteria/interface.h>
 #include <aspect/postprocess/interface.h>
 #include <aspect/adiabatic_conditions/interface.h>
+#include <aspect/particle/world.h>
 
 #include <boost/iostreams/tee.hpp>
 #include <boost/iostreams/stream.hpp>
@@ -1735,6 +1736,11 @@ namespace aspect
       BoundaryVelocity::Manager<dim>                                          boundary_velocity_manager;
       std::map<types::boundary_id,std::unique_ptr<BoundaryTraction::Interface<dim> > > boundary_traction;
       const std::unique_ptr<BoundaryHeatFlux::Interface<dim> >                boundary_heat_flux;
+
+      /**
+       * The world holding the particles
+       */
+      std::unique_ptr<Particle::World<dim> > particle_world;
 
       /**
        * @}

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -25,6 +25,7 @@
 #include <aspect/global.h>
 #include <aspect/parameters.h>
 #include <aspect/introspection.h>
+#include <aspect/particle/world.h>
 
 #include <deal.II/base/table_handler.h>
 #include <deal.II/base/timer.h>
@@ -150,6 +151,12 @@ namespace aspect
   }
 
   template <int dim> class NewtonHandler;
+
+
+  namespace Particle
+  {
+    template <int dim> class World;
+  }
 
   /**
    * SimulatorAccess is a base class for different plugins like postprocessors.
@@ -889,6 +896,22 @@ namespace aspect
        */
       const Postprocess::Manager<dim> &
       get_postprocess_manager () const;
+
+      /**
+       * Returns a const reference to the particle world, in case anyone
+       * wants to query something about particles.
+       */
+      const Particle::World<dim> &
+      get_particle_world() const;
+
+      /**
+       * Returns a reference to the particle world, in case anyone wants to
+       * change something within the particle world. Use with care, usually
+       * you want to only let the functions within the particle subsystem
+       * change member variables of the particle world.
+       */
+      Particle::World<dim> &
+      get_particle_world();
 
       /** @} */
 

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -720,6 +720,25 @@ namespace aspect
   {
     return simulator->postprocess_manager;
   }
+
+
+  template <int dim>
+  const Particle::World<dim> &
+  SimulatorAccess<dim>::get_particle_world() const
+  {
+    Assert (simulator->particle_world.get() != nullptr,
+            ExcMessage("You can not call this function if there is no particle world."));
+    return *simulator->particle_world.get();
+  }
+
+  template <int dim>
+  Particle::World<dim> &
+  SimulatorAccess<dim>::get_particle_world()
+  {
+    Assert (simulator->particle_world.get() != nullptr,
+            ExcMessage("You can not call this function if there is no particle world."));
+    return *simulator->particle_world.get();
+  }
 }
 
 


### PR DESCRIPTION
Currently the particle world is owned by the particle post-processor. This may have made sense in the beginning, but since particles can be active now it seems to make more sense to me for them to be part of the simulator. Furthermore, I am developing a plugin which needs access to up to date particle information. Currently this is only the case if the user provides that post processor after the particle post processor because the particle post-processor also moves and updates the particles.

Although further reorganization might we wanted in the future, this pull request is limited to just letting the simulator own the particle world and update the particles, so that the order given by the user of the post-processors do not matter any more.

I am still looking at a bug (there seems to be a subscriptor which is not deleted at the end of the simulation) and some of the code can probably be improved, but I thought it might be good to make this pull request now so that changes can be discussed early on.

And thanks @gassmoeller for the help and advice already giving :)

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
