### PR TITLE
Replace some more dynamic_casts

### DIFF
--- a/include/aspect/boundary_velocity/gplates.h
+++ b/include/aspect/boundary_velocity/gplates.h
@@ -24,7 +24,6 @@
 
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/simulator_access.h>
-#include <aspect/compat.h>
 
 #include <array>
 #include <deal.II/base/function_lib.h>

--- a/include/aspect/gravity_model/vertical.h
+++ b/include/aspect/gravity_model/vertical.h
@@ -23,6 +23,7 @@
 #define _aspect_gravity_model_vertical_h
 
 #include <aspect/gravity_model/interface.h>
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {

--- a/source/boundary_velocity/ascii_data.cc
+++ b/source/boundary_velocity/ascii_data.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/global.h>
-#include <aspect/geometry_model/box.h>
 #include <aspect/boundary_velocity/ascii_data.h>
 
 #include <deal.II/base/parameter_handler.h>
@@ -123,7 +122,7 @@ namespace aspect
         {
           use_spherical_unit_vectors = prm.get_bool("Use spherical unit vectors");
           if (use_spherical_unit_vectors)
-            AssertThrow ((dynamic_cast<const GeometryModel::Box<dim>*> (&this->get_geometry_model())) == nullptr,
+            AssertThrow (this->get_geometry_model().natural_coordinate_system() == Utilities::Coordinates::spherical,
                          ExcMessage ("Spherical unit vectors should not be used "
                                      "when geometry model is not spherical."));
         }

--- a/source/boundary_velocity/function.cc
+++ b/source/boundary_velocity/function.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/boundary_velocity/function.h>
-#include <aspect/geometry_model/box.h>
 #include <aspect/utilities.h>
 #include <aspect/global.h>
 #include <deal.II/base/signaling_nan.h>
@@ -127,7 +126,7 @@ namespace aspect
           coordinate_system = Utilities::Coordinates::string_to_coordinate_system(prm.get("Coordinate system"));
           use_spherical_unit_vectors = prm.get_bool("Use spherical unit vectors");
           if (use_spherical_unit_vectors)
-            AssertThrow ((dynamic_cast<const GeometryModel::Box<dim>*> (&this->get_geometry_model())) == nullptr,
+            AssertThrow (this->get_geometry_model().natural_coordinate_system() == Utilities::Coordinates::spherical,
                          ExcMessage ("Spherical unit vectors should not be used "
                                      "when geometry model is not spherical."));
         }

--- a/source/boundary_velocity/gplates.cc
+++ b/source/boundary_velocity/gplates.cc
@@ -31,9 +31,6 @@
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
-#include <aspect/geometry_model/spherical_shell.h>
-#include <aspect/geometry_model/chunk.h>
-
 
 namespace aspect
 {
@@ -568,15 +565,13 @@ namespace aspect
                 ExcMessage ("To define a plane for the 2D model the two assigned points "
                             "may not be equal."));
 
-      if (((dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model())) != nullptr)
-          || ((dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model())) != nullptr))
-        {
-          lookup = std_cxx14::make_unique<internal::GPlatesLookup<dim>>(pointone, pointtwo);
-          old_lookup = std_cxx14::make_unique<internal::GPlatesLookup<dim>>(pointone, pointtwo);
-        }
-      else
-        AssertThrow (false,ExcMessage ("This gplates plugin can only be used when using "
-                                       "a spherical shell or chunk geometry."));
+      AssertThrow (this->get_geometry_model().natural_coordinate_system() == Utilities::Coordinates::spherical,
+                   ExcMessage ("This gplates plugin can only be used when the "
+                               "preferred coordinate system of the geometry model is spherical "
+                               "(e.g. spherical shell, chunk, sphere)."));
+
+      lookup = std_cxx14::make_unique<internal::GPlatesLookup<dim>>(pointone, pointtwo);
+      old_lookup = std_cxx14::make_unique<internal::GPlatesLookup<dim>>(pointone, pointtwo);
 
       // display the GPlates module information at model start.
       this->get_pcout() << lookup->screen_output(pointone, pointtwo);

--- a/source/geometry_model/box.cc
+++ b/source/geometry_model/box.cc
@@ -43,7 +43,7 @@ namespace aspect
       // If so, connect the initial topography function
       // to the right signals: It should be applied after
       // the final initial adaptive refinement and after a restart.
-      if (dynamic_cast<InitialTopographyModel::ZeroTopography<dim>*>(topo_model) == nullptr)
+      if (Plugins::plugin_type_matches<InitialTopographyModel::ZeroTopography<dim>>(*topo_model) == false)
         {
           this->get_signals().pre_set_initial_state.connect(
             [&](typename parallel::distributed::Triangulation<dim> &tria)
@@ -281,8 +281,9 @@ namespace aspect
                   this->simulator_is_past_initialization() == false,
                   ExcMessage("After displacement of the free surface, this function can no longer be used to determine whether a point lies in the domain or not."));
 
-      AssertThrow(dynamic_cast<const InitialTopographyModel::ZeroTopography<dim>*>(&this->get_initial_topography_model()) != nullptr,
-                  ExcMessage("After adding topography, this function can no longer be used to determine whether a point lies in the domain or not."));
+      AssertThrow(Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()),
+                  ExcMessage("After adding topography, this function can no longer be used "
+                             "to determine whether a point lies in the domain or not."));
 
       for (unsigned int d = 0; d < dim; d++)
         if (point[d] > extents[d]+box_origin[d]+std::numeric_limits<double>::epsilon()*extents[d] ||

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -433,7 +433,7 @@ namespace aspect
                   this->get_timestep_number() == 0,
                   ExcMessage("After displacement of the mesh, this function can no longer be used to determine whether a point lies in the domain or not."));
 
-      AssertThrow(dynamic_cast<const InitialTopographyModel::ZeroTopography<dim>*>(&this->get_initial_topography_model()) != nullptr,
+      AssertThrow(Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()),
                   ExcMessage("After adding topography, this function can no longer be used to determine whether a point lies in the domain or not."));
 
       const Point<dim> spherical_point = manifold.pull_back(point);

--- a/source/geometry_model/initial_topography_model/ascii_data.cc
+++ b/source/geometry_model/initial_topography_model/ascii_data.cc
@@ -65,16 +65,16 @@ namespace aspect
       // add a coordinate here, and, for spherical geometries,
       // change to cartesian coordinates.
       Point<dim> global_point;
-      if (dynamic_cast<const GeometryModel::Box<dim>*> (&this->get_geometry_model()) != nullptr)
+      if (Plugins::plugin_type_matches<const GeometryModel::Box<dim>> (this->get_geometry_model()))
         {
           // No need to set the vertical coordinate correctly,
           // because it will be thrown away in get_data_component anyway
           for (unsigned int d=0; d<dim-1; d++)
             global_point[d] = surface_point[d];
         }
-      else if (dynamic_cast<const GeometryModel::Sphere<dim>*> (&this->get_geometry_model()) != nullptr ||
-               dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()) != nullptr ||
-               dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model()) != nullptr)
+      else if (Plugins::plugin_type_matches<const GeometryModel::Sphere<dim>> (this->get_geometry_model()) ||
+               Plugins::plugin_type_matches<const GeometryModel::SphericalShell<dim>> (this->get_geometry_model()) ||
+               Plugins::plugin_type_matches<const GeometryModel::Chunk<dim>> (this->get_geometry_model()))
         {
           // No need to set the radial coordinate correctly,
           // because it will be thrown away in get_data_component anyway

--- a/source/geometry_model/sphere.cc
+++ b/source/geometry_model/sphere.cc
@@ -144,7 +144,7 @@ namespace aspect
                   this->get_timestep_number() == 0,
                   ExcMessage("After displacement of the mesh, this function can no longer be used to determine whether a point lies in the domain or not."));
 
-      AssertThrow(dynamic_cast<const InitialTopographyModel::ZeroTopography<dim>*>(&this->get_initial_topography_model()) != nullptr,
+      AssertThrow(Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()),
                   ExcMessage("After adding topography, this function can no longer be used to determine whether a point lies in the domain or not."));
 
       const double radius = point.norm();

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -445,7 +445,7 @@ namespace aspect
                   this->get_timestep_number() == 0,
                   ExcMessage("After displacement of the mesh, this function can no longer be used to determine whether a point lies in the domain or not."));
 
-      AssertThrow(dynamic_cast<const InitialTopographyModel::ZeroTopography<dim>*>(&this->get_initial_topography_model()) != nullptr,
+      AssertThrow(Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()),
                   ExcMessage("After adding topography, this function can no longer be used to determine whether a point lies in the domain or not."));
 
       const std::array<double, dim> spherical_point = Utilities::Coordinates::cartesian_to_spherical_coordinates(point);

--- a/source/geometry_model/two_merged_boxes.cc
+++ b/source/geometry_model/two_merged_boxes.cc
@@ -278,7 +278,7 @@ namespace aspect
                   this->simulator_is_past_initialization() == false,
                   ExcMessage("After displacement of the mesh, this function can no longer be used to determine whether a point lies in the domain or not."));
 
-      AssertThrow(dynamic_cast<const InitialTopographyModel::ZeroTopography<dim>*>(&this->get_initial_topography_model()) != nullptr,
+      AssertThrow(Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()),
                   ExcMessage("After adding topography, this function can no longer be used to determine whether a point lies in the domain or not."));
 
       for (unsigned int d = 0; d < dim; d++)

--- a/source/gravity_model/ascii_data.cc
+++ b/source/gravity_model/ascii_data.cc
@@ -19,12 +19,7 @@
 */
 
 #include <aspect/gravity_model/ascii_data.h>
-
-#include <aspect/geometry_model/box.h>
-#include <aspect/geometry_model/spherical_shell.h>
-#include <aspect/geometry_model/sphere.h>
-#include <aspect/geometry_model/chunk.h>
-#include <aspect/geometry_model/ellipsoidal_chunk.h>
+#include <aspect/geometry_model/interface.h>
 
 namespace aspect
 {
@@ -55,12 +50,10 @@ namespace aspect
       const double magnitude = this->get_data_component(Point<1>(depth),gravity_index);
 
       // in dependence of what the geometry model is, gravity points in a different direction
-      if (dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model())
-          || dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model())
-          || dynamic_cast<const GeometryModel::EllipsoidalChunk<dim>*> (&this->get_geometry_model())
-          || dynamic_cast<const GeometryModel::Sphere<dim>*> (&this->get_geometry_model()))
+      if (this->get_geometry_model().natural_coordinate_system() == Utilities::Coordinates::spherical ||
+          this->get_geometry_model().natural_coordinate_system() == Utilities::Coordinates::ellipsoidal)
         return - magnitude * position/position.norm();
-      else if (dynamic_cast<const GeometryModel::Box<dim>*> (&this->get_geometry_model()))
+      else if (this->get_geometry_model().natural_coordinate_system() == Utilities::Coordinates::cartesian)
         {
           Tensor<1,dim> g;
           g[dim-1] = -magnitude;

--- a/source/gravity_model/radial.cc
+++ b/source/gravity_model/radial.cc
@@ -21,9 +21,6 @@
 
 #include <aspect/gravity_model/radial.h>
 #include <aspect/geometry_model/interface.h>
-#include <aspect/geometry_model/box.h>
-#include <aspect/geometry_model/two_merged_boxes.h>
-#include <aspect/geometry_model/sphere.h>
 #include <aspect/utilities.h>
 
 #include <deal.II/base/tensor.h>
@@ -79,12 +76,10 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      AssertThrow (Plugins::plugin_type_matches<const GeometryModel::Box<dim> >(this->get_geometry_model()) == false,
-                   ExcMessage ("Gravity model 'radial constant' should not be used with geometry model 'box'."));
-
-      AssertThrow (Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim> >(this->get_geometry_model()) == false,
-                   ExcMessage ("Gravity model 'radial constant' should not be used with geometry model 'box with "
-                               "lithosphere boundary indicators'."));
+      AssertThrow (this->get_geometry_model().natural_coordinate_system() == Utilities::Coordinates::spherical ||
+                   this->get_geometry_model().natural_coordinate_system() == Utilities::Coordinates::ellipsoidal,
+                   ExcMessage ("Gravity model 'radial constant' should not be used with geometry models that "
+                               "do not have either a spherical or ellipsoidal natural coordinate system."));
     }
 
 // ------------------------------ RadialEarthLike -------------------
@@ -175,11 +170,11 @@ namespace aspect
         prm.leave_subsection ();
       }
       prm.leave_subsection ();
-      AssertThrow (dynamic_cast<const GeometryModel::Box<dim>*> (&this->get_geometry_model()) == nullptr,
-                   ExcMessage ("Gravity model 'radial linear' should not be used with geometry model 'box'."));
-      AssertThrow (dynamic_cast<const GeometryModel::TwoMergedBoxes<dim>*> (&this->get_geometry_model()) == nullptr,
-                   ExcMessage ("Gravity model 'radial linear' should not be used with geometry model 'box with "
-                               "lithosphere boundary indicators'."));
+
+      AssertThrow (this->get_geometry_model().natural_coordinate_system() == Utilities::Coordinates::spherical ||
+                   this->get_geometry_model().natural_coordinate_system() == Utilities::Coordinates::ellipsoidal,
+                   ExcMessage ("Gravity model 'radial linear' should not be used with geometry models that "
+                               "do not have either a spherical or ellipsoidal natural coordinate system."));
 
     }
   }

--- a/source/gravity_model/vertical.cc
+++ b/source/gravity_model/vertical.cc
@@ -21,10 +21,7 @@
 
 #include <aspect/gravity_model/vertical.h>
 
-#include <aspect/geometry_model/sphere.h>
-#include <aspect/geometry_model/spherical_shell.h>
-#include <aspect/geometry_model/chunk.h>
-#include <aspect/geometry_model/ellipsoidal_chunk.h>
+#include <aspect/geometry_model/interface.h>
 
 #include <deal.II/base/tensor.h>
 
@@ -74,14 +71,9 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      AssertThrow (dynamic_cast<const GeometryModel::Sphere<dim>*> (&this->get_geometry_model()) == nullptr,
-                   ExcMessage ("Gravity model 'vertical' should not be used with geometry model 'sphere'."));
-      AssertThrow (dynamic_cast<const GeometryModel::SphericalShell<dim>*> (&this->get_geometry_model()) == nullptr,
-                   ExcMessage ("Gravity model 'vertical' should not be used with geometry model 'spherical shell'."));
-      AssertThrow (dynamic_cast<const GeometryModel::Chunk<dim>*> (&this->get_geometry_model()) == nullptr,
-                   ExcMessage ("Gravity model 'vertical' should not be used with geometry model 'chunk'."));
-      AssertThrow (dynamic_cast<const GeometryModel::EllipsoidalChunk<dim>*> (&this->get_geometry_model()) == nullptr,
-                   ExcMessage ("Gravity model 'vertical' should not be used with geometry model 'ellipsoidal chunk'."));
+      AssertThrow (this->get_geometry_model().natural_coordinate_system() == Utilities::Coordinates::cartesian,
+                   ExcMessage ("Gravity model 'vertical' should not be used with geometry models that "
+                               "do not have a cartesian natural coordinate system."));
     }
   }
 }


### PR DESCRIPTION
Follow-up to #3304. Replace some more dynamic_casts and simplify some checks. I replaced checks for specific geometry models with `natural_coordinate_system` wherever I was sure the functionality would work with any geometry model of that coordinate system someone could come up with. When I was unsure if that was true I left checks for specific geometry model plugins (like the initial topography).