### PR TITLE
Bypass topography in coordinate conversion

### DIFF
--- a/include/aspect/geometry_model/ellipsoidal_chunk.h
+++ b/include/aspect/geometry_model/ellipsoidal_chunk.h
@@ -106,12 +106,11 @@ namespace aspect
             push_forward(const Point<3> &chart_point) const override;
 
             /**
-             * Return a copy of this manifold.
+             * This function does the actual pull back from the ellipsoid.
+             * For the equation details, please see deal.ii step 53.
              */
-            std::unique_ptr<Manifold<dim,3> >
-            clone() const override;
+            Point<3> pull_back_ellipsoid (const Point<3> &x, const double semi_major_axis_a, const double eccentricity) const;
 
-          private:
             /**
              * This function does the actual push forward to the ellipsoid.
              * For the equation details, please see deal.ii step 53.
@@ -119,11 +118,12 @@ namespace aspect
             Point<3> push_forward_ellipsoid (const Point<3> &phi_theta_d, const double semi_major_axis_a, const double eccentricity) const;
 
             /**
-             * This function does the actual pull back from the ellipsoid.
-             * For the equation details, please see deal.ii step 53.
+             * Return a copy of this manifold.
              */
-            Point<3> pull_back_ellipsoid (const Point<3> &x, const double semi_major_axis_a, const double eccentricity) const;
+            std::unique_ptr<Manifold<dim,3> >
+            clone() const override;
 
+          private:
             /**
              * This function adds topography to the cartesian coordinates.
              * For the equation details, please see deal.ii step 53.


### PR DESCRIPTION
This PR avoids getting stuck into a loop when reading ascii data, which requires converting points to natural coordinates, which requires knowing the topography which is being read from the ascii data. Same change as was made to the chunk geometry. 

Actually using AsciiDataBoundary for the EllipsoidalChunk will require some changes to utilities.cc

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
