### PR TITLE
Simplify step limiting logic and add error message for negative timesteps

### DIFF
--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -631,24 +631,26 @@ namespace aspect
     double new_time_step = std::min(min_convection_timestep,
                                     min_conduction_timestep);
 
-    if (new_time_step == std::numeric_limits<double>::max())
-      {
-        // In some models the velocity is zero, either because that is the prescribed
-        // Stokes solution, or just because there is no buoyancy and nothing is moving.
-        // If this is the case, and if we either do not compute the conduction time
-        // step or do not have any conduction, it is somewhat arbitrary what time step
-        // we should choose. In that case, set the time step to the 'Maximum time step'.
-        new_time_step = parameters.maximum_time_step;
-      }
+    AssertThrow (new_time_step > 0,
+                 ExcMessage("The time step length for the each time step needs to be positive, "
+                            "but the computed step length was: " + std::to_string(new_time_step) + ". "
+                            "Please check for non-positive material properties."));
 
-    // make sure that the timestep doesn't increase too fast
+    // Make sure we do not exceed the maximum time step length. This can happen
+    // if velocities get too small or even zero in models that are stably stratified
+    // or use prescribed velocities.
+    new_time_step = std::min(new_time_step, parameters.maximum_time_step);
+
+    // Make sure that the time step doesn't increase too fast
     if (time_step != 0)
       new_time_step = std::min(new_time_step, time_step + time_step * parameters.maximum_relative_increase_time_step);
-    else
+
+    // Make sure we do not exceed the maximum length for the first time step
+    if (timestep_number == 0)
       new_time_step = std::min(new_time_step, parameters.maximum_first_time_step);
 
-    new_time_step = termination_manager.check_for_last_time_step(std::min(new_time_step,
-                                                                          parameters.maximum_time_step));
+    // Make sure we reduce the time step length appropriately if we terminate after this step
+    new_time_step = termination_manager.check_for_last_time_step(new_time_step);
 
     return new_time_step;
   }


### PR DESCRIPTION
After looking at #3356 I noticed two things: 
1. We can potentially allow negative time step sizes if the material model hands over negative densities, specific heat capacities or thermal conductivities and the conduction time step is used. This is addressed in this PR by adding a new AssertThrow that also trigger in release mode.
2. The logic for limiting time steps at the end of this function was pretty hard to understand. I simplified it here. All of the functionality should be preserved (every condition change should be equivalent to the conditions before).

Let me know what you think.