### PR TITLE
played with timestepping and added my results in the readme

### DIFF
--- a/benchmarks/free_surface_tractions/viscoelastic/README
+++ b/benchmarks/free_surface_tractions/viscoelastic/README
@@ -24,8 +24,8 @@ A surface pressure of rho_l*g*H0 (where rho_l is the load density,
 
 Changing the stress instantaneously as the load is applied/removed
  leads to oscillations in the elastic response. This can be addressed
- by setting a fixed elastic timestep equal to the numerical ("Maximum")
- timestep and turning on stress averaging:
+ by setting a fixed elastic timestep which is several times longer than 
+ the numerical ("Maximum") timestep and turning on stress averaging:
    'free_surface_VE_cylinder_2D_loading_fixed_elastic_dt.prm'
    'free_surface_VE_cylinder_3D_loading_fixed_elastic_dt.prm'
 
@@ -54,3 +54,12 @@ The solutions match well in 3-D. In 2-D, the geometries of the loading
  function are different (Cartesian in ASPECT vs cylindrical analytically).
  As such, the agreement in 2-D breaks down for small r0 (load width) or
  if the right boundary is placed further away.
+ 
+The fit between the numerical and the analytical solution can be improved
+ by choosing short elastic (and therewith even shorter numerical) time
+ steps. The shorter the elastic time step is, the more instantaneous is 
+ the surface response to loading and unloading. When using a very small 
+ time step in the analytical solution it can be seen that the response 
+ is indeed instantaneous, favoring small elastic and computational time
+ steps for an accurat numerical solution as well. 
+


### PR DESCRIPTION
I had a closer look at this benchmark and played with timestepping. I corrected parts of the text and added some more information on elastic and numerical time step sizes. In the example .prm files the numerical time step is actually 10 while the elastic time step is 100, so they were not equal as stated in the text. 

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
