### PR TITLE
add publications from 2019 and 2020

### DIFF
--- a/doc/manual/citing_aspect.bib
+++ b/doc/manual/citing_aspect.bib
@@ -591,6 +591,43 @@ url = {https://dspace.library.uu.nl/handle/1874/377338},
 year = {2019}
 }
 
+@article{lin2019mantle,
+  title={Mantle upwelling beneath the South China Sea and links to surrounding subduction systems},
+  author={Lin, Jian and Xu, Yigang and Sun, Zhen and Zhou, Zhiyuan},
+  journal={National Science Review},
+  volume={6},
+  number={5},
+  pages={877--881},
+  year={2019},
+  publisher={Oxford University Press},
+  doi={10.1093/nsr/nwz123},
+  url={https://doi.org/10.1093/nsr/nwz123}
+}
+
+@phdthesis{renaud2019study,
+  title={A Study of the Tidal and Thermal Evolution of Rocky \& Icy Worlds Utilizing Advanced Rheological Models},
+  author={Renaud, Joseph P},
+  year={2019},
+  school={George Mason University}, 
+  url={https://search.proquest.com/docview/2303307944?pq-origsite=gscholar}
+}
+
+@phdthesis{clevenger2019parallel,
+  title={A Parallel Geometric Multigrid Method for Adaptive Finite Elements},
+  author={Clevenger, Thomas Conrad},
+  year={2019}, 
+  school={Clemson University}, 
+  url={https://tigerprints.clemson.edu/all_dissertations/2523}
+}
+
+@mastersthesis{janssen2019comparison,
+  title={A comparison of GOCO05c satellite data to synthetic gravity fields computed from 3D density models in ASPECT},
+  author={Janssen, WJ},
+  year={2019}, 
+  school={Utrecht University}, 
+  url={https://dspace.library.uu.nl/handle/1874/393839}
+}
+
 @article{gassmoller2020formulations,
   title={On formulations of compressible mantle convection},
   author={Gassm{\"o}ller, Rene and Dannberg, Juliane and Bangerth, Wolfgang and Heister, Timo and Myhill, Robert},
@@ -629,3 +666,56 @@ year = {2019}
   doi={10.1038/s41561-020-0560-y},
   url={https://doi.org/10.1038/s41561-020-0560-y}
 }
+
+@article{mitrovica2020dynamic,
+author = {Mitrovica, J.X. and Austermann, J. and Coulson, S. and Creveling, J.R. and Hoggard, M.J. and Jarvis, G.T. and Richards, F.D.},
+title = {Dynamic Topography and Ice Age Paleoclimate},
+journal = {Annual Review of Earth and Planetary Sciences},
+volume = {48},
+number = {1},
+pages = {585-621},
+year = {2020},
+doi = {10.1146/annurev-earth-082517-010225},
+url = {https://doi.org/10.1146/annurev-earth-082517-010225}
+}
+
+@article{louis20203,
+  title={3-D numerical modelling of crustal polydiapirs with volume-of-fluid methods},
+  author={Louis-Napol{\'e}on, Aur{\'e}lie and Gerbault, Muriel and Bonometti, Thomas and Thieulot, C{\'e}dric and Martin, Roland and Vanderhaeghe, Olivier},
+  journal={Geophysical Journal International},
+  volume={222},
+  number={1},
+  pages={474--506},
+  year={2020},
+  publisher={Oxford University Press}, 
+  doi={10.1093/gji/ggaa141},
+  url={https://doi.org/10.1093/gji/ggaa141}
+}
+
+@article{rajaonarison2020numerical,
+  title={Numerical Modeling of Mantle Flow Beneath Madagascar to Constrain Upper Mantle Rheology Beneath Continental Regions},
+  author={Rajaonarison, TA and Stamps, DS and Fishwick, S and Brune, Sascha and Glerum, A and Hu, J},
+  journal={Journal of Geophysical Research. Solid Earth},
+  volume={125},
+  number={2},
+  pages={Art--No},
+  year={2020},
+  publisher={American Geophysical Union}, 
+  doi={10.1029/2019JB018560},
+  url={https://doi.org/10.1029/2019JB018560}
+}
+
+@article{citron2020effects,
+  title={Effects of Heat-Producing Elements on the Stability of Deep Mantle Thermochemical Piles},
+  author={Citron, Robert I and Louren{\c{c}}o, Diogo L and Wilson, Alfred J and Grima, Antoniette G and Wipperfurth, Scott A and Rudolph, Maxwell L and Cottaar, Sanne and Mont{\'e}si, Laurent GJ},
+  journal={Geochemistry, Geophysics, Geosystems},
+  volume={21},
+  number={4},
+  pages={e2019GC008895},
+  year={2020},
+  publisher={Wiley Online Library}, 
+  doi={10.1029/2019GC008895},
+  url={https://doi.org/10.1029/2019GC008895}
+}
+
+


### PR DESCRIPTION
This addresses #3517 and adds a few more publications. 
This list is probably not complete, I only checked for the last two years, going through the list of papers referencing our 2017 paper to check if they were using ASPECT.