### PR TITLE
Add adiabatic surface temperature to S20RTS cookbook

### DIFF
--- a/cookbooks/S20RTS.prm
+++ b/cookbooks/S20RTS.prm
@@ -15,9 +15,12 @@ set Output directory                       = output-S20RTS
 
 # The following variables describe how the pressure should
 # be normalized. Here, we choose a zero average pressure
-# at the surface of the domain 
+# at the surface of the domain. The 'Surface pressure' and
+# 'Adiabatic surface temperature' are used to compute
+# the adiabatic reference profile.
 set Pressure normalization                 = surface
 set Surface pressure                       = 0
+set Adiabatic surface temperature          = 1600
 
 # Here we specify the residual tolerance for the linear solver.
 subsection Solver parameters


### PR DESCRIPTION
This is not exactly a bug for this cookbook, but if you modify it for applications that rely on the reference profile we want to set the correct adiabatic surface temperature. I feel like having the wrong adiabatic profile is a classical bug in many of our models, we need to find a better way than this PR, but this is a start.