### PR TITLE
unity: move some files to the end

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,21 @@ SET(TARGET "aspect")
 FILE(GLOB_RECURSE TARGET_SRC
      "source/*.cc" "unit_tests/*.cc" "include/*.h" "contrib/catch/catch.hpp")
 
-# For the unity build we need to compile helper_functions.cc before core.cc
-# ensure this by reordering the files
-FIND_FILE(HELPER_PATH helper_functions.cc HINTS "${CMAKE_SOURCE_DIR}/source/simulator")
-LIST(REMOVE_ITEM TARGET_SRC ${HELPER_PATH})
-LIST(INSERT TARGET_SRC 0 ${HELPER_PATH})
+# special treatment of some files for unity builds:
+LIST(APPEND UNITY_LAST_FILES
+	"source/simulator/core.cc;source/volume_of_fluid/handler.cc")
+
+# Fine the files listed above and move them to the end of the list:
+FOREACH(_source_file ${UNITY_LAST_FILES})
+  SET(_full_name "${CMAKE_SOURCE_DIR}/${_source_file}")
+  LIST(FIND TARGET_SRC ${_full_name} _index)
+  IF(_index EQUAL -1)
+    MESSAGE(FATAL_ERROR "could not find ${_full_name}.")
+  ENDIF()
+
+  LIST(REMOVE_ITEM TARGET_SRC ${_full_name})
+  LIST(APPEND TARGET_SRC ${_full_name})
+ENDFOREACH()
 
 # Set up include directories. Put the ASPECT header files
 # to the front of the list, whereas the 'catch' headers can

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,14 @@ SET(TARGET "aspect")
 FILE(GLOB_RECURSE TARGET_SRC
      "source/*.cc" "unit_tests/*.cc" "include/*.h" "contrib/catch/catch.hpp")
 
-# special treatment of some files for unity builds:
-LIST(APPEND UNITY_LAST_FILES
-	"source/simulator/core.cc;source/volume_of_fluid/handler.cc")
+# Special treatment of some files for unity builds. We move the following
+# files to the end of the list of all .cc files (TARGET_SRC). This ordering is
+# required to not have specializations (for example helper_functions.cc)
+# appear after explicit class instantiation (for example core.cc) of the same
+# class that happen to be included in the same unity cxx file.
+SET(UNITY_LAST_FILES
+  "source/simulator/core.cc;source/volume_of_fluid/handler.cc")
 
-# Fine the files listed above and move them to the end of the list:
 FOREACH(_source_file ${UNITY_LAST_FILES})
   SET(_full_name "${CMAKE_SOURCE_DIR}/${_source_file}")
   LIST(FIND TARGET_SRC ${_full_name} _index)


### PR DESCRIPTION
This should fix instantiation warnings/errors

part of #3633
fixes #3651 
closes #3650 (better alternative)
related to #3637