### PR TITLE
add project_cellwise function

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1366,6 +1366,36 @@ namespace aspect
          */
         std::array<double,dim> coordinates;
     };
+
+
+    /**
+     * Compute the cellwise projection of @p function to the finite element space
+     * described by @p dof_handler.
+     *
+     * @param[in] mapping The mapping object to use.
+     * @param[in] dof_handler The DoFHandler the describes the finite element space to
+     * project into and that corresponds to @p vec_result.
+     * @param[in] component_index The component index of the @p dof_handler for which
+     * the projection is being performed. This component should be described by
+     * a DG finite element.
+     * @param[in] function The function to project into the finite element space.
+     * This function should store the value of the function at the points described
+     * by the 2nd argument into the 3rd argument as an std::vector<double>
+     * of size quadrature.size().
+     * @param[out] vec_result The output vector where the projected function will be
+     * stored in.
+     */
+    template <int dim, typename VectorType>
+    void
+    project_cellwise(const Mapping<dim>                                        &mapping,
+                     const DoFHandler<dim>                                     &dof_handler,
+                     const unsigned int                                         component_index,
+                     const Quadrature<dim>                                     &quadrature,
+                     const std::function<void(
+                       const typename DoFHandler<dim>::active_cell_iterator &,
+                       const std::vector<Point<dim> > &,
+                       std::vector<double> &)>                                 &function,
+                     VectorType                                                &vec_result);
   }
 }
 

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1369,7 +1369,7 @@ namespace aspect
 
 
     /**
-     * Compute the cellwise projection of @p function to the finite element space
+     * Compute the cellwise projection of component @p component_index of @p function to the finite element space
      * described by @p dof_handler.
      *
      * @param[in] mapping The mapping object to use.

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -375,9 +375,9 @@ namespace aspect
       }
     else
       {
-        // implement the local projection for the discontinuous pressure
-        // element. this is only going to work if, indeed, the element
-        // is discontinuous
+        // Find the local projection for the discontinuous pressure
+        // element. This is only going to work if, indeed, the element
+        // is discontinuous.
         Assert (finite_element.base_element(introspection.base_elements.pressure).dofs_per_face == 0,
                 ExcNotImplemented());
 
@@ -385,74 +385,20 @@ namespace aspect
         system_tmp.reinit (system_rhs);
 
         QGauss<dim> quadrature(parameters.stokes_velocity_degree+1);
-        UpdateFlags update_flags = UpdateFlags(update_values   |
-                                               update_quadrature_points |
-                                               update_JxW_values);
 
-        FEValues<dim> fe_values (*mapping, finite_element, quadrature, update_flags);
-
-        const unsigned int
-        dofs_per_cell = fe_values.dofs_per_cell,
-        n_q_points    = fe_values.n_quadrature_points;
-
-        std::vector<types::global_dof_index> local_dof_indices (dofs_per_cell);
-        Vector<double> cell_vector (dofs_per_cell);
-        Vector<double> local_projection (dofs_per_cell);
-        FullMatrix<double> local_mass_matrix (dofs_per_cell, dofs_per_cell);
-
-        std::vector<double> rhs_values(n_q_points);
-
-        ScalarFunctionFromFunctionObject<dim>
-        adiabatic_pressure (
-          [&](const Point<dim> &p) -> double
+        Utilities::project_cellwise<dim,LinearAlgebra::BlockVector>(*mapping,
+                                                                    dof_handler,
+                                                                    introspection.component_indices.pressure,
+                                                                    quadrature,
+                                                                    [&](const typename DoFHandler<dim>::active_cell_iterator & /*cell*/,
+                                                                        const std::vector<Point<dim> > &q_points,
+                                                                        std::vector<double> &values) -> void
         {
-          return adiabatic_conditions->pressure(p);
-        });
-
-
-        for (const auto &cell : dof_handler.active_cell_iterators())
-          if (cell->is_locally_owned())
-            {
-              cell->get_dof_indices (local_dof_indices);
-              fe_values.reinit(cell);
-
-              adiabatic_pressure.value_list (fe_values.get_quadrature_points(),
-                                             rhs_values);
-
-              cell_vector = 0;
-              local_mass_matrix = 0;
-              for (unsigned int point=0; point<n_q_points; ++point)
-                for (unsigned int i=0; i<dofs_per_cell; ++i)
-                  {
-                    if (finite_element.system_to_component_index(i).first == dim)
-                      cell_vector(i)
-                      +=
-                        rhs_values[point] *
-                        fe_values[introspection.extractors.pressure].value(i,point) *
-                        fe_values.JxW(point);
-
-                    // populate the local matrix; create the pressure mass matrix
-                    // in the pressure pressure block and the identity matrix
-                    // for all other variables so that the whole thing remains
-                    // invertible
-                    for (unsigned int j=0; j<dofs_per_cell; ++j)
-                      if ((finite_element.system_to_component_index(i).first == introspection.component_indices.pressure)
-                          &&
-                          (finite_element.system_to_component_index(j).first == introspection.component_indices.pressure))
-                        local_mass_matrix(j,i) += (fe_values[introspection.extractors.pressure].value(i,point) *
-                                                   fe_values[introspection.extractors.pressure].value(j,point) *
-                                                   fe_values.JxW(point));
-                      else if (i == j)
-                        local_mass_matrix(i,j) = 1;
-                  }
-
-              // now invert the local mass matrix and multiply it with the rhs
-              local_mass_matrix.gauss_jordan();
-              local_mass_matrix.vmult (local_projection, cell_vector);
-
-              // then set the global solution vector to the values just computed
-              cell->set_dof_values (local_projection, system_tmp);
-            }
+          for (unsigned int i=0; i<values.size(); ++i)
+            values[i] = adiabatic_conditions->pressure(q_points[i]);
+          return;
+        },
+        system_tmp);
 
         old_solution.block(introspection.block_indices.pressure) = system_tmp.block(introspection.block_indices.pressure);
       }


### PR DESCRIPTION
From https://github.com/geodynamics/aspect/pull/3495. This `project_cellwise` function computes a DGQ1 projection of a set of input values given in the std::function into a given vector. 

We will use this in the Q1 viscosity for GMG, and it is used once now in the code (DGQ1 pressure). I did not write a test, since every test which has `set Use locally conservative discretization = true` will be reliant on this code and will pass now if this is implemented correctly.