### PR TITLE
Fix an error message in normalize.pl.

### DIFF
--- a/tests/normalize.pl
+++ b/tests/normalize.pl
@@ -18,7 +18,7 @@
 $infilename = shift;
 $aspect_src_dir = shift;
 
-open my $in,  '<', $infilename or die "Can't read file: $!";
+open my $in,  '<', $infilename or die "Can't read file: $infilename!";
 
 while (<$in>)
 {


### PR DESCRIPTION
The current version happens to not show the file that can't be opened, and leads to a rather
confusing error message that took me a good long while to understand.
