### PR TITLE
Avoid a warning about missing braces.

### DIFF
--- a/source/material_model/rheology/strain_dependent.cc
+++ b/source/material_model/rheology/strain_dependent.cc
@@ -354,7 +354,7 @@ namespace aspect
             }
           }
 
-        std::array<double, 3> weakening_factors = {brittle_weakening.first,brittle_weakening.second,viscous_weakening};
+        const std::array<double, 3> weakening_factors = {{brittle_weakening.first,brittle_weakening.second,viscous_weakening}};
 
         return weakening_factors;
 


### PR DESCRIPTION
```
[127/297] Building CXX object CMakeFiles/aspect.dir/source/material_model/rheology/strain_dependent.cc.o
/home/bangerth/p/deal.II/1/projects/aspect/source/material_model/rheology/strain_dependent.cc: In instantiation of ‘std::array<double, 3> aspect::MaterialModel::Rheology::StrainDependent<dim>::compute_strain_weakening_factors(unsigned int, const std::vector<double, std::allocator<double> >&) const [with int dim = 2]’:
/home/bangerth/p/deal.II/1/projects/aspect/source/material_model/rheology/strain_dependent.cc:552:5:   required from here
/home/bangerth/p/deal.II/1/projects/aspect/source/material_model/rheology/strain_dependent.cc:357:31: warning: missing braces around initializer for ‘std::__array_traits<double, 3>::_Type {aka double [3]}’ [-Wmissing-braces]
         std::array<double, 3> weakening_factors = {brittle_weakening.first,brittle_weakening.second,viscous_weakening};
                               ^~~~~~~~~~~~~~~~~
/home/bangerth/p/deal.II/1/projects/aspect/source/material_model/rheology/strain_dependent.cc: In instantiation of ‘std::array<double, 3> aspect::MaterialModel::Rheology::StrainDependent<dim>::compute_strain_weakening_factors(unsigned int, const std::vector<double, std::allocator<double> >&) const [with int dim = 3]’:
/home/bangerth/p/deal.II/1/projects/aspect/source/material_model/rheology/strain_dependent.cc:552:5:   required from here
/home/bangerth/p/deal.II/1/projects/aspect/source/material_model/rheology/strain_dependent.cc:357:31: warning: missing braces around initializer for ‘std::__array_traits<double, 3>::_Type {aka double [3]}’ [-Wmissing-braces]
```