### PR TITLE
Add mapping as argument to some boundary value calls

### DIFF
--- a/source/mesh_deformation/function.cc
+++ b/source/mesh_deformation/function.cc
@@ -64,7 +64,8 @@ namespace aspect
       // Loop over all boundary indicators to set the velocity constraints
       for (std::set<types::boundary_id>::const_iterator boundary_id = boundary_ids.begin();
            boundary_id != boundary_ids.end(); ++boundary_id)
-        VectorTools::interpolate_boundary_values (mesh_deformation_dof_handler,
+        VectorTools::interpolate_boundary_values (this->get_mapping(),
+                                                  mesh_deformation_dof_handler,
                                                   *boundary_id,
                                                   function,
                                                   mesh_velocity_constraints);

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -353,7 +353,8 @@ namespace aspect
            p != sim.boundary_velocity_manager.get_zero_boundary_velocity_indicators().end(); ++p)
         if (mesh_deformation_boundary_indicators_set.find(*p) == mesh_deformation_boundary_indicators_set.end())
           {
-            VectorTools::interpolate_boundary_values (mesh_deformation_dof_handler, *p,
+            VectorTools::interpolate_boundary_values (*sim.mapping,
+                                                      mesh_deformation_dof_handler, *p,
                                                       ZeroFunction<dim>(dim), mesh_velocity_constraints);
           }
 
@@ -366,7 +367,8 @@ namespace aspect
             {
               if (mesh_deformation_boundary_indicators_set.find(p->first) == mesh_deformation_boundary_indicators_set.end())
                 {
-                  VectorTools::interpolate_boundary_values (mesh_deformation_dof_handler, p->first,
+                  VectorTools::interpolate_boundary_values (*sim.mapping,
+                                                            mesh_deformation_dof_handler, p->first,
                                                             ZeroFunction<dim>(dim), mesh_velocity_constraints);
                 }
             }


### PR DESCRIPTION
While looking into #3359 I came across these function calls that omit the mapping when interpolating boundary values. It does not fix the problems there, and it may not be a problem at all as we use a MappingQ1Eulerian for free surface at the moment, but it might be one in the future if we change that, or it might already be one if the mesh is already deformed? In the past we had some hard to find bugs because of forgotten mapping arguments, so I thought I better add these. Not sure if the tester will find a difference, lets see.