### PR TITLE
Limit number of MPI ranks for tests

### DIFF
--- a/tests/parallel_refine_crash.prm
+++ b/tests/parallel_refine_crash.prm
@@ -1,4 +1,4 @@
-# MPI: 7
+# MPI: 4
 
 # Test case that showed two problems:
 #

--- a/tests/vof_mpi_amr_no_dof.prm
+++ b/tests/vof_mpi_amr_no_dof.prm
@@ -1,4 +1,4 @@
-# MPI: 9
+# MPI: 4
 
 # Test for linear interface under constant velocity
 # Error should be at machine precision


### PR DESCRIPTION
This is just a test to see how much time this limitation saves on the slower jenkins agents. Obviously these test do not work any more with the new settings (they specifically test problems with many MPI ranks).