### PR TITLE
Fix a problem with template explicit specializations.

### DIFF
--- a/include/aspect/volume_of_fluid/utilities.h
+++ b/include/aspect/volume_of_fluid/utilities.h
@@ -40,8 +40,9 @@ namespace aspect
        *
        * Currently only works assuming constant Jacobian determinant.
        */
-      template<int dim>
-      double compute_fluid_fraction (const Tensor<1, dim, double> normal,
+      double compute_fluid_fraction (const Tensor<1, 2> normal,
+                                     const double d);
+      double compute_fluid_fraction (const Tensor<1, 3> normal,
                                      const double d);
 
       /**
@@ -51,8 +52,9 @@ namespace aspect
        *
        * Currently only works assuming constant Jacobian determinant.
        */
-      template<int dim>
-      double compute_interface_location (const Tensor<1, dim, double> normal,
+      double compute_interface_location (const Tensor<1, 2> normal,
+                                         const double volume_fraction);
+      double compute_interface_location (const Tensor<1, 3> normal,
                                          const double volume_fraction);
 
       /**
@@ -68,12 +70,17 @@ namespace aspect
        * @param points Locations to evaluate the constructed polynomial
        * @param values Values of the constructed polynomial at the specified points
        */
-      template<int dim>
       void xFEM_Heaviside(const unsigned int degree,
-                          const Tensor<1, dim, double> normal,
+                          const Tensor<1, 2> normal,
                           const double d,
-                          const std::vector<Point<dim>> &points,
+                          const std::vector<Point<2>> &points,
                           std::vector<double> &values);
+      void xFEM_Heaviside(const unsigned int degree,
+                          const Tensor<1, 3> normal,
+                          const double d,
+                          const std::vector<Point<3>> &points,
+                          std::vector<double> &values);
+
       /**
        * Obtain values at points for a polynomial function that is equivalent to
        * the function $\frac{d}{dd}H(d-normal*xhat)$ on the unit cell when
@@ -87,11 +94,15 @@ namespace aspect
        * @param points Locations to evaluate the constructed polynomial
        * @param values Values of the constructed polynomial at the specified points
        */
-      template<int dim>
       void xFEM_Heaviside_derivative_d(const unsigned int degree,
-                                       const Tensor<1, dim, double> normal,
+                                       const Tensor<1, 2> normal,
                                        const double d,
-                                       const std::vector<Point<dim>> &points,
+                                       const std::vector<Point<2>> &points,
+                                       std::vector<double> &values);
+      void xFEM_Heaviside_derivative_d(const unsigned int degree,
+                                       const Tensor<1, 3> normal,
+                                       const double d,
+                                       const std::vector<Point<3>> &points,
                                        std::vector<double> &values);
 
 

--- a/source/volume_of_fluid/setup_initial_conditions.cc
+++ b/source/volume_of_fluid/setup_initial_conditions.cc
@@ -207,7 +207,7 @@ namespace aspect
                     d += (0.5/dim)*(dH+dL);
                   }
                 // Use the basic fluid fraction formula to compute an approximation to the fluid fraction
-                const double fraction_at_point = VolumeOfFluid::Utilities::compute_fluid_fraction<dim> (grad, d);
+                const double fraction_at_point = VolumeOfFluid::Utilities::compute_fluid_fraction (grad, d);
                 volume_of_fluid_val += fraction_at_point * fe_init.JxW (i);
                 cell_vol += fe_init.JxW (i);
               }

--- a/source/volume_of_fluid/utilities.cc
+++ b/source/volume_of_fluid/utilities.cc
@@ -28,9 +28,9 @@ namespace aspect
     {
       using namespace dealii;
 
-      template<>
-      double compute_fluid_fraction<2> (const Tensor<1, 2> normal,
-                                        const double d)
+
+      double compute_fluid_fraction (const Tensor<1, 2> normal,
+                                     const double d)
       {
         const int dim = 2;
 
@@ -69,9 +69,10 @@ namespace aspect
         return 0.5 + dtest / (1.0 - mpos);
       }
 
-      template<>
-      double compute_interface_location<2> (const Tensor<1, 2> normal,
-                                            const double vol)
+
+
+      double compute_interface_location (const Tensor<1, 2> normal,
+                                         const double vol)
       {
         const int dim = 2;
 
@@ -112,12 +113,12 @@ namespace aspect
           {
             return norm1 * (1 - mpos) * (vol - 0.5);
           }
-
       }
 
-      template<>
-      double compute_fluid_fraction<3> (const Tensor<1, 3> normal,
-                                        const double d)
+
+
+      double compute_fluid_fraction (const Tensor<1, 3> normal,
+                                     const double d)
       {
         // Calculations done by Scardovelli and Zaleski in
         // doi:10.1006/jcph.2000.6567,
@@ -128,7 +129,7 @@ namespace aspect
         //Simplify calculation by reducing to case of d<=0
         if (d>0.0)
           {
-            return 1.0-compute_fluid_fraction<dim>(-normal, -d);
+            return 1.0-compute_fluid_fraction(-normal, -d);
           }
 
         //Get 1-Norm
@@ -211,9 +212,10 @@ namespace aspect
         return 0.5*(2.0*dtest+1.0-m12)/nnormal[2];
       }
 
-      template<>
-      double compute_interface_location<3> (const Tensor<1, 3, double> normal,
-                                            const double vol)
+
+
+      double compute_interface_location (const Tensor<1, 3, double> normal,
+                                         const double vol)
       {
         // Calculations done by Scardovelli and Zaleski in
         // doi:10.1006/jcph.2000.6567,
@@ -222,7 +224,7 @@ namespace aspect
         // Simplify to vol<0.5 case
         if (vol>0.5)
           {
-            return -compute_interface_location<dim>(-normal, 1.0-vol);
+            return -compute_interface_location(-normal, 1.0-vol);
           }
 
         //Get 1-Norm
@@ -332,12 +334,13 @@ namespace aspect
         return -0.5+m1*vol+0.5*m12;
       }
 
-      template<>
-      void xFEM_Heaviside<2>(const unsigned int degree,
-                             const Tensor<1, 2> normal,
-                             const double d,
-                             const std::vector<Point<2>> &points,
-                             std::vector<double> &values)
+
+
+      void xFEM_Heaviside(const unsigned int degree,
+                          const Tensor<1, 2> normal,
+                          const double d,
+                          const std::vector<Point<2>> &points,
+                          std::vector<double> &values)
       {
         const int basis_count=4;
         std::vector<double> coeffs(basis_count);
@@ -430,22 +433,24 @@ namespace aspect
           }
       }
 
-      template<>
-      void xFEM_Heaviside<3>(const unsigned int /*degree*/,
-                             const Tensor<1, 3> /*normal*/,
-                             const double /*d*/,
-                             const std::vector<Point<3>> &/*points*/,
-                             std::vector<double> &/*values*/)
+
+
+      void xFEM_Heaviside(const unsigned int /*degree*/,
+                          const Tensor<1, 3> /*normal*/,
+                          const double /*d*/,
+                          const std::vector<Point<3>> &/*points*/,
+                          std::vector<double> &/*values*/)
       {
         AssertThrow(false, ExcNotImplemented());
       }
 
-      template<>
-      void xFEM_Heaviside_derivative_d<2>(const unsigned int degree,
-                                          const Tensor<1, 2> normal,
-                                          const double d,
-                                          const std::vector<Point<2>> &points,
-                                          std::vector<double> &values)
+
+
+      void xFEM_Heaviside_derivative_d(const unsigned int degree,
+                                       const Tensor<1, 2> normal,
+                                       const double d,
+                                       const std::vector<Point<2>> &points,
+                                       std::vector<double> &values)
       {
         const int basis_count=4;
         std::vector<double> coeffs(basis_count);
@@ -537,15 +542,17 @@ namespace aspect
           }
       }
 
-      template<>
-      void xFEM_Heaviside_derivative_d<3>(const unsigned int /*degree*/,
-                                          const Tensor<1, 3> /*normal*/,
-                                          const double /*d*/,
-                                          const std::vector<Point<3>> &/*points*/,
-                                          std::vector<double> &/*values*/)
+
+
+      void xFEM_Heaviside_derivative_d(const unsigned int /*degree*/,
+                                       const Tensor<1, 3> /*normal*/,
+                                       const double /*d*/,
+                                       const std::vector<Point<3>> &/*points*/,
+                                       std::vector<double> &/*values*/)
       {
         AssertThrow(false, ExcNotImplemented());
       }
+
 
 
       template<int dim>

--- a/tests/vof_err_calc.h
+++ b/tests/vof_err_calc.h
@@ -306,14 +306,14 @@ namespace aspect
                   grad_t[di] = (dL - dH);
                   d_t += (0.5 / dim) * (dH + dL);
                 }
-              const double solution_fluid_fraction_at_point = VolumeOfFluid::Utilities::compute_fluid_fraction<dim> (grad_t, d_t);
+              const double solution_fluid_fraction_at_point = VolumeOfFluid::Utilities::compute_fluid_fraction (grad_t, d_t);
               volume_of_fluid_reinit += solution_fluid_fraction_at_point*(fe_err.JxW (i) / cell_vol);
               for (unsigned int di = 0; di < dim; ++di)
                 {
                   xU[di] -= 0.5;
                 }
               const double dot = normal * xU;
-              const double computed_fluid_fraction_at_point = VolumeOfFluid::Utilities::compute_fluid_fraction<dim> (h * normal,
+              const double computed_fluid_fraction_at_point = VolumeOfFluid::Utilities::compute_fluid_fraction (h * normal,
                                                               (d_compute - dot));
               const double diff = abs (solution_fluid_fraction_at_point - computed_fluid_fraction_at_point);
               val += diff * fe_err.JxW (i);


### PR DESCRIPTION
I think @tjhei was also working on this, but I haven't seen his patch posted yet and mine was nearly ready. So here it goes: Use overloads instead of explicit specializations to avoid having to use declarations of the explicit specializations. The previous code was wrong according to the C++ standard, but most compilers accept it anyway.

/rebuild