### PR TITLE
fix cookbooks/prescribed_velocity/ in 64 bit mode

### DIFF
--- a/cookbooks/prescribed_velocity/prescribed_velocity.cc
+++ b/cookbooks/prescribed_velocity/prescribed_velocity.cc
@@ -229,7 +229,7 @@ namespace aspect
           if (! cell->is_artificial())
             {
               fe_values.reinit (cell);
-              std::vector<unsigned int> local_dof_indices(simulator_access.get_fe().dofs_per_cell);
+              std::vector<types::global_dof_index> local_dof_indices(simulator_access.get_fe().dofs_per_cell);
               cell->get_dof_indices (local_dof_indices);
 
               for (unsigned int q=0; q<quadrature.size(); q++)


### PR DESCRIPTION
with 64 bit indices, compilation fails.
