### PR TITLE
Jenkins: ignore coveralls failure

### DIFF
--- a/Jenkinsfile.cig
+++ b/Jenkinsfile.cig
@@ -178,8 +178,10 @@ pipeline {
           // used to update the test results
           sh 'git diff tests > changes-test-results.diff'
           archiveArtifacts artifacts: 'changes-test-results.diff'
+        }
 
-          // post the coverage results to coveralls
+        success {
+          // post the coverage results to coveralls if the build and testing succeeded
           sh '''
           cd build-gcc-fast
           coveralls -r ../ -b . -i source --gcov-options '\\-lp'


### PR DESCRIPTION
The coveralls step is not useful to run if tests failed, so only run on
success. This fixes the problem that clicking on details of a failed run
no longer shows thousands of output lines from coveralls, that are
difficult to hide to see the actual error.
