### PR TITLE
Fixes and updates to citing_aspect.bib

### DIFF
--- a/doc/manual/citing_aspect.bib
+++ b/doc/manual/citing_aspect.bib
@@ -233,7 +233,7 @@ year = {2017}
   publisher={Nature Publishing Group}
 }
 @article{ONeill2018inception,
-  doi={10.1098/rsta.2017.0414}
+  doi={10.1098/rsta.2017.0414},
   title={The inception of plate tectonics: a record of failure},
   author={O'Neill, Craig and Turner, Simon and Rushmer, Tracy},
   journal={Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences},
@@ -337,7 +337,7 @@ title = {{ASPECT: Advanced Solver for Problems in Earth's ConvecTion}},
 url = {http://aspect.dealii.org/},
 year = {2015}
 }
-@techreport{Bangerth2017a,
+@Misc{Bangerth2017a,
 abstract = {This is the manual of the ASPECT mantle convection code},
 author = {Bangerth, Wolfgang and Dannberg, Juliane and Gassmoeller, Rene and Heister, Timo and Others},
 doi = {10.6084/M9.FIGSHARE.4865333},
@@ -497,7 +497,7 @@ year = {2018}
 }
 
 @article{gassmoller2019evaluating,
-  doi = {10.1093/gji/ggz405}
+  doi = {10.1093/gji/ggz405},
   title={Evaluating the accuracy of hybrid finite element/particle-in-cell methods for modelling incompressible Stokes flow},
   author={Gassm{\"o}ller, Rene and Lokavarapu, Harsha and Bangerth, Wolfgang and Puckett, Elbridge Gerry},
   journal={Geophysical Journal International},
@@ -514,6 +514,7 @@ year = {2018}
   title={On the Design, Implementation, and Use of a Volume-of-fluid Interface Tracking Algorithm for Modeling Convection and Other Processes in the Earth’s Mantle},
   journal={ProQuest Dissertations and Theses},
   pages={145},
+	school={University of California, Davis},
   note={Copyright - Database copyright ProQuest LLC; ProQuest does not claim copyright in the individual underlying works; Last updated - 2019-11-04},
   keywords={Geodynamics; Interface Tracking; Volume-of-fluid; Applied mathematics; 0364:Applied Mathematics},
   isbn={9781392640074},
@@ -735,17 +736,19 @@ opturl="http://www.nature.com/articles/s41467-020-16176-x"
 
 @article{doi:10.1029/2020GC008935,
 author = {Muluneh, Ameha A. and Brune, Sascha and Illsley-Kemp, Finnigan and Corti, Giacomo and Keir, Derek and Glerum, Anne and Kidane, Tesfaye and Mori, Jim},
-title = {Mechanism for deep crustal seismicity: Insight from modeling of deformation process at the Main Ethiopian Rift},
+title = {Mechanism for Deep Crustal Seismicity: Insight From Modeling of Deformation Processes at the Main Ethiopian Rift},
 journal = {Geochemistry, Geophysics, Geosystems},
-volume = {n/a},
-number = {n/a},
+volume = {21},
+number = {7},
 pages = {e2020GC008935},
-keywords = {Numerical Modeling, Earthquakes, Main Ethiopian Rift, Strain rate},
+keywords = {numerical modeling, earthquakes, Main Ethiopian Rift, strain rate},
 doi = {10.1029/2020GC008935},
 url = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2020GC008935},
 eprint = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2020GC008935},
-note = {e2020GC008935 2020GC008935},
-abstract = {Abstract We combine numerical modeling of lithospheric extension with analysis of seismic moment release and earthquake b-value in order to elucidate the mechanism for deep crustal seismicity and seismic swarms in the Main Ethiopian Rift (MER). We run 2D numerical simulations of lithospheric deformation calibrated by appropriate rheology and extensional history of the MER to simulate migration of deformation from mid-Miocene border faults to ~30 km wide zone of Pliocene to recent rift floor faults. While the highest strain rate is localized in a narrow zone within the rift axis, brittle strain has been accumulated in a wide region of the rift. The magnitude of deviatoric stress shows strong variation with depth. The uppermost crust deforms with maximum stress of 80 MPa, at 8-14 km depth stress sharply decreases to 10 MPa and then increases to a maximum of 160 MPa at ~18 km depth. These 2 peaks at which the crust deforms with maximum stress of 80 MPa or above correspond to peaks in the seismic moment release. Correspondingly, the drop in stress at 8-14 km correlates to a low in seismic moment release. At this depth range, the crust is weaker and deformation is mainly accommodated in a ductile manner. We therefore see a good correlation between depths at which the crust is strong and elevated seismic deformation, while regions where the crust is weaker deform more aseismically. Overall the bimodal depth distribution of seismic moment release is best explained by rheology of the deforming crust.}
+note = {e2020GC008935 10.1029/2020GC008935},
+abstract = {Abstract We combine numerical modeling of lithospheric extension with analysis of seismic moment release and earthquake b-value in order to elucidate the mechanism for deep crustal seismicity and seismic swarms in the Main Ethiopian Rift (MER). We run 2-D numerical simulations of lithospheric deformation calibrated by appropriate rheology and extensional history of the MER to simulate migration of deformation from mid-Miocene border faults to ∼30 km wide zone of Pliocene to recent rift floor faults. While currently the highest strain rate is localized in a narrow zone within the rift axis, brittle strain has been accumulated in a wide region of the rift. The magnitude of deviatoric stress shows strong variation with depth. The uppermost crust deforms with maximum stress of 80 MPa, at 8–14 km depth stress sharply decreases to 10 MPa and then increases to a maximum of 160 MPa at ∼18 km depth. These two peaks at which the crust deforms with maximum stress of 80 MPa or above correspond to peaks in the seismic moment release. Correspondingly, the drop in stress at 8–14 km correlates to a low in seismic moment release. At this depth range, the crust is weaker and deformation is mainly accommodated in a ductile manner. We therefore see a good correlation between depths at which the crust is strong and elevated seismic deformation, while regions where the crust is weaker deform more aseismically. Overall, the bimodal depth distribution of seismic moment release is best explained by the rheology of the deforming crust.},
+year = {2020}
+}
 
 @Article{Naliboff_etal2020,
 author="Naliboff, J.B.


### PR DESCRIPTION
This has a numerous miscellaneous corrections discovered while parsing the citing_aspect.bib file. 

Changes include:
- adding missing commas in multiple places
- adding 'school' attribute to Robey Thesis
- changing Bangerth2017a from type techreport to misc to be consistent with figshare (note consistent with manual.bib)
- updated Muluneh 2020
