### PR TITLE
update melt force vector test

### DIFF
--- a/tests/melt_force_vector.cc
+++ b/tests/melt_force_vector.cc
@@ -80,13 +80,11 @@ namespace aspect
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
         const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
-        double c = 1.0;
         MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>
         *force = out.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >();
 
         for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
-            const double porosity = in.composition[i][porosity_idx];
             const double x = in.position[i](0);
             const double z = in.position[i](1);
             out.viscosities[i] = 1.0;
@@ -144,15 +142,17 @@ namespace aspect
         double z = p(1);
 //**********
 // copy and paste here (add "out.")
-        values[0] = cos(z);
-        values[1] = sin(x);
-        values[2] = -0.2e1 * sin(x + z) + sin(x * z);
-        values[3] = sin(x + z);
-        values[4] = 1;
-        values[5] = 1;
-        values[6] = sin(x * z);
+        const double phi = 0.1000000000e-1 + 0.2000000000e0 * exp(-0.200e2 * pow(x + 0.20e1 * z, 0.2e1));
+
+        values[0] = cos(z);                                                 //ux
+        values[1] = sin(x);                                                 //uz
+        values[2] = -0.2e1 * sin(x + z) + sin(x * z);                       //p_f
+        values[3] = sin(x + z);                                             //p_c
+        values[4] = values[0] - 1.0/phi * (-2.0 * cos(x+z) + cos(x*z)*z);   //u_f_x
+        values[5] = values[1] - 1.0/phi * (-2.0 * cos(x+z) + cos(x*z)*x);   //u_f_z
+        values[6] = values[2] + values[3] / (1.0 - phi);                    //p_s = p_f + p_c / (1-phi)
         values[7] = 0;
-        values[8] = 0.1000000000e-1 + 0.2000000000e0 * exp(-0.200e2 * pow(x + 0.20e1 * z, 0.2e1));
+        values[8] = phi;                                                    //porosity
 //**********
       }
   };

--- a/tests/melt_force_vector/screen-output
+++ b/tests/melt_force_vector/screen-output
@@ -15,7 +15,7 @@ Number of degrees of freedom: 2,088 (851+578+81+289+289)
      RMS, max velocity:                               0.999 m/s, 1.3 m/s
      Pressure min/avg/max:                            -0.964 Pa, 0.000703 Pa, 1.733 Pa
      Max, min, and rms velocity along boundary parts: 1.307 m/s, 1.013 m/s, 1.198 m/s, 1.307 m/s, 1.013 m/s, 1.198 m/s, 0.9869 m/s, 0.541 m/s, 0.7514 m/s, 0.9869 m/s, 0.541 m/s, 0.7514 m/s
-     Errors                                            h = 3.535534e-01 ndofs= 2088 u_L2= 2.837164e-03 p_L2= 1.217818e+00 p_f_L2= 1.428258e-02 p_c_L2= 7.741754e-03 phi_L2= 1.736581e-02 u_f_L2= 3.631819e+02
+     Errors                                            h = 3.535534e-01 ndofs= 2088 u_L2= 2.837164e-03 p_L2= 3.329364e-02 p_f_L2= 1.428258e-02 p_c_L2= 7.741754e-03 phi_L2= 1.736581e-02 u_f_L2= 6.625314e+01
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 7,880 (3,235+2,178+289+1,089+1,089)
@@ -31,7 +31,7 @@ Number of degrees of freedom: 7,880 (3,235+2,178+289+1,089+1,089)
      RMS, max velocity:                               1 m/s, 1.3 m/s
      Pressure min/avg/max:                            -0.9565 Pa, 9.168e-05 Pa, 1.74 Pa
      Max, min, and rms velocity along boundary parts: 1.307 m/s, 1.006 m/s, 1.198 m/s, 1.307 m/s, 1.006 m/s, 1.198 m/s, 0.9935 m/s, 0.5405 m/s, 0.7514 m/s, 0.9935 m/s, 0.5405 m/s, 0.7514 m/s
-     Errors                                            h = 1.767767e-01 ndofs= 7880 u_L2= 7.150378e-04 p_L2= 1.234237e+00 p_f_L2= 3.576920e-03 p_c_L2= 1.942137e-03 phi_L2= 2.988517e-03 u_f_L2= 3.751121e+02
+     Errors                                            h = 1.767767e-01 ndofs= 7880 u_L2= 7.150378e-04 p_L2= 1.114860e-02 p_f_L2= 3.576920e-03 p_c_L2= 1.942137e-03 phi_L2= 2.988517e-03 u_f_L2= 3.008524e+01
 
 Termination requested by criterion: end time
 


### PR DESCRIPTION
This pull request updates the melt force vector test so that all errors in the screen output now converge. This is achieved by using the correct reference solution in the .cc file. 

This is useful because this is one of the few tests that uses additional material model outputs to add terms to the RHS of the equations, and this update makes it more clear how to use this feature. 

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).