### PR TITLE
update vep test parameter file

### DIFF
--- a/tests/viscoelastic_plastic_brick_extension.prm
+++ b/tests/viscoelastic_plastic_brick_extension.prm
@@ -35,6 +35,31 @@ subsection Initial composition model
   end
 end
 
+# Use viscoelastic plastic material model
+subsection Material model
+
+  set Model name = viscoelastic plastic
+
+  subsection Viscoelastic Plastic
+    set Densities                   = 2700
+    set Reference viscosity         = 1.e21
+    set Reference strain rate       = 1.e-15
+    set Maximum viscosity           = 1.e25
+    set Minimum viscosity           = 1.e20
+    set Linear viscosities          = 1.e25,1.e25,1.e25,1.e25,1.e20
+    set Elastic shear moduli        = 5.e10
+    set Use fixed elastic time step = false
+    set Fixed elastic time step     = 1e3
+    set Use stress averaging        = false
+    set Viscosity averaging scheme  = maximum composition
+    set Angles of internal friction = 30.
+    set Cohesions                   = 40.e6,40.e6,40.e6,40.e6,1.e20
+  end
+
+end
+
+
+
 # Post processing
 subsection Postprocess
   set List of postprocessors = velocity statistics


### PR DESCRIPTION
This PR is part of the preparation for the update to the visco_plastic material model in #3306. 

The test parameter file updated here is derived from the `kaus_2010_extension benchmark`, which uses the viscoelastic_plastic material model. In #3306 this benchmark will be modified to use the visco_plastic material, but for a short period we are going to keep the viscoelastic_plastic material for testing purposes. This change ensures continuity of the test suite and allows for easier comparisons of test results in #3306. 

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
