### PR TITLE
[WIP] Enable additional RHS terms and elasticity in Newton solver

### DIFF
--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -249,8 +249,8 @@ namespace aspect
                  internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const override;
 
         /**
-         * Create additional material models outputs for assembly of derivatives or adding additional 
-         * terms to the right hand side of the Stokes equations. The latter could include viscoelastic 
+         * Create additional material models outputs for assembly of derivatives or adding additional
+         * terms to the right hand side of the Stokes equations. The latter could include viscoelastic
          * forces or other user-defined values calculated within the material model.
          */
         void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const override;

--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -249,7 +249,9 @@ namespace aspect
                  internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const override;
 
         /**
-         * Create AdditionalMaterialOutputsStokesRHS if we need to do so.
+         * Create additional material models outputs for assembly of derivatives or adding additional 
+         * terms to the right hand side of the Stokes equations. The latter could include viscoelastic 
+         * forces or other user-defined values calculated within the material model.
          */
         void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const override;
     };

--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -247,6 +247,11 @@ namespace aspect
         void
         execute (internal::Assembly::Scratch::ScratchBase<dim>  &scratch_base,
                  internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const override;
+
+        /**
+         * Create AdditionalMaterialOutputsStokesRHS if we need to do so.
+         */
+        void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const override;
     };
 
     /**

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -173,7 +173,10 @@ namespace aspect
                      Parameters<dim>::NonlinearSolver::single_Advection_single_Stokes
                      ||
                      this->get_parameters().nonlinear_solver ==
-                     Parameters<dim>::NonlinearSolver::single_Advection_iterated_Stokes),
+                     Parameters<dim>::NonlinearSolver::single_Advection_iterated_Stokes
+                     ||
+                     this->get_parameters().nonlinear_solver ==
+                     Parameters<dim>::NonlinearSolver::single_Advection_iterated_Newton_Stokes),
                     ExcMessage("The material model will only work with the nonlinear "
                                "solver schemes 'single Advection, single Stokes' and "
                                "'single Advection, iterated Stokes'"));

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -485,6 +485,11 @@ namespace aspect
              ||
              outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim> >()->elastic_force.size()
              == n_points, ExcInternalError());
+
+      if (this->get_newton_handler().parameters.newton_derivative_scaling_factor == 0)
+        return;
+
+      NewtonHandler<dim>::create_material_model_outputs(outputs);
     }
 
 

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -486,10 +486,8 @@ namespace aspect
              outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim> >()->elastic_force.size()
              == n_points, ExcInternalError());
 
-      if (this->get_newton_handler().parameters.newton_derivative_scaling_factor == 0)
-        return;
-
-      NewtonHandler<dim>::create_material_model_outputs(outputs);
+      if (this->get_newton_handler().parameters.newton_derivative_scaling_factor != 0)
+        NewtonHandler<dim>::create_material_model_outputs(outputs);
     }
 
 


### PR DESCRIPTION
This PR enables additional RHS terms, including elasticity, in the Newton solver assembly. 

As the `viscoelastic` and `viscoelastic_plastic material` model currently do not setup the Newton derivatives, this PR should wait until #3306 is merged and this is rebased on top of it. 

The single added test using the Newton solver is a cheat in that only one nonlinear iteration is performed and thus no call to assemble derivatives is required.

@MFraters - opening this so you can take a look.

* [X] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [ ] I have tested my new feature locally to ensure it is correct.
* [X] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
