### PR TITLE
update chebyshev parameters

### DIFF
--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1523,6 +1523,18 @@ namespace aspect
       mg_smoother_Schur.initialize(mg_matrices_Schur_complement, smoother_data_Schur);
     }
 
+    // Estimate the eigenvalues for the Chebyshev smoothers.
+    for (unsigned int level = 0; level<sim.triangulation.n_global_levels(); ++level)
+      {
+        vector_t temp_velocity;
+        vector_t temp_pressure;
+        mg_matrices_A_block[level].initialize_dof_vector(temp_velocity);
+        mg_matrices_Schur_complement[level].initialize_dof_vector(temp_pressure);
+
+        mg_smoother_A[level].estimate_eigenvalues(temp_velocity);
+        mg_smoother_Schur[level].estimate_eigenvalues(temp_pressure);
+      }
+
     // Coarse Solver is just an application of the Chebyshev smoother setup
     // in such a way to be a solver
     //ABlock GMG

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1488,9 +1488,9 @@ namespace aspect
             }
           else
             {
-              smoother_data_A[0].smoothing_range = 15.;
+              smoother_data_A[0].smoothing_range = 1e-3;
               smoother_data_A[0].degree = 8;
-              smoother_data_A[0].eig_cg_n_iterations = 10;
+              smoother_data_A[0].eig_cg_n_iterations = 100;
             }
           smoother_data_A[level].preconditioner = mg_matrices_A_block[level].get_matrix_diagonal_inverse();
         }
@@ -1514,9 +1514,9 @@ namespace aspect
             }
           else
             {
-              smoother_data_Schur[0].smoothing_range = 15.;
+              smoother_data_Schur[0].smoothing_range = 1e-3;
               smoother_data_Schur[0].degree = 8;
-              smoother_data_Schur[0].eig_cg_n_iterations = 10;
+              smoother_data_Schur[0].eig_cg_n_iterations = 100;
             }
           smoother_data_Schur[level].preconditioner = mg_matrices_Schur_complement[level].get_matrix_diagonal_inverse();
         }

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1524,7 +1524,13 @@ namespace aspect
     }
 
 #if DEAL_II_VERSION_GTE(9,2,0)
-    // Estimate the eigenvalues for the Chebyshev smoothers.
+    // Estimate the eigenvalues for the Chebyshev smoothers. If not running with
+    // deal.II 9.2.0, the eigenvalue estimate will be performed during the first
+    // application of the Chebyshev smoother during the solve.
+
+    //TODO: The setup for the smoother (as well as the entire GMG setup) should
+    //       be moved to an assembly timing block instead of the Stokes solve
+    //       timing block (as is currently the case).
     for (unsigned int level = 0; level<sim.triangulation.n_global_levels(); ++level)
       {
         vector_t temp_velocity;

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1523,6 +1523,7 @@ namespace aspect
       mg_smoother_Schur.initialize(mg_matrices_Schur_complement, smoother_data_Schur);
     }
 
+#if DEAL_II_VERSION_GTE(9,2,0)
     // Estimate the eigenvalues for the Chebyshev smoothers.
     for (unsigned int level = 0; level<sim.triangulation.n_global_levels(); ++level)
       {
@@ -1534,6 +1535,7 @@ namespace aspect
         mg_smoother_A[level].estimate_eigenvalues(temp_velocity);
         mg_smoother_Schur[level].estimate_eigenvalues(temp_pressure);
       }
+#endif
 
     // Coarse Solver is just an application of the Chebyshev smoother setup
     // in such a way to be a solver

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1488,9 +1488,9 @@ namespace aspect
             }
           else
             {
-              smoother_data_A[0].smoothing_range = 1e-3;
-              smoother_data_A[0].degree = numbers::invalid_unsigned_int;
-              smoother_data_A[0].eig_cg_n_iterations = 100;
+              smoother_data_A[0].smoothing_range = 15.;
+              smoother_data_A[0].degree = 8;
+              smoother_data_A[0].eig_cg_n_iterations = 10;
             }
           smoother_data_A[level].preconditioner = mg_matrices_A_block[level].get_matrix_diagonal_inverse();
         }
@@ -1514,9 +1514,9 @@ namespace aspect
             }
           else
             {
-              smoother_data_Schur[0].smoothing_range = 1e-3;
-              smoother_data_Schur[0].degree = numbers::invalid_unsigned_int;
-              smoother_data_Schur[0].eig_cg_n_iterations = 100; /*mg_matrices_M[0].m();*/
+              smoother_data_Schur[0].smoothing_range = 15.;
+              smoother_data_Schur[0].degree = 8;
+              smoother_data_Schur[0].eig_cg_n_iterations = 10;
             }
           smoother_data_Schur[level].preconditioner = mg_matrices_Schur_complement[level].get_matrix_diagonal_inverse();
         }

--- a/tests/nonlinear_channel_flow_velocities_Newton_Stokes_GMG/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_Newton_Stokes_GMG/screen-output
@@ -175,7 +175,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 2.07949e-13, norm of the rhs: 151495, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 2.07948e-13, norm of the rhs: 151495, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
@@ -187,27 +187,27 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.07739e-14, norm of the rhs: 44275.1, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.07737e-14, norm of the rhs: 44275, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 4.03441e-14, norm of the rhs: 29391.6, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 4.03441e-14, norm of the rhs: 29391.5, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 2.67866e-14, norm of the rhs: 19514.7, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 2.67867e-14, norm of the rhs: 19514.7, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 1.77872e-14, norm of the rhs: 12958.4, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 1.77871e-14, norm of the rhs: 12958.3, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 1.18129e-14, norm of the rhs: 8605.93, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 1.18128e-14, norm of the rhs: 8605.9, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 7.84608e-15, norm of the rhs: 5716.04, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 7.84612e-15, norm of the rhs: 5716.07, newton_derivative_scaling_factor: 0
 
 
    Postprocessing:
@@ -264,31 +264,31 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 9.13974e-14, norm of the rhs: 66585.1, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 9.13976e-14, norm of the rhs: 66585.2, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.0664e-14, norm of the rhs: 44195.1, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.06641e-14, norm of the rhs: 44195.1, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 4.0272e-14, norm of the rhs: 29339.1, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 4.02719e-14, norm of the rhs: 29339, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 2.67386e-14, norm of the rhs: 19479.6, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 2.67385e-14, norm of the rhs: 19479.6, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 1.77549e-14, norm of the rhs: 12934.9, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 1.7755e-14, norm of the rhs: 12934.9, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 1.17915e-14, norm of the rhs: 8590.38, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 1.17913e-14, norm of the rhs: 8590.26, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 7.83175e-15, norm of the rhs: 5705.61, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 7.83169e-15, norm of the rhs: 5705.56, newton_derivative_scaling_factor: 0
 
 
    Postprocessing:
@@ -301,19 +301,19 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 7.28522e+17, v = 7.28522e+17, p = 0.0770426
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 2.35113e-14, norm of the rhs: 17128.5
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 2.35111e-14, norm of the rhs: 17128.4
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.56161e-14, norm of the rhs: 11376.7, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.56162e-14, norm of the rhs: 11376.7, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 1.03737e-14, norm of the rhs: 7557.5, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 1.03741e-14, norm of the rhs: 7557.74, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 6.89164e-15, norm of the rhs: 5020.71, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 6.89191e-15, norm of the rhs: 5020.91, newton_derivative_scaling_factor: 0
 
 
    Postprocessing:
@@ -326,7 +326,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 7.28522e+17, v = 7.28522e+17, p = 0.0770426
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.95354e-15, norm of the rhs: 4337.29
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.95391e-15, norm of the rhs: 4337.56
 
 
    Postprocessing:


### PR DESCRIPTION
Updates the Chebyshev parameters for the Coarse GMG solver. Previously, the coarse solver contained a full CG solve of eigenvalues. This is not an issue on meshes with small coarse levels, but is quite slow otherwise. 

An example of the time saved (over 4x faster) is discussed in https://github.com/geodynamics/aspect/pull/3382.

All current GMG tests should have the same output (or slightly lower iteration counts). 

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) document.
* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
