### PR TITLE
add unity build changelog entry

### DIFF
--- a/doc/modules/changes/20200706_tjhei
+++ b/doc/modules/changes/20200706_tjhei
@@ -1,0 +1,6 @@
+<li> New: We now support the CMake option CMAKE_UNITY_BUILD (off by default)
+and a rewritten ASPECT_PRECOMPILE_HEADERS option (ON by default) if you use
+CMake 3.16 or newer. Both options combined can speed up compilation by more
+than 3x.
+<br>
+(Rene Gassmoeller, Timo Heister, 2020/07/06)


### PR DESCRIPTION
see #3587 and #3585 for details.

For the record (old vs precompiled headers+unity builds):

~/aspect-git/build-nounity $ time ninja -j 16
real    3m25.492s
~/aspect-git/build-unity $ time ninja -j 16
real    0m54.797s

or a 3.6x faster build.
