### PR TITLE
.gitignore output folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@
 /benchmarks/**/Makefile
 /benchmarks/**/cmake_install.cmake
 /benchmarks/**/lib*.so
-/benchmarks/**/output*/
 /benchmarks/**/aspect
 /benchmarks/**/temp.prm
 /benchmarks/tangurnis/*/*csv
@@ -29,7 +28,6 @@
 /cookbooks/**/lib*.so
 /cookbooks/**/Makefile
 /cookbooks/**/aspect
-/cookbooks/**/output*/
 /detailed.log
 /doc/aspect.dox
 /doc/aspect.tag
@@ -50,12 +48,11 @@
 /doc/manual/prmindexfull.ind
 /doc/manual/cookbooks/**/*.out
 /doc/modules/changes.h
-/output/
+/**/output*/
 /tests/CMakeFiles/
 /tests/CTestTestfile.cmake
 /tests/Makefile
 /tests/cmake_install.cmake
-/tests/output-*/
 /tests/*.x.prm
 /tests/lib*.so
 /Testing


### PR DESCRIPTION
Add folders output* in any location of the repo to the ignore list. I
often create top-level folders for specific problems and end of with two
many untracked files.
