### PR TITLE
[WIP] disable mesh smoothing on refine/coarsen

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -197,14 +197,9 @@ namespace aspect
     triangulation (mpi_communicator,
                    (parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::block_gmg
                     ?
-                    typename Triangulation<dim>::MeshSmoothing
-                    (Triangulation<dim>::smoothing_on_refinement |
-                     Triangulation<dim>::smoothing_on_coarsening |
-                     Triangulation<dim>::limit_level_difference_at_vertices)
+                    (Triangulation<dim>::limit_level_difference_at_vertices)
                     :
-                    typename Triangulation<dim>::MeshSmoothing
-                    (Triangulation<dim>::smoothing_on_refinement |
-                     Triangulation<dim>::smoothing_on_coarsening))
+                    (Triangulation<dim>::none))
                    ,
                    (parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::block_gmg
                     ?


### PR DESCRIPTION
The mesh smoothing algorithms in deal.II change coarsening/refinement
flags but they are inconsistent in parallel leading to inconsistent
refinement that depends on the number of processors used (especially
with very few cells per processor).
Disable this setting until something better is realized in deal.II.

related: #3262
