### PR TITLE
Move VectorFunctionFromVelocityFunctionObject to Utilities namespace

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1397,6 +1397,59 @@ namespace aspect
                        const std::vector<Point<dim> > &,
                        std::vector<double> &)>                                 &function,
                      VectorType                                                &vec_result);
+
+    /**
+    * Conversion object where one can provide a function that returns
+    * a tensor for the velocity at a given point and it returns something
+    * that matches the dealii::Function interface with a number of output
+    * components equal to the number of components of the finite element
+    * in use.
+    */
+    template <int dim>
+    class VectorFunctionFromVelocityFunctionObject : public Function<dim>
+    {
+      public:
+        /**
+         * Given a function object that takes a Point and returns a Tensor<1,dim>,
+         * convert this into an object that matches the Function@<dim@>
+         * interface.
+         *
+         * @param n_components total number of components of the finite element system.
+         * @param function_object The function that will form one component
+         *     of the resulting Function object.
+         */
+        VectorFunctionFromVelocityFunctionObject (const unsigned int n_components,
+                                                  const std::function<Tensor<1,dim> (const Point<dim> &)> &function_object);
+
+        /**
+         * Return the value of the
+         * function at the given
+         * point. Returns the value the
+         * function given to the constructor
+         * produces for this point.
+         */
+        double value (const Point<dim>   &p,
+                      const unsigned int  component = 0) const override;
+
+        /**
+         * Return all components of a
+         * vector-valued function at a
+         * given point.
+         *
+         * <tt>values</tt> shall have the right
+         * size beforehand,
+         * i.e. #n_components.
+         */
+        void vector_value (const Point<dim>   &p,
+                           Vector<double>     &values) const override;
+
+      private:
+        /**
+         * The function object which we call when this class's value() or
+         * value_list() functions are called.
+         **/
+        const std::function<Tensor<1,dim> (const Point<dim> &)> function_object;
+    };
   }
 }
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -3492,6 +3492,57 @@ namespace aspect
           }
     }
 
+
+
+
+    template <int dim>
+    VectorFunctionFromVelocityFunctionObject<dim>::
+    VectorFunctionFromVelocityFunctionObject
+    (const unsigned int n_components,
+     const std::function<Tensor<1,dim> (const Point<dim> &)> &function_object)
+      :
+      Function<dim>(n_components),
+      function_object (function_object)
+    {
+    }
+
+
+
+    template <int dim>
+    double
+    VectorFunctionFromVelocityFunctionObject<dim>::value (const Point<dim> &p,
+                                                          const unsigned int component) const
+    {
+      Assert (component < this->n_components,
+              ExcIndexRange (component, 0, this->n_components));
+
+      if (component < dim)
+        {
+          const Tensor<1,dim> v = function_object(p);
+          return v[component];
+        }
+      else
+        return 0;
+    }
+
+
+
+    template <int dim>
+    void
+    VectorFunctionFromVelocityFunctionObject<dim>::
+    vector_value (const Point<dim>   &p,
+                  Vector<double>     &values) const
+    {
+      AssertDimension(values.size(), this->n_components);
+
+      // set everything to zero, and then the right components to their correct values
+      values = 0;
+
+      const Tensor<1,dim> v = function_object(p);
+      for (unsigned int d=0; d<dim; ++d)
+        values(d) = v[d];
+    }
+
 // Explicit instantiations
 
 #define INSTANTIATE(dim) \
@@ -3500,7 +3551,10 @@ namespace aspect
                                                       const ComponentMask &); \
   template \
   std::vector<std::string> \
-  expand_dimensional_variable_names<dim> (const std::vector<std::string> &var_declarations);
+  expand_dimensional_variable_names<dim> (const std::vector<std::string> &var_declarations); \
+  \
+  template \
+  class VectorFunctionFromVelocityFunctionObject<dim>;
 
     ASPECT_INSTANTIATE(INSTANTIATE)
 


### PR DESCRIPTION
I need access to this utility class in a different PR, but since it is a self-contained change it makes sense to merge it separately.