### PR TITLE
Allow requests for material properties

### DIFF
--- a/benchmarks/nonlinear_channel_flow/simple_nonlinear.cc
+++ b/benchmarks/nonlinear_channel_flow/simple_nonlinear.cc
@@ -167,7 +167,7 @@ namespace aspect
             thermal_conductivities += volume_fractions[c] * thermal_diffusivity[c] * heat_capacity[c] * densities[c];
 
           // calculate effective viscosity
-          if (in.strain_rate.size())
+          if (in.requests_property(MaterialProperties::viscosity))
             {
               // This function calculates viscosities assuming that all the compositional fields
               // experience the same strain rate (isostrain). Since there is only one process in

--- a/benchmarks/shear_bands/shear_bands.cc
+++ b/benchmarks/shear_bands/shear_bands.cc
@@ -124,7 +124,7 @@ namespace aspect
             {
               double porosity = std::max(in.composition[i][porosity_idx],1e-4);
               out.viscosities[i] = eta_0 * std::exp(alpha*(porosity - background_porosity));
-              if (in.strain_rate.size())
+              if (in.requests_property(MaterialProperties::viscosity))
                 {
                   const SymmetricTensor<2,dim> shear_strain_rate = in.strain_rate[i]
                                                                    - 1./dim * trace(in.strain_rate[i]) * unit_symmetric_tensor<dim>();

--- a/benchmarks/shear_bands/shear_bands.cc
+++ b/benchmarks/shear_bands/shear_bands.cc
@@ -124,7 +124,7 @@ namespace aspect
             {
               double porosity = std::max(in.composition[i][porosity_idx],1e-4);
               out.viscosities[i] = eta_0 * std::exp(alpha*(porosity - background_porosity));
-              if (in.requests_property(MaterialProperties::viscosity))
+              if (in.requests_property(MaterialModel::MaterialProperties::viscosity))
                 {
                   const SymmetricTensor<2,dim> shear_strain_rate = in.strain_rate[i]
                                                                    - 1./dim * trace(in.strain_rate[i]) * unit_symmetric_tensor<dim>();

--- a/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
+++ b/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
@@ -64,7 +64,7 @@ namespace aspect
 
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
-              if (in.strain_rate.size())
+              if (in.requests_property(MaterialProperties::viscosity))
                 {
                   double viscosity = 0.0;
 

--- a/cookbooks/morency_doin_2004/morency_doin.cc
+++ b/cookbooks/morency_doin_2004/morency_doin.cc
@@ -43,7 +43,7 @@ namespace aspect
           const std::vector<double> volume_fractions = MaterialUtilities::compute_volume_fractions(composition);
 
           SymmetricTensor<2,dim> strain_rate;
-          if (in.strain_rate.size())
+          if (in.requests_property(MaterialProperties::viscosity))
             strain_rate = in.strain_rate[i];
 
           const double depth = this->get_geometry_model().depth(position); // units: m

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -221,8 +221,7 @@ namespace aspect
       inline Property operator |= (Property &d1,
                                    const Property d2)
       {
-        d1 = (d1 | d2);
-        return d1;
+        return (d1 | d2);
       }
     }
 
@@ -237,216 +236,218 @@ namespace aspect
     template <int dim>
     struct MaterialModelInputs
     {
-      public:
-        /**
-         * Constructor. Initialize the various arrays of this structure with the
-         * given number of quadrature points and (finite element) components.
-         *
-         * @param n_points The number of quadrature points for which input
-         * quantities will be provided.
-         * @param n_comp The number of vector quantities (in the order in which
-         * the Introspection class reports them) for which input will be
-         * provided.
-        */
-        MaterialModelInputs(const unsigned int n_points,
-                            const unsigned int n_comp);
+      /**
+       * Constructor. Initialize the various arrays of this structure with the
+       * given number of quadrature points and (finite element) components.
+       *
+       * @param n_points The number of quadrature points for which input
+       * quantities will be provided.
+       * @param n_comp The number of vector quantities (in the order in which
+       * the Introspection class reports them) for which input will be
+       * provided.
+      */
+      MaterialModelInputs(const unsigned int n_points,
+                          const unsigned int n_comp);
 
-        /**
-         * Constructor. Initialize the arrays of the structure with the number
-         * of points in the `input_data` structure, and fills them appropriately.
-         *
-         * @param input_data The data used to populate the material model input quantities.
-         * @param introspection A reference to the simulator introspection object.
-         * @param use_strain_rate Whether to compute the strain rates.
-         */
-        MaterialModelInputs(const DataPostprocessorInputs::Vector<dim> &input_data,
-                            const Introspection<dim> &introspection,
-                            const bool use_strain_rate = true);
+      /**
+       * Constructor. Initialize the arrays of the structure with the number
+       * of points in the `input_data` structure, and fills them appropriately.
+       *
+       * @param input_data The data used to populate the material model input quantities.
+       * @param introspection A reference to the simulator introspection object.
+       * @param use_strain_rate Whether to compute the strain rates.
+       */
+      MaterialModelInputs(const DataPostprocessorInputs::Vector<dim> &input_data,
+                          const Introspection<dim> &introspection,
+                          const bool use_strain_rate = true);
 
 
-        /**
-         * Constructor. Initializes the various arrays of this
-         * structure with the FEValues and introspection objects and
-         * the solution_vector. This constructor calls the function
-         * reinit to populate the newly created arrays.
-         *
-         * @param fe_values An FEValuesBase object used to evaluate the finite elements.
-         * @param cell The currently active cell for the fe_values object.
-         * @param introspection A reference to the simulator introspection object.
-         * @param solution_vector The finite element vector from which to construct the inputs.
-         * @param use_strain_rates Whether to compute the strain rates.
-         */
-        MaterialModelInputs(const FEValuesBase<dim,dim> &fe_values,
-                            const typename DoFHandler<dim>::active_cell_iterator &cell,
-                            const Introspection<dim> &introspection,
-                            const LinearAlgebra::BlockVector &solution_vector,
-                            const bool use_strain_rates = true);
+      /**
+       * Constructor. Initializes the various arrays of this
+       * structure with the FEValues and introspection objects and
+       * the solution_vector. This constructor calls the function
+       * reinit to populate the newly created arrays.
+       *
+       * @param fe_values An FEValuesBase object used to evaluate the finite elements.
+       * @param cell The currently active cell for the fe_values object.
+       * @param introspection A reference to the simulator introspection object.
+       * @param solution_vector The finite element vector from which to construct the inputs.
+       * @param use_strain_rates Whether to compute the strain rates.
+       */
+      MaterialModelInputs(const FEValuesBase<dim,dim> &fe_values,
+                          const typename DoFHandler<dim>::active_cell_iterator &cell,
+                          const Introspection<dim> &introspection,
+                          const LinearAlgebra::BlockVector &solution_vector,
+                          const bool use_strain_rates = true);
 
-        /**
-         * Copy constructor. This constructor copies all data members of the
-         * source object except for the additional input data (of type
-         * AdditionalMaterialInputs) pointers, stored in the
-         * `source.additional_inputs` member variable.
-         *
-         * This is because these pointers can not be copied (they
-         * are unique to the @p source object). Since they can also not
-         * be recreated without the original code that created these objects
-         * in the first place, this constructor throws an exception if the
-         * @p source object had any additional input data objects
-         * associated with it.
-         */
-        MaterialModelInputs (const MaterialModelInputs &source);
+      /**
+       * Copy constructor. This constructor copies all data members of the
+       * source object except for the additional input data (of type
+       * AdditionalMaterialInputs) pointers, stored in the
+       * `source.additional_inputs` member variable.
+       *
+       * This is because these pointers can not be copied (they
+       * are unique to the @p source object). Since they can also not
+       * be recreated without the original code that created these objects
+       * in the first place, this constructor throws an exception if the
+       * @p source object had any additional input data objects
+       * associated with it.
+       */
+      MaterialModelInputs (const MaterialModelInputs &source);
 
-        /**
-         * Move constructor. This constructor simply moves all members.
-         */
-        MaterialModelInputs (MaterialModelInputs &&) = default;
+      /**
+       * Move constructor. This constructor simply moves all members.
+       */
+      MaterialModelInputs (MaterialModelInputs &&) = default;
 
-        /**
-         * Copy operator. Copying these objects is expensive and
-         * consequently prohibited
-         */
-        MaterialModelInputs &operator= (const MaterialModelInputs &source) = delete;
+      /**
+       * Copy operator. Copying these objects is expensive and
+       * consequently prohibited
+       */
+      MaterialModelInputs &operator= (const MaterialModelInputs &source) = delete;
 
-        /**
-         * Move operator.
-         */
-        MaterialModelInputs &operator= (MaterialModelInputs &&) = default;
+      /**
+       * Move operator.
+       */
+      MaterialModelInputs &operator= (MaterialModelInputs &&) = default;
 
-        /**
-         * Function to re-initialize and populate the pre-existing arrays
-         * created by the constructor MaterialModelInputs.
-         */
-        void reinit(const FEValuesBase<dim,dim> &fe_values,
-                    const typename DoFHandler<dim>::active_cell_iterator &cell,
-                    const Introspection<dim> &introspection,
-                    const LinearAlgebra::BlockVector &solution_vector,
-                    const bool use_strain_rates = true);
+      /**
+       * Function to re-initialize and populate the pre-existing arrays
+       * created by the constructor MaterialModelInputs.
+       */
+      void reinit(const FEValuesBase<dim,dim> &fe_values,
+                  const typename DoFHandler<dim>::active_cell_iterator &cell,
+                  const Introspection<dim> &introspection,
+                  const LinearAlgebra::BlockVector &solution_vector,
+                  const bool use_strain_rates = true);
 
-        /**
-         * Function that returns the number of points at which
-         * the material model is to be evaluated.
-         */
-        unsigned int n_evaluation_points() const;
+      /**
+       * Function that returns the number of points at which
+       * the material model is to be evaluated.
+       */
+      unsigned int n_evaluation_points() const;
 
-        /**
-         * Function that returns if the caller requests an evaluation
-         * of the handed over property. This is optional, because calculating
-         * some properties can be more expensive than the other material
-         * model properties and not all are needed for all applications.
-         */
-        bool requests_property(const MaterialProperties::Property &property) const;
+      /**
+       * Function that returns if the caller requests an evaluation
+       * of the handed over @p property. This is optional, because calculating
+       * some properties can be more expensive than the other material
+       * model properties and not all are needed for all applications.
+       */
+      bool requests_property(const MaterialProperties::Property &property) const;
 
-        /**
-         * Vector with global positions where the material has to be evaluated
-         * in evaluate().
-         */
-        std::vector<Point<dim> > position;
+      /**
+       * Vector with global positions where the material has to be evaluated
+       * in evaluate().
+       */
+      std::vector<Point<dim> > position;
 
-        /**
-         * Temperature values at the points given in the #position vector.
-         */
-        std::vector<double> temperature;
+      /**
+       * Temperature values at the points given in the #position vector.
+       */
+      std::vector<double> temperature;
 
-        /**
-         * Pressure values at the points given in the #position vector.
-         */
-        std::vector<double> pressure;
+      /**
+       * Pressure values at the points given in the #position vector.
+       */
+      std::vector<double> pressure;
 
-        /**
-         * Pressure gradients at the points given in the #position vector.
-         * This is important for the heating models.
-         */
-        std::vector<Tensor<1,dim> > pressure_gradient;
+      /**
+       * Pressure gradients at the points given in the #position vector.
+       * This is important for the heating models.
+       */
+      std::vector<Tensor<1,dim> > pressure_gradient;
 
-        /**
-         * Velocity values at the points given in the #position vector.
-         * This value is mostly important in the case of determining
-         * whether material crossed a certain region (e.g. a phase boundary).
-         * The timestep that is needed for this check can be requested from
-         * SimulatorAccess.
-         */
-        std::vector<Tensor<1,dim> > velocity;
+      /**
+       * Velocity values at the points given in the #position vector.
+       * This value is mostly important in the case of determining
+       * whether material crossed a certain region (e.g. a phase boundary).
+       * The timestep that is needed for this check can be requested from
+       * SimulatorAccess.
+       */
+      std::vector<Tensor<1,dim> > velocity;
 
-        /**
-         * Values of the compositional fields at the points given in the
-         * #position vector: composition[i][c] is the compositional field c at
-         * point i.
-         */
-        std::vector<std::vector<double> > composition;
+      /**
+       * Values of the compositional fields at the points given in the
+       * #position vector: composition[i][c] is the compositional field c at
+       * point i.
+       */
+      std::vector<std::vector<double> > composition;
 
-        /**
-         * Strain rate at the points given in the #position vector. Only the
-         * viscosity may depend on these values. This std::vector can be set to
-         * size 0 if the viscosity is not needed.
-         *
-         * @note The strain rate is computed as $\varepsilon(\mathbf u)=\frac 12
-         * (\nabla \mathbf u + \nabla \mathbf u^T)$, regardless of whether the
-         * model is compressible or not. This is relevant since in some other
-         * contexts, the strain rate in the compressible case is computed as
-         * $\varepsilon(\mathbf u)=\frac 12 (\nabla \mathbf u + \nabla \mathbf
-         * u^T) - \frac 13 \nabla \cdot \mathbf u \mathbf 1$.
-         */
-        std::vector<SymmetricTensor<2,dim> > strain_rate;
+      /**
+       * Strain rate at the points given in the #position vector. Only the
+       * viscosity may depend on these values. This std::vector can be set to
+       * size 0 if the viscosity is not needed.
+       *
+       * @note The strain rate is computed as $\varepsilon(\mathbf u)=\frac 12
+       * (\nabla \mathbf u + \nabla \mathbf u^T)$, regardless of whether the
+       * model is compressible or not. This is relevant since in some other
+       * contexts, the strain rate in the compressible case is computed as
+       * $\varepsilon(\mathbf u)=\frac 12 (\nabla \mathbf u + \nabla \mathbf
+       * u^T) - \frac 13 \nabla \cdot \mathbf u \mathbf 1$.
+       */
+      std::vector<SymmetricTensor<2,dim> > strain_rate;
 
-        /**
-         * Optional reference to the cell that contains these quadrature
-         * points. This allows for evaluating properties at the cell vertices
-         * and interpolating to the quadrature points, or to query the cell for
-         * material ids, neighbors, or other information that is not available
-         * solely from the locations. Note that not all calling functions can set
-         * this reference. In these cases it will be a nullptr, so make sure
-         * that your material model either fails with a proper error message
-         * or provide an alternative calculation for these cases.
-         *
-         * @deprecated Use DoFHandler<dim>::active_cell_iterator current_cell instead.
-         */
-        const typename DoFHandler<dim>::active_cell_iterator *cell DEAL_II_DEPRECATED;
+      /**
+       * Optional reference to the cell that contains these quadrature
+       * points. This allows for evaluating properties at the cell vertices
+       * and interpolating to the quadrature points, or to query the cell for
+       * material ids, neighbors, or other information that is not available
+       * solely from the locations. Note that not all calling functions can set
+       * this reference. In these cases it will be a nullptr, so make sure
+       * that your material model either fails with a proper error message
+       * or provide an alternative calculation for these cases.
+       *
+       * @deprecated Use DoFHandler<dim>::active_cell_iterator current_cell instead.
+       */
+      const typename DoFHandler<dim>::active_cell_iterator *cell DEAL_II_DEPRECATED;
 
-        /**
-         * Optional cell object that contains these quadrature
-         * points. This allows for evaluating properties at the cell vertices
-         * and interpolating to the quadrature points, or to query the cell for
-         * material ids, neighbors, or other information that is not available
-         * solely from the locations. Note that not all calling functions will
-         * set this cell iterator. In these cases it will be an invalid iterator
-         * constructed using the default constructor, so make sure that your
-         * material model either fails
-         * with a proper error message, or provides an alternative calculation for
-         * these cases. You can detect this with
-         * @code
-         * if (in.current_cell.state() == IteratorState::valid)
-         * @endcode
-         */
-        typename DoFHandler<dim>::active_cell_iterator current_cell;
+      /**
+       * Optional cell object that contains these quadrature
+       * points. This allows for evaluating properties at the cell vertices
+       * and interpolating to the quadrature points, or to query the cell for
+       * material ids, neighbors, or other information that is not available
+       * solely from the locations. Note that not all calling functions will
+       * set this cell iterator. In these cases it will be an invalid iterator
+       * constructed using the default constructor, so make sure that your
+       * material model either fails
+       * with a proper error message, or provides an alternative calculation for
+       * these cases. You can detect this with
+       * @code
+       * if (in.current_cell.state() == IteratorState::valid)
+       * @endcode
+       */
+      typename DoFHandler<dim>::active_cell_iterator current_cell;
 
-        /**
-         * Vector of shared pointers to additional material model input
-         * objects that can be added to MaterialModelInputs. By default,
-         * no inputs are added.
-         */
-        std::vector<std::unique_ptr<AdditionalMaterialInputs<dim> > > additional_inputs;
+      /**
+       * A member variable that stores which properties the material model
+       * should compute. You can check specific properties using
+       * the requests_property function and usually do not need to access
+       * this variable directly. For documentation on the internal storage
+       * of this variable see the documentation for MaterialProperties::Property.
+       */
+      MaterialProperties::Property requested_properties;
 
-        /**
-         * Given an additional material model input class as explicitly specified
-         * template argument, returns a pointer to this additional material model
-         * input object if it is used in the current simulation.
-         * If the output does not exist, a null pointer is returned.
-         */
-        template <class AdditionalInputType>
-        AdditionalInputType *get_additional_input();
+      /**
+       * Vector of shared pointers to additional material model input
+       * objects that can be added to MaterialModelInputs. By default,
+       * no inputs are added.
+       */
+      std::vector<std::unique_ptr<AdditionalMaterialInputs<dim> > > additional_inputs;
 
-        /**
-         * Constant version of get_additional_input() returning a const pointer.
-         */
-        template <class AdditionalInputType>
-        const AdditionalInputType *get_additional_input() const;
+      /**
+       * Given an additional material model input class as explicitly specified
+       * template argument, returns a pointer to this additional material model
+       * input object if it is used in the current simulation.
+       * If the output does not exist, a null pointer is returned.
+       */
+      template <class AdditionalInputType>
+      AdditionalInputType *get_additional_input();
 
-      private:
-        /**
-         * A member variable that stores which properties the material model should compute.
-         */
-        MaterialProperties::Property requested_properties;
+      /**
+       * Constant version of get_additional_input() returning a const pointer.
+       */
+      template <class AdditionalInputType>
+      const AdditionalInputType *get_additional_input() const;
     };
 
 

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -179,21 +179,23 @@ namespace aspect
        *
        * Because the values of the enum are chosen so that they represent
        * single bits in an integer, the result here is a number that can be
-       * represented in base-2 as 101 (the number 100=4 for the strain rate and
-       * 001=1 for the temperature).
+       * represented in base-2 as 110 (the number 100=4 for the density and
+       * 010=2 for the viscosity).
        */
       enum Property
       {
-        none                 = 0,
-        viscosity            = 1,
-        density              = 2,
-        thermal_expansion_coefficient = 4,
-        specific_heat        = 8,
-        thermal_conductivity = 16,
-        compressibility      = 32,
-        entropy_derivative_pressure = 64,
-        entropy_derivative_temperature = 128,
-        reaction_terms       = 256,
+        uninitialized        = 0,
+
+        none                 = 1,
+        viscosity            = 2,
+        density              = 4,
+        thermal_expansion_coefficient = 8,
+        specific_heat        = 16,
+        thermal_conductivity = 32,
+        compressibility      = 64,
+        entropy_derivative_pressure = 128,
+        entropy_derivative_temperature = 256,
+        reaction_terms       = 512,
 
         equation_of_state_properties = density |
                                        thermal_expansion_coefficient |

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -184,32 +184,33 @@ namespace aspect
        */
       enum Property
       {
-        uninitialized        = 0,
+        uninitialized                  = 0,
 
-        none                 = 1,
-        viscosity            = 2,
-        density              = 4,
-        thermal_expansion_coefficient = 8,
-        specific_heat        = 16,
-        thermal_conductivity = 32,
-        compressibility      = 64,
-        entropy_derivative_pressure = 128,
+        none                           = 1,
+        viscosity                      = 2,
+        density                        = 4,
+        thermal_expansion_coefficient  = 8,
+        specific_heat                  = 16,
+        thermal_conductivity           = 32,
+        compressibility                = 64,
+        entropy_derivative_pressure    = 128,
         entropy_derivative_temperature = 256,
-        reaction_terms       = 512,
+        reaction_terms                 = 512,
 
-        equation_of_state_properties = density |
-                                       thermal_expansion_coefficient |
-                                       specific_heat |
-                                       compressibility |
-                                       entropy_derivative_pressure |
-                                       entropy_derivative_temperature,
-        all_properties         = equation_of_state_properties |
-                                 viscosity |
-                                 reaction_terms
+        equation_of_state_properties   = density |
+                                         thermal_expansion_coefficient |
+                                         specific_heat |
+                                         compressibility |
+                                         entropy_derivative_pressure |
+                                         entropy_derivative_temperature,
+        all_properties                 = equation_of_state_properties |
+                                         viscosity |
+                                         reaction_terms
       };
 
       /**
-       * Provide an operator that or's two Property variables.
+       * Provide an operator that or's two Property variables. This allows to
+       * combine more than one property in a single variable.
        */
       inline Property operator | (const Property d1,
                                   const Property d2)

--- a/source/material_model/depth_dependent.cc
+++ b/source/material_model/depth_dependent.cc
@@ -166,7 +166,7 @@ namespace aspect
                                   typename Interface<dim>::MaterialModelOutputs &out) const
     {
       base_model->evaluate(in,out);
-      if (in.strain_rate.size())
+      if (in.requests_property(MaterialProperties::viscosity))
         {
           // Scale the base model viscosity value by the depth dependent prefactor
           for (unsigned int i=0; i < out.n_evaluation_points(); ++i)

--- a/source/material_model/diffusion_dislocation.cc
+++ b/source/material_model/diffusion_dislocation.cc
@@ -202,7 +202,7 @@ namespace aspect
             thermal_expansivity += volume_fractions[j] * thermal_expansivities[j];
 
           // calculate effective viscosity
-          if (in.strain_rate.size())
+          if (in.requests_property(MaterialProperties::viscosity))
             {
               // Currently, the viscosities for each of the compositional fields are calculated assuming
               // isostrain amongst all compositions, allowing calculation of the viscosity ratio.

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -48,7 +48,7 @@ namespace aspect
           const double pressure=std::max(in.pressure[i],0.0);
 
           // calculate effective viscosity
-          if (in.strain_rate.size() > 0)
+          if (in.requests_property(MaterialProperties::viscosity))
             {
               const SymmetricTensor<2,dim> strain_rate_deviator = deviator(in.strain_rate[i]);
 

--- a/source/material_model/dynamic_friction.cc
+++ b/source/material_model/dynamic_friction.cc
@@ -86,7 +86,7 @@ namespace aspect
         {
           const std::vector<double> volume_fractions = MaterialUtilities::compute_volume_fractions(in.composition[i]);
 
-          if (in.strain_rate.size() > 0)
+          if (in.requests_property(MaterialProperties::viscosity))
             {
               const std::vector<double> viscosities = compute_viscosities(in.pressure[i], in.strain_rate[i]);
               out.viscosities[i] = MaterialUtilities::average_value (volume_fractions, viscosities, viscosity_averaging);

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -848,7 +848,7 @@ namespace aspect
             disl_viscosities_out->boundary_area_change_work_fractions[i] =
               boundary_area_change_work_fraction[get_phase_index(in.position[i],in.temperature[i],pressure)];
 
-          if (in.requests_property(MaterialProperties::reaction_terms) > 0)
+          if (in.requests_property(MaterialProperties::reaction_terms))
             for (unsigned int c=0; c<composition.size(); ++c)
               {
                 if (this->introspection().name_for_compositional_index(c) == "grain_size")

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -816,7 +816,7 @@ namespace aspect
                   crossed_transition = k;
 
 
-          if (in.strain_rate.size() > 0)
+          if (in.requests_property(MaterialProperties::viscosity))
             {
               double effective_viscosity;
               double disl_viscosity = std::numeric_limits<double>::max();
@@ -848,7 +848,7 @@ namespace aspect
             disl_viscosities_out->boundary_area_change_work_fractions[i] =
               boundary_area_change_work_fraction[get_phase_index(in.position[i],in.temperature[i],pressure)];
 
-          if (in.strain_rate.size() > 0)
+          if (in.requests_property(MaterialProperties::reaction_terms) > 0)
             for (unsigned int c=0; c<composition.size(); ++c)
               {
                 if (this->introspection().name_for_compositional_index(c) == "grain_size")

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -416,14 +416,16 @@ namespace aspect
     MaterialModelInputs<dim>::requests_property(const MaterialProperties::Property &property) const
     {
       //TODO: Remove this once all callers set requested_properties correctly
-      if (property & MaterialProperties::viscosity != MaterialProperties::none)
-        return (strain_rate.size() != 0) && (requested_properties & property != MaterialProperties::none);
+      if ((property & MaterialProperties::Property::viscosity) != 0)
+        return (strain_rate.size() != 0);
 
       //TODO: Remove this once all callers set requested_properties correctly
-      if (property & MaterialProperties::reaction_terms != MaterialProperties::none)
-        return (strain_rate.size() != 0) && (requested_properties & property != MaterialProperties::none);
+      if ((property & MaterialProperties::Property::reaction_terms) != 0)
+        return (strain_rate.size() != 0);
 
-      return requested_properties & property != MaterialProperties::none;
+      // Note that this means requested_properties can have other properties than
+      // property, but at least property.
+      return (requested_properties & property) == property;
     }
 
 

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -425,7 +425,7 @@ namespace aspect
 
       // Note that this means 'requested_properties' can include other properties than
       // just 'property', but in any case it at least requests 'property'.
-      return (requested_properties & property) == property;
+      return (requested_properties & property) != 0;
     }
 
 

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -423,8 +423,8 @@ namespace aspect
       if ((property & MaterialProperties::Property::reaction_terms) != 0)
         return (strain_rate.size() != 0);
 
-      // Note that this means requested_properties can have other properties than
-      // property, but at least property.
+      // Note that this means 'requested_properties' can include other properties than
+      // just 'property', but in any case it at least requests 'property'.
       return (requested_properties & property) == property;
     }
 

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -172,7 +172,7 @@ namespace aspect
               // calculate viscosity based on local melt
               out.viscosities[i] *= exp(- alpha_phi * porosity);
 
-              if (include_melting_and_freezing && in.strain_rate.size())
+              if (include_melting_and_freezing && in.requests_property(MaterialProperties::reaction_terms))
                 {
                   const unsigned int peridotite_idx = this->introspection().compositional_index_for_name("peridotite");
 

--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -235,7 +235,7 @@ namespace aspect
           out.densities[i] = (reference_rho_s + delta_rho)
                              * temperature_dependence * std::exp(compressibility * (in.pressure[i] - this->get_surface_pressure()));
 
-          if (this->include_melt_transport() && in.strain_rate.size() > 0)
+          if (this->include_melt_transport() && in.requests_property(MaterialProperties::reaction_terms))
             {
               const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
               const unsigned int peridotite_idx = this->introspection().compositional_index_for_name("peridotite");

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -219,7 +219,7 @@ namespace aspect
         if (force_out == nullptr)
           return;
 
-        if (in.current_cell.state() == IteratorState::valid && this->get_timestep_number() > 0 && in.strain_rate.size() > 0)
+        if (in.current_cell.state() == IteratorState::valid && this->get_timestep_number() > 0 && in.requests_property(MaterialProperties::reaction_terms))
           {
             const double dte = elastic_timestep();
 
@@ -250,7 +250,7 @@ namespace aspect
                                               const std::vector<double> &average_elastic_shear_moduli,
                                               MaterialModel::MaterialModelOutputs<dim> &out) const
       {
-        if (in.current_cell.state() == IteratorState::valid && this->get_timestep_number() > 0 && in.strain_rate.size() > 0)
+        if (in.current_cell.state() == IteratorState::valid && this->get_timestep_number() > 0 && in.requests_property(MaterialProperties::reaction_terms))
           {
             // Get old (previous time step) velocity gradients
             std::vector<Point<dim> > quadrature_positions(in.n_evaluation_points());

--- a/source/material_model/rheology/strain_dependent.cc
+++ b/source/material_model/rheology/strain_dependent.cc
@@ -412,7 +412,7 @@ namespace aspect
         // when plastically yielding.
         // If viscous strain is also tracked, overwrite the second reaction term as well.
         // Calculate changes in strain and update the reaction terms
-        if  (this->simulator_is_past_initialization() && this->get_timestep_number() > 0 && in.strain_rate.size())
+        if  (this->simulator_is_past_initialization() && this->get_timestep_number() > 0 && in.requests_property(MaterialProperties::reaction_terms))
           {
             const double edot_ii = std::max(sqrt(std::fabs(second_invariant(deviator(in.strain_rate[i])))),min_strain_rate);
             const double e_ii = edot_ii*this->get_timestep();
@@ -442,7 +442,7 @@ namespace aspect
                                            MaterialModel::MaterialModelOutputs<dim> &out) const
       {
 
-        if (in.current_cell.state() == IteratorState::valid && this->get_timestep_number() > 0 && in.strain_rate.size())
+        if (in.current_cell.state() == IteratorState::valid && this->get_timestep_number() > 0 && in.requests_property(MaterialProperties::reaction_terms))
           {
             // We need the velocity gradient for the finite strain (they are not
             // in material model inputs), so we get them from the finite element.
@@ -468,7 +468,7 @@ namespace aspect
             for (unsigned int q=0; q < in.n_evaluation_points(); ++q)
               {
                 if (in.current_cell.state() == IteratorState::valid && weakening_mechanism == finite_strain_tensor
-                    && this->get_timestep_number() > 0 && in.strain_rate.size())
+                    && this->get_timestep_number() > 0 && in.requests_property(MaterialProperties::reaction_terms))
 
                   {
                     // Convert the compositional fields into the tensor quantity they represent.

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -473,7 +473,7 @@ namespace aspect
       for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           // We are only asked to give viscosities if strain_rate.size() > 0.
-          if (in.strain_rate.size() > 0)
+          if (in.requests_property(MaterialProperties::viscosity))
             out.viscosities[i]                  = viscosity                     (in.temperature[i], in.pressure[i], in.composition[i], in.strain_rate[i], in.position[i]);
 
           out.densities[i]                      = density                       (in.temperature[i], in.pressure[i], in.composition[i], in.position[i]);

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -526,7 +526,7 @@ namespace aspect
 
           // Compute the effective viscosity if requested and retrieve whether the material is plastically yielding
           bool plastic_yielding = false;
-          if (in.strain_rate.size())
+          if (in.requests_property(MaterialProperties::viscosity))
             {
               // Currently, the viscosities for each of the compositional fields are calculated assuming
               // isostrain amongst all compositions, allowing calculation of the viscosity ratio.

--- a/tests/grain_size_latent_heat.cc
+++ b/tests/grain_size_latent_heat.cc
@@ -172,7 +172,7 @@ namespace aspect
                          * ((in.position[i] - in.position[j]) * this->get_gravity_model().gravity_vector(in.position[i])) > 0))
                       crossed_transition = k;
 
-              if (in.strain_rate.size() > 0)
+              if (in.requests_property(MaterialProperties::viscosity))
                 out.viscosities[i] = std::min(std::max(this->min_eta,this->viscosity(in.temperature[i],
                                                                                      in.pressure[i],
                                                                                      composition,
@@ -206,7 +206,7 @@ namespace aspect
               out.compressibilities[i] = this->compressibility(in.temperature[i], in.pressure[i], composition, in.position[i]);
 
               // TODO: make this more general for not just olivine grains
-              if (in.strain_rate.size() > 0)
+              if (in.requests_property(MaterialProperties::reaction_terms))
                 for (unsigned int c=0; c<composition.size(); ++c)
                   {
                     if (this->introspection().name_for_compositional_index(c) == "olivine_grain_size")

--- a/tests/latent_heat_enthalpy.cc
+++ b/tests/latent_heat_enthalpy.cc
@@ -143,7 +143,7 @@ namespace aspect
 
           for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
             {
-              if (in.strain_rate.size() > 0)
+              if (in.requests_property(MaterialProperties::viscosity))
                 out.viscosities[i] = eta;
 
               out.densities[i] = material_lookup->density(in.temperature[i],in.pressure[i]);

--- a/tests/nonlinear_convergence_for_small_composition.cc
+++ b/tests/nonlinear_convergence_for_small_composition.cc
@@ -32,7 +32,7 @@ namespace aspect
             out.densities[i] = 30000.0*(1.0-1.e-5*in.temperature[i]);
             for (unsigned int c=0; c<in.composition[i].size(); ++c)
               {
-                if (in.strain_rate.size())
+                if (in.requests_property(MaterialProperties::reaction_terms))
                   out.reaction_terms[i][c] = trace(in.strain_rate[i]) * this->get_timestep();
                 else
                   out.reaction_terms[i][c] = 0.0;

--- a/tests/nonlinear_convergence_for_small_composition.cc
+++ b/tests/nonlinear_convergence_for_small_composition.cc
@@ -32,7 +32,7 @@ namespace aspect
             out.densities[i] = 30000.0*(1.0-1.e-5*in.temperature[i]);
             for (unsigned int c=0; c<in.composition[i].size(); ++c)
               {
-                if (in.requests_property(MaterialProperties::reaction_terms))
+                if (in.requests_property(MaterialModel::MaterialProperties::reaction_terms))
                   out.reaction_terms[i][c] = trace(in.strain_rate[i]) * this->get_timestep();
                 else
                   out.reaction_terms[i][c] = 0.0;

--- a/tests/shear_thinning.cc
+++ b/tests/shear_thinning.cc
@@ -34,7 +34,7 @@ namespace aspect
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       Simple<dim>::evaluate(in, out);
-      if (in.strain_rate.size())
+      if (in.requests_property(MaterialProperties::viscosity))
         for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
           out.viscosities[i] = 1./(1+in.strain_rate[i].norm());
     }

--- a/tests/spiegelman_fail_test.cc
+++ b/tests/spiegelman_fail_test.cc
@@ -282,7 +282,7 @@ namespace aspect
             thermal_conductivities += volume_fractions[c] * thermal_diffusivity[c] * heat_capacity[c] * densities[c];
 
           // calculate effective viscosity
-          if (in.strain_rate.size())
+          if (in.requests_property(MaterialProperties::viscosity))
             {
               // This function calculates viscosities assuming that all the compositional fields
               // experience the same strain rate (isostrain). Since there is only one process in

--- a/tests/velocity_divergence.cc
+++ b/tests/velocity_divergence.cc
@@ -32,7 +32,7 @@ namespace aspect
             out.densities[i] = 3000;
             for (unsigned int c=0; c<in.composition[i].size(); ++c)
               {
-                if (in.strain_rate.size())
+                if (in.requests_property(MaterialProperties::reaction_terms))
                   out.reaction_terms[i][c] = trace(in.strain_rate[i]) * this->get_timestep();
                 else
                   out.reaction_terms[i][c] = 0.0;

--- a/tests/velocity_divergence.cc
+++ b/tests/velocity_divergence.cc
@@ -32,7 +32,7 @@ namespace aspect
             out.densities[i] = 3000;
             for (unsigned int c=0; c<in.composition[i].size(); ++c)
               {
-                if (in.requests_property(MaterialProperties::reaction_terms))
+                if (in.requests_property(MaterialModel::MaterialProperties::reaction_terms))
                   out.reaction_terms[i][c] = trace(in.strain_rate[i]) * this->get_timestep();
                 else
                   out.reaction_terms[i][c] = 0.0;


### PR DESCRIPTION
Follow up to #3456, which allows to tell a material model which properties to compute, and for a material model to find out which properties are requested. This is implemented so that no current functionality should break. In later PRs I would suggest the following:

- [ ] make all calling sides set the request_properties variable correctly when creating their MaterialModelInputs object (modifying / creating new constructors for MaterialModelInputs)
- [ ] always input strain rate, because we now have material models that use them for reaction terms as well as viscosity (and who knows what else) and the calling side has no way of knowing what the material model might need.
- [ ] let the expensive material models respect the requested properties (in particular grain_size and diffusion_dislocation, which contain internal iterations for strain rate, but also the melt models)
- [ ] remove the two TODOs in this PR
- [ ] deprecate the MaterialModelInputs constructors that take the `compute_strainrate` input argument