### PR TITLE
Fix tangential BCs for GMG

### DIFF
--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -2215,9 +2215,7 @@ namespace aspect
             typename DoFHandler<dim>::level_cell_iterator cell = dof_handler_v.begin(level),
                                                           endc = dof_handler_v.end(level);
             for (; cell!=endc; ++cell)
-              if (cell->level_subdomain_id() != numbers::artificial_subdomain_id
-                  &&
-                  cell->level_subdomain_id() != numbers::invalid_subdomain_id)
+              if (cell->level_subdomain_id() == sim.triangulation.locally_owned_subdomain())
                 {
                   cell_matrix = 0;
                   fe_values.reinit (cell);
@@ -2260,6 +2258,7 @@ namespace aspect
                                                                    diagonal_matrix);
                 }
 
+            diagonal_matrix.compress(VectorOperation::add);
             mg_matrices_A_block[level].set_diagonal(diagonal_matrix.get_vector());
           }
         else

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -2215,7 +2215,9 @@ namespace aspect
             typename DoFHandler<dim>::level_cell_iterator cell = dof_handler_v.begin(level),
                                                           endc = dof_handler_v.end(level);
             for (; cell!=endc; ++cell)
-              if (cell->level_subdomain_id()==sim.triangulation.locally_owned_subdomain())
+              if (cell->level_subdomain_id() != numbers::artificial_subdomain_id
+                  &&
+                  cell->level_subdomain_id() != numbers::invalid_subdomain_id)
                 {
                   cell_matrix = 0;
                   fe_values.reinit (cell);


### PR DESCRIPTION
From issue https://github.com/geodynamics/aspect/issues/3512, the iteration counts for Stokes would increase when running in parallel on spherical mesh with Tangential boundary. Simple fix: ~~when~~ after constructing the diagonal of the A block operator (used in GMG smoothers), ~~we needed to loop over all owned and ghost cells (previously just looped over owned cells)~~, we need to call `compress()` to exchange contribution from ghosted cells (previously only contributions from owned cells were accounted for).

There is actually already a test (`shell_3d_gmg.prm.dealii_9.2`), but I believe that since it is only on version dealii9.2 it wasn't being run and the high iteration counts were overlooked. 