### PR TITLE
PerpleX lookup now uses column labels to assign properties

### DIFF
--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -164,6 +164,7 @@ namespace aspect
             double max_temp;
             unsigned int n_temperature;
             unsigned int n_pressure;
+            unsigned int n_columns;
             bool interpolation;
         };
 

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -472,17 +472,18 @@ namespace aspect
           // Read data from disk and distribute among processes
           std::istringstream in(Utilities::read_and_distribute_file_content(filename, comm));
 
-          std::getline(in, temp); // eat first line
-          std::getline(in, temp); // eat next line
-          std::getline(in, temp); // eat next line
-          std::getline(in, temp); // eat next line
+          // The following lines read in a PerpleX tab file in standard format
+          std::getline(in, temp); // eat first line, PerpleX version number
+          std::getline(in, temp); // eat next line, table file name
+          std::getline(in, temp); // eat next line, dimension of table
+          std::getline(in, temp); // eat next line, the string T(K)
 
           in >> min_temp;
           std::getline(in, temp);
           in >> delta_temp;
           std::getline(in, temp);
           in >> n_temperature;
-          std::getline(in, temp);
+          std::getline(in, temp); // eat next line, the string P(bar)
           std::getline(in, temp);
           in >> min_press;
           min_press *= 1e5;  // conversion from [bar] to [Pa]
@@ -491,9 +492,40 @@ namespace aspect
           delta_press *= 1e5; // conversion from [bar] to [Pa]
           std::getline(in, temp);
           in >> n_pressure;
-          std::getline(in, temp);
-          std::getline(in, temp);
-          std::getline(in, temp);
+          std::getline(in, temp); // eat next line, number of columns
+          in >> n_columns;
+          std::getline(in, temp); // eat next line, column labels
+
+          // here we string match to assign properties to columns
+          // column i in text file -> column j in properties
+          // Properties are stored in the order rho, alpha, cp, vp, vs, h
+          std::vector<int> prp_indices(6, -1);
+
+          for (unsigned int n=0; n<n_columns; n++)
+            {
+              std::string label;
+              in >> label;
+              if (label.compare("rho,kg/m3") == 0)
+                prp_indices[0] = n;
+              else if (label.compare("alpha,1/K") == 0)
+                prp_indices[1] = n;
+              else if (label.compare("cp,J/K/kg") == 0)
+                prp_indices[2] = n;
+              else if (label.compare("vp,km/s") == 0)
+                prp_indices[3] = n;
+              else if (label.compare("vs,km/s") == 0)
+                prp_indices[4] = n;
+              else if (label.compare("h,J/kg") == 0)
+                prp_indices[5] = n;
+            }
+          AssertThrow(std::all_of(prp_indices.begin(), prp_indices.end(), [](int i)
+          {
+            return i>=0;
+          }),
+          ExcMessage("PerpleX lookup files must contain columns with the labels "
+                     "rho,kg/m3, alpha,1/K, cp,J/K/kg, vp,km/s, vs,km/s and h,J/kg."));
+
+          std::getline(in, temp); // first data line
 
           AssertThrow(min_temp >= 0.0, ExcMessage("Read in of Material header failed (mintemp)."));
           AssertThrow(delta_temp > 0, ExcMessage("Read in of Material header failed (delta_temp)."));
@@ -514,58 +546,39 @@ namespace aspect
           enthalpy_values.reinit(n_temperature,n_pressure);
 
           unsigned int i = 0;
+          std::vector<double> previous_row_values(n_columns, 0.);
+
           while (!in.eof())
             {
-              double temp1,temp2;
-              double rho,alpha,cp,vp,vs,h;
-              in >> temp1 >> temp2;
-              in >> rho;
-              if (in.fail())
-                {
-                  in.clear();
-                  rho = density_values[(i-1)%n_temperature][(i-1)/n_temperature];
-                }
-              in >> alpha;
-              if (in.fail())
-                {
-                  in.clear();
-                  alpha = thermal_expansivity_values[(i-1)%n_temperature][(i-1)/n_temperature];
-                }
-              in >> cp;
-              if (in.fail())
-                {
-                  in.clear();
-                  cp = specific_heat_values[(i-1)%n_temperature][(i-1)/n_temperature];
-                }
-              in >> vp;
-              if (in.fail())
-                {
-                  in.clear();
-                  vp = vp_values[(i-1)%n_temperature][(i-1)/n_temperature];
-                }
-              in >> vs;
-              if (in.fail())
-                {
-                  in.clear();
-                  vs = vs_values[(i-1)%n_temperature][(i-1)/n_temperature];
-                }
-              in >> h;
-              if (in.fail())
-                {
-                  in.clear();
-                  h = enthalpy_values[(i-1)%n_temperature][(i-1)/n_temperature];
-                }
+              std::vector<double> row_values(n_columns);
 
-              std::getline(in, temp);
+              for (unsigned int n=0; n<n_columns; n++)
+                {
+                  in >> row_values[n];
+                  // PerpleX P-T grids sometimes contain rows filled with NaNs
+                  // in the corners of the grid.
+                  // These P-T regions are unimportant, and we don't want ASPECT
+                  // to crash just because it sees a NaN.
+                  // Here we choose to replace invalid doubles
+                  // with the most recent valid double.
+                  if (in.fail())
+                    {
+                      in.clear();
+                      row_values[n] = previous_row_values[n];
+                    }
+                }
+              previous_row_values = row_values;
+
+              std::getline(in, temp); // read next line
               if (in.eof())
                 break;
 
-              density_values[i%n_temperature][i/n_temperature]=rho;
-              thermal_expansivity_values[i%n_temperature][i/n_temperature]=alpha;
-              specific_heat_values[i%n_temperature][i/n_temperature]=cp;
-              vp_values[i%n_temperature][i/n_temperature]=vp;
-              vs_values[i%n_temperature][i/n_temperature]=vs;
-              enthalpy_values[i%n_temperature][i/n_temperature]=h;
+              density_values[i%n_temperature][i/n_temperature]=row_values[prp_indices[0]];
+              thermal_expansivity_values[i%n_temperature][i/n_temperature]=row_values[prp_indices[1]];
+              specific_heat_values[i%n_temperature][i/n_temperature]=row_values[prp_indices[2]];
+              vp_values[i%n_temperature][i/n_temperature]=row_values[prp_indices[3]];
+              vs_values[i%n_temperature][i/n_temperature]=row_values[prp_indices[4]];
+              enthalpy_values[i%n_temperature][i/n_temperature]=row_values[prp_indices[5]];
 
               i++;
             }

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -473,28 +473,46 @@ namespace aspect
           std::istringstream in(Utilities::read_and_distribute_file_content(filename, comm));
 
           // The following lines read in a PerpleX tab file in standard format
-          std::getline(in, temp); // eat first line, PerpleX version number
-          std::getline(in, temp); // eat next line, table file name
-          std::getline(in, temp); // eat next line, dimension of table
-          std::getline(in, temp); // eat next line, the string T(K)
+          // First line is the Perplex version number
+          std::getline(in, temp); // get next line, table file name
+          std::getline(in, temp); // get next line, dimension of table
+          std::getline(in, temp); // get next line, either T(K) or P(bar)
 
-          in >> min_temp;
-          std::getline(in, temp);
-          in >> delta_temp;
-          std::getline(in, temp);
-          in >> n_temperature;
-          std::getline(in, temp); // eat next line, the string P(bar)
-          std::getline(in, temp);
-          in >> min_press;
-          min_press *= 1e5;  // conversion from [bar] to [Pa]
-          std::getline(in, temp);
-          in >> delta_press;
-          delta_press *= 1e5; // conversion from [bar] to [Pa]
-          std::getline(in, temp);
-          in >> n_pressure;
-          std::getline(in, temp); // eat next line, number of columns
+          for (unsigned int i=0; i<2; i++)
+            {
+              std::string natural_variable;
+              in >> natural_variable;
+
+              if (natural_variable[0] == 'T')
+                {
+                  std::getline(in, temp);
+                  in >> min_temp;
+                  std::getline(in, temp);
+                  in >> delta_temp;
+                  std::getline(in, temp);
+                  in >> n_temperature;
+                  std::getline(in, temp); // get next line, either T(K), P(bar) or number of columns
+                }
+              else if (natural_variable[0] == 'P')
+                {
+                  std::getline(in, temp);
+                  in >> min_press;
+                  min_press *= 1e5;  // conversion from [bar] to [Pa]
+                  std::getline(in, temp);
+                  in >> delta_press;
+                  delta_press *= 1e5; // conversion from [bar] to [Pa]
+                  std::getline(in, temp);
+                  in >> n_pressure;
+                  std::getline(in, temp); // get next line, either T(K), P(bar) or number of columns
+                }
+              else
+                {
+                  AssertThrow (false, ExcMessage("The start of the PerpleX file does not have the expected format."));
+                }
+            }
+
           in >> n_columns;
-          std::getline(in, temp); // eat next line, column labels
+          std::getline(in, temp); // get next line, column labels
 
           // here we string match to assign properties to columns
           // column i in text file -> column j in properties


### PR DESCRIPTION
The PerpleX lookup table previously assumed a certain ordering of columns, and of units. This PR instead reads the column labels, and assigns properties according to those labels.

This PR is a first step toward adding additional columns to the lookup, such as individual phase volumes.