### PR TITLE
Update visco plastic is yielding

### DIFF
--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -254,11 +254,19 @@ namespace aspect
          * A function that returns whether the material is plastically yielding at
          * the given pressure, temperature, composition, and strain rate.
          */
+        DEAL_II_DEPRECATED
         bool
         is_yielding ( const double &pressure,
                       const double &temperature,
                       const std::vector<double> &composition,
                       const SymmetricTensor<2,dim> &strain_rate) const;
+
+        /**
+        * A function that returns whether the material is plastically yielding at
+        * the given pressure, temperature, composition, and strain rate.
+        */
+        bool
+        is_yielding (const MaterialModelInputs<dim> &in) const;
 
       private:
 

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -253,6 +253,9 @@ namespace aspect
         /**
          * A function that returns whether the material is plastically yielding at
          * the given pressure, temperature, composition, and strain rate.
+         *
+         * @deprecated: Use the other function with this name instead, which allows
+         * to pass in more general input variables.
          */
         DEAL_II_DEPRECATED
         bool
@@ -263,7 +266,8 @@ namespace aspect
 
         /**
         * A function that returns whether the material is plastically yielding at
-        * the given pressure, temperature, composition, and strain rate.
+        * the given input variables (pressure, temperature, composition, strain rate,
+        * and so on).
         */
         bool
         is_yielding (const MaterialModelInputs<dim> &in) const;

--- a/include/aspect/particle/property/viscoplastic_strain_invariants.h
+++ b/include/aspect/particle/property/viscoplastic_strain_invariants.h
@@ -91,6 +91,12 @@ namespace aspect
         private:
           unsigned int n_components;
 
+          /**
+           * An object that is used to compute the particle property. Since the
+           * object is expensive to create and is needed often it is kept as a
+           * member variable.
+           */
+          mutable MaterialModel::MaterialModelInputs<dim> material_inputs;
       };
     }
   }

--- a/include/aspect/particle/property/viscoplastic_strain_invariants.h
+++ b/include/aspect/particle/property/viscoplastic_strain_invariants.h
@@ -94,7 +94,11 @@ namespace aspect
           /**
            * An object that is used to compute the particle property. Since the
            * object is expensive to create and is needed often it is kept as a
-           * member variable.
+           * member variable. Because it is changed inside a const member function
+           * (update_particle_property) it has to be mutable, but since it is
+           * only used inside that function and always set before being used
+           * that is not a problem. This implementation is not thread safe,
+           * but it is currently not used in a threaded context.
            */
           mutable MaterialModel::MaterialModelInputs<dim> material_inputs;
       };

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -76,18 +76,16 @@ namespace aspect
     {
       Assert(in.n_evaluation_points() == 1, ExcInternalError());
 
+      const std::vector<double> volume_fractions = MaterialUtilities::compute_volume_fractions(in.composition[0], get_volumetric_composition_mask());
+
       /* The following returns whether or not the material is plastically yielding
        * as documented in evaluate.
        */
-      bool plastic_yielding = false;
-
-      const std::vector<double> volume_fractions = MaterialUtilities::compute_volume_fractions(in.composition[0], get_volumetric_composition_mask());
-
       const std::pair<std::vector<double>, std::vector<bool>> calculate_viscosities =
                                                              calculate_isostrain_viscosities(volume_fractions, in.pressure[0], in.temperature[0], in.composition[0], in.strain_rate[0], viscous_flow_law, yield_mechanism);
 
       std::vector<double>::const_iterator max_composition = std::max_element(volume_fractions.begin(), volume_fractions.end());
-      plastic_yielding = calculate_viscosities.second[std::distance(volume_fractions.begin(), max_composition)];
+      const bool plastic_yielding = calculate_viscosities.second[std::distance(volume_fractions.begin(), max_composition)];
 
       return plastic_yielding;
     }

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -67,6 +67,33 @@ namespace aspect
       return plastic_yielding;
     }
 
+
+
+    template <int dim>
+    bool
+    ViscoPlastic<dim>::
+    is_yielding(const MaterialModelInputs<dim> &in) const
+    {
+      Assert(in.n_evaluation_points() == 1, ExcInternalError());
+
+      /* The following returns whether or not the material is plastically yielding
+       * as documented in evaluate.
+       */
+      bool plastic_yielding = false;
+
+      const std::vector<double> volume_fractions = MaterialUtilities::compute_volume_fractions(in.composition[0], get_volumetric_composition_mask());
+
+      const std::pair<std::vector<double>, std::vector<bool>> calculate_viscosities =
+                                                             calculate_isostrain_viscosities(volume_fractions, in.pressure[0], in.temperature[0], in.composition[0], in.strain_rate[0], viscous_flow_law, yield_mechanism);
+
+      std::vector<double>::const_iterator max_composition = std::max_element(volume_fractions.begin(), volume_fractions.end());
+      plastic_yielding = calculate_viscosities.second[std::distance(volume_fractions.begin(), max_composition)];
+
+      return plastic_yielding;
+    }
+
+
+
     template <int dim>
     PlasticAdditionalOutputs<dim>::PlasticAdditionalOutputs (const unsigned int n_points)
       :

--- a/source/particle/property/viscoplastic_strain_invariants.cc
+++ b/source/particle/property/viscoplastic_strain_invariants.cc
@@ -32,6 +32,9 @@ namespace aspect
 
       template <int dim>
       ViscoPlasticStrainInvariant<dim>::ViscoPlasticStrainInvariant ()
+      :
+      n_components(0),
+      material_inputs(1,0)
       {}
 
       template <int dim>
@@ -42,6 +45,7 @@ namespace aspect
                     ExcMessage("This initial condition only makes sense in combination with the visco_plastic material model."));
 
         n_components = 0;
+        material_inputs = MaterialModel::MaterialModelInputs<dim>(1,this->n_compositional_fields());
 
         // Find out which fields are used.
         if (this->introspection().compositional_name_exists("plastic_strain"))
@@ -90,25 +94,24 @@ namespace aspect
         for (unsigned int d=0; d<dim; ++d)
           grad_u[d] = gradients[d];
 
+        material_inputs.pressure[0] = solution[this->introspection().component_indices.pressure];
+        material_inputs.temperature[0] = solution[this->introspection().component_indices.temperature];
+        material_inputs.position[0] = particle->get_location();
+
         // Calculate strain rate from velocity gradients
-        const SymmetricTensor<2,dim> strain_rate = symmetrize (grad_u);
+        material_inputs.strain_rate[0] = symmetrize (grad_u);
 
         // Put compositional fields into single variable
-        std::vector<double> composition(this->n_compositional_fields());
         for (unsigned int i = 0; i < this->n_compositional_fields(); i++)
           {
-            composition[i] = solution[this->introspection().component_indices.compositional_fields[i]];
+            material_inputs.composition[0][i] = solution[this->introspection().component_indices.compositional_fields[i]];
           }
 
         // Find out plastic yielding by calling function in material model.
         const MaterialModel::ViscoPlastic<dim> &viscoplastic
           = Plugins::get_plugin_as_type<const MaterialModel::ViscoPlastic<dim>>(this->get_material_model());
 
-        bool plastic_yielding = false;
-        plastic_yielding = viscoplastic.is_yielding(solution[this->introspection().component_indices.pressure],
-                                                    solution[this->introspection().component_indices.temperature],
-                                                    composition,
-                                                    strain_rate);
+        const bool plastic_yielding = viscoplastic.is_yielding(material_inputs);
 
 
         /* Next take the integrated strain invariant from the prior time step. When
@@ -124,7 +127,7 @@ namespace aspect
 
 
         // Calculate strain rate second invariant
-        const double edot_ii = std::sqrt(std::fabs(second_invariant(deviator(strain_rate))));
+        const double edot_ii = std::sqrt(std::fabs(second_invariant(deviator(material_inputs.strain_rate[0]))));
 
         // New strain is the old strain plus dt*edot_ii
         const double new_strain = old_strain + dt*edot_ii;

--- a/source/particle/property/viscoplastic_strain_invariants.cc
+++ b/source/particle/property/viscoplastic_strain_invariants.cc
@@ -32,9 +32,9 @@ namespace aspect
 
       template <int dim>
       ViscoPlasticStrainInvariant<dim>::ViscoPlasticStrainInvariant ()
-      :
-      n_components(0),
-      material_inputs(1,0)
+        :
+        n_components(0),
+        material_inputs(1,0)
       {}
 
       template <int dim>


### PR DESCRIPTION
This PR sits on top of #3612 and allows to input more properties into the `ViscoPlastic::is_yielding` function as is necessary for #3598. I have checked that the version of this function in this PR is as fast as the one in master (this is important because this function is called once per particle per timestep and can become very expensive). 