### PR TITLE
Unify screen output of fluid velocity with other systems

### DIFF
--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1277,8 +1277,14 @@ namespace aspect
       SolverControl solver_control(5*rhs.size(), 1e-8*rhs.block(block_idx).l2_norm());
       SolverCG<LinearAlgebra::Vector> cg(solver_control);
 
-      cg.solve (matrix.block(block_idx, block_idx), distributed_solution.block(block_idx), rhs.block(block_idx), preconditioner);
-      this->get_pcout() << "   Solving for u_f in " << solver_control.last_step() <<" iterations."<< std::endl;
+      this->get_pcout() << "   Solving fluid velocity system... " << std::flush;
+
+      cg.solve (matrix.block(block_idx, block_idx),
+                distributed_solution.block(block_idx),
+                rhs.block(block_idx),
+                preconditioner);
+
+      this->get_pcout() << solver_control.last_step() <<" iterations."<< std::endl;
 
       this->get_current_constraints().distribute (distributed_solution);
       solution.block(block_idx) = distributed_solution.block(block_idx);

--- a/tests/adiabatic_heating_with_melt/screen-output
+++ b/tests/adiabatic_heating_with_melt/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 58+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.88515e-16, 2.66112e-18, 0, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
@@ -17,7 +17,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.88515e-16, 2.66112e-18, 0, 4.42521e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 4.42521e-13
 
@@ -32,7 +32,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.71715e-06, 1.30016e-16, 0, 6.15473e-09
       Relative nonlinear residual (total system) after nonlinear iteration 1: 2.71715e-06
 
@@ -47,7 +47,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.95782e-06, 1.77717e-16, 0, 5.5658e-09
       Relative nonlinear residual (total system) after nonlinear iteration 1: 2.95782e-06
 
@@ -62,7 +62,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.16332e-08, 2.48667e-16, 0, 1.39165e-09
       Relative nonlinear residual (total system) after nonlinear iteration 1: 6.16332e-08
 

--- a/tests/advect_field_with_melt_velocity/screen-output
+++ b/tests/advect_field_with_melt_velocity/screen-output
@@ -11,7 +11,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.90385e-17, 2.38127e-16, 1.13416e-16, 1.13416e-16, 0.02614
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.02614
 
@@ -21,7 +21,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.90385e-17, 2.38127e-16, 1.13416e-16, 1.13416e-16, 5.77883e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.77883e-09
 
@@ -37,7 +37,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 17 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.91257e-15, 1.59226e-13, 0.0442513, 0.159394, 5.77883e-09
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.159394
 
@@ -47,7 +47,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.91257e-15, 1.59226e-13, 1.80773e-14, 9.49632e-13, 5.77883e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.77883e-09
 
@@ -63,7 +63,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 19 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.91647e-15, 1.06273e-13, 0.0154324, 0.0604684, 5.77883e-09
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0604684
 
@@ -73,7 +73,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.91647e-15, 1.06273e-13, 5.48776e-13, 8.11903e-13, 5.77883e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.77883e-09
 
@@ -89,7 +89,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 19 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.91647e-15, 1.06273e-13, 0.0104717, 0.0620668, 5.77883e-09
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0620668
 
@@ -99,7 +99,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.91647e-15, 1.06273e-13, 5.94512e-13, 7.33857e-13, 5.77883e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.77883e-09
 
@@ -115,7 +115,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 18 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.91647e-15, 1.06273e-13, 0.00494652, 0.0492745, 5.77883e-09
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0492745
 
@@ -125,7 +125,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.91647e-15, 1.06273e-13, 1.1418e-13, 9.55347e-13, 5.77883e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.77883e-09
 
@@ -141,7 +141,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 19 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.91647e-15, 1.06273e-13, 0.00277529, 0.0382927, 5.77883e-09
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0382927
 
@@ -151,7 +151,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.91647e-15, 1.06273e-13, 9.49488e-14, 2.08777e-13, 5.77883e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.77883e-09
 
@@ -167,7 +167,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 19 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.91647e-15, 1.06273e-13, 0.00159055, 0.0352807, 5.77883e-09
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0352807
 
@@ -177,7 +177,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.91647e-15, 1.06273e-13, 7.85963e-13, 3.33898e-13, 5.77883e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.77883e-09
 
@@ -193,7 +193,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.87802e-15, 4.96435e-14, 0.000415237, 0.00896686, 5.77883e-09
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00896686
 
@@ -203,7 +203,7 @@ Number of degrees of freedom: 39,050 (8,450+4,161+8,450+1,089+4,225+4,225+4,225+
    Solving melt_composition system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.87802e-15, 4.96435e-14, 5.10734e-13, 5.84423e-13, 5.77883e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.77883e-09
 

--- a/tests/average_density_boundary_fluid_pressure/screen-output
+++ b/tests/average_density_boundary_fluid_pressure/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 38+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.61474e-16, 1.5319e-16, 0, 0.000956596
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000956596
 
@@ -24,7 +24,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.61474e-16, 1.5319e-16, 0, 9.23112e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.23112e-09
 
@@ -43,7 +43,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000416768, 0.00426217, 0, 9.66278e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00426217
 
@@ -59,7 +59,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.94064e-08, 3.80197e-05, 0, 9.61903e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 3.80197e-05
 
@@ -75,7 +75,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.90172e-13, 8.06466e-15, 0, 9.61903e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 9.61903e-09
 

--- a/tests/compaction_length_refinement/screen-output
+++ b/tests/compaction_length_refinement/screen-output
@@ -8,9 +8,9 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.07834e-16, 1.65108e-16, 0, 3.72351e-14
-      Relative nonlinear residual (total system) after nonlinear iteration 1: 3.72351e-14
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.03229e-16, 1.44912e-16, 0, 3.62353e-14
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 3.62353e-14
 
 
 Number of active cells: 1,117 (on 7 levels)
@@ -22,9 +22,9 @@ Number of degrees of freedom: 39,086 (9,510+4,576+9,510+1,225+4,755+4,755+4,755)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 13 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.26524e-16, 1.78403e-16, 0, 3.0894e-14
-      Relative nonlinear residual (total system) after nonlinear iteration 1: 3.0894e-14
+   Solving fluid velocity system... 13 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.87132e-16, 1.54953e-16, 0, 2.96248e-14
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.96248e-14
 
 
 Number of active cells: 1,696 (on 8 levels)
@@ -36,9 +36,9 @@ Number of degrees of freedom: 59,307 (14,434+6,938+14,434+1,850+7,217+7,217+7,21
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 13 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.30335e-16, 1.19317e-16, 0, 2.70908e-14
-      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.70908e-14
+   Solving fluid velocity system... 13 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.87134e-16, 1.28759e-16, 0, 2.72556e-14
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.72556e-14
 
 
 Number of active cells: 2,023 (on 9 levels)
@@ -50,9 +50,9 @@ Number of degrees of freedom: 70,864 (17,250+8,279+17,250+2,210+8,625+8,625+8,62
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.32399e-16, 1.18962e-16, 0, 2.71343e-14
-      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.71343e-14
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.87863e-16, 1.28421e-16, 0, 2.73022e-14
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.73022e-14
 
 
 Number of active cells: 2,026 (on 9 levels)
@@ -64,9 +64,9 @@ Number of degrees of freedom: 70,956 (17,272+8,291+17,272+2,213+8,636+8,636+8,63
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 13 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.30336e-16, 1.19316e-16, 0, 2.70908e-14
-      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.70908e-14
+   Solving fluid velocity system... 13 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.87125e-16, 1.28759e-16, 0, 2.72557e-14
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.72557e-14
 
 
 Number of active cells: 2,023 (on 9 levels)
@@ -78,9 +78,9 @@ Number of degrees of freedom: 70,864 (17,250+8,279+17,250+2,210+8,625+8,625+8,62
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.32399e-16, 1.18962e-16, 0, 2.71343e-14
-      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.71343e-14
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.87863e-16, 1.28421e-16, 0, 2.73022e-14
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.73022e-14
 
 
    Postprocessing:

--- a/tests/compaction_length_visualization/screen-output
+++ b/tests/compaction_length_visualization/screen-output
@@ -1,5 +1,3 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 
 Number of active cells: 1,024 (on 6 levels)
 Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
@@ -10,7 +8,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.03229e-16, 1.44912e-16, 0, 3.62353e-14
       Relative nonlinear residual (total system) after nonlinear iteration 1: 3.62353e-14
 
@@ -24,7 +22,7 @@ Number of degrees of freedom: 39,086 (9,510+4,576+9,510+1,225+4,755+4,755+4,755)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.87132e-16, 1.54953e-16, 0, 2.96248e-14
       Relative nonlinear residual (total system) after nonlinear iteration 1: 2.96248e-14
 
@@ -38,7 +36,7 @@ Number of degrees of freedom: 59,307 (14,434+6,938+14,434+1,850+7,217+7,217+7,21
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.87134e-16, 1.28759e-16, 0, 2.72556e-14
       Relative nonlinear residual (total system) after nonlinear iteration 1: 2.72556e-14
 
@@ -52,7 +50,7 @@ Number of degrees of freedom: 70,864 (17,250+8,279+17,250+2,210+8,625+8,625+8,62
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.87863e-16, 1.28421e-16, 0, 2.73022e-14
       Relative nonlinear residual (total system) after nonlinear iteration 1: 2.73022e-14
 
@@ -66,7 +64,7 @@ Number of degrees of freedom: 70,956 (17,272+8,291+17,272+2,213+8,636+8,636+8,63
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.87125e-16, 1.28759e-16, 0, 2.72557e-14
       Relative nonlinear residual (total system) after nonlinear iteration 1: 2.72557e-14
 
@@ -80,7 +78,7 @@ Number of degrees of freedom: 70,864 (17,250+8,279+17,250+2,210+8,625+8,625+8,62
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.87863e-16, 1.28421e-16, 0, 2.73022e-14
       Relative nonlinear residual (total system) after nonlinear iteration 1: 2.73022e-14
 

--- a/tests/composition_active_with_melt/screen-output
+++ b/tests/composition_active_with_melt/screen-output
@@ -10,7 +10,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5 K, 1 K
@@ -22,7 +22,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5019 K, 1 K
@@ -34,7 +34,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5034 K, 1 K
@@ -46,7 +46,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5046 K, 1 K
@@ -58,7 +58,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5055 K, 1 K
@@ -70,7 +70,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5064 K, 1 K
@@ -82,7 +82,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5072 K, 1 K
@@ -94,7 +94,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5079 K, 1 K
@@ -106,7 +106,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5089 K, 1 K
@@ -118,7 +118,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5096 K, 1 K
@@ -130,7 +130,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5103 K, 1 K
@@ -142,7 +142,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5108 K, 1 K
@@ -154,7 +154,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5117 K, 1 K
@@ -166,7 +166,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5123 K, 1 K
@@ -178,7 +178,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.513 K, 1 K
@@ -190,7 +190,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5136 K, 1 K
@@ -202,7 +202,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5143 K, 1 K
@@ -214,7 +214,7 @@ Number of degrees of freedom: 1,850 (578+162+578+81+289+81+81)
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Temperature min/avg/max:   0 K, 0.5143 K, 1 K

--- a/tests/compression_heating/screen-output
+++ b/tests/compression_heating/screen-output
@@ -10,7 +10,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 83+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.12714e-16, 9.37333e-17, 0, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
@@ -19,7 +19,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.12714e-16, 9.37333e-17, 0, 1.34401e-12
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.34401e-12
 
@@ -35,7 +35,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 78+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000132792, 0.0833311, 0, 6.75635
       Relative nonlinear residual (total system) after nonlinear iteration 1: 6.75635
 
@@ -44,7 +44,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 40+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.02376e-06, 4.51302e-08, 0, 2.69929e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 4.02376e-06
 
@@ -60,7 +60,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 76+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.14114e-06, 0.000641121, 0, 1.99687
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.99687
 
@@ -69,7 +69,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 37+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.56703e-08, 1.56755e-08, 0, 5.52921e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.52921e-07
 

--- a/tests/free_surface_blob_melt/screen-output
+++ b/tests/free_surface_blob_melt/screen-output
@@ -11,7 +11,7 @@ Number of mesh deformation degrees of freedom: 1394
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+18 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
 Number of active cells: 664 (on 5 levels)
 Number of degrees of freedom: 20,360 (5,634+2,725+5,634+733+2,817+2,817)
@@ -23,7 +23,7 @@ Number of mesh deformation degrees of freedom: 1466
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+18 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
 
    Postprocessing:
      Topography min/max: 0 m, 0 m
@@ -35,7 +35,7 @@ Number of mesh deformation degrees of freedom: 1466
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+16 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
 
    Postprocessing:
      Topography min/max: -393.7 m, 876.7 m
@@ -47,7 +47,7 @@ Number of mesh deformation degrees of freedom: 1466
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+15 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
    Postprocessing:
      Topography min/max: -2260 m, 1102 m
@@ -59,7 +59,7 @@ Number of mesh deformation degrees of freedom: 1466
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+15 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
 
    Postprocessing:
      Topography min/max: -474.1 m, 223.3 m
@@ -71,7 +71,7 @@ Number of mesh deformation degrees of freedom: 1466
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+15 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
 
    Postprocessing:
      Topography min/max: -338.3 m, 713.2 m
@@ -83,7 +83,7 @@ Number of mesh deformation degrees of freedom: 1466
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+15 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
    Postprocessing:
      Topography min/max: -2422 m, 1241 m
@@ -101,7 +101,7 @@ Number of mesh deformation degrees of freedom: 1466
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+15 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
    Postprocessing:
      Topography min/max: -582.3 m, 293.6 m
@@ -113,7 +113,7 @@ Number of mesh deformation degrees of freedom: 1466
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+15 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
 
    Postprocessing:
      Topography min/max: -376.4 m, 744.4 m
@@ -125,7 +125,7 @@ Number of mesh deformation degrees of freedom: 1466
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+15 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
    Postprocessing:
      Topography min/max: -2390 m, 1289 m
@@ -137,7 +137,7 @@ Number of mesh deformation degrees of freedom: 1466
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+15 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
    Postprocessing:
      Topography min/max: -440.8 m, 233.4 m
@@ -149,7 +149,7 @@ Number of mesh deformation degrees of freedom: 1466
    Skipping porosity composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+15 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
 
    Postprocessing:
      Topography min/max: -385.6 m, 737.1 m

--- a/tests/free_surface_blob_nonzero_melt/screen-output
+++ b/tests/free_surface_blob_nonzero_melt/screen-output
@@ -11,7 +11,7 @@ Number of mesh deformation degrees of freedom: 1394
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+20 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
 Number of active cells: 760 (on 5 levels)
 Number of degrees of freedom: 23,646 (6,550+3,138+6,550+858+3,275+3,275)
@@ -23,7 +23,7 @@ Number of mesh deformation degrees of freedom: 1716
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+19 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
 Number of active cells: 1,360 (on 6 levels)
 Number of degrees of freedom: 42,688 (11,842+5,621+11,842+1,541+5,921+5,921)
@@ -35,7 +35,7 @@ Number of mesh deformation degrees of freedom: 3082
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+19 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
 
    Postprocessing:
      Topography min/max:        0 m, 0 m
@@ -49,7 +49,7 @@ Number of mesh deformation degrees of freedom: 3082
    Solving porosity system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+16 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
 
    Postprocessing:
      Topography min/max:        -124.8 m, 135 m
@@ -63,7 +63,7 @@ Number of mesh deformation degrees of freedom: 3082
    Solving porosity system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+15 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
 
    Postprocessing:
      Topography min/max:        -186.8 m, 203.6 m

--- a/tests/global_melt/screen-output
+++ b/tests/global_melt/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.99932e-16, 0, 0, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
@@ -17,7 +17,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.17188e-16, 0, 0, 0.799766
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.799766
 
@@ -26,7 +26,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.32692e-16, 0, 0, 0.173272
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.173272
 
@@ -35,7 +35,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.31357e-16, 0, 0, 0.0272016
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0272016
 
@@ -44,7 +44,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+10 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.14372e-16, 0, 0, 0.0032544
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.0032544
 
@@ -53,7 +53,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.29571e-16, 0, 0, 0.000312907
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000312907
 
@@ -62,7 +62,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.21066e-16, 0, 0, 2.51035e-05
       Relative nonlinear residual (total system) after nonlinear iteration 7: 2.51035e-05
 
@@ -71,7 +71,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.19363e-16, 0, 0, 1.72283e-06
       Relative nonlinear residual (total system) after nonlinear iteration 8: 1.72283e-06
 
@@ -89,7 +89,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000648657, 0, 0, 0.015132
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.015132
 
@@ -98,7 +98,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.4501e-05, 0, 0, 0.000648601
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000648601
 
@@ -107,7 +107,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.6166e-07, 0, 0, 7.47973e-05
       Relative nonlinear residual (total system) after nonlinear iteration 3: 7.47973e-05
 
@@ -116,7 +116,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.40363e-08, 0, 0, 1.69973e-05
       Relative nonlinear residual (total system) after nonlinear iteration 4: 1.69973e-05
 
@@ -125,7 +125,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.30546e-10, 0, 0, 2.55045e-06
       Relative nonlinear residual (total system) after nonlinear iteration 5: 2.55045e-06
 
@@ -143,7 +143,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.13564e-05, 0, 0, 0.00164661
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00164661
 
@@ -152,7 +152,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.75403e-06, 0, 0, 0.000135196
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000135196
 
@@ -161,7 +161,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.45253e-08, 0, 0, 2.99917e-05
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.99917e-05
 
@@ -170,7 +170,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.88654e-10, 0, 0, 4.81851e-06
       Relative nonlinear residual (total system) after nonlinear iteration 4: 4.81851e-06
 
@@ -188,7 +188,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.22597e-05, 0, 0, 0.000534279
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000534279
 
@@ -197,7 +197,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.95725e-07, 0, 0, 4.29583e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 4.29583e-05
 
@@ -206,7 +206,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.77406e-09, 0, 0, 9.82748e-06
       Relative nonlinear residual (total system) after nonlinear iteration 3: 9.82748e-06
 

--- a/tests/global_melt_parallel/screen-output
+++ b/tests/global_melt_parallel/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+13 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.05691e-16, 0, 0, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
@@ -17,7 +17,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+13 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.13182e-16, 0, 0, 0.799766
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.799766
 
@@ -26,7 +26,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+12 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.17525e-16, 0, 0, 0.173272
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.173272
 
@@ -35,7 +35,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+12 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.24402e-16, 0, 0, 0.0272016
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0272016
 
@@ -44,7 +44,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.13025e-16, 0, 0, 0.0032544
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.0032544
 
@@ -53,7 +53,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+8 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.30934e-16, 0, 0, 0.000312907
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000312907
 
@@ -62,7 +62,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.19706e-16, 0, 0, 2.51035e-05
       Relative nonlinear residual (total system) after nonlinear iteration 7: 2.51035e-05
 
@@ -71,7 +71,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.18778e-16, 0, 0, 1.72283e-06
       Relative nonlinear residual (total system) after nonlinear iteration 8: 1.72283e-06
 
@@ -89,7 +89,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000648657, 0, 0, 0.015132
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.015132
 
@@ -98,7 +98,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.4501e-05, 0, 0, 0.000648601
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000648601
 
@@ -107,7 +107,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.6166e-07, 0, 0, 7.47967e-05
       Relative nonlinear residual (total system) after nonlinear iteration 3: 7.47967e-05
 
@@ -116,7 +116,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.40355e-08, 0, 0, 1.69977e-05
       Relative nonlinear residual (total system) after nonlinear iteration 4: 1.69977e-05
 
@@ -125,7 +125,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.30782e-10, 0, 0, 2.55063e-06
       Relative nonlinear residual (total system) after nonlinear iteration 5: 2.55063e-06
 
@@ -143,7 +143,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.13564e-05, 0, 0, 0.00164661
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00164661
 
@@ -152,7 +152,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.75403e-06, 0, 0, 0.000135196
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000135196
 
@@ -161,7 +161,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.45253e-08, 0, 0, 2.99917e-05
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.99917e-05
 
@@ -170,7 +170,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.88675e-10, 0, 0, 4.81851e-06
       Relative nonlinear residual (total system) after nonlinear iteration 4: 4.81851e-06
 
@@ -188,7 +188,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.22597e-05, 0, 0, 0.000534279
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000534279
 
@@ -197,7 +197,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.95725e-07, 0, 0, 4.29583e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 4.29583e-05
 
@@ -206,7 +206,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.77401e-09, 0, 0, 9.82748e-06
       Relative nonlinear residual (total system) after nonlinear iteration 3: 9.82748e-06
 

--- a/tests/heat_advection_by_melt/screen-output
+++ b/tests/heat_advection_by_melt/screen-output
@@ -10,7 +10,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 36+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.67942e-16, 1.44551e-16, 0, 0.0526341
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0526341
 
@@ -19,7 +19,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.67942e-16, 1.44551e-16, 0, 9.76814e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.76814e-13
 
@@ -35,7 +35,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00075425, 1.23918e-15, 0, 9.76817e-13
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00075425
 
@@ -44,7 +44,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.68618e-13, 1.23918e-15, 0, 9.76817e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.76817e-13
 
@@ -60,7 +60,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000380678, 8.09815e-16, 0, 9.76817e-13
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000380678
 
@@ -69,7 +69,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.25536e-13, 8.09815e-16, 0, 9.76817e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.76817e-13
 
@@ -85,7 +85,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000154136, 8.09815e-16, 0, 9.76817e-13
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000154136
 
@@ -94,7 +94,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.26977e-13, 8.09815e-16, 0, 9.76817e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.76817e-13
 
@@ -110,7 +110,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.55833e-05, 2.60191e-16, 0, 9.7684e-13
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.55833e-05
 
@@ -119,7 +119,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.35653e-13, 2.60191e-16, 0, 9.7684e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.7684e-13
 

--- a/tests/heat_advection_by_melt_operator_splitting/screen-output
+++ b/tests/heat_advection_by_melt_operator_splitting/screen-output
@@ -10,7 +10,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 36+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.67942e-16, 1.44551e-16, 0, 0.0526341
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0526341
 
@@ -19,7 +19,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.67942e-16, 1.44551e-16, 0, 9.76814e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.76814e-13
 
@@ -36,7 +36,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00075425, 1.23918e-15, 0, 9.76817e-13
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00075425
 
@@ -45,7 +45,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.68618e-13, 1.23918e-15, 0, 9.76817e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.76817e-13
 
@@ -62,7 +62,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000380678, 8.09815e-16, 0, 9.76817e-13
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000380678
 
@@ -71,7 +71,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.25536e-13, 8.09815e-16, 0, 9.76817e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.76817e-13
 
@@ -88,7 +88,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000154136, 8.09815e-16, 0, 9.76817e-13
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000154136
 
@@ -97,7 +97,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.26977e-13, 8.09815e-16, 0, 9.76817e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.76817e-13
 
@@ -114,7 +114,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.55833e-05, 2.60191e-16, 0, 9.7684e-13
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.55833e-05
 
@@ -123,7 +123,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.35653e-13, 2.60191e-16, 0, 9.7684e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.7684e-13
 

--- a/tests/initial_porosity/screen-output
+++ b/tests/initial_porosity/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+36 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.93441e-16, 4.47907e-17, 0, 0.956793
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.956793
 
@@ -17,7 +17,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+36 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.14876e-16, 4.47907e-17, 0, 0.752886
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.752886
 
@@ -26,7 +26,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+34 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.1985e-16, 4.47907e-17, 0, 0.16311
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.16311
 
@@ -35,7 +35,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+31 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.21643e-16, 4.47907e-17, 0, 0.025768
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.025768
 
@@ -44,7 +44,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+29 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.11959e-16, 4.47907e-17, 0, 0.00311419
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.00311419
 
@@ -53,7 +53,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+25 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.17867e-16, 4.47907e-17, 0, 0.000303301
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000303301
 
@@ -62,7 +62,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+21 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.23017e-16, 4.47907e-17, 0, 2.46783e-05
       Relative nonlinear residual (total system) after nonlinear iteration 7: 2.46783e-05
 
@@ -71,7 +71,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+18 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.21988e-16, 4.47907e-17, 0, 1.71533e-06
       Relative nonlinear residual (total system) after nonlinear iteration 8: 1.71533e-06
 

--- a/tests/latent_heat_melt_transport/screen-output
+++ b/tests/latent_heat_melt_transport/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.38892e-16, 1.32493e-16, 1.50284e-16, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
@@ -17,7 +17,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.38892e-16, 1.32493e-16, 1.50284e-16, 8.60698e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 8.60698e-09
 
@@ -33,7 +33,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 13 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0203372, 0.208323, 0.34263, 3.83415e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.34263
 
@@ -42,7 +42,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.65897e-05, 0.00393758, 0.00327657, 4.12685e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00393758
 
@@ -51,7 +51,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.25466e-06, 9.48993e-05, 7.18688e-05, 9.10481e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 9.48993e-05
 
@@ -60,7 +60,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.52035e-12, 3.46556e-13, 2.06196e-13, 9.10481e-08
       Relative nonlinear residual (total system) after nonlinear iteration 4: 9.10481e-08
 
@@ -76,7 +76,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 12 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0134521, 0.0514912, 0.119514, 3.56785e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.119514
 
@@ -85,7 +85,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.00993e-05, 0.00195136, 0.00114018, 2.06538e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00195136
 
@@ -94,7 +94,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.944e-07, 3.11746e-05, 1.59699e-05, 1.39122e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 3.11746e-05
 
@@ -103,7 +103,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.08045e-12, 5.52719e-13, 9.49749e-13, 1.39122e-08
       Relative nonlinear residual (total system) after nonlinear iteration 4: 1.39122e-08
 
@@ -119,7 +119,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0110013, 0.0333073, 0.0805242, 4.91982e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0805242
 
@@ -128,7 +128,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.90839e-06, 0.000238651, 8.04162e-05, 2.28287e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000238651
 
@@ -137,7 +137,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.54575e-11, 1.84118e-13, 2.16076e-13, 2.28287e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.28287e-08
 
@@ -153,7 +153,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0105935, 0.0266904, 0.0347868, 5.04544e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0347868
 
@@ -162,7 +162,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.72329e-06, 0.000176435, 4.64466e-05, 1.51909e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000176435
 
@@ -171,7 +171,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.1294e-11, 1.29228e-13, 1.05638e-13, 1.51909e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.51909e-08
 
@@ -187,7 +187,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0111638, 0.019492, 0.0216321, 5.66948e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0216321
 
@@ -196,7 +196,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.25597e-06, 6.17494e-05, 1.38252e-05, 6.75861e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 6.17494e-05
 
@@ -205,7 +205,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.28673e-12, 2.16674e-13, 9.02759e-13, 6.75861e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 6.75861e-09
 
@@ -221,7 +221,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00989994, 0.00838076, 0.0224123, 3.74239e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0224123
 
@@ -230,7 +230,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.5296e-06, 0.000155981, 2.15529e-05, 7.29146e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000155981
 
@@ -239,7 +239,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.02612e-11, 1.40937e-13, 3.4674e-13, 7.29146e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 7.29146e-08
 
@@ -255,7 +255,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00939319, 0.00518338, 0.0202002, 6.23745e-07
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0202002
 
@@ -264,7 +264,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.44959e-05, 0.000149199, 4.40379e-05, 6.6554e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000149199
 
@@ -273,7 +273,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.404e-11, 1.8351e-13, 3.60902e-13, 6.6554e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 6.6554e-08
 
@@ -289,7 +289,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00816877, 0.00377133, 0.0172868, 7.85858e-07
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0172868
 
@@ -298,7 +298,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.00102e-06, 4.87897e-05, 2.04617e-05, 8.48819e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 4.87897e-05
 
@@ -307,7 +307,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.6851e-12, 5.98507e-13, 2.97702e-13, 8.48819e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 8.48819e-08
 
@@ -323,7 +323,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00664663, 0.000594045, 0.0150639, 2.91438e-07
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0150639
 
@@ -332,7 +332,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.49828e-05, 0.000102654, 6.33317e-05, 1.75077e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000102654
 
@@ -341,7 +341,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.09789e-12, 1.41307e-13, 1.61045e-13, 1.75077e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.75077e-08
 
@@ -357,7 +357,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0054996, 0.000244808, 0.0110773, 1.11052e-07
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0110773
 
@@ -366,7 +366,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.29481e-07, 1.88039e-05, 2.43462e-06, 9.58123e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.88039e-05
 
@@ -375,7 +375,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.31946e-12, 9.41679e-13, 7.33402e-13, 9.58123e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 9.58123e-08
 
@@ -391,7 +391,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00485511, 0.00187417, 0.00958299, 2.25669e-07
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00958299
 
@@ -400,7 +400,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.79973e-06, 4.08301e-05, 2.90984e-05, 5.40346e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 4.08301e-05
 
@@ -409,7 +409,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.09623e-12, 2.67524e-13, 5.63981e-13, 5.40346e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 5.40346e-09
 
@@ -425,7 +425,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00456928, 0.00330508, 0.009799, 5.19908e-07
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.009799
 
@@ -434,7 +434,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.09639e-06, 2.32237e-05, 1.78941e-05, 1.71974e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 2.32237e-05
 
@@ -443,7 +443,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.08195e-12, 1.87002e-13, 6.56441e-13, 1.71974e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.71974e-08
 
@@ -459,7 +459,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00407565, 0.00275376, 0.00656867, 2.39806e-07
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00656867
 
@@ -468,7 +468,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.85164e-06, 4.3387e-05, 2.11094e-05, 9.26902e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 4.3387e-05
 
@@ -477,7 +477,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.12016e-12, 5.58693e-13, 8.92568e-13, 9.26902e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 9.26902e-09
 
@@ -493,7 +493,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0033689, 0.000985317, 0.0050702, 3.82421e-07
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0050702
 
@@ -502,7 +502,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.7317e-06, 2.31856e-05, 1.64667e-05, 3.62525e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 2.31856e-05
 
@@ -511,7 +511,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.323e-12, 1.62083e-13, 8.37474e-13, 3.62525e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 3.62525e-08
 
@@ -527,7 +527,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00254504, 0.00138892, 0.00421194, 3.11778e-07
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00421194
 
@@ -536,7 +536,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.7554e-06, 2.46733e-05, 1.20988e-05, 5.66521e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 2.46733e-05
 
@@ -545,7 +545,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.49698e-13, 4.13345e-13, 5.97363e-13, 5.66521e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 5.66521e-09
 
@@ -561,7 +561,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000534043, 0.00292253, 0.00272007, 4.80968e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00292253
 
@@ -570,7 +570,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.35673e-06, 0.000102647, 1.38696e-05, 2.33941e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000102647
 
@@ -579,7 +579,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.79619e-12, 2.32636e-13, 2.54049e-13, 2.33941e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.33941e-08
 

--- a/tests/mass_reaction_term/screen-output
+++ b/tests/mass_reaction_term/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.48283e-16, 1.81237e-16, 1.83096e-16, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
@@ -17,7 +17,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.48283e-16, 1.81237e-16, 1.83096e-16, 1.07096e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.07096e-08
 
@@ -33,7 +33,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 19 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.17688e-16, 0.0996107, 0.149673, 0.163961
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.163961
 
@@ -42,7 +42,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.56189e-16, 0.0026523, 0.00236675, 0.406371
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.406371
 
@@ -51,7 +51,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.41715e-16, 2.43467e-11, 2.41832e-12, 2.50532e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.50532e-08
 
@@ -67,7 +67,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 16 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.25545e-16, 0.0301596, 0.0411334, 16.8349
       Relative nonlinear residual (total system) after nonlinear iteration 1: 16.8349
 
@@ -76,7 +76,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.19158e-16, 0.00217039, 0.00142437, 0.188481
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.188481
 
@@ -85,7 +85,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.14629e-16, 3.89299e-11, 2.65009e-11, 3.19e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 3.19e-08
 
@@ -101,7 +101,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.41853e-16, 0.0201219, 0.0357757, 10.0833
       Relative nonlinear residual (total system) after nonlinear iteration 1: 10.0833
 
@@ -110,7 +110,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 13 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.30102e-16, 0.000523044, 0.000121786, 0.0250177
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0250177
 
@@ -119,7 +119,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.29847e-16, 5.65648e-12, 7.72477e-13, 7.72283e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 7.72283e-09
 
@@ -135,7 +135,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.20718e-16, 0.0150812, 0.0222882, 2.54766
       Relative nonlinear residual (total system) after nonlinear iteration 1: 2.54766
 
@@ -144,7 +144,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 12 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.19239e-16, 0.000245468, 5.52473e-05, 0.0145358
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0145358
 
@@ -153,7 +153,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.28001e-16, 3.09251e-12, 6.8111e-13, 4.12187e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 4.12187e-08
 
@@ -169,7 +169,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.48683e-16, 0.0117259, 0.016307, 1.03774
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.03774
 
@@ -178,7 +178,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 12 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.12321e-16, 0.00022912, 4.59453e-05, 0.013438
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.013438
 
@@ -187,7 +187,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.12343e-16, 9.73633e-13, 2.30937e-13, 2.02088e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.02088e-09
 
@@ -203,7 +203,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.32648e-16, 0.00832064, 0.0139823, 0.58392
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.58392
 
@@ -212,7 +212,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 12 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.26571e-16, 0.000183135, 3.46841e-05, 0.0096182
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0096182
 
@@ -221,7 +221,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.31404e-16, 1.4444e-12, 3.07175e-13, 3.04544e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 3.04544e-09
 
@@ -237,7 +237,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.0527e-16, 0.00578231, 0.0128412, 0.390795
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.390795
 
@@ -246,7 +246,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 12 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.8173e-16, 0.000159073, 2.84344e-05, 0.00862387
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00862387
 
@@ -255,7 +255,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.94235e-16, 1.12296e-12, 3.33065e-13, 2.52446e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.52446e-09
 
@@ -271,7 +271,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.24767e-16, 0.00435581, 0.0108818, 0.309202
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.309202
 
@@ -280,7 +280,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 12 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.37459e-16, 0.000127629, 2.1756e-05, 0.00711993
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00711993
 
@@ -289,7 +289,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.29995e-16, 3.82251e-11, 1.16584e-11, 9.64634e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 9.64634e-08
 
@@ -305,7 +305,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.73914e-16, 0.00317972, 0.00911436, 0.22306
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.22306
 
@@ -314,7 +314,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 12 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.06767e-16, 0.000105713, 1.66219e-05, 0.00576988
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00576988
 
@@ -323,7 +323,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.53289e-16, 3.34278e-11, 1.03375e-11, 9.00862e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 9.00862e-08
 
@@ -339,7 +339,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.88486e-16, 0.00232488, 0.00831233, 0.145971
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.145971
 
@@ -348,7 +348,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 12 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.30139e-16, 8.33835e-05, 1.38648e-05, 0.00426249
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00426249
 
@@ -357,7 +357,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.71884e-16, 2.80766e-11, 8.36489e-12, 6.9307e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 6.9307e-08
 
@@ -373,7 +373,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.6708e-16, 0.00176424, 0.00739522, 0.098531
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.098531
 
@@ -382,7 +382,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.46679e-16, 6.38945e-05, 1.16853e-05, 0.00288522
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00288522
 
@@ -391,7 +391,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.61138e-16, 2.2995e-11, 6.21112e-12, 6.01073e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 6.01073e-08
 
@@ -407,7 +407,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.31056e-16, 0.00132785, 0.00673073, 0.0640016
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0640016
 
@@ -416,7 +416,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.76071e-16, 4.96169e-05, 9.70939e-06, 0.00187171
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00187171
 
@@ -425,7 +425,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.02654e-16, 1.87428e-11, 4.4024e-12, 5.3992e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 5.3992e-08
 
@@ -441,7 +441,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.03948e-16, 0.000996119, 0.00635311, 0.0390773
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0390773
 
@@ -450,7 +450,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.10714e-16, 3.88521e-05, 8.16719e-06, 0.00118884
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00118884
 
@@ -459,7 +459,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.20989e-16, 1.00393e-11, 2.17738e-12, 2.97694e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.97694e-08
 
@@ -475,7 +475,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.44824e-16, 0.000764009, 0.00598129, 0.0227771
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0227771
 
@@ -484,7 +484,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.33781e-16, 3.02213e-05, 6.78024e-06, 0.000737844
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000737844
 
@@ -493,7 +493,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.14057e-16, 1.26091e-11, 2.01658e-12, 4.95291e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 4.95291e-08
 
@@ -509,7 +509,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.79986e-16, 0.000580113, 0.0056495, 0.0127611
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0127611
 
@@ -518,7 +518,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.22025e-16, 2.36829e-05, 5.49578e-06, 0.000474592
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000474592
 
@@ -527,7 +527,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.95722e-16, 1.02206e-11, 1.81875e-12, 2.94464e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.94464e-08
 
@@ -543,7 +543,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.24553e-16, 0.000444026, 0.00541079, 0.00736583
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00736583
 
@@ -552,7 +552,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.23828e-16, 1.84339e-05, 4.37118e-06, 0.000326273
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000326273
 
@@ -561,7 +561,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.02325e-16, 1.08462e-11, 1.437e-12, 1.54892e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.54892e-08
 
@@ -577,7 +577,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.60681e-16, 0.000339563, 0.00516859, 0.00385043
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00516859
 
@@ -586,7 +586,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.99217e-16, 1.43352e-05, 3.40597e-06, 0.000236191
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000236191
 
@@ -595,7 +595,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.6998e-16, 7.82503e-12, 2.56394e-12, 1.86307e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.86307e-08
 
@@ -611,7 +611,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.17267e-16, 0.000259273, 0.00498781, 0.00209768
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00498781
 
@@ -620,7 +620,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.90365e-16, 1.10857e-05, 2.62675e-06, 0.000175462
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000175462
 
@@ -629,7 +629,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.91566e-16, 5.78074e-12, 2.04016e-12, 5.85334e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 5.85334e-08
 
@@ -645,7 +645,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.03147e-16, 0.000198806, 0.0048207, 0.00181288
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0048207
 
@@ -654,7 +654,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.84877e-16, 8.54843e-06, 2.02515e-06, 0.000131262
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000131262
 
@@ -663,7 +663,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.80624e-16, 4.4096e-12, 1.74382e-12, 1.01991e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.01991e-08
 
@@ -679,7 +679,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.75307e-16, 0.00015287, 0.00464623, 0.00147793
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00464623
 
@@ -688,7 +688,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.91902e-16, 6.57979e-06, 1.56753e-06, 9.78288e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.78288e-05
 
@@ -697,7 +697,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.09183e-16, 3.69071e-12, 1.63772e-12, 7.93307e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 7.93307e-09
 
@@ -713,7 +713,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.71941e-16, 0.000117446, 0.00454426, 0.00124904
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00454426
 
@@ -722,7 +722,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.64818e-16, 5.0608e-06, 1.22226e-06, 7.3334e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 7.3334e-05
 
@@ -731,7 +731,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.13912e-16, 2.84496e-12, 1.27146e-12, 6.29987e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 6.29987e-09
 
@@ -747,7 +747,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.62171e-16, 9.03844e-05, 0.00440809, 0.00104231
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00440809
 
@@ -756,7 +756,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.04354e-16, 3.88937e-06, 9.55467e-07, 5.60306e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.60306e-05
 
@@ -765,7 +765,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.77593e-16, 2.46856e-12, 1.38742e-12, 4.95587e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 4.95587e-09
 
@@ -781,7 +781,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.74313e-16, 6.96462e-05, 0.00428453, 0.000792811
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00428453
 
@@ -790,7 +790,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.37079e-16, 2.98911e-06, 7.48848e-07, 4.35566e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 4.35566e-05
 
@@ -799,7 +799,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.79506e-16, 2.07797e-12, 1.19835e-12, 4.1625e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 4.1625e-09
 
@@ -815,7 +815,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.24507e-16, 5.3627e-05, 0.00420589, 0.00059309
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00420589
 
@@ -824,7 +824,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.69955e-16, 2.29745e-06, 5.88546e-07, 3.41116e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 3.41116e-05
 
@@ -833,7 +833,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.9877e-16, 1.57552e-12, 9.29389e-13, 1.28039e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.28039e-08
 
@@ -849,7 +849,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.30775e-16, 4.13675e-05, 0.00409722, 0.000465228
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00409722
 
@@ -858,7 +858,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.07447e-16, 1.77383e-06, 4.63181e-07, 2.67782e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 2.67782e-05
 
@@ -867,7 +867,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.40464e-16, 8.89641e-13, 5.17748e-13, 1.66804e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.66804e-09
 
@@ -883,7 +883,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.4038e-16, 3.19469e-05, 0.00400852, 0.000380036
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00400852
 
@@ -892,7 +892,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.43799e-16, 1.36039e-06, 3.63753e-07, 2.09174e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 2.09174e-05
 
@@ -901,7 +901,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.36476e-16, 1.01677e-12, 1.06873e-12, 4.71403e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 4.71403e-08
 
@@ -917,7 +917,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.68647e-16, 2.4668e-05, 0.00394262, 0.000314532
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00394262
 
@@ -926,7 +926,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.57583e-16, 1.04891e-06, 2.86659e-07, 1.63995e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.63995e-05
 
@@ -935,7 +935,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.62448e-16, 8.09631e-13, 8.12355e-13, 1.52296e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.52296e-09
 
@@ -951,7 +951,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.80904e-16, 1.90572e-05, 0.00385631, 0.00025831
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00385631
 
@@ -960,7 +960,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.87441e-16, 8.09414e-07, 2.2531e-07, 1.28772e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.28772e-05
 
@@ -969,7 +969,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.09914e-16, 1.10469e-12, 6.51432e-13, 1.19328e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.19328e-09
 
@@ -985,7 +985,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.99372e-16, 1.47368e-05, 0.00379002, 0.000201166
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00379002
 
@@ -994,7 +994,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.17906e-16, 6.46844e-07, 1.7702e-07, 1.01687e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.01687e-05
 
@@ -1003,7 +1003,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.95082e-16, 1.12114e-12, 4.63216e-13, 9.25392e-10
       Relative nonlinear residual (total system) after nonlinear iteration 3: 9.25392e-10
 
@@ -1019,7 +1019,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.31986e-16, 1.13938e-05, 0.00372597, 0.000150696
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00372597
 
@@ -1028,7 +1028,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.39357e-16, 4.8229e-07, 1.37763e-07, 7.99189e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 7.99189e-06
 
@@ -1044,7 +1044,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.53305e-16, 8.81485e-06, 0.00365249, 0.000111064
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00365249
 
@@ -1053,7 +1053,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.40899e-16, 3.72834e-07, 1.08636e-07, 6.38445e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 6.38445e-06
 
@@ -1069,7 +1069,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.50163e-16, 6.82363e-06, 0.00360515, 7.86659e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00360515
 
@@ -1078,7 +1078,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.25032e-16, 2.8825e-07, 8.53146e-08, 5.07097e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.07097e-06
 
@@ -1094,7 +1094,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.94156e-16, 5.28177e-06, 0.00354047, 5.60701e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00354047
 
@@ -1103,7 +1103,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.56117e-16, 2.22924e-07, 6.67836e-08, 4.00656e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 4.00656e-06
 
@@ -1119,7 +1119,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.85368e-16, 4.08964e-06, 0.00348683, 4.27952e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00348683
 
@@ -1128,7 +1128,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.16868e-16, 1.72385e-07, 5.22099e-08, 3.14549e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 3.14549e-06
 
@@ -1144,7 +1144,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.85919e-16, 3.16817e-06, 0.00344032, 3.40864e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00344032
 
@@ -1153,7 +1153,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.79278e-16, 1.33203e-07, 4.07958e-08, 2.45225e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 2.45225e-06
 
@@ -1169,7 +1169,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.44293e-16, 2.45414e-06, 0.00338071, 2.77237e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00338071
 
@@ -1178,7 +1178,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.76593e-16, 1.02763e-07, 3.18636e-08, 1.90235e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.90235e-06
 
@@ -1194,7 +1194,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.15285e-16, 1.90169e-06, 0.00334131, 2.25583e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00334131
 
@@ -1203,7 +1203,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.58708e-16, 7.90604e-08, 2.4857e-08, 1.47386e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.47386e-06
 
@@ -1219,7 +1219,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.27276e-16, 1.47509e-06, 0.00329232, 1.80736e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00329232
 
@@ -1228,7 +1228,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.14862e-16, 6.06614e-08, 1.9332e-08, 1.14096e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.14096e-06
 
@@ -1244,7 +1244,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.05039e-16, 1.14615e-06, 0.00324603, 1.42687e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00324603
 
@@ -1253,7 +1253,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.17027e-16, 4.65661e-08, 1.49733e-08, 8.81224e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 8.81224e-07
 
@@ -1269,7 +1269,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.26983e-16, 8.92716e-07, 0.00320668, 1.11597e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00320668
 
@@ -1278,7 +1278,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.55877e-16, 3.59363e-08, 1.15408e-08, 6.77946e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 6.77946e-07
 
@@ -1294,7 +1294,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.18802e-16, 6.96635e-07, 0.00315701, 8.68292e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00315701
 
@@ -1303,7 +1303,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.0448e-16, 2.78792e-08, 8.85437e-09, 5.19365e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.19365e-07
 
@@ -1319,7 +1319,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.72149e-16, 5.43619e-07, 0.00311236, 6.73513e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00311236
 
@@ -1328,7 +1328,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.48368e-16, 2.14996e-08, 6.77683e-09, 3.96965e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 3.96965e-07
 
@@ -1344,7 +1344,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.81729e-16, 4.23462e-07, 0.00305894, 5.22537e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00305894
 
@@ -1353,7 +1353,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.50167e-16, 1.61696e-08, 5.19541e-09, 3.04094e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 3.04094e-07
 
@@ -1369,7 +1369,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.05741e-16, 3.29618e-07, 0.00299457, 4.06063e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00299457
 
@@ -1378,7 +1378,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.43827e-16, 1.17061e-08, 4.01653e-09, 2.35135e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 2.35135e-07
 
@@ -1394,7 +1394,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.69695e-16, 2.57535e-07, 0.00292312, 3.15413e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00292312
 
@@ -1403,7 +1403,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.34618e-16, 8.27351e-09, 3.15592e-09, 1.85305e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.85305e-07
 
@@ -1419,7 +1419,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.77403e-16, 2.02751e-07, 0.00283707, 2.44843e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00283707
 
@@ -1428,7 +1428,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.79194e-16, 6.0411e-09, 2.53615e-09, 1.63218e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.63218e-07
 
@@ -1444,7 +1444,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 15 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.85409e-16, 1.60521e-07, 0.00274225, 1.95328e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00274225
 
@@ -1453,7 +1453,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.90957e-16, 4.78553e-09, 2.1024e-09, 1.24974e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.24974e-07
 
@@ -1469,7 +1469,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.86237e-16, 1.2683e-07, 0.00265046, 1.4575e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00265046
 
@@ -1478,7 +1478,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.56229e-16, 3.8928e-09, 1.75951e-09, 1.05744e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.05744e-07
 
@@ -1494,7 +1494,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.60992e-16, 9.93047e-08, 0.0025789, 1.17006e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0025789
 
@@ -1503,7 +1503,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.85992e-16, 3.03309e-09, 1.50678e-09, 9.16031e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.16031e-08
 
@@ -1519,7 +1519,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.98131e-16, 7.70887e-08, 0.00254093, 1.06358e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00254093
 
@@ -1528,7 +1528,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.05777e-16, 2.21337e-09, 1.28532e-09, 7.88588e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 7.88588e-08
 
@@ -1544,7 +1544,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.89249e-16, 0.000156145, 0.000330127, 0.00571627
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00571627
 
@@ -1553,7 +1553,7 @@ Number of degrees of freedom: 1,985 (486+202+486+82+243+243+243)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.39666e-16, 8.15757e-10, 6.28257e-10, 4.09903e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 4.09903e-08
 

--- a/tests/melt_and_traction/screen-output
+++ b/tests/melt_and_traction/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 36+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.79208e-16, 2.00937e-16, 0, 0.000973208
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000973208
 
@@ -24,7 +24,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.79208e-16, 2.00937e-16, 0, 6.59645e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 6.59645e-09
 
@@ -43,7 +43,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000516901, 0.0138592, 0, 1.95544e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0138592
 
@@ -59,7 +59,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.92755e-08, 0.000115648, 0, 2.69089e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000115648
 
@@ -75,7 +75,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.65896e-10, 2.67033e-07, 0, 5.89889e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.67033e-07
 
@@ -91,7 +91,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.17697e-13, 1.13644e-13, 0, 5.89889e-09
       Relative nonlinear residual (total system) after nonlinear iteration 4: 5.89889e-09
 

--- a/tests/melt_compressible_advection/screen-output
+++ b/tests/melt_compressible_advection/screen-output
@@ -8,28 +8,28 @@ Number of degrees of freedom: 30,600 (12,611+8,450+1,089+4,225+4,225)
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.69836e-16, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.69836e-16, 0.387919
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.387919
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.69836e-16, 0.000266113
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000266113
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.69836e-16, 4.02116e-05
       Relative nonlinear residual (total system) after nonlinear iteration 4: 4.02116e-05
 
@@ -44,7 +44,7 @@ Number of degrees of freedom: 30,600 (12,611+8,450+1,089+4,225+4,225)
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 11 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.43573e-05, 4.22066e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 4.22066e-05
 
@@ -59,7 +59,7 @@ Number of degrees of freedom: 30,600 (12,611+8,450+1,089+4,225+4,225)
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 7 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.26864e-06, 4.65234e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 4.65234e-05
 

--- a/tests/melt_force_vector/screen-output
+++ b/tests/melt_force_vector/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 2,088 (851+578+81+289+289)
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Writing graphical output:                        output-melt_force_vector/solution/solution-00000
@@ -24,7 +24,7 @@ Number of degrees of freedom: 7,880 (3,235+2,178+289+1,089+1,089)
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
 
    Postprocessing:
      Writing graphical output:                        output-melt_force_vector/solution/solution-00001

--- a/tests/melt_introspection/screen-output
+++ b/tests/melt_introspection/screen-output
@@ -21,7 +21,7 @@ Number of degrees of freedom: 305 (50+21+50+9+25+100+25+25)
    Skipping B composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
 
    Postprocessing:
      Writing graphical output: output-melt_introspection/solution/solution-00000

--- a/tests/melt_material_1/screen-output
+++ b/tests/melt_material_1/screen-output
@@ -9,7 +9,7 @@ Number of degrees of freedom: 34,825 (12,611+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
    Postprocessing:
      Compositions min/max/mass: 0/0.3/3.749e+10 // 0/0.3/3.008e+10
@@ -19,7 +19,7 @@ Number of degrees of freedom: 34,825 (12,611+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 14 iterations.
    Solving porosity system ... 16 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
    Postprocessing:
      Compositions min/max/mass: -0.01951/0.3202/3.749e+10 // -0.01226/0.3131/3.008e+10
@@ -29,7 +29,7 @@ Number of degrees of freedom: 34,825 (12,611+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 18 iterations.
    Solving porosity system ... 18 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
    Postprocessing:
      Compositions min/max/mass: -0.01595/0.3168/3.749e+10 // -0.01207/0.3149/3.008e+10
@@ -39,7 +39,7 @@ Number of degrees of freedom: 34,825 (12,611+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 18 iterations.
    Solving porosity system ... 18 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
    Postprocessing:
      Compositions min/max/mass: -0.0118/0.3185/3.749e+10 // -0.007651/0.3185/3.008e+10
@@ -49,7 +49,7 @@ Number of degrees of freedom: 34,825 (12,611+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 18 iterations.
    Solving porosity system ... 18 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
    Postprocessing:
      Compositions min/max/mass: -0.01282/0.3167/3.749e+10 // -0.005148/0.3196/3.008e+10
@@ -59,7 +59,7 @@ Number of degrees of freedom: 34,825 (12,611+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 8 iterations.
    Solving porosity system ... 8 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
    Postprocessing:
      Compositions min/max/mass: -0.01272/0.3166/3.749e+10 // -0.005091/0.3194/3.008e+10

--- a/tests/melt_material_2/screen-output
+++ b/tests/melt_material_2/screen-output
@@ -8,11 +8,11 @@ Number of degrees of freedom: 30,600 (12,611+8,450+1,089+4,225+4,225)
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
 
    Postprocessing:
      RMS, max velocity:                               0.224 m/s, 0.496 m/s
-     Pressure min/avg/max:                            -2 Pa, -1 Pa, -5.291e-13 Pa
+     Pressure min/avg/max:                            -2 Pa, -1 Pa, -4.913e-13 Pa
      Max, min, and rms velocity along boundary parts: 0.4965 m/s, 6.202e-06 m/s, 0.2236 m/s, 0.4965 m/s, 6.202e-06 m/s, 0.2236 m/s, 0 m/s, 0 m/s, 0 m/s, 0.5 m/s, 0.5 m/s, 0.5 m/s
 
 Termination requested by criterion: end time

--- a/tests/melt_material_3/screen-output
+++ b/tests/melt_material_3/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 30,600 (12,611+8,450+1,089+4,225+4,225)
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
 
    Postprocessing:
      RMS, max velocity:                               0.224 m/s, 0.496 m/s

--- a/tests/melt_material_4/screen-output
+++ b/tests/melt_material_4/screen-output
@@ -8,23 +8,23 @@ Number of degrees of freedom: 30,600 (12,611+8,450+1,089+4,225+4,225)
    Solving temperature system... 3 iterations.
    Solving porosity system ... 3 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 10 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.9277e-16, 1.87568e-16, 1
+   Solving fluid velocity system... 10 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.91934e-16, 1.86051e-16, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 3 iterations.
    Solving porosity system ... 3 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 10 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.51232e-16, 1.37441e-16, 5.57132e-16
-      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.57132e-16
+   Solving fluid velocity system... 10 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.43009e-16, 1.17993e-16, 5.29819e-16
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.29819e-16
 
 
    Postprocessing:
      RMS, max velocity:                               0.236 m/s, 0.497 m/s
      Pressure min/avg/max:                            -1000 Pa, -277.5 Pa, -0.1001 Pa
      Max, min, and rms velocity along boundary parts: 0.4968 m/s, 0.005322 m/s, 0.2357 m/s, 0.4968 m/s, 0.005322 m/s, 0.2357 m/s, 0.005 m/s, 0.005 m/s, 0.005 m/s, 0.5 m/s, 0.5 m/s, 0.5 m/s
-     Errors u_L2, p_f_L2, porosity_L2:                2.773404e-07, 7.711126e-08, 2.928076e-05
+     Errors u_L2, p_f_L2, porosity_L2:                2.773404e-07, 7.711127e-08, 2.928076e-05
 
 Termination requested by criterion: end time
 

--- a/tests/melt_property_visualization/screen-output
+++ b/tests/melt_property_visualization/screen-output
@@ -8,8 +8,8 @@ Number of degrees of freedom: 30,600 (12,611+8,450+1,089+4,225+4,225)
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 11 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.06347e-16, 1
+   Solving fluid velocity system... 11 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.57339e-16, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
 

--- a/tests/melt_restart/log.txt1
+++ b/tests/melt_restart/log.txt1
@@ -8,7 +8,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.99932e-16, 0, 0, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
@@ -17,7 +17,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.17188e-16, 0, 0, 0.799766
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.799766
 
@@ -26,7 +26,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.32692e-16, 0, 0, 0.173272
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.173272
 
@@ -35,7 +35,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.31357e-16, 0, 0, 0.0272016
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0272016
 
@@ -44,7 +44,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+10 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.14372e-16, 0, 0, 0.0032544
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.0032544
 
@@ -53,7 +53,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.29571e-16, 0, 0, 0.000312907
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000312907
 
@@ -62,7 +62,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.21066e-16, 0, 0, 2.51035e-05
       Relative nonlinear residual (total system) after nonlinear iteration 7: 2.51035e-05
 
@@ -71,7 +71,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.19363e-16, 0, 0, 1.72283e-06
       Relative nonlinear residual (total system) after nonlinear iteration 8: 1.72283e-06
 
@@ -91,7 +91,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.49544e-07, 0, 0, 7.74054e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 7.74054e-06
 

--- a/tests/melt_restart/log.txt2
+++ b/tests/melt_restart/log.txt2
@@ -10,7 +10,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.74726e-05, 0, 0, 0.0156598
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0156598
 
@@ -19,7 +19,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+7 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.68974e-07, 0, 0, 0.000739673
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000739673
 
@@ -28,7 +28,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.27678e-07, 0, 0, 2.76332e-05
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.76332e-05
 
@@ -37,7 +37,7 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.13936e-09, 0, 0, 4.89116e-06
       Relative nonlinear residual (total system) after nonlinear iteration 4: 4.89116e-06
 

--- a/tests/melt_track/screen-output
+++ b/tests/melt_track/screen-output
@@ -1,11 +1,7 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 
 Loading shared library <./libmelt_track.so>
 
 Initialize solitary wave solution
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 Number of active cells: 640 (on 3 levels)
 Number of degrees of freedom: 20,864 (5,778+2,725+5,778+805+2,889+2,889)
 
@@ -14,7 +10,7 @@ Number of degrees of freedom: 20,864 (5,778+2,725+5,778+805+2,889+2,889)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Solving for u_f in 9 iterations.
+   Solving fluid velocity system... 9 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.57727e-16, 0.999743
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.999743
 
@@ -22,7 +18,7 @@ Number of degrees of freedom: 20,864 (5,778+2,725+5,778+805+2,889+2,889)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 9 iterations.
+   Solving fluid velocity system... 9 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.57727e-16, 9.36476e-11
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.36476e-11
 
@@ -41,5 +37,3 @@ Termination requested by criterion: end time
 +---------------------------------+-----------+------------+------------+
 +---------------------------------+-----------+------------+------------+
 
------------------------------------------------------------------------------
------------------------------------------------------------------------------

--- a/tests/melt_transport/screen-output
+++ b/tests/melt_transport/screen-output
@@ -7,7 +7,7 @@ Number of degrees of freedom: 28,553 (12,611+8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... done.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
    Postprocessing:
      Compositions min/max/mass: 0/0.3/3.739e+10 // 0/0/0
@@ -19,7 +19,7 @@ Number of degrees of freedom: 28,553 (12,611+8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 5 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... done.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
    Postprocessing:
      Compositions min/max/mass: -0.01666/0.3185/3.739e+10 // 0/0/0
@@ -31,7 +31,7 @@ Number of degrees of freedom: 28,553 (12,611+8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 4 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... done.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
    Postprocessing:
      Compositions min/max/mass: -0.0243/0.3287/3.739e+10 // 0/0/0
@@ -43,7 +43,7 @@ Number of degrees of freedom: 28,553 (12,611+8,450+1,089+4,225+1,089+1,089)
    Solving peridotite system ... 4 iterations.
    Skipping porosity composition solve because RHS is zero.
    Solving Stokes system... done.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
 
    Postprocessing:
      Compositions min/max/mass: -0.02113/0.3305/3.739e+10 // 0/0/0

--- a/tests/melt_transport_adaptive/screen-output
+++ b/tests/melt_transport_adaptive/screen-output
@@ -9,17 +9,17 @@ Number of degrees of freedom: 7,880 (2,178+1,057+2,178+289+1,089+1,089)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+21 iterations.
-   Solving for u_f in 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.0324e-16, 0.998954
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.9202e-16, 0.998954
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.998954
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.0324e-16, 3.09195e-13
-      Relative nonlinear residual (total system) after nonlinear iteration 2: 3.09195e-13
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.9202e-16, 3.09192e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 3.09192e-13
 
 
    Postprocessing:
@@ -36,17 +36,17 @@ Number of degrees of freedom: 9,971 (2,774+1,285+2,774+364+1,387+1,387)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+21 iterations.
-   Solving for u_f in 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.91226e-16, 0.998916
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.54822e-16, 0.998916
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.998916
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.91226e-16, 2.89826e-13
-      Relative nonlinear residual (total system) after nonlinear iteration 2: 2.89826e-13
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.54822e-16, 2.89854e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 2.89854e-13
 
 
    Postprocessing:
@@ -63,17 +63,17 @@ Number of degrees of freedom: 14,076 (3,906+1,851+3,906+507+1,953+1,953)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+21 iterations.
-   Solving for u_f in 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.07228e-16, 0.997716
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.63763e-16, 0.997716
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.997716
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.07228e-16, 2.60637e-13
-      Relative nonlinear residual (total system) after nonlinear iteration 2: 2.60637e-13
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.63763e-16, 2.60596e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 2.60596e-13
 
 
    Postprocessing:

--- a/tests/melt_transport_compressible/screen-output
+++ b/tests/melt_transport_compressible/screen-output
@@ -8,21 +8,21 @@ Number of degrees of freedom: 112,521 (41,732+33,282+4,225+16,641+16,641)
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.66767e-16, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.66767e-16, 0.0494135
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0494135
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.66767e-16, 7.32945e-06
       Relative nonlinear residual (total system) after nonlinear iteration 3: 7.32945e-06
 

--- a/tests/melt_transport_compressible_iterative/screen-output
+++ b/tests/melt_transport_compressible_iterative/screen-output
@@ -9,7 +9,7 @@ Number of degrees of freedom: 30,600 (8,450+4,161+8,450+1,089+4,225+4,225)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 61+0 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.57339e-16, 0.185585
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.185585
 
@@ -17,7 +17,7 @@ Number of degrees of freedom: 30,600 (8,450+4,161+8,450+1,089+4,225+4,225)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 53+0 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.57339e-16, 0.0177292
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0177292
 
@@ -25,7 +25,7 @@ Number of degrees of freedom: 30,600 (8,450+4,161+8,450+1,089+4,225+4,225)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 48+0 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.57339e-16, 0.00582084
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00582084
 
@@ -33,7 +33,7 @@ Number of degrees of freedom: 30,600 (8,450+4,161+8,450+1,089+4,225+4,225)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.57339e-16, 6.74483e-05
       Relative nonlinear residual (total system) after nonlinear iteration 4: 6.74483e-05
 
@@ -41,7 +41,7 @@ Number of degrees of freedom: 30,600 (8,450+4,161+8,450+1,089+4,225+4,225)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.57339e-16, 4.64638e-06
       Relative nonlinear residual (total system) after nonlinear iteration 5: 4.64638e-06
 

--- a/tests/melt_transport_convergence_simple/screen-output
+++ b/tests/melt_transport_convergence_simple/screen-output
@@ -9,24 +9,24 @@ Number of degrees of freedom: 30,600 (8,450+4,161+8,450+1,089+4,225+4,225)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+22 iterations.
-   Solving for u_f in 7 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.42904e-16, 1
+   Solving fluid velocity system... 7 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.38534e-16, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 7 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.42904e-16, 7.86706e-11
-      Relative nonlinear residual (total system) after nonlinear iteration 2: 7.86706e-11
+   Solving fluid velocity system... 7 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.38534e-16, 7.86809e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 7.86809e-11
 
 
    Postprocessing:
      RMS, max velocity:                                                  1.41 m/s, 1.41 m/s
      Pressure min/avg/max:                                               0.3686 Pa, 1.176 Pa, 2.718 Pa
      Max, min, and rms velocity along boundary parts:                    1.414 m/s, 1.414 m/s, 1.414 m/s, 1.414 m/s, 1.414 m/s, 1.414 m/s, 1.414 m/s, 1.414 m/s, 1.414 m/s, 1.414 m/s, 1.414 m/s, 1.414 m/s
-     Errors u_L2, p_L2, p_f_L2, p_c_bar_L2, p_c_L2, porosity_L2, u_f_L2: 1.026761e-04, 1.699041e-02, 1.709911e-02, 3.662042e-06, 8.694257e-05, 2.402420e-03, 4.347472e-03
+     Errors u_L2, p_L2, p_f_L2, p_c_bar_L2, p_c_L2, porosity_L2, u_f_L2: 1.026761e-04, 1.699048e-02, 1.709911e-02, 3.657377e-06, 8.694257e-05, 2.402420e-03, 4.347472e-03
 
 Termination requested by criterion: end time
 

--- a/tests/melt_transport_convergence_test/screen-output
+++ b/tests/melt_transport_convergence_test/screen-output
@@ -9,16 +9,16 @@ Number of degrees of freedom: 30,600 (8,450+4,161+8,450+1,089+4,225+4,225)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+15 iterations.
-   Solving for u_f in 11 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.6773e-16, 1
+   Solving fluid velocity system... 11 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.38714e-16, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 11 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.6773e-16, 5.16098e-07
+   Solving fluid velocity system... 11 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.38714e-16, 5.16098e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.16098e-07
 
 

--- a/tests/melt_velocity_boundary_conditions/screen-output
+++ b/tests/melt_velocity_boundary_conditions/screen-output
@@ -9,7 +9,7 @@ Number of degrees of freedom: 19,352 (5,346+2,617+5,346+697+2,673+2,673)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+10 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
 
    Postprocessing:
      Topography min/max:        0 m, 0 m

--- a/tests/melting_rate/screen-output
+++ b/tests/melting_rate/screen-output
@@ -9,7 +9,7 @@ Number of degrees of freedom: 17,673 (6,387+4,290+561+2,145+2,145+2,145)
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.63865e-16, 1.54902e-16, 1.54902e-16, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
@@ -17,7 +17,7 @@ Number of degrees of freedom: 17,673 (6,387+4,290+561+2,145+2,145+2,145)
    Solving porosity system ... 0 iterations.
    Solving peridotite system ... 0 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.63865e-16, 1.54902e-16, 1.54902e-16, 2.16566e-14
       Relative nonlinear residual (total system) after nonlinear iteration 2: 2.16566e-14
 
@@ -31,7 +31,7 @@ Number of degrees of freedom: 17,673 (6,387+4,290+561+2,145+2,145+2,145)
    Solving porosity system ... 9 iterations.
    Solving peridotite system ... 8 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.13515e-05, 0.00151313, 0.000407813, 0.0612804
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0612804
 
@@ -39,7 +39,7 @@ Number of degrees of freedom: 17,673 (6,387+4,290+561+2,145+2,145+2,145)
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 6 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.12497e-07, 5.76996e-05, 3.80818e-06, 0.00143009
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00143009
 
@@ -47,7 +47,7 @@ Number of degrees of freedom: 17,673 (6,387+4,290+561+2,145+2,145+2,145)
    Solving porosity system ... 5 iterations.
    Solving peridotite system ... 3 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.65011e-10, 1.51038e-07, 6.35396e-09, 1.86505e-06
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.86505e-06
 
@@ -61,7 +61,7 @@ Number of degrees of freedom: 17,673 (6,387+4,290+561+2,145+2,145+2,145)
    Solving porosity system ... 8 iterations.
    Solving peridotite system ... 8 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.24378e-07, 0.000341349, 0.000346458, 0.153238
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.153238
 
@@ -69,7 +69,7 @@ Number of degrees of freedom: 17,673 (6,387+4,290+561+2,145+2,145+2,145)
    Solving porosity system ... 7 iterations.
    Solving peridotite system ... 6 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.76771e-08, 3.64257e-05, 2.4875e-06, 0.00086587
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00086587
 
@@ -77,7 +77,7 @@ Number of degrees of freedom: 17,673 (6,387+4,290+561+2,145+2,145+2,145)
    Solving porosity system ... 4 iterations.
    Solving peridotite system ... 3 iterations.
    Solving Stokes system... done.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.84021e-11, 1.7431e-08, 7.18003e-10, 1.94732e-07
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.94732e-07
 

--- a/tests/melting_rate_operator_splitting/screen-output
+++ b/tests/melting_rate_operator_splitting/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 8,969 (2,178+1,057+2,178+289+1,089+1,089+1,089)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 0 iterations.
+   Solving fluid velocity system... 0 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.02829e-16, 0, 0, 0
       Relative nonlinear residual (total system) after nonlinear iteration 1: 2.02829e-16
 
@@ -25,7 +25,7 @@ Number of degrees of freedom: 8,969 (2,178+1,057+2,178+289+1,089+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 0 iterations.
+   Solving fluid velocity system... 0 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.39115e-16, 3.37689e-16, 3.37689e-16, 0
       Relative nonlinear residual (total system) after nonlinear iteration 1: 3.37689e-16
 
@@ -42,7 +42,7 @@ Number of degrees of freedom: 8,969 (2,178+1,057+2,178+289+1,089+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 0 iterations.
+   Solving fluid velocity system... 0 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.91338e-17, 1.05088e-16, 1.05088e-16, 0
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.05088e-16
 

--- a/tests/melting_rate_operator_splitting2/screen-output
+++ b/tests/melting_rate_operator_splitting2/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 8,969 (2,178+1,057+2,178+289+1,089+1,089+1,089)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 0 iterations.
+   Solving fluid velocity system... 0 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.95637e-16, 0, 0, 0
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.95637e-16
 
@@ -25,7 +25,7 @@ Number of degrees of freedom: 8,969 (2,178+1,057+2,178+289+1,089+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 0 iterations.
+   Solving fluid velocity system... 0 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.16753e-16, 7.61745e-17, 7.61745e-17, 0
       Relative nonlinear residual (total system) after nonlinear iteration 1: 2.16753e-16
 
@@ -42,7 +42,7 @@ Number of degrees of freedom: 8,969 (2,178+1,057+2,178+289+1,089+1,089+1,089)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 0 iterations.
+   Solving fluid velocity system... 0 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.1095e-16, 7.82073e-17, 7.82073e-17, 0
       Relative nonlinear residual (total system) after nonlinear iteration 1: 2.1095e-16
 

--- a/tests/mid_ocean_ridge/screen-output
+++ b/tests/mid_ocean_ridge/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 13,321 (3,234+1,577+3,234+425+1,617+1,617+1,617)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 44+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73839e-16, 0, 0, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
@@ -17,7 +17,7 @@ Number of degrees of freedom: 13,321 (3,234+1,577+3,234+425+1,617+1,617+1,617)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73839e-16, 0, 0, 8.7539e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 8.7539e-08
 
@@ -34,7 +34,7 @@ Number of degrees of freedom: 13,321 (3,234+1,577+3,234+425+1,617+1,617+1,617)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0206447, 0, 0, 0.000319384
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0206447
 
@@ -43,7 +43,7 @@ Number of degrees of freedom: 13,321 (3,234+1,577+3,234+425+1,617+1,617+1,617)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.58708e-05, 0, 0, 7.35391e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 4.58708e-05
 
@@ -52,7 +52,7 @@ Number of degrees of freedom: 13,321 (3,234+1,577+3,234+425+1,617+1,617+1,617)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.2291e-07, 0, 0, 6.71156e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.2291e-07
 

--- a/tests/no_dirichlet_on_outflow_melt/screen-output
+++ b/tests/no_dirichlet_on_outflow_melt/screen-output
@@ -10,7 +10,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.39226e-16, 2.35269e-16, 2.35269e-16, 0.207036
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.207036
 
@@ -19,7 +19,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.39226e-16, 2.35269e-16, 2.35269e-16, 5.71549e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.71549e-08
 
@@ -36,7 +36,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000117878, 0.303486, 0.0807578, 0.402384
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.402384
 
@@ -45,7 +45,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00552864, 0.172937, 0.0148272, 0.0895912
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.172937
 
@@ -54,7 +54,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.11034e-05, 0.0508953, 0.00264602, 0.0139785
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0508953
 
@@ -63,7 +63,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.10086e-05, 0.0293372, 0.00124731, 0.0142491
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0293372
 
@@ -72,7 +72,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.80781e-05, 0.0136652, 0.000399492, 0.00660097
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.0136652
 
@@ -81,7 +81,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.49173e-06, 0.00604589, 0.000153002, 0.00248428
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.00604589
 
@@ -90,7 +90,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.4097e-06, 0.00281616, 0.000100389, 0.00125119
       Relative nonlinear residual (total system) after nonlinear iteration 7: 0.00281616
 
@@ -99,7 +99,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.51436e-06, 0.0011265, 2.81308e-05, 0.000389437
       Relative nonlinear residual (total system) after nonlinear iteration 8: 0.0011265
 
@@ -108,7 +108,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.17253e-07, 0.00052028, 1.61601e-05, 0.000202848
       Relative nonlinear residual (total system) after nonlinear iteration 9: 0.00052028
 
@@ -117,7 +117,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.53599e-07, 0.000230804, 5.0632e-06, 8.23169e-05
       Relative nonlinear residual (total system) after nonlinear iteration 10: 0.000230804
 
@@ -126,7 +126,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.74388e-07, 0.000111891, 2.91291e-06, 4.41735e-05
       Relative nonlinear residual (total system) after nonlinear iteration 11: 0.000111891
 
@@ -135,7 +135,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.20617e-08, 5.17664e-05, 1.02099e-06, 1.96401e-05
       Relative nonlinear residual (total system) after nonlinear iteration 12: 5.17664e-05
 
@@ -144,7 +144,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.38843e-08, 2.49005e-05, 6.32653e-07, 1.02217e-05
       Relative nonlinear residual (total system) after nonlinear iteration 13: 2.49005e-05
 
@@ -153,7 +153,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.50271e-08, 1.11564e-05, 2.16974e-07, 4.21597e-06
       Relative nonlinear residual (total system) after nonlinear iteration 14: 1.11564e-05
 
@@ -162,7 +162,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.29833e-08, 5.16558e-06, 1.31991e-07, 2.11155e-06
       Relative nonlinear residual (total system) after nonlinear iteration 15: 5.16558e-06
 
@@ -179,7 +179,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00475364, 0.0625407, 0.0108374, 5.07349
       Relative nonlinear residual (total system) after nonlinear iteration 1: 5.07349
 
@@ -188,7 +188,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00225818, 0.044933, 0.00374051, 0.0263739
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.044933
 
@@ -197,7 +197,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.64974e-05, 0.00683009, 0.000292858, 0.00297071
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00683009
 
@@ -206,7 +206,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.35578e-06, 0.00148692, 5.60408e-05, 0.000825572
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00148692
 
@@ -215,7 +215,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.66872e-07, 0.000346778, 5.39242e-06, 0.000175989
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000346778
 
@@ -224,7 +224,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.40102e-07, 5.68304e-05, 1.78722e-06, 2.33912e-05
       Relative nonlinear residual (total system) after nonlinear iteration 6: 5.68304e-05
 
@@ -233,7 +233,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.32314e-08, 1.30055e-05, 4.54946e-07, 7.15154e-06
       Relative nonlinear residual (total system) after nonlinear iteration 7: 1.30055e-05
 
@@ -242,7 +242,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.43726e-09, 3.25817e-06, 6.22048e-08, 1.58757e-06
       Relative nonlinear residual (total system) after nonlinear iteration 8: 3.25817e-06
 
@@ -259,7 +259,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00323554, 0.0634532, 0.00520905, 0.741197
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.741197
 
@@ -268,7 +268,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00104414, 0.0307491, 0.00201387, 0.054847
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.054847
 
@@ -277,7 +277,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.59746e-06, 0.00756572, 0.000189526, 0.0108075
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0108075
 
@@ -286,7 +286,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.86041e-06, 0.00101442, 2.92969e-05, 0.00142753
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00142753
 
@@ -295,7 +295,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.43462e-07, 0.000120038, 3.5845e-06, 0.000169504
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000169504
 
@@ -304,7 +304,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.41634e-08, 2.3646e-05, 5.74909e-07, 3.0984e-05
       Relative nonlinear residual (total system) after nonlinear iteration 6: 3.0984e-05
 
@@ -313,7 +313,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.37304e-09, 3.49226e-06, 1.04694e-07, 4.93794e-06
       Relative nonlinear residual (total system) after nonlinear iteration 7: 4.93794e-06
 
@@ -330,7 +330,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00216098, 0.0632009, 0.00678657, 0.640349
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.640349
 
@@ -339,7 +339,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00559892, 0.0260933, 0.0010537, 0.0535904
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0535904
 
@@ -348,7 +348,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.94203e-05, 0.00706839, 0.000286879, 0.00977121
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00977121
 
@@ -357,7 +357,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.55503e-05, 0.00143081, 4.32536e-05, 0.00216565
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00216565
 
@@ -366,7 +366,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.41753e-06, 0.000266856, 2.90913e-06, 0.000391455
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000391455
 
@@ -375,7 +375,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.54913e-07, 3.9733e-05, 5.67464e-07, 6.05399e-05
       Relative nonlinear residual (total system) after nonlinear iteration 6: 6.05399e-05
 
@@ -384,7 +384,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.54224e-08, 5.56263e-06, 5.83778e-08, 6.61854e-06
       Relative nonlinear residual (total system) after nonlinear iteration 7: 6.61854e-06
 
@@ -401,7 +401,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0054401, 0.0630933, 0.00732867, 0.473346
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.473346
 
@@ -410,7 +410,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000232946, 0.0274505, 0.0011487, 0.0289724
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0289724
 
@@ -419,7 +419,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.57334e-06, 0.00203194, 6.25316e-05, 0.00216029
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00216029
 
@@ -428,7 +428,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.29631e-06, 0.000298342, 5.25447e-06, 0.000395414
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000395414
 
@@ -437,7 +437,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.06986e-07, 3.3211e-05, 9.75179e-07, 4.43705e-05
       Relative nonlinear residual (total system) after nonlinear iteration 5: 4.43705e-05
 
@@ -446,7 +446,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.59234e-08, 4.61749e-06, 8.81861e-08, 4.70163e-06
       Relative nonlinear residual (total system) after nonlinear iteration 6: 4.70163e-06
 
@@ -463,7 +463,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00286162, 0.050555, 0.00642737, 0.439664
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.439664
 
@@ -472,7 +472,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00063436, 0.0150613, 0.00176521, 0.0232385
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0232385
 
@@ -481,7 +481,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.00989e-05, 0.00266561, 0.000120117, 0.00298033
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00298033
 
@@ -490,7 +490,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.88803e-07, 0.000277892, 9.05286e-06, 0.000240313
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000277892
 
@@ -499,7 +499,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.46335e-08, 3.52731e-05, 9.81352e-07, 4.07215e-05
       Relative nonlinear residual (total system) after nonlinear iteration 5: 4.07215e-05
 
@@ -508,7 +508,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.05904e-09, 4.97119e-06, 2.27128e-07, 5.97208e-06
       Relative nonlinear residual (total system) after nonlinear iteration 6: 5.97208e-06
 
@@ -525,7 +525,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00125811, 0.0484743, 0.00570813, 0.463842
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.463842
 
@@ -534,7 +534,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00087541, 0.015811, 0.00208696, 0.0186096
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0186096
 
@@ -543,7 +543,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.99998e-06, 0.00348105, 0.000166047, 0.00324275
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00348105
 
@@ -552,7 +552,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.05372e-07, 0.000516703, 1.85934e-05, 0.000545152
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000545152
 
@@ -561,7 +561,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.27475e-08, 5.82481e-05, 1.41437e-06, 6.05323e-05
       Relative nonlinear residual (total system) after nonlinear iteration 5: 6.05323e-05
 
@@ -570,7 +570,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.07787e-09, 7.34238e-06, 3.65965e-07, 6.36561e-06
       Relative nonlinear residual (total system) after nonlinear iteration 6: 7.34238e-06
 
@@ -587,7 +587,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00138461, 0.0544532, 0.00630758, 0.445535
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.445535
 
@@ -596,7 +596,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0008373, 0.0152925, 0.00173726, 0.0156787
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0156787
 
@@ -605,7 +605,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.36606e-06, 0.00299976, 0.000156227, 0.00194039
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00299976
 
@@ -614,7 +614,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.40533e-07, 0.000545614, 2.38072e-05, 0.000442448
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000545614
 
@@ -623,7 +623,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.3812e-07, 8.55806e-05, 1.87892e-06, 8.77407e-05
       Relative nonlinear residual (total system) after nonlinear iteration 5: 8.77407e-05
 
@@ -632,7 +632,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.26437e-08, 1.18551e-05, 4.54393e-07, 1.02967e-05
       Relative nonlinear residual (total system) after nonlinear iteration 6: 1.18551e-05
 
@@ -641,7 +641,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.44968e-09, 1.63921e-06, 8.93843e-08, 9.55786e-07
       Relative nonlinear residual (total system) after nonlinear iteration 7: 1.63921e-06
 
@@ -658,7 +658,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00306239, 0.0635493, 0.00848503, 0.30635
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.30635
 
@@ -667,7 +667,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00661186, 0.0494553, 0.000567024, 0.0912064
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0912064
 
@@ -676,7 +676,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.94377e-05, 0.0123832, 0.000915525, 0.0132574
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0132574
 
@@ -685,7 +685,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.32843e-05, 0.00243488, 9.45377e-05, 0.00179255
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00243488
 
@@ -694,7 +694,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.32659e-06, 0.000698458, 3.95747e-05, 0.000509832
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000698458
 
@@ -703,7 +703,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.66556e-08, 0.000128917, 7.52179e-06, 8.8242e-05
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000128917
 
@@ -712,7 +712,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.96676e-08, 2.33847e-05, 4.59944e-07, 2.06141e-05
       Relative nonlinear residual (total system) after nonlinear iteration 7: 2.33847e-05
 
@@ -721,7 +721,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.4104e-08, 6.51447e-06, 3.45889e-07, 5.33593e-06
       Relative nonlinear residual (total system) after nonlinear iteration 8: 6.51447e-06
 
@@ -738,7 +738,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00589319, 0.0763036, 0.0110731, 0.210681
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.210681
 
@@ -747,7 +747,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00139605, 0.125704, 0.00551599, 0.0695673
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.125704
 
@@ -756,7 +756,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000491145, 0.0729724, 0.00561058, 0.055356
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0729724
 
@@ -765,7 +765,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000122612, 0.027569, 0.00207977, 0.0175601
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.027569
 
@@ -774,7 +774,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.74564e-05, 0.00844212, 0.000544358, 0.00469825
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.00844212
 
@@ -783,7 +783,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.02991e-06, 0.00286943, 8.40268e-05, 0.0009567
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.00286943
 
@@ -792,7 +792,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.95012e-06, 0.00101394, 4.87218e-05, 0.000640306
       Relative nonlinear residual (total system) after nonlinear iteration 7: 0.00101394
 
@@ -801,7 +801,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.02157e-06, 0.000384577, 2.78085e-05, 0.000286066
       Relative nonlinear residual (total system) after nonlinear iteration 8: 0.000384577
 
@@ -810,7 +810,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.28214e-07, 0.000133453, 1.00582e-05, 8.78523e-05
       Relative nonlinear residual (total system) after nonlinear iteration 9: 0.000133453
 
@@ -819,7 +819,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.54489e-08, 4.12093e-05, 2.38465e-06, 1.77105e-05
       Relative nonlinear residual (total system) after nonlinear iteration 10: 4.12093e-05
 
@@ -828,7 +828,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.35602e-08, 1.29503e-05, 3.21904e-07, 4.71233e-06
       Relative nonlinear residual (total system) after nonlinear iteration 11: 1.29503e-05
 
@@ -837,7 +837,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.39931e-08, 4.78385e-06, 2.38612e-07, 3.11808e-06
       Relative nonlinear residual (total system) after nonlinear iteration 12: 4.78385e-06
 
@@ -854,7 +854,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00362462, 0.154671, 0.00949281, 0.188703
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.188703
 
@@ -863,7 +863,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00107624, 0.05, 0.00313094, 0.032241
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.05
 
@@ -872,7 +872,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000245895, 0.0350225, 0.00172429, 0.030245
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0350225
 
@@ -881,7 +881,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000122297, 0.0221418, 0.00129389, 0.0209696
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0221418
 
@@ -890,7 +890,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.10676e-05, 0.0110579, 0.000663964, 0.0102384
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.0110579
 
@@ -899,7 +899,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.76392e-05, 0.0045211, 0.00027061, 0.00391252
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.0045211
 
@@ -908,7 +908,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.07332e-06, 0.00159773, 9.29714e-05, 0.00126719
       Relative nonlinear residual (total system) after nonlinear iteration 7: 0.00159773
 
@@ -917,7 +917,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.06272e-06, 0.000477376, 2.61239e-05, 0.000324051
       Relative nonlinear residual (total system) after nonlinear iteration 8: 0.000477376
 
@@ -926,7 +926,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.97853e-08, 0.000118509, 5.26958e-06, 5.29829e-05
       Relative nonlinear residual (total system) after nonlinear iteration 9: 0.000118509
 
@@ -935,7 +935,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.00648e-07, 2.71513e-05, 3.91938e-07, 1.23521e-05
       Relative nonlinear residual (total system) after nonlinear iteration 10: 2.71513e-05
 
@@ -944,7 +944,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.92821e-08, 1.22456e-05, 6.02787e-07, 1.20815e-05
       Relative nonlinear residual (total system) after nonlinear iteration 11: 1.22456e-05
 
@@ -953,7 +953,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.15747e-08, 6.53925e-06, 3.86565e-07, 6.39975e-06
       Relative nonlinear residual (total system) after nonlinear iteration 12: 6.53925e-06
 
@@ -970,7 +970,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00156417, 0.105132, 0.00246748, 0.281127
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.281127
 
@@ -979,7 +979,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00033114, 0.0444621, 0.00271031, 0.0679097
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0679097
 
@@ -988,7 +988,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.87107e-05, 0.0111676, 0.000555576, 0.0149517
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0149517
 
@@ -997,7 +997,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.84227e-06, 0.00236543, 0.000113183, 0.00274781
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00274781
 
@@ -1006,7 +1006,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.98123e-07, 0.000397488, 1.40459e-05, 0.000313547
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000397488
 
@@ -1015,7 +1015,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.62442e-07, 9.85834e-05, 1.8843e-06, 0.000122187
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000122187
 
@@ -1024,7 +1024,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.37551e-07, 4.88861e-05, 2.09416e-06, 7.3673e-05
       Relative nonlinear residual (total system) after nonlinear iteration 7: 7.3673e-05
 
@@ -1033,7 +1033,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.45761e-08, 2.07953e-05, 9.96372e-07, 3.10621e-05
       Relative nonlinear residual (total system) after nonlinear iteration 8: 3.10621e-05
 
@@ -1042,7 +1042,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.69145e-08, 7.54318e-06, 3.74129e-07, 1.10355e-05
       Relative nonlinear residual (total system) after nonlinear iteration 9: 1.10355e-05
 
@@ -1051,7 +1051,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.91643e-09, 2.43173e-06, 1.25152e-07, 3.50218e-06
       Relative nonlinear residual (total system) after nonlinear iteration 10: 3.50218e-06
 
@@ -1068,7 +1068,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000864892, 0.0533681, 0.00137245, 0.271958
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.271958
 
@@ -1077,7 +1077,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0113013, 0.0827231, 0.0018037, 0.144566
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.144566
 
@@ -1086,7 +1086,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000697681, 0.118749, 0.00462455, 0.099758
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.118749
 
@@ -1095,7 +1095,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.96903e-05, 0.00962986, 4.41998e-05, 0.00618293
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00962986
 
@@ -1104,7 +1104,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.1222e-06, 0.000362928, 3.05332e-06, 0.000252581
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000362928
 
@@ -1113,7 +1113,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.149e-08, 1.681e-05, 1.35839e-07, 7.39556e-06
       Relative nonlinear residual (total system) after nonlinear iteration 6: 1.681e-05
 
@@ -1122,7 +1122,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.24506e-09, 1.21681e-06, 3.68814e-09, 7.81831e-07
       Relative nonlinear residual (total system) after nonlinear iteration 7: 1.21681e-06
 
@@ -1139,7 +1139,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 14 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.128802, 0.806339, 0.156767, 12.5563
       Relative nonlinear residual (total system) after nonlinear iteration 1: 12.5563
 
@@ -1148,7 +1148,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 11 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0284851, 0.697876, 0.136913, 1.16123
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.16123
 
@@ -1157,7 +1157,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00406368, 0.162212, 0.0053757, 0.560185
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.560185
 
@@ -1166,7 +1166,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000574171, 0.0105566, 0.000400534, 0.000679957
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0105566
 
@@ -1175,7 +1175,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.14001e-05, 0.00185859, 0.000101745, 9.81504e-05
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.00185859
 
@@ -1184,7 +1184,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.98395e-06, 0.000514186, 2.08556e-05, 2.46239e-05
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000514186
 
@@ -1193,7 +1193,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.72232e-07, 0.000154832, 5.53065e-06, 7.34766e-06
       Relative nonlinear residual (total system) after nonlinear iteration 7: 0.000154832
 
@@ -1202,7 +1202,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.32064e-07, 4.74657e-05, 1.3553e-06, 2.3675e-06
       Relative nonlinear residual (total system) after nonlinear iteration 8: 4.74657e-05
 
@@ -1211,7 +1211,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.36359e-08, 1.44416e-05, 3.58143e-07, 7.43362e-07
       Relative nonlinear residual (total system) after nonlinear iteration 9: 1.44416e-05
 
@@ -1220,7 +1220,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.33925e-08, 4.35507e-06, 9.79966e-08, 2.26286e-07
       Relative nonlinear residual (total system) after nonlinear iteration 10: 4.35507e-06
 
@@ -1237,7 +1237,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0298604, 0.696512, 0.0110409, 0.746744
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.746744
 
@@ -1246,7 +1246,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00764955, 0.376804, 0.0136551, 0.350754
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.376804
 
@@ -1255,7 +1255,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000560342, 0.059034, 0.000748454, 0.0447685
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.059034
 
@@ -1264,7 +1264,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.55339e-05, 0.00661309, 8.36614e-05, 0.00454792
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00661309
 
@@ -1273,7 +1273,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.01021e-06, 0.00118342, 9.7236e-06, 0.00126656
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.00126656
 
@@ -1282,7 +1282,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.7253e-07, 0.000343116, 1.56087e-06, 0.0004637
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.0004637
 
@@ -1291,7 +1291,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.76687e-08, 0.000149711, 5.93247e-07, 0.000215577
       Relative nonlinear residual (total system) after nonlinear iteration 7: 0.000215577
 
@@ -1300,7 +1300,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.9972e-08, 7.14728e-05, 2.97685e-07, 0.000102578
       Relative nonlinear residual (total system) after nonlinear iteration 8: 0.000102578
 
@@ -1309,7 +1309,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.94699e-09, 3.51823e-05, 1.45234e-07, 5.00098e-05
       Relative nonlinear residual (total system) after nonlinear iteration 9: 5.00098e-05
 
@@ -1318,7 +1318,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.97286e-09, 1.77446e-05, 6.96389e-08, 2.50914e-05
       Relative nonlinear residual (total system) after nonlinear iteration 10: 2.50914e-05
 
@@ -1327,7 +1327,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.5931e-09, 9.17655e-06, 3.91339e-08, 1.29689e-05
       Relative nonlinear residual (total system) after nonlinear iteration 11: 1.29689e-05
 
@@ -1336,7 +1336,7 @@ Number of degrees of freedom: 2,377 (578+273+578+81+289+289+289)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.35341e-09, 4.74777e-06, 2.51429e-08, 6.6632e-06
       Relative nonlinear residual (total system) after nonlinear iteration 12: 6.6632e-06
 

--- a/tests/particle_melt_advection/screen-output
+++ b/tests/particle_melt_advection/screen-output
@@ -10,7 +10,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.77541e-16, 1.34525e-16, 1.34525e-16, 0.168325
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.168325
 
@@ -19,7 +19,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.77541e-16, 1.34525e-16, 1.34525e-16, 6.14908e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 6.14908e-08
 
@@ -38,7 +38,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000236462, 0.0309886, 0.0120506, 0.0189603
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0309886
 
@@ -47,7 +47,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.81952e-07, 0.00179812, 0.000110207, 0.000718215
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00179812
 
@@ -56,7 +56,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.61714e-08, 8.27806e-05, 3.99184e-06, 2.40155e-05
       Relative nonlinear residual (total system) after nonlinear iteration 3: 8.27806e-05
 
@@ -65,7 +65,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.55236e-09, 5.0909e-06, 2.37229e-07, 1.97178e-06
       Relative nonlinear residual (total system) after nonlinear iteration 4: 5.0909e-06
 
@@ -83,7 +83,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.4624e-05, 0.00624293, 0.00686836, 0.00510703
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00686836
 
@@ -92,7 +92,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.13644e-08, 0.000165993, 9.33159e-06, 7.10759e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000165993
 
@@ -101,7 +101,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.90637e-09, 9.27693e-06, 5.51317e-07, 4.3195e-06
       Relative nonlinear residual (total system) after nonlinear iteration 3: 9.27693e-06
 
@@ -119,7 +119,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.38719e-05, 0.00222937, 0.00270536, 0.00421727
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00421727
 
@@ -128,7 +128,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.89706e-08, 9.54987e-05, 3.96527e-06, 5.46183e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.54987e-05
 
@@ -137,7 +137,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.48117e-09, 4.29669e-06, 2.62764e-07, 1.95967e-06
       Relative nonlinear residual (total system) after nonlinear iteration 3: 4.29669e-06
 
@@ -155,7 +155,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.19733e-06, 0.00141076, 0.00113082, 0.00402036
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00402036
 
@@ -164,7 +164,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.47349e-08, 8.42171e-05, 2.50927e-06, 5.14584e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 8.42171e-05
 
@@ -173,7 +173,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.44761e-10, 2.76687e-06, 1.63597e-07, 1.30318e-06
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.76687e-06
 
@@ -191,7 +191,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.30711e-06, 0.00145138, 0.000507901, 0.0038979
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0038979
 
@@ -200,7 +200,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.93219e-08, 8.35307e-05, 2.2821e-06, 5.10433e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 8.35307e-05
 
@@ -209,7 +209,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.76494e-10, 2.32252e-06, 1.26399e-07, 1.12076e-06
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.32252e-06
 
@@ -227,7 +227,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.92566e-06, 0.00148539, 0.000275751, 0.00381803
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00381803
 
@@ -236,7 +236,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.01893e-08, 8.18872e-05, 2.26209e-06, 5.11471e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 8.18872e-05
 
@@ -245,7 +245,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.28702e-10, 2.16541e-06, 1.11351e-07, 1.09137e-06
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.16541e-06
 
@@ -263,7 +263,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.51032e-07, 0.000528147, 8.6418e-05, 0.00134408
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00134408
 
@@ -272,7 +272,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.6469e-09, 1.56799e-05, 4.4763e-07, 9.9732e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.56799e-05
 
@@ -281,7 +281,7 @@ Number of degrees of freedom: 14,505 (4,290+2,097+4,290+561+2,145+561+561)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.29074e-11, 2.27798e-07, 1.1674e-08, 1.37037e-07
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.27798e-07
 

--- a/tests/rising_melt_blob/screen-output
+++ b/tests/rising_melt_blob/screen-output
@@ -10,7 +10,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.63865e-16, 1.54902e-16, 1.54902e-16, 0.168632
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.168632
 
@@ -19,7 +19,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.63865e-16, 1.54902e-16, 1.54902e-16, 9.9118e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.9118e-08
 
@@ -34,7 +34,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00023904, 0.0308629, 0.00391777, 0.0163796
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0308629
 
@@ -43,7 +43,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.90203e-07, 0.00209119, 0.000128709, 0.000678522
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00209119
 
@@ -52,7 +52,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.79547e-08, 0.000130772, 5.4827e-06, 2.60127e-05
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000130772
 
@@ -61,7 +61,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.30773e-09, 1.22726e-05, 4.86751e-07, 3.63104e-06
       Relative nonlinear residual (total system) after nonlinear iteration 4: 1.22726e-05
 
@@ -70,7 +70,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.60532e-10, 9.10972e-07, 2.63005e-08, 2.35883e-07
       Relative nonlinear residual (total system) after nonlinear iteration 5: 9.10972e-07
 
@@ -85,7 +85,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.14339e-06, 0.00168946, 0.00195595, 0.00380948
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00380948
 
@@ -94,7 +94,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.76481e-08, 0.00011615, 4.93268e-06, 5.42261e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00011615
 
@@ -103,7 +103,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.2992e-09, 5.02239e-06, 2.97776e-07, 1.95455e-06
       Relative nonlinear residual (total system) after nonlinear iteration 3: 5.02239e-06
 
@@ -118,7 +118,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.40742e-06, 0.00154026, 0.000881503, 0.00368832
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00368832
 
@@ -127,7 +127,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.05135e-08, 0.000110216, 3.3128e-06, 5.04961e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000110216
 
@@ -136,7 +136,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.29342e-10, 4.01228e-06, 1.90562e-07, 1.57461e-06
       Relative nonlinear residual (total system) after nonlinear iteration 3: 4.01228e-06
 
@@ -151,7 +151,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.50664e-06, 0.00170367, 0.00041933, 0.00356014
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00356014
 
@@ -160,7 +160,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.60544e-08, 0.000107363, 2.90847e-06, 4.73745e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000107363
 
@@ -169,7 +169,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.98938e-10, 3.90932e-06, 1.61484e-07, 1.53678e-06
       Relative nonlinear residual (total system) after nonlinear iteration 3: 3.90932e-06
 
@@ -184,7 +184,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.05919e-06, 0.00174377, 0.000235037, 0.00347564
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00347564
 
@@ -193,7 +193,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.37825e-08, 0.000103659, 2.77925e-06, 4.50757e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000103659
 
@@ -202,7 +202,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.48558e-10, 3.81149e-06, 1.51609e-07, 1.52581e-06
       Relative nonlinear residual (total system) after nonlinear iteration 3: 3.81149e-06
 
@@ -217,7 +217,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.79371e-07, 0.0017283, 0.000152832, 0.00342903
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00342903
 
@@ -226,7 +226,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.66336e-08, 9.97322e-05, 2.72292e-06, 4.36399e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.97322e-05
 
@@ -235,7 +235,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.68576e-10, 3.62054e-06, 1.43564e-07, 1.48129e-06
       Relative nonlinear residual (total system) after nonlinear iteration 3: 3.62054e-06
 
@@ -250,7 +250,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.54556e-08, 0.000101891, 1.03697e-05, 0.000192532
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000192532
 
@@ -259,7 +259,7 @@ Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.00768e-10, 7.60782e-07, 2.25319e-08, 3.28868e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 7.60782e-07
 

--- a/tests/rising_melt_blob_freezing/screen-output
+++ b/tests/rising_melt_blob_freezing/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 32+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.77028e-16, 1.53541e-16, 0, 0.168633
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.168633
 
@@ -17,7 +17,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 12 iterations.
+   Solving fluid velocity system... 12 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.77028e-16, 1.53541e-16, 0, 6.8961e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 6.8961e-08
 
@@ -33,7 +33,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 35+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.79135e-16, 3.74036e-06, 2.4041e-07, 0.999997
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.999997
 
@@ -42,7 +42,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.81087e-16, 0.153679, 0.00657023, 2422.31
       Relative nonlinear residual (total system) after nonlinear iteration 2: 2422.31
 
@@ -51,7 +51,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.75318e-16, 0.00990237, 6.91011e-05, 28.1868
       Relative nonlinear residual (total system) after nonlinear iteration 3: 28.1868
 
@@ -60,7 +60,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.7423e-16, 0.00428079, 1.46053e-05, 11.9299
       Relative nonlinear residual (total system) after nonlinear iteration 4: 11.9299
 
@@ -69,7 +69,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.80842e-16, 0.00258416, 6.41555e-06, 11.2367
       Relative nonlinear residual (total system) after nonlinear iteration 5: 11.2367
 
@@ -78,7 +78,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.78044e-16, 0.0016122, 1.05146e-06, 8.51926
       Relative nonlinear residual (total system) after nonlinear iteration 6: 8.51926
 
@@ -87,7 +87,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 32+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.76725e-16, 0.00105046, 8.49739e-07, 8.21855
       Relative nonlinear residual (total system) after nonlinear iteration 7: 8.21855
 
@@ -96,7 +96,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 32+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.79407e-16, 0.000680275, 4.29194e-07, 4.06429
       Relative nonlinear residual (total system) after nonlinear iteration 8: 4.06429
 
@@ -105,7 +105,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 32+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.78605e-16, 0.000449345, 2.6834e-07, 2.23007
       Relative nonlinear residual (total system) after nonlinear iteration 9: 2.23007
 
@@ -114,7 +114,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 32+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.81021e-16, 0.0003172, 1.62084e-07, 1.43266
       Relative nonlinear residual (total system) after nonlinear iteration 10: 1.43266
 
@@ -123,7 +123,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.80168e-16, 0.000233844, 1.08111e-07, 1.01975
       Relative nonlinear residual (total system) after nonlinear iteration 11: 1.01975
 
@@ -132,7 +132,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.79965e-16, 0.000186216, 7.70026e-08, 0.867059
       Relative nonlinear residual (total system) after nonlinear iteration 12: 0.867059
 
@@ -141,7 +141,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.76562e-16, 0.000158724, 5.72222e-08, 0.82843
       Relative nonlinear residual (total system) after nonlinear iteration 13: 0.82843
 
@@ -150,7 +150,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.7495e-16, 0.000143762, 4.56275e-08, 0.855153
       Relative nonlinear residual (total system) after nonlinear iteration 14: 0.855153
 
@@ -159,7 +159,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.79552e-16, 0.000130785, 3.74706e-08, 0.853992
       Relative nonlinear residual (total system) after nonlinear iteration 15: 0.853992
 
@@ -168,7 +168,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.79631e-16, 9.05556e-05, 2.86708e-08, 0.485317
       Relative nonlinear residual (total system) after nonlinear iteration 16: 0.485317
 
@@ -177,7 +177,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73537e-16, 5.59363e-05, 2.03298e-08, 0.2328
       Relative nonlinear residual (total system) after nonlinear iteration 17: 0.2328
 
@@ -186,7 +186,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.78001e-16, 4.38206e-05, 1.52309e-08, 0.173181
       Relative nonlinear residual (total system) after nonlinear iteration 18: 0.173181
 
@@ -195,7 +195,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.75131e-16, 3.57301e-05, 1.19738e-08, 0.138815
       Relative nonlinear residual (total system) after nonlinear iteration 19: 0.138815
 
@@ -204,7 +204,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.76982e-16, 2.93864e-05, 9.59116e-09, 0.112732
       Relative nonlinear residual (total system) after nonlinear iteration 20: 0.112732
 
@@ -213,7 +213,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.7531e-16, 2.42518e-05, 7.72669e-09, 0.0919951
       Relative nonlinear residual (total system) after nonlinear iteration 21: 0.0919951
 
@@ -222,7 +222,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.7843e-16, 2.00522e-05, 6.26593e-09, 0.0752783
       Relative nonlinear residual (total system) after nonlinear iteration 22: 0.0752783
 
@@ -231,7 +231,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.76307e-16, 1.66018e-05, 5.08948e-09, 0.061753
       Relative nonlinear residual (total system) after nonlinear iteration 23: 0.061753
 
@@ -240,7 +240,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.76135e-16, 1.37579e-05, 4.13896e-09, 0.0507477
       Relative nonlinear residual (total system) after nonlinear iteration 24: 0.0507477
 
@@ -249,7 +249,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.80669e-16, 1.14108e-05, 3.38333e-09, 0.0417432
       Relative nonlinear residual (total system) after nonlinear iteration 25: 0.0417432
 
@@ -258,7 +258,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.75856e-16, 9.46929e-06, 2.75507e-09, 0.0343926
       Relative nonlinear residual (total system) after nonlinear iteration 26: 0.0343926
 
@@ -267,7 +267,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.79996e-16, 7.86258e-06, 2.26001e-09, 0.0283538
       Relative nonlinear residual (total system) after nonlinear iteration 27: 0.0283538
 
@@ -276,7 +276,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.78043e-16, 6.53021e-06, 1.84408e-09, 0.0234137
       Relative nonlinear residual (total system) after nonlinear iteration 28: 0.0234137
 
@@ -285,7 +285,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.75195e-16, 5.42693e-06, 1.51992e-09, 0.0193275
       Relative nonlinear residual (total system) after nonlinear iteration 29: 0.0193275
 
@@ -294,7 +294,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.79477e-16, 4.51102e-06, 1.25051e-09, 0.0159752
       Relative nonlinear residual (total system) after nonlinear iteration 30: 0.0159752
 
@@ -303,7 +303,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.78065e-16, 3.74906e-06, 1.03258e-09, 0.0132006
       Relative nonlinear residual (total system) after nonlinear iteration 31: 0.0132006
 
@@ -312,7 +312,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.75041e-16, 3.11856e-06, 8.47916e-10, 0.0109355
       Relative nonlinear residual (total system) after nonlinear iteration 32: 0.0109355
 
@@ -321,7 +321,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.72887e-16, 2.59429e-06, 6.98586e-10, 0.0090559
       Relative nonlinear residual (total system) after nonlinear iteration 33: 0.0090559
 
@@ -330,7 +330,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.8108e-16, 2.15551e-06, 5.78292e-10, 0.00748313
       Relative nonlinear residual (total system) after nonlinear iteration 34: 0.00748313
 
@@ -339,7 +339,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.82833e-16, 1.79506e-06, 4.78992e-10, 0.00621778
       Relative nonlinear residual (total system) after nonlinear iteration 35: 0.00621778
 
@@ -348,7 +348,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.75535e-16, 1.49427e-06, 3.92407e-10, 0.00515678
       Relative nonlinear residual (total system) after nonlinear iteration 36: 0.00515678
 
@@ -357,7 +357,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.81167e-16, 1.24138e-06, 3.32182e-10, 0.0042633
       Relative nonlinear residual (total system) after nonlinear iteration 37: 0.0042633
 
@@ -366,7 +366,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.80506e-16, 1.03454e-06, 2.72841e-10, 0.00354742
       Relative nonlinear residual (total system) after nonlinear iteration 38: 0.00354742
 
@@ -375,7 +375,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.7558e-16, 8.61708e-07, 2.21356e-10, 0.00294612
       Relative nonlinear residual (total system) after nonlinear iteration 39: 0.00294612
 
@@ -384,7 +384,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.79258e-16, 7.1737e-07, 1.95325e-10, 0.00243397
       Relative nonlinear residual (total system) after nonlinear iteration 40: 0.00243397
 
@@ -393,7 +393,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.80621e-16, 5.97481e-07, 1.53541e-10, 0.00203128
       Relative nonlinear residual (total system) after nonlinear iteration 41: 0.00203128
 
@@ -402,7 +402,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.76817e-16, 4.97858e-07, 1.26818e-10, 0.00168963
       Relative nonlinear residual (total system) after nonlinear iteration 42: 0.00168963
 
@@ -411,7 +411,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.79604e-16, 4.129e-07, 1.14199e-10, 0.00140143
       Relative nonlinear residual (total system) after nonlinear iteration 43: 0.00140143
 
@@ -420,7 +420,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.78288e-16, 3.44722e-07, 8.89148e-11, 0.00116555
       Relative nonlinear residual (total system) after nonlinear iteration 44: 0.00116555
 
@@ -429,7 +429,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.76712e-16, 2.87513e-07, 7.34485e-11, 0.000969739
       Relative nonlinear residual (total system) after nonlinear iteration 45: 0.000969739
 
@@ -438,7 +438,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.74655e-16, 2.36593e-07, 9.33391e-11, 0.000770457
       Relative nonlinear residual (total system) after nonlinear iteration 46: 0.000770457
 
@@ -447,7 +447,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.76906e-16, 1.98363e-07, 5.54406e-11, 0.000670035
       Relative nonlinear residual (total system) after nonlinear iteration 47: 0.000670035
 
@@ -456,7 +456,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.77714e-16, 1.65624e-07, 4.33185e-11, 0.000558386
       Relative nonlinear residual (total system) after nonlinear iteration 48: 0.000558386
 
@@ -465,7 +465,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.81301e-16, 1.36314e-07, 4.90813e-11, 0.000441982
       Relative nonlinear residual (total system) after nonlinear iteration 49: 0.000441982
 
@@ -474,7 +474,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 2 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.79832e-16, 1.14884e-07, 3.43731e-11, 0.000390436
       Relative nonlinear residual (total system) after nonlinear iteration 50: 0.000390436
 
@@ -490,7 +490,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 10 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-   Solving for u_f in 14 iterations.
+   Solving fluid velocity system... 14 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.70377e-16, 0.708387, 0.00571679, 0.999756
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.999756
 
@@ -499,7 +499,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.71706e-16, 0.879544, 0.00672182, 0.0795449
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.879544
 
@@ -508,7 +508,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.66883e-16, 0.0377939, 0.000110836, 0.122399
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.122399
 
@@ -517,7 +517,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 7 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.69884e-16, 0.0184102, 1.06886e-05, 0.0548735
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0548735
 
@@ -526,7 +526,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73829e-16, 0.00794907, 1.0225e-06, 0.0240239
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.0240239
 
@@ -535,7 +535,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 6 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.70453e-16, 0.00530676, 1.96677e-07, 0.0170663
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.0170663
 
@@ -544,7 +544,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.69956e-16, 0.00391195, 8.00266e-08, 0.0132178
       Relative nonlinear residual (total system) after nonlinear iteration 7: 0.0132178
 
@@ -553,7 +553,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.70867e-16, 0.00306845, 4.85423e-08, 0.0106202
       Relative nonlinear residual (total system) after nonlinear iteration 8: 0.0106202
 
@@ -562,7 +562,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.71077e-16, 0.00228493, 3.71844e-08, 0.00808949
       Relative nonlinear residual (total system) after nonlinear iteration 9: 0.00808949
 
@@ -571,7 +571,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.75061e-16, 0.00126896, 3.37126e-08, 0.00434324
       Relative nonlinear residual (total system) after nonlinear iteration 10: 0.00434324
 
@@ -580,7 +580,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.72469e-16, 0.000714717, 3.71618e-08, 0.00247245
       Relative nonlinear residual (total system) after nonlinear iteration 11: 0.00247245
 
@@ -589,7 +589,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73637e-16, 0.000524626, 3.04639e-08, 0.00198332
       Relative nonlinear residual (total system) after nonlinear iteration 12: 0.00198332
 
@@ -598,7 +598,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.72277e-16, 0.000407319, 2.41835e-08, 0.0015972
       Relative nonlinear residual (total system) after nonlinear iteration 13: 0.0015972
 
@@ -607,7 +607,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.7087e-16, 0.000325972, 1.93054e-08, 0.00129994
       Relative nonlinear residual (total system) after nonlinear iteration 14: 0.00129994
 
@@ -616,7 +616,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73291e-16, 0.000266935, 1.56201e-08, 0.00107353
       Relative nonlinear residual (total system) after nonlinear iteration 15: 0.00107353
 
@@ -625,7 +625,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 5 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.72433e-16, 0.000221999, 1.28102e-08, 0.000895871
       Relative nonlinear residual (total system) after nonlinear iteration 16: 0.000895871
 
@@ -634,7 +634,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.68198e-16, 0.000186373, 1.06251e-08, 0.00075222
       Relative nonlinear residual (total system) after nonlinear iteration 17: 0.00075222
 
@@ -643,7 +643,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.69862e-16, 0.000157317, 8.88331e-09, 0.000633964
       Relative nonlinear residual (total system) after nonlinear iteration 18: 0.000633964
 
@@ -652,7 +652,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.69829e-16, 0.000133192, 7.46906e-09, 0.000535494
       Relative nonlinear residual (total system) after nonlinear iteration 19: 0.000535494
 
@@ -661,7 +661,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.68919e-16, 0.000112942, 6.30413e-09, 0.000452793
       Relative nonlinear residual (total system) after nonlinear iteration 20: 0.000452793
 
@@ -670,7 +670,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.6895e-16, 9.58434e-05, 5.33271e-09, 0.000383157
       Relative nonlinear residual (total system) after nonlinear iteration 21: 0.000383157
 
@@ -679,7 +679,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.67399e-16, 8.13621e-05, 4.51799e-09, 0.000324423
       Relative nonlinear residual (total system) after nonlinear iteration 22: 0.000324423
 
@@ -688,7 +688,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.66416e-16, 6.90669e-05, 3.82994e-09, 0.000274665
       Relative nonlinear residual (total system) after nonlinear iteration 23: 0.000274665
 
@@ -697,7 +697,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73154e-16, 5.86251e-05, 3.24905e-09, 0.000232598
       Relative nonlinear residual (total system) after nonlinear iteration 24: 0.000232598
 
@@ -706,7 +706,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.72091e-16, 4.97544e-05, 2.75552e-09, 0.000196987
       Relative nonlinear residual (total system) after nonlinear iteration 25: 0.000196987
 
@@ -715,7 +715,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73934e-16, 4.27509e-05, 2.38313e-09, 0.000172816
       Relative nonlinear residual (total system) after nonlinear iteration 26: 0.000172816
 
@@ -724,7 +724,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.70775e-16, 3.68785e-05, 2.09277e-09, 0.000149134
       Relative nonlinear residual (total system) after nonlinear iteration 27: 0.000149134
 
@@ -733,7 +733,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.71137e-16, 3.16008e-05, 1.80903e-09, 0.000127525
       Relative nonlinear residual (total system) after nonlinear iteration 28: 0.000127525
 
@@ -742,7 +742,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 4 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.66715e-16, 2.6996e-05, 1.5518e-09, 0.000108726
       Relative nonlinear residual (total system) after nonlinear iteration 29: 0.000108726
 
@@ -751,7 +751,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.69813e-16, 2.30312e-05, 1.32378e-09, 9.2634e-05
       Relative nonlinear residual (total system) after nonlinear iteration 30: 9.2634e-05
 
@@ -760,7 +760,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.7297e-16, 1.96384e-05, 1.12914e-09, 7.88969e-05
       Relative nonlinear residual (total system) after nonlinear iteration 31: 7.88969e-05
 
@@ -769,7 +769,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.70772e-16, 1.67374e-05, 9.64868e-10, 6.71716e-05
       Relative nonlinear residual (total system) after nonlinear iteration 32: 6.71716e-05
 
@@ -778,7 +778,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.72182e-16, 1.42654e-05, 8.20463e-10, 5.72067e-05
       Relative nonlinear residual (total system) after nonlinear iteration 33: 5.72067e-05
 
@@ -787,7 +787,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.72476e-16, 1.21567e-05, 6.99144e-10, 4.87176e-05
       Relative nonlinear residual (total system) after nonlinear iteration 34: 4.87176e-05
 
@@ -796,7 +796,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.7269e-16, 1.03586e-05, 5.95698e-10, 4.14875e-05
       Relative nonlinear residual (total system) after nonlinear iteration 35: 4.14875e-05
 
@@ -805,7 +805,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.70503e-16, 8.8276e-06, 5.09727e-10, 3.53483e-05
       Relative nonlinear residual (total system) after nonlinear iteration 36: 3.53483e-05
 
@@ -814,7 +814,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.68471e-16, 7.51974e-06, 4.32798e-10, 3.00861e-05
       Relative nonlinear residual (total system) after nonlinear iteration 37: 3.00861e-05
 
@@ -823,7 +823,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.72085e-16, 6.40541e-06, 3.68503e-10, 2.56178e-05
       Relative nonlinear residual (total system) after nonlinear iteration 38: 2.56178e-05
 
@@ -832,7 +832,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.71349e-16, 5.45622e-06, 3.13854e-10, 2.18152e-05
       Relative nonlinear residual (total system) after nonlinear iteration 39: 2.18152e-05
 
@@ -841,7 +841,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.74129e-16, 4.65154e-06, 2.74582e-10, 1.8641e-05
       Relative nonlinear residual (total system) after nonlinear iteration 40: 1.8641e-05
 
@@ -850,7 +850,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.72275e-16, 3.9591e-06, 2.28432e-10, 1.58223e-05
       Relative nonlinear residual (total system) after nonlinear iteration 41: 1.58223e-05
 
@@ -859,7 +859,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.72381e-16, 3.37128e-06, 1.9421e-10, 1.34653e-05
       Relative nonlinear residual (total system) after nonlinear iteration 42: 1.34653e-05
 
@@ -868,7 +868,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.74087e-16, 2.87123e-06, 1.65357e-10, 1.14647e-05
       Relative nonlinear residual (total system) after nonlinear iteration 43: 1.14647e-05
 
@@ -877,7 +877,7 @@ Number of degrees of freedom: 34,825 (8,450+4,161+8,450+1,089+4,225+4,225+4,225)
    Solving peridotite system ... 3 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-   Solving for u_f in 13 iterations.
+   Solving fluid velocity system... 13 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.77007e-16, 2.45117e-06, 1.57881e-10, 9.79669e-06
       Relative nonlinear residual (total system) after nonlinear iteration 44: 9.79669e-06
 

--- a/tests/segregation_heating/screen-output
+++ b/tests/segregation_heating/screen-output
@@ -10,7 +10,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 41+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.14566e-16, 1.03548e-16, 0, 0.333482
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.333482
 
@@ -19,7 +19,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.14566e-16, 1.03548e-16, 0, 9.96759e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.96759e-13
 
@@ -35,7 +35,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-   Solving for u_f in 3 iterations.
+   Solving fluid velocity system... 3 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.24316e-05, 3.70165e-16, 0, 8.38159e-07
       Relative nonlinear residual (total system) after nonlinear iteration 1: 3.24316e-05
 
@@ -44,7 +44,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-   Solving for u_f in 3 iterations.
+   Solving fluid velocity system... 3 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.48606e-11, 1.37966e-08, 0, 7.40717e-09
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.37966e-08
 
@@ -60,7 +60,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-   Solving for u_f in 3 iterations.
+   Solving fluid velocity system... 3 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.09535e-07, 9.00825e-09, 0, 6.52636e-08
       Relative nonlinear residual (total system) after nonlinear iteration 1: 8.09535e-07
 
@@ -76,7 +76,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-   Solving for u_f in 3 iterations.
+   Solving fluid velocity system... 3 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10039e-06, 1.1847e-08, 0, 8.72267e-08
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.10039e-06
 
@@ -92,7 +92,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-   Solving for u_f in 4 iterations.
+   Solving fluid velocity system... 4 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.21036e-06, 1.27598e-08, 0, 8.92896e-08
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.21036e-06
 
@@ -108,7 +108,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-   Solving for u_f in 4 iterations.
+   Solving fluid velocity system... 4 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.21571e-06, 1.28495e-08, 0, 8.04954e-08
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.21571e-06
 
@@ -124,7 +124,7 @@ Number of degrees of freedom: 7,369 (2,178+1,057+2,178+289+1,089+289+289)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 4 iterations.
+   Solving fluid velocity system... 4 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10955e-12, 1.29794e-14, 0, 9.9592e-13
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.10955e-12
 

--- a/tests/shear_bands/screen-output
+++ b/tests/shear_bands/screen-output
@@ -9,7 +9,7 @@ Number of degrees of freedom: 30,824 (8,514+4,177+8,514+1,105+4,257+4,257)
    Solving porosity system ... 9 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.46945e-16, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
@@ -17,7 +17,7 @@ Number of degrees of freedom: 30,824 (8,514+4,177+8,514+1,105+4,257+4,257)
    Solving porosity system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.10489e-16, 0.0307523
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0307523
 
@@ -25,7 +25,7 @@ Number of degrees of freedom: 30,824 (8,514+4,177+8,514+1,105+4,257+4,257)
    Solving porosity system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.07051e-16, 0.0185082
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0185082
 
@@ -33,7 +33,7 @@ Number of degrees of freedom: 30,824 (8,514+4,177+8,514+1,105+4,257+4,257)
    Solving porosity system ... 8 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.04895e-16, 0.0132206
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0132206
 
@@ -48,7 +48,7 @@ Number of degrees of freedom: 30,824 (8,514+4,177+8,514+1,105+4,257+4,257)
    Solving porosity system ... 56 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00261589, 0.000398198
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000398198
 
@@ -56,7 +56,7 @@ Number of degrees of freedom: 30,824 (8,514+4,177+8,514+1,105+4,257+4,257)
    Solving porosity system ... 56 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000365111, 0.000244032
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000244032
 
@@ -64,7 +64,7 @@ Number of degrees of freedom: 30,824 (8,514+4,177+8,514+1,105+4,257+4,257)
    Solving porosity system ... 56 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000247165, 0.00017912
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00017912
 
@@ -72,7 +72,7 @@ Number of degrees of freedom: 30,824 (8,514+4,177+8,514+1,105+4,257+4,257)
    Solving porosity system ... 56 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-   Solving for u_f in 11 iterations.
+   Solving fluid velocity system... 11 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000210941, 0.000141889
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000141889
 

--- a/tests/shear_heating_with_melt/screen-output
+++ b/tests/shear_heating_with_melt/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.75134e-16, 0, 0, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
@@ -17,7 +17,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.68092e-16, 0, 0, 0.00866789
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00866789
 
@@ -26,7 +26,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.41348e-16, 0, 0, 0.000116155
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000116155
 
@@ -35,7 +35,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.62109e-16, 0, 0, 1.1321e-06
       Relative nonlinear residual (total system) after nonlinear iteration 4: 1.1321e-06
 
@@ -49,7 +49,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.75134e-16, 0, 0, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
@@ -58,7 +58,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.68092e-16, 0, 0, 0.00866789
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00866789
 
@@ -67,7 +67,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.41348e-16, 0, 0, 0.000116155
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000116155
 
@@ -76,7 +76,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.62109e-16, 0, 0, 1.1321e-06
       Relative nonlinear residual (total system) after nonlinear iteration 4: 1.1321e-06
 
@@ -96,7 +96,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.193663, 1, 1, 0.00130748
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
@@ -105,7 +105,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000272002, 0.0160944, 6.24117e-05, 3.71655e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0160944
 
@@ -114,7 +114,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.91189e-07, 9.09666e-05, 3.05302e-07, 2.53141e-07
       Relative nonlinear residual (total system) after nonlinear iteration 3: 9.09666e-05
 
@@ -123,7 +123,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.67436e-09, 7.01104e-07, 2.04536e-09, 4.2521e-09
       Relative nonlinear residual (total system) after nonlinear iteration 4: 7.01104e-07
 
@@ -142,7 +142,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0734628, 0.114058, 0.110868, 0.00400636
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.114058
 
@@ -151,7 +151,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.7193e-05, 0.0096766, 4.55465e-05, 5.92596e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0096766
 
@@ -160,7 +160,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.62086e-08, 1.51039e-05, 9.0291e-08, 3.64321e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.51039e-05
 
@@ -169,7 +169,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.54889e-12, 5.15988e-17, 2.02892e-16, 3.64301e-08
       Relative nonlinear residual (total system) after nonlinear iteration 4: 3.64301e-08
 
@@ -189,7 +189,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0565629, 0.0893261, 0.0894866, 0.00439696
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0894866
 
@@ -198,7 +198,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.9341e-05, 0.00084553, 3.19717e-06, 5.5652e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00084553
 
@@ -207,7 +207,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.63067e-08, 2.14633e-06, 2.119e-08, 3.88962e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.14633e-06
 
@@ -227,7 +227,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0403663, 0.075893, 0.07622, 0.000832884
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.07622
 
@@ -236,7 +236,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.24808e-05, 4.21137e-05, 1.87273e-08, 3.34782e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 4.21137e-05
 
@@ -245,7 +245,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.61702e-08, 1.03443e-06, 3.38149e-09, 1.13764e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.03443e-06
 
@@ -265,7 +265,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 5+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0039369, 0.185082, 0.182418, 0.000391578
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.185082
 
@@ -274,7 +274,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 4+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.5516e-06, 0.00257503, 3.00993e-05, 6.80893e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00257503
 
@@ -283,7 +283,7 @@ Number of degrees of freedom: 1,663 (486+202+486+82+243+82+82)
    Solving peridotite system ... 1 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 1 iterations.
+   Solving fluid velocity system... 1 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.20411e-09, 2.36105e-06, 1.991e-08, 2.34527e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.36105e-06
 

--- a/tests/solitary_wave/screen-output
+++ b/tests/solitary_wave/screen-output
@@ -10,7 +10,7 @@ Number of degrees of freedom: 20,864 (5,778+2,725+5,778+805+2,889+2,889)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+11 iterations.
-   Solving for u_f in 9 iterations.
+   Solving fluid velocity system... 9 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.57727e-16, 0.999743
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.999743
 
@@ -18,7 +18,7 @@ Number of degrees of freedom: 20,864 (5,778+2,725+5,778+805+2,889+2,889)
    Solving porosity system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 9 iterations.
+   Solving fluid velocity system... 9 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.57727e-16, 9.36476e-11
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.36476e-11
 
@@ -34,7 +34,7 @@ Number of degrees of freedom: 20,864 (5,778+2,725+5,778+805+2,889+2,889)
    Solving porosity system ... 13 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+5 iterations.
-   Solving for u_f in 9 iterations.
+   Solving fluid velocity system... 9 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.91122e-05, 2.37904e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 2.37904e-06
 

--- a/tests/statistics_output/screen-output
+++ b/tests/statistics_output/screen-output
@@ -8,7 +8,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 79+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.83986e-16, 1.77705e-16, 0, 0.994828
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.994828
 
@@ -17,7 +17,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.83986e-16, 1.77705e-16, 0, 9.01951e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 9.01951e-13
 
@@ -32,7 +32,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 46+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.77287e-05, 0.0281576, 0, 0.118567
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.118567
 
@@ -41,7 +41,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 42+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.22949e-07, 0.00760001, 0, 0.042328
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.042328
 
@@ -50,7 +50,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 39+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.51723e-07, 0.00202747, 0, 0.00801699
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00801699
 
@@ -59,7 +59,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 37+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.64182e-08, 0.000457928, 0, 0.000448407
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000457928
 
@@ -68,7 +68,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 34+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.16685e-09, 0.000116033, 0, 0.000145439
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000145439
 
@@ -77,7 +77,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 32+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.72375e-09, 3.52324e-05, 0, 4.13361e-05
       Relative nonlinear residual (total system) after nonlinear iteration 6: 4.13361e-05
 
@@ -86,7 +86,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.40875e-10, 1.08943e-05, 0, 1.25243e-05
       Relative nonlinear residual (total system) after nonlinear iteration 7: 1.25243e-05
 
@@ -95,7 +95,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.67833e-10, 3.49331e-06, 0, 3.67191e-06
       Relative nonlinear residual (total system) after nonlinear iteration 8: 3.67191e-06
 
@@ -110,7 +110,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 58+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.71554e-06, 0.00487262, 0, 0.105465
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.105465
 
@@ -119,7 +119,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 41+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.82049e-08, 0.0014561, 0, 0.0101889
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0101889
 
@@ -128,7 +128,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 37+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.66945e-08, 0.000169415, 0, 0.000203411
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000203411
 
@@ -137,7 +137,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 35+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.55875e-09, 3.13131e-05, 0, 2.89901e-05
       Relative nonlinear residual (total system) after nonlinear iteration 4: 3.13131e-05
 
@@ -146,7 +146,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.14689e-10, 6.7156e-06, 0, 2.80708e-05
       Relative nonlinear residual (total system) after nonlinear iteration 5: 2.80708e-05
 
@@ -155,7 +155,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.14553e-10, 1.42194e-06, 0, 1.20662e-06
       Relative nonlinear residual (total system) after nonlinear iteration 6: 1.42194e-06
 
@@ -170,7 +170,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 63+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.28483e-07, 0.00588964, 0, 0.244487
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.244487
 
@@ -179,7 +179,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 47+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.7004e-07, 0.00135588, 0, 0.00673787
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00673787
 
@@ -188,7 +188,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 42+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.09509e-08, 0.000240192, 0, 0.00215439
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00215439
 
@@ -197,7 +197,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 38+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.42849e-09, 4.96844e-05, 0, 0.000437375
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000437375
 
@@ -206,7 +206,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 36+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.77324e-10, 9.20501e-06, 0, 4.37038e-05
       Relative nonlinear residual (total system) after nonlinear iteration 5: 4.37038e-05
 
@@ -215,7 +215,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 32+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.72186e-10, 2.14294e-06, 0, 2.02421e-05
       Relative nonlinear residual (total system) after nonlinear iteration 6: 2.02421e-05
 
@@ -224,7 +224,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.9681e-11, 4.12415e-07, 0, 5.51168e-07
       Relative nonlinear residual (total system) after nonlinear iteration 7: 5.51168e-07
 
@@ -239,7 +239,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 83+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.88713e-07, 0.0050631, 0, 0.553188
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.553188
 
@@ -248,7 +248,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 61+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.86057e-07, 0.0021475, 0, 0.0513716
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0513716
 
@@ -257,7 +257,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 57+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.02466e-08, 0.000243246, 0, 0.00569345
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00569345
 
@@ -266,7 +266,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 47+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.65835e-09, 3.50651e-05, 0, 0.000320781
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000320781
 
@@ -275,7 +275,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 42+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.36173e-10, 7.70824e-06, 0, 0.000149387
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000149387
 
@@ -284,7 +284,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 41+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.47469e-10, 1.12809e-06, 0, 1.14431e-06
       Relative nonlinear residual (total system) after nonlinear iteration 6: 1.14431e-06
 
@@ -299,7 +299,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 110+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.56147e-07, 0.00321281, 0, 0.933133
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.933133
 
@@ -308,7 +308,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 84+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.25429e-07, 0.00168304, 0, 0.0463942
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0463942
 
@@ -317,7 +317,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 72+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.90577e-08, 0.000219407, 0, 0.0040847
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0040847
 
@@ -326,7 +326,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 71+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.29662e-09, 3.1016e-05, 0, 0.000474269
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000474269
 
@@ -335,7 +335,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 60+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.86427e-10, 7.64449e-06, 0, 0.00018691
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.00018691
 
@@ -344,7 +344,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 48+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.81617e-10, 1.04661e-06, 0, 9.02295e-06
       Relative nonlinear residual (total system) after nonlinear iteration 6: 9.02295e-06
 
@@ -359,7 +359,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 138+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.47309e-07, 0.00302761, 0, 1.03644
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.03644
 
@@ -368,7 +368,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 94+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.89405e-08, 0.000878269, 0, 0.0247334
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0247334
 
@@ -377,7 +377,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 91+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.04842e-08, 0.000183366, 0, 0.00632796
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00632796
 
@@ -386,7 +386,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 83+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.4559e-09, 1.86546e-05, 0, 8.23901e-05
       Relative nonlinear residual (total system) after nonlinear iteration 4: 8.23901e-05
 
@@ -395,7 +395,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 76+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.64654e-10, 3.71737e-06, 0, 0.000101407
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000101407
 
@@ -404,7 +404,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 62+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.0224e-11, 7.67584e-07, 0, 2.10226e-05
       Relative nonlinear residual (total system) after nonlinear iteration 6: 2.10226e-05
 
@@ -413,7 +413,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 56+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.20029e-11, 9.82331e-08, 0, 1.2298e-06
       Relative nonlinear residual (total system) after nonlinear iteration 7: 1.2298e-06
 
@@ -428,7 +428,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 146+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.72048e-07, 0.00277881, 0, 1.11566
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.11566
 
@@ -437,7 +437,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 129+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.08124e-07, 0.000776468, 0, 0.0196571
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0196571
 
@@ -446,7 +446,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 111+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.72211e-08, 0.000214476, 0, 0.0125901
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0125901
 
@@ -455,7 +455,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 81+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.36995e-09, 1.87572e-05, 0, 0.000757305
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000757305
 
@@ -464,7 +464,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 78+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.15426e-10, 4.67199e-06, 0, 0.000206564
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000206564
 
@@ -473,7 +473,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 70+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.44839e-10, 1.15634e-06, 0, 6.68192e-05
       Relative nonlinear residual (total system) after nonlinear iteration 6: 6.68192e-05
 
@@ -482,7 +482,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 49+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.40317e-11, 1.37456e-07, 0, 7.43444e-06
       Relative nonlinear residual (total system) after nonlinear iteration 7: 7.43444e-06
 
@@ -497,7 +497,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 194+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.25682e-06, 0.00234111, 0, 1.04014
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.04014
 
@@ -506,7 +506,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 139+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.79718e-07, 0.0014093, 0, 0.101743
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.101743
 
@@ -515,7 +515,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 145+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.08543e-07, 0.000359986, 0, 0.0326259
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0326259
 
@@ -524,7 +524,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 138+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.72916e-08, 7.9523e-05, 0, 0.00675407
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00675407
 
@@ -533,7 +533,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 128+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.47727e-09, 2.3733e-05, 0, 0.00200069
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.00200069
 
@@ -542,7 +542,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 98+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.91386e-09, 6.24349e-06, 0, 0.000547852
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000547852
 
@@ -551,7 +551,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 93+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.99522e-10, 1.5896e-06, 0, 0.000138221
       Relative nonlinear residual (total system) after nonlinear iteration 7: 0.000138221
 
@@ -560,7 +560,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 72+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.28677e-10, 4.29009e-07, 0, 3.70294e-05
       Relative nonlinear residual (total system) after nonlinear iteration 8: 3.70294e-05
 
@@ -569,7 +569,7 @@ Number of degrees of freedom: 9,825 (2,898+1,365+2,898+405+1,449+405+405)
    Skipping peridotite composition solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 61+0 iterations.
-   Solving for u_f in 10 iterations.
+   Solving fluid velocity system... 10 iterations.
       Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.4743e-11, 1.15e-07, 0, 9.97507e-06
       Relative nonlinear residual (total system) after nonlinear iteration 9: 9.97507e-06
 


### PR DESCRIPTION
Found while working on #3413. The output of the fluid velocity system always looked somewhat out of place, because it used a different wording and formatting than other equations. This PR unifies the format between them. 