### PR TITLE
Fix capitalization of Aspect -> ASPECT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ WRITE_BASIC_PACKAGE_VERSION_FILE(
 
 # Configure a cmake fragment that plugins can use to
 # set up compiler flags, include paths, etc to compile an
-# Aspect plugin.
+# ASPECT plugin.
 # Config for the build dir:
 SET(CONFIG_INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/include")
 SET(CONFIG_DIR "${CMAKE_BINARY_DIR}")
@@ -482,7 +482,7 @@ ELSE()
 ENDIF()
 
 
-# Find the libdap package so that Aspect can connect to the OPeNDAP servers
+# Find the libdap package so that ASPECT can connect to the OPeNDAP servers
 # Author: Kodi Neumiller
 SET(ASPECT_WITH_LIBDAP OFF CACHE BOOL "Check if the user wants to compile ASPECT with the libdap libraries.")
 MESSAGE(STATUS "Using ASPECT_WITH_LIBDAP = '${ASPECT_WITH_LIBDAP}'")

--- a/benchmarks/king2dcompressible/ala.prm
+++ b/benchmarks/king2dcompressible/ala.prm
@@ -64,7 +64,7 @@ end
 
 # The benchmark is defined in terms of the nondimensional numbers
 # Di (dissipation number) and Ra (Rayleigh number). 
-# As Aspect uses physical properties instead of these dimensionless 
+# As ASPECT uses physical properties instead of these dimensionless 
 # numbers in its equations, we replicate the benchmark formulation 
 # by using a new material model that fixes all of the material 
 # constants to 1, except for the thermal expansivity, which is set 

--- a/benchmarks/solitary_wave/solitary_wave.prm
+++ b/benchmarks/solitary_wave/solitary_wave.prm
@@ -62,7 +62,7 @@ end
 
 # we apply the phase speed of the wave here, so that it always stays in the same place in our model
 # the phase speed is c = 5.25e-11 m/s, but we have to convert it to m/years using the same conversion
-# that is used internally in Aspect: year_in_seconds = 60*60*24*365.2425
+# that is used internally in ASPECT: year_in_seconds = 60*60*24*365.2425
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = left, right
   set Prescribed velocity boundary indicators = top:function, bottom:function

--- a/benchmarks/tangurnis/ba/tan.prm
+++ b/benchmarks/tangurnis/ba/tan.prm
@@ -92,7 +92,7 @@ end
 
 # The benchmark is defined in terms of the nondimensional numbers
 # Di (dissipation number) and gamma (grueneisen parameter). 
-# As Aspect uses physical properties instead of these dimensionless 
+# As ASPECT uses physical properties instead of these dimensionless 
 # numbers in its equations, we replicate the benchmark formulation 
 # by using a new material model that fixes all of the material 
 # constants to 1, except for the thermal expansivity and the viscosity, 

--- a/benchmarks/tangurnis/tala/tan.prm
+++ b/benchmarks/tangurnis/tala/tan.prm
@@ -93,7 +93,7 @@ end
 
 # The benchmark is defined in terms of the nondimensional numbers
 # Di (dissipation number) and gamma (grueneisen parameter). 
-# As Aspect uses physical properties instead of these dimensionless 
+# As ASPECT uses physical properties instead of these dimensionless 
 # numbers in its equations, we replicate the benchmark formulation 
 # by using a new material model that fixes all of the material 
 # constants to 1, except for the thermal expansivity and the viscosity, 

--- a/benchmarks/tangurnis/tala_c/tan.prm
+++ b/benchmarks/tangurnis/tala_c/tan.prm
@@ -92,7 +92,7 @@ end
 
 # The benchmark is defined in terms of the nondimensional numbers
 # Di (dissipation number) and gamma (grueneisen parameter). 
-# As Aspect uses physical properties instead of these dimensionless 
+# As ASPECT uses physical properties instead of these dimensionless 
 # numbers in its equations, we replicate the benchmark formulation 
 # by using a new material model that fixes all of the material 
 # constants to 1, except for the thermal expansivity and the viscosity, 

--- a/cookbooks/prescribed_velocity/prescribed_velocity.cc
+++ b/cookbooks/prescribed_velocity/prescribed_velocity.cc
@@ -318,7 +318,7 @@ namespace aspect
     signals.post_constraints_creation.connect (&constrain_internal_velocities<dim>);
   }
 
-  // Tell Aspect to send signals to the connector functions
+  // Tell ASPECT to send signals to the connector functions
   ASPECT_REGISTER_SIGNALS_PARAMETER_CONNECTOR(parameter_connector)
   ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>, signal_connector<3>)
 }

--- a/doc/make_cite_html.py
+++ b/doc/make_cite_html.py
@@ -77,9 +77,9 @@ want.append("KHB12")
 bibformated = {
         "He_2017_DG" : "Ying He, Elbridge Gerry Puckett, and Magali I. Billen. 2017. “A Discontinuous Galerkin Method with a Bound Preserving Limiter for the Advection of Non-Diffusive Fields in Solid Earth Geodynamics.” Physics of the Earth and Planetary Interiors 263 (February): 23–37. doi:10.1016/j.pepi.2016.12.001. http://dx.doi.org/10.1016/j.pepi.2016.12.001.",
         "KHB12" : "Martin Kronbichler, Timo Heister, and Wolfgang Bangerth. 2012. “High Accuracy Mantle Convection Simulation through Modern Numerical Methods.” Geophysical Journal International 191 (1) (August 21): 12–29. doi:10.1111/j.1365-246x.2012.05609.x. http://dx.doi.org/10.1111/j.1365-246X.2012.05609.x.",
-        "aspect-doi-v1.5.0" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, Timo Heister, and others. 2017, March 1. ASPECT V1.5.0. Zenodo. https://doi.org/10.5281/zenodo.344623",
-        "aspect-doi-v2.0.0" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, and Timo Heister. 2018, May 10. ASPECT V2.0.0. Zenodo. https://doi.org/10.5281/zenodo.1244587",
-        "aspect-doi-v2.0.1" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, and Timo Heister. 2018, June 24. ASPECT V2.0.1. Zenodo. https://doi.org/10.5281/zenodo.1297145",
+        "aspect-doi-v1.5.0" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, Timo Heister, and others. 2017, March 1. ASPECT v1.5.0. Zenodo. https://doi.org/10.5281/zenodo.344623",
+        "aspect-doi-v2.0.0" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, and Timo Heister. 2018, May 10. ASPECT v2.0.0. Zenodo. https://doi.org/10.5281/zenodo.1244587",
+        "aspect-doi-v2.0.1" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, and Timo Heister. 2018, June 24. ASPECT v2.0.1. Zenodo. https://doi.org/10.5281/zenodo.1297145",
         "aspect-doi-v2.1.0" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, and Timo Heister. 2019, April 29. ASPECT v2.1.0. Zenodo. https://doi.org/10.5281/zenodo.2653531",
         "aspectmanual" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, Timo Heister, and others. 2019. ASPECT: Advanced Solver for Problems in Earth's ConvecTion, User Manual. <i>Figshare</i>. https://doi.org/10.6084/m9.figshare.4865333",
         "dannberg_melt" : "Juliane Dannberg, and Timo Heister. 2016. “Compressible Magma/mantle Dynamics: 3-D, Adaptive Simulations in ASPECT.” Geophysical Journal International 207 (3) (September 4): 1343–1366. doi:10.1093/gji/ggw329. http://dx.doi.org/10.1093/gji/ggw329.",

--- a/doc/make_cite_html.py
+++ b/doc/make_cite_html.py
@@ -77,9 +77,9 @@ want.append("KHB12")
 bibformated = {
         "He_2017_DG" : "Ying He, Elbridge Gerry Puckett, and Magali I. Billen. 2017. “A Discontinuous Galerkin Method with a Bound Preserving Limiter for the Advection of Non-Diffusive Fields in Solid Earth Geodynamics.” Physics of the Earth and Planetary Interiors 263 (February): 23–37. doi:10.1016/j.pepi.2016.12.001. http://dx.doi.org/10.1016/j.pepi.2016.12.001.",
         "KHB12" : "Martin Kronbichler, Timo Heister, and Wolfgang Bangerth. 2012. “High Accuracy Mantle Convection Simulation through Modern Numerical Methods.” Geophysical Journal International 191 (1) (August 21): 12–29. doi:10.1111/j.1365-246x.2012.05609.x. http://dx.doi.org/10.1111/j.1365-246X.2012.05609.x.",
-        "aspect-doi-v1.5.0" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, Timo Heister, and others. 2017, March 1. Aspect V1.5.0. Zenodo. https://doi.org/10.5281/zenodo.344623",
-        "aspect-doi-v2.0.0" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, and Timo Heister. 2018, May 10. Aspect V2.0.0. Zenodo. https://doi.org/10.5281/zenodo.1244587",
-        "aspect-doi-v2.0.1" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, and Timo Heister. 2018, June 24. Aspect V2.0.1. Zenodo. https://doi.org/10.5281/zenodo.1297145",
+        "aspect-doi-v1.5.0" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, Timo Heister, and others. 2017, March 1. ASPECT V1.5.0. Zenodo. https://doi.org/10.5281/zenodo.344623",
+        "aspect-doi-v2.0.0" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, and Timo Heister. 2018, May 10. ASPECT V2.0.0. Zenodo. https://doi.org/10.5281/zenodo.1244587",
+        "aspect-doi-v2.0.1" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, and Timo Heister. 2018, June 24. ASPECT V2.0.1. Zenodo. https://doi.org/10.5281/zenodo.1297145",
         "aspect-doi-v2.1.0" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, and Timo Heister. 2019, April 29. ASPECT v2.1.0. Zenodo. https://doi.org/10.5281/zenodo.2653531",
         "aspectmanual" : "Wolfgang Bangerth, Juliane Dannberg, Rene Gassmoeller, Timo Heister, and others. 2019. ASPECT: Advanced Solver for Problems in Earth's ConvecTion, User Manual. <i>Figshare</i>. https://doi.org/10.6084/m9.figshare.4865333",
         "dannberg_melt" : "Juliane Dannberg, and Timo Heister. 2016. “Compressible Magma/mantle Dynamics: 3-D, Adaptive Simulations in ASPECT.” Geophysical Journal International 207 (3) (September 4): 1343–1366. doi:10.1093/gji/ggw329. http://dx.doi.org/10.1093/gji/ggw329.",

--- a/doc/manual/citing_aspect.bib
+++ b/doc/manual/citing_aspect.bib
@@ -203,7 +203,7 @@ abstract = {This release includes the following changes:
 author = {Bangerth, Wolfgang and Dannberg, Juliane and Gassmoeller, Rene and Heister, Timo and Others},
 doi = {10.5281/ZENODO.344623},
 month = {jan},
-title = {{Aspect V1.5.0}},
+title = {{ASPECT v1.5.0}},
 year = {2017}
 }
 @article{Rose2017a,

--- a/doc/manual/cookbooks/benchmarks/solitary_wave/solitary_wave.prm
+++ b/doc/manual/cookbooks/benchmarks/solitary_wave/solitary_wave.prm
@@ -79,7 +79,7 @@ end
 # We apply the phase speed of the wave here, so that it always stays in the 
 # same place in our model. The phase speed is c = 5.25e-11 m/s, but we have 
 # to convert it to m/years using the same conversion that is used internally 
-# in Aspect: year_in_seconds = 60*60*24*365.2425.
+# in ASPECT: year_in_seconds = 60*60*24*365.2425.
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0,1
   set Prescribed velocity boundary indicators = 2:function, 3:function

--- a/doc/manual/cookbooks/geomio/run_geomio.part2.m
+++ b/doc/manual/cookbooks/geomio/run_geomio.part2.m
@@ -1,5 +1,5 @@
 % define the bounding box for the output mesh
-% (this should be the X extent and Y extent in your Aspect model)
+% (this should be the X extent and Y extent in your ASPECT model)
 xmin = 0; xmax = opt.svg.width;
 ymin = 0; ymax = opt.svg.height;
 

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -7503,7 +7503,7 @@ part of the visualization. The upwelling and downwelling flow along the
 equator causes alternating topography high and lows at the top and
 bottom surface (Figure~\ref{fig:pp}). 
 In Figure~\ref{fig:pp} c, d we have subtracted the mean dynamic topography from
-the output field as a postproceesing step outside of Aspect. Since mass is 
+the output field as a postproceesing step outside of \aspect{}. Since mass is 
 conserved within the Earth, the mean dynamic topography
 should always be zero, however, the outputted values might not fulfill this 
 constraint if the resolution of the model is not high enough to provide an

--- a/doc/modules/changes/20190528_thieulot
+++ b/doc/modules/changes/20190528_thieulot
@@ -1,4 +1,4 @@
 New: Slab detachment benchmark first presented in Schmalholtz (2011) and 
-run with Aspect by A. Glerum (2018).
+run with ASPECT by A. Glerum (2018).
 <br>
 (C. Thieulot and A. Glerum, 2019/05/28)

--- a/doc/modules/changes_header.template
+++ b/doc/modules/changes_header.template
@@ -1,7 +1,7 @@
 /**
  * @page changes_between_OLDVERSION_and_NEWVERSION Changes between version OLDVERSION and version NEWVERSION
  *
- * <p> This is the list of changes made after the release of Aspect version
+ * <p> This is the list of changes made after the release of ASPECT version
  * OLDVERSION for version NEWVERSION. All entries are signed with the names of the author.
  * </p>
  *

--- a/doc/modules/current_changes_header
+++ b/doc/modules/current_changes_header
@@ -1,7 +1,7 @@
 /**
  * @page changes_current Changes after the latest release (v2.1.0)
  *
- * <p> This is the list of changes made after the release of Aspect version
+ * <p> This is the list of changes made after the release of ASPECT version
  * 2.1.0. All entries are signed with the names of the author. </p>
  *
  *

--- a/doc/modules/current_changes_header.template
+++ b/doc/modules/current_changes_header.template
@@ -1,7 +1,7 @@
 /**
  * @page changes_current Changes after the latest release (vVERSION)
  *
- * <p> This is the list of changes made after the release of Aspect version
+ * <p> This is the list of changes made after the release of ASPECT version
  * VERSION. All entries are signed with the names of the author. </p>
  *
  *

--- a/doc/modules/to-0.2.h
+++ b/doc/modules/to-0.2.h
@@ -1,7 +1,7 @@
 /**
  * @page changes_between_0.1_and_0.2 Changes between version 0.1 and version 0.2
  *
- * <p> This is the list of changes made after the release of Aspect version
+ * <p> This is the list of changes made after the release of ASPECT version
  * 0.1 and before 0.2. All entries are signed with the names of the author.
  * </p>
  *
@@ -27,7 +27,7 @@
  * <li> Fixed: There were many places where we indiscriminately used
  * MPI_COMM_WORLD, rather than the communicator used for the actual
  * simulation. This is not a problem almost all the time, except for cases
- * where Aspect is run as part of a bigger simulation.
+ * where ASPECT is run as part of a bigger simulation.
  * <br>
  * (Wolfgang Bangerth, 2013/04/28)
  *
@@ -128,7 +128,7 @@
  * <br>
  * (Eric Heien, 2012/11/06)
  *
- * <li> New: Aspect now catches if the output directory specified in the
+ * <li> New: ASPECT now catches if the output directory specified in the
  * parameter file does not exist, rather than providing a cryptic error
  * message upon first attempt to write to this directory.
  * <br>
@@ -202,7 +202,7 @@
  * <br>
  * (Eric Heien, 2012/06/01)
  *
- * <li> New: Aspect now writes a <code>solution.pvd</code> for Paraview that
+ * <li> New: ASPECT now writes a <code>solution.pvd</code> for Paraview that
  * contains a list of the files that jointly make up the entire simulation
  * (and not just a single time step) together with the simulation time each of
  * the files that describe a time step correspond to.
@@ -220,7 +220,7 @@
  * <li> New: The variables we output in graphical format files are now user
  * selectable from the input parameter file. Functions that compute something
  * from velocity, pressure and temperature (e.g., the viscosity, strain rate,
- * etc) are now implemented as plugins like many of the other parts of Aspect.
+ * etc) are now implemented as plugins like many of the other parts of ASPECT.
  * now implemented
  * <br>
  * (Wolfgang Bangerth, 2012/05/08)

--- a/doc/modules/to-0.3.h
+++ b/doc/modules/to-0.3.h
@@ -1,7 +1,7 @@
 /**
  * @page changes_between_0.2_and_0.3 Changes between version 0.2 and version 0.3
  *
- * <p> This is the list of changes made after the release of Aspect version
+ * <p> This is the list of changes made after the release of ASPECT version
  * 0.2 and before 0.3. All entries are signed with the names of the author.
  * </p>
  *

--- a/doc/modules/to-1.0.h
+++ b/doc/modules/to-1.0.h
@@ -1,7 +1,7 @@
 /**
  * @page changes_between_0.3_and_1.0 Changes between version 0.3 and version 1.0
  *
- * <p> This is the list of changes made after the release of Aspect version
+ * <p> This is the list of changes made after the release of ASPECT version
  * 0.3 and before 1.0. All entries are signed with the names of the author.
  * </p>
  *
@@ -96,7 +96,7 @@
  * <br>
  * (Wolfgang Bangerth, Jacqueline Austermann 2014/03/20)
  *
- * <li>New: Aspect now installs a file <code>AspectConfig.cmake</code> into
+ * <li>New: ASPECT now installs a file <code>ASPECTConfig.cmake</code> into
  * the same directory as the executable that can be used by plugins to set up
  * compiler flags, include paths, etc, to compile a set of source files into a
  * shared library that can then be loaded at run time from the input file. See
@@ -148,7 +148,7 @@
  *
  * <li>New: Linear algebra can be done using PETSc instead of Trilinos. For
  * this, deal.II needs to be configured with PETSc and the preprocessor define
- * <code>USE_PETSC</code> needs to be set in the Aspect file
+ * <code>USE_PETSC</code> needs to be set in the ASPECT file
  * <code>include/aspect/global.h</code> before compiling. This feature is
  * still experimental.
  * <br>
@@ -170,8 +170,8 @@
  * <li>Fixed: Using the 'density', 'nonadiabatic temperature', 'thermal
  * energy' or 'viscosity' mesh refinement criterion for parallel computations
  * led to meshes that made no sense. This was due to a bug in deal.II, not
- * Aspect, and has been fixed starting with deal.II 8.1. Using this version of
- * deal.II now also fixes the problem in Aspect.
+ * ASPECT, and has been fixed starting with deal.II 8.1. Using this version of
+ * deal.II now also fixes the problem in ASPECT.
  * <br>
  * (Wolfgang Bangerth 2013/12/18)
  *
@@ -300,7 +300,7 @@
  * <br>
  * (Eric Heien 2013/10/14)
  *
- * <li>New: Aspect now not only generates a <code>solution-NNNNN.visit</code>
+ * <li>New: ASPECT now not only generates a <code>solution-NNNNN.visit</code>
  * file for each time step but also a global <code>solution.visit</code> file
  * that Visit can use to visualize the entire time dependent solution. (Both
  * of these work with versions of Visit that support this, including Visit
@@ -326,7 +326,7 @@
  * <br>
  * (Eric Heien, 2013/09/27)
  *
- * <li>New: Aspect now supports periodic domains (a recent development version
+ * <li>New: ASPECT now supports periodic domains (a recent development version
  * of deal.II is required).
  * <br>
  * (Ian Rose, Timo Heister, 2013/09/11)
@@ -378,9 +378,9 @@
  *
  * <li>New: In order to implement extensions, in particular new plugins for
  * material models, geometries, etc, it used to be necessary to put the new
- * files into the Aspect source directories and re-compile all of Aspect. This
+ * files into the ASPECT source directories and re-compile all of ASPECT. This
  * is now no longer necessary: You can just compile your additional plugins
- * into a shared library and tell Aspect via the parameter file to load this
+ * into a shared library and tell ASPECT via the parameter file to load this
  * shared library at start-up. Details on this process are provided in the
  * manual in the section "How to write a plugin".
  * <br>

--- a/doc/modules/to-1.0.h
+++ b/doc/modules/to-1.0.h
@@ -96,7 +96,7 @@
  * <br>
  * (Wolfgang Bangerth, Jacqueline Austermann 2014/03/20)
  *
- * <li>New: ASPECT now installs a file <code>ASPECTConfig.cmake</code> into
+ * <li>New: ASPECT now installs a file <code>AspectConfig.cmake</code> into
  * the same directory as the executable that can be used by plugins to set up
  * compiler flags, include paths, etc, to compile a set of source files into a
  * shared library that can then be loaded at run time from the input file. See

--- a/doc/modules/to-1.1.h
+++ b/doc/modules/to-1.1.h
@@ -1,7 +1,7 @@
 /**
  * @page changes_between_1.0_and_1.1 Changes between version 1.0 and version 1.1
  *
- * <p> This is the list of changes made after the release of Aspect version
+ * <p> This is the list of changes made after the release of ASPECT version
  * 1.0 for version 1.1. All entries are signed with the names of the author.
  * </p>
  *
@@ -69,7 +69,7 @@
  * (Timo Heister, 2014/05/27)
  *
  * <li> Fixed: The GPlates plugin now correctly handles meshes created by
- * GPlates 1.4 and later. Previous Aspect versions may only read in files
+ * GPlates 1.4 and later. Previous ASPECT versions may only read in files
  * created by GPlates 1.3.
  * <br>
  * (Rene Gassmoeller, 2014/05/23)
@@ -183,7 +183,7 @@
  * <br>
  * (Jacqueline Austermann, 2014/05/19)
  *
- * <li>Fixed: The GPlates cookbook in Aspect-1.0 contained a bug that
+ * <li>Fixed: The GPlates cookbook in ASPECT-1.0 contained a bug that
  * prevented it from using the GPlates plugin. This is fixed now.
  * <br>
  * (Rene Gassmoeller, 2014/05/18)

--- a/doc/modules/to-1.2.h
+++ b/doc/modules/to-1.2.h
@@ -1,7 +1,7 @@
 /**
  * @page changes_between_1.1_and_1.2 Changes between version 1.1 and version 1.2
  *
- * <p> This is the list of changes made after the release of Aspect version
+ * <p> This is the list of changes made after the release of ASPECT version
  * 1.1 for version 1.2. All entries are signed with the names of the author.
  * </p>
  *
@@ -118,7 +118,7 @@
  * spherical shell. However, remembering these numerical indicators when
  * writing or reading input files is a hassle and error prone.
  * <br>
- * Given this problem, there is now functionality in Aspect so that geometry
+ * Given this problem, there is now functionality in ASPECT so that geometry
  * models can (and, for the existing models, do) provide symbolic names for
  * each of the boundary parts. These symbolic names can then be used in the
  * input files wherever it was previously necessary to use numbers.

--- a/doc/modules/to-1.3.h
+++ b/doc/modules/to-1.3.h
@@ -1,7 +1,7 @@
 /**
  * @page changes_between_1.2_and_1.3 Changes between version 1.2 and version 1.3
  *
- * <p> This is the list of changes made after the release of Aspect version
+ * <p> This is the list of changes made after the release of ASPECT version
  * 1.2 for version 1.3. All entries are signed with the names of the author.
  * </p>
  *
@@ -124,7 +124,7 @@
  * The plugin works for box and shell geometries and allows for time-dependent
  * or constant boundary conditions. The data files must provide data for the
  * whole model domain and the plugin interpolates the data from a structured
- * grid to Aspect's mesh linearly.
+ * grid to ASPECT's mesh linearly.
  * <br>
  * (Eva Bredow, Rene Gassmoeller, 2015/02/03)
  *

--- a/doc/modules/to-1.4.0.h
+++ b/doc/modules/to-1.4.0.h
@@ -1,7 +1,7 @@
 /**
  * @page changes_between_1.3_and_1.4.0 Changes between version 1.3 and version 1.4.0
  *
- * <p> This is the list of changes made after the release of Aspect version
+ * <p> This is the list of changes made after the release of ASPECT version
  * 1.3 for version 1.4.0. All entries are signed with the names of the author.
  * </p>
  *
@@ -468,7 +468,7 @@
  * (Ian Rose, 2015/05/21)
  *
  * <li> Changed: The documentation for nullspace removal is now more
- * descriptive of what Aspect is actually doing.
+ * descriptive of what ASPECT is actually doing.
  * <br>
  * (Ian Rose, 2015/05/21)
  *

--- a/doc/modules/to-1.5.0.h
+++ b/doc/modules/to-1.5.0.h
@@ -1,7 +1,7 @@
 /**
  * @page changes_between_1.4.0_and_1.5.0 Changes between version 1.4.0 and version 1.5.0
  *
- * <p> This is the list of changes made after the release of Aspect version
+ * <p> This is the list of changes made after the release of ASPECT version
  * 1.4.0 for version 1.5.0. All entries are signed with the names of the author.
  * </p>
  *

--- a/doc/modules/to-2.0.0.h
+++ b/doc/modules/to-2.0.0.h
@@ -1,7 +1,7 @@
 /**
  * @page changes_between_1.5.0_and_2.0.0 Changes between version 1.5.0 and version 2.0.0
  *
- * <p> This is the list of changes made after the release of Aspect version
+ * <p> This is the list of changes made after the release of ASPECT version
  * 1.5.0 for version 2.0.0. All entries are signed with the names of the author.
  * </p>
  *
@@ -210,7 +210,7 @@
  * <br>
  * (Juliane Dannberg, 2018/02/12)
  *
- * <li> New: Aspect now supports using the free surface in models with 
+ * <li> New: ASPECT now supports using the free surface in models with 
  * melt migration, and with all nonlinear solver schemes.
  * <br>
  * (Juliane Dannberg, 2018/01/30)
@@ -434,7 +434,7 @@
  * <br>
  * (Juliane Dannberg, 2017/07/12)
  *
- * <li> New: Aspect now supports operator splitting as a new solver scheme. 
+ * <li> New: ASPECT now supports operator splitting as a new solver scheme. 
  * This allows it to decouple advection and reactions between 
  * compositional fields, and can also be used for temperature changes
  * related to these reactions. As part of this scheme, material models 
@@ -490,7 +490,7 @@
  * <br>
  * (Timo Heister, 2017/05/17)
  *
- * <li> New: Aspect can now initialize the compositional field by supplying
+ * <li> New: ASPECT can now initialize the compositional field by supplying
  * a list of plugins and operators determining how each plugin modifies the
  * field. The operators are specified as a new input file parameter
  * 'List of model operators', which takes a comma-separated list 
@@ -502,7 +502,7 @@
  * <br>
  * (Bob Myhill, 2017/05/16)
  *
- * <li> New: Aspect can now create initial temperature conditions by supplying 
+ * <li> New: ASPECT can now create initial temperature conditions by supplying 
  * a list of plugins and operators determining how each plugin modifies the 
  * temperature field. The operators are specified as a new input file 
  * parameter 'List of model operators', which takes a comma-separated list 
@@ -794,7 +794,7 @@
  * <br>
  * (Juliane Dannberg, 2017/04/13)
  *
- * <li> New: Aspect now supports postprocessing of nonlinear iterations,
+ * <li> New: ASPECT now supports postprocessing of nonlinear iterations,
  * in particular generating graphical output for each iteration.
  * <br>
  * (Juliane Dannberg, 2017/04/12)

--- a/doc/modules/to-2.1.0.h
+++ b/doc/modules/to-2.1.0.h
@@ -1,7 +1,7 @@
 /**
  * @page changes_between_2.0.0_and_2.1.0 Changes between version 2.0.0 and version 2.1.0
  *
- * <p> This is the list of changes made after the release of Aspect version
+ * <p> This is the list of changes made after the release of ASPECT version
  * 2.0.0 for version 2.1.0. All entries are signed with the names of the author.
  * </p>
  *

--- a/doc/update_all_files.sh
+++ b/doc/update_all_files.sh
@@ -9,8 +9,8 @@ DOC_DIR=`dirname $0`
 BASE_DIR=`pwd $DOC_DIR/..`
 
 # Update source files
-SOURCE_FILES=`find $BASE_DIR -type f \( -name *.cc -or -name *.h \) -and -not -name *.bak | grep -v doc`
-bash ${DOC_DIR}/update_source_files.sh $SOURCE_FILES
+#SOURCE_FILES=`find $BASE_DIR -type f \( -name *.cc -or -name *.h \) -and -not -name *.bak | grep -v doc`
+#bash ${DOC_DIR}/update_source_files.sh $SOURCE_FILES
 
 # Update prm files
 PRM_FILES=`find $BASE_DIR -type f -name *.prm* -not -name *update_script* -not -name *.bak`
@@ -19,4 +19,4 @@ bash ${DOC_DIR}/update_prm_files.sh $PRM_FILES
 # To remove the backup files that are created you will likely want to use the
 # following command. It is commented out by default, because you should think
 # carefully before automatically removing files.
-# find ${BASE_DIR} -name *.bak -delete
+find ${BASE_DIR} -name *.bak -delete

--- a/doc/update_all_files.sh
+++ b/doc/update_all_files.sh
@@ -9,8 +9,8 @@ DOC_DIR=`dirname $0`
 BASE_DIR=`pwd $DOC_DIR/..`
 
 # Update source files
-#SOURCE_FILES=`find $BASE_DIR -type f \( -name *.cc -or -name *.h \) -and -not -name *.bak | grep -v doc`
-#bash ${DOC_DIR}/update_source_files.sh $SOURCE_FILES
+SOURCE_FILES=`find $BASE_DIR -type f \( -name *.cc -or -name *.h \) -and -not -name *.bak | grep -v doc`
+bash ${DOC_DIR}/update_source_files.sh $SOURCE_FILES
 
 # Update prm files
 PRM_FILES=`find $BASE_DIR -type f -name *.prm* -not -name *update_script* -not -name *.bak`
@@ -19,4 +19,4 @@ bash ${DOC_DIR}/update_prm_files.sh $PRM_FILES
 # To remove the backup files that are created you will likely want to use the
 # following command. It is commented out by default, because you should think
 # carefully before automatically removing files.
-find ${BASE_DIR} -name *.bak -delete
+# find ${BASE_DIR} -name *.bak -delete

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -97,7 +97,7 @@ namespace aspect
   {
     /**
      * A namespace for the definition of classes that have to do with the
-     * plugin architecture of Aspect.
+     * plugin architecture of ASPECT.
      */
     namespace Plugins
     {

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -468,7 +468,7 @@ namespace aspect
         bool write_higher_order_output;
 
         /**
-         * For mesh deformation computations Aspect uses an Arbitrary-Lagrangian-
+         * For mesh deformation computations ASPECT uses an Arbitrary-Lagrangian-
          * Eulerian formulation to handle deforming the domain, so the mesh
          * has its own velocity field.  This may be written as an output field
          * by setting output_mesh_velocity to true.

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1120,7 +1120,7 @@ namespace aspect
        * $h_i \int g / |\Omega|$.
        *
        * The purpose of this function is described in the second paper on the
-       * numerical methods in Aspect.
+       * numerical methods in ASPECT.
        *
        * This function is implemented in
        * <code>source/simulator/helper_functions.cc</code>.

--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -108,7 +108,7 @@ namespace aspect
     /**
      * A signal that is called at the start of setup_dofs(). This allows for
      * editing of the parameters struct on the fly (such as changing boundary
-     * conditions) to give Aspect different behavior in mid-run than it
+     * conditions) to give ASPECT different behavior in mid-run than it
      * otherwise would have.
      *
      * The functions that connect to this signal must take two arguments, a

--- a/source/boundary_velocity/function.cc
+++ b/source/boundary_velocity/function.cc
@@ -53,12 +53,12 @@ namespace aspect
       if (use_spherical_unit_vectors)
         velocity = Utilities::Coordinates::spherical_to_cartesian_vector(velocity, position);
 
-      // Aspect always wants things in MKS system. however, as described
+      // ASPECT always wants things in MKS system. however, as described
       // in the documentation of this class, we interpret the formulas
       // given to this plugin as meters per year if the global flag
       // for using years instead of seconds is given. so if someone
       // write "5" in their parameter file and sets the flag, then this
-      // means "5 meters/year" and we need to convert it to the Aspect
+      // means "5 meters/year" and we need to convert it to the ASPECT
       // time system by dividing by the number of seconds per year
       // to get MKS units
       if (this->convert_output_to_years())

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -946,7 +946,7 @@ namespace aspect
 
           prm.declare_entry ("Output mesh velocity", "false",
                              Patterns::Bool(),
-                             "For computations with deforming meshes, Aspect uses an Arbitrary-Lagrangian-"
+                             "For computations with deforming meshes, ASPECT uses an Arbitrary-Lagrangian-"
                              "Eulerian formulation to handle deforming the domain, so the mesh "
                              "has its own velocity field.  This may be written as an output field "
                              "by setting this parameter to true.");

--- a/source/termination_criteria/user_request.cc
+++ b/source/termination_criteria/user_request.cc
@@ -54,7 +54,7 @@ namespace aspect
                              "directory (whose name is also specified in the input file) "
                              "will lead to termination of the simulation. "
                              "The file's location is chosen to be in the output directory, "
-                             "rather than in a generic location such as the Aspect directory, "
+                             "rather than in a generic location such as the ASPECT directory, "
                              "so that one can run multiple simulations at the same time (which "
                              "presumably write to different output directories) and can "
                              "selectively terminate a particular one.");
@@ -94,7 +94,7 @@ namespace aspect
                                           "gracefully exit the simulation at any time by simply creating "
                                           "such a file using, for example, \\texttt{touch output/terminate}. "
                                           "The file's location is chosen to be in the output directory, "
-                                          "rather than in a generic location such as the Aspect directory, "
+                                          "rather than in a generic location such as the ASPECT directory, "
                                           "so that one can run multiple simulations at the same time (which "
                                           "presumably write to different output directories) and can "
                                           "selectively terminate a particular one.")

--- a/tests/edit_parameters.cc
+++ b/tests/edit_parameters.cc
@@ -64,7 +64,7 @@ namespace aspect
     signals.edit_parameters_pre_setup_dofs.connect (&change_boundary_condition<dim>);
   }
 
-  // Tell Aspect to send signals to the connector functions
+  // Tell ASPECT to send signals to the connector functions
   ASPECT_REGISTER_SIGNALS_PARAMETER_CONNECTOR(parameter_connector)
   ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>, signal_connector<3>)
 }

--- a/tests/initial_condition_vs_to_density.prm
+++ b/tests/initial_condition_vs_to_density.prm
@@ -1,4 +1,4 @@
-# This tests whether Aspect reads in the 
+# This tests whether ASPECT reads in the 
 # vs to density scaling form a file correctly
 set Dimension                              = 3
 set Use years in output instead of seconds = false

--- a/tests/initial_condition_vs_to_density_SAVANI.prm
+++ b/tests/initial_condition_vs_to_density_SAVANI.prm
@@ -1,4 +1,4 @@
-# This tests whether Aspect reads in the 
+# This tests whether ASPECT reads in the 
 # vs to density scaling form a file correctly
 set Dimension                              = 3
 set Use years in output instead of seconds = false

--- a/tests/melt_track.prm
+++ b/tests/melt_track.prm
@@ -59,7 +59,7 @@ end
 
 # we apply the phase speed of the wave here, so that it always stays in the same place in our model
 # the phase speed is c = 5.25e-11 m/s, but we have to convert it to m/years using the same conversion
-# that is used internally in Aspect: year_in_seconds = 60*60*24*365.2425
+# that is used internally in ASPECT: year_in_seconds = 60*60*24*365.2425
 subsection Boundary velocity model
   subsection Function
 #    set Function expression = 0;-8.2836999e-5

--- a/tests/melt_transport_adaptive.prm
+++ b/tests/melt_transport_adaptive.prm
@@ -3,7 +3,7 @@
 # velocity and fluid pressure as well as porosity initial conditions 
 # are applied as described by the derived analytical solution,
 # which can be found in the manuscript on compressible melt transport 
-# in Aspect.
+# in ASPECT.
 # We compute these material properties in a new material model, which
 # is implemented in the .cc file, together with a postprocessor to calculate 
 # the error and a new pressure boundary cinsition.     

--- a/tests/melt_transport_compressible.prm
+++ b/tests/melt_transport_compressible.prm
@@ -3,7 +3,7 @@
 # velocity and fluid pressure as well as porosity initial conditions 
 # are applied as described by the derived analytical solution,
 # which can be found in the manuscript on compressible melt transport 
-# in Aspect.
+# in ASPECT.
 # We compute these material properties in a new material model, which
 # is implemented in the .cc file, together with a postprocessor to calculate 
 # the error and a new pressure boundary cinsition.     

--- a/tests/melt_transport_convergence_simple.prm
+++ b/tests/melt_transport_convergence_simple.prm
@@ -3,7 +3,7 @@
 # velocity and fluid pressure as well as porosity initial conditions 
 # are applied as described by the derived analytical solution,
 # which can be found in the manuscript on compressible melt transport 
-# in Aspect.
+# in ASPECT.
 # We compute these material properties in a new material model, which
 # is implemented in the .cc file, together with a postprocessor to calculate 
 # the error and a new pressure boundary condition.     

--- a/tests/melt_transport_convergence_test.prm
+++ b/tests/melt_transport_convergence_test.prm
@@ -3,7 +3,7 @@
 # velocity and fluid pressure as well as porosity initial conditions 
 # are applied as described by the derived analytical solution,
 # which can be found in the manuscript on compressible melt transport 
-# in Aspect.
+# in ASPECT.
 # We compute these material properties in a new material model, which
 # is implemented in the .cc file, together with a postprocessor to calculate 
 # the error and a new pressure boundary condition. 

--- a/tests/particle_property_composition.prm
+++ b/tests/particle_property_composition.prm
@@ -59,7 +59,7 @@ end
 
 # we apply the phase speed of the wave here, so that it always stays in the same place in our model
 # the phase speed is c = 5.25e-11 m/s, but we have to convert it to m/years using the same conversion
-# that is used internally in Aspect: year_in_seconds = 60*60*24*365.2425
+# that is used internally in ASPECT: year_in_seconds = 60*60*24*365.2425
 subsection Boundary velocity model
   subsection Function
 #    set Function expression = 0;-8.2836999e-5

--- a/tests/prescribed_velocity_dgp.cc
+++ b/tests/prescribed_velocity_dgp.cc
@@ -279,7 +279,7 @@ namespace aspect
     signals.post_constraints_creation.connect (&constrain_internal_velocities<dim>);
   }
 
-  // Tell Aspect to send signals to the connector functions
+  // Tell ASPECT to send signals to the connector functions
   ASPECT_REGISTER_SIGNALS_PARAMETER_CONNECTOR(parameter_connector)
   ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>, signal_connector<3>)
 }

--- a/tests/pressure_constraint.cc
+++ b/tests/pressure_constraint.cc
@@ -35,6 +35,6 @@ namespace aspect
     signals.post_constraints_creation.connect (&modify_constraints<dim>);
   }
 
-  // Tell Aspect to send signals to the connector functions
+  // Tell ASPECT to send signals to the connector functions
   ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>, signal_connector<3>)
 }

--- a/tests/solitary_wave.prm
+++ b/tests/solitary_wave.prm
@@ -57,7 +57,7 @@ end
 
 # we apply the phase speed of the wave here, so that it always stays in the same place in our model
 # the phase speed is c = 5.25e-11 m/s, but we have to convert it to m/years using the same conversion
-# that is used internally in Aspect: year_in_seconds = 60*60*24*365.2425
+# that is used internally in ASPECT: year_in_seconds = 60*60*24*365.2425
 subsection Boundary velocity model
   subsection Function
 #    set Function expression = 0;-8.2836999e-5


### PR DESCRIPTION
I think we usually use all caps for ASPECT whenever we use it. This is currently not fully consistent in our code base (and website, e.g. the changelog at https://aspect.geodynamics.org/doc/doxygen/changes_current.html). This PR fixes most occurences of 'Aspect'. @tjhei: I did not modify the CMakeLists.txt for now, however in there it is pretty inconsistent as well. I remember that you and Wolfgang changed the capitalization in there at a hackathon long ago. Do you remember if there was a reason why it was not consistently capitalized everywhere? Should I have a look to see what can be changed without breaking backward compatibility?