### PR TITLE
Extend particle property update interface

### DIFF
--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -344,6 +344,37 @@ namespace aspect
            * denotes the first component of this property, all other components
            * fill consecutive entries in the @p particle_properties vector.
            *
+           * @param [in] solution The values of the solution variables at the
+           * current particle position.
+           *
+           * @param [in] gradients The gradients of the solution variables at
+           * the current particle position.
+           *
+           * @param [in,out] particle The particle that is updated within
+           * the call of this function.
+           */
+          virtual
+          void
+          update_particle_property (const unsigned int data_position,
+                                    const Vector<double> &solution,
+                                    const std::vector<Tensor<1,dim> > &gradients,
+                                    typename ParticleHandler<dim>::particle_iterator &particle) const;
+
+          /**
+           * Update function. This function is called every time an update is
+           * request by need_update() for every particle for every property.
+           * It is obvious that
+           * this function is called a lot, so its code should be efficient.
+           * The interface provides a default implementation that does nothing,
+           * therefore derived plugins that do not require an update do not
+           * need to implement this function.
+           *
+           * @param [in] data_position An unsigned integer that denotes which
+           * component of the particle property vector is associated with the
+           * current property. For properties that own several components it
+           * denotes the first component of this property, all other components
+           * fill consecutive entries in the @p particle_properties vector.
+           *
            * @param [in] position The current particle position.
            *
            * @param [in] solution The values of the solution variables at the
@@ -354,7 +385,11 @@ namespace aspect
            *
            * @param [in,out] particle_properties The properties of the particle
            * that is updated within the call of this function.
+           *
+           * @deprecated Use the other overload of update_one_particle_property()
+           * instead.
            */
+          DEAL_II_DEPRECATED
           virtual
           void
           update_one_particle_property (const unsigned int data_position,

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -351,7 +351,9 @@ namespace aspect
            * the current particle position.
            *
            * @param [in,out] particle The particle that is updated within
-           * the call of this function.
+           * the call of this function. The particle location can be accessed
+           * using particle->get_location() and its properties using
+           * particle->get_properties().
            */
           virtual
           void
@@ -386,8 +388,7 @@ namespace aspect
            * @param [in,out] particle_properties The properties of the particle
            * that is updated within the call of this function.
            *
-           * @deprecated Use the other overload of update_one_particle_property()
-           * instead.
+           * @deprecated Use update_particle_property() instead.
            */
           DEAL_II_DEPRECATED
           virtual

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -214,6 +214,25 @@ namespace aspect
 
 
 
+      DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+      template <int dim>
+      void
+      Interface<dim>::update_particle_property (const unsigned int data_position,
+                                                const Vector<double> &solution,
+                                                const std::vector<Tensor<1,dim> > &gradients,
+                                                typename ParticleHandler<dim>::particle_iterator &particle) const
+      {
+        // call the deprecated version of this function
+        update_one_particle_property(data_position,
+                                     particle->get_location(),
+                                     solution,
+                                     gradients,
+                                     particle->get_properties());
+      }
+      DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
+
+
       template <int dim>
       void
       Interface<dim>::update_one_particle_property (const unsigned int,
@@ -409,11 +428,10 @@ namespace aspect
         for (typename std::list<std::unique_ptr<Interface<dim> > >::const_iterator
              p = property_list.begin(); p!=property_list.end(); ++p,++plugin_index)
           {
-            (*p)->update_one_particle_property(property_information.get_position_by_plugin_index(plugin_index),
-                                               particle->get_location(),
-                                               solution,
-                                               gradients,
-                                               particle->get_properties());
+            (*p)->update_particle_property(property_information.get_position_by_plugin_index(plugin_index),
+                                           solution,
+                                           gradients,
+                                           particle);
           }
       }
 


### PR DESCRIPTION
This follows a discussion with @naliboff. The current interface for updating particle properties does not give information about which cell the current particle is in, which e.g. prevents particle properties from calling some material models to figure out properties. I think we need to extend our current interface for that, and there is no reason particle properties should not know all information about the particle they are currently updating. 
In theory we could use the same interface as postprocessors (handing over a `DataPostprocessorInputs::Vector<dim>` input argument) or as the material model (handing over a `MaterialModelInputs` argument), but I think changing the interface as little as possible with just the small addition of handing over the particle iterator -- instead of the particle location and the particle properties -- works just as well. I have not yet updated all existing plugins (the change is backward compatible), but if we think this is useful and the right change I will do that.

@naliboff: You should now be able to create your particle property roughly the following way:
```
ElasticProperty<dim>::update_particle_property(const unsigned int data_position,
                                    const Vector<double> &solution,
                                    const std::vector<Tensor<1,dim> > &gradients,
                                    typename ParticleHandler<dim>::particle_iterator &particle)
{
MaterialModelInputs<dim> in(1, n_compositions);
in.temperature = solution[this->introspection().component_indices.temperature];
in.pressure, in.strain_rate ...
in.cell = particle->get_surrounding_cell(this->get_triangulation());

// create your additional outputs here

this->get_material_model().evaluate (in,out);
// get your additional outputs from out
additional_output = out. ...

particle->get_properties()[data_position] = additional_output[...];
}
```

