### PR TITLE
fix deal.II 9.2 instantiation bug in qprojector.h

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -26,7 +26,17 @@
 #include <aspect/material_model/utilities.h>
 
 #include <deal.II/base/point.h>
+
+// Work around an incorrect instantiation in qprojector.h of deal.II 9.2.0,
+// which requires including qprojector.h before quadrature.h (and not
+// after). This file doesn't actually need qprojector.h, so the include can be
+// removed when we require 9.3.. For more info see
+// https://github.com/geodynamics/aspect/issues/3728
+#if !DEAL_II_VERSION_GTE(9,3,0)
+#include <deal.II/base/qprojector.h>
+#endif
 #include <deal.II/base/quadrature.h>
+
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/dofs/dof_handler.h>


### PR DESCRIPTION
Fixes #3728, which could generate the following error
```
In file included from /hdscratch/shared/libs-
candi-9.2.0-r1/deal.II-v9.2.0/include/deal.II/fe/mapping_cartesian.h:22:0,
                 from /home/heister/aspect-
git/source/simulator/core.cc:53,
                 from CMakeFiles/aspect.dir/Unity/unity_2_cxx.cxx:97:
/hdscratch/shared/libs-
candi-9.2.0-r1/deal.II-v9.2.0/include/deal.II/base/qprojector.h:414:54:
error: specialization of ‘dealii::QIterated<dim>::QIterated(const
dealii::Quadrature<1>&, unsigned int) [with int dim = 1]’ after
instantiation
                         const unsigned int   n_copies);
```

This is due to deal.II 9.2. having an incorrect specialization of
QIterated inside quadrature.h.
