### PR TITLE
Add material inputs and outputs n_evaluation_points() function

### DIFF
--- a/benchmarks/annulus/annulus.cc
+++ b/benchmarks/annulus/annulus.cc
@@ -181,7 +181,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               const Point<dim> &pos = in.position[i];
 

--- a/benchmarks/burstedde/burstedde.cc
+++ b/benchmarks/burstedde/burstedde.cc
@@ -186,7 +186,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               const Point<dim> &p = in.position[i];
 

--- a/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
+++ b/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
@@ -147,7 +147,7 @@ namespace aspect
 
       const unsigned int density_field_index = this->introspection().compositional_index_for_name("density_field");
 
-      for (unsigned int i=0; i < in.temperature.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           double pressure_for_density = in.pressure[i];
 
@@ -182,7 +182,7 @@ namespace aspect
       // only happens inside Simulator<dim>::interpolate_material_output_into_compositional_field,
       // this just sets the correct term the field will be set to.
       if (PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim> >())
-        for (unsigned int i=0; i < in.position.size(); ++i)
+        for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
           prescribed_field_out->prescribed_field_outputs[i][density_field_index] = out.densities[i];
     }
 

--- a/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
+++ b/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
@@ -194,7 +194,7 @@ namespace aspect
     {
       if (out.template get_additional_output<PrescribedFieldOutputs<dim> >() == NULL)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std::unique_ptr<MaterialModel::AdditionalMaterialOutputs<dim> >
             (new MaterialModel::PrescribedFieldOutputs<dim> (n_points, this->n_compositional_fields())));

--- a/benchmarks/davies_et_al/case-2.3-plugin/VoT.cc
+++ b/benchmarks/davies_et_al/case-2.3-plugin/VoT.cc
@@ -107,7 +107,7 @@ namespace aspect
     evaluate(const typename Interface<dim>::MaterialModelInputs &in,
              typename Interface<dim>::MaterialModelOutputs &out) const
     {
-      for (unsigned int i=0; i<in.position.size(); ++i)
+      for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
         {
           out.viscosities[i] = eta*std::pow(1000,(-in.temperature[i]));
 

--- a/benchmarks/doneahuerta/doneahuerta.cc
+++ b/benchmarks/doneahuerta/doneahuerta.cc
@@ -122,7 +122,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               out.viscosities[i] = 1.;
               out.densities[i] = 1;

--- a/benchmarks/hollow_sphere/hollow_sphere.cc
+++ b/benchmarks/hollow_sphere/hollow_sphere.cc
@@ -284,7 +284,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               const Point<dim> &pos = in.position[i];
               const std::array<double,dim> spos = aspect::Utilities::Coordinates::cartesian_to_spherical_coordinates(pos);

--- a/benchmarks/inclusion/compositional_fields/inclusion_compositional_fields.h
+++ b/benchmarks/inclusion/compositional_fields/inclusion_compositional_fields.h
@@ -18,7 +18,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               out.viscosities[i] = in.composition[i][0];
               out.densities[i] = 0;

--- a/benchmarks/inclusion/inclusion.h
+++ b/benchmarks/inclusion/inclusion.h
@@ -157,7 +157,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               const Point<dim> &pos = in.position[i];
               double r2 = (pos[0]-1.0)*(pos[0]-1.0) + (pos[1]-1.0)*(pos[1]-1.0);

--- a/benchmarks/king2dcompressible/code.cc
+++ b/benchmarks/king2dcompressible/code.cc
@@ -74,7 +74,7 @@ namespace aspect
                               MaterialModelOutputs<dim> &out) const
         {
 
-          for (unsigned int i=0; i < in.temperature.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               const Point<dim> position = in.position[i];
               const double temperature = in.temperature[i];

--- a/benchmarks/layeredflow/layeredflow.cc
+++ b/benchmarks/layeredflow/layeredflow.cc
@@ -144,7 +144,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               const Point<dim> &pos = in.position[i];
 

--- a/benchmarks/nonlinear_channel_flow/simple_nonlinear.cc
+++ b/benchmarks/nonlinear_channel_flow/simple_nonlinear.cc
@@ -131,7 +131,7 @@ namespace aspect
       //set up additional output for the derivatives
       MaterialModelDerivatives<dim> *derivatives = out.template get_additional_output<MaterialModelDerivatives<dim> >();
 
-      for (unsigned int i=0; i < in.temperature.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const double temperature = in.temperature[i];
 

--- a/benchmarks/nsinker/nsinker.cc
+++ b/benchmarks/nsinker/nsinker.cc
@@ -45,7 +45,7 @@ namespace aspect
         {
           const double sqrt_dynamic_viscosity_ratio = std::sqrt(dynamic_viscosity_ratio);
 
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               const double chi = value(in.position[i]);
               out.viscosities[i] = (sqrt_dynamic_viscosity_ratio - 1/sqrt_dynamic_viscosity_ratio)*(1-chi) + 1/sqrt_dynamic_viscosity_ratio;

--- a/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
+++ b/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
@@ -208,7 +208,7 @@ namespace aspect
     {
       if (out.template get_additional_output<ReactionRateOutputs<dim> >() == NULL)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
         }

--- a/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
+++ b/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
@@ -122,7 +122,7 @@ namespace aspect
       base_model->evaluate(in,out);
       const double time_scale = this->convert_output_to_years() ? year_in_seconds : 1.0;
 
-      for (unsigned int q=0; q < in.position.size(); ++q)
+      for (unsigned int q=0; q < in.n_evaluation_points(); ++q)
         for (unsigned int c=0; c < this->introspection().n_compositional_fields; ++c)
           out.reaction_terms[q][c] = 0.0;
 
@@ -131,7 +131,7 @@ namespace aspect
 
       if (reaction_out != NULL)
         {
-          for (unsigned int q=0; q < in.position.size(); ++q)
+          for (unsigned int q=0; q < in.n_evaluation_points(); ++q)
             {
               // dC/dt = - z * lambda * C
               const double decay_constant = half_life > 0.0 ? log(2.0) / half_life : 0.0;
@@ -225,7 +225,7 @@ namespace aspect
               const MaterialModel::MaterialModelOutputs<dim> & /*out*/,
               HeatingModel::HeatingModelOutputs &heating_model_outputs) const
     {
-      Assert(heating_model_outputs.heating_source_terms.size() == in.position.size(),
+      Assert(heating_model_outputs.heating_source_terms.size() == in.n_evaluation_points(),
              ExcMessage ("Heating outputs need to have the same number of entries as the material model inputs."));
 
       const double time_scale = this->convert_output_to_years() ? year_in_seconds : 1.0;

--- a/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
+++ b/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
@@ -205,7 +205,7 @@ namespace aspect
     {
       if (out.template get_additional_output<ReactionRateOutputs<dim> >() == NULL)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
         }

--- a/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
+++ b/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
@@ -120,7 +120,7 @@ namespace aspect
       base_model->evaluate(in,out);
       const double time_scale = this->convert_output_to_years() ? year_in_seconds : 1.0;
 
-      for (unsigned int q=0; q < in.position.size(); ++q)
+      for (unsigned int q=0; q < in.n_evaluation_points(); ++q)
         for (unsigned int c=0; c < this->introspection().n_compositional_fields; ++c)
           out.reaction_terms[q][c] = 0.0;
 
@@ -129,7 +129,7 @@ namespace aspect
 
       if (reaction_out != NULL)
         {
-          for (unsigned int q=0; q < in.position.size(); ++q)
+          for (unsigned int q=0; q < in.n_evaluation_points(); ++q)
             {
               // dC/dt = - lambda * C
               const double decay_constant = half_life > 0.0 ? log(2.0) / half_life : 0.0;
@@ -223,7 +223,7 @@ namespace aspect
               const MaterialModel::MaterialModelOutputs<dim> & /*out*/,
               HeatingModel::HeatingModelOutputs &heating_model_outputs) const
     {
-      Assert(heating_model_outputs.heating_source_terms.size() == in.position.size(),
+      Assert(heating_model_outputs.heating_source_terms.size() == in.n_evaluation_points(),
              ExcMessage ("Heating outputs need to have the same number of entries as the material model inputs."));
 
       const double time_scale = this->convert_output_to_years() ? year_in_seconds : 1.0;

--- a/benchmarks/rayleigh_taylor_instability/rayleigh_taylor_instability.cc
+++ b/benchmarks/rayleigh_taylor_instability/rayleigh_taylor_instability.cc
@@ -56,7 +56,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               const Point<dim> &pos = in.position[i];
 

--- a/benchmarks/rigid_shear/plugin/rigid_shear.cc
+++ b/benchmarks/rigid_shear/plugin/rigid_shear.cc
@@ -98,7 +98,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               const double x = in.position[i][0];
               const double y = in.position[i][1];
@@ -147,7 +147,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               out.densities[i] = in.composition[i][1];
               out.viscosities[i] = 1.0;

--- a/benchmarks/shear_bands/shear_bands.cc
+++ b/benchmarks/shear_bands/shear_bands.cc
@@ -120,7 +120,7 @@ namespace aspect
           const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
           const double strain_rate_dependence = (1.0 - dislocation_creep_exponent) / dislocation_creep_exponent;
 
-          for (unsigned int i=0; i<in.position.size(); ++i)
+          for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
             {
               double porosity = std::max(in.composition[i][porosity_idx],1e-4);
               out.viscosities[i] = eta_0 * std::exp(alpha*(porosity - background_porosity));
@@ -148,7 +148,7 @@ namespace aspect
           aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
           if (melt_out != NULL)
-            for (unsigned int i=0; i<in.position.size(); ++i)
+            for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
               {
                 double porosity = std::max(in.composition[i][porosity_idx],1e-4);
 

--- a/benchmarks/sinking_block/sinking_block.cc
+++ b/benchmarks/sinking_block/sinking_block.cc
@@ -55,7 +55,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               const Point<dim> &pos = in.position[i];
               if (method==0)

--- a/benchmarks/solcx/compositional_fields/solcx_compositional_fields.h
+++ b/benchmarks/solcx/compositional_fields/solcx_compositional_fields.h
@@ -18,7 +18,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               out.densities[i] = in.composition[i][0];
               out.viscosities[i] = in.composition[i][1];

--- a/benchmarks/solcx/solcx.h
+++ b/benchmarks/solcx/solcx.h
@@ -2963,7 +2963,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
 
               const Point<dim> &pos = in.position[i];

--- a/benchmarks/solitary_wave/solitary_wave.cc
+++ b/benchmarks/solitary_wave/solitary_wave.cc
@@ -427,7 +427,7 @@ namespace aspect
         {
           const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
-          for (unsigned int i=0; i<in.position.size(); ++i)
+          for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
             {
               double porosity = in.composition[i][porosity_idx];
 
@@ -445,7 +445,7 @@ namespace aspect
           aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
           if (melt_out != NULL)
-            for (unsigned int i=0; i<in.position.size(); ++i)
+            for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
               {
                 double porosity = in.composition[i][porosity_idx];
 

--- a/benchmarks/solkz/compositional_fields/solkz_compositional_fields.h
+++ b/benchmarks/solkz/compositional_fields/solkz_compositional_fields.h
@@ -21,7 +21,7 @@ namespace aspect
         {
           SolKzMaterial<dim>::evaluate(in, out);
 
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               out.densities[i] = in.composition[i][0];
               out.viscosities[i] = in.composition[i][1];

--- a/benchmarks/solkz/solkz.h
+++ b/benchmarks/solkz/solkz.h
@@ -659,7 +659,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
 
               const Point<dim> &pos = in.position[i];

--- a/benchmarks/tangurnis/code/tangurnis.cc
+++ b/benchmarks/tangurnis/code/tangurnis.cc
@@ -81,7 +81,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               /**
                * @name Physical parameters used in the basic equations

--- a/benchmarks/time_dependent_annulus/plugin/time_dependent_annulus.h
+++ b/benchmarks/time_dependent_annulus/plugin/time_dependent_annulus.h
@@ -124,7 +124,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               if (use_analytic_density)
                 out.densities[i] = density_function->value(in.position[i]);

--- a/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
+++ b/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
@@ -62,7 +62,7 @@ namespace aspect
            * $\eta_{plast}(\dot\epsilon) = \text{eta\_asterisk} + \frac{\text{sigma\_yield}}{\sqrt(\dot\epsilon:\dot\epsilon)}$
            */
 
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               if (in.strain_rate.size())
                 {

--- a/cookbooks/anisotropic_viscosity/av_material.cc
+++ b/cookbooks/anisotropic_viscosity/av_material.cc
@@ -799,7 +799,7 @@ namespace aspect
     {
       if (out.template get_additional_output<AnisotropicViscosity<dim> >() == nullptr)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
         }

--- a/cookbooks/anisotropic_viscosity/av_material.cc
+++ b/cookbooks/anisotropic_viscosity/av_material.cc
@@ -583,11 +583,11 @@ namespace aspect
 
       // Get the grad_u tensor, at the center of this cell, if possible.
 
-      std::vector<Tensor<2,dim> > velocity_gradients (in.position.size());
+      std::vector<Tensor<2,dim> > velocity_gradients (in.n_evaluation_points());
       if (in.current_cell.state() == IteratorState::valid)
         {
-          std::vector<Point<dim> > quadrature_positions(in.position.size());
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          std::vector<Point<dim> > quadrature_positions(in.n_evaluation_points());
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             quadrature_positions[i] = this->get_mapping().transform_real_to_unit_cell(in.current_cell, in.position[i]);
 
           // FEValues requires a quadrature and we provide the default quadrature
@@ -601,7 +601,7 @@ namespace aspect
           .get_function_gradients(this->get_solution(), velocity_gradients);
         }
 
-      for (unsigned int q=0; q<in.position.size(); ++q)
+      for (unsigned int q=0; q<in.n_evaluation_points(); ++q)
         {
           out.densities[q] = (in.composition[q][c_idx_gamma] > 0.8 ? 1 : 0);
           out.viscosities[q] = eta_N;

--- a/cookbooks/finite_strain/finite_strain.cc
+++ b/cookbooks/finite_strain/finite_strain.cc
@@ -77,7 +77,7 @@ namespace aspect
           // Assign the strain components to the compositional fields reaction terms.
           // If there are too many fields, we simply fill only the first fields with the
           // existing strain rate tensor components.
-          for (unsigned int q=0; q < in.position.size(); ++q)
+          for (unsigned int q=0; q < in.n_evaluation_points(); ++q)
             {
               // Convert the compositional fields into the tensor quantity they represent.
               Tensor<2,dim> strain;

--- a/cookbooks/free-surface-with-crust/plugin/simpler-with-crust.cc
+++ b/cookbooks/free-surface-with-crust/plugin/simpler-with-crust.cc
@@ -108,7 +108,7 @@ namespace aspect
     SimplerWithCrust<dim>::
     evaluate(const typename Interface<dim>::MaterialModelInputs &in, typename Interface<dim>::MaterialModelOutputs &out ) const
     {
-      for (unsigned int i=0; i<in.position.size(); ++i)
+      for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
         {
           const double z = in.position[i][1];
           if (z>jump_height)

--- a/cookbooks/inner_core_convection/inner_core_convection.cc
+++ b/cookbooks/inner_core_convection/inner_core_convection.cc
@@ -199,7 +199,7 @@ namespace aspect
 
       // We want the right-hand side of the momentum equation to be (- Ra T gravity) and
       // density * cp to be 1
-      for (unsigned int q=0; q < in.position.size(); ++q)
+      for (unsigned int q=0; q < in.n_evaluation_points(); ++q)
         {
           out.densities[q] = - out.thermal_expansion_coefficients[q] * in.temperature[q]
                              + phase_function (in.position[q], in.temperature[q]) * transition_density_change;

--- a/cookbooks/morency_doin_2004/morency_doin.cc
+++ b/cookbooks/morency_doin_2004/morency_doin.cc
@@ -35,7 +35,7 @@ namespace aspect
     {
       const double R = 8.32; // J mol-1 K-1
       const double g = 9.8; // m s-2
-      for (unsigned int i=0; i < in.temperature.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const Point<dim> position = in.position[i];
           const double temperature = in.temperature[i];

--- a/doc/update_scripts/source_files/update_source_files_to_2.2.0_n_evaluation_points.pl
+++ b/doc/update_scripts/source_files/update_source_files_to_2.2.0_n_evaluation_points.pl
@@ -1,0 +1,11 @@
+#!/bin/perl
+#
+# This script removes uses the new n_evaluation_points functions
+# of the material model inputs object
+
+while (<>)
+{
+  s/in.position.size/in.n_evaluation_points/g;
+  s/in.temperature.size/in.n_evaluation_points/g;
+  print;
+}

--- a/doc/update_scripts/source_files/update_source_files_to_2.2.0_n_evaluation_points.pl
+++ b/doc/update_scripts/source_files/update_source_files_to_2.2.0_n_evaluation_points.pl
@@ -1,7 +1,7 @@
 #!/bin/perl
 #
-# This script removes uses the new n_evaluation_points functions
-# of the material model inputs object
+# This script uses the new n_evaluation_points functions
+# of the material model inputs and outputs objects
 
 while (<>)
 {

--- a/doc/update_scripts/source_files/update_source_files_to_2.2.0_n_evaluation_points.pl
+++ b/doc/update_scripts/source_files/update_source_files_to_2.2.0_n_evaluation_points.pl
@@ -7,5 +7,6 @@ while (<>)
 {
   s/in.position.size/in.n_evaluation_points/g;
   s/in.temperature.size/in.n_evaluation_points/g;
+  s/out.viscosities.size/out.n_evaluation_points/g;
   print;
 }

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -265,6 +265,11 @@ namespace aspect
                   const LinearAlgebra::BlockVector &solution_vector,
                   const bool use_strain_rates = true);
 
+      /**
+       * Function that returns the number of points at which
+       * the material model is to be evaluated.
+       */
+      unsigned int n_evaluation_points() const;
 
       /**
        * Vector with global positions where the material has to be evaluated
@@ -429,6 +434,11 @@ namespace aspect
        */
       MaterialModelOutputs &operator= (MaterialModelOutputs &&) = default;
 
+      /**
+      * Function that returns the number of points at which
+      * the material model is to be evaluated.
+      */
+      unsigned int n_evaluation_points() const;
 
       /**
        * Viscosity $\eta$ values at the given positions.

--- a/source/material_model/ascii_reference_profile.cc
+++ b/source/material_model/ascii_reference_profile.cc
@@ -237,7 +237,7 @@ namespace aspect
           && seismic_vp_index != numbers::invalid_unsigned_int
           && seismic_vs_index != numbers::invalid_unsigned_int)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
         }

--- a/source/material_model/ascii_reference_profile.cc
+++ b/source/material_model/ascii_reference_profile.cc
@@ -66,7 +66,7 @@ namespace aspect
     evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      for (unsigned int i=0; i < in.temperature.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const Point<dim> position = in.position[i];
           const double temperature_deviation = in.temperature[i] - this->get_adiabatic_conditions().temperature(position);

--- a/source/material_model/averaging.cc
+++ b/source/material_model/averaging.cc
@@ -338,7 +338,7 @@ namespace aspect
        * and the normalized weighted distance averaging schemes need the distance between
        * the points and can not handle a distance of zero.
        */
-      if (out.densities.size() > 1)
+      if (out.n_evaluation_points() > 1)
         {
           /* Average the base model values based on the chosen average */
           average (averaging_operation,in.position,out.viscosities);

--- a/source/material_model/compositing.cc
+++ b/source/material_model/compositing.cc
@@ -94,7 +94,7 @@ namespace aspect
     Compositing<dim>::evaluate(const typename Interface<dim>::MaterialModelInputs &in,
                                typename Interface<dim>::MaterialModelOutputs &out) const
     {
-      typename Interface<dim>::MaterialModelOutputs base_output(out.viscosities.size(),
+      typename Interface<dim>::MaterialModelOutputs base_output(out.n_evaluation_points(),
                                                                 this->introspection().n_compositional_fields);
 
       // Move the additional outputs to base_output so that our models can fill them if desired:

--- a/source/material_model/composition_reaction.cc
+++ b/source/material_model/composition_reaction.cc
@@ -42,7 +42,7 @@ namespace aspect
       const unsigned int n_compositions_for_eos = std::min(this->n_compositional_fields()+1, 3u);
       EquationOfStateOutputs<dim> eos_outputs (n_compositions_for_eos);
 
-      for (unsigned int i=0; i < in.position.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const double temperature = in.temperature[i];
           const std::vector<double> &composition = in.composition[i];

--- a/source/material_model/composition_reaction.cc
+++ b/source/material_model/composition_reaction.cc
@@ -233,7 +233,7 @@ namespace aspect
       if (this->get_parameters().use_operator_splitting
           && out.template get_additional_output<ReactionRateOutputs<dim> >() == nullptr)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points,
                                                                              this->n_compositional_fields()));

--- a/source/material_model/depth_dependent.cc
+++ b/source/material_model/depth_dependent.cc
@@ -169,7 +169,7 @@ namespace aspect
       if (in.strain_rate.size())
         {
           // Scale the base model viscosity value by the depth dependent prefactor
-          for (unsigned int i=0; i < out.viscosities.size(); ++i)
+          for (unsigned int i=0; i < out.n_evaluation_points(); ++i)
             {
               const double depth = this->get_geometry_model().depth(in.position[i]);
               out.viscosities[i] *= calculate_depth_dependent_prefactor( depth );

--- a/source/material_model/diffusion_dislocation.cc
+++ b/source/material_model/diffusion_dislocation.cc
@@ -176,7 +176,7 @@ namespace aspect
     evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      for (unsigned int i=0; i < in.temperature.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           // const Point<dim> position = in.position[i];
           const double temperature = in.temperature[i];

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -41,7 +41,7 @@ namespace aspect
 
       EquationOfStateOutputs<dim> eos_outputs (1);
 
-      for (unsigned int i=0; i < in.temperature.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           // To avoid negative yield strengths and eventually viscosities,
           // we make sure the pressure is not negative

--- a/source/material_model/dynamic_friction.cc
+++ b/source/material_model/dynamic_friction.cc
@@ -82,7 +82,7 @@ namespace aspect
     {
       EquationOfStateOutputs<dim> eos_outputs (this->n_compositional_fields()+1);
 
-      for (unsigned int i=0; i < in.position.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const std::vector<double> volume_fractions = MaterialUtilities::compute_volume_fractions(in.composition[i]);
 

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -749,7 +749,7 @@ namespace aspect
     GrainSize<dim>::
     evaluate(const typename Interface<dim>::MaterialModelInputs &in, typename Interface<dim>::MaterialModelOutputs &out) const
     {
-      for (unsigned int i=0; i<in.position.size(); ++i)
+      for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
         {
           // Use the adiabatic pressure instead of the real one, because of oscillations
           const double pressure = (this->get_adiabatic_conditions().is_initialized())
@@ -806,7 +806,7 @@ namespace aspect
                   crossed_transition = phase;
               }
           else
-            for (unsigned int j=0; j<in.position.size(); ++j)
+            for (unsigned int j=0; j<in.n_evaluation_points(); ++j)
               for (unsigned int k=0; k<transition_depths.size(); ++k)
                 if ((phase_function(in.position[i], in.temperature[i], pressure, k)
                      != phase_function(in.position[j], in.temperature[j], in.pressure[j], k))
@@ -877,20 +877,20 @@ namespace aspect
        */
       double average_temperature(0.0);
       double average_density(0.0);
-      for (unsigned int i = 0; i < in.position.size(); ++i)
+      for (unsigned int i = 0; i < in.n_evaluation_points(); ++i)
         {
           average_temperature += in.temperature[i];
           average_density += out.densities[i];
         }
-      average_temperature /= in.position.size();
-      average_density /= in.position.size();
+      average_temperature /= in.n_evaluation_points();
+      average_density /= in.n_evaluation_points();
 
       std::array<std::pair<double, unsigned int>,2> dH;
 
       if (use_table_properties && use_enthalpy)
         dH = enthalpy_derivative(in);
 
-      for (unsigned int i = 0; i < in.position.size(); ++i)
+      for (unsigned int i = 0; i < in.n_evaluation_points(); ++i)
         {
           //Use the adiabatic pressure instead of the real one, because of oscillations
           const double pressure = (this->get_adiabatic_conditions().is_initialized())

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -1447,7 +1447,7 @@ namespace aspect
       // reduce grain size.
       if (out.template get_additional_output<DislocationViscosityOutputs<dim> >() == nullptr)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::DislocationViscosityOutputs<dim>> (n_points));
         }
@@ -1455,7 +1455,7 @@ namespace aspect
       // These properties are only output properties.
       if (out.template get_additional_output<SeismicAdditionalOutputs<dim> >() == nullptr)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
         }

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -394,8 +394,18 @@ namespace aspect
       DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
       this->current_cell = cell_x;
-
     }
+
+
+
+    template <int dim>
+    unsigned int
+    MaterialModelInputs<dim>::n_evaluation_points() const
+    {
+      return position.size();
+    }
+
+
 
     template <int dim>
     MaterialModelOutputs<dim>::MaterialModelOutputs(const unsigned int n_points,
@@ -431,6 +441,16 @@ namespace aspect
               ExcMessage ("You can not copy MaterialModelOutputs objects that have "
                           "additional output objects attached"));
     }
+
+
+
+    template <int dim>
+    unsigned int
+    MaterialModelOutputs<dim>::n_evaluation_points() const
+    {
+      return densities.size();
+    }
+
 
 
     namespace MaterialAveraging

--- a/source/material_model/latent_heat.cc
+++ b/source/material_model/latent_heat.cc
@@ -34,7 +34,7 @@ namespace aspect
     evaluate(const MaterialModelInputs<dim> &in,
              MaterialModelOutputs<dim> &out) const
     {
-      for (unsigned int i=0; i < in.position.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const double temperature = in.temperature[i];
           const double pressure = in.pressure[i];

--- a/source/material_model/latent_heat_melt.cc
+++ b/source/material_model/latent_heat_melt.cc
@@ -34,7 +34,7 @@ namespace aspect
     evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      for (unsigned int i=0; i < in.position.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
 
           out.entropy_derivative_pressure[i] = 0;
@@ -247,7 +247,7 @@ namespace aspect
     melt_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
                     std::vector<double> &melt_fractions) const
     {
-      for (unsigned int q=0; q<in.temperature.size(); ++q)
+      for (unsigned int q=0; q<in.n_evaluation_points(); ++q)
         melt_fractions[q] = melt_fraction(in.temperature[q],
                                           std::max(0.0, in.pressure[q]),
                                           in.composition[q],

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -522,7 +522,7 @@ namespace aspect
       if (this->get_parameters().use_operator_splitting
           && out.template get_additional_output<ReactionRateOutputs<dim> >() == nullptr)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
         }

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -87,7 +87,7 @@ namespace aspect
     {
       double depletion = 0.0;
 
-      for (unsigned int q=0; q<in.temperature.size(); ++q)
+      for (unsigned int q=0; q<in.n_evaluation_points(); ++q)
         {
           if (this->include_melt_transport())
             {
@@ -107,7 +107,7 @@ namespace aspect
     MeltGlobal<dim>::
     evaluate(const typename Interface<dim>::MaterialModelInputs &in, typename Interface<dim>::MaterialModelOutputs &out) const
     {
-      std::vector<double> old_porosity(in.position.size());
+      std::vector<double> old_porosity(in.n_evaluation_points());
 
       ReactionRateOutputs<dim> *reaction_rate_out = out.template get_additional_output<ReactionRateOutputs<dim> >();
 
@@ -128,13 +128,13 @@ namespace aspect
                               this->introspection().component_indices.compositional_fields[porosity_idx]);
         }
       else if (this->get_parameters().use_operator_splitting)
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
             old_porosity[i] = in.composition[i][porosity_idx];
           }
 
-      for (unsigned int i=0; i<in.position.size(); ++i)
+      for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
         {
           // calculate density first, we need it for the reaction term
           // temperature dependence of density is 1 - alpha * (T - T(adiabatic))
@@ -255,7 +255,7 @@ namespace aspect
         {
           const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
-          for (unsigned int i=0; i<in.position.size(); ++i)
+          for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
             {
               double porosity = std::max(in.composition[i][porosity_idx],0.0);
 

--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -767,7 +767,7 @@ namespace aspect
     {
       if (this->get_parameters().use_operator_splitting && out.template get_additional_output<ReactionRateOutputs<dim> >() == nullptr)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
         }

--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -181,7 +181,7 @@ namespace aspect
     melt_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
                     std::vector<double> &melt_fractions) const
     {
-      for (unsigned int q=0; q<in.temperature.size(); ++q)
+      for (unsigned int q=0; q<in.n_evaluation_points(); ++q)
         melt_fractions[q] = this->melt_fraction(in.temperature[q],
                                                 this->get_adiabatic_conditions().pressure(in.position[q]));
     }
@@ -212,7 +212,7 @@ namespace aspect
     {
       ReactionRateOutputs<dim> *reaction_rate_out = out.template get_additional_output<ReactionRateOutputs<dim> >();
 
-      for (unsigned int i=0; i<in.position.size(); ++i)
+      for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
         {
           // calculate density first, we need it for the reaction term
           // first, calculate temperature dependence of density
@@ -376,7 +376,7 @@ namespace aspect
         {
           const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
-          for (unsigned int i=0; i<in.position.size(); ++i)
+          for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
             {
               double porosity = std::max(in.composition[i][porosity_idx],0.0);
 

--- a/source/material_model/modified_tait.cc
+++ b/source/material_model/modified_tait.cc
@@ -32,7 +32,7 @@ namespace aspect
     evaluate(const MaterialModelInputs<dim> &in,
              MaterialModelOutputs<dim> &out) const
     {
-      for (unsigned int i=0; i < in.temperature.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const double temperature = in.temperature[i];
           const double pressure = in.pressure[i];

--- a/source/material_model/multicomponent.cc
+++ b/source/material_model/multicomponent.cc
@@ -37,7 +37,7 @@ namespace aspect
     {
       EquationOfStateOutputs<dim> eos_outputs (this->n_compositional_fields()+1);
 
-      for (unsigned int i=0; i < in.temperature.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const std::vector<double> volume_fractions = MaterialUtilities::compute_volume_fractions(in.composition[i]);
 

--- a/source/material_model/multicomponent_compressible.cc
+++ b/source/material_model/multicomponent_compressible.cc
@@ -37,7 +37,7 @@ namespace aspect
     {
       EquationOfStateOutputs<dim> eos_outputs (this->n_compositional_fields()+1);
 
-      for (unsigned int i=0; i < in.temperature.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const std::vector<double> reference_volume_fractions = MaterialUtilities::compute_volume_fractions(in.composition[i]); // these are the reference (uncompressed) volume fractions - ASPECT does not currently compute the changes in volume fraction with pressure and temperature
 

--- a/source/material_model/nondimensional.cc
+++ b/source/material_model/nondimensional.cc
@@ -62,7 +62,7 @@ namespace aspect
     evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      for (unsigned int i=0; i < in.temperature.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const Point<dim> position = in.position[i];
           const double temperature_deviation = in.temperature[i] - this->get_adiabatic_conditions().temperature(position);

--- a/source/material_model/perplex_lookup.cc
+++ b/source/material_model/perplex_lookup.cc
@@ -83,7 +83,7 @@ namespace aspect
 
       int phaseq_dbg = 0;
 
-      unsigned int n_quad = in.position.size(); // number of quadrature points in cell
+      unsigned int n_quad = in.n_evaluation_points(); // number of quadrature points in cell
       unsigned int n_comp = in.composition[0].size(); // number of components in rock
 
       const double average_temperature = std::min(max_temperature,

--- a/source/material_model/replace_lithosphere_viscosity.cc
+++ b/source/material_model/replace_lithosphere_viscosity.cc
@@ -51,7 +51,7 @@ namespace aspect
     {
       base_model->evaluate(in,out);
 
-      for (unsigned int i=0; i < in.position.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const double depth = this->SimulatorAccess<dim>::get_geometry_model().depth(in.position[i]);
           const double lab_depth = lab_depth_lookup.get_lab_depth(in.position[i]);

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -223,7 +223,7 @@ namespace aspect
           {
             const double dte = elastic_timestep();
 
-            for (unsigned int i=0; i < in.position.size(); ++i)
+            for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
               {
                 // Get old stresses from compositional fields
                 SymmetricTensor<2,dim> stress_old;
@@ -253,8 +253,8 @@ namespace aspect
         if (in.current_cell.state() == IteratorState::valid && this->get_timestep_number() > 0 && in.strain_rate.size() > 0)
           {
             // Get old (previous time step) velocity gradients
-            std::vector<Point<dim> > quadrature_positions(in.position.size());
-            for (unsigned int i=0; i < in.position.size(); ++i)
+            std::vector<Point<dim> > quadrature_positions(in.n_evaluation_points());
+            for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
               quadrature_positions[i] = this->get_mapping().transform_real_to_unit_cell(in.current_cell, in.position[i]);
 
             // FEValues requires a quadrature and we provide the default quadrature
@@ -272,7 +272,7 @@ namespace aspect
             const double dte = elastic_timestep();
             const double dt = this->get_timestep();
 
-            for (unsigned int i=0; i < in.position.size(); ++i)
+            for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
               {
                 // Get old stresses from compositional fields
                 SymmetricTensor<2,dim> stress_old;

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -197,7 +197,7 @@ namespace aspect
       {
         if (out.template get_additional_output<ElasticAdditionalOutputs<dim> >() == nullptr)
           {
-            const unsigned int n_points = out.viscosities.size();
+            const unsigned int n_points = out.n_evaluation_points();
             out.additional_outputs.push_back(
               std_cxx14::make_unique<ElasticAdditionalOutputs<dim>> (n_points));
           }

--- a/source/material_model/rheology/strain_dependent.cc
+++ b/source/material_model/rheology/strain_dependent.cc
@@ -446,8 +446,8 @@ namespace aspect
           {
             // We need the velocity gradient for the finite strain (they are not
             // in material model inputs), so we get them from the finite element.
-            std::vector<Point<dim> > quadrature_positions(in.position.size());
-            for (unsigned int i=0; i < in.position.size(); ++i)
+            std::vector<Point<dim> > quadrature_positions(in.n_evaluation_points());
+            for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
               quadrature_positions[i] = this->get_mapping().transform_real_to_unit_cell(in.current_cell, in.position[i]);
 
             FEValues<dim> fe_values (this->get_mapping(),
@@ -465,7 +465,7 @@ namespace aspect
             // If there are too many fields, we simply fill only the first fields with the
             // existing strain tensor components.
 
-            for (unsigned int q=0; q < in.position.size(); ++q)
+            for (unsigned int q=0; q < in.n_evaluation_points(); ++q)
               {
                 if (in.current_cell.state() == IteratorState::valid && weakening_mechanism == finite_strain_tensor
                     && this->get_timestep_number() > 0 && in.strain_rate.size())

--- a/source/material_model/simple.cc
+++ b/source/material_model/simple.cc
@@ -38,7 +38,7 @@ namespace aspect
       const unsigned int n_compositions_for_eos = std::min(this->n_compositional_fields()+1, 2u);
       EquationOfStateOutputs<dim> eos_outputs (n_compositions_for_eos);
 
-      for (unsigned int i=0; i < in.position.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const double delta_temp = in.temperature[i]-reference_T;
           const double temperature_dependence

--- a/source/material_model/simple_compressible.cc
+++ b/source/material_model/simple_compressible.cc
@@ -32,7 +32,7 @@ namespace aspect
     evaluate(const MaterialModelInputs<dim> &in,
              MaterialModelOutputs<dim> &out) const
     {
-      for (unsigned int i=0; i < in.temperature.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const Point<dim> position = in.position[i];
           const double temperature = in.temperature[i];

--- a/source/material_model/simpler.cc
+++ b/source/material_model/simpler.cc
@@ -52,7 +52,7 @@ namespace aspect
       // The Simpler model does not depend on composition
       EquationOfStateOutputs<dim> eos_outputs (1);
 
-      for (unsigned int i=0; i<in.position.size(); ++i)
+      for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
         {
           equation_of_state.evaluate(in, i, eos_outputs);
 

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -470,7 +470,7 @@ namespace aspect
     Steinberger<dim>::evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                                MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      for (unsigned int i=0; i < in.temperature.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           // We are only asked to give viscosities if strain_rate.size() > 0.
           if (in.strain_rate.size() > 0)
@@ -505,19 +505,19 @@ namespace aspect
            */
           double average_temperature(0.0);
           double average_density(0.0);
-          for (unsigned int i = 0; i < in.position.size(); ++i)
+          for (unsigned int i = 0; i < in.n_evaluation_points(); ++i)
             {
               average_temperature += in.temperature[i];
               average_density += out.densities[i];
             }
-          average_temperature /= in.position.size();
-          average_density /= in.position.size();
+          average_temperature /= in.n_evaluation_points();
+          average_density /= in.n_evaluation_points();
 
           std::array<std::pair<double, unsigned int>,2> dH;
           if (in.current_cell.state() == IteratorState::valid)
             dH = enthalpy_derivative(in);
 
-          for (unsigned int i = 0; i < in.position.size(); ++i)
+          for (unsigned int i = 0; i < in.n_evaluation_points(); ++i)
             {
               // Use the adiabatic pressure instead of the real one,
               // to stabilize against pressure oscillations in phase transitions

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -704,7 +704,7 @@ namespace aspect
     {
       if (out.template get_additional_output<SeismicAdditionalOutputs<dim> >() == nullptr)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
         }

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -869,7 +869,7 @@ namespace aspect
     {
       if (out.template get_additional_output<PlasticAdditionalOutputs<dim> >() == nullptr)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::PlasticAdditionalOutputs<dim>> (n_points));
         }

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -458,10 +458,10 @@ namespace aspect
       EquationOfStateOutputs<dim> eos_outputs (this->n_compositional_fields()+1);
       EquationOfStateOutputs<dim> eos_outputs_all_phases (this->n_compositional_fields()+1+phase_function.n_phase_transitions());
 
-      std::vector<double> average_elastic_shear_moduli (in.temperature.size());
+      std::vector<double> average_elastic_shear_moduli (in.n_evaluation_points());
 
       // Loop through all requested points
-      for (unsigned int i=0; i < in.temperature.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           // First compute the equation of state variables and thermodynamic properties
           equation_of_state.evaluate(in, i, eos_outputs_all_phases);

--- a/source/material_model/viscoelastic.cc
+++ b/source/material_model/viscoelastic.cc
@@ -43,10 +43,10 @@ namespace aspect
       for (unsigned int i=0; i < SymmetricTensor<2,dim>::n_independent_components; ++i)
         composition_mask.set(i,false);
 
-      std::vector<double> average_elastic_shear_moduli (in.temperature.size());
+      std::vector<double> average_elastic_shear_moduli (in.n_evaluation_points());
       std::vector<double> elastic_shear_moduli(elastic_rheology.get_elastic_shear_moduli());
 
-      for (unsigned int i=0; i < in.temperature.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const std::vector<double> composition = in.composition[i];
           const std::vector<double> volume_fractions = MaterialUtilities::compute_volume_fractions(composition, composition_mask);

--- a/tests/anisotropic_viscosity.cc
+++ b/tests/anisotropic_viscosity.cc
@@ -670,7 +670,7 @@ namespace aspect
       center[1] = 0.5;
       if (dim == 3)
         center[2] = 0.5;
-      for (unsigned int i=0; i < in.position.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const double pressure = in.pressure[i];
           out.densities[i] = 1.0 + pressure;

--- a/tests/burstedde_stokes_rhs.cc
+++ b/tests/burstedde_stokes_rhs.cc
@@ -172,7 +172,7 @@ namespace aspect
           MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>
           *force = out.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >();
 
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               const Point<dim> &p = in.position[i];
 

--- a/tests/composition_active_with_melt.cc
+++ b/tests/composition_active_with_melt.cc
@@ -49,7 +49,7 @@ namespace aspect
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             out.viscosities[i] = 1.0;
             out.thermal_expansion_coefficients[i] = 0.01;
@@ -73,7 +73,7 @@ namespace aspect
         if (melt_out != nullptr)
           {
 
-            for (unsigned int i=0; i<in.position.size(); ++i)
+            for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
               {
                 melt_out->compaction_viscosities[i] = 1.0;
                 melt_out->fluid_viscosities[i] = 1.0;

--- a/tests/composition_reaction_iterated_IMPES.cc
+++ b/tests/composition_reaction_iterated_IMPES.cc
@@ -22,7 +22,7 @@ namespace aspect
                               MaterialModelOutputs<dim> &out) const
         {
           this->CompositionReaction<dim>::evaluate(in, out);
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               const double depth = this->get_geometry_model().depth(in.position[i]);
               for (unsigned int c=0; c<this->n_compositional_fields(); ++c)

--- a/tests/compressibility.cc
+++ b/tests/compressibility.cc
@@ -38,7 +38,7 @@ namespace aspect
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       Simple<dim>::evaluate(in, out);
-      for (unsigned int i=0; i < in.position.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const double pressure = in.pressure[i];
           out.densities[i] = 1.0 + pressure;

--- a/tests/compressibility_iterated_stokes.cc
+++ b/tests/compressibility_iterated_stokes.cc
@@ -39,7 +39,7 @@ namespace aspect
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       Simple<dim>::evaluate(in, out);
-      for (unsigned int i=0; i < in.position.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           out.densities[i] = 10.0/11.0*exp(in.pressure[i]/100.0);
           out.compressibilities[i] = 0.01;

--- a/tests/compression_heating.cc
+++ b/tests/compression_heating.cc
@@ -27,7 +27,7 @@ namespace aspect
     {
       MeltGlobal<dim>::evaluate(in, out);
       const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
-      for (unsigned int i=0; i < in.position.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           out.reaction_terms[i][porosity_idx] = 0.2;
         }

--- a/tests/cookbook_simpler_with_crust.cc
+++ b/tests/cookbook_simpler_with_crust.cc
@@ -109,7 +109,7 @@ namespace aspect
     SimplerWithCrust<dim>::
     evaluate(const typename Interface<dim>::MaterialModelInputs &in, typename Interface<dim>::MaterialModelOutputs &out ) const
     {
-      for (unsigned int i=0; i<in.position.size(); ++i)
+      for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
         {
           const double z = in.position[i][1];
           if (z>jump_height)

--- a/tests/free_surface_blob_melt.cc
+++ b/tests/free_surface_blob_melt.cc
@@ -78,7 +78,7 @@ namespace aspect
     evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      for (unsigned int i=0; i < in.position.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const double delta_temp = in.temperature[i]-reference_T;
           const double temperature_dependence = (reference_T > 0
@@ -128,7 +128,7 @@ namespace aspect
         {
           const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               const double porosity = std::max(in.composition[i][porosity_idx],0.0);
               melt_out->fluid_densities[i] = 300.;
@@ -146,7 +146,7 @@ namespace aspect
     melt_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
                     std::vector<double> &melt_fractions) const
     {
-      for (unsigned int q=0; q<in.temperature.size(); ++q)
+      for (unsigned int q=0; q<in.n_evaluation_points(); ++q)
         melt_fractions[q] = 0.0;
       return;
     }

--- a/tests/grain_size_latent_heat.cc
+++ b/tests/grain_size_latent_heat.cc
@@ -127,7 +127,7 @@ namespace aspect
                 }
             }
 
-          for (unsigned int i=0; i<in.position.size(); ++i)
+          for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
             {
               // convert the grain size from log to normal
               std::vector<double> composition (in.composition[i]);
@@ -163,7 +163,7 @@ namespace aspect
                       crossed_transition = phase;
                   }
               else
-                for (unsigned int j=0; j<in.position.size(); ++j)
+                for (unsigned int j=0; j<in.n_evaluation_points(); ++j)
                   for (unsigned int k=0; k<this->transition_depths.size(); ++k)
                     if ((this->phase_function(in.position[i], in.temperature[i], in.pressure[i], k)
                          != this->phase_function(in.position[j], in.temperature[j], in.pressure[j], k))

--- a/tests/heat_advection_by_melt.cc
+++ b/tests/heat_advection_by_melt.cc
@@ -62,14 +62,14 @@ namespace aspect
 
       // fill melt outputs if they exist
       MeltOutputs<dim> *melt_out = out.template get_additional_output<MeltOutputs<dim> >();
-      for (unsigned int i=0; i < in.position.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           out.densities[i] = 2.0;
         }
 
       if (melt_out != nullptr)
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               melt_out->fluid_densities[i] = 1.0;
               melt_out->permeabilities[i] = 1.0;

--- a/tests/hydrostatic_compression.cc
+++ b/tests/hydrostatic_compression.cc
@@ -35,7 +35,7 @@ namespace aspect
       {
         const double alpha = -0.2;     // T0 = 100
 
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             const double x = in.position[i](0);
             const double z = in.position[i](1);

--- a/tests/latent_heat_enthalpy.cc
+++ b/tests/latent_heat_enthalpy.cc
@@ -141,7 +141,7 @@ namespace aspect
                 }
             }
 
-          for (unsigned int i=0; i<in.position.size(); ++i)
+          for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
             {
               if (in.strain_rate.size() > 0)
                 out.viscosities[i] = eta;

--- a/tests/melt_compressible_advection.cc
+++ b/tests/melt_compressible_advection.cc
@@ -45,7 +45,7 @@ namespace aspect
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             out.viscosities[i] = 0.75;
             out.thermal_expansion_coefficients[i] = 0.0;
@@ -62,7 +62,7 @@ namespace aspect
 
         if (melt_out != nullptr)
           {
-            for (unsigned int i=0; i<in.position.size(); ++i)
+            for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
               {
                 melt_out->compaction_viscosities[i] = 0.5 * (in.position[i][1]+0.1)*(in.position[i][1]+0.1);
                 melt_out->fluid_viscosities[i] = 1.0;

--- a/tests/melt_force_vector.cc
+++ b/tests/melt_force_vector.cc
@@ -84,7 +84,7 @@ namespace aspect
         MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>
         *force = out.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >();
 
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             const double porosity = in.composition[i][porosity_idx];
             const double x = in.position[i](0);
@@ -113,7 +113,7 @@ namespace aspect
         aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim> >();
 
         if (melt_out != nullptr)
-          for (unsigned int i=0; i<in.position.size(); ++i)
+          for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
             {
               double porosity = in.composition[i][porosity_idx];
               // porosity = 0.1000000000e-1 + 0.2000000000e0 * exp(-0.200e2 * pow(x + 0.2e1 * z, 0.2e1));

--- a/tests/melt_introspection.cc
+++ b/tests/melt_introspection.cc
@@ -63,7 +63,7 @@ namespace aspect
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
 
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             out.viscosities[i] = 1.0;
             out.densities[i] = 1.0 + (in.composition[i][0]);
@@ -81,7 +81,7 @@ namespace aspect
         if (melt_out != nullptr)
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
-            for (unsigned int i=0; i<in.position.size(); ++i)
+            for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
               {
                 const double porosity = in.composition[i][porosity_idx];
 

--- a/tests/melt_material_1.cc
+++ b/tests/melt_material_1.cc
@@ -39,7 +39,7 @@ namespace aspect
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
 
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             out.viscosities[i] = 1.0;
             out.densities[i] = 1.0 + (in.composition[i][0]);
@@ -57,7 +57,7 @@ namespace aspect
         if (melt_out != nullptr)
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
-            for (unsigned int i=0; i<in.position.size(); ++i)
+            for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
               {
                 const double porosity = in.composition[i][porosity_idx];
 

--- a/tests/melt_material_2.cc
+++ b/tests/melt_material_2.cc
@@ -39,7 +39,7 @@ namespace aspect
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
 
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             out.viscosities[i] = 3.0/4.0;
             out.densities[i] = 3.0;
@@ -56,7 +56,7 @@ namespace aspect
 
         if (melt_out != nullptr)
           {
-            for (unsigned int i=0; i<in.position.size(); ++i)
+            for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
               {
                 melt_out->compaction_viscosities[i] = 1.0;
                 melt_out->fluid_viscosities[i]= 2.0;

--- a/tests/melt_material_3.cc
+++ b/tests/melt_material_3.cc
@@ -39,7 +39,7 @@ namespace aspect
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
 
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             out.viscosities[i] = 3.0/4.0;
             out.densities[i] = 4.0;
@@ -56,7 +56,7 @@ namespace aspect
 
         if (melt_out != nullptr)
           {
-            for (unsigned int i=0; i<in.position.size(); ++i)
+            for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
               {
                 melt_out->compaction_viscosities[i] = 1.0;
                 melt_out->fluid_viscosities[i]= 2.0;

--- a/tests/melt_material_4.cc
+++ b/tests/melt_material_4.cc
@@ -43,7 +43,7 @@ namespace aspect
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
 
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             const double y = in.position[i][dim-1] + 0.1;
             out.viscosities[i] = 3.0/4.0;
@@ -63,7 +63,7 @@ namespace aspect
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
-            for (unsigned int i=0; i<in.position.size(); ++i)
+            for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
               {
                 double porosity = in.composition[i][porosity_idx];
                 melt_out->compaction_viscosities[i] = 1.0;

--- a/tests/melt_transport_adaptive.cc
+++ b/tests/melt_transport_adaptive.cc
@@ -198,7 +198,7 @@ namespace aspect
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
         const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             const double x = in.position[i](0);
             const double z = in.position[i](1);
@@ -224,7 +224,7 @@ namespace aspect
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
-            for (unsigned int i=0; i<in.position.size(); ++i)
+            for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
               {
                 double porosity = in.composition[i][porosity_idx];
 

--- a/tests/melt_transport_compressible.cc
+++ b/tests/melt_transport_compressible.cc
@@ -43,7 +43,7 @@ namespace aspect
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
         const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             double porosity = in.composition[i][porosity_idx];
             out.viscosities[i] = 0.5 * std::exp(2.0 * in.position[i][0]);
@@ -61,7 +61,7 @@ namespace aspect
 
         if (melt_out != nullptr)
           {
-            for (unsigned int i=0; i<in.position.size(); ++i)
+            for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
               {
                 double porosity = in.composition[i][porosity_idx];
                 melt_out->compaction_viscosities[i] = xi_1 * std::exp(-in.position[i][1]) + 2.0/3.0 * std::exp(2.0 * in.position[i][0]) + xi_0;

--- a/tests/melt_transport_convergence_simple.cc
+++ b/tests/melt_transport_convergence_simple.cc
@@ -45,7 +45,7 @@ namespace aspect
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
         const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             const double porosity = in.composition[i][porosity_idx];
             const double x = in.position[i](0);
@@ -70,7 +70,7 @@ namespace aspect
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
-            for (unsigned int i=0; i<in.position.size(); ++i)
+            for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
               {
                 double porosity = in.composition[i][porosity_idx];
                 melt_out->compaction_viscosities[i] = std::exp(c * porosity);

--- a/tests/melt_transport_convergence_test.cc
+++ b/tests/melt_transport_convergence_test.cc
@@ -44,7 +44,7 @@ namespace aspect
       {
         const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
         double c = 1.0;
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             const double porosity = in.composition[i][porosity_idx];
             const double x = in.position[i](0);
@@ -71,7 +71,7 @@ namespace aspect
             double c = 1.0;
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
-            for (unsigned int i=0; i<in.position.size(); ++i)
+            for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
               {
                 double porosity = in.composition[i][porosity_idx];
                 melt_out->compaction_viscosities[i] = exp(c*porosity);

--- a/tests/melting_rate.cc
+++ b/tests/melting_rate.cc
@@ -39,7 +39,7 @@ namespace aspect
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
             const unsigned int peridotite_idx = this->introspection().compositional_index_for_name("peridotite");
@@ -81,7 +81,7 @@ namespace aspect
         if (melt_out != nullptr)
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
-            for (unsigned int i=0; i<in.position.size(); ++i)
+            for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
               {
                 const double porosity = in.composition[i][porosity_idx];
 

--- a/tests/multiple_named_additional_outputs.cc
+++ b/tests/multiple_named_additional_outputs.cc
@@ -40,7 +40,7 @@ namespace aspect
       PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim> >();
 
       if (prescribed_field_out != NULL)
-        for (unsigned int i=0; i < in.position.size(); ++i)
+        for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
           {
             const double y = in.position[i](1);
             prescribed_field_out->prescribed_field_outputs[i][1] = std::exp(-y*y/2.0);
@@ -49,7 +49,7 @@ namespace aspect
       SeismicAdditionalOutputs<dim> *seismic_out = out.template get_additional_output<SeismicAdditionalOutputs<dim> >();
 
       if (seismic_out != NULL)
-        for (unsigned int i=0; i < in.position.size(); ++i)
+        for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
           {
             const double y = in.position[i](1);
             seismic_out->vp[i] = std::exp(-y*y/3.0);

--- a/tests/multiple_named_additional_outputs.cc
+++ b/tests/multiple_named_additional_outputs.cc
@@ -64,14 +64,14 @@ namespace aspect
     {
       if (out.template get_additional_output<PrescribedFieldOutputs<dim> >() == NULL)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::PrescribedFieldOutputs<dim>> (n_points,this->n_compositional_fields()));
         }
 
       if (out.template get_additional_output<SeismicAdditionalOutputs<dim> >() == NULL)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
         }

--- a/tests/nonlinear_convergence_for_small_composition.cc
+++ b/tests/nonlinear_convergence_for_small_composition.cc
@@ -22,7 +22,7 @@ namespace aspect
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             out.viscosities[i] = 1e19;
             out.thermal_expansion_coefficients[i] = 1e-5;

--- a/tests/prescribed_dilation.cc
+++ b/tests/prescribed_dilation.cc
@@ -156,7 +156,7 @@ namespace aspect
           MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>
           *force = out.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >();
 
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               const Point<dim> &p = in.position[i];
 

--- a/tests/prescribed_field.cc
+++ b/tests/prescribed_field.cc
@@ -51,7 +51,7 @@ namespace aspect
     {
       if (out.template get_additional_output<PrescribedFieldOutputs<dim> >() == NULL)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::PrescribedFieldOutputs<dim>> (n_points, this->n_compositional_fields()));
         }

--- a/tests/prescribed_field.cc
+++ b/tests/prescribed_field.cc
@@ -40,7 +40,7 @@ namespace aspect
       PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim> >();
 
       if (prescribed_field_out != NULL)
-        for (unsigned int i=0; i < in.position.size(); ++i)
+        for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
           prescribed_field_out->prescribed_field_outputs[i][1] = out.densities[i];
     }
 

--- a/tests/prescribed_field_temperature.cc
+++ b/tests/prescribed_field_temperature.cc
@@ -40,7 +40,7 @@ namespace aspect
       PrescribedTemperatureOutputs<dim> *prescribed_temperature_out = out.template get_additional_output<PrescribedTemperatureOutputs<dim> >();
 
       if (prescribed_temperature_out != NULL)
-        for (unsigned int i=0; i < in.position.size(); ++i)
+        for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
           prescribed_temperature_out->prescribed_temperature_outputs[i] = in.pressure[i];
     }
 

--- a/tests/prescribed_field_temperature.cc
+++ b/tests/prescribed_field_temperature.cc
@@ -51,7 +51,7 @@ namespace aspect
     {
       if (out.template get_additional_output<PrescribedTemperatureOutputs<dim> >() == NULL)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::PrescribedTemperatureOutputs<dim>> (n_points));
         }

--- a/tests/prescribed_field_with_diffusion.cc
+++ b/tests/prescribed_field_with_diffusion.cc
@@ -40,7 +40,7 @@ namespace aspect
       PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim> >();
 
       if (prescribed_field_out != NULL)
-        for (unsigned int i=0; i < in.position.size(); ++i)
+        for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
           {
             const double y = in.position[i](1);
             prescribed_field_out->prescribed_field_outputs[i][1] = std::exp(-y*y/2.0);

--- a/tests/prescribed_field_with_diffusion.cc
+++ b/tests/prescribed_field_with_diffusion.cc
@@ -54,7 +54,7 @@ namespace aspect
     {
       if (out.template get_additional_output<PrescribedFieldOutputs<dim> >() == NULL)
         {
-          const unsigned int n_points = out.viscosities.size();
+          const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::PrescribedFieldOutputs<dim>> (n_points, this->n_compositional_fields()));
         }

--- a/tests/prescribed_velocity_boundary.cc
+++ b/tests/prescribed_velocity_boundary.cc
@@ -161,7 +161,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               const Point<dim> &pos = in.position[i];
               const double r2 = ( pos[0] - 1.0 ) * ( pos[0] - 1.0 ) + ( pos[1] - 1.0 ) * ( pos[1] - 1.0 );

--- a/tests/q1_q1.cc
+++ b/tests/q1_q1.cc
@@ -115,7 +115,7 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          for (unsigned int i=0; i < in.position.size(); ++i)
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
               out.viscosities[i] = 1.;
               out.densities[i] = 1;

--- a/tests/rising_melt_blob.cc
+++ b/tests/rising_melt_blob.cc
@@ -39,7 +39,7 @@ namespace aspect
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             for (unsigned int c=0; c<in.composition[i].size(); ++c)
               out.reaction_terms[i][c] = 0.0;
@@ -58,7 +58,7 @@ namespace aspect
         if (melt_out != nullptr)
           {
             const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
-            for (unsigned int i=0; i<in.position.size(); ++i)
+            for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
               {
                 const double porosity = in.composition[i][porosity_idx];
 

--- a/tests/shear_thinning.cc
+++ b/tests/shear_thinning.cc
@@ -35,7 +35,7 @@ namespace aspect
     {
       Simple<dim>::evaluate(in, out);
       if (in.strain_rate.size())
-        for (unsigned int i=0; i < in.position.size(); ++i)
+        for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
           out.viscosities[i] = 1./(1+in.strain_rate[i].norm());
     }
 

--- a/tests/simple_shear.cc
+++ b/tests/simple_shear.cc
@@ -57,7 +57,7 @@ namespace aspect
           // Assign the strain components to the compositional fields reaction terms.
           // If there are too many fields, we simply fill only the first fields with the
           // existing strain rate tensor components.
-          for (unsigned int q=0; q < in.position.size(); ++q)
+          for (unsigned int q=0; q < in.n_evaluation_points(); ++q)
             {
               // Convert the compositional fields into the tensor quantity they represent.
               Tensor<2,dim> strain;

--- a/tests/spiegelman_fail_test.cc
+++ b/tests/spiegelman_fail_test.cc
@@ -247,7 +247,7 @@ namespace aspect
       MaterialModelDerivatives<dim> *derivatives;
       derivatives = out.template get_additional_output<MaterialModelDerivatives<dim> >();
 
-      for (unsigned int i=0; i < in.temperature.size(); ++i)
+      for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           const double temperature = in.temperature[i];
           const double pressure = in.pressure[i];

--- a/tests/velocity_divergence.cc
+++ b/tests/velocity_divergence.cc
@@ -22,7 +22,7 @@ namespace aspect
       virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
-        for (unsigned int i=0; i<in.position.size(); ++i)
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
             out.viscosities[i] = 1e19;
             out.thermal_expansion_coefficients[i] = 0.0;


### PR DESCRIPTION
This PR adds a convenience function to `MaterialModelInputs` and `MaterialModelOutputs` that allows to ask for how many points should be evaluated (i.e. the length of the data fields in the structure). Currently we determined that in each file separately, which was somewhat inconsistent. Sometimes we used position sometimes temperature as the field to determine the number of points. In practice this did not matter, because all fields have the same length, but this was not explained. I think the new function name is easier to understand and it also allows us to change the implementation of the function if we ever need to.