### PR TITLE
Use Utilities::fexists where appropriate

### DIFF
--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -421,30 +421,21 @@ namespace aspect
   void Simulator<dim>::resume_from_snapshot()
   {
     // first check existence of the two restart files
-    {
-      const std::string filename = parameters.output_directory + "restart.mesh";
-      std::ifstream in (filename.c_str());
-      if (!in)
-        AssertThrow (false,
-                     ExcMessage (std::string("You are trying to restart a previous computation, "
-                                             "but the restart file <")
-                                 +
-                                 filename
-                                 +
-                                 "> does not appear to exist!"));
-    }
-    {
-      const std::string filename = parameters.output_directory + "restart.resume.z";
-      std::ifstream in (filename.c_str());
-      if (!in)
-        AssertThrow (false,
-                     ExcMessage (std::string("You are trying to restart a previous computation, "
-                                             "but the restart file <")
-                                 +
-                                 filename
-                                 +
-                                 "> does not appear to exist!"));
-    }
+    AssertThrow (Utilities::fexists(parameters.output_directory + "restart.mesh"),
+                 ExcMessage ("You are trying to restart a previous computation, "
+                             "but the restart file <"
+                             +
+                             parameters.output_directory + "restart.mesh"
+                             +
+                             "> does not appear to exist!"));
+
+    AssertThrow (Utilities::fexists(parameters.output_directory + "restart.resume.z"),
+                 ExcMessage ("You are trying to restart a previous computation, "
+                             "but the restart file <"
+                             +
+                             parameters.output_directory + "restart.resume.z"
+                             +
+                             "> does not appear to exist!"));
 
     pcout << "*** Resuming from snapshot!" << std::endl << std::endl;
 

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1382,9 +1382,7 @@ namespace aspect
       resume_computation = false;
     else if (prm.get ("Resume computation") == "auto")
       {
-        std::fstream check_file((output_directory+"restart.mesh").c_str());
-        resume_computation = check_file.is_open();
-        check_file.close();
+        resume_computation = Utilities::fexists(output_directory+"restart.mesh");
       }
     else
       AssertThrow (false, ExcMessage ("Resume computation parameter must be either `true', `false', or `auto'."));

--- a/source/termination_criteria/user_request.cc
+++ b/source/termination_criteria/user_request.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/termination_criteria/user_request.h>
+#include <aspect/utilities.h>
 
 namespace aspect
 {
@@ -34,8 +35,7 @@ namespace aspect
       // processors
       if (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
         {
-          std::fstream check_file((this->get_output_directory()+filename_to_test).c_str());
-          return check_file.is_open();
+          return Utilities::fexists(this->get_output_directory()+filename_to_test);
         }
       return false;
     }


### PR DESCRIPTION
Found while looking into #3468. This replaces some checks for the existence of files with the `Utilties::fexists` function.