### PR TITLE
avoid invalid arrary access warnings

### DIFF
--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -643,7 +643,7 @@ namespace aspect
     double
     EllipsoidalChunk<dim>::depth(const Point<dim> &position) const
     {
-      return std::max(std::min(-manifold.pull_back(position)[2], maximal_depth()), 0.0);
+      return std::max(std::min(-manifold.pull_back(position)[dim-1], maximal_depth()), 0.0);
     }
 
     template <int dim>

--- a/source/initial_temperature/lithosphere_mask.cc
+++ b/source/initial_temperature/lithosphere_mask.cc
@@ -61,9 +61,10 @@ namespace aspect
         if (LAB_depth_source == File)
           {
             //Get spherical coordinates for model
+            Assert (dim == 3, ExcNotImplemented());
             std::array<double,dim> scoord      = Utilities::Coordinates::cartesian_to_spherical_coordinates<dim>(position);
             const double phi = scoord[1];
-            const double theta = scoord[2];
+            const double theta = scoord[2 % dim]; // work-around to compile without warnings for dim==2
             const Point<2> phi_theta (phi, theta);
 
             //Get lab depth for specific phi and theta

--- a/source/postprocess/visualization/temperature_anomaly.cc
+++ b/source/postprocess/visualization/temperature_anomaly.cc
@@ -101,7 +101,6 @@ namespace aspect
             const double slice_depth = (depth*n_slices)/max_depth + 0.5;
             const unsigned int idx = static_cast<unsigned int>(slice_depth);
             const double fractional_slice = slice_depth - static_cast<double>(idx);
-            Assert(idx>=0, ExcInternalError());
             Assert(idx<n_slices+1, ExcInternalError());
             const double depth_average_temperature= (1. - fractional_slice)*padded_temperature_depth_average[idx] + fractional_slice*padded_temperature_depth_average[idx+1];
             computed_quantities[q](0) = temperature - depth_average_temperature;


### PR DESCRIPTION
Warnings reported by gcc10. These are irrelevant as the plugins only work for dim==3.