### PR TITLE
Fix .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@
 /benchmarks/tangurnis/*/solution*
 /build*/
 /cmake_install.cmake
-/cookbooks/**/**.prm.out
+/cookbooks/**/*.prm.out
 /cookbooks/**/lib*.so
 /cookbooks/**/Makefile
 /cookbooks/**/aspect


### PR DESCRIPTION
We really do just one `*`, `**` is for recursive matching of directories.