### PR TITLE
Output degrees instead of radians

### DIFF
--- a/doc/modules/changes/20200319_glerum
+++ b/doc/modules/changes/20200319_glerum
@@ -1,0 +1,5 @@
+Changed: The named additional outputs of the visco plastic material model
+now output the current internal angle of friction in degrees instead
+of radians.
+<br>
+(Anne Glerum, 2020/03/19)

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -261,7 +261,8 @@ namespace aspect
               // Calculate the strain weakening factors and weakened values
               const std::array<double, 3> weakening_factors = strain_rheology.compute_strain_weakening_factors(j, in.composition[i]);
               plastic_out->cohesions[i]   += volume_fractions[j] * (drucker_prager_parameters.cohesions[j] * weakening_factors[0]);
-              plastic_out->friction_angles[i] += volume_fractions[j] * (drucker_prager_parameters.angles_internal_friction[j] * weakening_factors[1]);
+              // Also convert radians to degrees
+              plastic_out->friction_angles[i] += 180.0/numbers::PI * volume_fractions[j] * (drucker_prager_parameters.angles_internal_friction[j] * weakening_factors[1]);
             }
         }
     }


### PR DESCRIPTION
The PlasticAdditionalOutputs output the internal angle of friction in radians. This PR outputs them in degrees, which is more intuitive. I don't think it will break any tests, because I didn't see any that combines a nonzero friction angle with named additional output and compares the gnuplot output. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
