### PR TITLE
fix trilinos amg bug

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -459,7 +459,14 @@ namespace aspect
 #ifdef ASPECT_USE_PETSC
     Amg_data.symmetric_operator = false;
 #else
+#if DEAL_II_VERSION_GTE(9,2,0)
     Amg_data.constant_modes = constant_modes;
+#else
+    // To avoid a Trilinos error, only define constant modes
+    // if this mpi rank owns any DoFs:
+    if (dof_handler.n_locally_owned_dofs() != 0)
+      Amg_data.constant_modes = constant_modes;
+#endif
     Amg_data.elliptic = true;
     Amg_data.higher_order_elements = true;
 


### PR DESCRIPTION
Fix for a Trilinos amg bug. 

If you do a Stokes solve with the AMG preconditioner where an mpi rank owns 0 DoFs, Trilinos gives either an error (version 12-10-1) or a warning (version 12-18-1) when initializing the preconditioner:
**trilinos-12-10-1:**
ML::FATAL ERROR:: 1, /hdscratch/shared/libs-candi-9.1.1-r2/tmp/unpack/Trilinos-trilinos-release-12-10-1/packages/ml/src/Utils/ml_MultiLevelPreconditioner_NullSpace.cpp, line 98

**trilinos-12-18-1:**
WARNING:  When no nullspace vector is specified, the number
of PDE equations must equal the nullspace dimension.

This pull request gets around this by only setting the `constant_modes` on ranks which own DoFs. Eventually, maybe the fix should instead be in deal.II (either return empty in `DoFTools::extract_constant_modes` or change the `TrilinosWrappers::PreconditionAMG::AdditionalData::set_operator_null_space()` to not set constant modes in this case), but for now I think this fix is appropriate for ASPECT.

I'm attaching a .prm file which demonstrates the bug for the current ASPECT master version (run with deal.II 9.2.0). It's Nsinker with 1 global refinement. Error/Warning is triggered if run with 2 or more cores.

[amg_error.prm.txt](https://github.com/geodynamics/aspect/files/4482337/amg_error.prm.txt)
