### PR TITLE
Set mesh displacement to zero

### DIFF
--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -661,12 +661,10 @@ namespace aspect
       DoFTools::extract_locally_relevant_dofs (mesh_deformation_dof_handler,
                                                mesh_locally_relevant);
 
+      // This will initialize the mesh displacement and free surface 
+      // mesh velocity vectors with zero-valued entries.
       mesh_displacements.reinit(mesh_locally_owned, mesh_locally_relevant, sim.mpi_communicator);
       fs_mesh_velocity.reinit(mesh_locally_owned, mesh_locally_relevant, sim.mpi_communicator);
-
-      // if we are just starting, we need to initialize the mesh displacement vector.
-      if (!this->simulator_is_past_initialization())
-        mesh_displacements = 0.;
 
       // We would like to make sure that the mesh stays conforming upon
       // redistribution, so we construct mesh_vertex_constraints, which

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -665,7 +665,7 @@ namespace aspect
       fs_mesh_velocity.reinit(mesh_locally_owned, mesh_locally_relevant, sim.mpi_communicator);
 
       // if we are just starting, we need to initialize the mesh displacement vector.
-      if (this->get_timestep_number() == 0)
+      if (!sim.simulator_is_past_initialization)
         mesh_displacements = 0.;
 
       // We would like to make sure that the mesh stays conforming upon

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -661,7 +661,7 @@ namespace aspect
       DoFTools::extract_locally_relevant_dofs (mesh_deformation_dof_handler,
                                                mesh_locally_relevant);
 
-      // This will initialize the mesh displacement and free surface 
+      // This will initialize the mesh displacement and free surface
       // mesh velocity vectors with zero-valued entries.
       mesh_displacements.reinit(mesh_locally_owned, mesh_locally_relevant, sim.mpi_communicator);
       fs_mesh_velocity.reinit(mesh_locally_owned, mesh_locally_relevant, sim.mpi_communicator);

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -665,7 +665,7 @@ namespace aspect
       fs_mesh_velocity.reinit(mesh_locally_owned, mesh_locally_relevant, sim.mpi_communicator);
 
       // if we are just starting, we need to initialize the mesh displacement vector.
-      if (!sim.simulator_is_past_initialization)
+      if (!this->simulator_is_past_initialization())
         mesh_displacements = 0.;
 
       // We would like to make sure that the mesh stays conforming upon


### PR DESCRIPTION
Originally, this was only triggered in case initial adaptive refinement is applied, not when only initial global refinement occurs.  From the documentation, I gather that some versions of LinearAlgebra::Vector::reinit set the vector entries to zero by default, but this particular version does not. Which also makes me wonder why this works for non adaptive initial meshes. 
 
With the new condition, the mesh_displacements are set to zero once, before solving for the mesh velocity on the coarse mesh. With `sim.time==0`, they would be set to zero before solving on the coarse mesh and again before solving on the initially adaptively refined mesh.

With just the free surface, it doesn't really matter when during the first timestep the displacements are set to zero, because the Stokes velocities are zero and thus the mesh velocities are zero on both the coarse and the adaptively refined mesh. But it would be nice if this does what we think it should do.

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
