### PR TITLE
Fix call to AsciiDataLookup::get_gradients()

### DIFF
--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1962,7 +1962,7 @@ namespace aspect
     AsciiDataLookup<dim>::get_gradients(const Point<dim> &position,
                                         const unsigned int component)
     {
-      return data[component]->gradient(position,component);
+      return data[component]->gradient(position,0);
     }
 
 


### PR DESCRIPTION
The class `AsciiDataLookup` stores its data internally in either a `InterpolatedUniformGridData` or a `InterpolatedTensorProductGridData` object. Both classes have the following clause in their documentation for `get_gradients`:
```
     * @param component The vector component. Since this function is scalar,
     * only zero is a valid argument here.
```
Previously we called this function also with other components, because the function implementation mixed up the component of `AsciiDataLookup` (which depends on the number of columns in the data file), and the component of the internally stored tables (each of the n_components tables only stores a single component).

I suspect this was not discovered earlier, because this function is rarely used, and if so, it was so far only used to compute the gradients for the first data table in the `AsciiDataLookup` class. This will change with #3499 in which I need to access other gradients as well. Therefore #3499 will deliver a test that uses this change.