### PR TITLE
Require at least one nonlinear iteration

### DIFF
--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -80,7 +80,7 @@ namespace aspect
                        "checkpoint file, otherwise started from scratch.");
 
     prm.declare_entry ("Max nonlinear iterations", "10",
-                       Patterns::Integer (0),
+                       Patterns::Integer (1),
                        "The maximal number of nonlinear iterations to be performed.");
 
     prm.declare_entry ("Max nonlinear iterations in pre-refinement", boost::lexical_cast<std::string>(std::numeric_limits<int>::max()),

--- a/tests/drucker_prager_derivatives_2d.prm
+++ b/tests/drucker_prager_derivatives_2d.prm
@@ -10,8 +10,7 @@ set Additional shared libraries = tests/libdrucker_prager_derivatives_2d.so
 set Dimension                              = 2
 set End time                               = 0
 set Use years in output instead of seconds = true
-set Nonlinear solver scheme                = iterated Advection and Newton Stokes
-set Max nonlinear iterations               = 0
+set Nonlinear solver scheme                = no Advection, no Stokes
 
 # Model geometry (100x100 km, 10 km spacing)
 subsection Geometry model

--- a/tests/drucker_prager_derivatives_3d.prm
+++ b/tests/drucker_prager_derivatives_3d.prm
@@ -10,8 +10,7 @@ set Additional shared libraries = tests/libdrucker_prager_derivatives_3d.so
 set Dimension                              = 3
 set End time                               = 0
 set Use years in output instead of seconds = true
-set Nonlinear solver scheme                = iterated Advection and Newton Stokes
-set Max nonlinear iterations               = 0
+set Nonlinear solver scheme                = no Advection, no Stokes
 
 # Model geometry (100x100 km, 10 km spacing)
 subsection Geometry model

--- a/tests/visco_plastic_derivatives_2d.prm
+++ b/tests/visco_plastic_derivatives_2d.prm
@@ -6,8 +6,7 @@ set Additional shared libraries = tests/libvisco_plastic_derivatives.so
 set Dimension                              = 2
 set End time                               = 0
 set Use years in output instead of seconds = true
-set Nonlinear solver scheme                = iterated Advection and Newton Stokes
-set Max nonlinear iterations               = 0
+set Nonlinear solver scheme                = no Advection, no Stokes
 
 # Model geometry (100x100 km, 10 km spacing)
 subsection Geometry model

--- a/tests/visco_plastic_derivatives_3d.prm
+++ b/tests/visco_plastic_derivatives_3d.prm
@@ -6,8 +6,7 @@ set Additional shared libraries = tests/libvisco_plastic_derivatives.so
 set Dimension                              = 3
 set End time                               = 0
 set Use years in output instead of seconds = true
-set Nonlinear solver scheme                = iterated Advection and Newton Stokes
-set Max nonlinear iterations               = 0
+set Nonlinear solver scheme                = no Advection, no Stokes
 
 # Model geometry (100x100 km, 10 km spacing)
 subsection Geometry model


### PR DESCRIPTION
In response to #3691 this sets the minimum number of nonlinear iterations to 1. If models require no solve performed at all they should choose the nonlinear solver scheme `no Advection, no Stokes` instead of setting the number of iterations to 0.