### PR TITLE
fix GMG for compressible computations - correct_stokes_rhs()

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -811,6 +811,13 @@ namespace aspect
     system_matrix.compress(VectorOperation::add);
     system_rhs.compress(VectorOperation::add);
 
+    // If we change the system_rhs, matrix-free Stokes must update
+    if (stokes_matrix_free)
+      {
+        stokes_matrix_free->evaluate_material_model();
+        stokes_matrix_free->correct_stokes_rhs();
+      }
+
     // if the model is compressible then we need to adjust the right hand
     // side of the equation to make it compatible with the matrix on the
     // left
@@ -818,14 +825,6 @@ namespace aspect
       {
         pressure_shape_function_integrals.compress(VectorOperation::add);
         make_pressure_rhs_compatible(system_rhs);
-      }
-
-
-    // If we change the system_rhs, matrix-free Stokes must update
-    if (stokes_matrix_free)
-      {
-        stokes_matrix_free->evaluate_material_model();
-        stokes_matrix_free->correct_stokes_rhs();
       }
 
     // record that we have just rebuilt the matrix

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -2206,7 +2206,8 @@ namespace aspect
 
     const bool is_compressible = sim.material_model->is_compressible();
 
-    // GMG diagonals
+    // Assemble and store the diagonal of the GMG level matrices derived from:
+    // 2*eta*(symgrad u, symgrad v) - (if compressible) 2*eta/3*(div u, div v)
     for (unsigned int level=0; level < sim.triangulation.n_global_levels(); ++level)
       {
         mg_matrices_Schur_complement[level].compute_diagonal();
@@ -2276,7 +2277,9 @@ namespace aspect
                       for (unsigned int k=0; k<dofs_per_cell; ++k)
                         {
                           symgrad_phi_u[k] = fe_values[velocities].symmetric_gradient (k, q);
-                          div_phi_u[k] = fe_values[velocities].divergence (k, q);
+
+                          if (is_compressible)
+                            div_phi_u[k] = fe_values[velocities].divergence (k, q);
                         }
 
                       const double JxW = fe_values.JxW(q);

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1405,6 +1405,8 @@ namespace aspect
   template <int dim, int velocity_degree>
   void StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::correct_stokes_rhs()
   {
+    const bool is_compressible = sim.material_model->is_compressible();
+
     dealii::LinearAlgebra::distributed::BlockVector<double> rhs_correction(2);
     dealii::LinearAlgebra::distributed::BlockVector<double> u0(2);
 
@@ -1440,13 +1442,17 @@ namespace aspect
             SymmetricTensor<2,dim,VectorizedArray<double>> sym_grad_u =
                                                           velocity.get_symmetric_gradient (q);
             VectorizedArray<double> pres = pressure.get_value(q);
-            VectorizedArray<double> div = -trace(sym_grad_u);
-            pressure.submit_value   (-1.0*sim.pressure_scaling*div, q);
+            VectorizedArray<double> div = trace(sym_grad_u);
+            pressure.submit_value   (sim.pressure_scaling*div, q);
 
             sym_grad_u *= cell_viscosity_x_2;
 
             for (unsigned int d=0; d<dim; ++d)
               sym_grad_u[d][d] -= sim.pressure_scaling*pres;
+
+            if (is_compressible)
+              for (unsigned int d=0; d<dim; ++d)
+                sym_grad_u[d][d] -= cell_viscosity_x_2/3.0*div;
 
             velocity.submit_symmetric_gradient(-1.0*sym_grad_u, q);
           }
@@ -1460,6 +1466,7 @@ namespace aspect
 
     LinearAlgebra::BlockVector stokes_rhs_correction (sim.introspection.index_sets.stokes_partitioning, sim.mpi_communicator);
     internal::ChangeVectorTypes::copy(stokes_rhs_correction,rhs_correction);
+
     sim.system_rhs.block(0) += stokes_rhs_correction.block(0);
     sim.system_rhs.block(1) += stokes_rhs_correction.block(1);
   }
@@ -2197,6 +2204,8 @@ namespace aspect
   {
     TimerOutput::Scope timer (this->sim.computing_timer, "Build Stokes preconditioner");
 
+    const bool is_compressible = sim.material_model->is_compressible();
+
     // GMG diagonals
     for (unsigned int level=0; level < sim.triangulation.n_global_levels(); ++level)
       {
@@ -2233,6 +2242,7 @@ namespace aspect
             const FEValuesExtractors::Vector velocities (0);
 
             std::vector<SymmetricTensor<2,dim> > symgrad_phi_u (dofs_per_cell);
+            std::vector<double> div_phi_u (dofs_per_cell);
 
             ConstraintMatrix boundary_constraints;
             boundary_constraints.reinit(locally_relevant_dofs);
@@ -2264,13 +2274,22 @@ namespace aspect
                   for (unsigned int q=0; q<n_q_points; ++q)
                     {
                       for (unsigned int k=0; k<dofs_per_cell; ++k)
-                        symgrad_phi_u[k] = fe_values[velocities].symmetric_gradient (k, q);
+                        {
+                          symgrad_phi_u[k] = fe_values[velocities].symmetric_gradient (k, q);
+                          div_phi_u[k] = fe_values[velocities].divergence (k, q);
+                        }
 
                       const double JxW = fe_values.JxW(q);
                       for (unsigned int i=0; i<dofs_per_cell; ++i)
                         for (unsigned int j=0; j<dofs_per_cell; ++j)
-                          cell_matrix(i,j) += 2. * viscosity * (symgrad_phi_u[i]*symgrad_phi_u[j])
-                                              * JxW;
+                          {
+                            cell_matrix(i,j) += 2. * viscosity * (symgrad_phi_u[i]*symgrad_phi_u[j])
+                                                * JxW;
+
+                            if (is_compressible)
+                              cell_matrix(i,j) +=  (-2./3.) * viscosity * (div_phi_u[i]*div_phi_u[j])
+                                                   * JxW;
+                          }
                     }
 
                   cell->get_mg_dof_indices (local_dof_indices);

--- a/tests/prescribed_dilation_gmg.cc
+++ b/tests/prescribed_dilation_gmg.cc
@@ -1,0 +1,1 @@
+#include "prescribed_dilation.cc"

--- a/tests/prescribed_dilation_gmg.prm
+++ b/tests/prescribed_dilation_gmg.prm
@@ -1,0 +1,18 @@
+# like prescribed_dilation.prm but using GMG
+
+set Dimension                              = 2
+
+include $ASPECT_SOURCE_DIR/tests/prescribed_dilation.prm
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block GMG
+    set Number of cheap Stokes solver steps = 200
+    #set Maximum number of expensive Stokes solver steps = 40
+  end
+end
+
+subsection Material model
+  set Material averaging = harmonic average
+end
+

--- a/tests/prescribed_dilation_gmg/screen-output
+++ b/tests/prescribed_dilation_gmg/screen-output
@@ -1,0 +1,40 @@
+
+Loading shared library <./libprescribed_dilation_gmg.so>
+
+Vectorization over 2 doubles = 128 bits (SSE2), VECTORIZATION_LEVEL=1
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 948 (578+81+289)
+
+*** Timestep 0:  t=0 seconds
+   Solving Stokes system... 24+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
+   Solving Stokes system... 0+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 4.01158e-13
+
+
+   Postprocessing:
+     RMS, max velocity:        2.13 m/s, 4.82 m/s
+     Errors u_L2, p_L2:        1.794314e-04, 8.890774e-05
+     Writing graphical output: output-prescribed_dilation_gmg/solution/solution-00000
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 3,556 (2,178+289+1,089)
+
+*** Timestep 0:  t=0 seconds
+   Solving Stokes system... 24+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
+   Solving Stokes system... 0+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 4.09552e-13
+
+
+   Postprocessing:
+     RMS, max velocity:        2.13 m/s, 4.88 m/s
+     Errors u_L2, p_L2:        2.245433e-05, 5.959027e-06
+     Writing graphical output: output-prescribed_dilation_gmg/solution/solution-00001
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/simple_compressibility_iterated_stokes_gmg.cc
+++ b/tests/simple_compressibility_iterated_stokes_gmg.cc
@@ -1,0 +1,2 @@
+#include "compressibility.cc"
+

--- a/tests/simple_compressibility_iterated_stokes_gmg.prm
+++ b/tests/simple_compressibility_iterated_stokes_gmg.prm
@@ -1,0 +1,18 @@
+# like simple_compressibility_iterated_stokes.prm but using GMG
+
+include $ASPECT_SOURCE_DIR/tests/simple_compressibility_iterated_stokes.prm
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 3
+end
+
+subsection Material model
+  set Material averaging = harmonic average
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block GMG
+  end
+end

--- a/tests/simple_compressibility_iterated_stokes_gmg/screen-output
+++ b/tests/simple_compressibility_iterated_stokes_gmg/screen-output
@@ -1,0 +1,31 @@
+
+Loading shared library <./libsimple_compressibility_iterated_stokes_gmg.so>
+
+Vectorization over 2 doubles = 128 bits (SSE2), VECTORIZATION_LEVEL=1
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 948 (578+81+289)
+
+*** Timestep 0:  t=0 seconds
+   Solving Stokes system... 11+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1.00145
+
+   Solving Stokes system... 6+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.037238
+
+   Solving Stokes system... 5+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.00199851
+
+   Solving Stokes system... 3+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 7.05891e-05
+
+   Solving Stokes system... 3+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 1.71062e-06
+
+
+   Postprocessing:
+     Top/bottom flux: 1/1
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/steinberger_compressible_gmg.prm.dealii9.2
+++ b/tests/steinberger_compressible_gmg.prm.dealii9.2
@@ -1,0 +1,18 @@
+# Like steinberger_compressible but with GMG and harmonic averaging for viscosity
+
+include $ASPECT_SOURCE_DIR/tests/steinberger_compressible.prm
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block GMG
+  end
+end
+
+subsection Material model
+ set Material averaging = harmonic average only viscosity
+end
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, basic statistics, temperature statistics, heat flux statistics
+end
+

--- a/tests/steinberger_compressible_gmg/screen-output
+++ b/tests/steinberger_compressible_gmg/screen-output
@@ -1,0 +1,32 @@
+
+Number of active cells: 192 (on 4 levels)
+Number of degrees of freedom: 2,724 (1,666+225+833)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 18+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:           output-steinberger_compressible/solution/solution-00000
+     RMS, max velocity:                  0.582 m/year, 1.12 m/year
+     Temperature min/avg/max:            273 K, 2254 K, 4250 K
+     Heat fluxes through boundary parts: 1.535e+06 W, -3.985e+06 W, 0 W, 0 W
+     Writing depth average:              output-steinberger_compressible/depth_average
+
+*** Timestep 1:  t=100000 years
+   Solving temperature system... 14 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 15+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:           output-steinberger_compressible/solution/solution-00001
+     RMS, max velocity:                  0.574 m/year, 1.11 m/year
+     Temperature min/avg/max:            273 K, 2253 K, 4250 K
+     Heat fluxes through boundary parts: -2.976e+06 W, -1.233e+06 W, 0 W, 0 W
+     Writing depth average:              output-steinberger_compressible/depth_average
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/steinberger_compressible_gmg/statistics
+++ b/tests/steinberger_compressible_gmg/statistics
@@ -1,0 +1,23 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Visualization file name
+# 12: RMS velocity (m/year)
+# 13: Max. velocity (m/year)
+# 14: Minimal temperature (K)
+# 15: Average temperature (K)
+# 16: Maximal temperature (K)
+# 17: Average nondimensional temperature (K)
+# 18: Outward heat flux through boundary with indicator 0 ("bottom") (W)
+# 19: Outward heat flux through boundary with indicator 1 ("top") (W)
+# 20: Outward heat flux through boundary with indicator 2 ("left") (W)
+# 21: Outward heat flux through boundary with indicator 3 ("right") (W)
+0 0.000000000000e+00 0.000000000000e+00 192 1891 833  0 17 19 18 output-steinberger_compressible/solution/solution-00000 5.81712054e-01 1.11601495e+00 2.73000000e+02 2.25420782e+03 4.25000000e+03 4.98166413e-01  1.53467059e+06 -3.98504362e+06 0.00000000e+00 0.00000000e+00 
+1 1.000000000000e+05 1.000000000000e+05 192 1891 833 14 14 16 16 output-steinberger_compressible/solution/solution-00001 5.74179075e-01 1.10692129e+00 2.73000000e+02 2.25311298e+03 4.25000000e+03 4.97891119e-01 -2.97567366e+06 -1.23285884e+06 0.00000000e+00 0.00000000e+00 


### PR DESCRIPTION
Two fixes are required for `StokesMatrixFree::correct_stokes_rhs()` function. 

1. When the variable `Simulator::do_pressure_rhs_compatibility_modification = true`, `make_pressure_rhs_compatible()` must  be called before adding the rhs correction to `system_rhs`. 
2. For compressible computations, the `2*eta/3*div` term needs to be included in the residual computation for the rhs correction. This was an oversight for this function and did not show up since I only had compressible tests with Zero or Tangential boundary (`correct_stokes_rhs()` is not necessary in that case).

I added two tests, prescribed_dilation_gmg and simple_compresssibility_iterated_Stokes_gmg. Both require fix 1. Fix 2. is required by simple_compresssibility_iterated_Stokes_gmg as it is a compressible computation with non-zero prescribed boundary. I have tested the solution norms for each test vs. AMG solver and they are correct.

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.