### PR TITLE
Improve preconditioner coupling and assembly

### DIFF
--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -42,8 +42,6 @@ namespace aspect
       const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
       const unsigned int n_q_points           = scratch.finite_element_values.n_quadrature_points;
       const double pressure_scaling = this->get_pressure_scaling();
-      const bool assemble_A_approximation = this->get_parameters().use_full_A_block_preconditioner == false &&
-                                            this->get_parameters().mesh_deformation_enabled == false;
 
       // First loop over all dofs and find those that are in the Stokes system
       // save the component (pressure and dim velocities) each belongs to.
@@ -111,7 +109,7 @@ namespace aspect
             {
               if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
                 {
-                  if (assemble_A_approximation)
+                  if (this->get_parameters().use_full_A_block_preconditioner == false)
                     scratch.grads_phi_u[i_stokes] =
                       scratch.finite_element_values[introspection.extractors
                                                     .velocities].symmetric_gradient(i, q);
@@ -127,7 +125,7 @@ namespace aspect
 
           const double JxW = scratch.finite_element_values.JxW(q);
 
-          if (assemble_A_approximation)
+          if (this->get_parameters().use_full_A_block_preconditioner == false)
             {
               for (unsigned int i = 0; i < stokes_dofs_per_cell; ++i)
                 for (unsigned int j = 0; j < stokes_dofs_per_cell; ++j)
@@ -197,11 +195,9 @@ namespace aspect
       Assert (this->get_parameters().use_equal_order_interpolation_for_stokes == false,
               ExcNotImplemented());
 
-      const bool assemble_A_approximation = this->get_parameters().use_full_A_block_preconditioner == false &&
-                                            this->get_parameters().mesh_deformation_enabled == false;
-
-      if (assemble_A_approximation == false)
-        return;
+      Assert (this->get_parameters().use_full_A_block_preconditioner == false,
+              ExcMessage("This assembler should only be called if the simplified A block "
+                         "preconditioner is used."));
 
       internal::Assembly::Scratch::StokesPreconditioner<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesPreconditioner<dim>& > (scratch_base);
       internal::Assembly::CopyData::StokesPreconditioner<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesPreconditioner<dim>& > (data_base);

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -42,7 +42,8 @@ namespace aspect
       const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
       const unsigned int n_q_points           = scratch.finite_element_values.n_quadrature_points;
       const double pressure_scaling = this->get_pressure_scaling();
-      const bool assemble_A_approximation = !this->get_parameters().use_full_A_block_preconditioner;
+      const bool assemble_A_approximation = this->get_parameters().use_full_A_block_preconditioner == false &&
+                                            this->get_parameters().mesh_deformation_enabled == false;
 
       // First loop over all dofs and find those that are in the Stokes system
       // save the component (pressure and dim velocities) each belongs to.
@@ -195,6 +196,12 @@ namespace aspect
     {
       Assert (this->get_parameters().use_equal_order_interpolation_for_stokes == false,
               ExcNotImplemented());
+
+      const bool assemble_A_approximation = this->get_parameters().use_full_A_block_preconditioner == false &&
+                                            this->get_parameters().mesh_deformation_enabled == false;
+
+      if (assemble_A_approximation == false)
+        return;
 
       internal::Assembly::Scratch::StokesPreconditioner<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesPreconditioner<dim>& > (scratch_base);
       internal::Assembly::CopyData::StokesPreconditioner<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesPreconditioner<dim>& > (data_base);

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -133,8 +133,10 @@ namespace aspect
 
     if (material_model->is_compressible())
       {
-        assemblers->stokes_preconditioner.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::StokesCompressiblePreconditioner<dim> >());
+        // The compressible part of the preconditioner is only necessary if we use the simplified A block
+        if (parameters.use_full_A_block_preconditioner == false)
+          assemblers->stokes_preconditioner.push_back(
+            std_cxx14::make_unique<aspect::Assemblers::StokesCompressiblePreconditioner<dim> >());
 
         assemblers->stokes_system.push_back(
           std_cxx14::make_unique<aspect::Assemblers::StokesCompressibleStrainRateViscosityTerm<dim> >());
@@ -521,7 +523,7 @@ namespace aspect
         Mp_preconditioner_AMG->initialize (system_preconditioner_matrix.block(1,1), Amg_data);
       }
 
-    if (parameters.mesh_deformation_enabled || parameters.include_melt_transport || parameters.use_full_A_block_preconditioner)
+    if (parameters.use_full_A_block_preconditioner)
       Amg_preconditioner->initialize (system_matrix.block(0,0),
                                       Amg_data);
     else

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -889,6 +889,17 @@ namespace aspect
 
 
     template <int dim>
+    bool solver_scheme_solves_stokes_equations(const Parameters<dim> &parameters)
+    {
+      // Check if we use a solver scheme that solves the advection equations
+      return (parameters.nonlinear_solver != Parameters<dim>::NonlinearSolver::Kind::no_Advection_no_Stokes
+              &&
+              parameters.nonlinear_solver != Parameters<dim>::NonlinearSolver::Kind::single_Advection_no_Stokes);
+    }
+
+
+
+    template <int dim>
     bool compositional_fields_need_matrix_block(const Introspection<dim> &introspection)
     {
       // Check if any compositional field method actually requires a matrix block
@@ -925,68 +936,71 @@ namespace aspect
     const typename Introspection<dim>::ComponentIndices &x
       = introspection.component_indices;
 
-    // The matrix-free solver does not work with melt transport
-    Assert(!(parameters.include_melt_transport && stokes_matrix_free),
-           ExcNotImplemented());
-
     // Determine which blocks in the Stokes blocks
     // of the matrix are in use. At the moment this distinguishes
     // 3 solvers: melt transport, matrix-free multigrid, and the default
     // matrix based algebraic multigrid.
-    if (stokes_matrix_free)
+    if (solver_scheme_solves_stokes_equations(parameters))
       {
-        // nothing couples in the matrix free solver
-      }
-    else if (parameters.include_melt_transport)
-      {
-        // For the melt transport solver velocities and pressures couple with themselves.
-        // Additionally velocities couple with all pressures, and all pressures
-        // couple with velocities.
-        for (unsigned int d=0; d<dim; ++d)
-          {
-            for (unsigned int c=0; c<dim; ++c)
-              coupling[x.velocities[c]][x.velocities[d]] = DoFTools::always;
+        // The matrix-free solver does not work with melt transport
+        Assert(!(parameters.include_melt_transport && stokes_matrix_free),
+               ExcNotImplemented());
 
-            coupling[x.velocities[d]][
-              introspection.variable("compaction pressure").first_component_index] = DoFTools::always;
-            coupling[introspection.variable("compaction pressure").first_component_index]
-            [x.velocities[d]]
-              = DoFTools::always;
-            coupling[x.velocities[d]]
+        if (stokes_matrix_free)
+          {
+            // nothing couples in the matrix free solver
+          }
+        else if (parameters.include_melt_transport)
+          {
+            // For the melt transport solver velocities and pressures couple with themselves.
+            // Additionally velocities couple with all pressures, and all pressures
+            // couple with velocities.
+            for (unsigned int d=0; d<dim; ++d)
+              {
+                for (unsigned int c=0; c<dim; ++c)
+                  coupling[x.velocities[c]][x.velocities[d]] = DoFTools::always;
+
+                coupling[x.velocities[d]][
+                  introspection.variable("compaction pressure").first_component_index] = DoFTools::always;
+                coupling[introspection.variable("compaction pressure").first_component_index]
+                [x.velocities[d]]
+                  = DoFTools::always;
+                coupling[x.velocities[d]]
+                [introspection.variable("fluid pressure").first_component_index]
+                  = DoFTools::always;
+                coupling[introspection.variable("fluid pressure").first_component_index]
+                [x.velocities[d]]
+                  = DoFTools::always;
+              }
+
+            coupling[introspection.variable("fluid pressure").first_component_index]
             [introspection.variable("fluid pressure").first_component_index]
               = DoFTools::always;
-            coupling[introspection.variable("fluid pressure").first_component_index]
-            [x.velocities[d]]
+            coupling[introspection.variable("compaction pressure").first_component_index]
+            [introspection.variable("compaction pressure").first_component_index]
               = DoFTools::always;
           }
-
-        coupling[introspection.variable("fluid pressure").first_component_index]
-        [introspection.variable("fluid pressure").first_component_index]
-          = DoFTools::always;
-        coupling[introspection.variable("compaction pressure").first_component_index]
-        [introspection.variable("compaction pressure").first_component_index]
-          = DoFTools::always;
-      }
-    else
-      {
-        // The AMG matrix based solver: all velocities couple with all velocities,
-        // pressure couples with all velocities and the other way around,
-        // and pressures only couple with themselves for equal order elements
-        for (unsigned int c=0; c<dim; ++c)
-          for (unsigned int d=0; d<dim; ++d)
-            coupling[x.velocities[c]][x.velocities[d]] = DoFTools::always;
-
-        for (unsigned int d=0; d<dim; ++d)
+        else
           {
-            coupling[x.velocities[d]][x.pressure] = DoFTools::always;
-            coupling[x.pressure][x.velocities[d]] = DoFTools::always;
-          }
+            // The AMG matrix based solver: all velocities couple with all velocities,
+            // pressure couples with all velocities and the other way around,
+            // and pressures only couple with themselves for equal order elements
+            for (unsigned int c=0; c<dim; ++c)
+              for (unsigned int d=0; d<dim; ++d)
+                coupling[x.velocities[c]][x.velocities[d]] = DoFTools::always;
 
-        // For equal-order interpolation, we need a stabilization term
-        // in the bottom right of Stokes matrix. Make sure we have the
-        // necessary entries.
-        if (parameters.use_equal_order_interpolation_for_stokes == true)
-          coupling[x.pressure][x.pressure] = DoFTools::always;
+            for (unsigned int d=0; d<dim; ++d)
+              {
+                coupling[x.velocities[d]][x.pressure] = DoFTools::always;
+                coupling[x.pressure][x.velocities[d]] = DoFTools::always;
+              }
+
+            // For equal-order interpolation, we need a stabilization term
+            // in the bottom right of Stokes matrix. Make sure we have the
+            // necessary entries.
+            if (parameters.use_equal_order_interpolation_for_stokes == true)
+              coupling[x.pressure][x.pressure] = DoFTools::always;
+          }
       }
 
     // Only enable temperature coupling if temperature block is needed
@@ -1131,8 +1145,11 @@ namespace aspect
     Mp_preconditioner.reset ();
     system_preconditioner_matrix.clear ();
 
-    // The preconditioner matrix is only used for the Stokes block (velocity and Schur complement) and only needed if we actually solve iteratively and matrix-based
-    if (parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::block_gmg)
+    // The preconditioner matrix is only used for the Stokes block (velocity and Schur complement)
+    // and only needed if we actually solve iteratively and matrix-based
+    if (solver_scheme_solves_stokes_equations(parameters) == false)
+      return;
+    else if (parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::block_gmg)
       return;
     else if (parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::block_amg)
       {
@@ -1150,9 +1167,19 @@ namespace aspect
     const typename Introspection<dim>::ComponentIndices &x
       = introspection.component_indices;
 
-    // velocity-velocity block (only block diagonal):
-    for (unsigned int d=0; d<dim; ++d)
-      coupling[x.velocities[d]][x.velocities[d]] = DoFTools::always;
+    // velocity-velocity block (only block diagonal) is only
+    // needed if we use the simplified A block preconditioner
+    if (parameters.mesh_deformation_enabled == false &&
+        parameters.include_melt_transport == false &&
+        parameters.use_full_A_block_preconditioner == false)
+      for (unsigned int d=0; d<dim; ++d)
+        coupling[x.velocities[d]][x.velocities[d]] = DoFTools::always;
+
+    // TODO: The newton handler always assembles the preconditioner matrix
+    // even if it is not used. Fix that by modifying the newton assemblers.
+    if (newton_handler.get() != nullptr)
+      for (unsigned int d=0; d<dim; ++d)
+        coupling[x.velocities[d]][x.velocities[d]] = DoFTools::always;
 
     // Schur complement block (pressure - pressure):
     if (parameters.include_melt_transport)
@@ -1215,7 +1242,8 @@ namespace aspect
       const unsigned int block_idx = introspection.block_indices.temperature;
       // TODO: using clear() would be nice here but clear() also resets the
       // size, so just reinit():
-      sp.block(block_idx, block_idx).reinit(sp.block(block_idx, block_idx).locally_owned_range_indices(),sp.block(block_idx, block_idx).locally_owned_domain_indices());
+      sp.block(block_idx, block_idx).reinit(sp.block(block_idx, block_idx).locally_owned_range_indices(),
+                                            sp.block(block_idx, block_idx).locally_owned_domain_indices());
       sp.block(block_idx, block_idx).compress();
     }
     // compositions:
@@ -1224,7 +1252,8 @@ namespace aspect
         const unsigned int block_idx = introspection.block_indices.compositional_fields[c];
         // TODO: using clear() would be nice here but clear() also resets the
         // size, so just reinit():
-        sp.block(block_idx, block_idx).reinit(sp.block(block_idx, block_idx).locally_owned_range_indices(),sp.block(block_idx, block_idx).locally_owned_domain_indices());
+        sp.block(block_idx, block_idx).reinit(sp.block(block_idx, block_idx).locally_owned_range_indices(),
+                                              sp.block(block_idx, block_idx).locally_owned_domain_indices());
         sp.block(block_idx, block_idx).compress();
       }
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -351,6 +351,10 @@ namespace aspect
     // Initialize the mesh deformation handler
     if (parameters.mesh_deformation_enabled)
       {
+        // Models with deformed boundaries require
+        // the full A block to converge consistently
+        parameters.use_full_A_block_preconditioner = true;
+
         // Allocate the MeshDeformationHandler object
         mesh_deformation = std_cxx14::make_unique<MeshDeformation::MeshDeformationHandler<dim>>(*this);
         mesh_deformation->initialize_simulator(*this);
@@ -360,6 +364,10 @@ namespace aspect
     // Initialize the melt handler
     if (parameters.include_melt_transport)
       {
+        // Models with melt transport require
+        // the full A block to converge consistently
+        parameters.use_full_A_block_preconditioner = true;
+
         melt_handler->initialize_simulator (*this);
         melt_handler->initialize();
       }
@@ -1169,9 +1177,7 @@ namespace aspect
 
     // velocity-velocity block (only block diagonal) is only
     // needed if we use the simplified A block preconditioner
-    if (parameters.mesh_deformation_enabled == false &&
-        parameters.include_melt_transport == false &&
-        parameters.use_full_A_block_preconditioner == false)
+    if (parameters.use_full_A_block_preconditioner == false)
       for (unsigned int d=0; d<dim; ++d)
         coupling[x.velocities[d]][x.velocities[d]] = DoFTools::always;
 

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -232,8 +232,6 @@ namespace aspect
 
               if (is_velocity_or_pressures(introspection,p_c_component_index,p_f_component_index,component_index_i))
                 {
-                  scratch.grads_phi_u[i_stokes] = scratch.finite_element_values[introspection.extractors.velocities].symmetric_gradient(i,q);
-                  scratch.div_phi_u[i_stokes]   = scratch.finite_element_values[introspection.extractors.velocities].divergence (i, q);
                   scratch.phi_p[i_stokes]       = scratch.finite_element_values[ex_p_f].value (i, q);
                   scratch.phi_p_c[i_stokes]     = scratch.finite_element_values[ex_p_c].value (i, q);
                   scratch.grad_phi_p[i_stokes]  = scratch.finite_element_values[ex_p_f].gradient (i, q);
@@ -244,7 +242,6 @@ namespace aspect
 
           const double eta = scratch.material_model_outputs.viscosities[q];
           const double one_over_eta = 1. / eta;
-          const double eta_two_thirds = scratch.material_model_outputs.viscosities[q] * 2.0 / 3.0;
           const double K_D = this->get_melt_handler().limited_darcy_coefficient(melt_outputs->permeabilities[q] / melt_outputs->fluid_viscosities[q],
                                                                                 p_c_scale > 0);
 
@@ -259,11 +256,7 @@ namespace aspect
             for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
               {
                 if (scratch.dof_component_indices[i] == scratch.dof_component_indices[j])
-                  data.local_matrix(i,j) += (2.0 * eta * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j])
-                                             -
-                                             eta_two_thirds * (scratch.div_phi_u[i] * scratch.div_phi_u[j])
-                                             +
-                                             (one_over_eta *
+                  data.local_matrix(i,j) += ((one_over_eta *
                                               pressure_scaling *
                                               pressure_scaling)
                                              * scratch.phi_p[i] * scratch.phi_p[j]


### PR DESCRIPTION
This is a follow up to #3404, which makes similar improvements to the coupling of the preconditioner matrix. It turns out we allocate the A block of the preconditioner matrix even if we use the system matrix for the preconditioner in the end.  Additionally, we also assemble the preconditioner A block for free surface models and for melt models, even though we use the system matrix block for the preconditioner. This PR should save some memory and some time in the assembly for all melt and free surface models.