### PR TITLE
Add appropriate #include file.

### DIFF
--- a/source/mesh_deformation/free_surface.cc
+++ b/source/mesh_deformation/free_surface.cc
@@ -29,6 +29,10 @@
 
 #include <deal.II/dofs/dof_tools.h>
 
+#ifdef ASPECT_USE_PETSC
+#  include <deal.II/lac/sparsity_tools.h>
+#endif
+
 namespace aspect
 {
   namespace Assemblers


### PR DESCRIPTION
When using PETSc for linear algebra, we use a function from namespace
SparsityTools. Make sure it is available.