### PR TITLE
Avoid a function if deal.II has a substitute.

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -188,6 +188,7 @@ namespace aspect
     expand_dimensional_variable_names (const std::vector<std::string> &var_declarations);
 
 
+#if !DEAL_II_VERSION_GTE(9,2,0)
     /**
      * Split the set of DoFs (typically locally owned or relevant) in @p whole_set into blocks
      * given by the @p dofs_per_block structure.
@@ -198,7 +199,7 @@ namespace aspect
     void split_by_block (const std::vector<types::global_dof_index> &dofs_per_block,
                          const IndexSet &whole_set,
                          std::vector<IndexSet> &partitioned);
-
+#endif
 
     /**
      * Returns an IndexSet that contains all locally active DoFs that belong to

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -314,7 +314,7 @@ namespace aspect
     }
 
 
-
+#if !DEAL_II_VERSION_GTE(9,2,0)
     /**
      * Split the set of DoFs (typically locally owned or relevant) in @p whole_set into blocks
      * given by the @p dofs_per_block structure.
@@ -334,6 +334,7 @@ namespace aspect
           start += dofs_per_block[i];
         }
     }
+#endif
 
     template <int dim>
     std::vector<std::string>


### PR DESCRIPTION
Follow-up to #3388.