### PR TITLE
Enable precompiling headers on CIG testers

### DIFF
--- a/Jenkinsfile.cig
+++ b/Jenkinsfile.cig
@@ -102,11 +102,10 @@ pipeline {
         -G 'Ninja' \
         -D CMAKE_CXX_FLAGS='-Werror --coverage' \
         -D ASPECT_TEST_GENERATOR='Ninja' \
-        -D ASPECT_PRECOMPILE_HEADERS=OFF \
+        -D ASPECT_PRECOMPILE_HEADERS=ON \
         -D ASPECT_UNITY_BUILD=OFF \
         -D ASPECT_USE_PETSC='OFF' \
         -D ASPECT_RUN_ALL_TESTS='ON' \
-        -D ASPECT_UNITY_BUILD='OFF' \
         ..
         '''
 


### PR DESCRIPTION
This was switched on before #3583 and it turns out some of the older CIG test agents can not finish compiling in 30 minutes without the setting (e.g. seen in #3598). Since the 'OFF'/'OFF' (precompiling headers/unity build) option is already tested on jenkins.tjhei.info, we can probably enable it here. The alternative is to increase the walltime limit and wait for a long time for some PRs.