### PR TITLE
Add spack installation file

### DIFF
--- a/contrib/spack/spack.yaml
+++ b/contrib/spack/spack.yaml
@@ -1,0 +1,12 @@
+# This file can be used to install either ASPECT, or only its dependencies
+# using the 'spack' package manager. Usage: `spack install` in this directory
+# will install the development version of ASPECT with minimal dependencies.
+# `spack install --only dependencies` will only install ASPECT's dependencies,
+# after which ASPECT can be compiled from this folder as usual.
+
+spack:
+  specs:
+  - aspect@develop
+    ^dealii@9.1.1~ginkgo~symengine~petsc~slepc~adol-c+optflags~gmsh+metis~netcdf~oce~arpack~scalapack~assimp~sundials
+    ^trilinos~suite-sparse~hypre
+    ^suite-sparse@5.2.0


### PR DESCRIPTION
This adds a 'spack' configuration file into `contrib/`, which allows for an easy installation on systems that already contain spack. `spack install` executed in that folder will install ASPECT and all its dependencies, `spack install --only dependencies` will install only dependencies (dealii and the necessary packages). The benefit of this file over doing `spack install aspect` is that I can explicitly disable a lot of options in our dependencies, which greatly reduces the time for compiling, and the likelihood of compiler problems (e.g. version 5.3.0 of suite-sparse does not seem to work with the other packages so I had to manually specify a version). For now I would keep this hidden, but perspectively, I think spack is the more sustainable installation option compared to candi (but that is a discussion for a different day).