### PR TITLE
Fix visco plastic finite difference

### DIFF
--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -349,6 +349,9 @@ namespace aspect
             {
               const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
 
+               // components that are not on the diagonal are multiplied by 0.5, because the symmetric tensor
+               // is modified by 0.5 in both symmetric directions (xy/yx) simultaneously and we compute the combined
+               // derivative
               const SymmetricTensor<2,dim> strain_rate_difference = in.strain_rate[i]
                                                                     + std::max(std::fabs(in.strain_rate[i][strain_rate_indices]), min_strain_rate)
                                                                     * (component > dim-1 ? 0.5 : 1 )

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -349,9 +349,9 @@ namespace aspect
             {
               const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
 
-               // components that are not on the diagonal are multiplied by 0.5, because the symmetric tensor
-               // is modified by 0.5 in both symmetric directions (xy/yx) simultaneously and we compute the combined
-               // derivative
+              // components that are not on the diagonal are multiplied by 0.5, because the symmetric tensor
+              // is modified by 0.5 in both symmetric directions (xy/yx) simultaneously and we compute the combined
+              // derivative
               const SymmetricTensor<2,dim> strain_rate_difference = in.strain_rate[i]
                                                                     + std::max(std::fabs(in.strain_rate[i][strain_rate_indices]), min_strain_rate)
                                                                     * (component > dim-1 ? 0.5 : 1 )

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -351,6 +351,7 @@ namespace aspect
 
               const SymmetricTensor<2,dim> strain_rate_difference = in.strain_rate[i]
                                                                     + std::max(std::fabs(in.strain_rate[i][strain_rate_indices]), min_strain_rate)
+                                                                    * (component > dim-1 ? 0.5 : 1 )
                                                                     * finite_difference_accuracy
                                                                     * Utilities::nth_basis_for_symmetric_tensors<dim>(component);
               std::vector<double> eta_component =

--- a/tests/visco_plastic_derivatives_2d.cc
+++ b/tests/visco_plastic_derivatives_2d.cc
@@ -171,6 +171,9 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
 
       for (unsigned int i = 0; i < 5; i++)
         {
+          // components that are not on the diagonal are multiplied by 0.5, because the symmetric tensor
+          // is modified by 0.5 in both symmetric directions (xy/yx) simultaneously and we compute the combined
+          // derivative
           in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
                                                     + std::fabs(in_base.strain_rate[i][strain_rate_indices])
                                                     * (component > dim-1 ? 0.5 : 1 )
@@ -249,4 +252,3 @@ void signal_connector (aspect::SimulatorSignals<dim> &signals)
 
 ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
                                   signal_connector<3>)
-

--- a/tests/visco_plastic_derivatives_2d.cc
+++ b/tests/visco_plastic_derivatives_2d.cc
@@ -173,6 +173,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
         {
           in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
                                                     + std::fabs(in_base.strain_rate[i][strain_rate_indices])
+                                                    * (component > dim-1 ? 0.5 : 1 )
                                                     * finite_difference_accuracy
                                                     * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
         }

--- a/tests/visco_plastic_derivatives_2d/screen-output
+++ b/tests/visco_plastic_derivatives_2d/screen-output
@@ -1,3 +1,5 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
 
 Loading shared library <./libvisco_plastic_derivatives_2d.so>
 
@@ -19,11 +21,11 @@ strain-rate: point = 1, component = 1, Finite difference = -6.58657e+26, Analyti
 strain-rate: point = 2, component = 1, Finite difference = -1.23761e+27, Analytical derivative = -1.23761e+27
 strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 4, component = 1, Finite difference = -8.83883e+32, Analytical derivative = -8.83883e+32
-strain-rate: point = 0, component = 2, Finite difference = -2.55212e+33, Analytical derivative = -2.55212e+33
-strain-rate: point = 1, component = 2, Finite difference = 3.5961e+28, Analytical derivative = 3.5961e+28
-strain-rate: point = 2, component = 2, Finite difference = -2.2502e+28, Analytical derivative = -2.2502e+28
+strain-rate: point = 0, component = 2, Finite difference = -1.27606e+33, Analytical derivative = -1.27606e+33
+strain-rate: point = 1, component = 2, Finite difference = 1.79805e+28, Analytical derivative = 1.79805e+28
+strain-rate: point = 2, component = 2, Finite difference = -1.1251e+28, Analytical derivative = -1.1251e+28
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 2, Finite difference = -8.83883e+32, Analytical derivative = -8.83883e+32
+strain-rate: point = 4, component = 2, Finite difference = -4.41942e+32, Analytical derivative = -4.41942e+32
 OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter geometric
@@ -42,11 +44,11 @@ strain-rate: point = 1, component = 1, Finite difference = -6.58596e+26, Analyti
 strain-rate: point = 2, component = 1, Finite difference = -1.23785e+27, Analytical derivative = -1.23761e+27
 strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 4, component = 1, Finite difference = -8.83883e+32, Analytical derivative = -8.83883e+32
-strain-rate: point = 0, component = 2, Finite difference = -2.55212e+33, Analytical derivative = -2.55212e+33
-strain-rate: point = 1, component = 2, Finite difference = 3.5961e+28, Analytical derivative = 3.5961e+28
-strain-rate: point = 2, component = 2, Finite difference = -2.2502e+28, Analytical derivative = -2.2502e+28
+strain-rate: point = 0, component = 2, Finite difference = -1.27607e+33, Analytical derivative = -1.27606e+33
+strain-rate: point = 1, component = 2, Finite difference = 1.79805e+28, Analytical derivative = 1.79805e+28
+strain-rate: point = 2, component = 2, Finite difference = -1.1251e+28, Analytical derivative = -1.1251e+28
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 2, Finite difference = -8.83883e+32, Analytical derivative = -8.83883e+32
+strain-rate: point = 4, component = 2, Finite difference = -4.41942e+32, Analytical derivative = -4.41942e+32
 OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter arithmetic
@@ -65,11 +67,11 @@ strain-rate: point = 1, component = 1, Finite difference = -6.58657e+26, Analyti
 strain-rate: point = 2, component = 1, Finite difference = -1.23761e+27, Analytical derivative = -1.23761e+27
 strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 4, component = 1, Finite difference = -8.83883e+32, Analytical derivative = -8.83883e+32
-strain-rate: point = 0, component = 2, Finite difference = -2.55212e+33, Analytical derivative = -2.55212e+33
-strain-rate: point = 1, component = 2, Finite difference = 3.5961e+28, Analytical derivative = 3.5961e+28
-strain-rate: point = 2, component = 2, Finite difference = -2.2502e+28, Analytical derivative = -2.2502e+28
+strain-rate: point = 0, component = 2, Finite difference = -1.27606e+33, Analytical derivative = -1.27606e+33
+strain-rate: point = 1, component = 2, Finite difference = 1.79805e+28, Analytical derivative = 1.79805e+28
+strain-rate: point = 2, component = 2, Finite difference = -1.1251e+28, Analytical derivative = -1.1251e+28
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 2, Finite difference = -8.83883e+32, Analytical derivative = -8.83883e+32
+strain-rate: point = 4, component = 2, Finite difference = -4.41942e+32, Analytical derivative = -4.41942e+32
 OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter maximum composition
@@ -88,12 +90,14 @@ strain-rate: point = 1, component = 1, Finite difference = -6.58657e+26, Analyti
 strain-rate: point = 2, component = 1, Finite difference = -1.23761e+27, Analytical derivative = -1.23761e+27
 strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 4, component = 1, Finite difference = -8.83883e+32, Analytical derivative = -8.83883e+32
-strain-rate: point = 0, component = 2, Finite difference = -2.55212e+33, Analytical derivative = -2.55212e+33
-strain-rate: point = 1, component = 2, Finite difference = 3.5961e+28, Analytical derivative = 3.5961e+28
-strain-rate: point = 2, component = 2, Finite difference = -2.2502e+28, Analytical derivative = -2.2502e+28
+strain-rate: point = 0, component = 2, Finite difference = -1.27606e+33, Analytical derivative = -1.27606e+33
+strain-rate: point = 1, component = 2, Finite difference = 1.79805e+28, Analytical derivative = 1.79805e+28
+strain-rate: point = 2, component = 2, Finite difference = -1.1251e+28, Analytical derivative = -1.1251e+28
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 2, Finite difference = -8.83883e+32, Analytical derivative = -8.83883e+32
+strain-rate: point = 4, component = 2, Finite difference = -4.41942e+32, Analytical derivative = -4.41942e+32
 OK
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
 Number of active cells: 100 (on 1 levels)
 Number of degrees of freedom: 2,767 (882+121+441+441+441+441)
 
@@ -107,4 +111,9 @@ Number of degrees of freedom: 2,767 (882+121+441+441+441+441)
 Termination requested by criterion: end time
 
 
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
 
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/visco_plastic_derivatives_3d.cc
+++ b/tests/visco_plastic_derivatives_3d.cc
@@ -186,6 +186,9 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
 
       for (unsigned int i = 0; i < 5; i++)
         {
+          // components that are not on the diagonal are multiplied by 0.5, because the symmetric tensor
+          // is modified by 0.5 in both symmetric directions (xy/yx) simultaneously and we compute the combined
+          // derivative
           in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
                                                     + std::fabs(in_base.strain_rate[i][strain_rate_indices])
                                                     * (component > dim-1 ? 0.5 : 1 )
@@ -264,4 +267,3 @@ void signal_connector (aspect::SimulatorSignals<dim> &signals)
 
 ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
                                   signal_connector<3>)
-

--- a/tests/visco_plastic_derivatives_3d.cc
+++ b/tests/visco_plastic_derivatives_3d.cc
@@ -188,6 +188,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
         {
           in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
                                                     + std::fabs(in_base.strain_rate[i][strain_rate_indices])
+                                                    * (component > dim-1 ? 0.5 : 1 )
                                                     * finite_difference_accuracy
                                                     * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
         }

--- a/tests/visco_plastic_derivatives_3d/screen-output
+++ b/tests/visco_plastic_derivatives_3d/screen-output
@@ -1,3 +1,5 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
 
 Loading shared library <./libvisco_plastic_derivatives_3d.so>
 
@@ -24,21 +26,21 @@ strain-rate: point = 1, component = 2, Finite difference = -1.24397e+26, Analyti
 strain-rate: point = 2, component = 2, Finite difference = 2.34886e+26, Analytical derivative = 2.34885e+26
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 4, component = 2, Finite difference = 1.72133e+32, Analytical derivative = 1.72133e+32
-strain-rate: point = 0, component = 3, Finite difference = -1.52145e+33, Analytical derivative = -1.52145e+33
-strain-rate: point = 1, component = 3, Finite difference = 1.01879e+28, Analytical derivative = 1.01879e+28
-strain-rate: point = 2, component = 3, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 0, component = 3, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
+strain-rate: point = 1, component = 3, Finite difference = 5.09393e+27, Analytical derivative = 5.09393e+27
+strain-rate: point = 2, component = 3, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
 strain-rate: point = 3, component = 3, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 3, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
-strain-rate: point = 0, component = 4, Finite difference = -1.52145e+33, Analytical derivative = -1.52145e+33
-strain-rate: point = 1, component = 4, Finite difference = 9.48845e+27, Analytical derivative = 9.48845e+27
-strain-rate: point = 2, component = 4, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 4, component = 3, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
+strain-rate: point = 0, component = 4, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
+strain-rate: point = 1, component = 4, Finite difference = 4.74422e+27, Analytical derivative = 4.74422e+27
+strain-rate: point = 2, component = 4, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
 strain-rate: point = 3, component = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 4, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
-strain-rate: point = 0, component = 5, Finite difference = -1.52145e+33, Analytical derivative = -1.52145e+33
-strain-rate: point = 1, component = 5, Finite difference = 9.13874e+27, Analytical derivative = 9.13874e+27
-strain-rate: point = 2, component = 5, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 4, component = 4, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
+strain-rate: point = 0, component = 5, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
+strain-rate: point = 1, component = 5, Finite difference = 4.56937e+27, Analytical derivative = 4.56937e+27
+strain-rate: point = 2, component = 5, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
 strain-rate: point = 3, component = 5, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 5, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
+strain-rate: point = 4, component = 5, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
 OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter geometric
@@ -65,21 +67,21 @@ strain-rate: point = 1, component = 2, Finite difference = -1.24701e+26, Analyti
 strain-rate: point = 2, component = 2, Finite difference = 2.3492e+26, Analytical derivative = 2.34885e+26
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 4, component = 2, Finite difference = 1.72133e+32, Analytical derivative = 1.72133e+32
-strain-rate: point = 0, component = 3, Finite difference = -1.52145e+33, Analytical derivative = -1.52145e+33
-strain-rate: point = 1, component = 3, Finite difference = 1.01879e+28, Analytical derivative = 1.01879e+28
-strain-rate: point = 2, component = 3, Finite difference = -6.40594e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 0, component = 3, Finite difference = -7.60731e+32, Analytical derivative = -7.60726e+32
+strain-rate: point = 1, component = 3, Finite difference = 5.09393e+27, Analytical derivative = 5.09393e+27
+strain-rate: point = 2, component = 3, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
 strain-rate: point = 3, component = 3, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 3, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
-strain-rate: point = 0, component = 4, Finite difference = -1.52145e+33, Analytical derivative = -1.52145e+33
-strain-rate: point = 1, component = 4, Finite difference = 9.48844e+27, Analytical derivative = 9.48845e+27
-strain-rate: point = 2, component = 4, Finite difference = -6.40594e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 4, component = 3, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
+strain-rate: point = 0, component = 4, Finite difference = -7.60731e+32, Analytical derivative = -7.60726e+32
+strain-rate: point = 1, component = 4, Finite difference = 4.74422e+27, Analytical derivative = 4.74422e+27
+strain-rate: point = 2, component = 4, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
 strain-rate: point = 3, component = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 4, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
-strain-rate: point = 0, component = 5, Finite difference = -1.52145e+33, Analytical derivative = -1.52145e+33
-strain-rate: point = 1, component = 5, Finite difference = 9.13873e+27, Analytical derivative = 9.13874e+27
-strain-rate: point = 2, component = 5, Finite difference = -6.40594e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 4, component = 4, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
+strain-rate: point = 0, component = 5, Finite difference = -7.60731e+32, Analytical derivative = -7.60726e+32
+strain-rate: point = 1, component = 5, Finite difference = 4.56937e+27, Analytical derivative = 4.56937e+27
+strain-rate: point = 2, component = 5, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
 strain-rate: point = 3, component = 5, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 5, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
+strain-rate: point = 4, component = 5, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
 Some parts of the test where not successful.
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter arithmetic
@@ -103,21 +105,21 @@ strain-rate: point = 1, component = 2, Finite difference = -1.24382e+26, Analyti
 strain-rate: point = 2, component = 2, Finite difference = 2.34884e+26, Analytical derivative = 2.34885e+26
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 4, component = 2, Finite difference = 1.72133e+32, Analytical derivative = 1.72133e+32
-strain-rate: point = 0, component = 3, Finite difference = -1.52145e+33, Analytical derivative = -1.52145e+33
-strain-rate: point = 1, component = 3, Finite difference = 1.01879e+28, Analytical derivative = 1.01879e+28
-strain-rate: point = 2, component = 3, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 0, component = 3, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
+strain-rate: point = 1, component = 3, Finite difference = 5.09393e+27, Analytical derivative = 5.09393e+27
+strain-rate: point = 2, component = 3, Finite difference = -3.20298e+27, Analytical derivative = -3.20297e+27
 strain-rate: point = 3, component = 3, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 3, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
-strain-rate: point = 0, component = 4, Finite difference = -1.52145e+33, Analytical derivative = -1.52145e+33
-strain-rate: point = 1, component = 4, Finite difference = 9.48845e+27, Analytical derivative = 9.48845e+27
-strain-rate: point = 2, component = 4, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 4, component = 3, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
+strain-rate: point = 0, component = 4, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
+strain-rate: point = 1, component = 4, Finite difference = 4.74422e+27, Analytical derivative = 4.74422e+27
+strain-rate: point = 2, component = 4, Finite difference = -3.20298e+27, Analytical derivative = -3.20297e+27
 strain-rate: point = 3, component = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 4, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
-strain-rate: point = 0, component = 5, Finite difference = -1.52145e+33, Analytical derivative = -1.52145e+33
-strain-rate: point = 1, component = 5, Finite difference = 9.13874e+27, Analytical derivative = 9.13874e+27
-strain-rate: point = 2, component = 5, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 4, component = 4, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
+strain-rate: point = 0, component = 5, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
+strain-rate: point = 1, component = 5, Finite difference = 4.56937e+27, Analytical derivative = 4.56937e+27
+strain-rate: point = 2, component = 5, Finite difference = -3.20298e+27, Analytical derivative = -3.20297e+27
 strain-rate: point = 3, component = 5, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 5, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
+strain-rate: point = 4, component = 5, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
 OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter maximum composition
@@ -141,22 +143,24 @@ strain-rate: point = 1, component = 2, Finite difference = -1.24382e+26, Analyti
 strain-rate: point = 2, component = 2, Finite difference = 2.34885e+26, Analytical derivative = 2.34885e+26
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 4, component = 2, Finite difference = 1.72133e+32, Analytical derivative = 1.72133e+32
-strain-rate: point = 0, component = 3, Finite difference = -1.52145e+33, Analytical derivative = -1.52145e+33
-strain-rate: point = 1, component = 3, Finite difference = 1.01879e+28, Analytical derivative = 1.01879e+28
-strain-rate: point = 2, component = 3, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 0, component = 3, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
+strain-rate: point = 1, component = 3, Finite difference = 5.09393e+27, Analytical derivative = 5.09393e+27
+strain-rate: point = 2, component = 3, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
 strain-rate: point = 3, component = 3, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 3, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
-strain-rate: point = 0, component = 4, Finite difference = -1.52145e+33, Analytical derivative = -1.52145e+33
-strain-rate: point = 1, component = 4, Finite difference = 9.48845e+27, Analytical derivative = 9.48845e+27
-strain-rate: point = 2, component = 4, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 4, component = 3, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
+strain-rate: point = 0, component = 4, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
+strain-rate: point = 1, component = 4, Finite difference = 4.74422e+27, Analytical derivative = 4.74422e+27
+strain-rate: point = 2, component = 4, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
 strain-rate: point = 3, component = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 4, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
-strain-rate: point = 0, component = 5, Finite difference = -1.52145e+33, Analytical derivative = -1.52145e+33
-strain-rate: point = 1, component = 5, Finite difference = 9.13874e+27, Analytical derivative = 9.13874e+27
-strain-rate: point = 2, component = 5, Finite difference = -6.40595e+27, Analytical derivative = -6.40595e+27
+strain-rate: point = 4, component = 4, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
+strain-rate: point = 0, component = 5, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
+strain-rate: point = 1, component = 5, Finite difference = 4.56937e+27, Analytical derivative = 4.56937e+27
+strain-rate: point = 2, component = 5, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
 strain-rate: point = 3, component = 5, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 5, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
+strain-rate: point = 4, component = 5, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
 OK
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
 Number of active cells: 100 (on 1 levels)
 Number of degrees of freedom: 9,503 (3,969+242+1,323+1,323+1,323+1,323)
 
@@ -170,4 +174,9 @@ Number of degrees of freedom: 9,503 (3,969+242+1,323+1,323+1,323+1,323)
 Termination requested by criterion: end time
 
 
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
 
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/visco_plastic_newton_nonlinear_channelflow.prm
+++ b/tests/visco_plastic_newton_nonlinear_channelflow.prm
@@ -1,0 +1,131 @@
+# Like the poiseuille_2d.prm test and based on the nonlinear channel 
+# flow benchmark. This is used to test the velocity boundary conditions 
+# of the Newton Stokes solver.
+
+set Output directory = vp_input_v_2_new 
+set Dimension = 2
+set CFL number                             = 1.0
+set Maximum time step                      = 1
+set End time                               = 0
+set Start time                             = 0
+set Adiabatic surface temperature          = 1
+set Surface pressure                       = 0
+set Use years in output instead of seconds = false  # default: true
+set Nonlinear solver scheme = Newton Stokes
+set Max nonlinear iterations = 150 
+set Nonlinear solver tolerance = 1e-14
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Linear solver tolerance = 1e-5
+  end
+
+  subsection Newton solver parameters
+     set Max pre-Newton nonlinear iterations = 10
+    set Nonlinear Newton solver switch tolerance = 1e-20
+    set Max Newton line search iterations = 0
+    set Maximum linear Stokes solver tolerance = 1e-2
+    set Use Newton residual scaling method = false
+    set Use Newton failsafe = false
+    set Stabilization preconditioner = SPD
+    set Stabilization velocity block = SPD
+  end
+end
+
+subsection Boundary temperature model
+  set List of model names = box
+  subsection Box
+    set Left temperature = 1
+  end
+end
+
+
+ subsection Initial temperature model
+   set Model name = function
+   subsection Function
+    set Function expression = 1
+   end
+ end
+
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 0
+  end
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 10e3 
+    set Y extent = 8e3 
+    set Y repetitions = 1 
+  end
+end
+
+subsection Material model
+  set Model name = visco plastic
+
+
+  subsection Visco Plastic 
+    set Viscous flow law = dislocation
+    set Minimum viscosity = 1e19
+    set Maximum viscosity = 1e24
+ set Prefactors for diffusion creep = 1
+  set Prefactors for dislocation creep = 1e-37
+  set Grain size exponents for diffusion creep = 0
+  	set Activation energies for diffusion creep = 0
+  	set Activation energies for dislocation creep = 0
+  	set Activation volumes for diffusion creep = 0
+  	set Activation volumes for dislocation creep = 0
+        set Stress exponents for dislocation creep = 3
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 2
+end
+
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = 2, 3
+end
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators       = 0, 1
+  set Prescribed velocity boundary indicators = 2: function, 3: function # velocity bc
+end
+
+
+subsection Boundary traction model
+  subsection Function
+    set Variable names = x,z
+    # We want to prescribe a pressure of 2 at the left boundary
+    # and -2 at the right boundary. 
+    # The traction in this case is defined as:
+    # tau =  - pressure * normal_vector.
+    # On the left boundary, the outward pointing normal vector is 
+    # (-1;0). On the right (1;0).
+    # Therefore:
+    # Left boundary:  tau = - pressure(left) (-1;0) = - (2) (-1;0) = (2;0).
+    # Right boundary: tau = - pressure(right) (1;0) = - (-2) (1;0) = (2;0). 
+    # Conveniently, the traction is the same on both boundaries.
+    set Function expression = 0;if(z>0,0,1e9)
+  end
+end
+
+
+subsection Boundary velocity model
+  subsection Function
+       set Function constants = n = 3
+    set Variable names = x,z
+    # For velocity boundary conditions both are used, for pressure boundary conditions only the first (x) component 
+    set Function expression = 0;(1e-37/(n+1))*((1e9/8e3)^n)*(((5e3)^(n+1))-(abs(x-(5e3))^(n+1)));  
+  end
+end
+

--- a/tests/visco_plastic_newton_nonlinear_channelflow.prm
+++ b/tests/visco_plastic_newton_nonlinear_channelflow.prm
@@ -77,10 +77,10 @@ subsection Material model
  set Prefactors for diffusion creep = 1
   set Prefactors for dislocation creep = 1e-37
   set Grain size exponents for diffusion creep = 0
-  	set Activation energies for diffusion creep = 0
-  	set Activation energies for dislocation creep = 0
-  	set Activation volumes for diffusion creep = 0
-  	set Activation volumes for dislocation creep = 0
+    set Activation energies for diffusion creep = 0
+    set Activation energies for dislocation creep = 0
+    set Activation volumes for diffusion creep = 0
+    set Activation volumes for dislocation creep = 0
         set Stress exponents for dislocation creep = 3
   end
 end

--- a/tests/visco_plastic_newton_nonlinear_channelflow/screen-output
+++ b/tests/visco_plastic_newton_nonlinear_channelflow/screen-output
@@ -1,0 +1,194 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 16 (on 3 levels)
+Number of degrees of freedom: 268 (162+25+81)
+
+*** Timestep 0:  t=0 seconds
+   Solving temperature system... 0 iterations.
+   Initial Newton Stokes residual = 1.53461e+16, v = 3.89267e+15, p = 1.48442e+16
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 12+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 1.53461e+16
+
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 15+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 4.04983e-05, norm of the rhs: 6.21491e+11, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 15+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 2.09222e-05, norm of the rhs: 3.21074e+11, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 16+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.1994e-05, norm of the rhs: 1.84061e+11, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 16+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 8.62833e-06, norm of the rhs: 1.32411e+11, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 17+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 2.59458e-06, norm of the rhs: 3.98166e+10, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 17+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 1.72089e-06, norm of the rhs: 2.6409e+10, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 16+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.09444e-06, norm of the rhs: 1.67954e+10, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 16+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 6.87209e-07, norm of the rhs: 1.0546e+10, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 16+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 4.28576e-07, norm of the rhs: 6.57698e+09, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 0 iterations.
+   Switching from defect correction form of Picard to the Newton solver scheme.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 9+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 2.60587e-07, norm of the rhs: 3.99899e+09, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 10+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 9.80591e-08, norm of the rhs: 1.50483e+09, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 10+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 2.27282e-08, norm of the rhs: 3.48789e+08, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 11+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 1.71259e-08, norm of the rhs: 2.62816e+08, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 9+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 1.1095e-08, norm of the rhs: 1.70265e+08, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 9+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 4.40787e-09, norm of the rhs: 6.76436e+07, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 9+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 1.01554e-09, norm of the rhs: 1.55845e+07, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 9+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 2.79445e-10, norm of the rhs: 4.28839e+06, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 10+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 2.53834e-10, norm of the rhs: 3.89537e+06, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 11+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 1.17374e-10, norm of the rhs: 1.80124e+06, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 9+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 3.06033e-11, norm of the rhs: 469642, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 11+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 8.84997e-12, norm of the rhs: 135813, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 9+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 8.32017e-12, norm of the rhs: 127682, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 11+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 4.11928e-12, norm of the rhs: 63214.9, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 10+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 1.19617e-12, norm of the rhs: 18356.6, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 9+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 2.10847e-13, norm of the rhs: 3235.68, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 10+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 2.06509e-13, norm of the rhs: 3169.11, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 11+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 1.18752e-13, norm of the rhs: 1822.38, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 9+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 3.96693e-14, norm of the rhs: 608.769, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 12+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 6.92791e-15, norm of the rhs: 106.316, newton_derivative_scaling_factor: 1
+
+
+   Postprocessing:
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/visco_plastic_newton_nonlinear_channelflow/screen-output
+++ b/tests/visco_plastic_newton_nonlinear_channelflow/screen-output
@@ -1,8 +1,4 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 Number of active cells: 16 (on 3 levels)
 Number of degrees of freedom: 268 (162+25+81)
 
@@ -64,121 +60,121 @@ Number of degrees of freedom: 268 (162+25+81)
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 2.60587e-07, norm of the rhs: 3.99899e+09, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 2.60586e-07, norm of the rhs: 3.99898e+09, newton_derivative_scaling_factor: 1
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 9.80591e-08, norm of the rhs: 1.50483e+09, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 9.80594e-08, norm of the rhs: 1.50483e+09, newton_derivative_scaling_factor: 1
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 2.27282e-08, norm of the rhs: 3.48789e+08, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 2.27278e-08, norm of the rhs: 3.48784e+08, newton_derivative_scaling_factor: 1
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 1.71259e-08, norm of the rhs: 2.62816e+08, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 1.71253e-08, norm of the rhs: 2.62806e+08, newton_derivative_scaling_factor: 1
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 1.1095e-08, norm of the rhs: 1.70265e+08, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 1.10948e-08, norm of the rhs: 1.70262e+08, newton_derivative_scaling_factor: 1
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 4.40787e-09, norm of the rhs: 6.76436e+07, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 4.40772e-09, norm of the rhs: 6.76413e+07, newton_derivative_scaling_factor: 1
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 1.01554e-09, norm of the rhs: 1.55845e+07, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 1.01567e-09, norm of the rhs: 1.55865e+07, newton_derivative_scaling_factor: 1
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 2.79445e-10, norm of the rhs: 4.28839e+06, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 2.79441e-10, norm of the rhs: 4.28833e+06, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 9+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 2.54087e-10, norm of the rhs: 3.89925e+06, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 11+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 1.17421e-10, norm of the rhs: 1.80196e+06, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 9+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 3.0548e-11, norm of the rhs: 468793, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 11+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 8.8852e-12, norm of the rhs: 136353, newton_derivative_scaling_factor: 1
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 2.53834e-10, norm of the rhs: 3.89537e+06, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 8.32067e-12, norm of the rhs: 127690, newton_derivative_scaling_factor: 1
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 1.17374e-10, norm of the rhs: 1.80124e+06, newton_derivative_scaling_factor: 1
-
-   Solving temperature system... 0 iterations.
-   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 3.06033e-11, norm of the rhs: 469642, newton_derivative_scaling_factor: 1
-
-   Solving temperature system... 0 iterations.
-   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 8.84997e-12, norm of the rhs: 135813, newton_derivative_scaling_factor: 1
-
-   Solving temperature system... 0 iterations.
-   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 8.32017e-12, norm of the rhs: 127682, newton_derivative_scaling_factor: 1
-
-   Solving temperature system... 0 iterations.
-   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 4.11928e-12, norm of the rhs: 63214.9, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 4.1261e-12, norm of the rhs: 63319.6, newton_derivative_scaling_factor: 1
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 1.19617e-12, norm of the rhs: 18356.6, newton_derivative_scaling_factor: 1
-
-   Solving temperature system... 0 iterations.
-   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
-   Rebuilding Stokes preconditioner...
-   Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 2.10847e-13, norm of the rhs: 3235.68, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 1.20119e-12, norm of the rhs: 18433.6, newton_derivative_scaling_factor: 1
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 2.06509e-13, norm of the rhs: 3169.11, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 2.11342e-13, norm of the rhs: 3243.27, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 10+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 2.07665e-13, norm of the rhs: 3186.84, newton_derivative_scaling_factor: 1
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 1.18752e-13, norm of the rhs: 1822.38, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 1.19156e-13, norm of the rhs: 1828.59, newton_derivative_scaling_factor: 1
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 3.96693e-14, norm of the rhs: 608.769, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 3.97303e-14, norm of the rhs: 609.705, newton_derivative_scaling_factor: 1
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 6.92791e-15, norm of the rhs: 106.316, newton_derivative_scaling_factor: 1
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 6.91604e-15, norm of the rhs: 106.134, newton_derivative_scaling_factor: 1
 
 
    Postprocessing:
@@ -186,9 +182,4 @@ Number of degrees of freedom: 268 (162+25+81)
 Termination requested by criterion: end time
 
 
-+----------------------------------------------+------------+------------+
-+----------------------------------+-----------+------------+------------+
-+----------------------------------+-----------+------------+------------+
 
------------------------------------------------------------------------------
------------------------------------------------------------------------------


### PR DESCRIPTION
in pull request #3460 a discussion came up about the 0.5 in the finite difference terms. This discussion was concluded that the 0.5 should be there. During that discussion I looked at the visco plastic material model for reference, and noticed that it wasn't there while it should be. 

I have done some testing to convince myself that this is actually better, and that was harder then expected. For the simple "compex" cases it converges very vast anyway or not at all anyway. The nonlinear channel flow was actually a nice in between case, where I could study the actual impact of adding the 0.5. The conclusion is that sometimes it is better, sometimes it is worse, but without the 0.5 the SPDness is lost. Without the 0.5 every now then the assert

```
The violated condition was: 
    data.local_matrix.matrix_norm_square(tmp)/(tmp*tmp) >= -1e-12*data.local_matrix.frobenius_norm()
Additional information: 
    The top left block of the local Newton-Stokes matrix is not positive definite but has an eigenvalue less than -2.0913049911280974e+21 < 0. This should not happen.

```
was triggers (not always, because the assert generates a few random tensors to test the SPDness). This never happened to me when the 0.5 was there. This convince me that the 0.5 should be there. 

I added that test and update the relevant tests.


### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.
* [X] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
