### PR TITLE
Abort expensive solve if Maximum number of expensive Stokes solver steps = 0

### DIFF
--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -860,8 +860,8 @@ namespace aspect
             try
               {
                 AssertThrow (parameters.n_expensive_stokes_solver_steps>0,
-                             ExcMessage ("The Stokes solver did not converge in the number of requested cheap iterations and you requested 0"
-                                         " for ``Maximum number of expensive Stokes solver steps``. Aborting."));
+                             ExcMessage ("The Stokes solver did not converge in the number of requested cheap iterations and "
+                                         "you requested 0 for ``Maximum number of expensive Stokes solver steps''. Aborting."));
 
                 solver.solve(stokes_block,
                              distributed_stokes_solution,

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -859,6 +859,10 @@ namespace aspect
 
             try
               {
+                AssertThrow (parameters.n_expensive_stokes_solver_steps>0,
+                             ExcMessage ("The Stokes solver did not converge in the number of requested cheap iterations and you requested 0"
+                                         " for ``Maximum number of expensive Stokes solver steps``. Aborting."));
+
                 solver.solve(stokes_block,
                              distributed_stokes_solution,
                              distributed_stokes_rhs,

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1700,8 +1700,8 @@ namespace aspect
         try
           {
             AssertThrow (sim.parameters.n_expensive_stokes_solver_steps>0,
-                         ExcMessage ("The Stokes solver did not converge in the number of requested cheap iterations and you requested 0"
-                                     " for ``Maximum number of expensive Stokes solver steps``. Aborting."));
+                         ExcMessage ("The Stokes solver did not converge in the number of requested cheap iterations and "
+                                     "you requested 0 for ``Maximum number of expensive Stokes solver steps''. Aborting."));
 
             solver.solve(stokes_matrix,
                          solution_copy,

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1699,6 +1699,10 @@ namespace aspect
 
         try
           {
+            AssertThrow (sim.parameters.n_expensive_stokes_solver_steps>0,
+                         ExcMessage ("The Stokes solver did not converge in the number of requested cheap iterations and you requested 0"
+                                     " for ``Maximum number of expensive Stokes solver steps``. Aborting."));
+
             solver.solve(stokes_matrix,
                          solution_copy,
                          rhs_copy,


### PR DESCRIPTION
We add an `AssertThrow(n_expensive_steps>0)` before starting the expensive Stokes solver. This just ensures we don't waste time by running the expensive solver with 0 max iterations if the user sets `Maximum number of expensive Stokes solver steps = 0`.

* [X] I have read the guidelines in our [CONTRIBUTING.md](../CONTRIBUTING.md) document.
* [X] I have followed the [instructions for indenting my code](../CONTRIBUTING.md#making-aspect-better).

