### PR TITLE
Add geoid citation info

### DIFF
--- a/include/aspect/postprocess/visualization/geoid.h
+++ b/include/aspect/postprocess/visualization/geoid.h
@@ -52,6 +52,15 @@ namespace aspect
           Geoid();
 
           /**
+           * Initialization function. This function is called once at the
+           * beginning of the program after parse_parameters is run and after
+           * the SimulatorAccess (if applicable) is initialized.
+          */
+          virtual
+          void
+          initialize ();
+
+          /**
            * @copydoc DataPostprocessorScalar<dim>::evaluate_vector_field()
            */
           void

--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -24,11 +24,12 @@
 #include <aspect/postprocess/geoid.h>
 #include <aspect/postprocess/dynamic_topography.h>
 #include <aspect/postprocess/boundary_densities.h>
+#include <aspect/geometry_model/spherical_shell.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>
 
-#include <aspect/geometry_model/spherical_shell.h>
+#include <aspect/citation_info.h>
 
 
 namespace aspect
@@ -958,6 +959,7 @@ namespace aspect
     void
     Geoid<dim>::parse_parameters (ParameterHandler &prm)
     {
+      CitationInfo::add("Geoid");
       prm.enter_subsection("Postprocess");
       {
         prm.enter_subsection("Geoid");

--- a/source/postprocess/visualization/geoid.cc
+++ b/source/postprocess/visualization/geoid.cc
@@ -23,6 +23,7 @@
 #include <aspect/utilities.h>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/postprocess/visualization/geoid.h>
+#include <aspect/citation_info.h>
 
 
 
@@ -39,6 +40,14 @@ namespace aspect
         DataPostprocessorScalar<dim> ("geoid",
                                       update_quadrature_points)
       {}
+
+      template <int dim>
+      void
+      Geoid<dim>::
+      initialize()
+      {
+        CitationInfo::add("Geoid");
+      }
 
       template <int dim>
       void


### PR DESCRIPTION
This PR adds the geoid citation info per discussion with Timo and Rene.

I put a call to geoid citation at both the main geoid postprocessor (parse prm section) and the geoid visualization postprocessor which calls the main geoid function.

Feel free to let me know whether I did this correctly.  @tjhei @gassmoeller 

### For all pull requests:

- [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).