### PR TITLE
Use new particle property interface

### DIFF
--- a/benchmarks/rigid_shear/plugin/rigid_shear.cc
+++ b/benchmarks/rigid_shear/plugin/rigid_shear.cc
@@ -41,6 +41,8 @@
 
 namespace aspect
 {
+  using namespace dealii;
+
   namespace RigidShearBenchmark
   {
     /**
@@ -62,8 +64,6 @@ namespace aspect
      */
     namespace AnalyticSolutions
     {
-      using namespace dealii;
-
       /**
        * The exact solution for the Rigid Shear benchmark.
        */
@@ -76,7 +76,7 @@ namespace aspect
           virtual void vector_value(const Point<dim> &p,
                                     Vector<double> &values) const
           {
-            const double pi = dealii::numbers::PI;
+            const double pi = numbers::PI;
             values[0] = std::sin(pi*p[0]) * std::cos(pi*p[1]);
             values[1] = -std::cos(pi*p[0]) * std::sin(pi*p[1]);
             values[2] = 2.0 * pi * std::cos(pi*p[0]) * std::cos(pi*p[1]);
@@ -212,7 +212,7 @@ namespace aspect
         update_particle_property (const unsigned int data_position,
                                   const Vector<double> &/*solution*/,
                                   const std::vector<Tensor<1,dim> > &/*gradients*/,
-                                  typename ParticleHandler<dim>::particle_iterator &particle) const
+                                  typename Particles::ParticleHandler<dim>::particle_iterator &particle) const
         {
           const auto &property_manager = this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::Particles<dim> >().
                                          get_particle_world().

--- a/benchmarks/rigid_shear/plugin/rigid_shear.cc
+++ b/benchmarks/rigid_shear/plugin/rigid_shear.cc
@@ -209,19 +209,19 @@ namespace aspect
 
         virtual
         void
-        update_one_particle_property (const unsigned int data_position,
-                                      const Point<dim> &position,
-                                      const Vector<double> &/*solution*/,
-                                      const std::vector<Tensor<1,dim> > &/*gradients*/,
-                                      const ArrayView<double> &particle_properties) const
+        update_particle_property (const unsigned int data_position,
+                                  const Vector<double> &/*solution*/,
+                                  const std::vector<Tensor<1,dim> > &/*gradients*/,
+                                  typename ParticleHandler<dim>::particle_iterator &particle) const
         {
           const auto &property_manager = this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::Particles<dim> >().
                                          get_particle_world().
                                          get_property_manager();
           const unsigned density_index = property_manager.get_data_info().get_field_index_by_name("function");
 
+          const Point<dim> position = particle->get_location();
           const double g_y = -4.0 * numbers::PI * numbers::PI * std::cos(numbers::PI * position[0]) / std::sin(numbers::PI * position[0]);
-          particle_properties[data_position] = particle_properties[density_index]*g_y;
+          particle->get_properties()[data_position] = particle->get_properties()[density_index]*g_y;
         }
 
         aspect::Particle::Property::UpdateTimeFlags

--- a/include/aspect/particle/property/composition.h
+++ b/include/aspect/particle/property/composition.h
@@ -58,32 +58,14 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * Update function. This function is called every time an update is
-           * request by need_update() for every particle for every property.
-           *
-           * @param [in] data_position An unsigned integer that denotes which
-           * component of the particle property vector is associated with the
-           * current property. For properties that own several components it
-           * denotes the first component of this property, all other components
-           * fill consecutive entries in the @p particle_properties vector.
-           *
-           * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
-           * @param [in,out] particle_properties The properties of the particle
-           * that is updated within the call of this function.
-           */
+          * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+          **/
+          virtual
           void
-          update_one_particle_property (const unsigned int data_position,
-                                        const Point<dim> &position,
-                                        const Vector<double> &solution,
-                                        const std::vector<Tensor<1,dim> > &gradients,
-                                        const ArrayView<double> &particle_properties) const override;
+          update_particle_property (const unsigned int data_position,
+                                    const Vector<double> &solution,
+                                    const std::vector<Tensor<1,dim> > &gradients,
+                                    typename ParticleHandler<dim>::particle_iterator &particle) const;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/integrated_strain.h
+++ b/include/aspect/particle/property/integrated_strain.h
@@ -59,32 +59,14 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * Update function. This function is called every time an update is
-           * request by need_update() for every particle for every property.
-           *
-           * @param [in] data_position An unsigned integer that denotes which
-           * component of the particle property vector is associated with the
-           * current property. For properties that own several components it
-           * denotes the first component of this property, all other components
-           * fill consecutive entries in the @p particle_properties vector.
-           *
-           * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
-           * @param [in,out] particle_properties The properties of the particle
-           * that is updated within the call of this function.
-           */
+          * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+          **/
+          virtual
           void
-          update_one_particle_property (const unsigned int data_position,
-                                        const Point<dim> &position,
-                                        const Vector<double> &solution,
-                                        const std::vector<Tensor<1,dim> > &gradients,
-                                        const ArrayView<double> &particle_properties) const override;
+          update_particle_property (const unsigned int data_position,
+                                    const Vector<double> &solution,
+                                    const std::vector<Tensor<1,dim> > &gradients,
+                                    typename ParticleHandler<dim>::particle_iterator &particle) const;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/integrated_strain_invariant.h
+++ b/include/aspect/particle/property/integrated_strain_invariant.h
@@ -58,33 +58,14 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * Update function. This function is called every time an update is
-           * request by need_update() for every particle for every property.
-           *
-           * @param [in] data_position An unsigned integer that denotes which
-           * component of the particle property vector is associated with the
-           * current property. For properties that own several components it
-           * denotes the first component of this property, all other
-           * components fill consecutive entries in the @p particle_properties
-           * vector.
-           *
-           * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
-           * @param [in,out] particle_properties The properties of the particle
-           * that is updated within the call of this function.
-           */
+          * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+          **/
+          virtual
           void
-          update_one_particle_property (const unsigned int data_position,
-                                        const Point<dim> &position,
-                                        const Vector<double> &solution,
-                                        const std::vector<Tensor<1,dim> > &gradients,
-                                        const ArrayView<double> &particle_properties) const override;
+          update_particle_property (const unsigned int data_position,
+                                    const Vector<double> &solution,
+                                    const std::vector<Tensor<1,dim> > &gradients,
+                                    typename ParticleHandler<dim>::particle_iterator &particle) const;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/melt_particle.h
+++ b/include/aspect/particle/property/melt_particle.h
@@ -59,32 +59,14 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * Update function. This function is called every time an update is
-           * request by need_update() for every particle for every property.
-           *
-           * @param [in] data_position An unsigned integer that denotes which
-           * component of the particle property vector is associated with the
-           * current property. For properties that own several components it
-           * denotes the first component of this property, all other components
-           * fill consecutive entries in the @p particle_properties vector.
-           *
-           * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
-           * @param [in,out] particle_properties The properties of the particle
-           * that is updated within the call of this function.
-           */
+          * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+          **/
+          virtual
           void
-          update_one_particle_property (const unsigned int data_position,
-                                        const Point<dim> &position,
-                                        const Vector<double> &solution,
-                                        const std::vector<Tensor<1,dim> > &gradients,
-                                        const ArrayView<double> &particle_properties) const override;
+          update_particle_property (const unsigned int data_position,
+                                    const Vector<double> &solution,
+                                    const std::vector<Tensor<1,dim> > &gradients,
+                                    typename ParticleHandler<dim>::particle_iterator &particle) const;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/pT_path.h
+++ b/include/aspect/particle/property/pT_path.h
@@ -59,32 +59,14 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * Update function. This function is called every time an update is
-           * request by need_update() for every particle for every property.
-           *
-           * @param [in] data_position An unsigned integer that denotes which
-           * component of the particle property vector is associated with the
-           * current property. For properties that own several components it
-           * denotes the first component of this property, all other components
-           * fill consecutive entries in the @p particle_properties vector.
-           *
-           * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
-           * @param [in,out] particle_properties The properties of the particle
-           * that is updated within the call of this function.
-           */
+          * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+          **/
+          virtual
           void
-          update_one_particle_property (const unsigned int data_position,
-                                        const Point<dim> &position,
-                                        const Vector<double> &solution,
-                                        const std::vector<Tensor<1,dim> > &gradients,
-                                        const ArrayView<double> &particle_properties) const override;
+          update_particle_property (const unsigned int data_position,
+                                    const Vector<double> &solution,
+                                    const std::vector<Tensor<1,dim> > &gradients,
+                                    typename ParticleHandler<dim>::particle_iterator &particle) const;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/position.h
+++ b/include/aspect/particle/property/position.h
@@ -54,32 +54,14 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * Update function. This function is called every time an update is
-           * request by need_update() for every particle for every property.
-           *
-           * @param [in] data_position An unsigned integer that denotes which
-           * component of the particle property vector is associated with the
-           * current property. For properties that own several components it
-           * denotes the first component of this property, all other components
-           * fill consecutive entries in the @p particle_properties vector.
-           *
-           * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
-           * @param [in,out] particle_properties The properties of the particle
-           * that is updated within the call of this function.
-           */
+          * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+          **/
+          virtual
           void
-          update_one_particle_property (const unsigned int data_position,
-                                        const Point<dim> &position,
-                                        const Vector<double> &solution,
-                                        const std::vector<Tensor<1,dim> > &gradients,
-                                        const ArrayView<double> &particle_properties) const override;
+          update_particle_property (const unsigned int data_position,
+                                    const Vector<double> &solution,
+                                    const std::vector<Tensor<1,dim> > &gradients,
+                                    typename ParticleHandler<dim>::particle_iterator &particle) const;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/velocity.h
+++ b/include/aspect/particle/property/velocity.h
@@ -55,32 +55,14 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * Update function. This function is called every time an update is
-           * request by need_update() for every particle for every property.
-           *
-           * @param [in] data_position An unsigned integer that denotes which
-           * component of the particle property vector is associated with the
-           * current property. For properties that own several components it
-           * denotes the first component of this property, all other components
-           * fill consecutive entries in the @p particle_properties vector.
-           *
-           * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
-           * @param [in,out] particle_properties The properties of the particle
-           * that is updated within the call of this function.
-           */
+          * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+          **/
+          virtual
           void
-          update_one_particle_property (const unsigned int data_position,
-                                        const Point<dim> &position,
-                                        const Vector<double> &solution,
-                                        const std::vector<Tensor<1,dim> > &gradients,
-                                        const ArrayView<double> &particle_properties) const override;
+          update_particle_property (const unsigned int data_position,
+                                    const Vector<double> &solution,
+                                    const std::vector<Tensor<1,dim> > &gradients,
+                                    typename ParticleHandler<dim>::particle_iterator &particle) const;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/viscoplastic_strain_invariants.h
+++ b/include/aspect/particle/property/viscoplastic_strain_invariants.h
@@ -61,14 +61,14 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-          * @copydoc aspect::Particle::Property::Interface::update_one_particle_property()
+          * @copydoc aspect::Particle::Property::Interface::update_particle_property()
           **/
+          virtual
           void
-          update_one_particle_property (const unsigned int data_position,
-                                        const Point<dim> &position,
-                                        const Vector<double> &solution,
-                                        const std::vector<Tensor<1,dim> > &gradients,
-                                        const ArrayView<double> &particle_properties) const override;
+          update_particle_property (const unsigned int data_position,
+                                    const Vector<double> &solution,
+                                    const std::vector<Tensor<1,dim> > &gradients,
+                                    typename ParticleHandler<dim>::particle_iterator &particle) const;
 
           /**
           * @copydoc aspect::Particle::Property::Interface::need_update()

--- a/source/particle/property/composition.cc
+++ b/source/particle/property/composition.cc
@@ -39,16 +39,15 @@ namespace aspect
 
       template <int dim>
       void
-      Composition<dim>::update_one_particle_property(const unsigned int data_position,
-                                                     const Point<dim> &,
-                                                     const Vector<double> &solution,
-                                                     const std::vector<Tensor<1,dim> > &,
-                                                     const ArrayView<double> &data) const
+      Composition<dim>::update_particle_property(const unsigned int data_position,
+                                                 const Vector<double> &solution,
+                                                 const std::vector<Tensor<1,dim> > &/*gradients*/,
+                                                 typename ParticleHandler<dim>::particle_iterator &particle) const
       {
         for (unsigned int i = 0; i < this->n_compositional_fields(); i++)
           {
             const unsigned int solution_component = this->introspection().component_indices.compositional_fields[i];
-            data[data_position+i] = solution[solution_component];
+            particle->get_properties()[data_position+i] = solution[solution_component];
           }
       }
 

--- a/source/particle/property/integrated_strain.cc
+++ b/source/particle/property/integrated_strain.cc
@@ -38,12 +38,13 @@ namespace aspect
 
       template <int dim>
       void
-      IntegratedStrain<dim>::update_one_particle_property(const unsigned int data_position,
-                                                          const Point<dim> &,
-                                                          const Vector<double> &,
-                                                          const std::vector<Tensor<1,dim> > &gradients,
-                                                          const ArrayView<double> &data) const
+      IntegratedStrain<dim>::update_particle_property(const unsigned int data_position,
+                                                      const Vector<double> &/*solution*/,
+                                                      const std::vector<Tensor<1,dim> > &gradients,
+                                                      typename ParticleHandler<dim>::particle_iterator &particle) const
       {
+        auto &data = particle->get_properties();
+
         Tensor<2,dim> old_strain;
         for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
           old_strain[Tensor<2,dim>::unrolled_to_component_indices(i)] = data[data_position + i];

--- a/source/particle/property/integrated_strain_invariant.cc
+++ b/source/particle/property/integrated_strain_invariant.cc
@@ -36,15 +36,13 @@ namespace aspect
 
       template <int dim>
       void
-      IntegratedStrainInvariant<dim>::update_one_particle_property(const unsigned int data_position,
-                                                                   const Point<dim> &,
-                                                                   const Vector<double> &,
-                                                                   const std::vector<Tensor<1,dim> > &gradients,
-                                                                   const ArrayView<double> &data) const
+      IntegratedStrainInvariant<dim>::update_particle_property(const unsigned int data_position,
+                                                               const Vector<double> &/*solution*/,
+                                                               const std::vector<Tensor<1,dim> > &gradients,
+                                                               typename ParticleHandler<dim>::particle_iterator &particle) const
       {
-
-
         // Integrated strain invariant from prior time step
+        auto &data = particle->get_properties();
         double old_strain = data[data_position];
 
         // Current timestep

--- a/source/particle/property/melt_particle.cc
+++ b/source/particle/property/melt_particle.cc
@@ -39,11 +39,10 @@ namespace aspect
 
       template <int dim>
       void
-      MeltParticle<dim>::update_one_particle_property(const unsigned int data_position,
-                                                      const Point<dim> &,
-                                                      const Vector<double> &solution,
-                                                      const std::vector<Tensor<1,dim> > &,
-                                                      const ArrayView<double> &data) const
+      MeltParticle<dim>::update_particle_property(const unsigned int data_position,
+                                                  const Vector<double> &solution,
+                                                  const std::vector<Tensor<1,dim> > &/*gradients*/,
+                                                  typename ParticleHandler<dim>::particle_iterator &particle) const
       {
         AssertThrow(this->introspection().compositional_name_exists("porosity"),
                     ExcMessage("Particle property melt particle only works if"
@@ -51,9 +50,9 @@ namespace aspect
         const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
         if (solution[this->introspection().component_indices.compositional_fields[porosity_idx]] > threshold_for_melt_presence)
-          data[data_position] = 1.0;
+          particle->get_properties()[data_position] = 1.0;
         else
-          data[data_position] =  0.0;
+          particle->get_properties()[data_position] = 0.0;
       }
 
       template <int dim>

--- a/source/particle/property/pT_path.cc
+++ b/source/particle/property/pT_path.cc
@@ -39,14 +39,13 @@ namespace aspect
 
       template <int dim>
       void
-      PTPath<dim>::update_one_particle_property(const unsigned int data_position,
-                                                const Point<dim> &,
-                                                const Vector<double> &solution,
-                                                const std::vector<Tensor<1,dim> > &,
-                                                const ArrayView<double> &data) const
+      PTPath<dim>::update_particle_property(const unsigned int data_position,
+                                            const Vector<double> &solution,
+                                            const std::vector<Tensor<1,dim> > &/*gradients*/,
+                                            typename ParticleHandler<dim>::particle_iterator &particle) const
       {
-        data[data_position] = solution[this->introspection().component_indices.pressure];
-        data[data_position+1] = solution[this->introspection().component_indices.temperature];
+        particle->get_properties()[data_position]   = solution[this->introspection().component_indices.pressure];
+        particle->get_properties()[data_position+1] = solution[this->introspection().component_indices.temperature];
       }
 
       template <int dim>

--- a/source/particle/property/position.cc
+++ b/source/particle/property/position.cc
@@ -37,14 +37,13 @@ namespace aspect
 
       template <int dim>
       void
-      Position<dim>::update_one_particle_property(const unsigned int data_position,
-                                                  const Point<dim> &position,
-                                                  const Vector<double> &,
-                                                  const std::vector<Tensor<1,dim> > &,
-                                                  const ArrayView<double> &data) const
+      Position<dim>::update_particle_property(const unsigned int data_position,
+                                              const Vector<double> &/*solution*/,
+                                              const std::vector<Tensor<1,dim> > &/*gradients*/,
+                                              typename ParticleHandler<dim>::particle_iterator &particle) const
       {
         for (unsigned int i = 0; i < dim; ++i)
-          data[data_position+i] = position[i];
+          particle->get_properties()[data_position+i] = particle->get_location()[i];
       }
 
       template <int dim>

--- a/source/particle/property/velocity.cc
+++ b/source/particle/property/velocity.cc
@@ -37,14 +37,13 @@ namespace aspect
 
       template <int dim>
       void
-      Velocity<dim>::update_one_particle_property(const unsigned int data_position,
-                                                  const Point<dim> &,
-                                                  const Vector<double> &solution,
-                                                  const std::vector<Tensor<1,dim> > &,
-                                                  const ArrayView<double> &data) const
+      Velocity<dim>::update_particle_property(const unsigned int data_position,
+                                              const Vector<double> &solution,
+                                              const std::vector<Tensor<1,dim> > &/*gradients*/,
+                                              typename ParticleHandler<dim>::particle_iterator &particle) const
       {
         for (unsigned int i = 0; i < dim; ++i)
-          data[data_position+i] = solution[this->introspection().component_indices.velocities[i]];
+          particle->get_properties()[data_position+i] = solution[this->introspection().component_indices.velocities[i]];
       }
 
       template <int dim>

--- a/source/particle/property/viscoplastic_strain_invariants.cc
+++ b/source/particle/property/viscoplastic_strain_invariants.cc
@@ -77,11 +77,10 @@ namespace aspect
 
       template <int dim>
       void
-      ViscoPlasticStrainInvariant<dim>::update_one_particle_property(const unsigned int data_position,
-                                                                     const Point<dim> &,
-                                                                     const Vector<double> &solution,
-                                                                     const std::vector<Tensor<1,dim> > &gradients,
-                                                                     const ArrayView<double> &data) const
+      ViscoPlasticStrainInvariant<dim>::update_particle_property(const unsigned int data_position,
+                                                                 const Vector<double> &solution,
+                                                                 const std::vector<Tensor<1,dim> > &gradients,
+                                                                 typename ParticleHandler<dim>::particle_iterator &particle) const
       {
         // Current timestep
         const double dt = this->get_timestep();
@@ -93,7 +92,6 @@ namespace aspect
 
         // Calculate strain rate from velocity gradients
         const SymmetricTensor<2,dim> strain_rate = symmetrize (grad_u);
-
 
         // Put compositional fields into single variable
         std::vector<double> composition(this->n_compositional_fields());
@@ -119,6 +117,7 @@ namespace aspect
          * In this case old_strain will first be given the plastic strain, and then,
          * if there is no plastic yielding it will update to the viscous strain instead.
          */
+        auto &data = particle->get_properties();
         double old_strain = data[data_position];
         if (n_components == 2 && plastic_yielding == false)
           old_strain = data[data_position+(n_components-1)];


### PR DESCRIPTION
This PR updates the particle property plugins to use the new interface function introduced in #3482, no functional changes are expected. The old function is already deprecated. This will be necessary to address a question raised in #3598. I will open a follow-up PR in which the connection will become more clear.