### PR TITLE
Fix a deprecation warning with deal.II dev

### DIFF
--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -31,6 +31,22 @@
 // for std_cxx14::make_unique:
 #include <deal.II/base/std_cxx14/memory.h>
 
+#if DEAL_II_VERSION_GTE(9,1,0)
+#include <deal.II/lac/affine_constraints.h>
+namespace aspect
+{
+  /**
+   * The ConstraintMatrix class was deprecated in deal.II 9.1 in favor
+   * of AffineConstraints. To make the name available for ASPECT
+   * nonetheless, use a `using` declaration. This injects the name
+   * into the `aspect` namespace, where it is visible before the
+   * deprecated name in the `dealii` namespace, thereby suppressing
+   * the deprecation message.
+   */
+  using ConstraintMatrix = class dealii::AffineConstraints<double>;
+}
+#endif
+
 #if !DEAL_II_VERSION_GTE(9,2,0)
 #include <deal.II/base/table.h>
 #include <deal.II/base/function_lib.h>

--- a/include/aspect/mesh_deformation/interface.h
+++ b/include/aspect/mesh_deformation/interface.h
@@ -45,18 +45,6 @@ namespace aspect
 
   template <int dim> class Simulator;
 
-#if DEAL_II_VERSION_GTE(9,1,0)
-  /**
-   * The ConstraintMatrix class was deprecated in deal.II 9.1 in favor
-   * of AffineConstraints. To make the name available for ASPECT
-   * nonetheless, use a `using` declaration. This injects the name
-   * into the `aspect` namespace, where it is visible before the
-   * deprecated name in the `dealii` namespace, thereby suppressing
-   * the deprecation message.
-   */
-  using ConstraintMatrix = class dealii::AffineConstraints<double>;
-#endif
-
   /**
    * A namespace that contains everything that is related to the deformation
    * of the mesh vertices over time.

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -50,18 +50,6 @@ namespace aspect
 {
   using namespace dealii;
 
-#if DEAL_II_VERSION_GTE(9,1,0)
-  /**
-   * The ConstraintMatrix class was deprecated in deal.II 9.1 in favor
-   * of AffineConstraints. To make the name available for ASPECT
-   * nonetheless, use a `using` declaration. This injects the name
-   * into the `aspect` namespace, where it is visible before the
-   * deprecated name in the `dealii` namespace, thereby suppressing
-   * the deprecation message.
-   */
-  using ConstraintMatrix = class dealii::AffineConstraints<double>;
-#endif
-
   // forward declarations:
   template <int dim> class Simulator;
   template <int dim> struct SimulatorSignals;


### PR DESCRIPTION
With deal.II-dev and gcc 8.3.0 I still get deprecation warnings complaining about the use of `ConstraintMatrix` despite the fixes in #2847 and #3172. Moving the fix into compat.h fixes it (likely it is now included everywhere, and before any other includes that might use it). I think this makes sense, because perspectively we want to remove this workaround, once we require 9.1 and have removed all usage of ConstraintMatrix from other parts of the code.