### PR TITLE
Remove unnecessary include from simulator_access.h

### DIFF
--- a/benchmarks/rigid_shear/plugin/rigid_shear.cc
+++ b/benchmarks/rigid_shear/plugin/rigid_shear.cc
@@ -24,6 +24,7 @@
 #include <aspect/material_model/interface.h>
 #include <aspect/postprocess/particles.h>
 #include <aspect/particle/property/interface.h>
+#include <aspect/particle/world.h>
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/postprocess/particles.h
+++ b/include/aspect/postprocess/particles.h
@@ -24,6 +24,7 @@
 #include <aspect/postprocess/interface.h>
 
 #include <aspect/simulator_access.h>
+#include <aspect/particle/property/interface.h>
 
 #include <deal.II/particles/particle_handler.h>
 #include <deal.II/base/data_out_base.h>

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -25,7 +25,6 @@
 #include <aspect/global.h>
 #include <aspect/parameters.h>
 #include <aspect/introspection.h>
-#include <aspect/particle/world.h>
 
 #include <deal.II/base/table_handler.h>
 #include <deal.II/base/timer.h>

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -20,6 +20,7 @@
 
 #include <aspect/global.h>
 #include <aspect/postprocess/particles.h>
+#include <aspect/particle/world.h>
 #include <aspect/utilities.h>
 
 #include <boost/archive/text_oarchive.hpp>

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -22,6 +22,7 @@
 #include <aspect/simulator.h>
 #include <aspect/mesh_deformation/free_surface.h>
 #include <aspect/mesh_deformation/interface.h>
+#include <aspect/particle/world.h>
 
 namespace aspect
 {


### PR DESCRIPTION
Found while working on #3587. Simulator_access.h already has a forward declaration and most users of the header do not need this expensive include. Some may rely on it (though I find it reasonable to expect from a particle plugin to include `particle/world.h`).