### PR TITLE
fix parameter_view in firefox

### DIFF
--- a/doc/parameter_view/parameters.js
+++ b/doc/parameter_view/parameters.js
@@ -212,9 +212,6 @@ function reorderList() {
   sortTopNodes("subsection");
 }
 
-if (document.addEventListener)
-  document.addEventListener("DOMContentLoaded", autorun, false);
-else if (document.attachEvent)
-  document.attachEvent("onreadystatechange", autorun);
-else
-  window.onload = autorun;
+
+
+window.onload = autorun;


### PR DESCRIPTION
the fancy logic to call the autorun function doesn't work in firefox causing expand/collapse not to work.
Fix this.
