### PR TITLE
fix warning for SimulatorSignals

### DIFF
--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -45,7 +45,7 @@
 namespace aspect
 {
   template<int dim>
-  class SimulatorSignals;
+  struct SimulatorSignals;
 
   namespace Particle
   {


### PR DESCRIPTION
Fix: warning: class template 'SimulatorSignals' was previously declared
as a struct template [-Wmismatched-tags]
Reported by clang-6