### PR TITLE
CI: add github actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,46 @@
+name: linux
+
+on: [push, pull_request]
+
+jobs:
+  linux:
+    name: linux build
+    runs-on: [ubuntu-18.04]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup
+      run: |
+        sudo apt-get install -y software-properties-common
+        sudo add-apt-repository ppa:ginggs/deal.ii-9.2.0-backports
+        sudo apt-get update
+        sudo apt-get install -yq --no-install-recommends texlive-generic-extra texlive-base texlive-latex-recommended texlive-latex-base texlive-fonts-recommended texlive-bibtex-extra lmodern texlive-latex-extra texlive-science graphviz python-pip python-setuptools libdeal.ii-dev doxygen
+        doxygen --version
+
+        wget http://sourceforge.net/projects/astyle/files/astyle/astyle%202.04/astyle_2.04_linux.tar.gz
+        tar xf astyle_2.04_linux.tar.gz
+        cd astyle/build/gcc && make
+        sudo USER=root make install
+        cd
+        rm -rf astyle*
+        astyle --version
+    - name: indent
+      run: |
+        ./contrib/utilities/indent
+        git diff --exit-code
+    - name: compile
+      run: |
+        mkdir build
+        cd build
+        cmake -D ASPECT_PRECOMPILE_HEADERS=ON -D ASPECT_UNITY_BUILD=ON ..
+        make -j 2
+    - name: doc
+      run: |
+        cd doc
+        ./update_parameters.sh $GITHUB_WORKSPACE/build/aspect
+        make manual.pdf
+    - name: archive
+      uses: actions/upload-artifact@v1
+      with:
+        name: manual.log
+        path: doc/manual/manual.log


### PR DESCRIPTION
As discussed during the meeting today.
This CI job runs unconditionally in about 12 minutes and checks indentation, compilation (unity build), and documentation. This will help us with rapid iteration for pull requests but our own testers are obviously required before merging anything.

Github actions currently runs 20 concurrent linux jobs for open source projects.