### PR TITLE
Improve performance dcpicard and newton solver

### DIFF
--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -376,12 +376,12 @@ namespace aspect
                                                 eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j])
                                                 // assemble \nabla p as -(p, div v):
                                                 - (pressure_scaling *
-                                                   (scratch.div_phi_u[i] * scratch.phi_p[j]))
+                                                   scratch.div_phi_u[i] * scratch.phi_p[j])
                                                 // assemble the term -div(u) as -(div u, q).
                                                 // Note the negative sign to make this
                                                 // operator adjoint to the grad p term:
                                                 - (pressure_scaling *
-                                                   (scratch.phi_p[i] * scratch.div_phi_u[j])))
+                                                   scratch.phi_p[i] * scratch.div_phi_u[j]))
                                               * JxW;
                   }
 
@@ -424,7 +424,7 @@ namespace aspect
                           {
                             data.local_matrix(i,j) += ( derivative_scaling_factor * alpha * (scratch.grads_phi_u[i] * deta_deps_times_eps_times_phi[j]
                                                                                              + scratch.grads_phi_u[j] * deta_deps_times_eps_times_phi[i])
-                                                        + derivative_scaling_factor * pressure_scaling * 2.0 * viscosity_derivative_wrt_pressure * (scratch.phi_p[j] * scratch.grads_phi_u[i]) * strain_rate )
+                                                        + derivative_scaling_factor * pressure_scaling * 2.0 * viscosity_derivative_wrt_pressure * scratch.phi_p[j] * scratch.grads_phi_u[i] * strain_rate )
                                                       * JxW;
 
                             Assert(dealii::numbers::is_finite(data.local_matrix(i,j)),
@@ -439,7 +439,7 @@ namespace aspect
                         for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
                           {
                             data.local_matrix(i,j) += ( derivative_scaling_factor * alpha * 2.0 * (scratch.grads_phi_u[i] * deta_deps_times_eps_times_phi[j])
-                                                        + derivative_scaling_factor * pressure_scaling * 2.0 * viscosity_derivative_wrt_pressure * (scratch.phi_p[j] * scratch.grads_phi_u[i]) * strain_rate )
+                                                        + derivative_scaling_factor * pressure_scaling * 2.0 * viscosity_derivative_wrt_pressure * scratch.phi_p[j] * scratch.grads_phi_u[i] * strain_rate )
                                                       * JxW;
 
                             Assert(dealii::numbers::is_finite(data.local_matrix(i,j)),

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -268,11 +268,20 @@ namespace aspect
       const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
       const double derivative_scaling_factor = this->get_newton_handler().parameters.newton_derivative_scaling_factor;
 
-      const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>
-      *force = scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >();
 
-      const MaterialModel::ElasticOutputs<dim>
-      *elastic_outputs = scratch.material_model_outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim> >();
+      const bool enable_additional_stokes_rhs = this->get_parameters().enable_additional_stokes_rhs;
+
+      const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> *force = enable_additional_stokes_rhs ?
+                                                                            scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >()
+                                                                            :
+                                                                            nullptr;
+
+      const bool enable_elasticity = this->get_parameters().enable_elasticity;
+
+      const MaterialModel::ElasticOutputs<dim> *elastic_outputs = enable_elasticity ?
+                                                                  scratch.material_model_outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim> >()
+                                                                  :
+                                                                  nullptr;
 
       const MaterialModel::PrescribedPlasticDilation<dim>
       *prescribed_dilation =
@@ -328,16 +337,16 @@ namespace aspect
                                     -(density * gravity * scratch.phi_u[i]))
                                    * JxW;
 
-              if (force != nullptr && this->get_parameters().enable_additional_stokes_rhs)
+              if (enable_additional_stokes_rhs)
                 data.local_rhs(i) += (force->rhs_u[q] * scratch.phi_u[i]
                                       + pressure_scaling * force->rhs_p[q] * scratch.phi_p[i])
                                      * JxW;
 
-              if (elastic_outputs != nullptr && this->get_parameters().enable_elasticity)
+              if (enable_elasticity)
                 data.local_rhs(i) += (scalar_product(elastic_outputs->elastic_force[q],Tensor<2,dim>(scratch.grads_phi_u[i])))
                                      * JxW;
 
-              if (prescribed_dilation != nullptr)
+              if (enable_additional_stokes_rhs)
                 data.local_rhs(i) += (
                                        // RHS of - (div u,q) = - (R,q)
                                        - pressure_scaling
@@ -347,7 +356,7 @@ namespace aspect
 
               // Only assemble this term if we are running incompressible, otherwise this term
               // is already included on the LHS of the equation.
-              if (prescribed_dilation != nullptr && !material_model_is_compressible)
+              if (enable_additional_stokes_rhs && !material_model_is_compressible)
                 data.local_rhs(i) += (
                                        // RHS of momentum eqn: - \int 2/3 eta R, div v
                                        - 2.0 / 3.0 * eta
@@ -367,12 +376,12 @@ namespace aspect
                                                 eta * 2.0 * (scratch.grads_phi_u[i] * scratch.grads_phi_u[j])
                                                 // assemble \nabla p as -(p, div v):
                                                 - (pressure_scaling *
-                                                   scratch.div_phi_u[i] * scratch.phi_p[j])
+                                                   (scratch.div_phi_u[i] * scratch.phi_p[j]))
                                                 // assemble the term -div(u) as -(div u, q).
                                                 // Note the negative sign to make this
                                                 // operator adjoint to the grad p term:
                                                 - (pressure_scaling *
-                                                   scratch.phi_p[i] * scratch.div_phi_u[j]))
+                                                   (scratch.phi_p[i] * scratch.div_phi_u[j])))
                                               * JxW;
                   }
 
@@ -415,7 +424,7 @@ namespace aspect
                           {
                             data.local_matrix(i,j) += ( derivative_scaling_factor * alpha * (scratch.grads_phi_u[i] * deta_deps_times_eps_times_phi[j]
                                                                                              + scratch.grads_phi_u[j] * deta_deps_times_eps_times_phi[i])
-                                                        + derivative_scaling_factor * pressure_scaling * 2.0 * viscosity_derivative_wrt_pressure * scratch.phi_p[j] * scratch.grads_phi_u[i] * strain_rate )
+                                                        + derivative_scaling_factor * pressure_scaling * 2.0 * viscosity_derivative_wrt_pressure * (scratch.phi_p[j] * scratch.grads_phi_u[i]) * strain_rate )
                                                       * JxW;
 
                             Assert(dealii::numbers::is_finite(data.local_matrix(i,j)),
@@ -430,7 +439,7 @@ namespace aspect
                         for (unsigned int j=0; j<stokes_dofs_per_cell; ++j)
                           {
                             data.local_matrix(i,j) += ( derivative_scaling_factor * alpha * 2.0 * (scratch.grads_phi_u[i] * deta_deps_times_eps_times_phi[j])
-                                                        + derivative_scaling_factor * pressure_scaling * 2.0 * viscosity_derivative_wrt_pressure * scratch.phi_p[j] * scratch.grads_phi_u[i] * strain_rate )
+                                                        + derivative_scaling_factor * pressure_scaling * 2.0 * viscosity_derivative_wrt_pressure * (scratch.phi_p[j] * scratch.grads_phi_u[i]) * strain_rate )
                                                       * JxW;
 
                             Assert(dealii::numbers::is_finite(data.local_matrix(i,j)),

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -438,9 +438,7 @@ namespace aspect
     // cases, just assembling the RHS will be incorrect.  If no active
     // boundaries exist, we only have no-slip or free slip conditions, so we
     // don't need to force assembly of the matrix.
-    if ((nonlinear_iteration == 0 && time_step == 0)
-        ||
-        stokes_matrix_depends_on_solution()
+    if (stokes_matrix_depends_on_solution()
         ||
         (boundary_velocity_manager.get_active_boundary_velocity_conditions().size() > 0))
       rebuild_stokes_matrix = rebuild_stokes_preconditioner = assemble_newton_stokes_matrix = true;


### PR DESCRIPTION
This pull request is a split off from some work done on pull request #3112. Aligning the iterated dc picard nonlinear tolerance with the stokes one turned out to be a worst case scenario for the dc picard method because because of the change the amount of non-linear iterations was determined by the compositional residual instead of the stokes residual, and the extra assembly time was in this case dominating the performance gains of the stokes solve. This pull request changes to code to speed up the assembly enough to be slightly faster in this particular case than the stokes system. The averaged time over at least 25 run of the iterated advection dc picard stokes solver for that case went down from 21.02 seconds to 15.21 seconds, compared to 16.95 seconds for the normal iterated advection and stokes solver.

This pull request consists of two parts. The first part has a very minimal but measurable performance gain, but I think the code is more clean. If others have a significant other opinion on it, I am fine with reverting it. The second part contains the most significant performance gain and is the most important part of this pull request. The second part gains performance by not rebuilding the preconditioner and part of the matrix when it is not needed. This add the same logic of rebuilding which is used by the default stokes solver.
