### PR TITLE
Fix cmake version check in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,9 +510,9 @@ CONFIGURE_FILE(
 # 3.9. Starting with cmake 3.16 there is native support inside cmake and we can
 # use that.
 IF(CMAKE_VERSION VERSION_LESS 3.9)
-  SET(ASPECT_PRECOMPILE_HEADERS OFF CACHE BOOL "Precompile external header files using cotire to speedup compile time. Currently only supported for cmake versions older than 3.9 or newer than 3.15.")
+  SET(ASPECT_PRECOMPILE_HEADERS OFF CACHE BOOL "Precompile external header files using cotire to speedup compile time. Currently only supported for cmake 3.8 and older versions, or 3.16 and newer versions.")
 ELSEIF(NOT CMAKE_VERSION VERSION_LESS 3.16)
-  SET(ASPECT_PRECOMPILE_HEADERS ON CACHE BOOL "Precompile external header files to speedup compile time. Currently only supported for cmake versions older than 3.9 or newer than 3.15.")
+  SET(ASPECT_PRECOMPILE_HEADERS ON CACHE BOOL "Precompile external header files to speedup compile time. Currently only supported for cmake 3.8 and older versions or 3.16 and newer versions.")
 ELSE()
   SET(ASPECT_PRECOMPILE_HEADERS OFF)
 ENDIF()
@@ -547,7 +547,7 @@ IF (ASPECT_PRECOMPILE_HEADERS)
       <deal.II/particles/particle_handler.h>)
 
   ELSE()
-    MESSAGE(FATAL_ERROR "ASPECT_PRECOMPILE_HEADERS is currently only supported for CMake versions less than 3.9 and greater than 3.15.")
+    MESSAGE(FATAL_ERROR "ASPECT_PRECOMPILE_HEADERS is currently only supported for CMake 3.8 and older versions or 3.16 and newer versions.")
   ENDIF()
 
 ELSE()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,12 +507,12 @@ CONFIGURE_FILE(
 # but can fail on some machines with old cmake, therefore it is disabled by
 # default. Also cotire currently has issues with cmake generator expressions
 # used in deal.II for cmake version 3.9 and above. Disable cotire for cmake >=
-# 3.9. Starting with cmake 3.15 there is native support inside cmake and we can
+# 3.9. Starting with cmake 3.16 there is native support inside cmake and we can
 # use that.
 IF(CMAKE_VERSION VERSION_LESS 3.9)
   SET(ASPECT_PRECOMPILE_HEADERS OFF CACHE BOOL "Precompile external header files using cotire to speedup compile time. Currently only supported for cmake versions older than 3.9 or newer than 3.15.")
-ELSEIF(CMAKE_VERSION VERSION_GREATER 3.15)
-  SET(ASPECT_PRECOMPILE_HEADERS ON CACHE BOOL "Precompile external header files to speedup compile time. Currently only supported for cmake versions older than 3.9 or newer than 3.9.")
+ELSEIF(NOT CMAKE_VERSION VERSION_LESS 3.16)
+  SET(ASPECT_PRECOMPILE_HEADERS ON CACHE BOOL "Precompile external header files to speedup compile time. Currently only supported for cmake versions older than 3.9 or newer than 3.15.")
 ELSE()
   SET(ASPECT_PRECOMPILE_HEADERS OFF)
 ENDIF()
@@ -534,7 +534,7 @@ IF (ASPECT_PRECOMPILE_HEADERS)
     # and therefore the whole precompilation
     cotire(aspect)
 
-  ELSEIF (CMAKE_VERSION VERSION_GREATER 3.15)
+  ELSEIF (NOT CMAKE_VERSION VERSION_LESS 3.16)
     MESSAGE(STATUS "Precompiling common header files.")
     # Use the native cmake support to precompile some common headers
     # from ASPECT and deal.II that are frequently included, but rarely changed.


### PR DESCRIPTION
This was reported by Kiran Chotalia for cmake version 3.15.6. Our current cmake check tries to precompile headers for this version, but the feature is only available starting with 3.16. Ideally we would like to use `CMAKE_VERSION VERSION_GREATER_EQUAL 3.16`, but `VERSION_GREATER_EQUAL` is only available since cmake version 3.7 (and we allow versions since 2.8.12). This workaround fixes the problem (as long as cmake never releases a version 3.15.100).