### PR TITLE
fix HeatingModelOutputs warning

### DIFF
--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -109,7 +109,6 @@ namespace aspect
        * outputs to their uninitialized values (NaN for the source and latent
        * heat terms, 0 for the rates of temperature change).
        */
-      virtual
       void
       reset ();
     };


### PR DESCRIPTION
fix clang warning

   'aspect::HeatingModel::HeatingModelOutputs' that has virtual
functions but non-virtual destructor [-Wdelete-non-virtual-dtor]

There is no reason to have a virtual function in this struct.