### PR TITLE
Make parameter file update script work on Mac

### DIFF
--- a/benchmarks/entropy_adiabat/entropy_adiabat.prm
+++ b/benchmarks/entropy_adiabat/entropy_adiabat.prm
@@ -113,7 +113,7 @@ end
 # be different from the initial entropy in the model.
 subsection Boundary composition model
   set Fixed composition boundary indicators = top
-  set Model name = function
+  set List of model names = function
   subsection Function
     # Only the first component (entropy) matters, the other equations
     # are not solved but computed from entropy.

--- a/doc/update_scripts/prm_files/update_prm_files_to_2.0.0.sed
+++ b/doc/update_scripts/prm_files/update_prm_files_to_2.0.0.sed
@@ -16,11 +16,11 @@ s/set Model name = initial profile/set Model name = compute profile/g
 # when we find it, check if 'Magnitude at bottom' is inside, and
 # insert it, if not.
 :jump_before_gravity
-/subsection Radial linear/,/^[[:space:]]*end[[:space:]]*/ {
+/subsection Radial linear/,/[[:space:]]*end[[:space:]]*/ {
 # Print the line 'subsection ...' and read next line
 n
 # If next line was already 'end' jump out of this part
-/^ *end/b jump_before_gravity
+/^[[:space:]]*end/b jump_before_gravity
 
 :jump_in_gravity
 # Add next line to current pattern space until we found 'end'

--- a/doc/update_scripts/prm_files/update_prm_files_to_2.0.0.sed
+++ b/doc/update_scripts/prm_files/update_prm_files_to_2.0.0.sed
@@ -16,7 +16,7 @@ s/set Model name = initial profile/set Model name = compute profile/g
 # when we find it, check if 'Magnitude at bottom' is inside, and
 # insert it, if not.
 :jump_before_gravity
-/subsection Radial linear/,/\bend\b/ {
+/subsection Radial linear/,/^[[:space:]]*end[[:space:]]*/ {
 # Print the line 'subsection ...' and read next line
 n
 # If next line was already 'end' jump out of this part
@@ -45,15 +45,15 @@ b jump_before_gravity
 # belongs to the opening subsection (i.e. if the parameter is set
 # after a subsection nested inside the 'Boundary temperature model'
 # subsection the following will simply do nothing).
-/subsection Boundary temperature model/,/^ *\bend\b/ {
+/subsection Boundary temperature model/,/^[[:space:]]*end[[:space:]]*/ {
      s/set Model name/set List of model names/g
 }
 
-/subsection Boundary composition model/,/^ *\bend\b/ {
+/subsection Boundary composition model/,/^[[:space:]]*end[[:space:]]*/ {
      s/set Model name/set List of model names/g
 }
 
-/subsection Heating model/,/^ *\bend\b/ {
+/subsection Heating model/,/^[[:space:]]*end[[:space:]]*/ {
      s/set Model name/set List of model names/g
 }
 

--- a/doc/update_scripts/prm_files/update_prm_files_to_2.0.0_model_settings.sed
+++ b/doc/update_scripts/prm_files/update_prm_files_to_2.0.0_model_settings.sed
@@ -9,7 +9,7 @@
 # multiple times, this works just fine.
 
 :jump
-/subsection Model settings/,/^ *\bend\b/ {
+/subsection Model settings/,/^[[:space:]]*end[[:space:]]*/ {
 # Remove empty lines, they would make the rest complicated.
 /^ *$/d
 
@@ -192,9 +192,9 @@ d
 # Now the Model settings subsection should be empty.
 # Remove any remaining lines (e.g. empty lines, comments),
 # except for the last one (to not jump over it).
-/^ *end/ !d
+/^[[:space:]]*end/ !d
 
-/^ *end/ {
+/^[[:space:]]*end/ {
 # At the end of the subsection, add a comment and the content of the hold space
 x
 

--- a/doc/update_scripts/prm_files/update_prm_files_to_2.0.0_model_settings.sed
+++ b/doc/update_scripts/prm_files/update_prm_files_to_2.0.0_model_settings.sed
@@ -206,8 +206,7 @@ i\
 # safely merged with any existing subsections with the same name.
 
 # remove the empty line at the end of the hold space
-s/\
- *$//
+s/\n *$//
 }
 
 # If the hold space was empty, remove the single newline it would produce

--- a/doc/update_scripts/prm_files/update_prm_files_to_2.0.0_model_settings.sed
+++ b/doc/update_scripts/prm_files/update_prm_files_to_2.0.0_model_settings.sed
@@ -200,12 +200,14 @@ x
 
 # if the hold space is not empty, print comment
 /..*/ {
-i # The parameters below this comment were created by the update script\
+i\
+# The parameters below this comment were created by the update script\
 # as replacement for the old 'Model settings' subsection. They can be\
 # safely merged with any existing subsections with the same name.
 
 # remove the empty line at the end of the hold space
-s/\n *$//
+s/\
+ *$//
 }
 
 # If the hold space was empty, remove the single newline it would produce

--- a/tests/visco_plastic_newton_nonlinear_channelflow.prm
+++ b/tests/visco_plastic_newton_nonlinear_channelflow.prm
@@ -11,7 +11,7 @@ set Start time                             = 0
 set Adiabatic surface temperature          = 1
 set Surface pressure                       = 0
 set Use years in output instead of seconds = false  # default: true
-set Nonlinear solver scheme = Newton Stokes
+set Nonlinear solver scheme = iterated Advection and Newton Stokes
 set Max nonlinear iterations = 150 
 set Nonlinear solver tolerance = 1e-14
 


### PR DESCRIPTION
The script to update parameter files to more recent versions did use GNU sed extensions that are not available on MacOS leading to broken files (see #2347). This PR fixes some of the issues.