### PR TITLE
Replace dynamic_casts by proper function calls

### DIFF
--- a/source/boundary_composition/box.cc
+++ b/source/boundary_composition/box.cc
@@ -39,12 +39,6 @@ namespace aspect
                           const Point<dim> &/*position*/,
                           const unsigned int compositional_field) const
     {
-      // verify that the geometry is a box since only for this geometry
-      // do we know for sure what boundary indicators it uses and what they mean
-      Assert (Plugins::plugin_type_matches<const GeometryModel::Box<dim>>(this->get_geometry_model()),
-              ExcMessage ("This boundary model is only implemented if the geometry is "
-                          "a box."));
-
       Assert (boundary_indicator<2*dim, ExcMessage ("The given boundary indicator needs to be less than 2*dimension.."));
       return composition_values[boundary_indicator][compositional_field];
     }
@@ -140,6 +134,12 @@ namespace aspect
     void
     Box<dim>::initialize()
     {
+      // verify that the geometry is a box since only for this geometry
+      // do we know for sure what boundary indicators it uses and what they mean
+      AssertThrow (Plugins::plugin_type_matches<const GeometryModel::Box<dim>>(this->get_geometry_model()),
+                   ExcMessage ("This boundary model is only implemented if the geometry is "
+                               "a box."));
+
       // Verify that each of the lists for boundary values
       // has the requisite number of elements if it is in the set
       // of prescribed boundary indicators.

--- a/source/boundary_composition/box.cc
+++ b/source/boundary_composition/box.cc
@@ -41,8 +41,7 @@ namespace aspect
     {
       // verify that the geometry is a box since only for this geometry
       // do we know for sure what boundary indicators it uses and what they mean
-      Assert (dynamic_cast<const GeometryModel::Box<dim>*>(&this->get_geometry_model())
-              != nullptr,
+      Assert (Plugins::plugin_type_matches<const GeometryModel::Box<dim>>(this->get_geometry_model()),
               ExcMessage ("This boundary model is only implemented if the geometry is "
                           "a box."));
 

--- a/source/boundary_composition/spherical_constant.cc
+++ b/source/boundary_composition/spherical_constant.cc
@@ -64,8 +64,7 @@ namespace aspect
     SphericalConstant<dim>::
     minimal_composition (const std::set<types::boundary_id> &) const
     {
-      const GeometryModel::Interface<dim> *geometry_model = &this->get_geometry_model();
-      if (dynamic_cast<const GeometryModel::Sphere<dim>*>(geometry_model) != nullptr)
+      if (Plugins::plugin_type_matches<const GeometryModel::Sphere<dim>>(this->get_geometry_model()))
         return outer_composition;
       else
         return std::min (inner_composition, outer_composition);
@@ -78,8 +77,7 @@ namespace aspect
     SphericalConstant<dim>::
     maximal_composition (const std::set<types::boundary_id> &) const
     {
-      const GeometryModel::Interface<dim> *geometry_model = &this->get_geometry_model();
-      if (dynamic_cast<const GeometryModel::Sphere<dim>*>(geometry_model) != nullptr)
+      if (Plugins::plugin_type_matches<const GeometryModel::Sphere<dim>>(this->get_geometry_model()))
         return outer_composition;
       else
         return std::max (inner_composition, outer_composition);

--- a/source/boundary_composition/two_merged_boxes.cc
+++ b/source/boundary_composition/two_merged_boxes.cc
@@ -38,13 +38,6 @@ namespace aspect
                           const Point<dim> &/*position*/,
                           const unsigned int compositional_field) const
     {
-      // verify that the geometry is a box since only for this geometry
-      // do we know for sure what boundary indicators it uses and what they mean
-      Assert (dynamic_cast<const GeometryModel::TwoMergedBoxes<dim>*>(&this->get_geometry_model())
-              != nullptr,
-              ExcMessage ("This boundary model is only useful if the geometry is "
-                          "a box with additional lithosphere boundary indicators."));
-
       Assert (boundary_indicator<2*dim+2*(dim-1), ExcMessage ("The given boundary indicator needs to be less than 2*dimension+2*(dim-1)."));
 
       return composition_values[boundary_indicator][compositional_field];
@@ -167,6 +160,12 @@ namespace aspect
     void
     TwoMergedBoxes<dim>::initialize()
     {
+      // verify that the geometry is a box since only for this geometry
+      // do we know for sure what boundary indicators it uses and what they mean
+      AssertThrow (Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim>>(this->get_geometry_model()),
+                   ExcMessage ("This boundary model is only useful if the geometry is "
+                               "a box with additional lithosphere boundary indicators."));
+
       // verify that each of the lists for boundary values
       // has the requisite number of elements
       for (unsigned int f=0; f<2*dim+2*(dim-1); ++f)

--- a/source/boundary_temperature/box.cc
+++ b/source/boundary_temperature/box.cc
@@ -38,13 +38,6 @@ namespace aspect
     boundary_temperature (const types::boundary_id boundary_indicator,
                           const Point<dim> &/*position*/) const
     {
-      // verify that the geometry is a box since only for this geometry
-      // do we know for sure what boundary indicators it uses and what they mean
-      Assert (dynamic_cast<const GeometryModel::Box<dim>*>(&this->get_geometry_model())
-              != nullptr,
-              ExcMessage ("This boundary model is only implemented if the geometry is "
-                          "a box."));
-
       Assert (boundary_indicator<2*dim, ExcMessage ("Given boundary indicator needs to be less than 2*dimension."));
       return temperature_[boundary_indicator];
     }
@@ -149,6 +142,13 @@ namespace aspect
               default:
                 Assert (false, ExcNotImplemented());
             }
+
+          // verify that the geometry is a box since only for this geometry
+          // do we know for sure what boundary indicators it uses and what they mean
+          AssertThrow (Plugins::plugin_type_matches<const GeometryModel::Box<dim>>(this->get_geometry_model()),
+                       ExcMessage ("This boundary model is only implemented if the geometry is "
+                                   "a box."));
+
         }
         prm.leave_subsection ();
       }

--- a/source/boundary_temperature/two_merged_boxes.cc
+++ b/source/boundary_temperature/two_merged_boxes.cc
@@ -37,12 +37,6 @@ namespace aspect
     boundary_temperature (const types::boundary_id boundary_indicator,
                           const Point<dim> &) const
     {
-      // verify that the geometry is a box since only for this geometry
-      // do we know for sure what boundary indicators it uses and what they mean
-      Assert (dynamic_cast<const GeometryModel::TwoMergedBoxes<dim>*>(&this->get_geometry_model()) != nullptr,
-              ExcMessage ("This boundary model is only useful if the geometry is "
-                          "a box with additional boundary indicators."));
-
       Assert (boundary_indicator<2*dim+2*(dim-1), ExcMessage ("Given boundary indicator needs to be less than 2*dimension+2*(dimension-1)."));
 
       return temperature_values[boundary_indicator];
@@ -145,6 +139,12 @@ namespace aspect
       {
         prm.enter_subsection("Box with lithosphere boundary indicators");
         {
+          // verify that the geometry is a box since only for this geometry
+          // do we know for sure what boundary indicators it uses and what they mean
+          AssertThrow (Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim>>(this->get_geometry_model()),
+                       ExcMessage ("This boundary model is only useful if the geometry is "
+                                   "a box with additional boundary indicators."));
+
           switch (dim)
             {
               case 2:


### PR DESCRIPTION
This is a follow-up to #3173 that replaces some more dynamic casts by the functions in the `Plugins` namespace. I also moved some geometry model checks into more appropriate functions (only check once per model run instead of every call).