### PR TITLE
Fix world builder external dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ if(ASPECT_WITH_WORLD_BUILDER)
   MESSAGE(STATUS "Using World Builder version ${WORLD_BUILDER_VERSION} found at ${WORLD_BUILDER_SOURCE_DIR}.")
 
   # add source and include dirs:
-  FILE(GLOB_RECURSE wb_files "contrib/world_builder/source/*.cc")
+  FILE(GLOB_RECURSE wb_files "${WORLD_BUILDER_SOURCE_DIR}/source/*.cc")
   LIST(APPEND TARGET_SRC ${wb_files})
 
   # generate config.cc and include it:


### PR DESCRIPTION
@gassmoeller found that compiling with an external world builder gave a error. It turned out I made a small mistake in the cmake file. This fixes it.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
