### PR TITLE
add particle advection substep update call.

### DIFF
--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -259,7 +259,17 @@ namespace aspect
          * integration of solution properties or time varying particle
          * properties are used while solving the model problem.
          */
-        update_time_step
+        update_time_step,
+        /**
+         * Update the particles at every particle advection substep. The substeps are
+         * defined by the particle integrator which include an euler, a RK2 and a RK4
+         * scheme. This flags make sure that the update function is called at every
+         * integration substep and at the end (which is the same time as update_time_step).
+         * This flag is only necessary if the particle properties need to update the data
+         * based on the integration substeps, for example a tensor which needs to be
+         * rotated by the advection.
+         */
+        update_time_substep
       };
 
       /**

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -731,6 +731,8 @@ namespace aspect
       do
         {
           advect_particles();
+          if (property_manager->need_update() == Property::update_time_substep)
+            update_particles();
         }
       // Keep calling the integrator until it indicates it is finished
       while (integrator->new_integration_step());
@@ -738,7 +740,7 @@ namespace aspect
       apply_particle_per_cell_bounds();
 
       // Update particle properties
-      if (property_manager->need_update() == Property::update_time_step)
+      if (property_manager->need_update() == Property::update_time_step || property_manager->need_update() == Property::update_time_substep)
         update_particles();
 
       // Now that all particle information was updated, exchange the new


### PR DESCRIPTION
This change allows for particle property plugin to ask for an update every advection step so that they can internally carry out the integration scheme to update the particle properties while the particles are advected. It would be the responsibility of the particle property plugins themselves to ask which integration scheme is being used, store all the substeps, and combine them at the correct update call.