### PR TITLE
Fix use of invalid iterator

### DIFF
--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -386,7 +386,7 @@ namespace aspect
            p != x_no_flux_boundary_indicators.end(); ++p)
         if (mesh_deformation_boundary_indicators_set.find(*p) != mesh_deformation_boundary_indicators_set.end())
           {
-            x_no_flux_boundary_indicators.erase(*p);
+            p = x_no_flux_boundary_indicators.erase(p);
           }
 
       sim.signals.pre_compute_no_normal_flux_constraints(sim.triangulation);

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -381,22 +381,20 @@ namespace aspect
       // The list of tangential boundary indicators for which we need to set
       // no_normal_flux_constraints, which means the tangential boundary indicators
       // minus the mesh deformation boundary indicators.
-      std::set< types::boundary_id > x_no_flux_boundary_indicators = tangential_mesh_boundary_indicators;
-      for (std::set<types::boundary_id>::const_iterator p = x_no_flux_boundary_indicators.begin();
-           p != x_no_flux_boundary_indicators.end();)
-        {
-          if (mesh_deformation_boundary_indicators_set.find(*p) != mesh_deformation_boundary_indicators_set.end())
-            p = x_no_flux_boundary_indicators.erase(p);
-          else
-            ++p;
-        }
+      std::set<types::boundary_id> no_normal_flux_boundary_indicators;
+      std::set_difference (tangential_mesh_boundary_indicators.begin(),
+                           tangential_mesh_boundary_indicators.end(),
+                           mesh_deformation_boundary_indicators_set.begin(),
+                           mesh_deformation_boundary_indicators_set.end(),
+                           std::inserter (no_normal_flux_boundary_indicators,
+                                          no_normal_flux_boundary_indicators.begin()));
 
       sim.signals.pre_compute_no_normal_flux_constraints(sim.triangulation);
       // Make the no flux boundary constraints
       VectorTools::compute_no_normal_flux_constraints (mesh_deformation_dof_handler,
                                                        /* first_vector_component= */
                                                        0,
-                                                       x_no_flux_boundary_indicators,
+                                                       no_normal_flux_boundary_indicators,
                                                        mesh_velocity_constraints, *sim.mapping);
 
       // make the periodic boundary indicators no displacement normal to the boundary

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -383,11 +383,13 @@ namespace aspect
       // minus the mesh deformation boundary indicators.
       std::set< types::boundary_id > x_no_flux_boundary_indicators = tangential_mesh_boundary_indicators;
       for (std::set<types::boundary_id>::const_iterator p = x_no_flux_boundary_indicators.begin();
-           p != x_no_flux_boundary_indicators.end(); ++p)
-        if (mesh_deformation_boundary_indicators_set.find(*p) != mesh_deformation_boundary_indicators_set.end())
-          {
+           p != x_no_flux_boundary_indicators.end();)
+        {
+          if (mesh_deformation_boundary_indicators_set.find(*p) != mesh_deformation_boundary_indicators_set.end())
             p = x_no_flux_boundary_indicators.erase(p);
-          }
+          else
+            ++p;
+        }
 
       sim.signals.pre_compute_no_normal_flux_constraints(sim.triangulation);
       // Make the no flux boundary constraints

--- a/tests/free_surface_tangential_mesh_velocity_2.prm
+++ b/tests/free_surface_tangential_mesh_velocity_2.prm
@@ -20,22 +20,6 @@ subsection Geometry model
   end
 end
 
-# The parameters below this comment were created by the update script
-# as replacement for the old 'Model settings' subsection. They can be
-# safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = bottom, top
-end
-
-subsection Boundary velocity model
-  set Tangential velocity boundary indicators = bottom, left, right
-end
-
-subsection Boundary velocity model
-#  set Prescribed velocity boundary indicators = left x: function, right x: function
-end
-
 subsection Mesh deformation
   set Mesh deformation boundary indicators        = top: free surface
     set Additional tangential mesh velocity boundary indicators = left,right, top
@@ -45,17 +29,16 @@ subsection Mesh deformation
 end
 
 subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = bottom, top
   set List of model names = function
 
-  # box prescribes a constant temp, function is for a function
   subsection Function
     set Function expression = if(y<5e4,1613,273)
   end
 end
 
-# The velocity along the top boundary models a spreading
-# center
 subsection Boundary velocity model
+  set Tangential velocity boundary indicators = bottom, left, right
   subsection Function
     set Function expression = if(x>0, 1e-2 , -1e-2); 0
   end

--- a/tests/free_surface_tangential_mesh_velocity_2.prm
+++ b/tests/free_surface_tangential_mesh_velocity_2.prm
@@ -1,0 +1,100 @@
+# A copy of free_surface_tangential_mesh_velocity that has tangential
+# mesh velocity constraints on the same boundary as prescribed constraints
+# (in this case a free surface).
+
+set Dimension                              = 2
+set End time                               = 1e6
+set Use years in output instead of seconds = true
+set Output directory                       = output
+set Adiabatic surface temperature          = 1613
+set CFL number                             = 1.0
+set Pressure normalization                 = no
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 2e5
+    set X repetitions = 2
+    set Y extent = 1e5
+  end
+end
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = bottom, top
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = bottom, left, right
+end
+
+subsection Boundary velocity model
+#  set Prescribed velocity boundary indicators = left x: function, right x: function
+end
+
+subsection Mesh deformation
+  set Mesh deformation boundary indicators        = top: free surface
+    set Additional tangential mesh velocity boundary indicators = left,right, top
+  subsection Free surface
+    set Free surface stabilization theta = 0.5
+  end
+end
+
+subsection Boundary temperature model
+  set List of model names = function
+
+  # box prescribes a constant temp, function is for a function
+  subsection Function
+    set Function expression = if(y<5e4,1613,273)
+  end
+end
+
+# The velocity along the top boundary models a spreading
+# center
+subsection Boundary velocity model
+  subsection Function
+    set Function expression = if(x>0, 1e-2 , -1e-2); 0
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 9.8
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = adiabatic
+end
+
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density     = 3300
+    set Thermal conductivity  = 3.3
+    set Thermal expansion coefficient  = 3e-5
+    set Reference specific heat        = 1200
+    set Viscosity             = 1e21
+    set Reference temperature = 1600
+  end
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 4
+  set Time steps between mesh refinement = 0
+  set Strategy                           = strain rate, topography
+end
+
+subsection Postprocess
+  set List of postprocessors = topography
+end

--- a/tests/free_surface_tangential_mesh_velocity_2/screen-output
+++ b/tests/free_surface_tangential_mesh_velocity_2/screen-output
@@ -1,0 +1,30 @@
+
+Number of active cells: 512 (on 5 levels)
+Number of degrees of freedom: 6,996 (4,290+561+2,145)
+
+Number of mesh deformation degrees of freedom: 1122
+*** Timestep 0:  t=0 years
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 35+0 iterations.
+
+   Postprocessing:
+     Topography min/max: 0 m, 0 m
+
+*** Timestep 1:  t=1e+06 years
+   Solving mesh velocity system... 1 iterations.
+   Solving temperature system... 26 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 34+0 iterations.
+
+   Postprocessing:
+     Topography min/max: -2.037e-05 m, 8.606e-06 m
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+

--- a/tests/free_surface_tangential_mesh_velocity_2/statistics
+++ b/tests/free_surface_tangential_mesh_velocity_2/statistics
@@ -1,0 +1,14 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Minimum topography (m)
+# 12: Maximum topography (m)
+0 0.000000000000e+00 0.000000000000e+00 512 4851 2145  0 34 36 35  0.00000000e+00 0.00000000e+00 
+1 1.000000000000e+06 1.000000000000e+06 512 4851 2145 26 33 35 35 -2.03657255e-05 8.60566797e-06 


### PR DESCRIPTION
Found while looking into #3407. If we apply tangential mesh constraints to the same boundary that has some other prescribed mesh deformation (e.g. tangential movement) we try to increment an iterator after it was invalidated by erasing its target. This application is very rare.