### PR TITLE
Fix a doxygen flag.

### DIFF
--- a/doc/options.dox
+++ b/doc/options.dox
@@ -1206,7 +1206,7 @@ GENERATE_LATEX         = NO
 # If a relative path is entered the value of OUTPUT_DIRECTORY will be
 # put in front of it. If left blank `latex' will be used as the default path.
 
-LATEX_OUTPUT           = me-latex
+LATEX_OUTPUT           = aspect-latex
 
 # The LATEX_CMD_NAME tag can be used to specify the LaTeX command name to be
 # invoked. If left blank `latex' will be used as the default command name.


### PR DESCRIPTION
The flag in question determines the doxygen output directory if one
generates LaTeX output -- which is not something that we probably want
to do, but it's still worth giving the flag a meaningful directory
name. (The previous value, 'me-latex', refers to the 'multiple experiment
inverse problem' code I wrote during my PhD thesis and from which this
options.dox file apparently derives.)