### PR TITLE
jenkins: remove unity build

### DIFF
--- a/Jenkinsfile.cig
+++ b/Jenkinsfile.cig
@@ -66,56 +66,30 @@ pipeline {
       }
     }
 
-    stage('Unity Build') {
+    stage('Build') {
       options {
         timeout(time: 30, unit: 'MINUTES')
       }
       steps {
         sh '''
-        # running cmake for unity build...
-        mkdir build-gcc-unity
-        cd build-gcc-unity
-
-        # Set up build system and compile ASPECT
-        cmake \
-        -G Ninja \
-        -D ASPECT_UNITY_BUILD=ON \
-        -D ASPECT_PRECOMPILE_HEADERS=ON \
-        ..
-        '''
-
-        sh '''
-        # executing unity build...
-        cd build-gcc-unity
-        ninja
-        '''
-      }
-    }
-
-    stage('Build') {
-      options {
-        timeout(time: 60, unit: 'MINUTES')
-      }
-      steps {
-        sh '''
         # running cmake...
-        mkdir build-gcc-fast
-        cd build-gcc-fast
+        mkdir build
+        cd build
 
         cmake \
         -G 'Ninja' \
         -D CMAKE_CXX_FLAGS='-Werror --coverage' \
         -D ASPECT_TEST_GENERATOR='Ninja' \
-        -D ASPECT_PRECOMPILE_HEADERS=OFF \
-        -D ASPECT_UNITY_BUILD=OFF \
-        -D ASPECT_USE_PETSC='OFF' \
+        -D ASPECT_PRECOMPILE_HEADERS=ON \
+        -D ASPECT_UNITY_BUILD=ON \
+        -D ASPECT_USE_PETSC=OFF \
         -D ASPECT_RUN_ALL_TESTS='ON' \
         ..
         '''
 
         sh '''
         # compiling...
-        cd build-gcc-fast
+        cd build
         ninja
         '''
       }
@@ -123,7 +97,7 @@ pipeline {
 
     stage('Build Documentation') {
       steps {
-        sh 'cd doc && ./update_parameters.sh ./build-gcc-fast/aspect'
+        sh 'cd doc && ./update_parameters.sh ./build/aspect'
         sh 'cd doc && make manual.pdf || touch ~/FAILED-DOC'
         archiveArtifacts artifacts: 'doc/manual/manual.log', allowEmptyArchive: true
         sh 'if [ -f ~/FAILED-DOC ]; then exit 1; fi'
@@ -136,7 +110,7 @@ pipeline {
       }
       steps {
         sh '''
-        export BUILDDIR=`pwd`/build-gcc-fast
+        export BUILDDIR=`pwd`/build
         export NP=`grep -c ^processor /proc/cpuinfo`
         cd cookbooks && make -f check.mk CHECK=--validate BUILD=$BUILDDIR -j $NP
         cd ..
@@ -161,7 +135,7 @@ pipeline {
         // most efficient way to build the tests).
         sh '''
         # prebuilding tests...
-        cd build-gcc-fast/tests
+        cd build/tests
         ninja -k 0 tests || true
         '''
 
@@ -172,7 +146,7 @@ pipeline {
         // does not support running ctest with -j.
         sh '''
         # generating test results...
-        cd build-gcc-fast
+        cd build
         ctest \
         --no-compress-output \
         --test-action Test \
@@ -185,12 +159,12 @@ pipeline {
           xunit testTimeMargin: '3000',
           thresholdMode: 1,
           thresholds: [failed(), skipped()],
-          tools: [CTest(pattern: 'build-gcc-fast/Testing/**/*.xml')]
+          tools: [CTest(pattern: 'build/Testing/**/*.xml')]
 
           // Update the reference test output with the new test results
           sh '''
           # generating reference output...
-          cd build-gcc-fast
+          cd build
           ninja generate_reference_output
           '''
 
@@ -203,7 +177,7 @@ pipeline {
         success {
           // post the coverage results to coveralls if the build and testing succeeded
           sh '''
-          cd build-gcc-fast
+          cd build
           coveralls -r ../ -b . -i source --gcov-options '\\-lp'
           '''
         }

--- a/tests/cmake/default
+++ b/tests/cmake/default
@@ -31,5 +31,12 @@ while ( <STDIN> )
 	$skip=1;
     }
 
+    if ($_ =~ m/^Stacktrace:/)
+    {
+	print "$_";
+	print "(rest of the output replaced by default.sh script)\n";
+	last;
+    }
+
     print "$_";
 }

--- a/tests/zero_matrix/screen-output
+++ b/tests/zero_matrix/screen-output
@@ -43,15 +43,4 @@ There are two common cases where this situation happens. First, your code (or so
 In any case, when trying to find the source of the error, recall that the location where you are getting this error is simply the first place in the program where there is a check that a number (e.g., an element of a solution vector) is in fact finite, but that the actual error that computed the number may have happened far earlier. To find this location, you may want to add checks for finiteness in places of your program visited before the place where this error is produced. One way to check for finiteness is to use the 'AssertIsFinite' macro.
 
 Stacktrace:
-#0  ASPECT_DIR/build-gcc-fast/aspect: dealii::TrilinosWrappers::MPI::Vector::add(double, dealii::TrilinosWrappers::MPI::Vector const&)
-#1  ASPECT_DIR/build-gcc-fast/aspect: dealii::TrilinosWrappers::MPI::Vector::add_and_dot(double, dealii::TrilinosWrappers::MPI::Vector const&, dealii::TrilinosWrappers::MPI::Vector const&)
-#2  ASPECT_DIR/build-gcc-fast/aspect: dealii::SolverGMRES<dealii::TrilinosWrappers::MPI::Vector>::modified_gram_schmidt(dealii::internal::SolverGMRESImplementation::TmpVectors<dealii::TrilinosWrappers::MPI::Vector> const&, unsigned int, unsigned int, dealii::TrilinosWrappers::MPI::Vector&, dealii::Vector<double>&, bool&, boost::signals2::signal<void (int), boost::signals2::optional_last_value<void>, int, std::less<int>, boost::function<void (int)>, boost::function<void (boost::signals2::connection const&, int)>, boost::signals2::mutex> const&)
-#3  ASPECT_DIR/build-gcc-fast/aspect: void dealii::SolverGMRES<dealii::TrilinosWrappers::MPI::Vector>::solve<dealii::TrilinosWrappers::SparseMatrix, dealii::TrilinosWrappers::PreconditionILU>(dealii::TrilinosWrappers::SparseMatrix const&, dealii::TrilinosWrappers::MPI::Vector&, dealii::TrilinosWrappers::MPI::Vector const&, dealii::TrilinosWrappers::PreconditionILU const&)
-#4  ASPECT_DIR/build-gcc-fast/aspect: aspect::Simulator<2>::solve_advection(aspect::Simulator<2>::AdvectionField const&)
-#5  ASPECT_DIR/build-gcc-fast/aspect: aspect::Simulator<2>::assemble_and_solve_temperature(bool, double*)
-#6  ASPECT_DIR/build-gcc-fast/aspect: aspect::Simulator<2>::solve_single_advection_iterated_stokes()
-#7  ASPECT_DIR/build-gcc-fast/aspect: aspect::Simulator<2>::solve_timestep()
-#8  ASPECT_DIR/build-gcc-fast/aspect: aspect::Simulator<2>::run()
-#9  ASPECT_DIR/build-gcc-fast/aspect: void run_simulator<2>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, bool, bool)
-#10  ASPECT_DIR/build-gcc-fast/aspect: main
-
+(rest of the output replaced by default.sh script)


### PR DESCRIPTION
We added the unity build to github actions in #3636, so we can remove it
from Jenkins to improve CI times:
- remove unity build from both jenkins
- take over some changes from cig->tjhei
- rename build directory

part of #3630