### PR TITLE
parameter_view: add run.sh script

### DIFF
--- a/doc/parameter_view/run.sh
+++ b/doc/parameter_view/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "opening http://localhost:8011/parameters.xml"
+xdg-open "http://localhost:8011/parameters.xml" &
+python3 -m http.server 8011


### PR DESCRIPTION
Chrome can not open .xls from file:// urls locally for security reasons.
Add a simple shell script to launch the browser.