### PR TITLE
Add info unit boundary velocity

### DIFF
--- a/source/mesh_deformation/function.cc
+++ b/source/mesh_deformation/function.cc
@@ -130,7 +130,10 @@ namespace aspect
                                            "deformation velocity, i.e. the return value of "
                                            "this plugin is later multiplied by the time step length "
                                            "to compute the displacement increment in this time step. "
-                                           "The format of the "
+                                           "Although the function's time variable is interpreted as "
+                                           "years when Use years in output instead of seconds is set to true, "
+                                           "the boundary deformation velocity should still be given "
+                                           "in m/s. The format of the "
                                            "functions follows the syntax understood by the "
                                            "muparser library, see Section~\\ref{sec:muparser-format}.")
   }


### PR DESCRIPTION
I added a sentence to the description of the Boundary function mesh deformation plugin to explain that the velocity should always be given in m/s, even if Use years in output instead of seconds = true. I didn't see a quick fix as the function is directly given to the interpolate_boundary_values function. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
