### PR TITLE
add IDR(s) Stokes Kylov solver

### DIFF
--- a/doc/modules/changes/20200525_clevenger
+++ b/doc/modules/changes/20200525_clevenger
@@ -1,0 +1,6 @@
+New: The IDR(s) Krylov method can now be used for solving the Stokes
+system, only when using the matrix-free GMG solver. The parameter
+s can be chosen by the user. This method has a short term recurrence
+and can greatly reduce the memory requirement as compared to GMRES.
+<br>
+(Thomas C. Clevenger, 2020/05/25)

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -324,6 +324,37 @@ namespace aspect
     };
 
     /**
+     * This enum represents the different choices for the Krylov method
+     * used in the cheap GMG Stokes solve.
+     */
+    struct StokesKrylovType
+    {
+      enum Kind
+      {
+        gmres,
+        idr_s
+      };
+
+      static const std::string pattern()
+      {
+        return "GMRES|IDR(s)";
+      }
+
+      static Kind
+      parse(const std::string &input)
+      {
+        if (input == "GMRES")
+          return gmres;
+        else if (input == "IDR(s)")
+          return idr_s;
+        else
+          AssertThrow(false, ExcNotImplemented());
+
+        return Kind();
+      }
+    };
+
+    /**
      * Constructor. Fills the values of member functions from the given
      * parameter object.
      *
@@ -428,6 +459,8 @@ namespace aspect
     // subsection: Stokes solver parameters
     bool                           use_direct_stokes_solver;
     typename StokesSolverType::Kind stokes_solver_type;
+    typename StokesKrylovType::Kind stokes_krylov_type;
+    unsigned int                    idr_s_parameter;
 
     double                         linear_stokes_solver_tolerance;
     unsigned int                   n_cheap_stokes_solver_steps;

--- a/tests/nsinker_gmg_idr.cc
+++ b/tests/nsinker_gmg_idr.cc
@@ -1,0 +1,1 @@
+#include "../benchmarks/nsinker/nsinker.cc"

--- a/tests/nsinker_gmg_idr.prm.dealii_9.2
+++ b/tests/nsinker_gmg_idr.prm.dealii_9.2
@@ -1,0 +1,23 @@
+# Nsinker benchmark using geometric multigrid preconditioner
+# with an IDR(2) solver
+
+set Dimension = 3
+
+include $ASPECT_SOURCE_DIR/benchmarks/nsinker/nsinker_gmg.prm 
+
+subsection Material model
+  set Material averaging = harmonic average only viscosity
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block GMG
+    set Krylov method for cheap solver steps = IDR(s)
+    set IDR(s) parameter = 2
+  end
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0                    
+  set Initial global refinement          = 2                    
+end

--- a/tests/nsinker_gmg_idr/screen-output
+++ b/tests/nsinker_gmg_idr/screen-output
@@ -1,0 +1,29 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libnsinker_gmg_idr.so>
+
+Vectorization over 4 doubles = 256 bits (AVX), VECTORIZATION_LEVEL=2
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 64 (on 3 levels)
+Number of degrees of freedom: 3,041 (2,187+125+729)
+
+*** Timestep 0:  t=0 seconds
+   Solving Stokes system... 9+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.999954
+
+
+   Postprocessing:
+     System matrix memory consumption:  0.05 MB
+     Writing graphical output:          output-nsinker_gmg_idr/solution/solution-00000
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------


### PR DESCRIPTION
This pull request adds the IDR(s) solver discussed in Chapter 5 of my [PhD thesis](https://tigerprints.clemson.edu/all_dissertations/2523/) and section 3.4 of the [GMG Stokes paper](https://arxiv.org/pdf/1907.06696.pdf) @tjhei and I wrote (under review). Here is a summary chart from the preprint for IDR(2) compared with GMRES, as well as a scaling plot of IDR(2) (I think these are the largest runs done with ASPECT, even if they aren't that interesting scientifically).

![compare-idr](https://user-images.githubusercontent.com/11428698/82707494-29249e00-9c4a-11ea-864e-14f039bd0d30.png)

![scale](https://user-images.githubusercontent.com/11428698/82704002-aa783280-9c42-11ea-9170-8ed1249b7008.png)

Summary: Around the same cost as GMRES, but much less memory required (roughly 1/3 in the example above). There is no convergence guarantee like GMRES, but various papers suggest the behavior is similar to GMRES as `s` is increased. 