### PR TITLE
Added stabilization interface for advection assemblers

### DIFF
--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -261,7 +261,7 @@ namespace aspect
      * the case of melt migration on a single cell.
      */
     template <int dim>
-    class MeltAdvectionSystem : public MeltInterface<dim>
+    class MeltAdvectionSystem : public MeltInterface<dim>, public Assemblers::AdvectionStabilizationInterface<dim>
     {
       public:
         void

--- a/include/aspect/simulator/assemblers/advection.h
+++ b/include/aspect/simulator/assemblers/advection.h
@@ -34,7 +34,7 @@ namespace aspect
      * equation for the current cell.
      */
     template <int dim>
-    class AdvectionSystem : public Assemblers::Interface<dim>,
+    class AdvectionSystem : public Assemblers::Interface<dim>, public Assemblers::AdvectionStabilizationInterface<dim>,
       public SimulatorAccess<dim>
     {
       public:
@@ -51,7 +51,7 @@ namespace aspect
      * current cell in case we only want to solve the diffusion equation.
      */
     template <int dim>
-    class DiffusionSystem : public Assemblers::Interface<dim>,
+    class DiffusionSystem : public Assemblers::Interface<dim>, public Assemblers::AdvectionStabilizationInterface<dim>,
       public SimulatorAccess<dim>
     {
       public:

--- a/include/aspect/simulator/assemblers/interface.h
+++ b/include/aspect/simulator/assemblers/interface.h
@@ -568,6 +568,45 @@ namespace aspect
     };
 
     /**
+     * A base class for objects that implement assembly
+     * operations for advection-diffusion problems.
+     *
+     * This class implements functions that provide information
+     * for stabilization mechanisms.
+     */
+    template <int dim>
+    class AdvectionStabilizationInterface
+    {
+      public:
+        virtual ~AdvectionStabilizationInterface ();
+
+        /**
+         * This function returns a representative prefactor for the advection
+         * term of the equation. In the non-dimensional case this is simply
+         * 1.0, but for other quantities like temperature it is computed
+         * using physical units (like density and specific heat capacity).
+         * This information is useful for algorithms depending on the size of
+         * individual terms, like stabilization methods.
+         */
+        virtual
+        std::vector<double>
+        advection_prefactors(internal::Assembly::Scratch::ScratchBase<dim> &scratch_base) const;
+
+        /**
+         * This function returns a representative conductivity for the
+         * diffusion part of the equation. In the pure advection case
+         * this is 0.0, in a non-dimensional advection-diffusion case this
+         * is simply 1.0, but for other quantities like temperature it is
+         * computed using physical units (like thermal conductivity).
+         * This information is useful for algorithms depending on the size of
+         * individual terms, like stabilization methods.
+         */
+        virtual
+        std::vector<double>
+        diffusion_prefactors(internal::Assembly::Scratch::ScratchBase<dim> &scratch_base) const;
+    };
+
+    /**
      * A class that owns member variables representing
      * all assemblers that need to be called when
      * assembling right hand side vectors, matrices, or complete linear

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -124,21 +124,29 @@ namespace aspect
     if (advection_field.is_discontinuous(introspection))
       return 0.;
 
-    std::vector<double> residual = assemblers->advection_system[0]->compute_residual(scratch);
+    double max_residual = 0.0;
+    double max_velocity = 0.0;
+    double max_advection_prefactor = 0.0;
+    double max_conductivity = 0.0;
 
-    for (unsigned int i=1; i<assemblers->advection_system.size(); ++i)
+    std::vector<double> residual (scratch.finite_element_values.n_quadrature_points,0.0);
+
+    for (unsigned int i=0; i<assemblers->advection_system.size(); ++i)
       {
         const std::vector<double> new_residual = assemblers->advection_system[i]->compute_residual(scratch);
         for (unsigned int j=0; j<residual.size(); ++j)
           residual[j] += new_residual[j];
+
+        if (auto *stabilization_assembler =
+              dynamic_cast<Assemblers::AdvectionStabilizationInterface<dim>* > ((assemblers->advection_system[i]).get()))
+          {
+            const std::vector<double> max_advection_prefactors = stabilization_assembler->advection_prefactors(scratch);
+            const std::vector<double> max_conductivities = stabilization_assembler->diffusion_prefactors(scratch);
+
+            max_advection_prefactor = *std::max_element(max_advection_prefactors.begin(),max_advection_prefactors.end());
+            max_conductivity = *std::max_element(max_conductivities.begin(),max_conductivities.end());
+          }
       }
-
-
-    double max_residual = 0;
-    double max_velocity = 0;
-    double max_density = (advection_field.is_temperature()) ? 0.0 : 1.0;
-    double max_specific_heat = (advection_field.is_temperature()) ? 0.0 : 1.0;
-    double max_conductivity = 0;
 
     std::vector<Tensor<1,dim> > old_fluid_velocity_values(scratch.finite_element_values.n_quadrature_points);
     std::vector<Tensor<1,dim> > old_old_fluid_velocity_values(scratch.finite_element_values.n_quadrature_points);
@@ -175,13 +183,6 @@ namespace aspect
         max_velocity = std::max (velocity_norm
                                  + parameters.stabilization_gamma * strain_rate * cell_diameter,
                                  max_velocity);
-
-        if (advection_field.is_temperature())
-          {
-            max_density = std::max       (scratch.material_model_outputs.densities[q],              max_density);
-            max_specific_heat = std::max (scratch.material_model_outputs.specific_heat[q],          max_specific_heat);
-            max_conductivity = std::max  (scratch.material_model_outputs.thermal_conductivities[q], max_conductivity);
-          }
       }
 
     // If the velocity is 0 we have to assume a sensible velocity to calculate
@@ -196,8 +197,7 @@ namespace aspect
              cell_diameter;
 
     const double max_viscosity = parameters.stabilization_beta[advection_field.field_index()] *
-                                 max_density *
-                                 max_specific_heat *
+                                 max_advection_prefactor *
                                  max_velocity * cell_diameter;
 
     if (timestep_number <= 1


### PR DESCRIPTION
This is an interface that allows assemblers for the advection equation to scale the stabilization terms of the entropy viscosity method. The current implementation keeps all current functionality, however it looks a bit awkward for the following reason: I think it makes sense to eventually use this for entropy viscosity and SUPG, however the two methods use different algorithms to determine the scaling of the equations:
SUPG computes the cell-wise maximum of the point-wise quantity rho\*cp
EV computes the cell-wise maximum of rho and cp and then compute rho_max \* cp_max.
EV will always compute a bigger quantity than SUPG, although SUPG is likely closer to the real maximum of rho\*cp in the cell.
Should I:
1. Keep the interface as I implemented here, returning a vector of values? 
2. Simplify the interface to only return a single cell-wise value?
In both cases: Should the default implementation follow the current algorithm for EV or SUPG?

I tend towards 1. and using the implementation of SUPG, but that potentially changes a lot of tests. It would slightly decrease the stabilization parameter for EV.