### PR TITLE
Make some runtime checks AssertThrow

### DIFF
--- a/source/gravity_model/radial.cc
+++ b/source/gravity_model/radial.cc
@@ -79,12 +79,12 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      Assert (Plugins::plugin_type_matches<const GeometryModel::Box<dim> >(this->get_geometry_model()) == false,
-              ExcMessage ("Gravity model 'radial constant' should not be used with geometry model 'box'."));
+      AssertThrow (Plugins::plugin_type_matches<const GeometryModel::Box<dim> >(this->get_geometry_model()) == false,
+                   ExcMessage ("Gravity model 'radial constant' should not be used with geometry model 'box'."));
 
-      Assert (Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim> >(this->get_geometry_model()) == false,
-              ExcMessage ("Gravity model 'radial constant' should not be used with geometry model 'box with "
-                          "lithosphere boundary indicators'."));
+      AssertThrow (Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim> >(this->get_geometry_model()) == false,
+                   ExcMessage ("Gravity model 'radial constant' should not be used with geometry model 'box with "
+                               "lithosphere boundary indicators'."));
     }
 
 // ------------------------------ RadialEarthLike -------------------
@@ -175,11 +175,11 @@ namespace aspect
         prm.leave_subsection ();
       }
       prm.leave_subsection ();
-      Assert (dynamic_cast<const GeometryModel::Box<dim>*> (&this->get_geometry_model()) == nullptr,
-              ExcMessage ("Gravity model 'radial linear' should not be used with geometry model 'box'."));
-      Assert (dynamic_cast<const GeometryModel::TwoMergedBoxes<dim>*> (&this->get_geometry_model()) == nullptr,
-              ExcMessage ("Gravity model 'radial linear' should not be used with geometry model 'box with "
-                          "lithosphere boundary indicators'."));
+      AssertThrow (dynamic_cast<const GeometryModel::Box<dim>*> (&this->get_geometry_model()) == nullptr,
+                   ExcMessage ("Gravity model 'radial linear' should not be used with geometry model 'box'."));
+      AssertThrow (dynamic_cast<const GeometryModel::TwoMergedBoxes<dim>*> (&this->get_geometry_model()) == nullptr,
+                   ExcMessage ("Gravity model 'radial linear' should not be used with geometry model 'box with "
+                               "lithosphere boundary indicators'."));
 
     }
   }

--- a/source/gravity_model/vertical.cc
+++ b/source/gravity_model/vertical.cc
@@ -74,14 +74,14 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      Assert (dynamic_cast<const GeometryModel::Sphere<dim>*> (&this->get_geometry_model()) == nullptr,
-              ExcMessage ("Gravity model 'vertical' should not be used with geometry model 'sphere'."));
-      Assert (dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()) == nullptr,
-              ExcMessage ("Gravity model 'vertical' should not be used with geometry model 'spherical shell'."));
-      Assert (dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model()) == nullptr,
-              ExcMessage ("Gravity model 'vertical' should not be used with geometry model 'chunk'."));
-      Assert (dynamic_cast<const GeometryModel::EllipsoidalChunk<dim>*> (&this->get_geometry_model()) == nullptr,
-              ExcMessage ("Gravity model 'vertical' should not be used with geometry model 'ellipsoidal chunk'."));
+      AssertThrow (dynamic_cast<const GeometryModel::Sphere<dim>*> (&this->get_geometry_model()) == nullptr,
+                   ExcMessage ("Gravity model 'vertical' should not be used with geometry model 'sphere'."));
+      AssertThrow (dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()) == nullptr,
+                   ExcMessage ("Gravity model 'vertical' should not be used with geometry model 'spherical shell'."));
+      AssertThrow (dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model()) == nullptr,
+                   ExcMessage ("Gravity model 'vertical' should not be used with geometry model 'chunk'."));
+      AssertThrow (dynamic_cast<const GeometryModel::EllipsoidalChunk<dim>*> (&this->get_geometry_model()) == nullptr,
+                   ExcMessage ("Gravity model 'vertical' should not be used with geometry model 'ellipsoidal chunk'."));
     }
   }
 }


### PR DESCRIPTION
We usually use AssertThrow for checks depending on runtime parameters, because they can be triggered by changing a parameter file. These asserts were likely older than the convention.