### PR TITLE
undef INSTANTIATE macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,8 +550,6 @@ IF (ASPECT_PRECOMPILE_HEADERS)
   SET_TARGET_PROPERTIES (aspect PROPERTIES
       COTIRE_PREFIX_HEADER_IGNORE_PATH
       "/usr/include/;${CMAKE_SOURCE_DIR};${CMAKE_BINARY_DIR}")
-  SET_SOURCE_FILES_PROPERTIES (${TARGET_SRC} PROPERTIES
-      COTIRE_UNITY_SOURCE_POST_UNDEFS "INSTANTIATE")
 
   # This line activates the cotire module for the aspect target, 
   # and therefore the whole precompilation

--- a/source/adiabatic_conditions/interface.cc
+++ b/source/adiabatic_conditions/interface.cc
@@ -245,5 +245,7 @@ namespace aspect
   create_adiabatic_conditions<dim> (ParameterHandler &prm);
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -412,5 +412,7 @@ namespace aspect
   template class Manager<dim>;
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/boundary_fluid_pressure/interface.cc
+++ b/source/boundary_fluid_pressure/interface.cc
@@ -171,5 +171,7 @@ namespace aspect
   create_boundary_fluid_pressure<dim> (ParameterHandler &prm);
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/boundary_heat_flux/interface.cc
+++ b/source/boundary_heat_flux/interface.cc
@@ -176,5 +176,7 @@ namespace aspect
   create_boundary_heat_flux<dim> (ParameterHandler &prm);
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -422,5 +422,7 @@ namespace aspect
   template class Manager<dim>;
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/boundary_traction/interface.cc
+++ b/source/boundary_traction/interface.cc
@@ -210,5 +210,7 @@ namespace aspect
   create_boundary_traction<dim> (const std::string &);
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/boundary_velocity/interface.cc
+++ b/source/boundary_velocity/interface.cc
@@ -446,5 +446,7 @@ namespace aspect
   template class Manager<dim>;
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/fe_variable_collection.cc
+++ b/source/fe_variable_collection.cc
@@ -256,4 +256,6 @@ namespace aspect
   template class FEVariableCollection<dim>; \
    
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/geometry_model/initial_topography_model/interface.cc
+++ b/source/geometry_model/initial_topography_model/interface.cc
@@ -193,5 +193,7 @@ namespace aspect
   create_initial_topography_model<dim> (ParameterHandler &prm);
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/geometry_model/interface.cc
+++ b/source/geometry_model/interface.cc
@@ -371,5 +371,7 @@ namespace aspect
   create_geometry_model<dim> (ParameterHandler &prm);
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/gravity_model/interface.cc
+++ b/source/gravity_model/interface.cc
@@ -188,5 +188,7 @@ namespace aspect
   create_gravity_model<dim> (ParameterHandler &prm);
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -398,5 +398,7 @@ namespace aspect
   get_valid_model_names_pattern<dim> ();
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -283,5 +283,7 @@ namespace aspect
   get_valid_model_names_pattern<dim> ();
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -274,5 +274,7 @@ namespace aspect
   get_valid_model_names_pattern<dim> ();
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/material_model/equation_of_state/interface.cc
+++ b/source/material_model/equation_of_state/interface.cc
@@ -102,5 +102,7 @@ namespace aspect
                                                               EquationOfStateOutputs<dim> &);
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/material_model/equation_of_state/linearized_incompressible.cc
+++ b/source/material_model/equation_of_state/linearized_incompressible.cc
@@ -150,7 +150,10 @@ namespace aspect
     {
 #define INSTANTIATE(dim) \
   template class LinearizedIncompressible<dim>;
+
       ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
     }
   }
 }

--- a/source/material_model/equation_of_state/multicomponent_compressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_compressible.cc
@@ -166,7 +166,10 @@ namespace aspect
     {
 #define INSTANTIATE(dim) \
   template class MulticomponentCompressible<dim>;
+
       ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
     }
   }
 }

--- a/source/material_model/equation_of_state/multicomponent_incompressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_incompressible.cc
@@ -136,7 +136,10 @@ namespace aspect
     {
 #define INSTANTIATE(dim) \
   template class MulticomponentIncompressible<dim>;
+
       ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
     }
   }
 }

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -1497,5 +1497,7 @@ namespace aspect
   template class DislocationViscosityOutputs<dim>;
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -1104,5 +1104,7 @@ namespace aspect
 
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/material_model/rheology/constant_viscosity_prefactors.cc
+++ b/source/material_model/rheology/constant_viscosity_prefactors.cc
@@ -88,6 +88,8 @@ namespace aspect
   }
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }
 

--- a/source/material_model/rheology/diffusion_creep.cc
+++ b/source/material_model/rheology/diffusion_creep.cc
@@ -127,5 +127,7 @@ namespace aspect
   }
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/material_model/rheology/dislocation_creep.cc
+++ b/source/material_model/rheology/dislocation_creep.cc
@@ -124,5 +124,7 @@ namespace aspect
   }
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/material_model/rheology/drucker_prager.cc
+++ b/source/material_model/rheology/drucker_prager.cc
@@ -156,5 +156,7 @@ namespace aspect
   }
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -388,5 +388,7 @@ namespace aspect
   }
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/material_model/rheology/strain_dependent.cc
+++ b/source/material_model/rheology/strain_dependent.cc
@@ -550,6 +550,8 @@ namespace aspect
   }
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }
 

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -979,6 +979,8 @@ namespace aspect
   template class PhaseFunction<dim>;
 
       ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
     }
   }
 }

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -777,5 +777,7 @@ namespace aspect
   get_valid_model_names_pattern<dim> ();
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/mesh_refinement/interface.cc
+++ b/source/mesh_refinement/interface.cc
@@ -548,5 +548,7 @@ namespace aspect
   template class Manager<dim>;
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/particle/generator/interface.cc
+++ b/source/particle/generator/interface.cc
@@ -297,6 +297,8 @@ namespace aspect
   create_particle_generator<dim> (ParameterHandler &prm);
 
       ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
     }
   }
 }

--- a/source/particle/integrator/interface.cc
+++ b/source/particle/integrator/interface.cc
@@ -277,6 +277,8 @@ namespace aspect
   create_particle_integrator<dim> (ParameterHandler &prm);
 
       ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
     }
   }
 }

--- a/source/particle/interpolator/interface.cc
+++ b/source/particle/interpolator/interface.cc
@@ -189,6 +189,8 @@ namespace aspect
   create_particle_interpolator<dim> (ParameterHandler &prm);
 
       ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
     }
   }
 }

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -699,6 +699,8 @@ namespace aspect
   template class Manager<dim>;
 
       ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
     }
   }
 }

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -932,5 +932,7 @@ namespace aspect
   template class World<dim>;
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/postprocess/heat_flux_map.cc
+++ b/source/postprocess/heat_flux_map.cc
@@ -546,6 +546,8 @@ namespace aspect
   template LinearAlgebra::BlockVector compute_dirichlet_boundary_heat_flux_solution_vector (const SimulatorAccess<dim> &simulator_access);
 
       ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
     }
 
     ASPECT_REGISTER_POSTPROCESSOR(HeatFluxMap,

--- a/source/postprocess/interface.cc
+++ b/source/postprocess/interface.cc
@@ -445,5 +445,7 @@ namespace aspect
   template class Manager<dim>;
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -738,6 +738,8 @@ namespace aspect
   template class ParticleOutput<dim>;
 
       ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
     }
 
     ASPECT_REGISTER_POSTPROCESSOR(Particles,

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -1326,6 +1326,8 @@ namespace aspect
   template class Interface<dim>;
 
       ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
     }
   }
 

--- a/source/prescribed_stokes_solution/interface.cc
+++ b/source/prescribed_stokes_solution/interface.cc
@@ -180,5 +180,7 @@ namespace aspect
   create_prescribed_stokes_solution<dim> (ParameterHandler &prm);
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -1416,5 +1416,7 @@ namespace aspect
   template class AdvectionSystemBoundaryHeatFlux<dim>;
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/simulator/assemblers/interface.cc
+++ b/source/simulator/assemblers/interface.cc
@@ -566,4 +566,6 @@ namespace aspect
     template class Manager<dim>; \
   }
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -786,5 +786,7 @@ namespace aspect
   template class NewtonStokesIsentropicCompressionTerm<dim>;
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -958,5 +958,7 @@ namespace aspect
   template class StokesBoundaryTraction<dim>;
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1294,4 +1294,6 @@ namespace aspect
 
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -618,4 +618,6 @@ namespace aspect
   template void Simulator<dim>::resume_from_snapshot();
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -2096,4 +2096,6 @@ namespace aspect
   template class Simulator<dim>;
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -684,4 +684,6 @@ namespace aspect
    
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -2535,4 +2535,6 @@ namespace aspect
                                                                             const double newton_residual_old);
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -425,4 +425,6 @@ namespace aspect
 
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -341,4 +341,6 @@ namespace aspect
   construct_default_variables (const Parameters<dim> &parameters);
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/simulator/lateral_averaging.cc
+++ b/source/simulator/lateral_averaging.cc
@@ -705,4 +705,6 @@ namespace aspect
 #define INSTANTIATE(dim) \
   template class LateralAveraging<dim>;
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1923,4 +1923,6 @@ namespace aspect
    
   ASPECT_INSTANTIATE(INSTANTIATE)
 
+#undef INSTANTIATE
+
 }

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -332,4 +332,6 @@ namespace aspect
 
   ASPECT_INSTANTIATE(INSTANTIATE)
 
+#undef INSTANTIATE
+
 }

--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -485,4 +485,6 @@ namespace aspect
   template void Simulator<dim>::setup_nullspace_constraints (ConstraintMatrix &);
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -2114,4 +2114,6 @@ namespace aspect
   template void Simulator<dim>::declare_parameters (ParameterHandler &prm);
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -759,4 +759,6 @@ namespace aspect
   template class SimulatorAccess<dim>;
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/simulator/simulator_signals.cc
+++ b/source/simulator/simulator_signals.cc
@@ -98,4 +98,6 @@ namespace aspect
 
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -971,4 +971,6 @@ namespace aspect
   template std::pair<double,double> Simulator<dim>::solve_stokes ();
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -1090,4 +1090,6 @@ namespace aspect
   template void Simulator<dim>::solve_no_advection_no_stokes();
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -2543,4 +2543,6 @@ namespace aspect
   template class StokesMatrixFreeHandlerImplementation<dim,3>;
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/termination_criteria/interface.cc
+++ b/source/termination_criteria/interface.cc
@@ -307,5 +307,7 @@ namespace aspect
   template class Manager<dim>;
 
     ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -3499,6 +3499,8 @@ namespace aspect
 
     ASPECT_INSTANTIATE(INSTANTIATE)
 
+#undef INSTANTIATE
+
 
 
     template class AsciiDataLookup<1>;

--- a/source/volume_of_fluid/assembler.cc
+++ b/source/volume_of_fluid/assembler.cc
@@ -649,5 +649,7 @@ namespace aspect
 
     ASPECT_INSTANTIATE(INSTANTIATE)
 
+#undef INSTANTIATE
+
   }
 }

--- a/source/volume_of_fluid/assembly.cc
+++ b/source/volume_of_fluid/assembly.cc
@@ -292,4 +292,6 @@ namespace aspect
 
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/volume_of_fluid/handler.cc
+++ b/source/volume_of_fluid/handler.cc
@@ -372,4 +372,6 @@ namespace aspect
   template class VolumeOfFluidHandler<dim>;
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/volume_of_fluid/setup_initial_conditions.cc
+++ b/source/volume_of_fluid/setup_initial_conditions.cc
@@ -240,4 +240,6 @@ namespace aspect
   template void VolumeOfFluidHandler<dim>::initialize_from_level_set (const VolumeOfFluidField<dim> &field);
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/volume_of_fluid/solver.cc
+++ b/source/volume_of_fluid/solver.cc
@@ -114,4 +114,6 @@ namespace aspect
 
 
   ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
 }

--- a/source/volume_of_fluid/utilities.cc
+++ b/source/volume_of_fluid/utilities.cc
@@ -680,6 +680,8 @@ namespace aspect
                                             const std::vector<double> &weights);
 
       ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
     }
   }
 }


### PR DESCRIPTION
This is needed for unity builds to work correctly.

part of #3585 