### PR TITLE
reduce gmg storage

### DIFF
--- a/include/aspect/stokes_matrix_free.h
+++ b/include/aspect/stokes_matrix_free.h
@@ -75,17 +75,9 @@ namespace aspect
          * Fills in the viscosity table, sets the value for the pressure scaling constant,
          * and gives information regarding compressibility.
          */
-        void fill_cell_data(const dealii::LinearAlgebra::distributed::Vector<number> &viscosity_values,
-                            const double pressure_scaling,
-                            const Triangulation<dim> &tria,
-                            const DoFHandler<dim> &dof_handler_for_projection,
-                            const bool is_compressible);
-
-        /**
-         * Returns the viscosity table.
-         */
-        const Table<1, VectorizedArray<number> > &
-        get_viscosity_x_2_table();
+        void fill_cell_data (const Table<1, VectorizedArray<number>> &viscosity_table,
+                             const double pressure_scaling,
+                             const bool is_compressible);
 
         /**
          * Computes the diagonal of the matrix. Since matrix-free operators have not access
@@ -114,7 +106,7 @@ namespace aspect
         /**
          * Table which stores a viscosity value for each cell.
          */
-        Table<1, VectorizedArray<number> > viscosity_x_2;
+        const Table<1, VectorizedArray<number>> *viscosity;
 
         /**
          * Pressure scaling constant.
@@ -151,10 +143,7 @@ namespace aspect
          * @p is_mg_level_data describes whether the viscosity values are defined for a multigrid level
          * matrix or for the active level matrix.
          */
-        void fill_cell_data (const dealii::LinearAlgebra::distributed::Vector<number> &viscosity_values,
-                             const Triangulation<dim> &tria,
-                             const DoFHandler<dim> &dof_handler_for_projection,
-                             const bool is_mg_level_data,
+        void fill_cell_data (const Table<1, VectorizedArray<number>> &viscosity_table,
                              const double pressure_scaling);
 
 
@@ -194,7 +183,7 @@ namespace aspect
         /**
          * Table which stores a viscosity value for each cell.
          */
-        Table<1, VectorizedArray<number> > one_over_viscosity;
+        const Table<1, VectorizedArray<number>> *viscosity;
 
         /**
          * Pressure scaling constant.
@@ -227,11 +216,8 @@ namespace aspect
          * @p is_mg_level_data describes whether the viscosity values are defined for a multigrid level
          * matrix or for the active level matrix.
          */
-        void fill_cell_data(const dealii::LinearAlgebra::distributed::Vector<number> &viscosity_values,
-                            const Triangulation<dim> &tria,
-                            const DoFHandler<dim> &dof_handler_for_projection,
-                            const bool is_mg_level_data,
-                            const bool is_compressible);
+        void fill_cell_data (const Table<1, VectorizedArray<number>> &viscosity_table,
+                             const bool is_compressible);
 
         /**
          * Computes the diagonal of the matrix. Since matrix-free operators have not access
@@ -275,7 +261,7 @@ namespace aspect
         /**
          * Table which stores a viscosity value for each cell.
          */
-        Table<1, VectorizedArray<number> > viscosity_x_2;
+        const Table<1, VectorizedArray<number>> *viscosity;
 
         /**
           * Information on the compressibility of the flow.
@@ -419,10 +405,16 @@ namespace aspect
       DoFHandler<dim> dof_handler_p;
       DoFHandler<dim> dof_handler_projection;
 
-      FESystem<dim> stokes_fe;
       FESystem<dim> fe_v;
       FESystem<dim> fe_p;
       FESystem<dim> fe_projection;
+
+      Table<1, VectorizedArray<double>> active_viscosity_table;
+      MGLevelObject<Table<1, VectorizedArray<double>>> level_viscosity_tables;
+
+      // This variable is needed only in the setup in both evaluate_material_model()
+      // and build_preconditioner(). It will be deleted after the last use.
+      MGLevelObject<dealii::LinearAlgebra::distributed::Vector<double> > level_viscosity_vector;
 
       typedef MatrixFreeStokesOperators::StokesOperator<dim,velocity_degree,double> StokesMatrixType;
       typedef MatrixFreeStokesOperators::MassMatrixOperator<dim,velocity_degree-1,double> SchurComplementMatrixType;
@@ -434,7 +426,6 @@ namespace aspect
 
       ConstraintMatrix constraints_v;
       ConstraintMatrix constraints_p;
-      ConstraintMatrix constraints_projection;
 
       MGLevelObject<ABlockMatrixType> mg_matrices_A_block;
       MGLevelObject<SchurComplementMatrixType> mg_matrices_Schur_complement;
@@ -442,9 +433,6 @@ namespace aspect
       MGConstrainedDoFs mg_constrained_dofs_A_block;
       MGConstrainedDoFs mg_constrained_dofs_Schur_complement;
       MGConstrainedDoFs mg_constrained_dofs_projection;
-
-      dealii::LinearAlgebra::distributed::Vector<double> active_coef_dof_vec;
-      MGLevelObject<dealii::LinearAlgebra::distributed::Vector<double> > level_coef_dof_vec;
 
       MGTransferMatrixFree<dim,double> mg_transfer_A_block;
       MGTransferMatrixFree<dim,double> mg_transfer_Schur_complement;

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -672,47 +672,20 @@ namespace aspect
   void
   MatrixFreeStokesOperators::StokesOperator<dim,degree_v,number>::clear ()
   {
-    viscosity_x_2.reinit(TableIndices<1>(0));
+    viscosity = nullptr;
     MatrixFreeOperators::Base<dim,dealii::LinearAlgebra::distributed::BlockVector<number> >::clear();
   }
 
   template <int dim, int degree_v, typename number>
   void
   MatrixFreeStokesOperators::StokesOperator<dim,degree_v,number>::
-  fill_cell_data (const dealii::LinearAlgebra::distributed::Vector<number> &viscosity_values,
+  fill_cell_data (const Table<1, VectorizedArray<number>> &viscosity_table,
                   const double pressure_scaling,
-                  const Triangulation<dim> &tria,
-                  const DoFHandler<dim> &dof_handler_for_projection,
                   const bool is_compressible)
   {
-    const unsigned int n_cells = this->data->n_macro_cells();
-    viscosity_x_2.reinit(TableIndices<1>(n_cells));
-
-    std::vector<types::global_dof_index> local_dof_indices(dof_handler_for_projection.get_fe().dofs_per_cell);
-    for (unsigned int cell=0; cell<n_cells; ++cell)
-      for (unsigned int i=0; i<this->get_matrix_free()->n_components_filled(cell); ++i)
-        {
-          typename DoFHandler<dim>::active_cell_iterator FEQ_cell = this->get_matrix_free()->get_cell_iterator(cell,i);
-          typename DoFHandler<dim>::active_cell_iterator DG_cell(&tria,
-                                                                 FEQ_cell->level(),
-                                                                 FEQ_cell->index(),
-                                                                 &dof_handler_for_projection);
-          DG_cell->get_active_or_mg_dof_indices(local_dof_indices);
-
-          //TODO: projection with higher degree
-          Assert(local_dof_indices.size() == 1, ExcNotImplemented());
-          viscosity_x_2(cell)[i] = 2.0*viscosity_values(local_dof_indices[0]);
-        }
-
+    viscosity = &viscosity_table;
     this->pressure_scaling = pressure_scaling;
     this->is_compressible = is_compressible;
-  }
-
-  template <int dim, int degree_v, typename number>
-  const Table<1, VectorizedArray<number> > &
-  MatrixFreeStokesOperators::StokesOperator<dim,degree_v,number>::get_viscosity_x_2_table()
-  {
-    return viscosity_x_2;
   }
 
   template <int dim, int degree_v, typename number>
@@ -739,7 +712,7 @@ namespace aspect
 
     for (unsigned int cell=cell_range.first; cell<cell_range.second; ++cell)
       {
-        const VectorizedArray<number> &cell_viscosity_x_2 = viscosity_x_2(cell);
+        const VectorizedArray<number> cell_viscosity_x_2 = 2.0*(*viscosity)(cell);
 
         velocity.reinit (cell);
         velocity.read_dof_values (src.block(0));
@@ -754,7 +727,7 @@ namespace aspect
                                                           velocity.get_symmetric_gradient (q);
             VectorizedArray<number> pres = pressure.get_value(q);
             VectorizedArray<number> div = trace(sym_grad_u);
-            pressure.submit_value(-1.0*pressure_scaling*div, q);
+            pressure.submit_value(-pressure_scaling*div, q);
 
             sym_grad_u *= cell_viscosity_x_2;
 
@@ -798,50 +771,17 @@ namespace aspect
   void
   MatrixFreeStokesOperators::MassMatrixOperator<dim,degree_p,number>::clear ()
   {
-    one_over_viscosity.reinit(TableIndices<1>(0));
+    viscosity = nullptr;
     MatrixFreeOperators::Base<dim,dealii::LinearAlgebra::distributed::Vector<number> >::clear();
   }
 
   template <int dim, int degree_p, typename number>
   void
   MatrixFreeStokesOperators::MassMatrixOperator<dim,degree_p,number>::
-  fill_cell_data (const dealii::LinearAlgebra::distributed::Vector<number> &viscosity_values,
-                  const Triangulation<dim> &tria,
-                  const DoFHandler<dim> &dof_handler_for_projection,
-                  const bool is_mg_level_data,
+  fill_cell_data (const Table<1, VectorizedArray<number>> &viscosity_table,
                   const double pressure_scaling)
   {
-    const unsigned int n_cells = this->data->n_macro_cells();
-    one_over_viscosity.reinit(TableIndices<1>(n_cells));
-
-    std::vector<types::global_dof_index> local_dof_indices(dof_handler_for_projection.get_fe().dofs_per_cell);
-    for (unsigned int cell=0; cell<n_cells; ++cell)
-      for (unsigned int i=0; i<this->get_matrix_free()->n_components_filled(cell); ++i)
-        {
-          if (is_mg_level_data)
-            {
-              typename DoFHandler<dim>::level_cell_iterator FEQ_cell = this->get_matrix_free()->get_cell_iterator(cell,i);
-              typename DoFHandler<dim>::level_cell_iterator DG_cell(&tria,
-                                                                    FEQ_cell->level(),
-                                                                    FEQ_cell->index(),
-                                                                    &dof_handler_for_projection);
-              DG_cell->get_active_or_mg_dof_indices(local_dof_indices);
-            }
-          else
-            {
-              typename DoFHandler<dim>::active_cell_iterator FEQ_cell = this->get_matrix_free()->get_cell_iterator(cell,i);
-              typename DoFHandler<dim>::active_cell_iterator DG_cell(&tria,
-                                                                     FEQ_cell->level(),
-                                                                     FEQ_cell->index(),
-                                                                     &dof_handler_for_projection);
-              DG_cell->get_active_or_mg_dof_indices(local_dof_indices);
-            }
-
-          //TODO: projection with higher degree
-          Assert(local_dof_indices.size() == 1, ExcNotImplemented());
-          one_over_viscosity(cell)[i] = 1.0/viscosity_values(local_dof_indices[0]);
-        }
-
+    viscosity = &viscosity_table;
     this->pressure_scaling = pressure_scaling;
   }
 
@@ -857,13 +797,18 @@ namespace aspect
 
     for (unsigned int cell=cell_range.first; cell<cell_range.second; ++cell)
       {
-        const VectorizedArray<number> &cell_one_over_viscosity = one_over_viscosity(cell);
+        // The /= operator for VectorizedArray results in a foating point operation
+        // (divide by 0) since the (*viscosity)(cell) array is not completely filled.
+        // Therefore, we need to divide each entry manually.
+        VectorizedArray<number> one_over_cell_viscosity = (*viscosity)(cell);
+        for (unsigned int c=0; c<this->get_matrix_free()->n_components_filled(cell); ++c)
+          one_over_cell_viscosity[c] = pressure_scaling*pressure_scaling/one_over_cell_viscosity[c];
 
         pressure.reinit (cell);
         pressure.read_dof_values(src);
         pressure.evaluate (true, false);
         for (unsigned int q=0; q<pressure.n_q_points; ++q)
-          pressure.submit_value(cell_one_over_viscosity*pressure_scaling*pressure_scaling*
+          pressure.submit_value(one_over_cell_viscosity*
                                 pressure.get_value(q),q);
         pressure.integrate (true, false);
         pressure.distribute_local_to_global (dst);
@@ -926,7 +871,12 @@ namespace aspect
     FEEvaluation<dim,degree_p,degree_p+2,1,number> pressure (data, 0);
     for (unsigned int cell=cell_range.first; cell<cell_range.second; ++cell)
       {
-        const VectorizedArray<number> &cell_one_over_viscosity = one_over_viscosity(cell);
+        // The /= operator for VectorizedArray results in a foating point operation
+        // (divide by 0) since the (*viscosity)(cell) array is not completely filled.
+        // Therefore, we need to divide each entry manually.
+        VectorizedArray<number> one_over_cell_viscosity = (*viscosity)(cell);
+        for (unsigned int c=0; c<this->get_matrix_free()->n_components_filled(cell); ++c)
+          one_over_cell_viscosity[c] = pressure_scaling*pressure_scaling/one_over_cell_viscosity[c];
 
         pressure.reinit (cell);
         AlignedVector<VectorizedArray<number> > diagonal(pressure.dofs_per_cell);
@@ -938,7 +888,7 @@ namespace aspect
 
             pressure.evaluate (true,false,false);
             for (unsigned int q=0; q<pressure.n_q_points; ++q)
-              pressure.submit_value(cell_one_over_viscosity*pressure_scaling*pressure_scaling*
+              pressure.submit_value(one_over_cell_viscosity*
                                     pressure.get_value(q),q);
             pressure.integrate (true,false);
 
@@ -964,50 +914,17 @@ namespace aspect
   void
   MatrixFreeStokesOperators::ABlockOperator<dim,degree_v,number>::clear ()
   {
-    viscosity_x_2.reinit(TableIndices<1>(0));
+    viscosity = nullptr;
     MatrixFreeOperators::Base<dim,dealii::LinearAlgebra::distributed::Vector<number> >::clear();
   }
 
   template <int dim, int degree_v, typename number>
   void
   MatrixFreeStokesOperators::ABlockOperator<dim,degree_v,number>::
-  fill_cell_data (const dealii::LinearAlgebra::distributed::Vector<number> &viscosity_values,
-                  const Triangulation<dim> &tria,
-                  const DoFHandler<dim> &dof_handler_for_projection,
-                  const bool is_mg_level_data,
+  fill_cell_data (const Table<1, VectorizedArray<number>> &viscosity_table,
                   const bool is_compressible)
   {
-    const unsigned int n_cells = this->data->n_macro_cells();
-    viscosity_x_2.reinit(TableIndices<1>(n_cells));
-
-    std::vector<types::global_dof_index> local_dof_indices(dof_handler_for_projection.get_fe().dofs_per_cell);
-    for (unsigned int cell=0; cell<n_cells; ++cell)
-      for (unsigned int i=0; i<this->get_matrix_free()->n_components_filled(cell); ++i)
-        {
-          if (is_mg_level_data)
-            {
-              typename DoFHandler<dim>::level_cell_iterator FEQ_cell = this->get_matrix_free()->get_cell_iterator(cell,i);
-              typename DoFHandler<dim>::level_cell_iterator DG_cell(&tria,
-                                                                    FEQ_cell->level(),
-                                                                    FEQ_cell->index(),
-                                                                    &dof_handler_for_projection);
-              DG_cell->get_active_or_mg_dof_indices(local_dof_indices);
-            }
-          else
-            {
-              typename DoFHandler<dim>::active_cell_iterator FEQ_cell = this->get_matrix_free()->get_cell_iterator(cell,i);
-              typename DoFHandler<dim>::active_cell_iterator DG_cell(&tria,
-                                                                     FEQ_cell->level(),
-                                                                     FEQ_cell->index(),
-                                                                     &dof_handler_for_projection);
-              DG_cell->get_active_or_mg_dof_indices(local_dof_indices);
-            }
-
-          //TODO: projection with higher degree
-          Assert(local_dof_indices.size() == 1, ExcNotImplemented());
-          viscosity_x_2(cell)[i] = 2.0*viscosity_values(local_dof_indices[0]);
-        }
-
+    viscosity = &viscosity_table;
     this->is_compressible = is_compressible;
   }
 
@@ -1023,7 +940,7 @@ namespace aspect
 
     for (unsigned int cell=cell_range.first; cell<cell_range.second; ++cell)
       {
-        const VectorizedArray<number> &cell_viscosity_x_2 = viscosity_x_2(cell);
+        const VectorizedArray<number> cell_viscosity_x_2 = 2.0*(*viscosity)(cell);
 
         velocity.reinit (cell);
         velocity.read_dof_values(src);
@@ -1094,7 +1011,7 @@ namespace aspect
     FEEvaluation<dim,degree_v,degree_v+1,dim,number> velocity (data, 0);
     for (unsigned int cell=cell_range.first; cell<cell_range.second; ++cell)
       {
-        const VectorizedArray<number> &cell_viscosity_x_2 = viscosity_x_2(cell);
+        const VectorizedArray<number> cell_viscosity_x_2 = 2.0*(*viscosity)(cell);
 
         velocity.reinit (cell);
         AlignedVector<VectorizedArray<number> > diagonal(velocity.dofs_per_cell);
@@ -1207,8 +1124,6 @@ namespace aspect
       dof_handler_p(simulator.triangulation),
       dof_handler_projection(simulator.triangulation),
 
-      stokes_fe (FE_Q<dim>(sim.parameters.stokes_velocity_degree),dim,
-                 FE_Q<dim>(sim.parameters.stokes_velocity_degree-1),1),
       fe_v (FE_Q<dim>(sim.parameters.stokes_velocity_degree), dim),
       fe_p (FE_Q<dim>(sim.parameters.stokes_velocity_degree-1),1),
       fe_projection(FE_DGQ<dim>(0),1)
@@ -1303,6 +1218,9 @@ namespace aspect
   template <int dim, int velocity_degree>
   void StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::evaluate_material_model ()
   {
+    // Create active viscosity vector
+    dealii::LinearAlgebra::distributed::Vector<double> active_viscosity_vector(dof_handler_projection.locally_owned_dofs(),
+                                                                               sim.triangulation.get_communicator());
     {
       const QGauss<dim> quadrature_formula (sim.parameters.stokes_velocity_degree+1);
 
@@ -1318,7 +1236,6 @@ namespace aspect
       MaterialModel::MaterialModelOutputs<dim> out(fe_values.n_quadrature_points, sim.introspection.n_compositional_fields);
 
       std::vector<types::global_dof_index> local_dof_indices(fe_projection.dofs_per_cell);
-      active_coef_dof_vec = 0.;
 
       // compute the integral quantities by quadrature
       for (const auto &cell: sim.dof_handler.active_cell_iterators())
@@ -1345,59 +1262,88 @@ namespace aspect
                                                                    &dof_handler_projection);
             dg_cell->get_dof_indices(local_dof_indices);
             for (unsigned int i = 0; i < fe_projection.dofs_per_cell; ++i)
-              active_coef_dof_vec[local_dof_indices[i]] = viscosity;
+              active_viscosity_vector[local_dof_indices[i]] = viscosity;
           }
-      active_coef_dof_vec.compress(VectorOperation::insert);
+      active_viscosity_vector.compress(VectorOperation::insert);
+    }
+
+    // Create active viscosity table
+    {
+      const unsigned int n_cells = stokes_matrix.get_matrix_free()->n_macro_cells();
+      active_viscosity_table.reinit(TableIndices<1>(n_cells));
+
+      std::vector<types::global_dof_index> local_dof_indices(dof_handler_projection.get_fe().dofs_per_cell);
+      for (unsigned int cell=0; cell<n_cells; ++cell)
+        for (unsigned int i=0; i<stokes_matrix.get_matrix_free()->n_components_filled(cell); ++i)
+          {
+            typename DoFHandler<dim>::active_cell_iterator FEQ_cell =
+              stokes_matrix.get_matrix_free()->get_cell_iterator(cell,i);
+            typename DoFHandler<dim>::active_cell_iterator DG_cell(&(sim.triangulation),
+                                                                   FEQ_cell->level(),
+                                                                   FEQ_cell->index(),
+                                                                   &dof_handler_projection);
+            DG_cell->get_active_or_mg_dof_indices(local_dof_indices);
+
+            Assert(local_dof_indices.size() == 1, ExcNotImplemented());
+            active_viscosity_table(cell)[i] = active_viscosity_vector(local_dof_indices[0]);
+          }
     }
 
     const bool is_compressible = sim.material_model->is_compressible();
 
-    stokes_matrix.fill_cell_data(active_coef_dof_vec,
+    stokes_matrix.fill_cell_data(active_viscosity_table,
                                  sim.pressure_scaling,
-                                 sim.triangulation,
-                                 dof_handler_projection,
                                  is_compressible);
 
     if (sim.parameters.n_expensive_stokes_solver_steps > 0)
       {
-        A_block_matrix.fill_cell_data(active_coef_dof_vec,
-                                      sim.triangulation,
-                                      dof_handler_projection,
-                                      /*is_mg_level_data*/false,
+        A_block_matrix.fill_cell_data(active_viscosity_table,
                                       is_compressible);
-
-        Schur_complement_block_matrix.fill_cell_data(active_coef_dof_vec,
-                                                     sim.triangulation,
-                                                     dof_handler_projection,
-                                                     /*is_mg_level_data*/false,
+        Schur_complement_block_matrix.fill_cell_data(active_viscosity_table,
                                                      sim.pressure_scaling);
       }
 
-
-    // Project to MG
+    // Project active viscosity to levels
     const unsigned int n_levels = sim.triangulation.n_global_levels();
-    level_coef_dof_vec = 0.;
-    level_coef_dof_vec.resize(0,n_levels-1);
+    level_viscosity_vector = 0.;
+    level_viscosity_vector.resize(0,n_levels-1);
 
     MGTransferMatrixFree<dim,double> transfer;
     transfer.build(dof_handler_projection);
     transfer.interpolate_to_mg(dof_handler_projection,
-                               level_coef_dof_vec,
-                               active_coef_dof_vec);
+                               level_viscosity_vector,
+                               active_viscosity_vector);
+
+    level_viscosity_tables.resize(0,n_levels-1);
 
     for (unsigned int level=0; level<n_levels; ++level)
       {
-        mg_matrices_A_block[level].fill_cell_data(level_coef_dof_vec[level],
-                                                  sim.triangulation,
-                                                  dof_handler_projection,
-                                                  /*is_mg_level_data*/true,
-                                                  is_compressible);
+        // Create level viscosity table
+        {
+          const unsigned int n_cells = mg_matrices_A_block[level].get_matrix_free()->n_macro_cells();
+          level_viscosity_tables[level].reinit(TableIndices<1>(n_cells));
 
-        mg_matrices_Schur_complement[level].fill_cell_data(level_coef_dof_vec[level],
-                                                           sim.triangulation,
-                                                           dof_handler_projection,
-                                                           /*is_mg_level_data*/true,
-                                                           sim.pressure_scaling);
+          std::vector<types::global_dof_index> local_dof_indices(dof_handler_projection.get_fe().dofs_per_cell);
+          for (unsigned int cell=0; cell<n_cells; ++cell)
+            for (unsigned int i=0; i<mg_matrices_A_block[level].get_matrix_free()->n_components_filled(cell); ++i)
+              {
+                typename DoFHandler<dim>::level_cell_iterator FEQ_cell =
+                  mg_matrices_A_block[level].get_matrix_free()->get_cell_iterator(cell,i);
+                typename DoFHandler<dim>::level_cell_iterator DG_cell(&(sim.triangulation),
+                                                                      FEQ_cell->level(),
+                                                                      FEQ_cell->index(),
+                                                                      &dof_handler_projection);
+                DG_cell->get_active_or_mg_dof_indices(local_dof_indices);
+
+                Assert(local_dof_indices.size() == 1, ExcNotImplemented());
+                level_viscosity_tables[level](cell)[i] = level_viscosity_vector[level](local_dof_indices[0]);
+              }
+        }
+
+        mg_matrices_A_block[level].fill_cell_data (level_viscosity_tables[level],
+                                                   is_compressible);
+        mg_matrices_Schur_complement[level].fill_cell_data (level_viscosity_tables[level],
+                                                            sim.pressure_scaling);
       }
   }
 
@@ -1429,7 +1375,7 @@ namespace aspect
 
     for (unsigned int cell=0; cell<stokes_matrix.get_matrix_free()->n_macro_cells(); ++cell)
       {
-        const VectorizedArray<double> &cell_viscosity_x_2 = stokes_matrix.get_viscosity_x_2_table()(cell);
+        const VectorizedArray<double> cell_viscosity_x_2 = 2.0*active_viscosity_table(cell);
 
         velocity.reinit (cell);
         velocity.read_dof_values_plain (u0.block(0));
@@ -1929,6 +1875,7 @@ namespace aspect
     if (sim.parameters.include_melt_transport)
       sim.melt_handler->compute_melt_variables(sim.system_matrix,sim.solution,sim.system_rhs);
 
+
     return std::pair<double,double>(initial_nonlinear_residual,
                                     final_linear_residual);
   }
@@ -1986,8 +1933,6 @@ namespace aspect
       dof_handler_projection.distribute_dofs(fe_projection);
 
       DoFRenumbering::hierarchical(dof_handler_projection);
-
-      active_coef_dof_vec.reinit(dof_handler_projection.locally_owned_dofs(), sim.triangulation.get_communicator());
     }
 
     // Multigrid DoF setup
@@ -2271,7 +2216,7 @@ namespace aspect
                                                                         &dof_handler_projection);
                   std::vector<types::global_dof_index> dg_dof_indices(dof_handler_projection.get_fe(0).dofs_per_cell);
                   DG_cell->get_active_or_mg_dof_indices(dg_dof_indices);
-                  double viscosity = level_coef_dof_vec[level](dg_dof_indices[0]);
+                  double viscosity = level_viscosity_vector[level](dg_dof_indices[0]);
 
                   for (unsigned int q=0; q<n_q_points; ++q)
                     {
@@ -2309,6 +2254,9 @@ namespace aspect
           {
             mg_matrices_A_block[level].compute_diagonal();
           }
+
+        // This vector is no longer needed. Resize to 0.
+        level_viscosity_vector[level].reinit(0);
       }
   }
 

--- a/tests/nonlinear_channel_flow_velocities_Newton_Stokes_GMG/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_Newton_Stokes_GMG/screen-output
@@ -171,7 +171,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 3.13483e-13, norm of the rhs: 228379, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 3.13482e-13, norm of the rhs: 228379, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
@@ -183,31 +183,31 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 9.15621e-14, norm of the rhs: 66705, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 9.1562e-14, norm of the rhs: 66705, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.07737e-14, norm of the rhs: 44275, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.07738e-14, norm of the rhs: 44275.1, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 4.03441e-14, norm of the rhs: 29391.5, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 4.03442e-14, norm of the rhs: 29391.6, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 2.67867e-14, norm of the rhs: 19514.7, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 2.67868e-14, norm of the rhs: 19514.8, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 1.77871e-14, norm of the rhs: 12958.3, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 1.77872e-14, norm of the rhs: 12958.4, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 1.18128e-14, norm of the rhs: 8605.9, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 1.18129e-14, norm of the rhs: 8605.93, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 7.84612e-15, norm of the rhs: 5716.07, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 7.84599e-15, norm of the rhs: 5715.98, newton_derivative_scaling_factor: 0
 
 
    Postprocessing:
@@ -248,7 +248,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 4.71847e-13, norm of the rhs: 343751, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 4.71846e-13, norm of the rhs: 343751, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
@@ -264,31 +264,31 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 9.13976e-14, norm of the rhs: 66585.2, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 9.13977e-14, norm of the rhs: 66585.2, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.06641e-14, norm of the rhs: 44195.1, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.06639e-14, norm of the rhs: 44195, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 4.02719e-14, norm of the rhs: 29339, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 4.0272e-14, norm of the rhs: 29339.1, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 2.67385e-14, norm of the rhs: 19479.6, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 2.67386e-14, norm of the rhs: 19479.7, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 1.7755e-14, norm of the rhs: 12934.9, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 1.77551e-14, norm of the rhs: 12935, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 1.17913e-14, norm of the rhs: 8590.26, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 1.17914e-14, norm of the rhs: 8590.31, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 7.83169e-15, norm of the rhs: 5705.56, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 7.83174e-15, norm of the rhs: 5705.6, newton_derivative_scaling_factor: 0
 
 
    Postprocessing:
@@ -301,7 +301,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 7.28522e+17, v = 7.28522e+17, p = 0.0770426
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 2.35111e-14, norm of the rhs: 17128.4
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 2.3511e-14, norm of the rhs: 17128.3
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
@@ -309,11 +309,11 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 1.03741e-14, norm of the rhs: 7557.74, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 1.03742e-14, norm of the rhs: 7557.82, newton_derivative_scaling_factor: 0
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 6.89191e-15, norm of the rhs: 5020.91, newton_derivative_scaling_factor: 0
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 6.89176e-15, norm of the rhs: 5020.8, newton_derivative_scaling_factor: 0
 
 
    Postprocessing:
@@ -326,7 +326,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 7.28522e+17, v = 7.28522e+17, p = 0.0770426
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.95391e-15, norm of the rhs: 4337.56
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.95377e-15, norm of the rhs: 4337.45
 
 
    Postprocessing:


### PR DESCRIPTION
Reduces the storage requirement for the `block GMG` Stokes solver. Now, only 1 active level coefficient table needs to by stored instead of 3 (was 1 for each StokesOperator, ABlockOperator, and MassMatrixOperator), and only 1 multievel set of coefficient tables needs to be stored instead of 2 (was 1 for each ABlock GMG and SchurComplement GMG).

This is not too consequential for the current setup (cellwise constant viscosity), but will be necessary for the initial version of DGQ1 viscosity. The pull request for the DG1 projected viscosity will be able to be submitted once this change is incorporated. 