### PR TITLE
github-actions: test no-unity build and unittests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,7 +4,8 @@ on: [push, pull_request]
 
 jobs:
   linux-nounity:
-    name: linux build with unity build
+    #linux build with unity/precomiled headers disabled
+    name: no-unity
     runs-on: [ubuntu-18.04]
 
     steps:
@@ -24,7 +25,8 @@ jobs:
         ./aspect --test
 
   linux:
-    name: linux build including indent and documentation
+    #linux build including indent and documentation
+    name: indent+documentation
     runs-on: [ubuntu-18.04]
 
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,8 +3,28 @@ name: linux
 on: [push, pull_request]
 
 jobs:
+  linux-nounity:
+    name: linux build with unity build
+    runs-on: [ubuntu-18.04]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup
+      run: |
+        sudo apt-get install -y software-properties-common
+        sudo add-apt-repository ppa:ginggs/deal.ii-9.2.0-backports
+        sudo apt-get update
+        sudo apt-get install -yq --no-install-recommends libdeal.ii-dev
+    - name: compile
+      run: |
+        mkdir build-no-unity
+        cd build-no-unity
+        cmake -D ASPECT_PRECOMPILE_HEADERS=OFF -D ASPECT_UNITY_BUILD=OFF ..
+        make -j 2
+        ./aspect --test
+
   linux:
-    name: linux build
+    name: linux build including indent and documentation
     runs-on: [ubuntu-18.04]
 
     steps:
@@ -34,6 +54,7 @@ jobs:
         cd build
         cmake -D ASPECT_PRECOMPILE_HEADERS=ON -D ASPECT_UNITY_BUILD=ON ..
         make -j 2
+        ./aspect --test
     - name: doc
       run: |
         cd doc


### PR DESCRIPTION
- add second github actions to do a build without unity/precompiled
header
- also run the unittests

as discussed with @gassmoeller 