### PR TITLE
fix several benchmarks

### DIFF
--- a/benchmarks/check.mk
+++ b/benchmarks/check.mk
@@ -129,10 +129,18 @@ operator_splitting/: dummy
 	+@$(def); make_lib $@/exponential_decay
 	@$(def); run_all_prms $@/exponential_decay
 
+rayleigh_taylor_instability/: dummy
+	+@$(def); make_lib $@
+	@$(def); run_prm $@ rayleigh_taylor_instability.prm
+
 rigid_shear/: dummy
 	+@$(def); make_lib $@/plugin
 	@$(def); run_all_prms $@/instantaneous
 	@$(def); run_all_prms $@/time-dependent
+
+sinking_block/: dummy
+	+@$(def); make_lib $@
+	@$(def); run_prm $@ sinking_block.prm
 
 solcx/: dummy
 	+@$(def); make_lib $@

--- a/benchmarks/slab_detachment/slab_detachment.prm
+++ b/benchmarks/slab_detachment/slab_detachment.prm
@@ -141,7 +141,7 @@ subsection Postprocess
     set Particle generator name   = ascii file
     subsection Generator
       subsection Ascii file
-        set Data directory = benchmarks/slab_detachment/
+        set Data directory = $ASPECT_SOURCE_DIR/benchmarks/slab_detachment/
         set Data file name = initial_particle_location.dat
       end
     end


### PR DESCRIPTION
fix benchmarks/slab_detachment/ data directory
only run specific prms in rayleigh_taylor_instability and sinking_block
