### PR TITLE
Build world builder with unity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,18 +144,30 @@ if(ASPECT_WITH_WORLD_BUILDER)
   CONFIGURE_FILE("${WORLD_BUILDER_SOURCE_DIR}/source/config.cc.in" "${CMAKE_BINARY_DIR}/world_builder_config.cc" @ONLY)
   LIST(INSERT TARGET_SRC 0 "${CMAKE_BINARY_DIR}/world_builder_config.cc")
 
+  SET(UNITY_WB_LAST_FILES
+  "${WORLD_BUILDER_SOURCE_DIR}/source/parameters.cc")
+
   FOREACH(_source_file ${wb_files})
     # exclude the world builder files from including precompiled headers, they
     # do not include ASPECT's dependencies at all.
     SET_PROPERTY(SOURCE ${_source_file} PROPERTY COTIRE_EXCLUDED TRUE )
     SET_PROPERTY(SOURCE ${_source_file} PROPERTY SKIP_PRECOMPILE_HEADERS TRUE )
-    # exclude the world builder from unity builds (avoids compilation errors):
-    SET_PROPERTY(SOURCE ${_source_file} PROPERTY SKIP_UNITY_BUILD_INCLUSION TRUE )
   ENDFOREACH()
 
   SET_PROPERTY(SOURCE "${CMAKE_BINARY_DIR}/world_builder_config.cc" PROPERTY COTIRE_EXCLUDED TRUE )
   SET_PROPERTY(SOURCE "${CMAKE_BINARY_DIR}/world_builder_config.cc" PROPERTY SKIP_PRECOMPILE_HEADERS TRUE )
 endif()
+
+FOREACH(_source_file ${UNITY_WB_LAST_FILES})
+  SET(_full_name "${_source_file}")
+  LIST(FIND TARGET_SRC ${_full_name} _index)
+  IF(_index EQUAL -1)
+    MESSAGE(FATAL_ERROR "could not find ${_full_name}.")
+  ENDIF()
+
+  LIST(REMOVE_ITEM TARGET_SRC ${_full_name})
+  LIST(APPEND TARGET_SRC ${_full_name})
+ENDFOREACH()
 
 
 # load in version info and export it

--- a/contrib/world_builder/source/features/fault.cc
+++ b/contrib/world_builder/source/features/fault.cc
@@ -363,15 +363,15 @@ namespace WorldBuilder
           // This function only returns positive values, because we want
           // the fault to be centered around the line provided by the user.
           std::map<std::string,double> distance_from_planes =
-            Utilities::distance_point_from_curved_planes(position,
-                                                         reference_point,
-                                                         coordinates,
-                                                         slab_segment_lengths,
-                                                         slab_segment_angles,
-                                                         starting_radius,
-                                                         this->world->parameters.coordinate_system,
-                                                         true,
-                                                         one_dimensional_coordinates);
+            WorldBuilder::Utilities::distance_point_from_curved_planes(position,
+                                                                       reference_point,
+                                                                       coordinates,
+                                                                       slab_segment_lengths,
+                                                                       slab_segment_angles,
+                                                                       starting_radius,
+                                                                       this->world->parameters.coordinate_system,
+                                                                       true,
+                                                                       one_dimensional_coordinates);
 
           const double distance_from_plane = distance_from_planes["distanceFromPlane"];
           const double distance_along_plane = distance_from_planes["distanceAlongPlane"];
@@ -491,15 +491,15 @@ namespace WorldBuilder
           // This function only returns positive values, because we want
           // the fault to be centered around the line provided by the user.
           std::map<std::string,double> distance_from_planes =
-            Utilities::distance_point_from_curved_planes(position,
-                                                         reference_point,
-                                                         coordinates,
-                                                         slab_segment_lengths,
-                                                         slab_segment_angles,
-                                                         starting_radius,
-                                                         this->world->parameters.coordinate_system,
-                                                         true,
-                                                         one_dimensional_coordinates);
+            WorldBuilder::Utilities::distance_point_from_curved_planes(position,
+                                                                       reference_point,
+                                                                       coordinates,
+                                                                       slab_segment_lengths,
+                                                                       slab_segment_angles,
+                                                                       starting_radius,
+                                                                       this->world->parameters.coordinate_system,
+                                                                       true,
+                                                                       one_dimensional_coordinates);
 
           const double distance_from_plane = distance_from_planes["distanceFromPlane"];
           const double distance_along_plane = distance_from_planes["distanceAlongPlane"];
@@ -622,15 +622,15 @@ namespace WorldBuilder
           // This function only returns positive values, because we want
           // the fault to be centered around the line provided by the user.
           std::map<std::string,double> distance_from_planes =
-            Utilities::distance_point_from_curved_planes(position,
-                                                         reference_point,
-                                                         coordinates,
-                                                         slab_segment_lengths,
-                                                         slab_segment_angles,
-                                                         starting_radius,
-                                                         this->world->parameters.coordinate_system,
-                                                         true,
-                                                         one_dimensional_coordinates);
+            WorldBuilder::Utilities::distance_point_from_curved_planes(position,
+                                                                       reference_point,
+                                                                       coordinates,
+                                                                       slab_segment_lengths,
+                                                                       slab_segment_angles,
+                                                                       starting_radius,
+                                                                       this->world->parameters.coordinate_system,
+                                                                       true,
+                                                                       one_dimensional_coordinates);
 
           const double distance_from_plane = distance_from_planes["distanceFromPlane"];
           const double distance_along_plane = distance_from_planes["distanceAlongPlane"];

--- a/contrib/world_builder/source/features/oceanic_plate.cc
+++ b/contrib/world_builder/source/features/oceanic_plate.cc
@@ -146,8 +146,8 @@ namespace WorldBuilder
 
 
       if (depth <= max_depth && depth >= min_depth &&
-          Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
-                                                                  world->parameters.coordinate_system->natural_coordinate_system())))
+          WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
+                                                                                world->parameters.coordinate_system->natural_coordinate_system())))
         {
           for (auto &temperature_model: temperature_models)
             {
@@ -179,8 +179,8 @@ namespace WorldBuilder
                                                                       *(world->parameters.coordinate_system));
 
       if (depth <= max_depth && depth >= min_depth &&
-          Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
-                                                                  world->parameters.coordinate_system->natural_coordinate_system())))
+          WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
+                                                                                world->parameters.coordinate_system->natural_coordinate_system())))
         {
           for (auto &composition_model: composition_models)
             {
@@ -212,8 +212,8 @@ namespace WorldBuilder
                                                                       *(world->parameters.coordinate_system));
 
       if (depth <= max_depth && depth >= min_depth &&
-          Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
-                                                                  world->parameters.coordinate_system->natural_coordinate_system())))
+          WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
+                                                                                world->parameters.coordinate_system->natural_coordinate_system())))
         {
           for (auto &grains_model: grains_models)
             {

--- a/contrib/world_builder/source/features/subducting_plate.cc
+++ b/contrib/world_builder/source/features/subducting_plate.cc
@@ -378,15 +378,15 @@ namespace WorldBuilder
                    << ") and one_dimensional_coordinates (" << one_dimensional_coordinates.size() << ") are different.");*/
           // todo: explain
           std::map<std::string,double> distance_from_planes =
-            Utilities::distance_point_from_curved_planes(position,
-                                                         reference_point,
-                                                         coordinates,
-                                                         slab_segment_lengths,
-                                                         slab_segment_angles,
-                                                         starting_radius,
-                                                         this->world->parameters.coordinate_system,
-                                                         false,
-                                                         one_dimensional_coordinates);
+            WorldBuilder::Utilities::distance_point_from_curved_planes(position,
+                                                                       reference_point,
+                                                                       coordinates,
+                                                                       slab_segment_lengths,
+                                                                       slab_segment_angles,
+                                                                       starting_radius,
+                                                                       this->world->parameters.coordinate_system,
+                                                                       false,
+                                                                       one_dimensional_coordinates);
 
           const double distance_from_plane = distance_from_planes["distanceFromPlane"];
           const double distance_along_plane = distance_from_planes["distanceAlongPlane"];
@@ -503,15 +503,15 @@ namespace WorldBuilder
         {
           // todo: explain
           std::map<std::string,double> distance_from_planes =
-            Utilities::distance_point_from_curved_planes(position,
-                                                         reference_point,
-                                                         coordinates,
-                                                         slab_segment_lengths,
-                                                         slab_segment_angles,
-                                                         starting_radius,
-                                                         this->world->parameters.coordinate_system,
-                                                         false,
-                                                         one_dimensional_coordinates);
+            WorldBuilder::Utilities::distance_point_from_curved_planes(position,
+                                                                       reference_point,
+                                                                       coordinates,
+                                                                       slab_segment_lengths,
+                                                                       slab_segment_angles,
+                                                                       starting_radius,
+                                                                       this->world->parameters.coordinate_system,
+                                                                       false,
+                                                                       one_dimensional_coordinates);
 
           const double distance_from_plane = distance_from_planes["distanceFromPlane"];
           const double distance_along_plane = distance_from_planes["distanceAlongPlane"];
@@ -635,15 +635,15 @@ namespace WorldBuilder
         {
           // todo: explain
           std::map<std::string,double> distance_from_planes =
-            Utilities::distance_point_from_curved_planes(position,
-                                                         reference_point,
-                                                         coordinates,
-                                                         slab_segment_lengths,
-                                                         slab_segment_angles,
-                                                         starting_radius,
-                                                         this->world->parameters.coordinate_system,
-                                                         false,
-                                                         one_dimensional_coordinates);
+            WorldBuilder::Utilities::distance_point_from_curved_planes(position,
+                                                                       reference_point,
+                                                                       coordinates,
+                                                                       slab_segment_lengths,
+                                                                       slab_segment_angles,
+                                                                       starting_radius,
+                                                                       this->world->parameters.coordinate_system,
+                                                                       false,
+                                                                       one_dimensional_coordinates);
 
           const double distance_from_plane = distance_from_planes["distanceFromPlane"];
           const double distance_along_plane = distance_from_planes["distanceAlongPlane"];


### PR DESCRIPTION
After the suggestion of @tjhei I played around with the unity build for the world builder inside aspect a bit, and the fixes where very simple. It does require some changes to the world builder source files, but that only includes clarifying the scope (I am not sure why that was a problem for the unity build). Normally I would be really hesitant to have any changes in the world builder in ASPECT, without going to a newer version of the world builder, but since the change are so minimal that we can verify that it can't influence the results or the (internal or external) api, I would be fine with merging this change in aspect independent of the world builder.