### PR TITLE
Introduce TimeStepping::Manager

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -61,7 +61,7 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #include <aspect/boundary_fluid_pressure/interface.h>
 #include <aspect/boundary_traction/interface.h>
 #include <aspect/mesh_refinement/interface.h>
-#include <aspect/termination_criteria/interface.h>
+#include <aspect/time_stepping/interface.h>
 #include <aspect/postprocess/interface.h>
 #include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/particle/world.h>
@@ -1467,14 +1467,14 @@ namespace aspect
       void maybe_write_timing_output () const;
 
       /**
-       * Check if a checkpoint should be written in this timestep. Is so create
+       * Check if a checkpoint should be written in this timestep. If so create
        * one. Returns whether a checkpoint was written.
        *
        * This function is implemented in
        * <code>source/simulator/helper_functions.cc</code>.
        */
       bool maybe_write_checkpoint (const time_t last_checkpoint_time,
-                                   const std::pair<bool,bool> termination_output);
+                                   const bool force_writing_checkpoint);
 
       /**
        * Check if we should do an initial refinement cycle in this timestep.
@@ -1504,18 +1504,6 @@ namespace aspect
        */
       void maybe_refine_mesh (const double new_time_step,
                               unsigned int &max_refinement_level);
-
-      /**
-       * Compute the size of the next time step from the mesh size and the
-       * velocity on each cell. The computed time step has to satisfy the CFL
-       * number chosen in the input parameter file on each cell of the mesh.
-       * If specified in the parameter file, the time step will be the minimum
-       * of the convection *and* conduction time steps.
-       *
-       * This function is implemented in
-       * <code>source/simulator/helper_functions.cc</code>.
-       */
-      double compute_time_step () const;
 
       /**
        * Advance the current time by the given @p step_size and update the
@@ -1835,10 +1823,10 @@ namespace aspect
        */
 
       /**
-       * @name Variables related to simulation termination
+       * @name Variables related to simulation time stepping
        * @{
        */
-      TerminationCriteria::Manager<dim>                         termination_manager;
+      TimeStepping::Manager<dim>                                time_stepping_manager;
       /**
        * @}
        */

--- a/include/aspect/termination_criteria/interface.h
+++ b/include/aspect/termination_criteria/interface.h
@@ -160,10 +160,8 @@ namespace aspect
          * Execute all of the termination criteria objects that have been
          * requested in the input file.
          *
-         * The function returns a pair of values. The first part of the
-         * returned pair indicates whether the simulation should be
-         * terminated. The second part indicates whether a final checkpoint
-         * should be performed.
+         * The function returns a bool indicating whether the simulation should be
+         * terminated.
          *
          * To avoid undefined situations, this function only requires that a
          * single processor's termination request comes back positive for a
@@ -172,7 +170,7 @@ namespace aspect
          * that the simulation should be terminated, then this is enough.
          */
         virtual
-        std::pair<bool,bool>
+        bool
         execute () const;
 
         /**
@@ -264,11 +262,6 @@ namespace aspect
          */
         std::list<std::string>                       termination_obj_names;
 
-        /**
-         * Whether to do a final checkpoint before termination. This is
-         * specified in the parameters.
-         */
-        bool do_checkpoint_on_terminate;
     };
 
 

--- a/include/aspect/time_stepping/interface.h
+++ b/include/aspect/time_stepping/interface.h
@@ -1,0 +1,101 @@
+/*
+  Copyright (C) 2019 - 2020 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef _aspect_time_stepping_interface_h
+#define _aspect_time_stepping_interface_h
+
+#include <aspect/global.h>
+#include <aspect/simulator_access.h>
+#include <aspect/termination_criteria/interface.h>
+
+namespace aspect
+{
+  using namespace dealii;
+
+  namespace TimeStepping
+  {
+
+    /**
+     * A class to handle computation of the next time step (as desired by the user) and
+     * checking if the simulation is finished.
+     */
+    template <int dim>
+    class Manager : public SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * Override initialize_simulator() so that we can also initialize the contained
+         * termination_manager.
+         */
+        virtual void initialize_simulator (const Simulator<dim> &simulator_object) override;
+
+        /**
+         * Compute the size of the next time step potentially taking into account
+         * the current solution (convection time step, conduction time step), settings
+         * from parameters, and termination criteria (to hit the end time exactly).
+         */
+        double compute_time_step_size() const;
+
+        /**
+         * If true, the simulator should perform a checkpoint before terminating.
+         */
+        bool need_checkpoint_on_terminate() const;
+
+        /**
+         * Check if the simulation is ready to terminate sucessfully.
+         */
+        bool should_simulation_terminate_now() const;
+
+        /**
+         * Declare the parameters of all known termination criteria plugins,
+         * as well as of ones this class has itself.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         * This determines which termination criteria objects will be created;
+         * then let these objects read their parameters as well.
+         */
+        void
+        parse_parameters (ParameterHandler &prm);
+
+      private:
+
+        /**
+         * Whether to do a final checkpoint before termination. This is
+         * specified in the parameters.
+         */
+        bool do_checkpoint_on_terminate;
+
+        /**
+         * The termination manager keeps track of the termination plugins and we use
+         * it to determine the time_step size in the final time step.
+         */
+        TerminationCriteria::Manager<dim> termination_manager;
+    };
+
+  }
+}
+
+#endif

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -2085,7 +2085,7 @@ namespace aspect
     MeshDeformation::MeshDeformationHandler<dim>::declare_parameters (prm);
     Postprocess::Manager<dim>::declare_parameters (prm);
     MeshRefinement::Manager<dim>::declare_parameters (prm);
-    TerminationCriteria::Manager<dim>::declare_parameters (prm);
+    TimeStepping::Manager<dim>::declare_parameters (prm);
     MaterialModel::declare_parameters<dim> (prm);
     HeatingModel::Manager<dim>::declare_parameters (prm);
     GeometryModel::declare_parameters <dim>(prm);

--- a/source/termination_criteria/interface.cc
+++ b/source/termination_criteria/interface.cc
@@ -81,7 +81,7 @@ namespace aspect
     }
 
     template <int dim>
-    std::pair<bool,bool>
+    bool
     Manager<dim>::execute () const
     {
       bool terminate_simulation = false;
@@ -157,8 +157,7 @@ namespace aspect
             }
         }
 
-      return std::make_pair (terminate_simulation,
-                             do_checkpoint_on_terminate);
+      return terminate_simulation;
     }
 
 
@@ -184,11 +183,6 @@ namespace aspect
       // choose from
       prm.enter_subsection("Termination criteria");
       {
-        // Whether to checkpoint the simulation right before termination
-        prm.declare_entry("Checkpoint on termination", "false",
-                          Patterns::Bool (),
-                          "Whether to checkpoint the simulation right before termination.");
-
         // construct a string for Patterns::MultipleSelection that
         // contains the names of all registered termination criteria
         const std::string pattern_of_names
@@ -224,8 +218,6 @@ namespace aspect
       std::vector<std::string> plugin_names;
       prm.enter_subsection("Termination criteria");
       {
-        do_checkpoint_on_terminate = prm.get_bool("Checkpoint on termination");
-
         plugin_names = Utilities::split_string_list(prm.get("Termination criteria"));
         AssertThrow(Utilities::has_unique_entries(plugin_names),
                     ExcMessage("The list of strings for the parameter "

--- a/source/time_stepping/interface.cc
+++ b/source/time_stepping/interface.cc
@@ -1,0 +1,261 @@
+/*
+  Copyright (C) 2019 - 2020 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <aspect/time_stepping/interface.h>
+#include <aspect/simulator.h>
+
+namespace aspect
+{
+  namespace TimeStepping
+  {
+
+    template <int dim>
+    double
+    Manager<dim>::
+    compute_time_step_size() const
+    {
+      const QIterated<dim> quadrature_formula (QTrapez<1>(),
+                                               this->get_parameters().stokes_velocity_degree);
+
+      FEValues<dim> fe_values (this->get_mapping(),
+                               this->get_fe(),
+                               quadrature_formula,
+                               update_values |
+                               update_gradients |
+                               ((this->get_parameters().use_conduction_timestep || this->get_parameters().include_melt_transport)
+                                ?
+                                update_quadrature_points
+                                :
+                                update_default));
+
+      const unsigned int n_q_points = quadrature_formula.size();
+
+
+      std::vector<Tensor<1,dim> > velocity_values(n_q_points);
+      std::vector<Tensor<1,dim> > fluid_velocity_values(n_q_points);
+      std::vector<std::vector<double> > composition_values (this->introspection().n_compositional_fields,std::vector<double> (n_q_points));
+
+      double max_local_speed_over_meshsize = 0;
+      double min_local_conduction_timestep = std::numeric_limits<double>::max();
+
+      MaterialModel::MaterialModelInputs<dim> in(n_q_points,
+                                                 this->introspection().n_compositional_fields);
+      MaterialModel::MaterialModelOutputs<dim> out(n_q_points,
+                                                   this->introspection().n_compositional_fields);
+
+      for (const auto &cell : this->get_dof_handler().active_cell_iterators())
+        if (cell->is_locally_owned())
+          {
+            fe_values.reinit (cell);
+            fe_values[this->introspection().extractors.velocities].get_function_values (this->get_solution(),
+                                                                                        velocity_values);
+
+            double max_local_velocity = 0;
+            for (unsigned int q=0; q<n_q_points; ++q)
+              max_local_velocity = std::max (max_local_velocity,
+                                             velocity_values[q].norm());
+
+            if (this->get_parameters().include_melt_transport)
+              {
+                const FEValuesExtractors::Vector ex_u_f = this->introspection().variable("fluid velocity").extractor_vector();
+                fe_values[ex_u_f].get_function_values (this->get_solution(), fluid_velocity_values);
+
+                for (unsigned int q=0; q<n_q_points; ++q)
+                  max_local_velocity = std::max (max_local_velocity,
+                                                 fluid_velocity_values[q].norm());
+              }
+
+            max_local_speed_over_meshsize = std::max(max_local_speed_over_meshsize,
+                                                     max_local_velocity
+                                                     /
+                                                     cell->minimum_vertex_distance());
+
+            if (this->get_parameters().use_conduction_timestep)
+              {
+                in.reinit(fe_values,
+                          cell,
+                          this->introspection(),
+                          this->get_solution());
+
+                this->get_material_model().evaluate(in, out);
+
+                if (this->get_parameters().formulation_temperature_equation
+                    == Parameters<dim>::Formulation::TemperatureEquation::reference_density_profile)
+                  {
+                    // Overwrite the density by the reference density coming from the
+                    // adiabatic conditions as required by the formulation
+                    for (unsigned int q=0; q<n_q_points; ++q)
+                      out.densities[q] = this->get_adiabatic_conditions().density(in.position[q]);
+                  }
+                else if (this->get_parameters().formulation_temperature_equation
+                         == Parameters<dim>::Formulation::TemperatureEquation::real_density)
+                  {
+                    // use real density
+                  }
+                else
+                  AssertThrow(false, ExcNotImplemented());
+
+
+                // Evaluate thermal diffusivity at each quadrature point and
+                // calculate the corresponding conduction timestep, if applicable
+                for (unsigned int q=0; q<n_q_points; ++q)
+                  {
+                    const double k = out.thermal_conductivities[q];
+                    const double rho = out.densities[q];
+                    const double c_p = out.specific_heat[q];
+
+                    Assert(rho * c_p > 0,
+                           ExcMessage ("The product of density and c_P needs to be a "
+                                       "non-negative quantity."));
+
+                    const double thermal_diffusivity = k/(rho*c_p);
+
+                    if (thermal_diffusivity > 0)
+                      {
+                        min_local_conduction_timestep = std::min(min_local_conduction_timestep,
+                                                                 this->get_parameters().CFL_number*pow(cell->minimum_vertex_distance(),2.)
+                                                                 / thermal_diffusivity);
+                      }
+                  }
+              }
+          }
+
+      const double max_global_speed_over_meshsize
+        = Utilities::MPI::max (max_local_speed_over_meshsize, this->get_mpi_communicator());
+
+      double min_convection_timestep = std::numeric_limits<double>::max();
+      double min_conduction_timestep = std::numeric_limits<double>::max();
+
+      if (max_global_speed_over_meshsize != 0.0)
+        min_convection_timestep = this->get_parameters().CFL_number / (this->get_parameters().temperature_degree * max_global_speed_over_meshsize);
+
+      if (this->get_parameters().use_conduction_timestep)
+        min_conduction_timestep = - Utilities::MPI::max (-min_local_conduction_timestep, this->get_mpi_communicator());
+
+      double new_time_step = std::min(min_convection_timestep,
+                                      min_conduction_timestep);
+
+      AssertThrow (new_time_step > 0,
+                   ExcMessage("The time step length for the each time step needs to be positive, "
+                              "but the computed step length was: " + std::to_string(new_time_step) + ". "
+                              "Please check for non-positive material properties."));
+
+      // Make sure we do not exceed the maximum time step length. This can happen
+      // if velocities get too small or even zero in models that are stably stratified
+      // or use prescribed velocities.
+      new_time_step = std::min(new_time_step, this->get_parameters().maximum_time_step);
+
+      // Make sure that the time step doesn't increase too fast
+      if (this->get_timestep() != 0)
+        new_time_step = std::min(new_time_step, this->get_timestep() + this->get_timestep() * this->get_parameters().maximum_relative_increase_time_step);
+
+      // Make sure we do not exceed the maximum length for the first time step
+      if (this->get_timestep_number() == 0)
+        new_time_step = std::min(new_time_step, this->get_parameters().maximum_first_time_step);
+
+      // Make sure we reduce the time step length appropriately if we terminate after this step
+      return termination_manager.check_for_last_time_step(new_time_step);
+    }
+
+
+
+    template <int dim>
+    bool
+    Manager<dim>::
+    need_checkpoint_on_terminate() const
+    {
+      return do_checkpoint_on_terminate;
+    }
+
+
+
+    template <int dim>
+    bool
+    Manager<dim>::should_simulation_terminate_now() const
+    {
+      return termination_manager.execute();
+    }
+
+
+
+    template <int dim>
+    void
+    Manager<dim>::initialize_simulator (const Simulator<dim> &simulator_object)
+    {
+      SimulatorAccess<dim>::initialize_simulator(simulator_object);
+      termination_manager.initialize_simulator(simulator_object);
+    }
+
+
+
+    template <int dim>
+    void
+    Manager<dim>:: declare_parameters (ParameterHandler &prm)
+    {
+      TerminationCriteria::Manager<dim>::declare_parameters(prm);
+      prm.enter_subsection("Termination criteria");
+      {
+        // Whether to checkpoint the simulation right before termination
+        prm.declare_entry("Checkpoint on termination", "false",
+                          Patterns::Bool (),
+                          "Whether to checkpoint the simulation right before termination.");
+      }
+      prm.leave_subsection();
+
+    }
+
+
+
+    template <int dim>
+    void
+    Manager<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      termination_manager.parse_parameters(prm);
+      prm.enter_subsection("Termination criteria");
+      {
+        do_checkpoint_on_terminate = prm.get_bool("Checkpoint on termination");
+      }
+      prm.leave_subsection();
+    }
+
+  }
+}
+
+
+
+
+// explicit instantiation of the functions we implement in this file
+namespace aspect
+{
+
+  namespace TimeStepping
+  {
+#define INSTANTIATE(dim) \
+  \
+  template \
+  class \
+  Manager<dim>;
+
+    ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
+  }
+}


### PR DESCRIPTION
    This is step 1 of N to introduce a new facility to handle the task to
    determinate time step sizes and allow redoing time steps for various
    reasons.
    This PR creates a new TimeStepping::Manager class without changing
    functionality:
    
    - Introduce TimeStepping::Manager that contains the TerminationManager
    - move do_checkpoint_on_terminate to it
    - simplify core.cc termination handling

part of #3549