### PR TITLE
separate two merged boxes from box geometry model

### DIFF
--- a/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
+++ b/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
@@ -548,7 +548,7 @@ namespace aspect
     std::pair<std::string,std::string>
     TosiPostprocessor<dim>::execute (TableHandler &statistics)
     {
-      AssertThrow(Plugins::plugin_type_matches<const GeometryModel::Box<dim> >(this->get_geometry_model()),
+      AssertThrow(this->get_geometry_model().natural_coordinate_system() == aspect::Utilities::Coordinates::CoordinateSystem::cartesian,
                   ExcMessage("The current calculation of rate of work only makes sense in a Cartesian geometry."));
 
       AssertThrow(Plugins::plugin_type_matches<const TosiMaterial<dim>>(this->get_material_model()),

--- a/include/aspect/geometry_model/two_merged_boxes.h
+++ b/include/aspect/geometry_model/two_merged_boxes.h
@@ -22,8 +22,8 @@
 #ifndef _aspect_geometry_model_two_merged_boxes_h
 #define _aspect_geometry_model_two_merged_boxes_h
 
-#include <aspect/geometry_model/box.h>
-
+#include <aspect/geometry_model/interface.h>
+#include <aspect/simulator_access.h>
 
 namespace aspect
 {
@@ -37,7 +37,7 @@ namespace aspect
      * for the lithospheric part of the vertical boundaries.
      */
     template <int dim>
-    class TwoMergedBoxes : public Box<dim>
+    class TwoMergedBoxes : public Interface<dim>, public SimulatorAccess<dim>
     {
       public:
 
@@ -50,13 +50,13 @@ namespace aspect
          * Return a point that denotes the size of the box in each dimension
          * of the domain.
          */
-        Point<dim> get_extents () const override;
+        Point<dim> get_extents () const;
 
         /**
          * Return a point that denotes the lower left corner of the box
          * domain.
          */
-        Point<dim> get_origin () const override;
+        Point<dim> get_origin () const;
 
         /**
          * Return the typical length scale one would expect of features in
@@ -80,6 +80,12 @@ namespace aspect
          * that also matches these definitions.
          */
         double depth(const Point<dim> &position) const override;
+
+        /**
+         * Return the height of the given position relative to
+         * the initial box height.
+         */
+        double height_above_reference_surface(const Point<dim> &position) const override;
 
         /**
          * @copydoc Interface<dim>::representative_point()

--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -82,9 +82,9 @@ namespace aspect
         }
 
       // Check that the representative point lies in the domain.
-      AssertThrow((Plugins::plugin_type_matches<const GeometryModel::Box<dim>> (this->get_geometry_model())) ?
-                  (this->get_geometry_model().point_is_in_domain(representative_point)) :
-                  (this->get_geometry_model().point_is_in_domain(Utilities::Coordinates::spherical_to_cartesian_coordinates<dim>(spherical_representative_point))),
+      AssertThrow(((this->get_geometry_model().natural_coordinate_system() == Utilities::Coordinates::CoordinateSystem::cartesian) ?
+                   (this->get_geometry_model().point_is_in_domain(representative_point)) :
+                   (this->get_geometry_model().point_is_in_domain(Utilities::Coordinates::spherical_to_cartesian_coordinates<dim>(spherical_representative_point)))),
                   ExcMessage("The reference point does not lie with the domain."));
 
       // Set the radius of the representative point to the surface radius for spherical domains
@@ -111,6 +111,8 @@ namespace aspect
         spherical_representative_point[0] =  Plugins::get_plugin_as_type<const GeometryModel::Sphere<dim>>(this->get_geometry_model()).radius();
       else if (Plugins::plugin_type_matches<const GeometryModel::Box<dim>> (this->get_geometry_model()))
         representative_point[dim-1]=  Plugins::get_plugin_as_type<const GeometryModel::Box<dim>>(this->get_geometry_model()).get_extents()[dim-1];
+      else if (Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim>> (this->get_geometry_model()))
+        representative_point[dim-1]=  Plugins::get_plugin_as_type<const GeometryModel::TwoMergedBoxes<dim>>(this->get_geometry_model()).get_extents()[dim-1];
       else
         AssertThrow(false, ExcNotImplemented());
 

--- a/source/geometry_model/initial_topography_model/ascii_data.cc
+++ b/source/geometry_model/initial_topography_model/ascii_data.cc
@@ -22,6 +22,7 @@
 #include <aspect/global.h>
 #include <aspect/geometry_model/initial_topography_model/ascii_data.h>
 #include <aspect/geometry_model/box.h>
+#include <aspect/geometry_model/two_merged_boxes.h>
 #include <aspect/geometry_model/sphere.h>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/chunk.h>
@@ -65,7 +66,8 @@ namespace aspect
       // add a coordinate here, and, for spherical geometries,
       // change to cartesian coordinates.
       Point<dim> global_point;
-      if (Plugins::plugin_type_matches<const GeometryModel::Box<dim>> (this->get_geometry_model()))
+      if (Plugins::plugin_type_matches<const GeometryModel::Box<dim>> (this->get_geometry_model()) ||
+          Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim>> (this->get_geometry_model()))
         {
           // No need to set the vertical coordinate correctly,
           // because it will be thrown away in get_data_component anyway

--- a/source/geometry_model/initial_topography_model/function.cc
+++ b/source/geometry_model/initial_topography_model/function.cc
@@ -47,7 +47,7 @@ namespace aspect
     value (const Point<dim-1> &surface_point) const
     {
       Point<dim> global_point;
-      if (Plugins::plugin_type_matches<GeometryModel::Box<dim> >(this->get_geometry_model())||
+      if (Plugins::plugin_type_matches<GeometryModel::Box<dim> >(this->get_geometry_model()) ||
           Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim>> (this->get_geometry_model()))
         {
           // No need to set the vertical coordinate correctly,

--- a/source/geometry_model/initial_topography_model/function.cc
+++ b/source/geometry_model/initial_topography_model/function.cc
@@ -22,6 +22,7 @@
 #include <aspect/geometry_model/initial_topography_model/function.h>
 #include <aspect/geometry_model/interface.h>
 #include <aspect/geometry_model/box.h>
+#include <aspect/geometry_model/two_merged_boxes.h>
 #include <aspect/geometry_model/sphere.h>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/chunk.h>
@@ -46,7 +47,8 @@ namespace aspect
     value (const Point<dim-1> &surface_point) const
     {
       Point<dim> global_point;
-      if (Plugins::plugin_type_matches<GeometryModel::Box<dim> >(this->get_geometry_model()))
+      if (Plugins::plugin_type_matches<GeometryModel::Box<dim> >(this->get_geometry_model())||
+          Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim>> (this->get_geometry_model()))
         {
           // No need to set the vertical coordinate correctly,
           // because it will be thrown away in get_data_component anyway

--- a/source/geometry_model/two_merged_boxes.cc
+++ b/source/geometry_model/two_merged_boxes.cc
@@ -34,6 +34,7 @@ namespace aspect
   namespace GeometryModel
   {
 
+
     template <int dim>
     void
     TwoMergedBoxes<dim>::
@@ -238,6 +239,15 @@ namespace aspect
       const double d = maximal_depth()-(position(dim-1)-lower_box_origin[dim-1]);
       return std::min (std::max (d, 0.), maximal_depth());
     }
+
+
+    template <int dim>
+    double
+    TwoMergedBoxes<dim>::height_above_reference_surface(const Point<dim> &position) const
+    {
+      return (position(dim-1)-lower_box_origin[dim-1]) - extents[dim-1];
+    }
+
 
 
     template <int dim>

--- a/source/geometry_model/two_merged_boxes.cc
+++ b/source/geometry_model/two_merged_boxes.cc
@@ -33,8 +33,6 @@ namespace aspect
 {
   namespace GeometryModel
   {
-
-
     template <int dim>
     void
     TwoMergedBoxes<dim>::

--- a/source/initial_temperature/adiabatic.cc
+++ b/source/initial_temperature/adiabatic.cc
@@ -23,6 +23,7 @@
 #include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/boundary_temperature/interface.h>
 #include <aspect/geometry_model/box.h>
+#include <aspect/geometry_model/two_merged_boxes.h>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/chunk.h>
 
@@ -190,6 +191,18 @@ namespace aspect
               mid_point = box_geometry_model.get_origin();
               for (unsigned int i=0; i<dim-1; ++i)
                 mid_point(i) += 0.5 * box_geometry_model.get_extents()[i];
+            }
+          else if (Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim>> (this->get_geometry_model()))
+            {
+              const GeometryModel::TwoMergedBoxes<dim> &two_merged_boxes_geometry_model =
+                Plugins::get_plugin_as_type<const GeometryModel::TwoMergedBoxes<dim>> (this->get_geometry_model());
+
+              // for the box geometry, choose a point at the center of the bottom face.
+              // (note that the loop only runs over the first dim-1 coordinates, leaving
+              // the depth variable at zero)
+              mid_point = two_merged_boxes_geometry_model.get_origin();
+              for (unsigned int i=0; i<dim-1; ++i)
+                mid_point(i) += 0.5 * two_merged_boxes_geometry_model.get_extents()[i];
             }
           else
             AssertThrow (false,

--- a/source/initial_temperature/harmonic_perturbation.cc
+++ b/source/initial_temperature/harmonic_perturbation.cc
@@ -22,6 +22,7 @@
 #include <aspect/initial_temperature/harmonic_perturbation.h>
 #include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/geometry_model/box.h>
+#include <aspect/geometry_model/two_merged_boxes.h>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/chunk.h>
 #include <aspect/utilities.h>
@@ -113,6 +114,26 @@ namespace aspect
           // that is scaled to the extent of the geometry.
           // This way the perturbation is always 0 at the model borders.
           const Point<dim> extent = box_geometry_model.get_extents();
+
+          if (dim==2)
+            {
+              lateral_perturbation = std::sin(lateral_wave_number_1*position(0)*numbers::PI/extent(0));
+            }
+          else if (dim==3)
+            {
+              lateral_perturbation = std::sin(lateral_wave_number_1*position(0)*numbers::PI/extent(0))
+                                     * std::sin(lateral_wave_number_2*position(1)*numbers::PI/extent(1));
+            }
+        }
+      else if (Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim>> (this->get_geometry_model()))
+        {
+          const GeometryModel::TwoMergedBoxes<dim> &two_merged_boxes_geometry_model =
+            Plugins::get_plugin_as_type<const GeometryModel::TwoMergedBoxes<dim>> (this->get_geometry_model());
+
+          // In case of Box model use a sine as lateral perturbation
+          // that is scaled to the extent of the geometry.
+          // This way the perturbation is always 0 at the model borders.
+          const Point<dim> extent = two_merged_boxes_geometry_model.get_extents();
 
           if (dim==2)
             {

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2077,7 +2077,7 @@ namespace aspect
                    || (Plugins::plugin_type_matches<const GeometryModel::Box<dim>> (this->get_geometry_model()))
                    || (Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim>> (this->get_geometry_model())),
                    ExcMessage ("This ascii data plugin can only be used when using "
-                               "a spherical shell, chunk or box geometry."));
+                               "a spherical shell, chunk, box or two merged boxes geometry."));
 
 
       for (const auto &boundary_id : boundary_ids)
@@ -2566,9 +2566,10 @@ namespace aspect
       AssertThrow ((Plugins::plugin_type_matches<GeometryModel::SphericalShell<dim> >(this->get_geometry_model()) ||
                     Plugins::plugin_type_matches<GeometryModel::Chunk<dim> >(this->get_geometry_model()) ||
                     Plugins::plugin_type_matches<GeometryModel::Sphere<dim> >(this->get_geometry_model()) ||
-                    Plugins::plugin_type_matches<GeometryModel::Box<dim> >(this->get_geometry_model())),
+                    Plugins::plugin_type_matches<GeometryModel::Box<dim> >(this->get_geometry_model())) ||
+                   Plugins::plugin_type_matches<GeometryModel::TwoMergedBoxes<dim>> (this->get_geometry_model()),
                    ExcMessage ("This ascii data plugin can only be used when using "
-                               "a spherical shell, chunk, sphere or box geometry."));
+                               "a spherical shell, chunk, sphere, box or two merged boxes geometry."));
 
       // Create the lookups for each file
       number_of_layer_boundaries = data_file_names.size();
@@ -2611,7 +2612,7 @@ namespace aspect
 
       double vertical_position;
       Point<dim-1> horizontal_position;
-      if (Plugins::plugin_type_matches<GeometryModel::Box<dim> >(this->get_geometry_model()))
+      if (this->get_geometry_model().natural_coordinate_system() == Utilities::Coordinates::CoordinateSystem::cartesian)
         {
           // in cartesian coordinates, the vertical component comes last
           vertical_position = internal_position[dim-1];


### PR DESCRIPTION
Separate two merged boxes from box geometry model and define a independent height_above_reference_surface function.

I found that the world builder didn't work for a model anymore where I did work before, and it turned out that due to pull request #3378, now the wrong height above the surface was passed (always 0) because the two merged boxes relied on the function from the box model, which relied on a point variable which was never filled in the two merged boxes model. To prevent these kind of problems in the future I separated them.  

I have not added a test yet, but will do that later.


### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
