### PR TITLE
CI: fix github actions update_parameters.sh

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,6 +37,7 @@ jobs:
     - name: doc
       run: |
         cd doc
+        export OMPI_MCA_btl="self,vader"
         ./update_parameters.sh $GITHUB_WORKSPACE/build/aspect
         make manual.pdf
     - name: archive

--- a/doc/update_parameters.sh
+++ b/doc/update_parameters.sh
@@ -89,8 +89,9 @@ cd ../..
 echo Creating plugin graph
 $ASPECT --output-plugin-graph doc/manual/empty.prm >plugin_graph.dot 2>/dev/null \
     || { echo "Running ASPECT for the plugin graph failed"; exit 1; }
+
 neato plugin_graph.dot -Tpdf -o plugin_graph.pdf \
-    || { echo "Can't run neato" ; exit 1; }
+    || { echo "Can't run neato"; cat plugin_graph.dot; exit 1; }
 mv plugin_graph.pdf plugin_graph.dot doc/manual/ || echo "ERROR: could not copy plugin_graph.*"
 
 popd


### PR DESCRIPTION
1. Disable openmpi warning for the github actions run (breaks documentation and is detected with the merge of #3622)
2. Output the .dot file if generation fails to help with this in the future.