### PR TITLE
Remove unused input parameter

### DIFF
--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -670,8 +670,6 @@ namespace aspect
           Rheology::Elasticity<dim>::declare_parameters (prm);
 
           // Reference and minimum/maximum values
-          prm.declare_entry ("Reference temperature", "293.", Patterns::Double (0.),
-                             "For calculating density by thermal expansivity. Units: $\\si{K}$");
           prm.declare_entry ("Minimum strain rate", "1.0e-20", Patterns::Double (0.),
                              "Stabilizes strain dependent viscosity. Units: $1 / s$");
           prm.declare_entry ("Reference strain rate","1.0e-15",Patterns::Double (0.),


### PR DESCRIPTION
This parameter is declared twice, once in `EquationOfState::MulticomponentIncompressible<dim>::declare_parameters (prm);` (a few lines above) and again here. It is not actually used in `ViscoPlastic`, so remove it.