### PR TITLE
fix conflicting lib detection for deal.II ubuntu package

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -207,7 +207,8 @@ void validate_shared_lib_list (const bool before_loading_shared_libs)
   // find everything that is interesting
   std::set<std::string> dealii_shared_lib_names;
   for (const auto &p : shared_lib_names)
-    if (p.find ("libdeal_II") != std::string::npos)
+    if (p.find ("libdeal_II") != std::string::npos ||
+        p.find ("libdeal.ii") != std::string::npos)
       dealii_shared_lib_names.insert (p);
 
   // produce an error if we load deal.II more than once


### PR DESCRIPTION
The deal.II ubuntu package is
/lib/x86_64-linux-gnu/libdeal.ii.g.so.9.2.0
so the detection for library mismatch between plugin and binary fails.
Fix this.
