### PR TITLE
Fix cookbook phase for slow testers

### DIFF
--- a/Jenkinsfile.cig
+++ b/Jenkinsfile.cig
@@ -137,9 +137,10 @@ pipeline {
       steps {
         sh '''
         export BUILDDIR=`pwd`/build-gcc-fast
-        cd cookbooks && make -f check.mk CHECK=--validate BUILD=$BUILDDIR -j8
+        export NP=`grep -c ^processor /proc/cpuinfo`
+        cd cookbooks && make -f check.mk CHECK=--validate BUILD=$BUILDDIR -j $NP
         cd ..
-        cd benchmarks && make -f check.mk CHECK=--validate BUILD=$BUILDDIR -j8
+        cd benchmarks && make -f check.mk CHECK=--validate BUILD=$BUILDDIR -j $NP
         '''
       }
     }


### PR DESCRIPTION
The cookbook testing phase introduced in #3621 does not finish in time on the slow testers (see some of the other current PRs). Reduce concurrency and increase acceptable runtime.