### PR TITLE
fix benchmarks/viscoelastic_beam_modified

### DIFF
--- a/benchmarks/viscoelastic_beam_modified/20km_opentopbot.prm
+++ b/benchmarks/viscoelastic_beam_modified/20km_opentopbot.prm
@@ -40,6 +40,12 @@ subsection Mesh refinement
   set Strategy                           = viscosity
 end
 
+# override boundary conditions:
+subsection Boundary velocity model
+  set Zero velocity boundary indicators       = left
+  set Tangential velocity boundary indicators = right
+end
+
 # Traction Boundary Conditions
 subsection Boundary traction model
   set Prescribed traction boundary indicators = top: initial lithostatic pressure, bottom: initial lithostatic pressure


### PR DESCRIPTION
this fixes the error
Boundary indicator <2> with symbolic name <bottom> is listed as having more than one type of velocity or traction boundary condition in
the input file.
