### PR TITLE
Change input method, allowing single input value for compositions and…

### DIFF
--- a/doc/modules/changes/20200506_haoyuanli
+++ b/doc/modules/changes/20200506_haoyuanli
@@ -1,0 +1,3 @@
+New: Added flexibility to the parse_map_to_double_array input method. The new input method will allow a single value for a given key (e.g. density of a composition), even if multiple values (e.g. for different phases) are expected. The single value will be expanded to be the same for all values associated with that key.
+For examples of applying this in a input file, see the test visco_plastic_phases.
+<br>

--- a/source/material_model/equation_of_state/multicomponent_incompressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_incompressible.cc
@@ -70,17 +70,17 @@ namespace aspect
         prm.declare_entry ("Densities", "3300.",
                            Patterns::Anything(),
                            "List of densities for background mantle and compositional fields,"
-                           "for a total of N+1 values, where N is the number of compositional fields."
+                           "for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. "
                            "If only one value is given, then all use the same value.  Units: $kg / m^3$");
         prm.declare_entry ("Thermal expansivities", std::to_string(default_thermal_expansion),
                            Patterns::Anything(),
                            "List of thermal expansivities for background mantle and compositional fields,"
-                           "for a total of N+1 values, where N is the number of compositional fields."
+                           "for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. "
                            "If only one value is given, then all use the same value. Units: $1/K$");
         prm.declare_entry ("Heat capacities", "1250.",
                            Patterns::Anything(),
                            "List of specific heats $C_p$ for background mantle and compositional fields,"
-                           "for a total of N+1 values, where N is the number of compositional fields."
+                           "for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. "
                            "If only one value is given, then all use the same value. Units: $J /kg /K$");
         prm.declare_alias ("Heat capacities", "Specific heats");
       }

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -294,11 +294,17 @@ namespace aspect
 
             if (check_structure)
               {
-                AssertThrow((*n_values_per_key)[field_index] == n_values,
+                AssertThrow(((*n_values_per_key)[field_index] == n_values || n_values == 1),
                             ExcMessage("The key <" + field_names[field_index] + "> in <"+ property_name + "> does not have "
                                        + "the expected number of values. It expects " + std::to_string((*n_values_per_key)[field_index])
-                                       + " values, but we found " + std::to_string(n_values) + " values."));
-
+                                       + "or 1 values, but we found " + std::to_string(n_values) + " values."));
+                if (n_values == 1)
+                  {
+                    const std::string field_name = field_names[field_index];
+                    const double field_value = parsed_map.find(field_name)->second;
+                    for (unsigned int i=1; i<(*n_values_per_key)[field_index]; ++i)
+                      parsed_map.emplace(field_name, field_value);
+                  }
               }
 
             ++field_index;
@@ -316,7 +322,6 @@ namespace aspect
           for (auto entry = entry_range.first; entry != entry_range.second; ++entry)
             return_values.push_back(entry->second);
         }
-
       return return_values;
     }
 

--- a/unit_tests/parse_map_to_double_array.cc
+++ b/unit_tests/parse_map_to_double_array.cc
@@ -213,6 +213,29 @@ TEST_CASE("Utilities::parse_map_to_double_array")
     {100.0,200.0,300.0,300.0,500.0});
   }
 
+  {
+    INFO("check 18: ");
+    auto n_values_per_key = std::make_shared<std::vector<unsigned int>>(std::vector<unsigned int>({2,2}));
+
+    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:300|400, C2:200",
+    {"C1","C2"},
+    false,
+    "TestField",
+    true,
+    n_values_per_key),
+    {300.0,400.0,200.0,200.0});
+
+    INFO("check 19: ");
+
+    // still using the compare_vectors_approx defined before
+    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("200",
+    {"C1","C2"},
+    false,
+    "TestField",
+    true,
+    n_values_per_key),
+    {200.0,200.0,200.0,200.0});
+  }
   INFO("check complete");
 
 }


### PR DESCRIPTION
… phases

Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

I change the input method for phases and compositions in ViscoPlastic module in material model.
Now we can input a single value for all the compositions or all the phases for a composition.

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
