### PR TITLE
markup for units in composition reaction

### DIFF
--- a/doc/manual/parameters.tex
+++ b/doc/manual/parameters.tex
@@ -8836,7 +8836,7 @@ Viscous stress may also be limited by a non-linear stress limiter that has a for
 {\it Default:} 0.
 
 
-{\it Description:} Above this depth the compositional fields react: The first field gets converted to the second field. Units: $m$.
+{\it Description:} Above this depth the compositional fields react: The first field gets converted to the second field. Units: \si{\meter}.
 
 
 {\it Possible values:} A floating point number $v$ such that $0 \leq v \leq \text{MAX\_DOUBLE}$
@@ -8887,7 +8887,7 @@ Viscous stress may also be limited by a non-linear stress limiter that has a for
 {\it Default:} 293.
 
 
-{\it Description:} The reference temperature $T_0$. Units: $\si{K}$.
+{\it Description:} The reference temperature $T_0$. Units: \si{\kelvin}.
 
 
 {\it Possible values:} A floating point number $v$ such that $0 \leq v \leq \text{MAX\_DOUBLE}$
@@ -8904,7 +8904,7 @@ Viscous stress may also be limited by a non-linear stress limiter that has a for
 {\it Default:} 4.7
 
 
-{\it Description:} The value of the thermal conductivity $k$. Units: $W/m/K$.
+{\it Description:} The value of the thermal conductivity $k$. Units: \si{\watt\per\meter\per\kelvin}.
 
 
 {\it Possible values:} A floating point number $v$ such that $0 \leq v \leq \text{MAX\_DOUBLE}$
@@ -8955,7 +8955,7 @@ Viscous stress may also be limited by a non-linear stress limiter that has a for
 {\it Default:} 5e24
 
 
-{\it Description:} The value of the constant viscosity. Units: $kg/m/s$.
+{\it Description:} The value of the constant viscosity. Units: \si{\kilo\gram\per\meter\per\second}.
 
 
 {\it Possible values:} A floating point number $v$ such that $0 \leq v \leq \text{MAX\_DOUBLE}$
@@ -14974,7 +14974,7 @@ Units: $Pa \, s$
 {\it Default:} 293.
 
 
-{\it Description:} For calculating density by thermal expansivity. Units: $\si{K}$
+{\it Description:} The reference temperature $T_0$. Units: $\si{K}$.
 
 
 {\it Possible values:} A floating point number $v$ such that $0 \leq v \leq \text{MAX\_DOUBLE}$

--- a/source/material_model/composition_reaction.cc
+++ b/source/material_model/composition_reaction.cc
@@ -152,10 +152,10 @@ namespace aspect
 
           prm.declare_entry ("Reference temperature", "293.",
                              Patterns::Double (0.),
-                             "The reference temperature $T_0$. Units: $\\si{K}$.");
+                             "The reference temperature $T_0$. Units: \\si{\\kelvin}.");
           prm.declare_entry ("Viscosity", "5e24",
                              Patterns::Double (0.),
-                             "The value of the constant viscosity. Units: $kg/m/s$.");
+                             "The value of the constant viscosity. Units: \\si{\\kilo\\gram\\per\\meter\\per\\second}.");
           prm.declare_entry ("Composition viscosity prefactor 1", "1.0",
                              Patterns::Double (0.),
                              "A linear dependency of viscosity on the first compositional field. "
@@ -172,12 +172,12 @@ namespace aspect
           prm.declare_entry ("Thermal conductivity", "4.7",
                              Patterns::Double (0.),
                              "The value of the thermal conductivity $k$. "
-                             "Units: $W/m/K$.");
+                             "Units: \\si{\\watt\\per\\meter\\per\\kelvin}.");
           prm.declare_entry ("Reaction depth", "0.",
                              Patterns::Double (0.),
                              "Above this depth the compositional fields react: "
                              "The first field gets converted to the second field. "
-                             "Units: $m$.");
+                             "Units: \\si{\\meter}.");
         }
         prm.leave_subsection();
       }


### PR DESCRIPTION
This PR starts to address Issue #3046 by using proper markup for units in parameter descriptions, using the latex package siunitx (already a dependency for the manual).

Currently, this PR has only changed the descriptions in composition_reaction.cc. 
If this method is approved, then I'll work on doing the same for the other descriptions.
